### PR TITLE
Fix crash when hovering over events to select

### DIFF
--- a/frontend/src/scenes/trends/ActionSelectInfo.js
+++ b/frontend/src/scenes/trends/ActionSelectInfo.js
@@ -17,68 +17,56 @@ export class ActionSelectInfo extends Component {
         let { entity, isOpen } = this.props
         if (!entity) return null
         return (
-            <div
-                className="select-box-info"
-                ref={this.infoDiv}
-                style={{ opacity: isOpen ? 1 : 0 }}
-            >
+            <div className="select-box-info" ref={this.infoDiv} style={{ opacity: isOpen ? 1 : 0 }}>
                 <div style={{ marginBottom: '0.5rem' }}>{entity.name}</div>
-                {entity.steps && entity.steps.map((step, index) => (
-                    <div key={step.id}>
-                        <Card key={step.id} style={{ marginBottom: 0 }}>
-                            <div className="card-body">
-                                <strong>
-                                    {step.event[0] == '$'
-                                        ? step.event[1].toUpperCase() +
-                                          step.event.slice(2)
-                                        : step.event}
-                                </strong>
-                                <ul style={{ listStyle: 'none' }}>
-                                    {step.selector && (
-                                        <li>
-                                            CSS selector matches
-                                            <pre>{step.selector}</pre>
-                                        </li>
-                                    )}
-                                    {step.tag_name && (
-                                        <li>
-                                            Tag name matches{' '}
-                                            <pre>{step.tag_name}</pre>
-                                        </li>
-                                    )}
-                                    {step.text && (
-                                        <li>
-                                            Text matches <pre>{step.text}</pre>
-                                        </li>
-                                    )}
-                                    {step.href && (
-                                        <li>
-                                            Link HREF matches{' '}
-                                            <pre>{step.href}</pre>
-                                        </li>
-                                    )}
-                                    {step.url && (
-                                        <li>
-                                            URL{' '}
-                                            {step.url_matching == 'contains'
-                                                ? 'contains'
-                                                : 'matches'}{' '}
-                                            <pre>{step.url}</pre>
-                                        </li>
-                                    )}
-                                </ul>
-                            </div>
-                        </Card>
-                        {index < entity.steps.length - 1 && (
-                            <div
-                                className="secondary"
-                                style={{ textAlign: 'center', margin: '1rem' }}
-                            >
-                                OR
-                            </div>
-                        )}
-                    </div>
-                ))}
+                {entity.steps &&
+                    entity.steps.map((step, index) => (
+                        <div key={step.id}>
+                            <Card key={step.id} style={{ marginBottom: 0 }}>
+                                <div className="card-body">
+                                    <strong>
+                                        {step.event && step.event[0] == '$'
+                                            ? step.event[1].toUpperCase() + step.event.slice(2)
+                                            : step.event}
+                                    </strong>
+                                    <ul style={{ listStyle: 'none' }}>
+                                        {step.selector && (
+                                            <li>
+                                                CSS selector matches
+                                                <pre>{step.selector}</pre>
+                                            </li>
+                                        )}
+                                        {step.tag_name && (
+                                            <li>
+                                                Tag name matches <pre>{step.tag_name}</pre>
+                                            </li>
+                                        )}
+                                        {step.text && (
+                                            <li>
+                                                Text matches <pre>{step.text}</pre>
+                                            </li>
+                                        )}
+                                        {step.href && (
+                                            <li>
+                                                Link HREF matches <pre>{step.href}</pre>
+                                            </li>
+                                        )}
+                                        {step.url && (
+                                            <li>
+                                                URL {step.url_matching == 'contains' ? 'contains' : 'matches'}{' '}
+                                                <pre>{step.url}</pre>
+                                            </li>
+                                        )}
+                                    </ul>
+                                </div>
+                            </Card>
+                            {index < entity.steps.length - 1 && (
+                                <div className="secondary" style={{ textAlign: 'center', margin: '1rem' }}>
+                                    OR
+                                </div>
+                            )}
+                        </div>
+                    ))}
             </div>
         )
     }


### PR DESCRIPTION
## Changes

For some reason, both on app.posthog.com and locally, when adding actions the page crashes when I hover over some events. Possibly because I have some old and incorrect data in the system.

![crash event](https://user-images.githubusercontent.com/53387/80086048-71707380-8559-11ea-9269-9344d61a4515.gif)

In any case, it shouldn't crash. This PR fixes the bug.


## Checklist
- [x] All querysets/queries filter by Team
- [ ] Code reviewed
- [ ] QA'd
