### PR TITLE
fixed redirect to be explicit

### DIFF
--- a/frontend/src/lib/components/SaveToDashboard.js
+++ b/frontend/src/lib/components/SaveToDashboard.js
@@ -22,7 +22,7 @@ export class SaveToDashboard extends Component {
         return (
             <div>
                 Panel added to dashboard.&nbsp;
-                <Link to="/">Click here to see it.</Link>
+                <Link to="/dashboard">Click here to see it.</Link>
             </div>
         )
     }


### PR DESCRIPTION
## Changes
-explicitly re-route to `/dashboard` now that the main page has changed otherwise link would bring you to trends

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
