### PR TITLE
Gunzip request body json

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -33,7 +33,7 @@ def cors_response(request, response):
 def _load_data(request) -> Optional[Union[Dict, List]]:
     if request.method == 'POST':
         if request.content_type == 'application/json':
-            if request.headers['content-encoding'] == 'gzip':
+            if request.headers.get('content-encoding', '').lower() == 'gzip':
                 data = gzip.decompress(request.body)
             else:
                 data = request.body

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from posthog.tasks.process_event import process_event
 import json
 import base64
+import gzip
 import datetime
 
 
@@ -32,7 +33,10 @@ def cors_response(request, response):
 def _load_data(request) -> Optional[Union[Dict, List]]:
     if request.method == 'POST':
         if request.content_type == 'application/json':
-            data = request.body
+            if request.headers['content-encoding'] == 'gzip':
+                data = gzip.decompress(request.body)
+            else:
+                data = request.body
         else:
             data = request.POST.get('data')
     else:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -33,10 +33,10 @@ def cors_response(request, response):
 def _load_data(request) -> Optional[Union[Dict, List]]:
     if request.method == 'POST':
         if request.content_type == 'application/json':
+            data = request.body
+
             if request.headers.get('content-encoding', '').lower() == 'gzip':
-                data = gzip.decompress(request.body)
-            else:
-                data = request.body
+                data = gzip.decompress(data)
         else:
             data = request.POST.get('data')
     else:


### PR DESCRIPTION
## Changes

This makes posthog accept gzip-encoded json. Required to get the iOS integration working.

## Checklist
- [x] All querysets/queries filter by Team
- [ ] Code reviewed
- [ ] QA'd
