### PR TITLE
Refactor Paths and add property filtering

### DIFF
--- a/frontend/src/lib/components/PathSelect.js
+++ b/frontend/src/lib/components/PathSelect.js
@@ -5,7 +5,8 @@ const options = {
     $pageview: 'Pageview (Web)',
     $screen: 'Screen (Mobile)',
     $autocapture: 'Autocaptured Events',
-    custom_event: 'All Other Events',
+    custom_event: 'Custom Events',
+    all: 'All Events',
 }
 
 export function PathSelect(props) {

--- a/frontend/src/lib/components/PathSelect.js
+++ b/frontend/src/lib/components/PathSelect.js
@@ -6,7 +6,6 @@ const options = {
     $screen: 'Screen (Mobile)',
     $autocapture: 'Autocaptured Events',
     custom_event: 'Custom Events',
-    all: 'All Events',
 }
 
 export function PathSelect(props) {

--- a/frontend/src/lib/components/PathSelect.js
+++ b/frontend/src/lib/components/PathSelect.js
@@ -10,7 +10,13 @@ const options = {
 
 export function PathSelect(props) {
     return (
-        <Select bordered={false} defaultValue="$pageview" dropdownMatchSelectWidth={false} {...props}>
+        <Select
+            value={props.value || '$pageview'}
+            bordered={false}
+            defaultValue="$pageview"
+            dropdownMatchSelectWidth={false}
+            {...props}
+        >
             {Object.entries(options).map(([value, name], index) => {
                 return (
                     <Select.Option key={index} value={value}>

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -1,12 +1,14 @@
 import React, { useRef, useState, useEffect } from 'react'
 import api from 'lib/api'
-import { toParams, Card, Loading } from 'lib/utils'
+import { Card, Loading } from 'lib/utils'
 import { DateFilter } from 'lib/components/DateFilter'
 import { PathSelect } from '~/lib/components/PathSelect'
 import { Row, Modal, Button, Spin } from 'antd'
 import { EventElements } from 'scenes/events/EventElements'
 import * as d3 from 'd3'
 import * as Sankey from 'd3-sankey'
+
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 
 import { useActions, useValues } from 'kea'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
@@ -225,6 +227,7 @@ export function Paths() {
     return (
         <div>
             <h1 className="page-header">Paths</h1>
+            <PropertyFilters pageKey="Paths" />
             <Card
                 title={
                     <Row justify="space-between">

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -233,7 +233,7 @@ export function Paths() {
                     <Row justify="space-between">
                         <Row align="middle">
                             Path Type:
-                            <PathSelect onChange={value => setFilter({ type: value })} />
+                            <PathSelect value={filter.type} onChange={value => setFilter({ type: value })} />
                         </Row>
                         <DateFilter
                             onChange={(date_from, date_to) =>

--- a/frontend/src/scenes/paths/pathsLogic.js
+++ b/frontend/src/scenes/paths/pathsLogic.js
@@ -1,0 +1,62 @@
+import { kea } from 'kea'
+import { toParams } from 'lib/utils'
+import api from 'lib/api'
+
+export const pathsLogic = kea({
+    loaders: ({ values }) => ({
+        paths: {
+            __default: {
+                nodes: [],
+                links: [],
+            },
+            loadPaths: async (_, breakpoint) => {
+                const params = toParams(values.filter)
+                const paths = await api.get(`api/paths${params ? `/?${params}` : ''}`)
+                const response = {
+                    nodes: [
+                        ...paths.map(path => ({ name: path.source, id: path.source_id })),
+                        ...paths.map(path => ({ name: path.target, id: path.target_id })),
+                    ],
+                    links: paths,
+                }
+                breakpoint()
+                return response
+            },
+        },
+    }),
+
+    reducers: () => ({
+        filter: [
+            {
+                dateFrom: null,
+                dateTo: null,
+            },
+            {
+                setFilter: (state, filter) => ({ ...state, ...filter }),
+            },
+        ],
+        properties: [
+            {},
+            {
+                setProperties: (_, { properties }) => properties,
+            },
+        ],
+    }),
+
+    actions: () => ({
+        setProperties: properties => ({ properties }),
+        setFilter: filter => filter,
+    }),
+
+    listeners: ({ actions }) => ({
+        setProperties: () => {
+            actions.loadPaths()
+        },
+        setFilter: () => {
+            actions.loadPaths()
+        },
+    }),
+    events: ({ actions }) => ({
+        afterMount: actions.loadPaths,
+    }),
+})

--- a/frontend/src/scenes/paths/pathsLogic.js
+++ b/frontend/src/scenes/paths/pathsLogic.js
@@ -2,6 +2,7 @@ import { kea } from 'kea'
 import { toParams, objectsEqual } from 'lib/utils'
 import api from 'lib/api'
 import { router } from 'kea-router'
+import lo from 'lodash'
 
 export const pathsLogic = kea({
     loaders: ({ values }) => ({
@@ -25,7 +26,6 @@ export const pathsLogic = kea({
             },
         },
     }),
-
     reducers: () => ({
         initialPathname: [state => router.selectors.location(state).pathname, { noop: a => a }],
         filter: [
@@ -44,12 +44,10 @@ export const pathsLogic = kea({
             },
         ],
     }),
-
     actions: () => ({
         setProperties: properties => ({ properties }),
         setFilter: filter => filter,
     }),
-
     listeners: ({ actions }) => ({
         setProperties: () => {
             actions.loadPaths()
@@ -88,7 +86,12 @@ export const pathsLogic = kea({
                 return
             }
 
-            if (!objectsEqual(searchParams.properties || {}, values.properties)) {
+            if (
+                !objectsEqual(
+                    (!lo.isEmpty(searchParams.properties) && searchParams.properties) || {},
+                    values.properties
+                )
+            ) {
                 actions.setProperties(searchParams.properties || {})
             }
         },

--- a/frontend/src/scenes/paths/pathsLogic.js
+++ b/frontend/src/scenes/paths/pathsLogic.js
@@ -29,10 +29,7 @@ export const pathsLogic = kea({
     reducers: () => ({
         initialPathname: [state => router.selectors.location(state).pathname, { noop: a => a }],
         filter: [
-            {
-                dateFrom: null,
-                dateTo: null,
-            },
+            {},
             {
                 setFilter: (state, filter) => ({ ...state, ...filter }),
             },
@@ -58,18 +55,27 @@ export const pathsLogic = kea({
     }),
     selectors: ({ selectors }) => ({
         propertiesForUrl: [
-            () => [selectors.properties],
-            properties => {
-                if (Object.keys(properties).length > 0) {
-                    return { properties }
-                } else {
-                    return ''
+            () => [selectors.properties, selectors.filter],
+            (properties, filter) => {
+                let result = {}
+                if (!lo.isEmpty(properties)) {
+                    result['properties'] = properties
                 }
+
+                if (!lo.isEmpty(filter)) {
+                    result['filter'] = filter
+                }
+
+                if (lo.isEmpty(result)) return ''
+                return result
             },
         ],
     }),
     actionToUrl: ({ values }) => ({
         setProperties: () => {
+            return [router.values.location.pathname, values.propertiesForUrl]
+        },
+        setFilter: () => {
             return [router.values.location.pathname, values.propertiesForUrl]
         },
     }),
@@ -93,6 +99,10 @@ export const pathsLogic = kea({
                 )
             ) {
                 actions.setProperties(searchParams.properties || {})
+            }
+
+            if (!objectsEqual(!lo.isEmpty(searchParams.filter) || {}, values.filter)) {
+                actions.setFilter(searchParams.filter || {})
             }
         },
     }),

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from django.db.models.expressions import Window
 from django.db.models.functions import Lag
-from django.db.models import F
+from django.db.models import F, Q
 from django.db import connection
 
 import json
@@ -53,7 +53,7 @@ class PathsViewSet(viewsets.ViewSet):
                 **({"event":event} if event else {'event__regex':'^[^\$].*'}), #anything without $ (default)
                 **date_query
             )\
-            .filter(Filter(data={'properties': json.loads(properties)}).properties_to_Q() if properties else {})\
+            .filter(Filter(data={'properties': json.loads(properties)}).properties_to_Q() if properties else Q())\
             .annotate(previous_timestamp=Window(
                 expression=Lag('timestamp', default=None),
                 partition_by=F('distinct_id'),

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -1,15 +1,17 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
-from posthog.models import Event, PersonDistinctId, Team, ElementGroup, Element
-from posthog.utils import request_to_date_query, dict_from_cursor_fetchall
-from django.db.models import Subquery, OuterRef, Count, QuerySet
+from posthog.models import Event, Filter
+from posthog.utils import request_to_date_query
+from django.db.models import OuterRef
 from django.db import connection
-from typing import List, Optional
+from typing import Optional
 
 from django.db.models.expressions import Window
 from django.db.models.functions import Lag
 from django.db.models import F
 from django.db import connection
+
+import json
 
 # At the moment, paths don't support users changing distinct_ids midway through.
 # See: https://github.com/PostHog/posthog/issues/185
@@ -44,12 +46,14 @@ class PathsViewSet(viewsets.ViewSet):
         resp = []
         date_query = request_to_date_query(request.GET)
         event, path_type = self._determine_path_type(request)
+        properties = request.GET.get('properties')
 
         sessions = Event.objects.filter(
                 team=team,
                 **({"event":event} if event else {'event__regex':'^[^\$].*'}), #anything without $ (default)
                 **date_query
             )\
+            .filter(Filter(data={'properties': json.loads(properties)}).properties_to_Q() if properties else {})\
             .annotate(previous_timestamp=Window(
                 expression=Lag('timestamp', default=None),
                 partition_by=F('distinct_id'),

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -24,7 +24,7 @@ class PathsViewSet(viewsets.ViewSet):
         
         # Default
         event: Optional[str] = "$pageview"
-        event_filter = {}
+        event_filter = {"event":event}
         path_type = "properties->> \'$current_url\'"
 
         # determine requested type
@@ -41,10 +41,6 @@ class PathsViewSet(viewsets.ViewSet):
                 event = None
                 event_filter = {'event__regex':'^[^\$].*'}
                 path_type = "event"
-            elif requested_type == "all":
-                event = None
-                path_type = "event"
-                event_filter = {}
         return event, path_type, event_filter
 
     # FIXME: Timestamp is timezone aware timestamp, date range uses naive date.

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -52,7 +52,7 @@ class PathsViewSet(viewsets.ViewSet):
         event, path_type, event_filter = self._determine_path_type(request)
         properties = request.GET.get('properties')
 
-        sessions = Event.objects.filter(
+        sessions = Event.objects.add_person_id(team.pk).filter(
                 team=team,
                 **(event_filter), #anything without $ (default)
                 **date_query


### PR DESCRIPTION
## Changes
- refactor paths to use hook with kea logic
- fixes a bug where paths weren't always loading (because the sankey and d3 librariers weren't always loading on time)
- add property filtering on paths
- address #849 

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
