### PR TITLE
Last seen bug fix

### DIFF
--- a/frontend/src/scenes/users/PeopleTable.js
+++ b/frontend/src/scenes/users/PeopleTable.js
@@ -42,6 +42,7 @@ export function PeopleTable({ loading, people, onClickProperty }) {
                         <th />
                         <th>Person</th>
                         <th>Last seen</th>
+                        <th>First seen</th>
                     </tr>
                     {people && people.length === 0 && (
                         <tr>
@@ -70,6 +71,7 @@ export function PeopleTable({ loading, people, onClickProperty }) {
                                     </Link>
                                 </td>
                                 <td>{person.last_event && moment(person.last_event.timestamp).fromNow()}</td>
+                                <td>{person.first_event && moment(person.first_event.timestamp).fromNow()}</td>
                             </tr>,
                             personSelected === person.id && (
                                 <tr key={person.id + '_open'}>

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -8,11 +8,12 @@ from .base import CursorPagination
 
 class PersonSerializer(serializers.HyperlinkedModelSerializer):
     last_event = serializers.SerializerMethodField()
+    first_event = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
 
     class Meta:
         model = Person
-        fields = ['id', 'name', 'distinct_ids', 'properties', 'last_event', 'created_at']
+        fields = ['id', 'name', 'distinct_ids', 'properties', 'last_event', 'first_event', 'created_at']
 
     def get_last_event(self, person: Person) -> Union[dict, None]:
         if not self.context['request'].GET.get('include_last_event'):
@@ -20,6 +21,15 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         last_event = Event.objects.filter(team_id=person.team_id, distinct_id__in=person.distinct_ids).order_by('-timestamp').first()
         if last_event:
             return {'timestamp': last_event.timestamp}
+        else:
+            return None
+
+    def get_first_event(self, person: Person) -> Union[dict, None]:
+        if not self.context['request'].GET.get('include_last_event'):
+            return None
+        first_event = Event.objects.filter(team_id=person.team_id, distinct_id__in=person.distinct_ids).order_by('timestamp').first()
+        if first_event:
+            return {'timestamp': first_event.timestamp}
         else:
             return None
 


### PR DESCRIPTION
An attempt to fix #132 

I just added a similar logic for "first_seen" field, with events sorted in ascending order of timestamp. I am not sure if this is what was asked for in #132

But I can see the following changes now:
![image](https://user-images.githubusercontent.com/14195048/78457697-c2631980-76c9-11ea-8b64-c4c1260be22b.png)

If this is indeed what is required, I think it might be better to implement to implement "first_seen" as Person model's field because then it will only need to be calculated once during the object creation. However, I am not sure yet whether same person with different sessions might have any consequences on the logic.

@timgl let me know what you think when you get some time.