### PR TITLE
Set default password for postgres in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       POSTGRES_USER: posthog
       POSTGRES_DB: posthog
+      POSTGRES_PASSWORD: posthog
   web:
     image: posthog/posthog:latest
     container_name: posthog_web
@@ -14,7 +15,7 @@ services:
       - "8000:8000"
     environment:
       IS_DOCKER: "true"
-      DATABASE_URL: "postgres://posthog@db:5432/posthog"
+      DATABASE_URL: "postgres://posthog:posthog@db:5432/posthog"
       SECRET_KEY: "<randomly generated secret key>"
     depends_on:
       - db


### PR DESCRIPTION
Hi. 

Current configuration produces this error:
```
db_1   | Error: Database is uninitialized and superuser password is not specified.
db_1   |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db_1   |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db_1   | 
db_1   |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db_1   |        connections without a password. This is *not* recommended.
db_1   | 
db_1   |        See PostgreSQL documentation about "trust":
db_1   |        https://www.postgresql.org/docs/current/auth-trust.html
posthog_db exited with code 1
```

I added default password for postgres so it won't fail now. 