### PR TITLE
514 trends people bug

### DIFF
--- a/frontend/src/scenes/trends/ActionsLineGraph.js
+++ b/frontend/src/scenes/trends/ActionsLineGraph.js
@@ -23,7 +23,11 @@ export function ActionsLineGraph({ dashboardItemId = null, filters: filtersParam
                 onClick={
                     dashboardItemId
                         ? null
-                        : ({ dataset: { action }, day }) => {
+                        : point => {
+                              const {
+                                  dataset: { action },
+                                  day,
+                              } = point
                               showPeople(action, day)
                           }
                 }

--- a/frontend/src/scenes/trends/trendsLogic.js
+++ b/frontend/src/scenes/trends/trendsLogic.js
@@ -198,11 +198,11 @@ export const trendsLogic = kea({
                 type: action.type,
             })
 
-            if (`${day}`.match(/^\d{4}-\d{2}-\d{2}$/)) {
+            if (values.filters.shown_as === 'Stickiness') {
+                params.stickiness_days = day
+            } else {
                 params.date_from = day
                 params.date_to = day
-            } else {
-                params.stickiness_days = day
             }
 
             const filterParams = toParams(params)

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -187,7 +187,8 @@ class ActionViewSet(viewsets.ModelViewSet):
             date_to = datetime.date.today()
 
         # UTC is what is set in setting.py
-        date_from = pd.Timestamp(date_from, tz='UTC')
+        if date_from is not None:
+            date_from = pd.Timestamp(date_from, tz='UTC')
         date_to = pd.Timestamp(date_to, tz='UTC')
         return date_from, date_to
 
@@ -212,7 +213,7 @@ class ActionViewSet(viewsets.ModelViewSet):
             return filters
         properties = json.loads(request.GET['properties'])
         filters &= properties_to_Q(properties)
-        
+
         return filters
 
     def _breakdown(self, append: Dict, filtered_events: QuerySet, filters: Dict[Any, Any],request: request.Request, breakdown_by: str) -> Dict:
@@ -279,7 +280,7 @@ class ActionViewSet(viewsets.ModelViewSet):
         if len(aggregates) > 0:
             date_from, date_to = self._get_dates_from_request(request)
             if not date_from:
-                date_from = aggregates[0][interval].date()
+                date_from = pd.Timestamp(aggregates[0][interval])
             dates_filled = self._group_events_to_date(date_from=date_from, date_to=date_to, aggregates=aggregates, interval=interval)
             append = self._append_data(append, dates_filled, interval)
         if request.GET.get('breakdown'):

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -193,7 +193,13 @@ class ActionViewSet(viewsets.ModelViewSet):
         if date_from:
             filters &= Q(timestamp__gte=date_from)
         if date_to:
-            filters &= Q(timestamp__lte=date_to + relativedelta(days=1))
+            interval = request.GET['interval']
+            relativity = relativedelta(days=1)
+            if interval == 'hour':
+                relativity = relativedelta(hours=1)
+            elif interval == 'minute':
+                relativity = relativedelta(minutes=1)
+            filters &= Q(timestamp__lte=date_to + relativity)
         if not request.GET.get('properties'):
             return filters
         properties = json.loads(request.GET['properties'])

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -148,11 +148,11 @@ class ActionViewSet(viewsets.ModelViewSet):
     def _group_events_to_date(self, date_from: datetime.date, date_to: datetime.date, aggregates, interval):
         aggregates = pd.DataFrame([{'date': a[interval], 'count': a['count']} for a in aggregates])
         if interval == 'week':
-            aggregates['date'] = aggregates['date'].apply(lambda x: x - pd.offsets.Week(weekday=6)).dt.date
+            aggregates['date'] = aggregates['date'].apply(lambda x: x - pd.offsets.Week(weekday=6))
         elif interval == 'month':
-            aggregates['date'] = aggregates['date'].apply(lambda x: x - pd.offsets.MonthEnd(n=1)).dt.date
+            aggregates['date'] = aggregates['date'].apply(lambda x: x - pd.offsets.MonthEnd(n=1))
         else:
-            aggregates['date'] = aggregates['date'].dt.tz_localize(None)
+            aggregates['date'] = aggregates['date']
 
         freq_map = {
             'minute': '60S',
@@ -185,6 +185,10 @@ class ActionViewSet(viewsets.ModelViewSet):
             date_to = relative_date_parse(request.GET['date_to'])
         else:
             date_to = datetime.date.today()
+
+        # UTC is what is set in setting.py
+        date_from = pd.Timestamp(date_from, tz='UTC')
+        date_to = pd.Timestamp(date_to, tz='UTC')
         return date_from, date_to
 
     def _filter_events(self, request: request.Request) -> Q:

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -199,12 +199,16 @@ class ActionViewSet(viewsets.ModelViewSet):
                 relativity = relativedelta(hours=1)
             elif interval == 'minute':
                 relativity = relativedelta(minutes=1)
+            elif interval == 'week':
+                relativity = relativedelta(weeks=1)
+            elif interval == 'month':
+                relativity = relativedelta(months=1) - relativity # go to last day of month instead of first of next
             filters &= Q(timestamp__lte=date_to + relativity)
         if not request.GET.get('properties'):
             return filters
         properties = json.loads(request.GET['properties'])
         filters &= properties_to_Q(properties)
-
+        
         return filters
 
     def _breakdown(self, append: Dict, filtered_events: QuerySet, filters: Dict[Any, Any],request: request.Request, breakdown_by: str) -> Dict:

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -193,7 +193,7 @@ class ActionViewSet(viewsets.ModelViewSet):
         if date_from:
             filters &= Q(timestamp__gte=date_from)
         if date_to:
-            interval = request.GET['interval']
+            interval = request.GET.get('interval')
             relativity = relativedelta(days=1)
             if interval == 'hour':
                 relativity = relativedelta(hours=1)

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -226,6 +226,7 @@ class ActionViewSet(viewsets.ModelViewSet):
 
         if interval == 'hour' or interval == 'minute':
             labels_format += ', %H:%M'
+            days_format += ' %H:%M:%S'
 
         for key, value in dates_filled.iterrows():
             append['days'].append(key.strftime(days_format))
@@ -409,7 +410,6 @@ class ActionViewSet(viewsets.ModelViewSet):
 
     @action(methods=['GET'], detail=False)
     def people(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-
         entityId = request.GET.get('entityId')
         entityType = request.GET.get('type')
 

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -314,6 +314,43 @@ class TestTrends(BaseTest):
         self.assertEqual(action_response[0]['people'][0]['id'], person1.pk)
         self.assertTrue(self._compare_entity_response(action_response, event_response, remove=['action']))
 
+    def test_people_endpoint_with_intervals(self):
+        sign_up_action, person = self._create_events()
+
+        person1 = Person.objects.create(team=self.team, distinct_ids=['person1'])
+        person2 = Person.objects.create(team=self.team, distinct_ids=['person2'])
+        person3 = Person.objects.create(team=self.team, distinct_ids=['person3'])
+        person4 = Person.objects.create(team=self.team, distinct_ids=['person4'])
+        person5 = Person.objects.create(team=self.team, distinct_ids=['person5'])
+
+        Event.objects.create(team=self.team, event='sign up', distinct_id='person1', timestamp='2020-01-04T14:10:00Z') # solo
+        Event.objects.create(team=self.team, event='sign up', distinct_id='person2', timestamp='2020-01-04T16:30:00Z') # group by hour
+        Event.objects.create(team=self.team, event='sign up', distinct_id='person3', timestamp='2020-01-04T16:50:00Z') # group by hour
+        Event.objects.create(team=self.team, event='sign up', distinct_id='person4', timestamp='2020-01-04T19:20:00Z') # group by min
+        Event.objects.create(team=self.team, event='sign up', distinct_id='person5', timestamp='2020-01-04T19:20:00Z') # group by min
+
+        # check solo hour
+        action_response = self.client.get('/api/action/people/?interval=hour&date_from=2020-01-04%s&date_to=2020-01-04%s&type=actions&entityId=%s' % (' 14:00', ' 14:00', sign_up_action.id)).json()
+        event_response = self.client.get('/api/action/people/?interval=hour&date_from=2020-01-04%2014%3A00&date_to=2020-01-04%2014%3A00&type=events&entityId=sign%20up').json()
+        self.assertEqual(action_response[0]['people'][0]['id'], person1.pk)
+        self.assertEqual(len(action_response[0]['people']), 1)
+        self.assertTrue(self._compare_entity_response(action_response, event_response, remove=['action']))
+
+        # check grouped hour
+        hour_grouped_action_response = self.client.get('/api/action/people/?interval=hour&date_from=2020-01-04%s&date_to=2020-01-04%s&type=actions&entityId=%s' % (' 16:00', ' 16:00', sign_up_action.id)).json()
+        hour_grouped_grevent_response = self.client.get('/api/action/people/?interval=hour&date_from=2020-01-04%2016%3A00&date_to=2020-01-04%2016%3A00&type=events&entityId=sign%20up').json()
+        self.assertEqual(hour_grouped_action_response[0]['people'][0]['id'], person2.pk)
+        self.assertEqual(hour_grouped_action_response[0]['people'][1]['id'], person3.pk)
+        self.assertEqual(len(hour_grouped_action_response[0]['people']), 2)
+        self.assertTrue(self._compare_entity_response(hour_grouped_action_response, hour_grouped_grevent_response, remove=['action']))
+
+        # check grouped minute
+        min_grouped_action_response = self.client.get('/api/action/people/?interval=hour&date_from=2020-01-04%s&date_to=2020-01-04%s&type=actions&entityId=%s' % (' 19:20', ' 19:20', sign_up_action.id)).json()
+        min_grouped_grevent_response = self.client.get('/api/action/people/?interval=hour&date_from=2020-01-04%2019%3A20&date_to=2020-01-04%2019%3A20&type=events&entityId=sign%20up').json()
+        self.assertEqual(min_grouped_action_response[0]['people'][0]['id'], person4.pk)
+        self.assertEqual(min_grouped_action_response[0]['people'][1]['id'], person5.pk)
+        self.assertEqual(len(min_grouped_action_response[0]['people']), 2)
+        self.assertTrue(self._compare_entity_response(min_grouped_action_response, min_grouped_grevent_response, remove=['action']))
 
     def test_stickiness(self):
         person1 = Person.objects.create(team=self.team, distinct_ids=['person1'])

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -217,7 +217,7 @@ class TestTrends(BaseTest):
             Event.objects.create(team=self.team, event='sign up', distinct_id='blabla')
         # test today + hourly
         with freeze_time('2020-01-02'):
-            action_response = self.client.get('/api/action/trends/?date_from=2020-01-02&date_to=2020-01-02&interval=hour').json()
+            action_response = self.client.get('/api/action/trends/?date_from=2020-01-02%2023%3A00&date_to=2020-01-02%2023%3A00&interval=hour').json()
         self.assertEqual(action_response[0]['labels'][23], 'Thu. 2 January, 23:00')
         self.assertEqual(action_response[0]['data'][23], 1.0)
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -14,6 +14,13 @@ def relative_date_parse(input: str) -> datetime.date:
         return datetime.datetime.strptime(input, '%Y-%m-%d').date()
     except ValueError:
         pass
+    
+    # when input also contains the time for intervals "hour" and "minute"
+    # the above try fails. Try one more time from isoformat.
+    try:
+        return datetime.datetime.fromisoformat(input)
+    except ValueError:
+        pass
 
     regex = r"\-?(?P<number>[0-9]+)?(?P<type>[a-z])(?P<position>Start|End)?"
     match = re.search(regex, input)


### PR DESCRIPTION
## Changes
Resolves issue: #514 

- Updates `day` format to include time if minute or hour interval is selected. This was to easily send the time upon a /people request with minimal changes to frontend.
- Updates to the util.py function `relative_date_parse` to account for this new time attached to a `date_from` and `date_to`.
- Some conditional logic to handle the relativity in `_filter_events` in action.py. Previously it would always add 1 day to the date. This is the reason at the hour/minute interval we would see a days worth of people. It now account for hour/minute interval.
- Additional test to ensure the correct people and amount of people are retrieved.

## Checklist
- [ ] Code reviewed
- [ ] QA'd
