### PR TITLE
Fix selecting filters

### DIFF
--- a/cypress/integration/trends_elements.js
+++ b/cypress/integration/trends_elements.js
@@ -30,10 +30,6 @@ describe('Trends actions & events', () => {
     })
 
     it('Apply 1 overall filter', () => {
-        cy.contains('Add action/event').click()
-        cy.get('[data-attr=trend-element-subject-1]').click()
-        cy.contains('Pageviews').click()
-
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=prop-filter-event-1]').click()
         cy.get('[data-attr=prop-val]').click()

--- a/frontend/src/scenes/trends/Trends.js
+++ b/frontend/src/scenes/trends/Trends.js
@@ -52,7 +52,11 @@ export function Trends() {
                                     <ActionFilter filters={filters} setFilters={setFilters} typeKey="trends" />
                                     <hr />
                                     <h4 className="secondary">Filters</h4>
-                                    <PropertyFilters pageKey="trends-filters" style={{ marginBottom: 0 }} />
+                                    <PropertyFilters
+                                        pageKey="trends-filters"
+                                        style={{ marginBottom: 0 }}
+                                        onChange={properties => setFilters({ properties })}
+                                    />
                                     <hr />
                                     <h4 className="secondary">
                                         Break down by

--- a/frontend/src/scenes/trends/Trends.js
+++ b/frontend/src/scenes/trends/Trends.js
@@ -52,11 +52,7 @@ export function Trends() {
                                     <ActionFilter filters={filters} setFilters={setFilters} typeKey="trends" />
                                     <hr />
                                     <h4 className="secondary">Filters</h4>
-                                    <PropertyFilters
-                                        pageKey="trends-filters"
-                                        style={{ marginBottom: 0 }}
-                                        onChange={properties => setFilters({ properties })}
-                                    />
+                                    <PropertyFilters pageKey="trends-filters" style={{ marginBottom: 0 }} />
                                     <hr />
                                     <h4 className="secondary">
                                         Break down by

--- a/frontend/src/scenes/trends/trendsLogic.js
+++ b/frontend/src/scenes/trends/trendsLogic.js
@@ -236,8 +236,13 @@ export const trendsLogic = kea({
 
             const cleanSearchParams = cleanFilters(searchParams)
 
+            const keys = Object.keys(searchParams)
             // opening /trends without any params, just open $pageview, $screen or the first random event
-            if (Object.keys(searchParams).length === 0 && values.eventNames && values.eventNames[0]) {
+            if (
+                (keys.length === 0 || (keys.length === 1 && keys[0] === 'properties')) &&
+                values.eventNames &&
+                values.eventNames[0]
+            ) {
                 const event = values.eventNames.includes('$pageview')
                     ? '$pageview'
                     : values.eventNames.includes('$screen')


### PR DESCRIPTION
## Changes

- Previously, if you selected a filter on the /trends page without touching the entities, it would just go blank and you'd have to reselect $pageview event


## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [x] Cypress E2E tests (if applicable)
