### PR TITLE
Add gunicorn workers in docker-server script

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-gunicorn posthog.wsgi --config gunicorn.config.py --bind 0.0.0.0:8000 --log-file -
+gunicorn posthog.wsgi --config gunicorn.config.py --bind 0.0.0.0:8000 --log-file - --worker-tmp-dir /dev/shm --workers=2 --threads=4 --worker-class=gthread


### PR DESCRIPTION
Once this gets merged, I can update the helm script to use the docker-server script instead of having a custom gunicorn command.