### PR TITLE
Use the correct $screen_name parameter for screen names

### DIFF
--- a/frontend/src/scenes/events/EventRow.js
+++ b/frontend/src/scenes/events/EventRow.js
@@ -48,7 +48,7 @@ export function EventRow({
                 let value = event.properties[param]
 
                 if (param === '$current_url' && !value) {
-                    param = '$screen'
+                    param = '$screen_name'
                     value = event.properties[param]
                 }
 


### PR DESCRIPTION
## Changes

We changed the screen name property to `$screen_name` at some point, yet the events table was still trying to use $screen. This fixes that

![image](https://user-images.githubusercontent.com/53387/82422538-df3d8b80-9a82-11ea-8e5d-b4fc180f6810.png)


## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
