### PR TITLE
#412 - Dashboard missing action error

### DIFF
--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -20,6 +20,7 @@ import json
 from dateutil.relativedelta import relativedelta
 from .person import PersonSerializer
 
+
 class ActionStepSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = ActionStep
@@ -43,6 +44,7 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
             return Event.objects.filter_by_action(action).count()
         return None
 
+
 class TemporaryTokenAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request: request.Request):
         # if the Origin is different, the only authentication method should be temporary_token
@@ -60,6 +62,7 @@ class TemporaryTokenAuthentication(authentication.BaseAuthentication):
                 raise AuthenticationFailed(detail='User doesnt exist')
             return (user.first(), None)
         return None
+
 
 class ActionViewSet(viewsets.ModelViewSet):
     queryset = Action.objects.all()
@@ -285,9 +288,14 @@ class ActionViewSet(viewsets.ModelViewSet):
         actions_list = []
 
         parsed_actions = self._parse_actions(request)
+
         if parsed_actions:
             for filters in parsed_actions:
-                db_action = [a for a in actions if a.id == filters['id']][0]
+                try:
+                    db_action = actions.get(pk=filters['id'])
+                except Action.DoesNotExist:
+                    continue
+
                 actions_list.append(self._serialize_action(
                     action=db_action,
                     filters=filters,
@@ -300,6 +308,7 @@ class ActionViewSet(viewsets.ModelViewSet):
                     filters={},
                     request=request,
                 ))
+
         return Response(actions_list)
 
     @action(methods=['GET'], detail=False)

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -10,7 +10,7 @@ def json_to_url(input) -> str:
 class TestCreateAction(BaseTest):
     TESTS_API = True
 
-    def test_create_and_update_action(self): 
+    def test_create_and_update_action(self):
         response = self.client.post('/api/action/', data={
             'name': 'user signed up',
             'steps': [{
@@ -171,6 +171,13 @@ class TestTrends(BaseTest):
         with freeze_time('2020-01-04'):
             response = self.client.get('/api/action/trends/?actions=%s' % json_to_url([{'id': sign_up_action.id}])).json()
         self.assertEqual(len(response), 1)
+
+    def test_trends_for_non_existing_action(self):
+        with freeze_time('2020-01-04'):
+            response = self.client.get('/api/action/trends/?actions=%s' % json_to_url([{'id': 4000000}])).json()
+
+        self.assertEqual(len(response), 0)
+
 
     def test_dau_filtering(self):
         sign_up_action, person = self._create_events()


### PR DESCRIPTION
## Issue

Issue #412 - When an action is deleted but a dashboard item uses it our app doesn't know how to handle it. 

## Solution

Added better errors and exception handling to the trends function. Now a standard error message appears:

![Captura de ecrã 2020-03-30, às 11 52 59](https://user-images.githubusercontent.com/29898180/77904787-0941b100-727d-11ea-9d17-c67b3ceac6b3.png)
