### PR TITLE
Add Django-debug-toolbar for profiling requests performance

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -42,3 +42,6 @@ ignore_missing_imports = True
 
 [mypy-freezegun]
 ignore_missing_imports = True
+
+[mypy-debug_toolbar]
+ignore_missing_imports = True

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -85,8 +85,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'loginas',
     'corsheaders',
-    'social_django',
-    'debug_toolbar'
+    'social_django'j
 ]
 
 MIDDLEWARE = [
@@ -99,9 +98,17 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware'
+    'whitenoise.middleware.WhiteNoiseMiddleware'
 ]
+
+# Load debug_toolbar if we can (DEBUG and Dev modes)
+try:
+    import debug_toolbar
+    INSTALLED_APPS.append('debug_toolbar')
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+except ImportError:
+    pass
+
 INTERNAL_IPS = [
     '127.0.0.1',
     '172.18.0.1' # Docker IP

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -85,7 +85,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'loginas',
     'corsheaders',
-    'social_django'
+    'social_django',
+    'debug_toolbar'
 ]
 
 MIDDLEWARE = [
@@ -98,9 +99,13 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware'
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware'
 ]
-INTERNAL_IPS = ['127.0.0.1']
+INTERNAL_IPS = [
+    '127.0.0.1',
+    '172.18.0.1' # Docker IP
+    ]
 CORS_ORIGIN_ALLOW_ALL = True
 
 ROOT_URLCONF = 'posthog.urls'

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -85,7 +85,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'loginas',
     'corsheaders',
-    'social_django'j
+    'social_django'
 ]
 
 MIDDLEWARE = [
@@ -103,7 +103,7 @@ MIDDLEWARE = [
 
 # Load debug_toolbar if we can (DEBUG and Dev modes)
 try:
-    import debug_toolbar
+    import debug_toolbar # type: ignore
     INSTALLED_APPS.append('debug_toolbar')
     MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 except ImportError:

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -103,7 +103,7 @@ MIDDLEWARE = [
 
 # Load debug_toolbar if we can (DEBUG and Dev modes)
 try:
-    import debug_toolbar # type: ignore
+    import debug_toolbar
     INSTALLED_APPS.append('debug_toolbar')
     MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 except ImportError:

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -182,6 +182,9 @@ urlpatterns = urlpatterns + [
 if settings.DEBUG:
     try:
         import debug_toolbar
+        urlpatterns += [
+            path('__debug__/', include(debug_toolbar.urls)),
+        ]
     except ImportError:
         pass
 
@@ -190,7 +193,6 @@ if settings.DEBUG:
         assert False, locals()
     urlpatterns += [
         path('debug/', debug),
-        path('__debug__/', include(debug_toolbar.urls)),
     ]
 
 urlpatterns += [

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -180,7 +180,10 @@ urlpatterns = urlpatterns + [
 ]
 
 if settings.DEBUG:
-    import debug_toolbar # type: ignore
+    try:
+        import debug_toolbar
+    except ImportError:
+        pass
 
     @csrf_exempt
     def debug(request):

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -180,11 +180,14 @@ urlpatterns = urlpatterns + [
 ]
 
 if settings.DEBUG:
+    import debug_toolbar 
+
     @csrf_exempt
     def debug(request):
         assert False, locals()
     urlpatterns += [
-        path('debug/', debug)
+        path('debug/', debug),
+        path('__debug__/', include(debug_toolbar.urls)),
     ]
 
 urlpatterns += [

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -180,7 +180,7 @@ urlpatterns = urlpatterns + [
 ]
 
 if settings.DEBUG:
-    import debug_toolbar 
+    import debug_toolbar # type: ignore
 
     @csrf_exempt
     def debug(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,4 +82,4 @@ wcwidth==0.1.9
 Werkzeug==1.0.0
 whitenoise==5.0.1
 zipp==3.1.0
-
+django-debug-toolbar==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,4 +82,3 @@ wcwidth==0.1.9
 Werkzeug==1.0.0
 whitenoise==5.0.1
 zipp==3.1.0
-django-debug-toolbar==2.2

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,3 +7,4 @@ flake8-import-order
 flake8-logging-format
 flake8-print
 pip-tools
+django-debug-toolbar

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,13 @@
 #
 #    pip-compile requirements/dev.in
 #
+--index-url https://pypi.python.org/simple
+
+asgiref==3.2.7            # via django
 attrs==19.3.0             # via flake8-bugbear
 click==7.1.1              # via pip-tools
+django-debug-toolbar==2.2  # via -r requirements/dev.in
+django==3.0.6             # via django-debug-toolbar
 entrypoints==0.3          # via flake8
 flake8-bugbear==20.1.4    # via -r requirements/dev.in
 flake8-colors==0.1.6      # via -r requirements/dev.in
@@ -15,11 +20,15 @@ flake8-import-order==0.18.1  # via -r requirements/dev.in
 flake8-logging-format==0.6.0  # via -r requirements/dev.in
 flake8-print==3.1.4       # via -r requirements/dev.in
 flake8==3.7.9             # via -r requirements/dev.in, flake8-bugbear, flake8-colors, flake8-commas, flake8-comprehensions, flake8-print
+importlib-metadata==1.6.0  # via flake8-comprehensions
 mccabe==0.6.1             # via flake8
 pip-tools==5.0.0          # via -r requirements/dev.in
 pycodestyle==2.5.0        # via flake8, flake8-import-order, flake8-print
 pyflakes==2.1.1           # via flake8
+pytz==2020.1              # via django
 six==1.14.0               # via flake8-print, pip-tools
+sqlparse==0.3.1           # via django, django-debug-toolbar
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
## Changes
- Add django-debug-toolbar for profiling what is slowing down funnel generation.
- Forward port to Postgres from docker-compose for running queries direct to Postgres

Really helps figure out what Django is trying to do on the backend and if it's the DB that's the problem or the app.
![image](https://user-images.githubusercontent.com/391319/81887174-65257800-9553-11ea-86bb-c362dca851e3.png)

This is only enabled when `DEBUG` is True



## Checklist
- [ NA ] All querysets/queries filter by Team (if applicable)
- [ NA ] Backend tests (if applicable)
