### PR TITLE
Updated Prop Filters to be "tokenized"

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import Select from 'react-select'
-import { CloseButton, selectStyle } from '../../utils'
+import { selectStyle } from '../../utils'
 import { PropertyValue } from './PropertyValue'
 import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
@@ -18,7 +18,7 @@ const operatorOptions = Object.entries(operatorMap).map(([key, value]) => ({
     value: key,
 }))
 
-export function PropertyFilter({ index, endpoint, onChange, pageKey }) {
+export function PropertyFilter({ index, endpoint, onChange, pageKey, onComplete }) {
     const { properties, filters } = useValues(propertyFilterLogic({ onChange, pageKey }))
     const { setFilter, remove } = useActions(propertyFilterLogic({ onChange, pageKey }))
     let item = filters[index]
@@ -26,12 +26,11 @@ export function PropertyFilter({ index, endpoint, onChange, pageKey }) {
     let value = Object.values(item)[0]
 
     return (
-        <div className="row" style={{ margin: '0.5rem -15px' }}>
-            <div className="col-3" style={{ paddingRight: 0 }}>
+        <div className="row" style={{ margin: '0.5rem -15px', minWidth: key[0] ? 700 : 200 }}>
+            <div className={key[0] ? 'col-3' : 'col-10'} style={{ paddingRight: 0 }}>
                 {properties && (
                     <Select
                         options={properties}
-                        style={{ width: 200 }}
                         value={[{ label: key[0], value: key[0] }]}
                         isLoading={!properties}
                         placeholder="Property key"
@@ -72,16 +71,16 @@ export function PropertyFilter({ index, endpoint, onChange, pageKey }) {
                         key={Object.keys(item)[0]}
                         propertyKey={Object.keys(item)[0]}
                         value={value}
-                        onSet={(key, value) => setFilter(index, key, value)}
+                        onSet={(key, value) => {
+                            onComplete()
+                            setFilter(index, key, value)
+                        }}
                     />
                     {(key[1] == 'gt' || key[1] == 'lt') && isNaN(value) && (
                         <p className="text-danger">Value needs to be a number. Try "equals" or "contains" instead.</p>
                     )}
                 </div>
             )}
-            <div className="col-1 cursor-pointer" onClick={() => remove(index)}>
-                <CloseButton style={{ float: 'none' }} />
-            </div>
         </div>
     )
 }

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -5,7 +5,7 @@ import { PropertyValue } from './PropertyValue'
 import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 
-const operatorMap = {
+export const operatorMap = {
     null: 'equals',
     is_not: "doesn't equal",
     icontains: 'contains',
@@ -27,8 +27,8 @@ export function PropertyFilter({ index, endpoint, onChange, pageKey, onComplete 
 
     return (
         <div className="row" style={{ margin: '0.5rem -15px', minWidth: key[0] ? 700 : 200 }}>
-            <div className={key[0] ? 'col-3' : 'col-10'} style={{ paddingRight: 0 }}>
-                {properties && (
+            {properties && (
+                <div className={key[0] ? 'col-4' : 'col'}>
                     <Select
                         options={properties}
                         value={[{ label: key[0], value: key[0] }]}
@@ -45,10 +45,11 @@ export function PropertyFilter({ index, endpoint, onChange, pageKey, onComplete 
                         autoFocus={!key[0]}
                         openMenuOnFocus={true}
                     />
-                )}
-            </div>
+                </div>
+            )}
+
             {key[0] && (
-                <div className="col-3">
+                <div className="col-3 pl-0">
                     <Select
                         options={operatorOptions}
                         style={{ width: 200 }}
@@ -65,7 +66,7 @@ export function PropertyFilter({ index, endpoint, onChange, pageKey, onComplete 
                 </div>
             )}
             {key[0] && (
-                <div className="col-5" style={{ paddingLeft: 0 }}>
+                <div className="col-5 pl-0">
                     <PropertyValue
                         endpoint={endpoint}
                         key={Object.keys(item)[0]}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -1,12 +1,72 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { PropertyFilter } from './PropertyFilter'
 import { Button } from 'antd'
 import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
+import { Popover, Row } from 'antd'
+import { CloseButton } from '../../utils'
+import { CloseOutlined } from '@ant-design/icons'
 
-export function PropertyFilters({ endpoint, propertyFilters, className, style, onChange, pageKey }) {
+const formatFilterName = str => {
+    if (str.includes('__is_not')) return str.replace('__is_not', '') + ' is not '
+    else if (str.includes('__icontains')) return str.replace('__icontains', '') + ' contains '
+    else if (str.includes('__not_icontains')) return str.replace('__not_icontains', '') + ' does not contain '
+    else if (str.includes('__gt')) return str.replace('__gt', '') + ' > '
+    else if (str.includes('__lt')) return str.replace('__lt', '') + ' < '
+    else return str.replace('__null', '') + ' = '
+}
+
+function FilterRow({ endpoint, propertyFilters, item, index, onChange, pageKey, filters }) {
+    const { remove } = useActions(propertyFilterLogic({ propertyFilters, endpoint, onChange, pageKey }))
+    let [open, setOpen] = useState(false)
+
+    let handleVisibleChange = visible => setOpen(visible)
+
+    return (
+        <Row align="middle">
+            <Popover
+                trigger="click"
+                onVisibleChange={handleVisibleChange}
+                defaultVisible={false}
+                visible={open}
+                placement="bottomLeft"
+                content={
+                    <PropertyFilter
+                        key={index}
+                        index={index}
+                        endpoint={endpoint || 'event'}
+                        onChange={onChange}
+                        onComplete={() => setOpen(false)}
+                        pageKey={pageKey}
+                    />
+                }
+            >
+                {Object.keys(item).length !== 0 ? (
+                    <Button type="primary" shape="round" style={{ marginTop: '0.5rem' }}>
+                        <span>{formatFilterName(Object.keys(item)[0]) + item[Object.keys(item)[0]]}</span>
+                    </Button>
+                ) : (
+                    <Button type="default" shape="round" style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
+                        {filters.length == 0 ? 'Filter by property' : 'Add another filter'}
+                    </Button>
+                )}
+            </Popover>
+            {index != filters.length - 1 && (
+                <CloseButton
+                    className="ml-1"
+                    onClick={() => {
+                        remove(index)
+                    }}
+                    style={{ cursor: 'pointer', float: 'none' }}
+                />
+            )}
+        </Row>
+    )
+}
+
+export function PropertyFilters(props) {
+    let { endpoint, propertyFilters, className, style, onChange, pageKey } = props
     const { filters } = useValues(propertyFilterLogic({ propertyFilters, endpoint, onChange, pageKey }))
-    const { newFilter } = useActions(propertyFilterLogic({ propertyFilters, endpoint, onChange, pageKey }))
 
     return (
         <div
@@ -14,31 +74,16 @@ export function PropertyFilters({ endpoint, propertyFilters, className, style, o
             style={{
                 marginBottom: '2rem',
                 padding: 0,
+                display: 'inline',
                 style,
             }}
         >
-            {filters &&
-                filters.map((item, index) => (
-                    <span>
-                        <PropertyFilter
-                            key={index}
-                            index={index}
-                            endpoint={endpoint || 'event'}
-                            onChange={onChange}
-                            pageKey={pageKey}
-                        />
-                        {index != filters.length - 1 && (
-                            <div className="row">
-                                <div className="secondary offset-4 col-2" style={{ textAlign: 'center' }}>
-                                    AND
-                                </div>
-                            </div>
-                        )}
-                    </span>
-                ))}
-            <Button type="primary" onClick={() => newFilter()} style={{ marginTop: '0.5rem' }}>
-                {filters.length == 0 ? 'Filter by property' : 'Add another filter'}
-            </Button>
+            <div className="column">
+                {filters &&
+                    filters.map((item, index) => {
+                        return <FilterRow {...props} item={item} index={index} filters={filters}></FilterRow>
+                    })}
+            </div>
         </div>
     )
 }

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -19,10 +19,15 @@ function FilterRow({ endpoint, propertyFilters, item, index, onChange, pageKey, 
     const { remove } = useActions(propertyFilterLogic({ propertyFilters, endpoint, onChange, pageKey }))
     let [open, setOpen] = useState(false)
 
-    let handleVisibleChange = visible => setOpen(visible)
+    let handleVisibleChange = visible => {
+        if (!visible && Object.keys(item).length !== 0) {
+            remove(index)
+        }
+        setOpen(visible)
+    }
 
     return (
-        <Row align="middle">
+        <Row align="middle" className="mt-2 mb-2">
             <Popover
                 trigger="click"
                 onVisibleChange={handleVisibleChange}
@@ -41,12 +46,12 @@ function FilterRow({ endpoint, propertyFilters, item, index, onChange, pageKey, 
                 }
             >
                 {Object.keys(item).length !== 0 ? (
-                    <Button type="primary" shape="round" style={{ marginTop: '0.5rem' }}>
+                    <Button type="primary" shape="round">
                         <span>{formatFilterName(Object.keys(item)[0]) + item[Object.keys(item)[0]]}</span>
                     </Button>
                 ) : (
-                    <Button type="default" shape="round" style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
-                        {filters.length == 0 ? 'Filter by property' : 'Add another filter'}
+                    <Button type="default" shape="round">
+                        {'Add Filter'}
                     </Button>
                 )}
             </Popover>
@@ -71,8 +76,8 @@ export function PropertyFilters(props) {
         <div
             className={className || 'col-8'}
             style={{
-                marginBottom: '2rem',
                 padding: 0,
+                marginBottom: '2rem',
                 display: 'inline',
                 style,
             }}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -5,12 +5,11 @@ import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 import { Popover, Row } from 'antd'
 import { CloseButton } from '../../utils'
-import { CloseOutlined } from '@ant-design/icons'
 
 const formatFilterName = str => {
     if (str.includes('__is_not')) return str.replace('__is_not', '') + ' is not '
     else if (str.includes('__icontains')) return str.replace('__icontains', '') + ' contains '
-    else if (str.includes('__not_icontains')) return str.replace('__not_icontains', '') + ' does not contain '
+    else if (str.includes('__not_icontains')) return str.replace('__not_icontains', '') + " doesn't contain "
     else if (str.includes('__gt')) return str.replace('__gt', '') + ' > '
     else if (str.includes('__lt')) return str.replace('__lt', '') + ' < '
     else return str.replace('__null', '') + ' = '

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -6,8 +6,10 @@ import { propertyFilterLogic } from './propertyFilterLogic'
 import { Popover, Row } from 'antd'
 import { CloseButton } from '../../utils'
 
+const operatorEntries = Object.entries(operatorMap).reverse()
+
 const formatFilterName = str => {
-    for (let [key, value] of Object.entries(operatorMap).reverse()) {
+    for (let [key, value] of operatorEntries) {
         if (str.includes(key)) return str.replace('__' + key, '') + ` ${value} `
     }
     return str + ` ${operatorMap['null']} `

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { PropertyFilter } from './PropertyFilter'
+import { PropertyFilter, operatorMap } from './PropertyFilter'
 import { Button } from 'antd'
 import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
@@ -7,12 +7,10 @@ import { Popover, Row } from 'antd'
 import { CloseButton } from '../../utils'
 
 const formatFilterName = str => {
-    if (str.includes('__is_not')) return str.replace('__is_not', '') + ' is not '
-    else if (str.includes('__icontains')) return str.replace('__icontains', '') + ' contains '
-    else if (str.includes('__not_icontains')) return str.replace('__not_icontains', '') + " doesn't contain "
-    else if (str.includes('__gt')) return str.replace('__gt', '') + ' > '
-    else if (str.includes('__lt')) return str.replace('__lt', '') + ' < '
-    else return str.replace('__null', '') + ' = '
+    for (let [key, value] of Object.entries(operatorMap)) {
+        if (str.includes(key)) return str.replace('__' + key, '') + ` ${value} `
+    }
+    return str + ` ${operatorMap['null']} `
 }
 
 function FilterRow({ endpoint, propertyFilters, item, index, onChange, pageKey, filters }) {
@@ -85,7 +83,9 @@ export function PropertyFilters(props) {
             <div className="column">
                 {filters &&
                     filters.map((item, index) => {
-                        return <FilterRow {...props} item={item} index={index} filters={filters}></FilterRow>
+                        return (
+                            <FilterRow key={index} {...props} item={item} index={index} filters={filters}></FilterRow>
+                        )
                     })}
             </div>
         </div>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -20,7 +20,7 @@ function FilterRow({ endpoint, propertyFilters, item, index, onChange, pageKey, 
     let [open, setOpen] = useState(false)
 
     let handleVisibleChange = visible => {
-        if (!visible && Object.keys(item).length !== 0) {
+        if (!visible && Object.keys(item).length >= 0 && !item[Object.keys(item)[0]]) {
             remove(index)
         }
         setOpen(visible)

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -7,7 +7,7 @@ import { Popover, Row } from 'antd'
 import { CloseButton } from '../../utils'
 
 const formatFilterName = str => {
-    for (let [key, value] of Object.entries(operatorMap)) {
+    for (let [key, value] of Object.entries(operatorMap).reverse()) {
         if (str.includes(key)) return str.replace('__' + key, '') + ` ${value} `
     }
     return str + ` ${operatorMap['null']} `

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
@@ -59,13 +59,18 @@ export const propertyFilterLogic = kea({
         [actions.setFilter]: ({ value }) => value && actions.update(),
         [actions.remove]: () => actions.update(),
         [actions.update]: () => {
-            if (values.filters.length == 0) return props.onChange({})
+            if (values.filters.length == 0) {
+                actions.newFilter()
+                return props.onChange({})
+            }
+            if (Object.keys(values.filters[values.filters.length - 1]).length != 0) actions.newFilter()
             let dict = values.filters.reduce((result, item) => ({ ...result, ...item }))
             props.onChange(dict)
         },
     }),
     events: ({ actions, props, values }) => ({
         afterMount: () => {
+            actions.newFilter()
             if (props.endpoint == 'person') {
                 actions.loadPeopleProperties()
             } else {


### PR DESCRIPTION
Took some liberties and removed the 'and' because they were looking really out of place with the new UI. If we're still convinced we need some indicator of the relation between the filters, I can figure something out to add

<img width="588" alt="Screen Shot 2020-04-16 at 2 45 46 PM" src="https://user-images.githubusercontent.com/13127476/79494554-34ecc700-7ff1-11ea-9e32-9c05e9005844.png">
