### PR TITLE
Ignore invalid utf8

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from posthog.tasks.process_event import process_event
 from datetime import datetime
 from dateutil import parser
+from sentry_sdk import push_scope
 import re
 import json
 import base64
@@ -38,6 +39,10 @@ def _load_data(request) -> Optional[Union[Dict, List]]:
         data = request.GET.get('data')
     if not data:
         return None
+
+    # add the data in sentry's scope in case there's an exception
+    with push_scope() as scope:
+        scope.set_context("data", data)
 
     #  Is it plain json?
     try:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -49,7 +49,12 @@ def _load_data(request) -> Optional[Union[Dict, List]]:
         data = json.loads(data)
     except json.JSONDecodeError:
         # if not, it's probably base64 encoded from other libraries
-        data = json.loads(base64.b64decode(data + "===").decode('utf8', 'surrogatepass').encode('utf-16', 'surrogatepass'))
+        data = base64.b64decode(data + "===")
+        try:
+            data = data.decode('utf8', 'surrogatepass').encode('utf-16', 'surrogatepass')
+        except:
+            data = data.decode('utf8', 'ignore').encode('utf-16', 'surrogatepass')
+        data = json.loads(data)
     # FIXME: data can also be an array, function assumes it's either None or a dictionary.
     return data
 


### PR DESCRIPTION
## Changes

This should fix a bunch of errors we've been getting on app.posthog.com, where there is random gibberish in the payload (e.g. URLs with non-utf8 or raw binary query params). 

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
