### PR TITLE
sentry request_bodies to always

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -42,7 +42,8 @@ if not DEBUG and not TEST:
     if os.environ.get('SENTRY_DSN'):
         sentry_sdk.init(
             dsn=os.environ['SENTRY_DSN'],
-            integrations=[DjangoIntegration()]
+            integrations=[DjangoIntegration()],
+            request_bodies="always",
         )
 
 if os.environ.get('DISABLE_SECURE_SSL_REDIRECT'):


### PR DESCRIPTION
## Changes

- It's hard to debug some errors when sentry cuts off the request body.
- This PR set the `request_bodies` key in sentry's configuration to `"always"`
- [From the docs](https://docs.sentry.io/error-reporting/configuration/?platform=python#request-bodies): "always: the SDK will always capture the request body for as long as sentry can make sense of it" (vs "medium" that captures the first 10kb)

The hope is that this fix will give us better data in sentry to help figure out why some event captures fail.

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
