### PR TITLE
Improve app urls

### DIFF
--- a/cypress/integration/setup.js
+++ b/cypress/integration/setup.js
@@ -1,9 +1,24 @@
 describe('Setup', () => {
-    beforeEach(() => {
+    it('Setup loaded', () => {
         cy.get('[data-attr=menu-item-setup]').click()
+        cy.get('[data-attr=layout-content]').should('exist')
     })
 
-    it('Setup loaded', () => {
-        cy.get('[data-attr=layout-content]').should('exist')
+    it('See suggestion and save', () => {
+        cy.getCookie('csrftoken')
+        .then((csrftoken) => {
+            cy.request({
+                url: '/api/user/',
+                body: {team: {app_urls: []}},
+                method: 'PATCH',
+                headers: {
+                'X-CSRFToken': csrftoken.value,
+            }})
+        })
+        cy.reload(true)
+        cy.get('[data-attr=menu-item-setup]').click()
+        cy.get('[data-attr=app-url-suggestion]').click()
+        cy.wait(500) // not ideal but toast has a delay render
+        cy.get('.Toastify__toast').should('contain', 'URLs saved')
     })
 })

--- a/cypress/integration/setup.js
+++ b/cypress/integration/setup.js
@@ -18,7 +18,6 @@ describe('Setup', () => {
         cy.reload(true)
         cy.get('[data-attr=menu-item-setup]').click()
         cy.get('[data-attr=app-url-suggestion]').click()
-        cy.wait(500) // not ideal but toast has a delay render
-        cy.get('.Toastify__toast').should('contain', 'URLs saved')
+        cy.get('[data-attr=app-url-item]').should('contain', '/demo')
     })
 })

--- a/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
+++ b/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
@@ -81,15 +81,6 @@ const appUrlsLogic = kea({
                 [actions.addUrl]: (state, { value }) => [...state].filter(item => value !== item),
             },
         ],
-        isSaved: [
-            false,
-            {
-                [actions.addUrl]: () => false,
-                [actions.removeUrl]: () => false,
-                [actions.updateUrl]: () => false,
-                [userLogic.actions.userUpdateSuccess]: (state, { updateKey }) => updateKey === 'SetupAppUrls' || state,
-            },
-        ],
     }),
 
     listeners: ({ values, sharedListeners, props }) => ({
@@ -112,7 +103,7 @@ const appUrlsLogic = kea({
 })
 
 export function EditAppUrls({ actionId, allowNavigation }) {
-    const { appUrls, suggestions, suggestionsLoading, isSaved } = useValues(appUrlsLogic({ actionId }))
+    const { appUrls, suggestions, suggestionsLoading } = useValues(appUrlsLogic({ actionId }))
     const { addUrl, addUrlAndGo, removeUrl, updateUrl } = useActions(appUrlsLogic({ actionId }))
     const [loadMore, setLoadMore] = useState()
 
@@ -136,7 +127,7 @@ export function EditAppUrls({ actionId, allowNavigation }) {
                     suggestions.slice(0, loadMore ? suggestions.length : 5).map(url => (
                         <List.Item
                             key={url}
-                            onClick={() => addUrlAndGo(url)}
+                            onClick={() => (allowNavigation ? addUrlAndGo(url) : addUrl(url))}
                             style={{ cursor: 'pointer', justifyContent: 'space-between' }}
                         >
                             <a href={url} onClick={e => e.preventDefault()}>
@@ -158,12 +149,6 @@ export function EditAppUrls({ actionId, allowNavigation }) {
                     </div>
                 )}
             </List>
-
-            {isSaved && (
-                <span className="text-success float-right" style={{ marginLeft: 10 }}>
-                    URLs saved.
-                </span>
-            )}
             <Button
                 type="link"
                 onClick={() => addUrl()}

--- a/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
+++ b/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
@@ -130,7 +130,7 @@ export function EditAppUrls({ actionId, allowNavigation }) {
                             onClick={() => (allowNavigation ? addUrlAndGo(url) : addUrl(url))}
                             style={{ cursor: 'pointer', justifyContent: 'space-between' }}
                         >
-                            <a href={url} onClick={e => e.preventDefault()}>
+                            <a href={url} onClick={e => e.preventDefault()} data-attr='app-url-suggestion'>
                                 {url}
                             </a>
                             <PlusOutlined style={{ color: 'var(--success)' }} />

--- a/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
+++ b/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
@@ -89,14 +89,14 @@ const appUrlsLogic = kea({
             await api.update('api/user', { team: { app_urls } })
             window.location.href = appEditorUrl(props.actionId, value)
         },
-        addUrl: sharedListeners.saveAppUrls,
         removeUrl: sharedListeners.saveAppUrls,
         updateUrl: sharedListeners.saveAppUrls,
     }),
 
     sharedListeners: ({ values }) => ({
-        saveAppUrls: () => {
-            toast('URLs saved', { toastId: 'EditAppUrls' })
+        saveAppUrls: ({ value }) => {
+            // Only show toast when clicking "Save"
+            if (value) toast('URLs saved', { toastId: 'EditAppUrls' })
             userLogic.actions.userUpdateRequest({ team: { app_urls: values.appUrls } }, 'SetupAppUrls')
         },
     }),
@@ -130,7 +130,7 @@ export function EditAppUrls({ actionId, allowNavigation }) {
                             onClick={() => (allowNavigation ? addUrlAndGo(url) : addUrl(url))}
                             style={{ cursor: 'pointer', justifyContent: 'space-between' }}
                         >
-                            <a href={url} onClick={e => e.preventDefault()} data-attr='app-url-suggestion'>
+                            <a href={url} onClick={e => e.preventDefault()} data-attr="app-url-suggestion">
                                 {url}
                             </a>
                             <PlusOutlined style={{ color: 'var(--success)' }} />

--- a/frontend/src/lib/components/AppEditorLink/UrlRow.js
+++ b/frontend/src/lib/components/AppEditorLink/UrlRow.js
@@ -68,7 +68,9 @@ export function UrlRow({ actionId, url, saveUrl, deleteUrl, allowNavigation }) {
                 </div>
             ) : (
                 <div key="list" style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                    <a href={appEditorUrl(actionId, editedValue)} onClick={e => !allowNavigation && e.preventDefault()}>
+                    <a
+                    data-attr="app-url-item"
+                    href={appEditorUrl(actionId, editedValue)} onClick={e => !allowNavigation && e.preventDefault()}>
                         {editedValue}
                     </a>
                     <span style={{ float: 'right' }}>


### PR DESCRIPTION
## Changes

- While doing the demos, a lot of people would click the suggested URL, and then sit around and wait for something to happen. Now clicking a suggestion takes you to the url immediately (if you're creating an action)
- Removed "URLs saved" message b/c we also have the toast
- Remove suggestions row if no suggestions

## Checklist
- [ ] Cypress E2E tests (if applicable)
