### PR TITLE
Better paths query

### DIFF
--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -251,11 +251,14 @@ export class Paths extends Component {
     }
 
     updateFilter = changes => {
-        this.setState({ filter: { ...this.state.filter, ...changes }, rendered: false }, this.fetchPaths)
+        this.setState(
+            { filter: { ...this.state.filter, ...changes }, rendered: false, dataLoaded: false },
+            this.fetchPaths
+        )
     }
 
     render() {
-        let { paths, rendered, filter, dataLoaded } = this.state
+        let { paths, filter, dataLoaded } = this.state
 
         return (
             <div>

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -25,8 +25,7 @@ class PathsViewSet(viewsets.ViewSet):
         sessions = Event.objects.filter(
                 team=team,
                 event='$pageview',
-                **date_query,
-                **{'properties__$current_url__isnull': False},
+                **date_query
             )\
             .annotate(previous_timestamp=Window(
                 expression=Lag('timestamp', default=None),

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -72,17 +72,11 @@ class TestPaths(BaseTest):
     def test_paths_in_window(self):
         Person.objects.create(team=self.team, distinct_ids=['person_1'])
 
-        with freeze_time("2020-04-14T03:25:34.000Z"):
-            Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
-            Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
-        
-        with freeze_time("2020-04-15T03:25:34.000Z"):
-            Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
-            Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
+        Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+        Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
 
-        response = self.client.get('/api/paths/?date_from=2020-04-13').json()
-        print(response)
+        response = self.client.get('/api/paths/').json()
         self.assertEqual(response[0]['source'], '1_/')
         self.assertEqual(response[0]['target'], '2_/about')
-        self.assertEqual(response[0]['value'], 2)
+        self.assertEqual(response[0]['value'], 1)
 

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -72,6 +72,11 @@ class TestPaths(BaseTest):
     def test_paths_in_window(self):
         Person.objects.create(team=self.team, distinct_ids=['person_1'])
 
+        with freeze_time("2020-04-14T03:25:34.000Z"):
+            Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+        with freeze_time("2020-04-14T03:30:34.000Z"):
+            Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
+
         with freeze_time("2020-04-15T03:25:34.000Z"):
             Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
         with freeze_time("2020-04-15T03:30:34.000Z"):
@@ -80,5 +85,5 @@ class TestPaths(BaseTest):
         response = self.client.get('/api/paths/?date_from=2020-04-13').json()
         self.assertEqual(response[0]['source'], '1_/')
         self.assertEqual(response[0]['target'], '2_/about')
-        self.assertEqual(response[0]['value'], 1)
+        self.assertEqual(response[0]['value'], 2)
 

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -72,23 +72,15 @@ class TestPaths(BaseTest):
     def test_paths_in_window(self):
         Person.objects.create(team=self.team, distinct_ids=['person_1'])
 
-        first_day = now() - relativedelta(days=5)
-        with freeze_time(first_day.strftime("%Y-%m-%d")):
+        with freeze_time("2020-04-14T03:25:34.000Z"):
             Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
-        first_day = first_day + relativedelta(minutes=5)
-        with freeze_time(first_day.strftime("%Y-%m-%d")):
             Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
         
-        second_day = now() - relativedelta(days=4)
-        with freeze_time(second_day.strftime("%Y-%m-%d")):
+        with freeze_time("2020-04-15T03:25:34.000Z"):
             Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
-        second_day = second_day + relativedelta(minutes=4)
-        with freeze_time(second_day.strftime("%Y-%m-%d")):
             Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
 
-        begin_query_range = now() - relativedelta(days=7)
-        response = self.client.get('/api/paths/?date_from=' + begin_query_range.strftime("%Y-%m-%d")).json()
-
+        response = self.client.get('/api/paths/?date_from=2020-04-13').json()
         self.assertEqual(response[0]['source'], '1_/')
         self.assertEqual(response[0]['target'], '2_/about')
         self.assertEqual(response[0]['value'], 2)

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -81,6 +81,7 @@ class TestPaths(BaseTest):
             Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
 
         response = self.client.get('/api/paths/?date_from=2020-04-13').json()
+        print(response)
         self.assertEqual(response[0]['source'], '1_/')
         self.assertEqual(response[0]['target'], '2_/about')
         self.assertEqual(response[0]['value'], 2)

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -70,20 +70,23 @@ class TestPaths(BaseTest):
         self.assertEqual(len(response), 0)
 
     def test_paths_in_window(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=['person_1'])
+        Person.objects.create(team=self.team, distinct_ids=['person_1'])
 
         first_day = now() - relativedelta(days=5)
-        second_day = now() - relativedelta(days=4)
-        begin_query_range = now() - relativedelta(days=7)
-
         with freeze_time(first_day.strftime("%Y-%m-%d")):
             Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+        first_day = first_day + relativedelta(minutes=5)
+        with freeze_time(first_day.strftime("%Y-%m-%d")):
             Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
         
+        second_day = now() - relativedelta(days=4)
         with freeze_time(second_day.strftime("%Y-%m-%d")):
             Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+        second_day = second_day + relativedelta(minutes=4)
+        with freeze_time(second_day.strftime("%Y-%m-%d")):
             Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
 
+        begin_query_range = now() - relativedelta(days=7)
         response = self.client.get('/api/paths/?date_from=' + begin_query_range.strftime("%Y-%m-%d")).json()
 
         self.assertEqual(response[0]['source'], '1_/')

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -74,10 +74,11 @@ class TestPaths(BaseTest):
 
         with freeze_time("2020-04-15T03:25:34.000Z"):
             Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+        with freeze_time("2020-04-15T03:30:34.000Z"):
             Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
 
         response = self.client.get('/api/paths/?date_from=2020-04-13').json()
         self.assertEqual(response[0]['source'], '1_/')
         self.assertEqual(response[0]['target'], '2_/about')
-        self.assertEqual(response[0]['value'], 2)
+        self.assertEqual(response[0]['value'], 1)
 

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -2,6 +2,7 @@ from .base import BaseTest
 from posthog.models import Person, Event
 from django.utils.timezone import now
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 class TestPaths(BaseTest):
     TESTS_API = True
@@ -67,3 +68,25 @@ class TestPaths(BaseTest):
         date_to = now() - relativedelta(days=7)
         response = self.client.get('/api/paths/?date_from=' + date_from.strftime("%Y-%m-%d") + '&date_to=' + date_to.strftime("%Y-%m-%d")).json()
         self.assertEqual(len(response), 0)
+
+    def test_paths_in_window(self):
+        person1 = Person.objects.create(team=self.team, distinct_ids=['person_1'])
+
+        first_day = now() - relativedelta(days=5)
+        second_day = now() - relativedelta(days=4)
+        begin_query_range = now() - relativedelta(days=7)
+
+        with freeze_time(first_day.strftime("%Y-%m-%d")):
+            Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+            Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
+        
+        with freeze_time(second_day.strftime("%Y-%m-%d")):
+            Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+            Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
+
+        response = self.client.get('/api/paths/?date_from=' + begin_query_range.strftime("%Y-%m-%d")).json()
+
+        self.assertEqual(response[0]['source'], '1_/')
+        self.assertEqual(response[0]['target'], '2_/about')
+        self.assertEqual(response[0]['value'], 2)
+

--- a/posthog/api/test/test_paths.py
+++ b/posthog/api/test/test_paths.py
@@ -72,11 +72,12 @@ class TestPaths(BaseTest):
     def test_paths_in_window(self):
         Person.objects.create(team=self.team, distinct_ids=['person_1'])
 
-        Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
-        Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
+        with freeze_time("2020-04-15T03:25:34.000Z"):
+            Event.objects.create(properties={'$current_url': '/'}, distinct_id='person_1', event='$pageview', team=self.team)
+            Event.objects.create(properties={'$current_url': '/about'}, distinct_id='person_1', event='$pageview', team=self.team)
 
-        response = self.client.get('/api/paths/').json()
+        response = self.client.get('/api/paths/?date_from=2020-04-13').json()
         self.assertEqual(response[0]['source'], '1_/')
         self.assertEqual(response[0]['target'], '2_/about')
-        self.assertEqual(response[0]['value'], 1)
+        self.assertEqual(response[0]['value'], 2)
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,7 +1,9 @@
 import os
 
 from celery import Celery
+from celery.schedules import crontab
 from django.conf import settings
+from django.db import connection
 import redis
 import time
 
@@ -27,10 +29,21 @@ def setup_periodic_tasks(sender, **kwargs):
     # Heartbeat every 10sec to make sure the worker is alive
     sender.add_periodic_task(10.0, redis_heartbeat.s(), name='10 sec heartbeat')
 
+    # Keep event partitions a week ahead and check on this daily
+    sender.add_periodic_task(
+        crontab(),
+        update_event_partitions.s(),
+    )
 
 @app.task
 def redis_heartbeat():
     redis_instance.set("POSTHOG_HEARTBEAT", int(time.time()))
+
+@app.task
+def update_event_partitions():
+    with connection.cursor() as cursor:
+        cursor.execute("DO $$ BEGIN PERFORM update_partitions(); END $$;")
+    
 
 
 @app.task(bind=True)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,9 +1,7 @@
 import os
 
 from celery import Celery
-from celery.schedules import crontab
 from django.conf import settings
-from django.db import connection
 import redis
 import time
 
@@ -29,21 +27,10 @@ def setup_periodic_tasks(sender, **kwargs):
     # Heartbeat every 10sec to make sure the worker is alive
     sender.add_periodic_task(10.0, redis_heartbeat.s(), name='10 sec heartbeat')
 
-    # Keep event partitions a week ahead and check on this daily
-    sender.add_periodic_task(
-        crontab(),
-        update_event_partitions.s(),
-    )
 
 @app.task
 def redis_heartbeat():
     redis_instance.set("POSTHOG_HEARTBEAT", int(time.time()))
-
-@app.task
-def update_event_partitions():
-    with connection.cursor() as cursor:
-        cursor.execute("DO $$ BEGIN PERFORM update_partitions(); END $$;")
-    
 
 
 @app.task(bind=True)


### PR DESCRIPTION
## Changes
- Reduce path query from querying each event order to a single query. improves runtime and allows for easy extendability for querying more depth
- make sure loader is shown when paths date filter is changed

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
