### PR TITLE
set SECURE_PROXY_SSL_HEADER

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -34,6 +34,10 @@ if not DEBUG and not TEST:
             integrations=[DjangoIntegration()]
         )
 
+
+if os.environ.get('IS_BEHIND_PROXY', False):
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 


### PR DESCRIPTION
Set SECURE_PROXY_SSL_HEADER if the `IS_BEHIND_PROXY` env var is present. Fixes #100 