### PR TITLE
management command for creating bulk events

### DIFF
--- a/posthog/management/commands/create_bulk_events.py
+++ b/posthog/management/commands/create_bulk_events.py
@@ -1,0 +1,125 @@
+
+import random
+import json
+import uuid
+
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+from django.core import serializers
+
+from dateutil.relativedelta import relativedelta
+from pathlib import Path
+from typing import List
+
+from posthog.models import Event, Element, Team, Person, PersonDistinctId, Funnel, Action, ActionStep, FunnelStep
+
+
+class Command(BaseCommand):
+    help = 'Create bulk events for testing'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--team_id', nargs='+', type=int, help='specify the team id eg. --team_id 1')
+        parser.add_argument('--mode', nargs='+', default=['create'], help="""
+                                                    'delete' for deleting bulk demo data 
+                                                    or 'create' for creating bulk demo data;
+                                                    default 'create'
+                                                    eg. --mode delete
+                                                     """
+                            )
+                            
+        parser.add_argument('--count', nargs='+', default=['1M'], help="""
+                                                        '1M' for creating about 1 million random events
+                                                        or 
+                                                        '100K' for creating about 100 thousand random events
+                                                        default 1M
+                                                        """
+                            )
+
+    def handle(self, *args, **options):
+        team_id = options['team_id']
+        mode =  options['mode'][0]
+        count = options['count'][0]
+
+        if not team_id:
+            print ("Please specify the --team id")
+            return
+
+        team = Team.objects.get(pk=team_id[0])
+
+        if count.lower() == "100k":
+            limit = 1000
+        else:
+            limit = 10000
+            print("This may take a while...")
+
+
+        with open(Path('posthog/demo_data.json').resolve(), 'r') as demo_data_file:
+            demo_data = json.load(demo_data_file)
+        
+        base_url = '127.0.0.1/bulk_demo/'
+
+        if mode.lower() == 'delete':
+            self._delete_demo_data(team)
+        else:
+            self._delete_demo_data(team)
+            self._create_funnel(base_url, team)
+            self._create_events(demo_data,team, limit)
+        
+    def _create_events(self, demo_data, team, limit):
+        Person.objects.bulk_create([
+        Person(team=team, properties={'is_demo': True}) for _ in range(0, 100)])
+
+        distinct_ids: List[PersonDistinctId] = []
+        events: List[Event] = []
+        days_ago = 7
+        demo_data_index = 0
+ 
+        base_url = '127.0.0.1/bulk_demo/'
+
+        for index, person in enumerate(Person.objects.filter(team=team)):
+            print (index)
+            if index > 0 and index % 14 == 0:
+                days_ago -= 1
+
+            distinct_id = str(uuid.uuid4())
+            distinct_ids.append(PersonDistinctId(team=team, person=person, distinct_id=distinct_id))
+            date = now() - relativedelta(days=days_ago)
+
+            if index % 3 == 0:
+                person.properties.update(demo_data[demo_data_index])
+                person.save()
+                demo_data_index += 1
+
+                for i in range(3):
+                    Event.objects.bulk_create([Event(
+                        event=random.choice(['$autocapture', '$pageview', '$signup']), team=team, distinct_id=distinct_id, 
+                        properties={'$current_url': base_url + random.choice(['', '1/', '2/']), 
+                        '$browser': random.choice(['Chrome', 'Safari', 'Firefox']), '$lib': 'web'}, timestamp=date + relativedelta(seconds=15),
+                        elements= [serializers.serialize('json', [Element(
+                            tag_name= random.choice(['a', 'button']) , href='/demo/1', attr_class=['btn', 'btn-success'], attr_id='sign-up', text=random.choice(['Sign up', 'Pay $10'])), ])]
+                        ) for _ in range(limit)])
+            
+        PersonDistinctId.objects.bulk_create(distinct_ids)
+
+    def _delete_demo_data(self,team):
+        people = PersonDistinctId.objects.filter(team=team, person__properties__is_demo=True)
+        Event.objects.filter(team=team, distinct_id__in=people.values('distinct_id')).delete()
+        Person.objects.filter(team=team, properties__is_demo=True).delete()
+        Funnel.objects.filter(team=team, name__contains="HogFlix").delete()
+        Action.objects.filter(team=team, name__contains="HogFlix").delete()
+        
+    def _create_funnel(self, base_url, team):
+        homepage = Action.objects.create(team=team, name='HogFlix homepage view')
+        ActionStep.objects.create(action=homepage, event='$pageview', url=base_url, url_matching='exact')
+
+        user_signed_up = Action.objects.create(team=team, name='HogFlix signed up')
+        ActionStep.objects.create(action=homepage, event='$autocapture', url='%s1/' % base_url, url_matching='exact')
+
+        user_paid = Action.objects.create(team=team, name='HogFlix paid')
+        ActionStep.objects.create(action=homepage, event='$autocapture', url='%s2/' % base_url, url_matching='exact')
+
+        funnel = Funnel.objects.create(team=team, name='HogFlix signup -> watching movie')
+        FunnelStep.objects.create(funnel=funnel, action=homepage, order=0)
+        FunnelStep.objects.create(funnel=funnel, action=user_signed_up, order=1)
+        FunnelStep.objects.create(funnel=funnel, action=user_paid, order=2)
+


### PR DESCRIPTION
Addresses: #456 
Command options:
To delete existing demo data
`DEBUG=1 python manage.py create_bulk_events --team_id 1 --mode delete`

To delete the demo data and create 1M events:
`DEBUG=1 python manage.py create_bulk_events --team_id 1`

To create 100k event records
`DEBUG=1 python manage.py create_bulk_events --team_id 1 --count 100k`

It is taking roughly 6 minutes to create 1M events using this command and roughly 2 minutes to delete these 1M events. Will optimize this further.
