### PR TITLE
595 offload storing events to workers

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,10 @@ check_untyped_defs = True
 warn_unreachable = True
 strict_equality = True
 
+[mypy-posthog.tasks.*]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
 [mypy.plugins.django-stubs]
 django_settings_module = posthog.settings
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -89,8 +89,8 @@ def get_event(request):
 
     if isinstance(data, dict):
         if data.get('batch'): # posthog-python and posthog-ruby
-            events = data['batch']
-            assert events is not None
+            data = data['batch']
+            assert data is not None
         elif 'engage' in request.path_info: # JS identify call
             data['event'] = '$identify' # make sure it has an event name
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -20,35 +20,36 @@ class TestCapture(BaseTest):
         return base64.b64encode(json.dumps(data).encode('utf-8')).decode('utf-8')
 
     @patch('posthog.tasks.process_event.process_event.delay')
-    def test_capture_new_person(self, patch_process_event):
-        properties = {
-            'distinct_id': 2,
-            'token': self.team.api_token,
-            '$elements': [
-                {'tag_name': 'a', 'nth_child': 1, 'nth_of_type': 2, 'attr__class': 'btn btn-sm'},
-                {'tag_name': 'div', 'nth_child': 1, 'nth_of_type': 2, '$el_text': '💻'}
-            ]
+    def test_capture_event(self, patch_process_event):
+        data = {
+            'event': '$autocapture',
+            'properties': {
+                'distinct_id': 2,
+                'token': self.team.api_token,
+                '$elements': [
+                    {'tag_name': 'a', 'nth_child': 1, 'nth_of_type': 2, 'attr__class': 'btn btn-sm'},
+                    {'tag_name': 'div', 'nth_child': 1, 'nth_of_type': 2, '$el_text': '💻'}
+                ]
+            }
         }
         now = timezone.now()
         with freeze_time(now):
             with self.assertNumQueries(1):
-                response = self.client.get('/e/?data=%s' % self._dict_to_json({
-                    'event': '$autocapture',
-                    'properties': properties,
-                }), content_type='application/json', HTTP_ORIGIN='https://localhost')
+                response = self.client.get('/e/?data=%s' % self._dict_to_json(data), content_type='application/json', HTTP_ORIGIN='https://localhost')
         self.assertEqual(response.get('access-control-allow-origin'), 'https://localhost')
-        patch_process_event.assert_has_calls([call(
-            ip='127.0.0.1',
-            site_url='http://testserver',
-            data=properties,
-            event='$autocapture',
-            team_id=self.team.pk,
-            distinct_id=2,
-            timestamp=now
-        )])
+        arguments = patch_process_event.call_args[1]
+        arguments.pop('now') # can't compare fakedate
+        self.assertDictEqual(arguments, {
+            'distinct_id': '2',
+            'ip': '127.0.0.1',
+            'site_url': 'http://testserver',
+            'data': data,
+            'team_id': self.team.pk,
+        })
 
-    def test_multiple_events(self):
-        response = self.client.post('/track/', data={
+    @patch('posthog.tasks.process_event.process_event.delay')
+    def test_multiple_events(self, patch_process_event):
+        self.client.post('/track/', data={
             'data': json.dumps([{
                 'event': 'beep',
                 'properties': {
@@ -65,138 +66,29 @@ class TestCapture(BaseTest):
             } ]),
             'api_key': self.team.api_token
         })
+        self.assertEqual(patch_process_event.call_count, 2)
 
-        events = Event.objects.all().count()
-        self.assertEqual(events, 2)
-
-    def test_emojis_in_text(self):
+    @patch('posthog.tasks.process_event.process_event.delay')
+    def test_emojis_in_text(self, patch_process_event):
         self.team.api_token = 'xp9qT2VLY76JJg'
         self.team.save()
-        response = self.client.post('/track/', data={
+        self.client.post('/track/', data={
             'data': "eyJldmVudCI6ICIkd2ViX2V2ZW50IiwicHJvcGVydGllcyI6IHsiJG9zIjogIk1hYyBPUyBYIiwiJGJyb3dzZXIiOiAiQ2hyb21lIiwiJHJlZmVycmVyIjogImh0dHBzOi8vYXBwLmhpYmVybHkuY29tL2xvZ2luP25leHQ9LyIsIiRyZWZlcnJpbmdfZG9tYWluIjogImFwcC5oaWJlcmx5LmNvbSIsIiRjdXJyZW50X3VybCI6ICJodHRwczovL2FwcC5oaWJlcmx5LmNvbS8iLCIkYnJvd3Nlcl92ZXJzaW9uIjogNzksIiRzY3JlZW5faGVpZ2h0IjogMjE2MCwiJHNjcmVlbl93aWR0aCI6IDM4NDAsInBoX2xpYiI6ICJ3ZWIiLCIkbGliX3ZlcnNpb24iOiAiMi4zMy4xIiwiJGluc2VydF9pZCI6ICJnNGFoZXFtejVrY3AwZ2QyIiwidGltZSI6IDE1ODA0MTAzNjguMjY1LCJkaXN0aW5jdF9pZCI6IDYzLCIkZGV2aWNlX2lkIjogIjE2ZmQ1MmRkMDQ1NTMyLTA1YmNhOTRkOWI3OWFiLTM5NjM3YzBlLTFhZWFhMC0xNmZkNTJkZDA0NjQxZCIsIiRpbml0aWFsX3JlZmVycmVyIjogIiRkaXJlY3QiLCIkaW5pdGlhbF9yZWZlcnJpbmdfZG9tYWluIjogIiRkaXJlY3QiLCIkdXNlcl9pZCI6IDYzLCIkZXZlbnRfdHlwZSI6ICJjbGljayIsIiRjZV92ZXJzaW9uIjogMSwiJGhvc3QiOiAiYXBwLmhpYmVybHkuY29tIiwiJHBhdGhuYW1lIjogIi8iLCIkZWxlbWVudHMiOiBbCiAgICB7InRhZ19uYW1lIjogImJ1dHRvbiIsIiRlbF90ZXh0IjogIu2gve2yuyBXcml0aW5nIGNvZGUiLCJjbGFzc2VzIjogWwogICAgImJ0biIsCiAgICAiYnRuLXNlY29uZGFyeSIKXSwiYXR0cl9fY2xhc3MiOiAiYnRuIGJ0bi1zZWNvbmRhcnkiLCJhdHRyX19zdHlsZSI6ICJjdXJzb3I6IHBvaW50ZXI7IG1hcmdpbi1yaWdodDogOHB4OyBtYXJnaW4tYm90dG9tOiAxcmVtOyIsIm50aF9jaGlsZCI6IDIsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImNsYXNzZXMiOiBbCiAgICAiZmVlZGJhY2stc3RlcCIsCiAgICAiZmVlZGJhY2stc3RlcC1zZWxlY3RlZCIKXSwiYXR0cl9fY2xhc3MiOiAiZmVlZGJhY2stc3RlcCBmZWVkYmFjay1zdGVwLXNlbGVjdGVkIiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJnaXZlLWZlZWRiYWNrIgpdLCJhdHRyX19jbGFzcyI6ICJnaXZlLWZlZWRiYWNrIiwiYXR0cl9fc3R5bGUiOiAid2lkdGg6IDkwJTsgbWFyZ2luOiAwcHggYXV0bzsgZm9udC1zaXplOiAxNXB4OyBwb3NpdGlvbjogcmVsYXRpdmU7IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiYXR0cl9fc3R5bGUiOiAib3ZlcmZsb3c6IGhpZGRlbjsiLCJudGhfY2hpbGQiOiAxLCJudGhfb2ZfdHlwZSI6IDF9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJjbGFzc2VzIjogWwogICAgIm1vZGFsLWJvZHkiCl0sImF0dHJfX2NsYXNzIjogIm1vZGFsLWJvZHkiLCJhdHRyX19zdHlsZSI6ICJmb250LXNpemU6IDE1cHg7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbC1jb250ZW50IgpdLCJhdHRyX19jbGFzcyI6ICJtb2RhbC1jb250ZW50IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbC1kaWFsb2ciLAogICAgIm1vZGFsLWxnIgpdLCJhdHRyX19jbGFzcyI6ICJtb2RhbC1kaWFsb2cgbW9kYWwtbGciLCJhdHRyX19yb2xlIjogImRvY3VtZW50IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbCIsCiAgICAiZmFkZSIsCiAgICAic2hvdyIKXSwiYXR0cl9fY2xhc3MiOiAibW9kYWwgZmFkZSBzaG93IiwiYXR0cl9fc3R5bGUiOiAiZGlzcGxheTogYmxvY2s7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJrLXBvcnRsZXRfX2JvZHkiLAogICAgIiIKXSwiYXR0cl9fY2xhc3MiOiAiay1wb3J0bGV0X19ib2R5ICIsImF0dHJfX3N0eWxlIjogInBhZGRpbmc6IDBweDsiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDJ9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJjbGFzc2VzIjogWwogICAgImstcG9ydGxldCIsCiAgICAiay1wb3J0bGV0LS1oZWlnaHQtZmx1aWQiCl0sImF0dHJfX2NsYXNzIjogImstcG9ydGxldCBrLXBvcnRsZXQtLWhlaWdodC1mbHVpZCIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImNsYXNzZXMiOiBbCiAgICAiY29sLWxnLTYiCl0sImF0dHJfX2NsYXNzIjogImNvbC1sZy02IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJyb3ciCl0sImF0dHJfX2NsYXNzIjogInJvdyIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImF0dHJfX3N0eWxlIjogInBhZGRpbmc6IDQwcHggMzBweCAwcHg7IGJhY2tncm91bmQtY29sb3I6IHJnYigyMzksIDIzOSwgMjQ1KTsgbWFyZ2luLXRvcDogLTQwcHg7IG1pbi1oZWlnaHQ6IGNhbGMoMTAwdmggLSA0MHB4KTsiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDJ9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJhdHRyX19zdHlsZSI6ICJtYXJnaW4tdG9wOiAwcHg7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJBcHAiCl0sImF0dHJfX2NsYXNzIjogIkFwcCIsImF0dHJfX3N0eWxlIjogImNvbG9yOiByZ2IoNTIsIDYxLCA2Mik7IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiYXR0cl9faWQiOiAicm9vdCIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImJvZHkiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDF9Cl0sInRva2VuIjogInhwOXFUMlZMWTc2SkpnIn19"
         })
 
-        self.assertEqual(Person.objects.get().distinct_ids, ["63"])
-        event = Event.objects.get()
-        element = ElementGroup.objects.get(hash=event.elements_hash).element_set.all().first()
-        assert element is not None
-        self.assertEqual(element.text, '💻 Writing code')
+        self.assertEqual(patch_process_event.call_args[1]['data']['properties']['$elements'][0]['$el_text'], '💻 Writing code')
 
-    def test_incorrect_padding(self):
+    @patch('posthog.tasks.process_event.process_event.delay')
+    def test_incorrect_padding(self, patch_process_event):
         response = self.client.get('/e/?data=eyJldmVudCI6IndoYXRldmVmciIsInByb3BlcnRpZXMiOnsidG9rZW4iOiJ0b2tlbjEyMyIsImRpc3RpbmN0X2lkIjoiYXNkZiJ9fQ', content_type='application/json', HTTP_REFERER='https://localhost')
         self.assertEqual(response.json()['status'], 1)
+        self.assertEqual(patch_process_event.call_args[1]['data']['event'], 'whatevefr')
 
-    def test_ignore_empty_request(self):
+    @patch('posthog.tasks.process_event.process_event.delay')
+    def test_ignore_empty_request(self, patch_process_event):
         response = self.client.get('/e/?data=', content_type='application/json', HTTP_ORIGIN='https://localhost')
         self.assertEqual(response.content, b"1")
-
-
-class TestBatch(BaseTest):
-    TESTS_API = True
-    def test_batch_capture(self):
-        response = self.client.post('/batch/', data={
-            'api_key': self.team.api_token,
-            "batch":[
-                {
-                    "properties":{
-                        "property1":"value",
-                        "property2":"value",
-                    },
-                    "timestamp":"2020-02-10T01:45:20.777210+00:00",
-                    "library": "posthog-python",
-                    "library_version": "1.3.0b1",
-                    "distinct_id":"test_id",
-                    "type":"capture",
-                    "event":"user signed up",
-                    "messageId":"2b5c5750-46fc-4b21-8aa8-27032e8afb16"
-                },
-                {
-                    "timestamp":"2020-02-10T01:46:20.777210+00:00",
-                    "library": "posthog-python",
-                    "library_version": "1.3.0b1",
-                    "distinct_id":"test_id",
-                    "type":"identify",
-                    "$set": {
-                        "email": "some@gmail.com"
-                    },
-                    "event":"$identify",
-                    "messageId":"2b5c5750-46fc-4b21-8aa8-27032e8afb16",
-                }
-            ]
-        }, content_type='application/json')
-
-        events = Event.objects.all().order_by('id')
-        self.assertEqual(events[0].event, 'user signed up')
-        self.assertEqual(events[0].properties, {'property1': 'value', 'property2': 'value', '$ip': '127.0.0.1'})
-        self.assertEqual(events[0].timestamp, datetime.datetime(2020, 2, 10, 1, 45, 20, 777210, tzinfo=pytz.UTC))
-        self.assertEqual(events[1].event, '$identify')
-        self.assertEqual(events[1].properties['email'], 'some@gmail.com')
-
-        self.assertEqual(Person.objects.get(persondistinctid__distinct_id='test_id').distinct_ids, ['test_id'])
-        self.assertEqual(Person.objects.get(persondistinctid__distinct_id='test_id').properties['email'], 'some@gmail.com')
-
-    def test_batch_alias(self):
-        Person.objects.create(team=self.team, distinct_ids=['old_distinct_id'])
-        response = self.client.post('/batch/', data={
-            "api_key": self.team.api_token,
-            "batch":[{
-                "properties":{
-                    "distinct_id":"old_distinct_id",
-                    "alias":"new_distinct_id"
-                },
-                "timestamp":"2020-02-10T01:45:20.777395+00:00",
-                "library": "posthog-python",
-                "version": "1.3.0b1",
-                "type":"alias",
-                "event":"$create_alias",
-                "messageId":"7723c0fa-9801-497c-bf06-6d61e5572a84",
-                "distinct_id": None,
-            }]
-        }, content_type='application/json')
-
-        self.assertEqual(Event.objects.count(), 1)
-        self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id"])
-
-    def test_batch_engage(self):
-        Person.objects.create(team=self.team, distinct_ids=["3", '455'])
-        response = self.client.post('/batch/', data={
-            "api_key": self.team.api_token,
-            "batch": [{
-                "timestamp":"2020-02-10T01:45:20.777635+00:00",
-                "library": "posthog-python",
-                "version":"1.3.0b1",
-                "type":"identify",
-                "distinct_id": "3",
-                "$set":{
-                    "email": "something@something.com"
-                },
-                "event":"$identify",
-                "messageId":"90ac5fe7-713c-46fd-8552-5954baf478f6",
-            }]
-        }, content_type='application/json')
-
-        person = Person.objects.get()
-        self.assertEqual(person.properties['email'], 'something@something.com')
-
-    def test_batch_engage_create_user(self):
-        response = self.client.post('/batch/', data={
-            "api_key": self.team.api_token,
-            "batch": [{
-                "timestamp":"2020-02-10T01:45:20.777635+00:00",
-                "library": "posthog-python",
-                "version":"1.3.0b1",
-                "type":"identify",
-                "distinct_id": "3",
-                "$set":{
-                    "email": "something@something.com"
-                },
-                "event":"$identify",
-                "messageId":"90ac5fe7-713c-46fd-8552-5954baf478f6",
-            }]
-        }, content_type='application/json')
-
-        person = Person.objects.get()
-        self.assertEqual(person.properties['email'], 'something@something.com')
+        self.assertEqual(patch_process_event.call_count, 0)
 
     def test_batch_incorrect_token(self):
         response = self.client.post('/batch/', data={
@@ -240,24 +132,3 @@ class TestBatch(BaseTest):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['message'], "You need to set a distinct_id.")
-
-    def test_batch_offset(self):
-        Person.objects.create(team=self.team, distinct_ids=['distinct_id'])
-        with freeze_time("2020-01-01T12:00:05.200Z"):
-            response = self.client.post('/batch/', data={
-                "api_key": self.team.api_token,
-                "batch":[{
-                    "offset": 1500,
-                    "event":"$autocapture",
-                    "distinct_id": "distinct_id",
-                },
-                {
-                    "offset": 150,
-                    "event":"$autocapture",
-                    "distinct_id": "distinct_id",
-                }]
-            }, content_type='application/json')
-
-        events = Event.objects.all().order_by('timestamp')
-        self.assertEqual(events[0].timestamp.isoformat(), '2020-01-01T12:00:03.700000+00:00')
-        self.assertEqual(events[1].timestamp.isoformat(), '2020-01-01T12:00:05.050000+00:00')

--- a/posthog/models.py
+++ b/posthog/models.py
@@ -10,7 +10,7 @@ from django.dispatch import receiver
 from django.forms.models import model_to_dict
 from django.utils import timezone
 from posthog.utils import properties_to_Q, request_to_date_query
-from posthog.tasks import post_event_to_slack
+from posthog.tasks.slack import post_event_to_slack
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
 from typing import List, Tuple, Optional, Any, Union, Dict
 from django.db import transaction

--- a/posthog/models.py
+++ b/posthog/models.py
@@ -250,7 +250,10 @@ class EventManager(models.QuerySet):
     def create(self, site_url: Optional[str] = None, *args: Any, **kwargs: Any):
         with transaction.atomic():
             if kwargs.get('elements'):
-                kwargs['elements_hash'] = ElementGroup.objects.create(team=kwargs['team'], elements=kwargs.pop('elements')).hash
+                if kwargs.get('team'):
+                    kwargs['elements_hash'] = ElementGroup.objects.create(team=kwargs['team'], elements=kwargs.pop('elements')).hash
+                else:
+                    kwargs['elements_hash'] = ElementGroup.objects.create(team_id=kwargs['team_id'], elements=kwargs.pop('elements')).hash
             event = super().create(*args, **kwargs)
             should_post_to_slack = False
             relations = []

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -1,0 +1,124 @@
+from celery import shared_task
+from posthog.models import Person, Element, Event, Team
+from typing import Union, Dict
+from dateutil.relativedelta import relativedelta
+from django.db import IntegrityError
+import datetime
+
+def _alias(distinct_id: str, new_distinct_id: str, team_id: int) -> None:
+    try:
+        person = Person.objects.get(team_id=team_id, persondistinctid__distinct_id=distinct_id)
+    except Person.DoesNotExist:
+        # no reason to alias if it doesn't exist
+        # mostly happens if someone calls identify before the user has done anything
+        return
+    try:
+        person.add_distinct_id(new_distinct_id)
+    except IntegrityError:
+        # IntegrityError means a person with new_distinct_id already exists
+        # That can either mean `person` already has that distinct_id, in which case we do nothing
+        # OR it means there is _another_ Person with that distinct _id, in which case we want to remove that person
+        # and add that distinct ID to `person`
+        previous_person = Person.objects.filter(team_id=team_id, persondistinctid__distinct_id=new_distinct_id).exclude(pk=person.id)
+        if previous_person.exists():
+            person.properties.update(previous_person.first().properties) # type: ignore
+            previous_person.delete()
+            person.add_distinct_id(new_distinct_id)
+            person.save()
+
+def _store_names_and_properties(team_id: int, event: str, properties: Dict) -> None:
+    team = Team.objects.get(pk=team_id)
+    save = False
+    if event not in team.event_names:
+        save = True
+        team.event_names.append(event)
+    for key in properties.keys():
+        if key not in team.event_properties:
+            team.event_properties.append(key)
+            save = True
+    if save:
+        team.save()
+
+def _capture(ip: str, site_url: str, team_id: int, event: str, distinct_id: str, properties: Dict, timestamp: Union[datetime.datetime, str]) -> None:
+    elements = properties.get('$elements')
+    elements_list = None
+    if elements:
+        del properties['$elements']
+        elements_list = [
+            Element(
+                text=el.get('$el_text'),
+                tag_name=el['tag_name'],
+                href=el.get('attr__href'),
+                attr_class=el['attr__class'].split(' ') if el.get('attr__class') else None,
+                attr_id=el.get('attr__id'),
+                nth_child=el.get('nth_child'),
+                nth_of_type=el.get('nth_of_type'),
+                attributes={key: value for key, value in el.items() if key.startswith('attr__')},
+                order=index
+            ) for index, el in enumerate(elements)
+        ]
+    properties["$ip"] = ip
+
+    Event.objects.create(
+        event=event,
+        distinct_id=distinct_id,
+        properties=properties,
+        team_id=team_id,
+        site_url=site_url,
+        **({'timestamp': timestamp} if timestamp else {}),
+        **({'elements': elements_list} if elements_list else {})
+    )
+    _store_names_and_properties(team_id=team_id, event=event, properties=properties)
+    # try to create a new person
+    try:
+        Person.objects.create(team_id=team_id, distinct_ids=[str(distinct_id)])
+    except IntegrityError: 
+        pass # person already exists, which is fine
+
+def _update_person_properties(team_id: int, distinct_id: str, properties: Dict) -> None:
+    try:
+        person = Person.objects.get(team_id=team_id, persondistinctid__distinct_id=str(distinct_id))
+    except Person.DoesNotExist:
+        try:
+            person = Person.objects.create(team_id=team_id, distinct_ids=[str(distinct_id)])
+        # Catch race condition where in between getting and creating, another request already created this user.
+        except:
+            person = Person.objects.get(team_id=team_id, persondistinctid__distinct_id=str(distinct_id))
+    person.properties.update(properties)
+    person.save()
+
+def _handle_timestamp(data: dict, now: datetime.datetime) -> Union[datetime.datetime, str]:
+    if data.get('timestamp'):
+        return data['timestamp']
+    if data.get('offset'):
+        return now - relativedelta(microseconds=data['offset'] * 1000)
+    return now
+
+@shared_task
+def process_event(ip: str, site_url: str, data: dict, team_id: int, now: datetime.datetime) -> None:
+    try:
+        distinct_id = str(data['properties']['distinct_id'])
+    except KeyError:
+        try:
+            distinct_id = str(data['$distinct_id'])
+        except KeyError:
+            distinct_id = str(data['distinct_id'])
+
+    if data['event'] == '$create_alias':
+        _alias(distinct_id=distinct_id, new_distinct_id=data['properties']['alias'], team_id=team_id)
+
+    if data['event'] == '$identify' and data.get('properties') and data['properties'].get('$anon_distinct_id'):
+        _alias(distinct_id=data['properties']['$anon_distinct_id'], new_distinct_id=distinct_id, team_id=team_id)
+
+    if data['event'] == '$identify' and data.get('$set'):
+        _update_person_properties(team_id=team_id, distinct_id=distinct_id, properties=data['$set'])
+
+    _capture(
+        ip=ip,
+        site_url=site_url,
+        team_id=team_id,
+        event=data['event'],
+        distinct_id=distinct_id,
+        properties=data.get('properties', data.get('$set', {})),
+        timestamp=_handle_timestamp(data, now)
+    )

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -95,15 +95,7 @@ def _handle_timestamp(data: dict, now: datetime.datetime) -> Union[datetime.date
     return now
 
 @shared_task
-def process_event(ip: str, site_url: str, data: dict, team_id: int, now: datetime.datetime) -> None:
-    try:
-        distinct_id = str(data['properties']['distinct_id'])
-    except KeyError:
-        try:
-            distinct_id = str(data['$distinct_id'])
-        except KeyError:
-            distinct_id = str(data['distinct_id'])
-
+def process_event(distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: datetime.datetime) -> None:
     if data['event'] == '$create_alias':
         _alias(distinct_id=distinct_id, new_distinct_id=data['properties']['alias'], team_id=team_id)
 

--- a/posthog/tasks/slack.py
+++ b/posthog/tasks/slack.py
@@ -1,16 +1,10 @@
-# Create your tasks here
-
 from celery import shared_task
 from django.apps import apps
 from django.conf import settings
 import requests
 
 @shared_task
-def add(x, y):
-    return x + y
-
-@shared_task
-def post_event_to_slack(event_id: int, site_url: str):
+def post_event_to_slack(event_id: int, site_url: str) -> None:
     # must import "Event" like this to avoid circular dependency with models.py (it imports tasks.py)
     event_model = apps.get_model(app_label='posthog', model_name='Event')
     event = event_model.objects.get(pk=event_id)

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -1,9 +1,10 @@
-from posthog.api.test.base import BaseTest
-from unittest.mock import patch, call
-from posthog.tasks.process_event import process_event
-from posthog.models import Event, Action, ActionStep, Person, ElementGroup, Team
+from django.test import TransactionTestCase
 from django.utils.timezone import now
-
+from freezegun import freeze_time
+from posthog.api.test.base import BaseTest
+from posthog.models import Event, Action, ActionStep, Person, ElementGroup, Team, User
+from posthog.tasks.process_event import process_event
+from unittest.mock import patch, call
 
 class ProcessEvent(BaseTest):
     def test_capture_new_person(self):
@@ -52,19 +53,6 @@ class ProcessEvent(BaseTest):
         event = Event.objects.get()
         self.assertEqual(event.event, '$pageview')
 
-    # def test_emojis_in_text(self):
-    #     self.team.api_token = 'xp9qT2VLY76JJg'
-    #     self.team.save()
-    #     response = self.client.post('/track/', data={
-    #         'data': "eyJldmVudCI6ICIkd2ViX2V2ZW50IiwicHJvcGVydGllcyI6IHsiJG9zIjogIk1hYyBPUyBYIiwiJGJyb3dzZXIiOiAiQ2hyb21lIiwiJHJlZmVycmVyIjogImh0dHBzOi8vYXBwLmhpYmVybHkuY29tL2xvZ2luP25leHQ9LyIsIiRyZWZlcnJpbmdfZG9tYWluIjogImFwcC5oaWJlcmx5LmNvbSIsIiRjdXJyZW50X3VybCI6ICJodHRwczovL2FwcC5oaWJlcmx5LmNvbS8iLCIkYnJvd3Nlcl92ZXJzaW9uIjogNzksIiRzY3JlZW5faGVpZ2h0IjogMjE2MCwiJHNjcmVlbl93aWR0aCI6IDM4NDAsInBoX2xpYiI6ICJ3ZWIiLCIkbGliX3ZlcnNpb24iOiAiMi4zMy4xIiwiJGluc2VydF9pZCI6ICJnNGFoZXFtejVrY3AwZ2QyIiwidGltZSI6IDE1ODA0MTAzNjguMjY1LCJkaXN0aW5jdF9pZCI6IDYzLCIkZGV2aWNlX2lkIjogIjE2ZmQ1MmRkMDQ1NTMyLTA1YmNhOTRkOWI3OWFiLTM5NjM3YzBlLTFhZWFhMC0xNmZkNTJkZDA0NjQxZCIsIiRpbml0aWFsX3JlZmVycmVyIjogIiRkaXJlY3QiLCIkaW5pdGlhbF9yZWZlcnJpbmdfZG9tYWluIjogIiRkaXJlY3QiLCIkdXNlcl9pZCI6IDYzLCIkZXZlbnRfdHlwZSI6ICJjbGljayIsIiRjZV92ZXJzaW9uIjogMSwiJGhvc3QiOiAiYXBwLmhpYmVybHkuY29tIiwiJHBhdGhuYW1lIjogIi8iLCIkZWxlbWVudHMiOiBbCiAgICB7InRhZ19uYW1lIjogImJ1dHRvbiIsIiRlbF90ZXh0IjogIu2gve2yuyBXcml0aW5nIGNvZGUiLCJjbGFzc2VzIjogWwogICAgImJ0biIsCiAgICAiYnRuLXNlY29uZGFyeSIKXSwiYXR0cl9fY2xhc3MiOiAiYnRuIGJ0bi1zZWNvbmRhcnkiLCJhdHRyX19zdHlsZSI6ICJjdXJzb3I6IHBvaW50ZXI7IG1hcmdpbi1yaWdodDogOHB4OyBtYXJnaW4tYm90dG9tOiAxcmVtOyIsIm50aF9jaGlsZCI6IDIsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImNsYXNzZXMiOiBbCiAgICAiZmVlZGJhY2stc3RlcCIsCiAgICAiZmVlZGJhY2stc3RlcC1zZWxlY3RlZCIKXSwiYXR0cl9fY2xhc3MiOiAiZmVlZGJhY2stc3RlcCBmZWVkYmFjay1zdGVwLXNlbGVjdGVkIiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJnaXZlLWZlZWRiYWNrIgpdLCJhdHRyX19jbGFzcyI6ICJnaXZlLWZlZWRiYWNrIiwiYXR0cl9fc3R5bGUiOiAid2lkdGg6IDkwJTsgbWFyZ2luOiAwcHggYXV0bzsgZm9udC1zaXplOiAxNXB4OyBwb3NpdGlvbjogcmVsYXRpdmU7IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiYXR0cl9fc3R5bGUiOiAib3ZlcmZsb3c6IGhpZGRlbjsiLCJudGhfY2hpbGQiOiAxLCJudGhfb2ZfdHlwZSI6IDF9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJjbGFzc2VzIjogWwogICAgIm1vZGFsLWJvZHkiCl0sImF0dHJfX2NsYXNzIjogIm1vZGFsLWJvZHkiLCJhdHRyX19zdHlsZSI6ICJmb250LXNpemU6IDE1cHg7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbC1jb250ZW50IgpdLCJhdHRyX19jbGFzcyI6ICJtb2RhbC1jb250ZW50IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbC1kaWFsb2ciLAogICAgIm1vZGFsLWxnIgpdLCJhdHRyX19jbGFzcyI6ICJtb2RhbC1kaWFsb2cgbW9kYWwtbGciLCJhdHRyX19yb2xlIjogImRvY3VtZW50IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbCIsCiAgICAiZmFkZSIsCiAgICAic2hvdyIKXSwiYXR0cl9fY2xhc3MiOiAibW9kYWwgZmFkZSBzaG93IiwiYXR0cl9fc3R5bGUiOiAiZGlzcGxheTogYmxvY2s7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJrLXBvcnRsZXRfX2JvZHkiLAogICAgIiIKXSwiYXR0cl9fY2xhc3MiOiAiay1wb3J0bGV0X19ib2R5ICIsImF0dHJfX3N0eWxlIjogInBhZGRpbmc6IDBweDsiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDJ9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJjbGFzc2VzIjogWwogICAgImstcG9ydGxldCIsCiAgICAiay1wb3J0bGV0LS1oZWlnaHQtZmx1aWQiCl0sImF0dHJfX2NsYXNzIjogImstcG9ydGxldCBrLXBvcnRsZXQtLWhlaWdodC1mbHVpZCIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImNsYXNzZXMiOiBbCiAgICAiY29sLWxnLTYiCl0sImF0dHJfX2NsYXNzIjogImNvbC1sZy02IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJyb3ciCl0sImF0dHJfX2NsYXNzIjogInJvdyIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImF0dHJfX3N0eWxlIjogInBhZGRpbmc6IDQwcHggMzBweCAwcHg7IGJhY2tncm91bmQtY29sb3I6IHJnYigyMzksIDIzOSwgMjQ1KTsgbWFyZ2luLXRvcDogLTQwcHg7IG1pbi1oZWlnaHQ6IGNhbGMoMTAwdmggLSA0MHB4KTsiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDJ9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJhdHRyX19zdHlsZSI6ICJtYXJnaW4tdG9wOiAwcHg7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJBcHAiCl0sImF0dHJfX2NsYXNzIjogIkFwcCIsImF0dHJfX3N0eWxlIjogImNvbG9yOiByZ2IoNTIsIDYxLCA2Mik7IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiYXR0cl9faWQiOiAicm9vdCIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImJvZHkiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDF9Cl0sInRva2VuIjogInhwOXFUMlZMWTc2SkpnIn19"
-    #     })
-
-    #     self.assertEqual(Person.objects.get().distinct_ids, ["63"])
-    #     event = Event.objects.get()
-    #     element = ElementGroup.objects.get(hash=event.elements_hash).element_set.all().first()
-    #     assert element is not None
-    #     self.assertEqual(element.text, '💻 Writing code')
-
     def test_alias(self):
         Person.objects.create(team=self.team, distinct_ids=['old_distinct_id'])
 
@@ -95,8 +83,27 @@ class ProcessEvent(BaseTest):
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ['new_distinct_id'])
 
+    def test_offset_timestamp(self):
+        with freeze_time("2020-01-01T12:00:05.200Z"):
+            process_event('', '', {
+                "offset": 150,
+                "event":"$autocapture",
+                "distinct_id": "distinct_id",
+            }, self.team.pk, now())
 
-class TestIdentify(BaseTest):
+        event = Event.objects.get()
+        self.assertEqual(event.timestamp.isoformat(), '2020-01-01T12:00:05.050000+00:00')
+
+class TestIdentify(TransactionTestCase):
+    def setUp(self, **kwargs) -> User:
+        user: User = User.objects.create_user('tim@posthog.com', **kwargs)
+        if not hasattr(self, 'team'):
+            self.team: Team = Team.objects.create(api_token='token123')
+        self.team.users.add(user)
+        self.team.save()
+        self.client.force_login(user)
+        return user
+
     def test_distinct_with_anonymous_id(self):
         Person.objects.create(team=self.team, distinct_ids=['anonymous_id'])
 

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -1,0 +1,171 @@
+from posthog.api.test.base import BaseTest
+from unittest.mock import patch, call
+from posthog.tasks.process_event import process_event
+from posthog.models import Event, Action, ActionStep, Person, ElementGroup, Team
+from django.utils.timezone import now
+
+
+class ProcessEvent(BaseTest):
+    def test_capture_new_person(self):
+        user = self._create_user('tim')
+        action1 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(action=action1, selector='a')
+        action2 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(action=action2, selector='a')
+
+        with self.assertNumQueries(18):
+            process_event('', '', {
+                'event': '$autocapture',
+                'properties': {
+                    'distinct_id': 2,
+                    'token': self.team.api_token,
+                    '$elements': [
+                        {'tag_name': 'a', 'nth_child': 1, 'nth_of_type': 2, 'attr__class': 'btn btn-sm'},
+                        {'tag_name': 'div', 'nth_child': 1, 'nth_of_type': 2, '$el_text': '💻'}
+                    ]
+                },
+            }, self.team.pk, now())
+
+        self.assertEqual(Person.objects.get().distinct_ids, ["2"])
+        event = Event.objects.get()
+        self.assertEqual(event.event, '$autocapture')
+        elements = ElementGroup.objects.get(hash=event.elements_hash).element_set.all().order_by('order')
+        self.assertEqual(elements[0].tag_name, 'a')
+        self.assertEqual(elements[0].attr_class, ['btn', 'btn-sm'])
+        self.assertEqual(elements[1].order, 1)
+        self.assertEqual(elements[1].text, '💻')
+        self.assertEqual(event.distinct_id, "2")
+
+    def test_capture_no_element(self):
+        user = self._create_user('tim')
+        Person.objects.create(team=self.team, distinct_ids=['asdfasdfasdf'])
+
+        process_event('', '', {
+            'event': '$pageview',
+            'properties': {
+                'distinct_id': 'asdfasdfasdf',
+                'token': self.team.api_token,
+            },
+        }, self.team.pk, now())
+
+        self.assertEqual(Person.objects.get().distinct_ids, ["asdfasdfasdf"])
+        event = Event.objects.get()
+        self.assertEqual(event.event, '$pageview')
+
+    # def test_emojis_in_text(self):
+    #     self.team.api_token = 'xp9qT2VLY76JJg'
+    #     self.team.save()
+    #     response = self.client.post('/track/', data={
+    #         'data': "eyJldmVudCI6ICIkd2ViX2V2ZW50IiwicHJvcGVydGllcyI6IHsiJG9zIjogIk1hYyBPUyBYIiwiJGJyb3dzZXIiOiAiQ2hyb21lIiwiJHJlZmVycmVyIjogImh0dHBzOi8vYXBwLmhpYmVybHkuY29tL2xvZ2luP25leHQ9LyIsIiRyZWZlcnJpbmdfZG9tYWluIjogImFwcC5oaWJlcmx5LmNvbSIsIiRjdXJyZW50X3VybCI6ICJodHRwczovL2FwcC5oaWJlcmx5LmNvbS8iLCIkYnJvd3Nlcl92ZXJzaW9uIjogNzksIiRzY3JlZW5faGVpZ2h0IjogMjE2MCwiJHNjcmVlbl93aWR0aCI6IDM4NDAsInBoX2xpYiI6ICJ3ZWIiLCIkbGliX3ZlcnNpb24iOiAiMi4zMy4xIiwiJGluc2VydF9pZCI6ICJnNGFoZXFtejVrY3AwZ2QyIiwidGltZSI6IDE1ODA0MTAzNjguMjY1LCJkaXN0aW5jdF9pZCI6IDYzLCIkZGV2aWNlX2lkIjogIjE2ZmQ1MmRkMDQ1NTMyLTA1YmNhOTRkOWI3OWFiLTM5NjM3YzBlLTFhZWFhMC0xNmZkNTJkZDA0NjQxZCIsIiRpbml0aWFsX3JlZmVycmVyIjogIiRkaXJlY3QiLCIkaW5pdGlhbF9yZWZlcnJpbmdfZG9tYWluIjogIiRkaXJlY3QiLCIkdXNlcl9pZCI6IDYzLCIkZXZlbnRfdHlwZSI6ICJjbGljayIsIiRjZV92ZXJzaW9uIjogMSwiJGhvc3QiOiAiYXBwLmhpYmVybHkuY29tIiwiJHBhdGhuYW1lIjogIi8iLCIkZWxlbWVudHMiOiBbCiAgICB7InRhZ19uYW1lIjogImJ1dHRvbiIsIiRlbF90ZXh0IjogIu2gve2yuyBXcml0aW5nIGNvZGUiLCJjbGFzc2VzIjogWwogICAgImJ0biIsCiAgICAiYnRuLXNlY29uZGFyeSIKXSwiYXR0cl9fY2xhc3MiOiAiYnRuIGJ0bi1zZWNvbmRhcnkiLCJhdHRyX19zdHlsZSI6ICJjdXJzb3I6IHBvaW50ZXI7IG1hcmdpbi1yaWdodDogOHB4OyBtYXJnaW4tYm90dG9tOiAxcmVtOyIsIm50aF9jaGlsZCI6IDIsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImNsYXNzZXMiOiBbCiAgICAiZmVlZGJhY2stc3RlcCIsCiAgICAiZmVlZGJhY2stc3RlcC1zZWxlY3RlZCIKXSwiYXR0cl9fY2xhc3MiOiAiZmVlZGJhY2stc3RlcCBmZWVkYmFjay1zdGVwLXNlbGVjdGVkIiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJnaXZlLWZlZWRiYWNrIgpdLCJhdHRyX19jbGFzcyI6ICJnaXZlLWZlZWRiYWNrIiwiYXR0cl9fc3R5bGUiOiAid2lkdGg6IDkwJTsgbWFyZ2luOiAwcHggYXV0bzsgZm9udC1zaXplOiAxNXB4OyBwb3NpdGlvbjogcmVsYXRpdmU7IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiYXR0cl9fc3R5bGUiOiAib3ZlcmZsb3c6IGhpZGRlbjsiLCJudGhfY2hpbGQiOiAxLCJudGhfb2ZfdHlwZSI6IDF9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJjbGFzc2VzIjogWwogICAgIm1vZGFsLWJvZHkiCl0sImF0dHJfX2NsYXNzIjogIm1vZGFsLWJvZHkiLCJhdHRyX19zdHlsZSI6ICJmb250LXNpemU6IDE1cHg7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbC1jb250ZW50IgpdLCJhdHRyX19jbGFzcyI6ICJtb2RhbC1jb250ZW50IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbC1kaWFsb2ciLAogICAgIm1vZGFsLWxnIgpdLCJhdHRyX19jbGFzcyI6ICJtb2RhbC1kaWFsb2cgbW9kYWwtbGciLCJhdHRyX19yb2xlIjogImRvY3VtZW50IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJtb2RhbCIsCiAgICAiZmFkZSIsCiAgICAic2hvdyIKXSwiYXR0cl9fY2xhc3MiOiAibW9kYWwgZmFkZSBzaG93IiwiYXR0cl9fc3R5bGUiOiAiZGlzcGxheTogYmxvY2s7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJrLXBvcnRsZXRfX2JvZHkiLAogICAgIiIKXSwiYXR0cl9fY2xhc3MiOiAiay1wb3J0bGV0X19ib2R5ICIsImF0dHJfX3N0eWxlIjogInBhZGRpbmc6IDBweDsiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDJ9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJjbGFzc2VzIjogWwogICAgImstcG9ydGxldCIsCiAgICAiay1wb3J0bGV0LS1oZWlnaHQtZmx1aWQiCl0sImF0dHJfX2NsYXNzIjogImstcG9ydGxldCBrLXBvcnRsZXQtLWhlaWdodC1mbHVpZCIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImNsYXNzZXMiOiBbCiAgICAiY29sLWxnLTYiCl0sImF0dHJfX2NsYXNzIjogImNvbC1sZy02IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJyb3ciCl0sImF0dHJfX2NsYXNzIjogInJvdyIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImRpdiIsImF0dHJfX3N0eWxlIjogInBhZGRpbmc6IDQwcHggMzBweCAwcHg7IGJhY2tncm91bmQtY29sb3I6IHJnYigyMzksIDIzOSwgMjQ1KTsgbWFyZ2luLXRvcDogLTQwcHg7IG1pbi1oZWlnaHQ6IGNhbGMoMTAwdmggLSA0MHB4KTsiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDJ9LAogICAgeyJ0YWdfbmFtZSI6ICJkaXYiLCJhdHRyX19zdHlsZSI6ICJtYXJnaW4tdG9wOiAwcHg7IiwibnRoX2NoaWxkIjogMiwibnRoX29mX3R5cGUiOiAyfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiY2xhc3NlcyI6IFsKICAgICJBcHAiCl0sImF0dHJfX2NsYXNzIjogIkFwcCIsImF0dHJfX3N0eWxlIjogImNvbG9yOiByZ2IoNTIsIDYxLCA2Mik7IiwibnRoX2NoaWxkIjogMSwibnRoX29mX3R5cGUiOiAxfSwKICAgIHsidGFnX25hbWUiOiAiZGl2IiwiYXR0cl9faWQiOiAicm9vdCIsIm50aF9jaGlsZCI6IDEsIm50aF9vZl90eXBlIjogMX0sCiAgICB7InRhZ19uYW1lIjogImJvZHkiLCJudGhfY2hpbGQiOiAyLCJudGhfb2ZfdHlwZSI6IDF9Cl0sInRva2VuIjogInhwOXFUMlZMWTc2SkpnIn19"
+    #     })
+
+    #     self.assertEqual(Person.objects.get().distinct_ids, ["63"])
+    #     event = Event.objects.get()
+    #     element = ElementGroup.objects.get(hash=event.elements_hash).element_set.all().first()
+    #     assert element is not None
+    #     self.assertEqual(element.text, '💻 Writing code')
+
+    def test_alias(self):
+        Person.objects.create(team=self.team, distinct_ids=['old_distinct_id'])
+
+        process_event('', '', {
+            'event': '$create_alias',
+            'properties': {
+                'distinct_id': 'old_distinct_id',
+                'token': self.team.api_token,
+                'alias': 'new_distinct_id'
+            },
+        }, self.team.pk, now())
+
+        self.assertEqual(Event.objects.count(), 1)
+        self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id"])
+
+    # This tends to happen when .init and .identify get called right after each other, causing a race condition
+    # in this case the 'anonymous_id' won't have any actions anyway
+    def test_alias_to_non_existent_distinct_id(self):
+        process_event('', '', {
+            'event': '$identify',
+            'properties': {
+                '$anon_distinct_id': 'doesnt_exist',
+                'token': self.team.api_token,
+                'distinct_id': 'new_distinct_id'
+            },
+        }, self.team.pk, now())
+
+        self.assertEqual(Event.objects.count(), 1)
+        self.assertEqual(Person.objects.get().distinct_ids, ['new_distinct_id'])
+
+
+class TestIdentify(BaseTest):
+    def test_distinct_with_anonymous_id(self):
+        Person.objects.create(team=self.team, distinct_ids=['anonymous_id'])
+
+        process_event('', '', {
+            'event': '$identify',
+            'properties': {
+                '$anon_distinct_id': 'anonymous_id',
+                'token': self.team.api_token,
+                'distinct_id': 'new_distinct_id'
+            },
+        }, self.team.pk, now())
+
+        self.assertEqual(Event.objects.count(), 1)
+        self.assertEqual(Person.objects.get().distinct_ids, ["anonymous_id", "new_distinct_id"])
+
+        # check no errors as this call can happen multiple times
+        process_event('', '', {
+            'event': '$identify',
+            'properties': {
+                '$anon_distinct_id': 'anonymous_id',
+                'token': self.team.api_token,
+                'distinct_id': 'new_distinct_id'
+            },
+        }, self.team.pk, now())
+
+    # This case is likely to happen after signup, for example:
+    # 1. User browses website with anonymous_id
+    # 2. User signs up, triggers event with their new_distinct_id (creating a new Person)
+    # 3. In the frontend, try to alias anonymous_id with new_distinct_id
+    # Result should be that we end up with one Person with both ID's
+    def test_distinct_with_anonymous_id_which_was_already_created(self):
+        Person.objects.create(team=self.team, distinct_ids=['anonymous_id'])
+        Person.objects.create(team=self.team, distinct_ids=['new_distinct_id'], properties={'email': 'someone@gmail.com'})
+
+        process_event('', '', {
+            'event': '$identify',
+            'properties': {
+                '$anon_distinct_id': 'anonymous_id',
+                'token': self.team.api_token,
+                'distinct_id': 'new_distinct_id'
+            },
+        }, self.team.pk, now())
+
+        # self.assertEqual(Event.objects.count(), 0)
+        person = Person.objects.get()
+        self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+        self.assertEqual(person.properties['email'], 'someone@gmail.com')
+
+    def test_distinct_team_leakage(self):
+        team2 = Team.objects.create()
+        Person.objects.create(team=team2, distinct_ids=['2'], properties={'email': 'team2@gmail.com'})
+        Person.objects.create(team=self.team, distinct_ids=['1', '2'])
+
+        try:
+            process_event('', '', {
+                'event': '$identify',
+                'properties': {
+                    '$anon_distinct_id': '1',
+                    'token': self.team.api_token,
+                    'distinct_id': '2'
+                },
+            }, self.team.pk, now())
+        except:
+            pass
+
+        people = Person.objects.all()
+        self.assertEqual(people.count(), 2)
+        self.assertEqual(people[1].team, self.team)
+        self.assertEqual(people[1].properties, {})
+        self.assertEqual(people[1].distinct_ids, ["1", "2"])
+        self.assertEqual(people[0].team, team2)
+        self.assertEqual(people[0].distinct_ids, ["2"])

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -15,7 +15,7 @@ class ProcessEvent(BaseTest):
         ActionStep.objects.create(action=action2, selector='a')
 
         with self.assertNumQueries(18):
-            process_event('', '', {
+            process_event(2, '', '', {
                 'event': '$autocapture',
                 'properties': {
                     'distinct_id': 2,
@@ -41,7 +41,7 @@ class ProcessEvent(BaseTest):
         user = self._create_user('tim')
         Person.objects.create(team=self.team, distinct_ids=['asdfasdfasdf'])
 
-        process_event('', '', {
+        process_event('asdfasdfasdf', '', '', {
             'event': '$pageview',
             'properties': {
                 'distinct_id': 'asdfasdfasdf',
@@ -56,7 +56,7 @@ class ProcessEvent(BaseTest):
     def test_alias(self):
         Person.objects.create(team=self.team, distinct_ids=['old_distinct_id'])
 
-        process_event('', '', {
+        process_event('old_distinct_id', '', '', {
             'event': '$create_alias',
             'properties': {
                 'distinct_id': 'old_distinct_id',
@@ -85,7 +85,7 @@ class ProcessEvent(BaseTest):
 
     def test_offset_timestamp(self):
         with freeze_time("2020-01-01T12:00:05.200Z"):
-            process_event('', '', {
+            process_event('distinct_id', '', '', {
                 "offset": 150,
                 "event":"$autocapture",
                 "distinct_id": "distinct_id",
@@ -107,7 +107,7 @@ class TestIdentify(TransactionTestCase):
     def test_distinct_with_anonymous_id(self):
         Person.objects.create(team=self.team, distinct_ids=['anonymous_id'])
 
-        process_event('', '', {
+        process_event('new_distinct_id', '', '', {
             'event': '$identify',
             'properties': {
                 '$anon_distinct_id': 'anonymous_id',
@@ -120,7 +120,7 @@ class TestIdentify(TransactionTestCase):
         self.assertEqual(Person.objects.get().distinct_ids, ["anonymous_id", "new_distinct_id"])
 
         # check no errors as this call can happen multiple times
-        process_event('', '', {
+        process_event('new_distinct_id', '', '', {
             'event': '$identify',
             'properties': {
                 '$anon_distinct_id': 'anonymous_id',
@@ -138,7 +138,7 @@ class TestIdentify(TransactionTestCase):
         Person.objects.create(team=self.team, distinct_ids=['anonymous_id'])
         Person.objects.create(team=self.team, distinct_ids=['new_distinct_id'], properties={'email': 'someone@gmail.com'})
 
-        process_event('', '', {
+        process_event('new_distinct_id', '', '', {
             'event': '$identify',
             'properties': {
                 '$anon_distinct_id': 'anonymous_id',
@@ -158,7 +158,7 @@ class TestIdentify(TransactionTestCase):
         Person.objects.create(team=self.team, distinct_ids=['1', '2'])
 
         try:
-            process_event('', '', {
+            process_event('2', '', '', {
                 'event': '$identify',
                 'properties': {
                     '$anon_distinct_id': '1',

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -25,7 +25,7 @@ class ProcessEvent(BaseTest):
                         {'tag_name': 'div', 'nth_child': 1, 'nth_of_type': 2, '$el_text': '💻'}
                     ]
                 },
-            }, self.team.pk, now())
+            }, self.team.pk, now().isoformat())
 
         self.assertEqual(Person.objects.get().distinct_ids, ["2"])
         event = Event.objects.get()
@@ -47,7 +47,7 @@ class ProcessEvent(BaseTest):
                 'distinct_id': 'asdfasdfasdf',
                 'token': self.team.api_token,
             },
-        }, self.team.pk, now())
+        }, self.team.pk, now().isoformat())
 
         self.assertEqual(Person.objects.get().distinct_ids, ["asdfasdfasdf"])
         event = Event.objects.get()
@@ -56,14 +56,14 @@ class ProcessEvent(BaseTest):
     def test_alias(self):
         Person.objects.create(team=self.team, distinct_ids=['old_distinct_id'])
 
-        process_event('old_distinct_id', '', '', {
+        process_event('new_distinct_id', '', '', {
             'event': '$create_alias',
             'properties': {
-                'distinct_id': 'old_distinct_id',
+                'distinct_id': 'new_distinct_id',
                 'token': self.team.api_token,
-                'alias': 'new_distinct_id'
+                'alias': 'old_distinct_id'
             },
-        }, self.team.pk, now())
+        }, self.team.pk, now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id"])
@@ -71,14 +71,14 @@ class ProcessEvent(BaseTest):
     # This tends to happen when .init and .identify get called right after each other, causing a race condition
     # in this case the 'anonymous_id' won't have any actions anyway
     def test_alias_to_non_existent_distinct_id(self):
-        process_event('', '', {
+        process_event('new_distinct_id', '', '', {
             'event': '$identify',
             'properties': {
                 '$anon_distinct_id': 'doesnt_exist',
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now())
+        }, self.team.pk, now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ['new_distinct_id'])
@@ -89,7 +89,7 @@ class ProcessEvent(BaseTest):
                 "offset": 150,
                 "event":"$autocapture",
                 "distinct_id": "distinct_id",
-            }, self.team.pk, now())
+            }, self.team.pk, now().isoformat())
 
         event = Event.objects.get()
         self.assertEqual(event.timestamp.isoformat(), '2020-01-01T12:00:05.050000+00:00')
@@ -114,7 +114,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now())
+        }, self.team.pk, now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ["anonymous_id", "new_distinct_id"])
@@ -127,7 +127,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now())
+        }, self.team.pk, now().isoformat())
 
     # This case is likely to happen after signup, for example:
     # 1. User browses website with anonymous_id
@@ -145,7 +145,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now())
+        }, self.team.pk, now().isoformat())
 
         # self.assertEqual(Event.objects.count(), 0)
         person = Person.objects.get()
@@ -165,7 +165,7 @@ class TestIdentify(TransactionTestCase):
                     'token': self.team.api_token,
                     'distinct_id': '2'
                 },
-            }, self.team.pk, now())
+            }, self.team.pk, now().isoformat())
         except:
             pass
 


### PR DESCRIPTION
Calling the storing endpoints now take milliseconds rather than seconds
![image](https://user-images.githubusercontent.com/1727427/79493226-113d7700-8019-11ea-85e4-e1dca427f3ec.png)

This also fixes #611. When calling alias, we were using the new distinct_id to find the person, which meant instead of aliasing it created 2 people. 