### PR TITLE
Event row hover color

### DIFF
--- a/frontend/src/style/events.scss
+++ b/frontend/src/style/events.scss
@@ -21,8 +21,10 @@
         text-align: center;
     }
     .event-row {
-        transition: background-color 2s;
         background-color: #fff;
+    }
+    .event-row:hover {
+        background-color: rgb(236, 236, 236);
     }
     .event-new-events {
         opacity: 1;


### PR DESCRIPTION
Sidenote: main blocker from changing event table and live action table to use antd is that we'll lose the custom rows that we're currently inserting to delineate the days

## Changes
- show a gray tint when hovering event rows to indicate that it's clickable for more info

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
