### PR TITLE
Fix today + hourly filtering not working

### DIFF
--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import AuthenticationFailed
 from django.db.models import Q, Count, Prefetch, functions, QuerySet
 from django.db import connection
+from django.utils.timezone import now
 from typing import Any, List, Dict, Optional, Tuple
 import pandas as pd
 import datetime
@@ -145,10 +146,6 @@ class ActionViewSet(viewsets.ModelViewSet):
             'month': 'M'
         }
         response = {}
-        # handle "today" date range
-        if date_from == date_to:
-            date_from = pd.Timestamp(ts_input=date_from).replace(hour=0)
-            date_to = pd.Timestamp(ts_input=date_to).replace(hour=23)
 
         time_index = pd.date_range(date_from, date_to, freq=freq_map[interval])
         if len(aggregates) > 0:
@@ -240,7 +237,7 @@ class ActionViewSet(viewsets.ModelViewSet):
 
         dates_filled = self._group_events_to_date(
             date_from=filter.date_from if filter.date_from else pd.Timestamp(aggregates[0][interval]),
-            date_to=filter.date_to,
+            date_to=filter.date_to if filter.date_to else now(),
             aggregates=aggregates,
             interval=interval,
             breakdown=breakdown
@@ -259,7 +256,7 @@ class ActionViewSet(viewsets.ModelViewSet):
         return cursor.fetchall()
 
     def _stickiness(self, filtered_events: QuerySet, filter: Filter) -> Dict[str, Any]:
-        range_days = (filter.date_to - filter.date_from).days + 2 if filter.date_from else 90
+        range_days = (filter.date_to - filter.date_from).days + 2 if filter.date_from and filter.date_to else 90
 
         events = filtered_events\
             .filter(self._filter_events(filter))\

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -279,13 +279,13 @@ class TestTrends(BaseTest):
 
         with freeze_time('2020-01-02 23:30'):
             Event.objects.create(team=self.team, event='sign up', distinct_id='blabla')
+
         # test today + hourly
-        with freeze_time('2020-01-02'):
+        with freeze_time('2020-01-02T23:31:00Z'):
             action_response = self.client.get(
                 '/api/action/trends/',
                 data={
-                    'date_from': '2020-01-02 23:00:00',
-                    'date_to': '2020-01-02 23:00:00',
+                    'date_from': 'dStart',
                     'interval': 'hour',
                 },
             ).json()

--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -67,7 +67,7 @@ class Filter(object):
         return timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(days=7)
 
     @property
-    def date_to(self) -> datetime.datetime:
+    def date_to(self) -> Optional[datetime.datetime]:
         if self._date_to:
             return relative_date_parse(self._date_to)
-        return timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        return None


### PR DESCRIPTION
## Changes

- Previously we would set a date_to with hour 0, which meant that if you filtered by day you only saw data for the first hour of the day
![image](https://user-images.githubusercontent.com/1727427/80733453-a22a4d00-8b05-11ea-9721-5a702f5f108f.png)


## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
