### PR TITLE
Parse env values in settings.py

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1,17 +1,18 @@
+import re
+from ipaddress import ip_address, ip_network
+
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
-from django.http import HttpResponse, HttpRequest
-from ipaddress import ip_address, ip_network
-import re
+from django.http import HttpRequest, HttpResponse
+
 
 class AllowIP(object):
     def __init__(self, get_response):
-        if getattr(settings, 'ALLOWED_IP_BLOCKS', False):
-            self.ip_blocks = [item.strip() for item in settings.ALLOWED_IP_BLOCKS.split(',')]  # type: ignore
-        else:
+        if not settings.ALLOWED_IP_BLOCKS:
             # this will make Django skip this middleware for all future requests
             raise MiddlewareNotUsed()
 
+        self.ip_blocks = settings.ALLOWED_IP_BLOCKS
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest):

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -6,7 +6,7 @@ class TestSignup(TestCase):
         self.client = Client()
      
     def test_ip_range(self):
-        with self.settings(ALLOWED_IP_BLOCKS='192.168.0.0/31, 127.0.0.0/25,128.0.0.1'):
+        with self.settings(ALLOWED_IP_BLOCKS=['192.168.0.0/31', '127.0.0.0/25', '128.0.0.1']):
             # not in list
             response = self.client.get('/', REMOTE_ADDR='10.0.0.1')
             self.assertIn(b'IP is not allowed', response.content)


### PR DESCRIPTION
## Changes
I've found a couple of bugs in settings.py
- Boolean values were not evaluated, therefore setting an env variable as "false" would still be "true" in the application
- Setting excepting list was taking "False" as an optional value

## As a matter of discussion:
I'd opt for setting `ALLOWED_HOSTS` to localhost/127.0.0.1, and not setting `SECRET_KEY` at all. Current settings are dangerous as someone could inevitably ship a project with the default value left in the code.