### PR TITLE
Fix issue with datetimes not being comparable

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -54,7 +54,7 @@ def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
     else:
         timestamp_number = int(timestamp)
 
-    return datetime.utcfromtimestamp(timestamp_number)
+    return datetime.fromtimestamp(timestamp_number, timezone.utc)
 
 
 def _get_sent_at(data, request) -> Optional[datetime]:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -237,6 +237,9 @@ class TestCapture(BaseTest):
         arguments.pop('now')  # can't compare fakedate
 
         # right time sent as sent_at to process_event
+
+        self.assertEqual(arguments['sent_at'].tzinfo, timezone.utc)
+
         timediff = arguments['sent_at'].timestamp() - tomorrow_sent_at.timestamp()
         self.assertLess(abs(timediff), 1)
         self.assertEqual(

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -132,6 +132,8 @@ def _handle_timestamp(data: dict, now: str, sent_at: Optional[str]) -> Union[dat
             # sent_at - timestamp == now - x
             # x = now + (timestamp - sent_at)
             try:
+                # timestamp and sent_at must both be in the same format: either both with or both without timezones
+                # otherwise we can't get a diff to add to now
                 return parser.isoparse(now) + (parser.isoparse(data['timestamp']) - parser.isoparse(sent_at))
             except TypeError as e:
                 capture_exception(e)

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -130,9 +130,9 @@ def _handle_timestamp(data: dict, now: str, sent_at: Optional[str]) -> Union[dat
     if data.get('timestamp'):
         if sent_at:
             # sent_at - timestamp == now - x
-            # x = timestamp + (now - sent_at)
+            # x = now + (timestamp - sent_at)
             try:
-                return parser.isoparse(data['timestamp']) + (parser.isoparse(now) - parser.isoparse(sent_at))
+                return parser.isoparse(now) + (parser.isoparse(data['timestamp']) - parser.isoparse(sent_at))
             except TypeError as e:
                 capture_exception(e)
 


### PR DESCRIPTION
## Changes

Add UTC to timestamps

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
