### PR TITLE
Updates Dockeringore to include (not ignore) staticfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !bin/docker
 !requirements.txt
 !posthog
+!staticfiles
 !manage.py
 !frontend/package.json
 !frontend/*.html


### PR DESCRIPTION
Error in Docker

```
/usr/local/lib/python3.8/site-packages/whitenoise/base.py:116: UserWarning: No directory at: /code/staticfiles/
```

How this manifests:

![image](https://user-images.githubusercontent.com/487897/75496326-731d2100-5986-11ea-8515-23080a6193df.png)

