### PR TITLE
Fix showing highlight of event tab

### DIFF
--- a/frontend/src/ActionEdit.js
+++ b/frontend/src/ActionEdit.js
@@ -20,7 +20,7 @@ let getSafeText = (el) => {
 class EventName extends Component {
     constructor(props) {
         super(props)
-    
+
         this.state = {
         }
         this.fetchNames.call(this);
@@ -175,12 +175,12 @@ class ActionStep extends Component {
                 <button
                     type="button"
                     onClick={() => this.sendStep({...step, event: ''})}
-                    className={'btn ' + (step.event &&step.event != '$autocapture' && step.event != '$pageview' ? 'btn-secondary' : 'btn-light')}>
+                    className={'btn ' + (typeof step.event !== 'undefined' && step.event != '$autocapture' && step.event != '$pageview' ? 'btn-secondary' : 'btn-light')}>
                     Match event
                 </button>
                 <button
                     type="button"
-                    onClick={() => { 
+                    onClick={() => {
                         this.setState({selection: ['url']}, () => this.sendStep({
                                 ...step,
                                 event: '$pageview',
@@ -263,7 +263,7 @@ ActionStep.propTypes = {
 export class ActionEdit extends Component {
     constructor(props) {
         super(props)
-    
+
         this.state = {
             action: {name: '', steps: []}
         }


### PR DESCRIPTION
Without an event name selected, the "Match event" tab was not highlighted. This PR fixes that.

![ezgif-6-82d3f9b73ffc](https://user-images.githubusercontent.com/53387/75863444-c832ba00-5e00-11ea-915f-b327b6c70aa0.gif)
