### PR TITLE
Fix issues with $create_alias when users have multiple distinct_ids attached to them

### DIFF
--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -53,7 +53,8 @@ def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_f
         if old_person == new_person:
             return
 
-        new_person.properties.update(old_person.properties)
+        new_person.properties = {**old_person.properties, **new_person.properties}
+        new_person.save()
 
         old_person_distinct_ids = PersonDistinctId.objects.filter(person=old_person, team_id=team_id)
 

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 from posthog.models import Person, Element, Event, Team, PersonDistinctId
-from typing import Union, Dict
+from typing import Union, Dict, Optional
 from dateutil.relativedelta import relativedelta
 from dateutil import parser
 
@@ -8,15 +8,18 @@ from django.db import IntegrityError
 import datetime
 
 def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_failed:bool = True) -> None:
+    old_person: Optional[Person] = None
+    new_person: Optional[Person] = None
+
     try:
         old_person = Person.objects.get(team_id=team_id, persondistinctid__distinct_id=previous_distinct_id)
     except Person.DoesNotExist:
-        old_person = None  # type: ignore
+        pass
 
     try:
         new_person = Person.objects.get(team_id=team_id, persondistinctid__distinct_id=distinct_id)
     except Person.DoesNotExist:
-        new_person = None  # type: ignore
+        pass
 
     if old_person and not new_person:
         try:


### PR DESCRIPTION
## Changes

Hi @timgl , I need your opinion on this. I might be doing something wrong (it's late)... or I may have discovered a weird bug.

When testing the iOS integration, I ran into an issue. This is a simplified version of what I was doing:

```
1) posthog.screen('login screen') // distinct_id == 'anon1'
2) posthog.identify('greatuse2r', { $anon_distinct_id: 'anon1' })

3) reset to a clean state

4) posthog.screen('login screen') // distinct_id == 'NEW anon'
5) posthog.identify('greatuse2r', { $anon_distinct_id: 'NEW anon' })
```

At the end of this I just had one user with the distinct_ids `greatuse2r` and `NEW anon`. The old `anon1` was nowhere to be found... and some old events were weirdly unconnected.

Opening the "greatuse2r" user shows only one of the connected distinct ids:

<img width="986" alt="Screenshot 2020-04-22 at 00 28 14" src="https://user-images.githubusercontent.com/53387/79920542-a208be00-8430-11ea-9dc4-2d73ba0ee9b3.png">

When clicking on the old user in the list, I even get a 404

<img width="980" alt="Screenshot 2020-04-22 at 00 32 26" src="https://user-images.githubusercontent.com/53387/79920666-e72cf000-8430-11ea-8c98-5c4f0321f4cf.png">

```
DoesNotExist at /api/person/by_distinct_id/
Person matching query does not exist.

Request Method: GET
Request URL: http://localhost:8000/api/person/by_distinct_id/?distinct_id=78FD2C0A-A27B-4FFF-BD84-F61E654796C0
```

I tried to replicate this in the posthog (python) tests and found that just calling `alias` twice with different aliases and the same real "distinct id" fails.

I have added a two test cases to this PR which fail. One via "alias" and one via "identify".

```
======================================================================
FAIL: test_distinct_with_multiple_anonymous_ids_which_were_already_created (posthog.tasks.test.test_process_event.TestIdentify)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/posthog/posthog/posthog/tasks/test/test_process_event.py", line 214, in test_distinct_with_multiple_anonymous_ids_which_were_already_created
    self.assertEqual(person.distinct_ids, ["anonymous_id", "anonymous_id_2", "new_distinct_id"])
AssertionError: Lists differ: ['anonymous_id_2', 'new_distinct_id'] != ['anonymous_id', 'anonymous_id_2', 'new_distinct_id']

First differing element 0:
'anonymous_id_2'
'anonymous_id'

Second list contains 1 additional elements.
First extra element 2:
'new_distinct_id'

- ['anonymous_id_2', 'new_distinct_id']
+ ['anonymous_id', 'anonymous_id_2', 'new_distinct_id']
?  ++++++++++++++++
```

I'm too tired to debug it further today, so I'll just leave all these notes here. @timgl if you have any suggestions on next steps, please let me know... or if you feel like taking a crack at this yourself, feel free :)

Sidenote: I also noticed that the tests under `tasks/test` were not running in CI at all. Adding a `__init__.py` file solved that.


## Checklist
- [x] All querysets/queries filter by Team
- [ ] Code reviewed
- [ ] QA'd
