### PR TITLE
Allow wildcard filtering on action url

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -334,7 +334,7 @@ export class ActionStep extends Component {
                                     extra_options={<this.URLMatching step={step} isEditor={isEditor} />}
                                     label="URL"
                                 />
-                                {step.url_matching == 'contains' && (
+                                {(!step.url_matching || step.url_matching == 'contains') && (
                                     <small style={{ display: 'block', marginTop: -12 }}>
                                         Use '%' for wildcard, for example: /user/%/edit
                                     </small>

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -328,11 +328,18 @@ export class ActionStep extends Component {
                             <this.AutocaptureFields step={step} isEditor={isEditor} actionId={actionId} />
                         )}
                         {step.event === '$pageview' && (
-                            <this.Option
-                                item="url"
-                                extra_options={<this.URLMatching step={step} isEditor={isEditor} />}
-                                label="URL"
-                            />
+                            <div>
+                                <this.Option
+                                    item="url"
+                                    extra_options={<this.URLMatching step={step} isEditor={isEditor} />}
+                                    label="URL"
+                                />
+                                {step.url_matching == 'contains' && (
+                                    <small style={{ display: 'block', marginTop: -12 }}>
+                                        Use '%' for wildcard, for example: /user/%/edit
+                                    </small>
+                                )}
+                            </div>
                         )}
                     </div>
                 </div>

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -108,7 +108,7 @@ class TestFilterByActions(BaseTest):
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0], event1)
 
-    def test_filter_events_by_url_exact(self):
+    def test_filter_events_by_url(self):
         Person.objects.create(distinct_ids=['whatever'], team=self.team)
         action1 = Action.objects.create(team=self.team)
         ActionStep.objects.create(action=action1, url='https://posthog.com/feedback/123', url_matching=ActionStep.EXACT)
@@ -116,6 +116,9 @@ class TestFilterByActions(BaseTest):
 
         action2 = Action.objects.create(team=self.team)
         ActionStep.objects.create(action=action2, url='123', url_matching=ActionStep.CONTAINS)
+
+        action3 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(action=action3, url='https://posthog.com/%/123', url_matching=ActionStep.CONTAINS)
 
         event1 = Event.objects.create(team=self.team, distinct_id='whatever')
         event2 = Event.objects.create(team=self.team, distinct_id='whatever', properties={'$current_url': 'https://posthog.com/feedback/123'}, elements=[
@@ -127,6 +130,10 @@ class TestFilterByActions(BaseTest):
         self.assertEqual(len(events), 1)
 
         events = Event.objects.filter_by_action(action2)
+        self.assertEqual(events[0], event2)
+        self.assertEqual(len(events), 1)
+
+        events = Event.objects.filter_by_action(action3)
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 


### PR DESCRIPTION
## Changes

- Allow filtering using wildcards
- Django automatically strips wildcards in normal filters, so had to do a subquery. This doesn't seem to slow things down (though we should still offload this to workers)
-

## Checklist
- [x] All querysets/queries filter by Team
- [ ] Code reviewed
- [ ] QA'd
