### PR TITLE
Tweak action toolbar

### DIFF
--- a/frontend/src/editor/index.js
+++ b/frontend/src/editor/index.js
@@ -87,9 +87,8 @@ class App extends Component {
             if (this.state.actions.filter(action => action.id === false).length == 0)
                 this.state.actions.push({ id: false })
         }
-        this.onActionSave = this.onActionSave.bind(this)
     }
-    onActionSave(action, isNew, createNew) {
+    onActionSave = (action, isNew, createNew) => {
         let { actions, openActionId } = this.state
         if (isNew) {
             actions = actions.map(a => (!a.id ? action : a))
@@ -99,12 +98,8 @@ class App extends Component {
         }
         if (createNew) {
             actions.push({ id: false })
-            openActionId = false
-        } else {
-            window.location.href = this.props.apiURL + 'action/' + action.id
-            sessionStorage.setItem('editorActions', '[]')
-            return sessionStorage.setItem('editorParams', '')
         }
+        openActionId = false
         this.setState({ actions, openActionId })
         sessionStorage.setItem('editorActions', JSON.stringify(actions))
     }
@@ -170,6 +165,7 @@ class App extends Component {
                                     {action.id && (
                                         <a
                                             href={this.props.apiURL + 'action/' + action.id}
+                                            onClick={() => sessionStorage.setItem('editorActions', '[]')}
                                             className="float-right mr-1"
                                         >
                                             View

--- a/frontend/src/editor/index.js
+++ b/frontend/src/editor/index.js
@@ -164,8 +164,17 @@ class App extends Component {
                                         href="#"
                                         className="float-right"
                                     >
-                                        edit
+                                        Edit
                                     </a>
+                                    {'  '}
+                                    {action.id && (
+                                        <a
+                                            href={this.props.apiURL + 'action/' + action.id}
+                                            className="float-right mr-1"
+                                        >
+                                            View
+                                        </a>
+                                    )}
                                 </div>
                             )
                         )}

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -143,7 +143,6 @@ export function ActionEdit({ actionId, apiURL, onSave, user, isEditor, simmer, s
                     {!isEditor ? addGroup : null}
                     <button
                         disabled={!edited}
-                        htmlType="submit"
                         data-attr="save-action-button"
                         className={
                             edited ? 'btn-success btn btn-sm float-right' : 'btn-secondary btn btn-sm float-right'

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -35,7 +35,14 @@ export function ActionEdit({ actionId, apiURL, onSave, user, isEditor, simmer, s
 
     return (
         <div className={isEditor ? '' : 'card'} style={{ marginTop: isEditor ? 8 : '' }}>
-            <form className={isEditor ? '' : 'card-body'} onSubmit={e => e.preventDefault()}>
+            <form
+                className={isEditor ? '' : 'card-body'}
+                onSubmit={e => {
+                    e.preventDefault()
+                    if (isEditor && showNewActionButton) setCreateNew(true)
+                    saveAction()
+                }}
+            >
                 <input
                     required
                     className="form-control"
@@ -135,9 +142,8 @@ export function ActionEdit({ actionId, apiURL, onSave, user, isEditor, simmer, s
                 <div className={isEditor ? 'btn-group save-buttons' : ''}>
                     {!isEditor ? addGroup : null}
                     <button
-                        type="submit"
                         disabled={!edited}
-                        onClick={() => saveAction()}
+                        htmlType="submit"
                         data-attr="save-action-button"
                         className={
                             edited ? 'btn-success btn btn-sm float-right' : 'btn-secondary btn btn-sm float-right'
@@ -145,20 +151,6 @@ export function ActionEdit({ actionId, apiURL, onSave, user, isEditor, simmer, s
                     >
                         Save action
                     </button>
-
-                    {isEditor && showNewActionButton && (
-                        <button
-                            type="submit"
-                            disabled={!edited}
-                            onClick={() => {
-                                setCreateNew(true)
-                                saveAction()
-                            }}
-                            className="btn btn-secondary btn-sm float-right"
-                        >
-                            Save & new action
-                        </button>
-                    )}
                 </div>
             </form>
         </div>

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -321,6 +321,7 @@ export class ActionStep extends Component {
                     >
                         {isEditor && [
                             <button
+                                key="inspect-button"
                                 type="button"
                                 className="btn btn-sm btn-secondary"
                                 style={{ margin: '10px 0px 10px 12px' }}
@@ -329,7 +330,7 @@ export class ActionStep extends Component {
                                 Inspect element
                             </button>,
                             this.state.inspecting && (
-                                <p style={{ marginLeft: 10, marginRight: 10 }}>
+                                <p key="inspect-prompt" style={{ marginLeft: 10, marginRight: 10 }}>
                                     Hover over and click on an element you want to create an action for
                                 </p>
                             ),

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -23,15 +23,9 @@ export class ActionStep extends Component {
         this.state = {
             step: props.step,
             selection: Object.keys(props.step).filter(key => key != 'id' && key != 'isNew' && props.step[key]),
+            inspecting: false,
         }
-        this.onMouseOver = this.onMouseOver.bind(this)
-        this.onKeyDown = this.onKeyDown.bind(this)
-        this.Option = this.Option.bind(this)
-        this.sendStep = this.sendStep.bind(this)
         this.AutocaptureFields = this.AutocaptureFields.bind(this)
-        this.TypeSwitcher = this.TypeSwitcher.bind(this)
-        this.URLMatching = this.URLMatching.bind(this)
-        this.stop = this.stop.bind(this)
 
         this.box = document.createElement('div')
         document.body.appendChild(this.box)
@@ -48,7 +42,7 @@ export class ActionStep extends Component {
         this.box.style.opacity = '0.5'
         this.box.style.zIndex = '9999999999'
     }
-    onMouseOver(event) {
+    onMouseOver = event => {
         let el = event.currentTarget
         this.drawBox(el)
         let query = this.props.simmer(el)
@@ -78,11 +72,12 @@ export class ActionStep extends Component {
             () => this.sendStep(step)
         )
     }
-    onKeyDown(event) {
+    onKeyDown = event => {
         // stop selecting if esc key was pressed
         if (event.keyCode == 27) this.stop()
     }
     start() {
+        this.setState({ inspecting: true })
         document.querySelectorAll('a, button, input, select, textarea, label').forEach(element => {
             element.addEventListener('mouseover', this.onMouseOver, {
                 capture: true,
@@ -94,7 +89,8 @@ export class ActionStep extends Component {
         document.body.style.boxShadow = 'inset 0 0px 30px -5px #007bff'
         this.box.addEventListener('click', this.stop)
     }
-    stop() {
+    stop = () => {
+        this.setState({ inspecting: false })
         this.box.style.display = 'none'
         document.body.style.boxShadow = 'none'
         document.querySelectorAll('a, button, input, select, textarea, label').forEach(element => {
@@ -104,11 +100,11 @@ export class ActionStep extends Component {
         })
         document.removeEventListener('keydown', this.onKeyDown)
     }
-    sendStep(step) {
+    sendStep = step => {
         step.selection = this.state.selection
         this.props.onChange(step)
     }
-    Option(props) {
+    Option = props => {
         let onChange = e => {
             this.props.step[props.item] = e.target.value
 
@@ -171,7 +167,7 @@ export class ActionStep extends Component {
             </div>
         )
     }
-    TypeSwitcher() {
+    TypeSwitcher = () => {
         let { step, isEditor } = this.props
         return (
             <div>
@@ -268,7 +264,7 @@ export class ActionStep extends Component {
             </div>
         )
     }
-    URLMatching({ step, isEditor }) {
+    URLMatching = ({ step, isEditor }) => {
         return (
             <div className="btn-group" style={{ margin: isEditor ? '4px 0 0 8px' : '0 0 0 8px' }}>
                 <button
@@ -320,9 +316,10 @@ export class ActionStep extends Component {
                     <div
                         style={{
                             marginTop: step.event === '$pageview' && !isEditor ? 20 : 8,
+                            paddingBottom: isEditor ? 1 : 0,
                         }}
                     >
-                        {isEditor && (
+                        {isEditor && [
                             <button
                                 type="button"
                                 className="btn btn-sm btn-secondary"
@@ -330,8 +327,13 @@ export class ActionStep extends Component {
                                 onClick={() => this.start()}
                             >
                                 Inspect element
-                            </button>
-                        )}
+                            </button>,
+                            this.state.inspecting && (
+                                <p style={{ marginLeft: 10, marginRight: 10 }}>
+                                    Hover over and click on an element you want to create an action for
+                                </p>
+                            ),
+                        ]}
 
                         {step.event === '$autocapture' && (
                             <this.AutocaptureFields step={step} isEditor={isEditor} actionId={actionId} />

--- a/frontend/src/scenes/actions/NewActionButton.js
+++ b/frontend/src/scenes/actions/NewActionButton.js
@@ -17,37 +17,47 @@ export function NewActionButton() {
                 style={{ cursor: 'pointer' }}
                 onCancel={() => setVisible(false)}
                 title="Create new action"
-                footer={<Button onClick={() => setVisible(true)}>Cancel</Button>}
+                footer={[
+                    appUrlsVisible && <Button onClick={() => setAppUrlsVisible(false)}>Back</Button>,
+                    <Button
+                        onClick={() => {
+                            setVisible(false)
+                            setAppUrlsVisible(false)
+                        }}
+                    >
+                        Cancel
+                    </Button>,
+                ]}
             >
-                <Row gutter={2} justify="space-between">
-                    <Col xs={11}>
-                        <Card title="Inspect element on your site" onClick={() => setAppUrlsVisible(true)} size="small">
-                            <div style={{ textAlign: 'center', fontSize: 40 }}>
-                                <SearchOutlined />
-                            </div>
-                        </Card>
-                    </Col>
-                    <Col xs={11}>
-                        <Card
-                            title="From event or pageview"
-                            onClick={() => {
-                                router.actions.push('/action')
-                            }}
-                            size="small"
-                        >
-                            <div style={{ textAlign: 'center', fontSize: 40 }} data-attr="new-action-pageview">
-                                <EditOutlined />
-                            </div>
-                        </Card>
-                    </Col>
-                </Row>
-            </Modal>
-            <Modal
-                visible={appUrlsVisible}
-                onCancel={() => setAppUrlsVisible(false)}
-                footer={<Button onClick={() => setAppUrlsVisible(true)}>Cancel</Button>}
-            >
-                <EditAppUrls allowNavigation={true} />
+                {!appUrlsVisible && (
+                    <Row gutter={2} justify="space-between">
+                        <Col xs={11}>
+                            <Card
+                                title="Inspect element on your site"
+                                onClick={() => setAppUrlsVisible(true)}
+                                size="small"
+                            >
+                                <div style={{ textAlign: 'center', fontSize: 40 }}>
+                                    <SearchOutlined />
+                                </div>
+                            </Card>
+                        </Col>
+                        <Col xs={11}>
+                            <Card
+                                title="From event or pageview"
+                                onClick={() => {
+                                    router.actions.push('/action')
+                                }}
+                                size="small"
+                            >
+                                <div style={{ textAlign: 'center', fontSize: 40 }} data-attr="new-action-pageview">
+                                    <EditOutlined />
+                                </div>
+                            </Card>
+                        </Col>
+                    </Row>
+                )}
+                {appUrlsVisible && <EditAppUrls allowNavigation={true} />}
             </Modal>
         </>
     )

--- a/frontend/src/scenes/actions/NewActionButton.js
+++ b/frontend/src/scenes/actions/NewActionButton.js
@@ -15,11 +15,19 @@ export function NewActionButton() {
             <Modal
                 visible={visible}
                 style={{ cursor: 'pointer' }}
-                onCancel={() => setVisible(false)}
+                onCancel={() => {
+                    setVisible(false)
+                    setAppUrlsVisible(false)
+                }}
                 title="Create new action"
                 footer={[
-                    appUrlsVisible && <Button onClick={() => setAppUrlsVisible(false)}>Back</Button>,
+                    appUrlsVisible && (
+                        <Button key="back-button" onClick={() => setAppUrlsVisible(false)}>
+                            Back
+                        </Button>
+                    ),
                     <Button
+                        key="cancel-button"
                         onClick={() => {
                             setVisible(false)
                             setAppUrlsVisible(false)

--- a/frontend/src/scenes/actions/actionEditLogic.js
+++ b/frontend/src/scenes/actions/actionEditLogic.js
@@ -60,7 +60,7 @@ export const actionEditLogic = kea({
             })
             try {
                 if (action.id) {
-                    action = await api.update(props.apiURL + 'api/action/' + action.id, action)
+                    action = await api.update(props.apiURL + 'api/action/' + action.id + '/', action)
                 } else {
                     action = await api.create(props.apiURL + 'api/action/', action)
                 }


### PR DESCRIPTION
## Changes
- fixes #889 
- took some liberties with reshaping the toolbar (removed save & new action, added a view button to redirect users back to posthog.com)
- updating an action on toolbar wasn't working
- updated new modal so it doesn't double over itself

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
