### PR TITLE
Fix property filter array issue on events page

### DIFF
--- a/frontend/src/lib/components/FilterPropertyLink.js
+++ b/frontend/src/lib/components/FilterPropertyLink.js
@@ -4,11 +4,20 @@ import PropTypes from 'prop-types'
 
 import { Property } from 'lib/components/Property'
 import { Link } from 'lib/components/Link'
+import { parseProperties } from 'lib/components/PropertyFilters/propertyFilterLogic'
 
 export function FilterPropertyLink({ property, value, filters, onClick }) {
+    const cleanedProperties = Array.isArray(filters.properties)
+        ? filters.properties
+        : parseProperties(filters.properties)
+
+    const properties = cleanedProperties.find(p => p.key === property && p.value === value && !p.operator)
+        ? cleanedProperties.filter(p => p.key !== property || p.value !== value || p.operator)
+        : [...cleanedProperties, { key: property, value: value }]
+
     const { url } = combineUrl(window.location.pathname, {
         ...filters,
-        properties: { ...filters.properties, [property]: value },
+        properties,
     })
 
     return (

--- a/frontend/src/lib/components/FilterPropertyLink.js
+++ b/frontend/src/lib/components/FilterPropertyLink.js
@@ -11,6 +11,7 @@ export function FilterPropertyLink({ property, value, filters, onClick }) {
         ? filters.properties
         : parseProperties(filters.properties)
 
+    // In case the property we're linking to is already in the filter, remove it, otherwise add it
     const properties = cleanedProperties.find(p => p.key === property && p.value === value && !p.operator)
         ? cleanedProperties.filter(p => p.key !== property || p.value !== value || p.operator)
         : [...cleanedProperties, { key: property, value: value }]

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
@@ -4,7 +4,7 @@ import { userLogic } from 'scenes/userLogic'
 import { objectsEqual } from 'lib/utils'
 import { router } from 'kea-router'
 
-function parseProperties(input) {
+export function parseProperties(input) {
     if (Array.isArray(input) || !input) return input
     // Old style dict properties
     return Object.entries(input).map(([key, value]) => {

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -24,7 +24,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true }) {
         newEvents,
         highlightEvents,
     } = useValues(logic)
-    const { updateProperty, setSelectedEvent, fetchNextEvents, flipSort, prependNewEvents } = useActions(logic)
+    const { setSelectedEvent, fetchNextEvents, flipSort, prependNewEvents } = useActions(logic)
     const {
         location: { search },
     } = useValues(router)
@@ -74,7 +74,6 @@ export function EventsTable({ fixedFilters, filtersEnabled = true }) {
                                     selectedEvent={selectedEvent}
                                     properties={properties}
                                     setSelectedEvent={setSelectedEvent}
-                                    setFilter={updateProperty}
                                     filtersEnabled={filtersEnabled}
                                     showLinkToPerson={showLinkToPerson}
                                 />

--- a/frontend/src/scenes/events/eventsTableLogic.js
+++ b/frontend/src/scenes/events/eventsTableLogic.js
@@ -20,7 +20,6 @@ export const eventsTableLogic = kea({
 
     actions: () => ({
         setProperties: properties => ({ properties }),
-        updateProperty: (key, value) => ({ key, value }),
         fetchEvents: (nextParams = null) => ({ nextParams }),
         fetchEventsSuccess: (events, hasNext = false, isNext = false) => ({ events, hasNext, isNext }),
         fetchNextEvents: true,
@@ -38,10 +37,9 @@ export const eventsTableLogic = kea({
         // we use it to NOT update the filters when the user moves away from this path, yet the scene is still active
         initialPathname: [state => router.selectors.location(state).pathname, { noop: a => a }],
         properties: [
-            {},
+            [],
             {
                 setProperties: (_, { properties }) => properties,
-                updateProperty: (state, { key, value }) => ({ ...state, [key]: value }),
             },
         ],
         isLoading: [
@@ -133,9 +131,6 @@ export const eventsTableLogic = kea({
         setProperties: () => {
             return [router.values.location.pathname, values.propertiesForUrl]
         },
-        updateProperty: () => {
-            return [router.values.location.pathname, values.propertiesForUrl]
-        },
     }),
 
     urlToAction: ({ actions, values }) => ({
@@ -159,9 +154,6 @@ export const eventsTableLogic = kea({
 
     listeners: ({ actions, values, props }) => ({
         setProperties: () => {
-            actions.fetchEvents()
-        },
-        updateProperty: () => {
             actions.fetchEvents()
         },
         flipSort: () => {


### PR DESCRIPTION
## Changes

Fixes this case where if there was a filter active and you clicked on something in the events list to filter even more, the page crashed:

![screencast 2020-05-14 09-08-31](https://user-images.githubusercontent.com/53387/81905423-f5e86c00-95c4-11ea-9251-9bb3725dad83.gif)


## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
