### PR TITLE
Fix colored dashboard item table background

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -75,10 +75,6 @@
         background: transparent;
     }
 
-    table.table {
-        margin: 0;
-    }
-
     &.blue {
         --item-background: hsl(212, 63%, 40%);
         --item-darker: hsl(212, 63%, 35%);
@@ -139,11 +135,20 @@
         h1 {
             color: rgba(255, 255, 255, 0.9);
         }
-        table.table {
-            color: white;
-            tr td,
-            tr th {
-                border-top-color: rgba(255, 255, 255, 0.2);
+        .ant-table {
+            background: none;
+            table {
+                color: white;
+                tr td,
+                tr th {
+                    color: white;
+                    background: rgba(255, 255, 255, 0.1);
+                    border-top-color: rgba(255, 255, 255, 0.2);
+                    border-bottom-color: rgba(255, 255, 255, 0.2);
+                }
+                tr th {
+                    background: rgba(255, 255, 255, 0.2);
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes

Fix tables on dashboard on items with colored backgrounds. Moving to antd tables broke the styling.

Before:
<img width="399" alt="Screenshot 2020-05-25 at 11 12 49" src="https://user-images.githubusercontent.com/53387/82799047-b26de780-9e79-11ea-9d41-470d749f6d8f.png">

After:
![image](https://user-images.githubusercontent.com/53387/82799106-ca456b80-9e79-11ea-85e6-8fa6e736a344.png)


## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
