### PR TITLE
Added slack group invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ See [PostHog docs](https://github.com/PostHog/posthog/wiki) for in-depth walk th
 
 ![PostHog dashboard screenshot](https://posthog.com/wp-content/uploads/2020/02/Screenshot-2020-02-13-at-23.14.36-2.png)
 
+Join the [PostHog Users Slack](https://join.slack.com/t/posthogusers/shared_invite/enQtOTUwNjU1ODc1MjQ5LTU5ZDhlYTRiYmUyMDAxNDZjNzk4MDEwNzZkNTQ2YzMxMjVjY2EzYmIzZjllN2YwYmExODI5M2I3NGNiODFhZmU) if you need help, want to chat, or are thinking of a new feature idea.
+
 ## Features
 
 - **Event-based** analytics at a user level - see which users are doing what in your application.


### PR DESCRIPTION
Added slack group invite.

I kept it fairly low key (ie not a huge button) else I feel we're pulling people in too many directions.