### PR TITLE
Add support for event posts as a list

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -100,6 +100,28 @@ class TestCapture(BaseTest):
         event = Event.objects.get()
         self.assertEqual(event.event, '$pageview')
 
+    def test_multiple_events(self):
+        response = self.client.post('/track/', data={
+            'data': json.dumps([{
+                'event': 'beep',
+                'properties': {
+                    'distinct_id': 'eeee',
+                    'token': self.team.api_token,
+                },
+            },
+                {
+                'event': 'boop',
+                'properties': {
+                    'distinct_id': 'aaaa',
+                    'token': self.team.api_token,
+                },
+            } ]),
+            'api_key': self.team.api_token
+        })
+
+        events = Event.objects.all().count()
+        self.assertEqual(events, 2)
+
     def test_emojis_in_text(self):
         self.team.api_token = 'xp9qT2VLY76JJg'
         self.team.save()


### PR DESCRIPTION
This is used by at least the Mixpanel swift SDK, as requests are batched
every minute or so.

I avoided touching the batch endpoint for now as I'm pretty sure the two
functionalities are separate. Pretty annoying the mobile libs don't use
that though.

I haven't fully tested the Swift SDK just yet, but I'll file changes for any more fixes if they come up!