### PR TITLE
Update Trends dotted line UX

### DIFF
--- a/frontend/src/scenes/trends/ActionsLineGraph.js
+++ b/frontend/src/scenes/trends/ActionsLineGraph.js
@@ -20,6 +20,7 @@ export function ActionsLineGraph({ dashboardItemId = null, filters: filtersParam
                 type="line"
                 datasets={results}
                 labels={results[0].labels}
+                isInProgress={!filters.date_to}
                 onClick={
                     dashboardItemId
                         ? null

--- a/frontend/src/scenes/trends/LineGraph.js
+++ b/frontend/src/scenes/trends/LineGraph.js
@@ -60,7 +60,14 @@ export class LineGraph extends Component {
                           let datasetCopy = Object.assign({}, dataset)
                           let datasetLength = datasetCopy.data.length
                           datasetCopy.dotted = true
-                          datasetCopy.borderDash = [10, 10]
+
+                          // if last date is still active show dotted line
+                          let inputDate = new Date(datasetCopy.days[datasetCopy.days.length - 1])
+                          let todaysDate = new Date()
+                          if (inputDate.setHours(0, 0, 0, 0) == todaysDate.setHours(0, 0, 0, 0)) {
+                              datasetCopy.borderDash = [10, 10]
+                          }
+
                           datasetCopy.data =
                               datasetCopy.data.length > 2
                                   ? datasetCopy.data.map((datum, index) =>

--- a/frontend/src/scenes/trends/LineGraph.js
+++ b/frontend/src/scenes/trends/LineGraph.js
@@ -62,9 +62,7 @@ export class LineGraph extends Component {
                           datasetCopy.dotted = true
 
                           // if last date is still active show dotted line
-                          let inputDate = new Date(datasetCopy.days[datasetCopy.days.length - 1])
-                          let todaysDate = new Date()
-                          if (inputDate.setHours(0, 0, 0, 0) == todaysDate.setHours(0, 0, 0, 0)) {
+                          if (this.props.isInProgress) {
                               datasetCopy.borderDash = [10, 10]
                           }
 


### PR DESCRIPTION
Only shows dotted line if last date is today. 

Fixes #713.

![dotted-line](https://user-images.githubusercontent.com/5521110/81359645-905d2280-908e-11ea-9dff-5929af4b9131.png)


(Notes)

One thing that still needs to be approved is custom _Date range_ in future shows no dotted line for last point, which was still occurring before this PR.