### PR TITLE
Add $screen to events table

### DIFF
--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -219,7 +219,7 @@ export class EventsTable extends Component {
                         <tr>
                             <th>Event</th>
                             <th>Person</th>
-                            <th>Path</th>
+                            <th>Path / Screen</th>
                             <th>Source</th>
                             <th onClick={this.onTimestapHeaderClick}>
                                 When <i className="fi flaticon-sort" />

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -155,26 +155,36 @@ export class EventsTable extends Component {
                         {event.person}
                     </Link>
                 </td>
-                {params.map(param => (
-                    <td key={param} title={event.properties[param]}>
-                        <FilterLink
-                            property={param}
-                            value={event.properties[param]}
-                            filters={properties}
-                            onClick={(key, value) =>
-                                this.setState(
-                                    {
-                                        properties: {
-                                            ...properties,
-                                            [key]: value,
+                {params.map(paramRequest => {
+                    let param = paramRequest
+                    let value = event.properties[param]
+
+                    if (param === '$current_url' && !value) {
+                        param = '$screen'
+                        value = event.properties[param]
+                    }
+
+                    return (
+                        <td key={param} title={value}>
+                            <FilterLink
+                                property={param}
+                                value={event.properties[param]}
+                                filters={properties}
+                                onClick={(key, value) =>
+                                    this.setState(
+                                        {
+                                            properties: {
+                                                ...properties,
+                                                [key]: value,
+                                            },
                                         },
-                                    },
-                                    this.fetchEvents
-                                )
-                            }
-                        />
-                    </td>
-                ))}
+                                        this.fetchEvents
+                                    )
+                                }
+                            />
+                        </td>
+                    )
+                })}
                 <td>{moment(event.timestamp).fromNow()}</td>
             </tr>
         )


### PR DESCRIPTION
## Changes

This is a rather "quick-n-dirty" tweak to show the name of `$screen` in the "Path" column in the events table.

![image](https://user-images.githubusercontent.com/53387/80540903-7ba3cf00-89aa-11ea-9e58-860e971a240f.png)

There are more things to do to get proper $screen support (how to create actions?), but this is a start. This can either be merged directly or I can add work on the rest tomorrow.


## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
