### PR TITLE
Update "See Documentation" URL in Actions

### DIFF
--- a/frontend/src/scenes/actions/ActionsTable.js
+++ b/frontend/src/scenes/actions/ActionsTable.js
@@ -82,7 +82,7 @@ export function ActionsTable() {
                     Funnels, Live actions and Trends.
                     <br />
                     <br />
-                    <a href="https://github.com/PostHog/posthog/wiki/Actions" target="_blank" rel="noopener noreferrer">
+                    <a href="https://docs.posthog.com/#/features/actions" target="_blank" rel="noopener noreferrer">
                         See documentation
                     </a>
                 </i>

--- a/frontend/src/scenes/actions/ActionsTable.js
+++ b/frontend/src/scenes/actions/ActionsTable.js
@@ -82,7 +82,7 @@ export function ActionsTable() {
                     Funnels, Live actions and Trends.
                     <br />
                     <br />
-                    <a href="https://docs.posthog.com/#/features/actions" target="_blank" rel="noopener noreferrer">
+                    <a href="https://posthog.com/docs/features/actions" target="_blank" rel="noopener noreferrer">
                         See documentation
                     </a>
                 </i>


### PR DESCRIPTION
Current URL 30X redirects to your github page. Actual URL seems like it should be: https://docs.posthog.com/#/features/actions

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
