### PR TITLE
Minor event insert improvements

### DIFF
--- a/posthog/models/person.py
+++ b/posthog/models/person.py
@@ -28,7 +28,7 @@ class Person(models.Model):
 
     def add_distinct_id(self, distinct_id: str) -> None:
         PersonDistinctId.objects.create(
-            person=self, distinct_id=distinct_id, team=self.team
+            person=self, distinct_id=distinct_id, team_id=self.team_id
         )
 
     def add_distinct_ids(self, distinct_ids: List[str]) -> None:

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -66,6 +66,7 @@ def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_f
         old_person.delete()
 
 def _store_names_and_properties(team: Team, event: str, properties: Dict) -> None:
+    # In _capture we only prefetch a couple of fields in Team to avoid fetching too much data
     save = False
     if event not in team.event_names:
         save = True

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -146,6 +146,7 @@ def _handle_timestamp(data: dict, now: str, sent_at: Optional[str]) -> Union[dat
 
 @shared_task
 def process_event(distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str]) -> None:
+    print("IM EXECUTED HERE")
     if data['event'] == '$create_alias':
         _alias(previous_distinct_id=data['properties']['alias'], distinct_id=distinct_id, team_id=team_id)
 

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -65,8 +65,7 @@ def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_f
 
         old_person.delete()
 
-def _store_names_and_properties(team_id: int, event: str, properties: Dict) -> None:
-    team = Team.objects.get(pk=team_id)
+def _store_names_and_properties(team: Team, event: str, properties: Dict) -> None:
     save = False
     if event not in team.event_names:
         save = True
@@ -97,17 +96,18 @@ def _capture(ip: str, site_url: str, team_id: int, event: str, distinct_id: str,
             ) for index, el in enumerate(elements)
         ]
     properties["$ip"] = ip
+    team = Team.objects.only('slack_incoming_webhook', 'event_names', 'event_properties').get(pk=team_id)
 
     Event.objects.create(
         event=event,
         distinct_id=distinct_id,
         properties=properties,
-        team_id=team_id,
+        team=team,
         site_url=site_url,
         **({'timestamp': timestamp} if timestamp else {}),
         **({'elements': elements_list} if elements_list else {})
     )
-    _store_names_and_properties(team_id=team_id, event=event, properties=properties)
+    _store_names_and_properties(team=team, event=event, properties=properties)
     # try to create a new person
     try:
         Person.objects.create(team_id=team_id, distinct_ids=[str(distinct_id)])
@@ -146,7 +146,6 @@ def _handle_timestamp(data: dict, now: str, sent_at: Optional[str]) -> Union[dat
 
 @shared_task
 def process_event(distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str]) -> None:
-    print("IM EXECUTED HERE")
     if data['event'] == '$create_alias':
         _alias(previous_distinct_id=data['properties']['alias'], distinct_id=distinct_id, team_id=team_id)
 

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -11,11 +11,12 @@ class ProcessEvent(BaseTest):
     def test_capture_new_person(self) -> None:
         user = self._create_user('tim')
         action1 = Action.objects.create(team=self.team)
-        ActionStep.objects.create(action=action1, selector='a')
+        ActionStep.objects.create(action=action1, selector='a', event='$autocapture')
         action2 = Action.objects.create(team=self.team)
-        ActionStep.objects.create(action=action2, selector='a')
+        ActionStep.objects.create(action=action2, selector='a', event='$autocapture')
+        team_id = self.team.pk
 
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(19):
             process_event(2, '', '', {
                 'event': '$autocapture',
                 'properties': {
@@ -26,7 +27,7 @@ class ProcessEvent(BaseTest):
                         {'tag_name': 'div', 'nth_child': 1, 'nth_of_type': 2, '$el_text': '💻'}
                     ]
                 },
-            }, self.team.pk, now().isoformat(), now().isoformat())
+            }, team_id, now().isoformat(), now().isoformat())
 
         self.assertEqual(Person.objects.get().distinct_ids, ["2"])
         event = Event.objects.get()


### PR DESCRIPTION
## Changes

- Only load the Team object once instead of twice
- Only load fields we need
- Save another query if we don't store actions

## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
