### PR TITLE
Fix event name test

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
         }
     },
     "lint-staged": {
-        "!*.{js,css,scss}": "prettier --write"
+        "*.{js,css,scss}": "prettier --write"
     }
 }

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -24,10 +24,9 @@ class TestEvents(BaseTest):
     def test_filter_events_by_event_name(self):
         person = Person.objects.create(properties={'email': 'tim@posthog.com'}, team=self.team, distinct_ids=["2", 'some-random-uid'])
         event1 = Event.objects.create(event='event_name',team=self.team, distinct_id="2", properties={"$ip": '8.8.8.8'})
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(7):
             response = self.client.get('/api/event/?event=event_name').json()
         self.assertEqual(response['results'][0]['event'], 'event_name')
-        self.assertEqual(response['results'][0]['elements'][0]['tag_name'], 'button')
 
     def test_filter_by_person(self):
         person = Person.objects.create(properties={'email': 'tim@posthog.com'}, distinct_ids=["2", 'some-random-uid'], team=self.team)


### PR DESCRIPTION
Introduced by #571 -- annoyingly when people create a fork it doesn't automatically run the test.