### PR TITLE
411 export cohort csv

### DIFF
--- a/frontend/src/scenes/users/Cohorts.js
+++ b/frontend/src/scenes/users/Cohorts.js
@@ -49,6 +49,9 @@ export class Cohorts extends Component {
                                         </Link>
                                     </td>
                                     <td>
+                                        <a href={'/api/person.csv?cohort=' + cohort.id}>
+                                            <i className="fi flaticon-export" />
+                                        </a>
                                         <DeleteWithUndo
                                             endpoint="cohort"
                                             object={cohort}

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -32,27 +32,30 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
             return person.distinct_ids[-1]
         return person.pk
 
+
 class PersonCsvRenderer (csvrenderers.PaginatedCSVRenderer):
-    header = ['id', 'name', 'properties.email', 'properties.name.first', 'properties.name.last', 'properties.phone', 'created_at'] # controls column ordering in returned csv
+    header = ['id', 'name', 'properties.email', 'properties.name.first',
+              'properties.name.last', 'properties.phone',
+              'created_at']  # controls column ordering in returned csv
     labels = {
         'team_id': 'Team',
         'properties.email': 'Person',
-        'properties.name.first' : 'FirstName',
-        'properties.name.last' : 'LastName',
-        'properties.phone' : 'Phone'
-    } # controls column labels in returned csv
+        'properties.name.first': 'FirstName',
+        'properties.name.last': 'LastName',
+        'properties.phone': 'Phone'
+    }  # controls column labels in returned csv
 
 class PersonViewSet(viewsets.ModelViewSet):
-    renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (PersonCsvRenderer, )
+    renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES)\
+        + (PersonCsvRenderer, )
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
     pagination_class = CursorPagination
 
-    def paginate_queryset(self, queryset, view=None):
+    def paginate_queryset(self, queryset):
         if 'text/csv' in self.request.accepted_media_type:
             return None
-        else:
-            return self.paginator.paginate_queryset(queryset, self.request, view=self)
+        return self.paginator.paginate_queryset(queryset, self.request, view=self)
 
     def _filter_cohort(self, request: request.Request, queryset: QuerySet, team: Team) -> QuerySet:
         cohort = Cohort.objects.get(team=team, pk=request.GET['cohort'])

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -48,6 +48,12 @@ class PersonViewSet(viewsets.ModelViewSet):
     serializer_class = PersonSerializer
     pagination_class = CursorPagination
 
+    def paginate_queryset(self, queryset, view=None):
+        if 'text/csv' in self.request.accepted_media_type:
+            return None
+        else:
+            return self.paginator.paginate_queryset(queryset, self.request, view=self)
+
     def _filter_cohort(self, request: request.Request, queryset: QuerySet, team: Team) -> QuerySet:
         cohort = Cohort.objects.get(team=team, pk=request.GET['cohort'])
         queryset = queryset.filter(pk__in=cohort.person_ids)

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -2,7 +2,7 @@ from posthog.models import Event, Team, Person, PersonDistinctId, Cohort
 from rest_framework import serializers, viewsets, response, request
 from rest_framework.decorators import action
 from rest_framework.settings import api_settings
-from rest_framework_csv import renderers as csvrenderers
+from rest_framework_csv import renderers as csvrenderers  # type: ignore
 from django.db.models import Q, Prefetch, QuerySet, Subquery, OuterRef, Count, Func
 from .event import EventSerializer
 from typing import Union

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -32,22 +32,9 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
             return person.distinct_ids[-1]
         return person.pk
 
-
-class PersonCsvRenderer (csvrenderers.PaginatedCSVRenderer):
-    header = ['id', 'name', 'properties.email', 'properties.name.first',
-              'properties.name.last', 'properties.phone',
-              'created_at']  # controls column ordering in returned csv
-    labels = {
-        'team_id': 'Team',
-        'properties.email': 'Person',
-        'properties.name.first': 'FirstName',
-        'properties.name.last': 'LastName',
-        'properties.phone': 'Phone'
-    }  # controls column labels in returned csv
-
 class PersonViewSet(viewsets.ModelViewSet):
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES)\
-        + (PersonCsvRenderer, )
+        + (csvrenderers.PaginatedCSVRenderer, )
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
     pagination_class = CursorPagination

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-cors-headers==3.2.1
 django-loginas==0.3.8
 django-stubs==1.4.0
 djangorestframework==3.11.0
+djangorestframework-csv==2.1.0
 djangorestframework-stubs==1.1.0
 drf-yasg==1.17.0
 freezegun==0.3.14


### PR DESCRIPTION
Addresses #411 

<img width="1361" alt="Screenshot 2020-04-04 at 1 14 51 AM" src="https://user-images.githubusercontent.com/12211622/78399121-f67b0380-7611-11ea-9e2d-93c1bfb08aa2.png">

The csv export api is defined at `/api/person.csv`
A query for cohort_id of 1 is run like this:- `/api/person.csv?cohort=1` which returns a csv file with with columns `id, name, Person, FirstName, LastName, Phone, created_at`

As an example, please find attached one such csv file for a cohort of users whose email field contains the word `gmail` [person.csv.zip](https://github.com/PostHog/posthog/files/4429602/person.csv.zip)


