### PR TITLE
move dashboard menu item up

### DIFF
--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -96,18 +96,19 @@ export default function Sidebar(props) {
                         <Link to={`/dashboard/${dashboard.id}`} />
                     </Menu.Item>
                 ))}
+
+                <Menu.Item key="dashboards" style={itemStyle} data-attr="menu-item-dashboards">
+                    <FundOutlined />
+                    <span className="sidebar-label">Dashboards</span>
+                    <Link to="/dashboard" />
+                </Menu.Item>
+
                 {pinnedDashboards.length > 0 ? <Menu.Divider /> : null}
 
                 <Menu.Item key="trends" style={itemStyle} data-attr="menu-item-trends">
                     <RiseOutlined />
                     <span className="sidebar-label">{'Trends'}</span>
                     <Link to={'/trends'} />
-                </Menu.Item>
-
-                <Menu.Item key="dashboards" style={itemStyle} data-attr="menu-item-dashboards">
-                    <FundOutlined />
-                    <span className="sidebar-label">Dashboards</span>
-                    <Link to="/dashboard" />
                 </Menu.Item>
 
                 <Menu.SubMenu


### PR DESCRIPTION
## Changes

This PR moves the "dashboards" sidebar item above "trends" and above the divider.

Before:
![image](https://user-images.githubusercontent.com/53387/82898052-e79d3700-9f58-11ea-8e33-bd7bac795d0f.png)

After:
![image](https://user-images.githubusercontent.com/53387/82898097-fbe13400-9f58-11ea-8836-0367de989921.png)

I think it's a bit cleaner this way. It felt weird having "trends" wedged in between all the dashboard items.

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
