### PR TITLE
Use `sent_at` or `_` when calculating timestamps

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -58,14 +58,12 @@ def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
 
 
 def _get_sent_at(data, request) -> Optional[datetime]:
-    # posthog-android, posthog-ios
-    if isinstance(data, dict) and data.get('sent_at'):
+    if isinstance(data, dict) and data.get('sent_at'):  # posthog-android, posthog-ios
         sent_at = data['sent_at']
-
-    # posthog-js
-    elif request.GET.get('_'):
+    elif request.POST.get('sent_at'):  # when urlencoded body and not JSON (in some test)
+        sent_at = request.POST['sent_at']
+    elif request.GET.get('_'):  # posthog-js
         sent_at = request.GET['_']
-
     else:
         return None
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -66,16 +66,17 @@ def _get_sent_at(data, request) -> Optional[datetime]:
         sent_at = request.POST['sent_at']
     elif request.POST.get('sentAt'):
         sent_at = request.POST['sentAt']
-    elif data.get('sent_at'):
+    elif isinstance(data, dict) and data.get('sent_at'):
         sent_at = data['sent_at']
-    elif data.get('sentAt'):
+    elif isinstance(data, dict) and data.get('sentAt'):
         sent_at = data['sentAt']
+    else:
+        return None
 
-    if sent_at:
-        if re.match(r"^[0-9]+$", sent_at):
-            return _datetime_from_seconds_or_millis(sent_at)
-        return parser.isoparse(sent_at)
-    return None
+    if re.match(r"^[0-9]+$", sent_at):
+        return _datetime_from_seconds_or_millis(sent_at)
+
+    return parser.isoparse(sent_at)
 
 
 def _get_token(data, request) -> Union[str, bool]:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -62,14 +62,14 @@ def _get_sent_at(data, request) -> Optional[datetime]:
         sent_at = request.GET['_']
     elif request.POST.get('_'):
         sent_at = request.POST['_']
+    elif isinstance(data, dict) and data.get('sent_at'):  # posthog-android
+        sent_at = data['sent_at']
+    elif isinstance(data, dict) and data.get('sentAt'):  # posthog-ios
+        sent_at = data['sentAt']
     elif request.POST.get('sent_at'):
         sent_at = request.POST['sent_at']
     elif request.POST.get('sentAt'):
         sent_at = request.POST['sentAt']
-    elif isinstance(data, dict) and data.get('sent_at'):
-        sent_at = data['sent_at']
-    elif isinstance(data, dict) and data.get('sentAt'):
-        sent_at = data['sentAt']
     else:
         return None
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -58,18 +58,14 @@ def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
 
 
 def _get_sent_at(data, request) -> Optional[datetime]:
-    if request.GET.get('_'):  # posthog-js
-        sent_at = request.GET['_']
-    elif request.POST.get('_'):
-        sent_at = request.POST['_']
-    elif isinstance(data, dict) and data.get('sent_at'):  # posthog-android
+    # posthog-android, posthog-ios
+    if isinstance(data, dict) and data.get('sent_at'):
         sent_at = data['sent_at']
-    elif isinstance(data, dict) and data.get('sentAt'):  # posthog-ios
-        sent_at = data['sentAt']
-    elif request.POST.get('sent_at'):
-        sent_at = request.POST['sent_at']
-    elif request.POST.get('sentAt'):
-        sent_at = request.POST['sentAt']
+
+    # posthog-js
+    elif request.GET.get('_'):
+        sent_at = request.GET['_']
+
     else:
         return None
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -6,10 +6,12 @@ from posthog.utils import get_ip_address
 from typing import Dict, Union, Optional, List, Any
 from urllib.parse import urlparse
 from posthog.tasks.process_event import process_event
+from datetime import datetime
+from dateutil import parser
+import re
 import json
 import base64
 import gzip
-import datetime
 
 
 def cors_response(request, response):
@@ -46,6 +48,36 @@ def _load_data(request) -> Optional[Union[Dict, List]]:
     return data
 
 
+def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
+    if len(timestamp) > 11:  # assuming milliseconds / update "11" to "12" if year > 5138 (set a reminder!)
+        timestamp_number = float(timestamp) / 1000
+    else:
+        timestamp_number = int(timestamp)
+
+    return datetime.utcfromtimestamp(timestamp_number)
+
+
+def _get_sent_at(data, request) -> Optional[datetime]:
+    if request.GET.get('_'):  # posthog-js
+        sent_at = request.GET['_']
+    elif request.POST.get('_'):
+        sent_at = request.POST['_']
+    elif request.POST.get('sent_at'):
+        sent_at = request.POST['sent_at']
+    elif request.POST.get('sentAt'):
+        sent_at = request.POST['sentAt']
+    elif data.get('sent_at'):
+        sent_at = data['sent_at']
+    elif data.get('sentAt'):
+        sent_at = data['sentAt']
+
+    if sent_at:
+        if re.match(r"^[0-9]+$", sent_at):
+            return _datetime_from_seconds_or_millis(sent_at)
+        return parser.isoparse(sent_at)
+    return None
+
+
 def _get_token(data, request) -> Union[str, bool]:
     if request.POST.get('api_key'):
         return request.POST['api_key']
@@ -74,6 +106,7 @@ def get_event(request):
     data = _load_data(request)
     if not data:
         return cors_response(request, HttpResponse("1"))
+    sent_at = _get_sent_at(data, request)
     token = _get_token(data, request)
     if not token:
         return cors_response(request, JsonResponse({'code': 'validation', 'message': "No api_key set. You can find your API key in the /setup page in posthog"}, status=400))
@@ -106,7 +139,8 @@ def get_event(request):
             site_url=request.build_absolute_uri('/')[:-1],
             data=event,
             team_id=team.pk,
-            now=now
+            now=now,
+            sent_at=sent_at,
         )
 
     return cors_response(request, JsonResponse({'status': 1}))

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -35,6 +35,7 @@ class TestCapture(BaseTest):
         self.assertEqual(response.get('access-control-allow-origin'), 'https://localhost')
         arguments = patch_process_event.call_args[1]
         arguments.pop('now') # can't compare fakedate
+        arguments.pop('sent_at') # can't compare fakedate
         self.assertDictEqual(arguments, {
             'distinct_id': '2',
             'ip': '127.0.0.1',
@@ -47,19 +48,18 @@ class TestCapture(BaseTest):
     def test_multiple_events(self, patch_process_event):
         self.client.post('/track/', data={
             'data': json.dumps([{
-                'event': 'beep',
-                'properties': {
-                    'distinct_id': 'eeee',
-                    'token': self.team.api_token,
-                },
-            },
-                {
-                'event': 'boop',
-                'properties': {
-                    'distinct_id': 'aaaa',
-                    'token': self.team.api_token,
-                },
-            } ]),
+                    'event': 'beep',
+                    'properties': {
+                        'distinct_id': 'eeee',
+                        'token': self.team.api_token,
+                    },
+                }, {
+                    'event': 'boop',
+                    'properties': {
+                        'distinct_id': 'aaaa',
+                        'token': self.team.api_token,
+                    },
+                }]),
             'api_key': self.team.api_token
         })
         self.assertEqual(patch_process_event.call_count, 2)
@@ -99,6 +99,7 @@ class TestCapture(BaseTest):
         }, content_type='application/json')
         arguments = patch_process_event.call_args[1]
         arguments.pop('now') # can't compare fakedate
+        arguments.pop('sent_at') # can't compare fakedate
         self.assertDictEqual(arguments, {
             'distinct_id': '2',
             'ip': '127.0.0.1',
@@ -123,6 +124,7 @@ class TestCapture(BaseTest):
 
         arguments = patch_process_event.call_args[1]
         arguments.pop('now') # can't compare fakedate
+        arguments.pop('sent_at') # can't compare fakedate
         self.assertDictEqual(arguments, {
             'distinct_id': '2',
             'ip': '127.0.0.1',
@@ -188,6 +190,7 @@ class TestCapture(BaseTest):
         arguments = patch_process_event.call_args[1]
         self.assertEqual(arguments['data']['event'], '$identify')
         arguments.pop('now') # can't compare fakedate
+        arguments.pop('sent_at') # can't compare fakedate
         arguments.pop('data') # can't compare fakedate
         self.assertDictEqual(arguments, {
             'distinct_id': '3',

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -244,7 +244,6 @@ class TestCapture(BaseTest):
             tomorrow.isoformat()
         )
 
-
     @patch('posthog.tasks.process_event.process_event.delay')
     def test_sent_at_field(self, patch_process_event):
         now = timezone.now()

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -25,7 +25,7 @@ class ProcessEvent(BaseTest):
                         {'tag_name': 'div', 'nth_child': 1, 'nth_of_type': 2, '$el_text': '💻'}
                     ]
                 },
-            }, self.team.pk, now().isoformat())
+            }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Person.objects.get().distinct_ids, ["2"])
         event = Event.objects.get()
@@ -47,7 +47,7 @@ class ProcessEvent(BaseTest):
                 'distinct_id': 'asdfasdfasdf',
                 'token': self.team.api_token,
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Person.objects.get().distinct_ids, ["asdfasdfasdf"])
         event = Event.objects.get()
@@ -63,7 +63,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'old_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id"])
@@ -78,7 +78,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'new_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id"])
@@ -93,7 +93,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'old_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         Person.objects.create(team=self.team, distinct_ids=['old_distinct_id_2'])
 
@@ -104,7 +104,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'old_distinct_id_2'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Event.objects.count(), 2)
         self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id", "old_distinct_id_2"])
@@ -117,7 +117,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'old_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         person1 = Person.objects.get(team=self.team, persondistinctid__distinct_id='old_distinct_id')
         person2 = Person.objects.get(team=self.team, persondistinctid__distinct_id='new_distinct_id')
@@ -138,7 +138,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'old_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ["old_distinct_id", "new_distinct_id"])
@@ -149,7 +149,7 @@ class ProcessEvent(BaseTest):
                 "offset": 150,
                 "event":"$autocapture",
                 "distinct_id": "distinct_id",
-            }, self.team.pk, now().isoformat())
+            }, self.team.pk, now().isoformat(), now().isoformat())
 
         event = Event.objects.get()
         self.assertEqual(event.timestamp.isoformat(), '2020-01-01T12:00:05.050000+00:00')
@@ -172,7 +172,7 @@ class ProcessEvent(BaseTest):
                 'token': self.team.api_token,
                 'alias': 'old_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
 
@@ -204,7 +204,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Person.objects.get().distinct_ids, ["anonymous_id", "new_distinct_id"])
@@ -217,7 +217,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
     # This case is likely to happen after signup, for example:
     # 1. User browses website with anonymous_id
@@ -235,7 +235,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         # self.assertEqual(Event.objects.count(), 0)
         person = Person.objects.get()
@@ -254,7 +254,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         # self.assertEqual(Event.objects.count(), 0)
         person = Person.objects.get()
@@ -272,7 +272,7 @@ class TestIdentify(TransactionTestCase):
                 'token': self.team.api_token,
                 'distinct_id': 'new_distinct_id'
             },
-        }, self.team.pk, now().isoformat())
+        }, self.team.pk, now().isoformat(), now().isoformat())
 
         person = Person.objects.get()
         self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id", "anonymous_id_2"])
@@ -293,7 +293,7 @@ class TestIdentify(TransactionTestCase):
                     'token': self.team.api_token,
                     'distinct_id': '2'
                 },
-            }, self.team.pk, now().isoformat())
+            }, self.team.pk, now().isoformat(), now().isoformat())
         except:
             pass
 

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -199,7 +199,18 @@ class ProcessEvent(BaseTest):
                 "offset": 150,
                 "event":"$autocapture",
                 "distinct_id": "distinct_id",
-            }, self.team.pk, now().isoformat(), now().isoformat())
+            }, self.team.pk, now().isoformat(), now().isoformat())  # sent at makes no difference for offset
+
+        event = Event.objects.get()
+        self.assertEqual(event.timestamp.isoformat(), '2020-01-01T12:00:05.050000+00:00')
+
+    def test_offset_timestamp_no_sent_at(self) -> None:
+        with freeze_time("2020-01-01T12:00:05.200Z"):
+            process_event('distinct_id', '', '', {
+                "offset": 150,
+                "event":"$autocapture",
+                "distinct_id": "distinct_id",
+            }, self.team.pk, now().isoformat(), None)  # no sent at makes no difference for offset
 
         event = Event.objects.get()
         self.assertEqual(event.timestamp.isoformat(), '2020-01-01T12:00:05.050000+00:00')


### PR DESCRIPTION
Fixes #533

## Changes

This PR takes the "current timestamp" returned by the integrations (field "_" in posthog-js and field "sent_at" in some others) and calculates the event timestamps by comparing this "sent_at" value to the timestamps returned.

It's a cleaner approach to the "offset" implementation currently in posthog-js, as is doesn't require going into each sent event and adding a "offset" field client side. This would get quite complicated with the number of integrations we have. Plus it makes it possible to retry requests and retain correct times.

I'm making this PR now for feedback, yet still TODO: backend tests

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
