### PR TITLE
fix issue with default trends route

### DIFF
--- a/frontend/src/scenes/App.js
+++ b/frontend/src/scenes/App.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useValues } from 'kea'
-import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom'
+import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom'
 import { ToastContainer, Slide } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 import 'react-datepicker/dist/react-datepicker.css'
@@ -45,8 +45,10 @@ export default function App() {
     }
 
     return (
-        <Router path='/'>
-            <Redirect to='/trends'/>
+        <Router path="/">
+            <Switch>
+                <Redirect exact from="/" to="/trends" />
+            </Switch>
             <Layout className="bg-white">
                 <Sidebar user={user} />
                 <Layout className="bg-white" style={{ height: '100vh' }}>


### PR DESCRIPTION
Fixes error with new default trends route where refreshing the trends page would enact the redirect which would clear the params on the trends page and redirect back to trends page after any refresh

## Changes
- put redirect in switch and only redirect when '/' is exactly matched as the redirect shouldn't happen for everything

## Checklist
- [x] All querysets/queries filter by Team
- [x] Code reviewed
- [x] QA'd
