### PR TITLE
Helm chart updates

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,20 +35,20 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 8000
               protocol: TCP
           livenessProbe:
             failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
             httpGet:
               path: /_health/
-              port: 8080
+              port: 8000
             initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
           readinessProbe:
             failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
             httpGet:
               path: /_health/
-              port: 8080
+              port: 8000
             initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
           resources:

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -7,3 +7,4 @@ metadata:
 type: Opaque
 data:
   DATABASE_URL: {{ required "databaseURL is a required value." .Values.databaseURL | b64enc | quote }}
+  SECRET_KEY: {{ required "secretKey is a required value." .Values.secretKey | b64enc | quote }}

--- a/chart/values-local.yaml
+++ b/chart/values-local.yaml
@@ -1,4 +1,5 @@
 databaseURL: postgres://postgres:posthog@posthog-postgresql/posthog
+secretKey: THIS_IS_JUST_A_TEST_KEY_USE_A_BETTER_ONE_IN_PRODUCTION
 
 postgresql:
   enabled: true

--- a/chart/values-local.yaml
+++ b/chart/values-local.yaml
@@ -8,4 +8,4 @@ postgresql:
   postgresqlDatabase: posthog
 
   persistence:
-    enabled: false
+    enabled: true

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -10,6 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from .api import router, capture, user
 from .models import Team, User
 from .utils import render_template
+from .views import health
 from posthog.demo import demo, delete_demo_data
 import json
 import posthoganalytics # type: ignore
@@ -96,6 +97,7 @@ def logout(request):
     return auth_views.logout_then_login(request)
 
 urlpatterns = [
+    path('_health/', health),
     path('admin/', admin.site.urls),
     path('admin/', include('loginas.urls')),
     path('api/', include(router.urls)),

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -1,0 +1,4 @@
+from django.http import HttpResponse
+
+def health(request):
+    return HttpResponse("ok", content_type="text/plain")


### PR DESCRIPTION
This PR:
- Adds a /_health/ endpoint to the app, which will be used by k8s to check if the app is running
- Add a value to specify the SECRET_KEY, to secure the app's cookies
- Makes the `values-local.yaml` database persistent by default

Please merge (if ok of course) and then publish a new docker image, so that the `/_health/` endpoint would work.