### PR TITLE
Disable stickiness and breakdown

### DIFF
--- a/frontend/src/scenes/trends/BreakdownFilter.js
+++ b/frontend/src/scenes/trends/BreakdownFilter.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { selectStyle } from '../../lib/utils'
-import { Select, Tabs, Popover, Button } from 'antd'
+import { Tooltip, Select, Tabs, Popover, Button } from 'antd'
 import { useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { cohortsModel } from '../../models/cohortsModel'
@@ -78,8 +78,9 @@ function Content({ breakdown, breakdown_type, onChange }) {
     )
 }
 
-export function BreakdownFilter({ breakdown, breakdown_type, onChange }) {
+export function BreakdownFilter({ filters, onChange }) {
     const { cohorts } = useValues(cohortsModel)
+    const { breakdown, breakdown_type, shown_as } = filters
     let [open, setOpen] = useState(false)
     let label = breakdown
     if (breakdown_type === 'cohort' && breakdown) {
@@ -106,9 +107,13 @@ export function BreakdownFilter({ breakdown, breakdown_type, onChange }) {
             trigger="click"
             placement="bottomLeft"
         >
-            <Button shape="round" type={breakdown ? 'primary' : 'default'}>
-                {label || 'Add breakdown'}
-            </Button>
+            <Tooltip
+                title={shown_as == 'Stickiness' && 'Break down by is not yet available in combination with Stickiness'}
+            >
+                <Button shape="round" type={breakdown ? 'primary' : 'default'} disabled={shown_as == 'Stickiness'}>
+                    {label || 'Add breakdown'}
+                </Button>
+            </Tooltip>
         </Popover>
     )
 }

--- a/frontend/src/scenes/trends/ShownAsFilter.js
+++ b/frontend/src/scenes/trends/ShownAsFilter.js
@@ -1,19 +1,22 @@
 import React from 'react'
-import { Select, Row } from 'antd'
+import { Select, Row, Tooltip } from 'antd'
 
-export function ShownAsFilter({ shown_as, onChange }) {
+export function ShownAsFilter({ filters, onChange }) {
     return (
         <div>
             <Row>
-                <Select
-                    defaultValue={shown_as}
-                    value={shown_as || 'Volume'}
-                    onChange={value => onChange(value)}
-                    style={{ width: 200 }}
-                >
-                    <Select.Option value={'Volume'}>{'Volume'}</Select.Option>
-                    <Select.Option value={'Stickiness'}>{'Stickiness'}</Select.Option>
-                </Select>
+                <Tooltip title={filters.breakdown && 'Shown as is not yet available in combination with breakdown'}>
+                    <Select
+                        defaultValue={filters.shown_as}
+                        value={filters.shown_as || 'Volume'}
+                        onChange={value => onChange(value)}
+                        style={{ width: 200 }}
+                        disabled={filters.breakdown}
+                    >
+                        <Select.Option value={'Volume'}>{'Volume'}</Select.Option>
+                        <Select.Option value={'Stickiness'}>{'Stickiness'}</Select.Option>
+                    </Select>
+                </Tooltip>
             </Row>
         </div>
     )

--- a/frontend/src/scenes/trends/Trends.js
+++ b/frontend/src/scenes/trends/Trends.js
@@ -64,8 +64,7 @@ export function Trends() {
                                     </h4>
                                     <Row>
                                         <BreakdownFilter
-                                            breakdown={filters.breakdown}
-                                            breakdown_type={filters.breakdown_type}
+                                            filters={filters}
                                             onChange={(breakdown, breakdown_type) =>
                                                 setFilters({ breakdown, breakdown_type })
                                             }
@@ -90,10 +89,7 @@ export function Trends() {
                                             <small className="info">info</small>
                                         </Tooltip>
                                     </h4>
-                                    <ShownAsFilter
-                                        shown_as={filters.shown_as}
-                                        onChange={shown_as => setFilters({ shown_as })}
-                                    />
+                                    <ShownAsFilter filters={filters} onChange={shown_as => setFilters({ shown_as })} />
                                 </TabPane>
                                 <TabPane tab="Sessions" key={ViewType.SESSIONS}>
                                     <SessionFilter value={filters.session} onChange={v => setFilters({ session: v })} />


### PR DESCRIPTION
## Changes

- Disable buttons to avoid being able to select breakdown + stickiness

I think we should try to allow stickiness + breakdown but it got a little too complicated trying to automatically fetch the variations of the breakdown in 1 query. I just wanted to fix this sentry error quickly: https://sentry.io/organizations/posthog/issues/1665297099/?referrer=slack

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
