### PR TITLE
Fix menu scrollbar when mouse connected

### DIFF
--- a/frontend/src/layout/Sidebar.scss
+++ b/frontend/src/layout/Sidebar.scss
@@ -32,7 +32,7 @@ aside.ant-layout-sider {
     height: 100vh;
 
     .ant-layout-sider-children {
-        overflow-y: scroll;
+        overflow-y: auto;
     }
 
     .ant-layout-sider-zero-width-trigger {


### PR DESCRIPTION
## Changes

Fixes the browser from always having a scrollbar in the sidebar. Now it will only show if the content is long enough.

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
