### PR TITLE
Improve the actions form display

### DIFF
--- a/frontend/src/Action.js
+++ b/frontend/src/Action.js
@@ -6,7 +6,7 @@ import { ActionEdit } from './ActionEdit';
 export default class Action extends Component {
     constructor(props) {
         super(props)
-    
+
         this.state = {
             newEvents: [],
             action: {id: this.props.match.params.id}
@@ -15,13 +15,20 @@ export default class Action extends Component {
     render() {
         return <div>
             <h1>{this.props.match.params.id ? 'Edit action' : 'New action'}</h1>
-            <ActionEdit apiURL='' user={this.props.user} actionId={this.state.action.id} onSave={(action) => {
-                this.setState({action, refresh: new Date()})
-                if(!this.props.match.params.id) this.props.history.push({
-                    pathname: '/action/' + action.id,
-                    state: {id: action.id}
-                })
-            }}/>
+            <ActionEdit
+                apiURL=''
+                user={this.props.user}
+                actionId={this.state.action.id}
+                onSave={(action) => {
+                    this.setState({action, refresh: new Date()})
+                    if(!this.props.match.params.id) {
+                        this.props.history.push({
+                            pathname: '/action/' + action.id,
+                            state: {id: action.id}
+                        })
+                    }
+                }}
+            />
             {this.state.action.id && <div>
                 <br /><br />
 

--- a/frontend/src/ActionEdit.js
+++ b/frontend/src/ActionEdit.js
@@ -423,7 +423,7 @@ export class ActionEdit extends Component {
                             type="submit"
                             onClick={(e) => this.onSubmit(e, true)}
                             className='btn btn-secondary btn-sm float-right'>
-                              Save & new action!!
+                              Save & new action
                           </button>
                         )}
                     </div>

--- a/frontend/src/ActionEdit.js
+++ b/frontend/src/ActionEdit.js
@@ -182,7 +182,7 @@ class ActionStep extends Component {
                 <button
                     type="button"
                     onClick={() => this.sendStep({...step, event: ''})}
-                    className={'btn ' + (step.event &&step.event != '$autocapture' && step.event != '$pageview' ? 'btn-secondary' : 'btn-light')}>
+                    className={'btn ' + (typeof step.event !== 'undefined' && step.event != '$autocapture' && step.event != '$pageview' ? 'btn-secondary' : 'btn-light')}>
                     Match event
                 </button>
                 <button

--- a/frontend/src/ActionEdit.js
+++ b/frontend/src/ActionEdit.js
@@ -138,7 +138,14 @@ class ActionStep extends Component {
     Option(props) {
         let onChange = (e) => {
             this.props.step[props.item] = e.target.value;
-            this.sendStep(this.props.step);
+
+            if (e.target.value && this.state.selection.indexOf(props.item) === -1) {
+                this.setState({selection: this.state.selection.concat([props.item])}, () => this.sendStep(this.props.step))
+            } else if (!e.target.value && this.state.selection.indexOf(props.item) > -1) {
+                this.setState({selection: this.state.selection.filter((i) => i !== props.item)}, () => this.sendStep(this.props.step))
+            } else {
+                this.sendStep(this.props.step);
+            }
         }
         return <div className={'form-group ' + (this.state.selection.indexOf(props.item) > -1 && 'selected')}>
             {props.selector && this.props.isEditor && <small className='form-text text-muted float-right'>Matches {document.querySelectorAll(props.selector).length} elements</small>}
@@ -151,14 +158,14 @@ class ActionStep extends Component {
                     if(e.target.checked) {
                         this.state.selection.push(props.item);
                     } else {
-                        this.state.selection = this.state.selection.filter((i) => i != props.item)
+                        this.state.selection = this.state.selection.filter((i) => i !== props.item)
                     }
                     this.setState({selection: this.state.selection}, () => this.sendStep(this.props.step))
                 }}
                 /> {props.label} {props.extra_options}</label>
             {props.item == 'selector' ?
-                <textarea className='form-control' onChange={onChange} value={this.props.step[props.item]} /> :
-                <input className='form-control' onChange={onChange} value={this.props.step[props.item]} />}
+                <textarea className='form-control' onChange={onChange} value={this.props.step[props.item] || ''} /> :
+                <input className='form-control' onChange={onChange} value={this.props.step[props.item] || ''} />}
         </div>
     }
     TypeSwitcher() {

--- a/frontend/src/ActionEvents.js
+++ b/frontend/src/ActionEvents.js
@@ -11,7 +11,7 @@ import PropertyFilters from './PropertyFilter';
 export class ActionEventsTable extends Component {
     constructor(props) {
         super(props)
-    
+
         this.state = {
             propertyFilters: fromParams(),
             newEvents: [],
@@ -35,7 +35,7 @@ export class ActionEventsTable extends Component {
         })
     }
     pollEvents() {
-        let params = { 
+        let params = {
             ...this.props.fixedFilters,
             ...this.state.propertyFilters
         }
@@ -64,7 +64,7 @@ export class ActionEventsTable extends Component {
         let params = ['$current_url']
         let { loading, propertyFilters, events } = this.state;
         return (
-            <div class='events'>
+            <div className='events'>
                 <PropertyFilters propertyFilters={propertyFilters} onChange={(propertyFilters) => this.setState({propertyFilters}, this.fetchEvents)} />
                 <table className='table'>
                     <tbody>


### PR DESCRIPTION
This is how the actions new/edit form now looks like:
![image](https://user-images.githubusercontent.com/53387/75873784-d4267800-5e10-11ea-8191-43ff5d268ae8.png)

This is how the editor looks like:
![image](https://user-images.githubusercontent.com/53387/75873831-eb656580-5e10-11ea-9ee7-652483eb4a20.png)

This PR fixes issue #54 and also contains the commits for PRs #268 and #269