### PR TITLE
Sidebar divider fix and CSS cleanup

### DIFF
--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -3,7 +3,7 @@ import './Sidebar.scss'
 import React, { useState } from 'react'
 import { router } from 'kea-router'
 import { InviteTeam } from 'lib/components/InviteTeam'
-import { Menu, Layout, Modal, Divider } from 'antd'
+import { Menu, Layout, Modal } from 'antd'
 import {
     UserOutlined,
     ForkOutlined,
@@ -92,7 +92,7 @@ export default function Sidebar(props) {
                         <Link to={`/dashboard/${dashboard.id}`} />
                     </Menu.Item>
                 ))}
-                {pinnedDashboards.length > 0 ? <Divider /> : null}
+                {pinnedDashboards.length > 0 ? <Menu.Divider /> : null}
 
                 <Menu.Item key="trends" style={itemStyle}>
                     <RiseOutlined />

--- a/frontend/src/layout/Sidebar.scss
+++ b/frontend/src/layout/Sidebar.scss
@@ -1,3 +1,14 @@
 .ant-layout-sider-zero-width-trigger {
     top: 10px;
 }
+.ant-menu-dark .ant-menu-item-divider {
+    opacity: 0.1;
+    margin: 16px 0;
+}
+.sidebar-label {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+.ant-menu-dark .ant-menu-inline.ant-menu-sub {
+    background: hsla(210, 19%, 19%, 1) !important;
+}

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -252,22 +252,8 @@ label.disabled {
     margin-left: 8px;
 }
 
-.sidebar-label {
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
 .ant-layout.bg-dashboard {
     background: var(--gray-background);
-}
-
-.ant-menu-dark .ant-menu-inline.ant-menu-sub {
-    background: hsla(210, 19%, 19%, 1) !important;
-}
-
-.ant-menu-dark .ant-divider {
-    opacity: 0.1;
-    margin: 16px 0;
 }
 
 .ant-modal-mask {


### PR DESCRIPTION
Some leftovers from the touch dashboards & sidebar task.

## Changes

- use a menu divider that doesn't throw a million console errors
- move some sidebar css closer to component
