### PR TITLE
Run tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: python
+python:
+  - "3.7"
+#addons:
+#  postgresql: "12"
+cache:
+  pip: true
+  yarn: true
+  directories:
+    - $HOME/.cache/yarn
+env:
+  - DEBUG=1
+before_install:
+  - nvm install 12
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements/dev.txt
+  - yarn install
+services:
+  - postgresql
+  - redis
+jobs:
+  include:
+    - name: 'Unit Tests'
+      script: |
+          mkdir -p frontend/dist
+          touch frontend/dist/index.html
+          touch frontend/dist/layout.html
+          python manage.py test --keepdb -v 2
+    - name: 'MyPy'
+      script: mypy posthog
+    - name: 'Flake8'
+      script: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: 'Cypress'
+      script: |
+          yarn build
+          dropdb --if-exists posthog_e2e_test
+          createdb posthog_e2e_test
+          DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py migrate
+          DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler &
+          DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py runserver &
+          sleep 10
+          yarn run cypress run --config-file cypress.json


### PR DESCRIPTION
Hi! I got tired of the slow github actions, so I integrated Travis.

It's free for OSS and runs pretty well. Instead of building a new docker image every time, we just checkout the code, build locally what is needed and run the tests. The travis.com integration might need to be enabled for the posthog organisation before you see the tests run here, but you can see a run here: https://travis-ci.org/github/mariusandra/posthog

The "pytest" run takes about 3min. About 60sec of the tests goes under "yarn install". Caching that should yield a good boost. 30sec goes under "pip", which can probably be optimised further. Thus we can probably have it complete in 1.5min.

Unfortunately cypress still fails, but only for some pages. It took 12min from the start until the end, including the yarn, etc time we could shave off.

![image](https://user-images.githubusercontent.com/53387/83242959-82865300-a19d-11ea-8d14-0d82bbdc2798.png)

I'm not going to spend time investigating it further right now, as I really want to get to the toolbar :). However for cypress, the obvious next step is to split it up into multiple tests that run in parallel... and also cache the "yarn build" output.

I don't know how much parallelisation travis gives us by default, but we could surely get all the tests under 5min or so, with enough workers.