### PR TITLE
add carets to drop downs in trend page

### DIFF
--- a/frontend/src/lib/components/Dropdown.js
+++ b/frontend/src/lib/components/Dropdown.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { CaretDownOutlined } from '@ant-design/icons'
+import { DownOutlined } from '@ant-design/icons'
 
 export function Dropdown({ className, style, 'data-attr': dataAttr, buttonStyle, children, buttonClassName, title }) {
     const [menuOpen, setMenuOpen] = useState(false)
@@ -27,8 +27,8 @@ export function Dropdown({ className, style, 'data-attr': dataAttr, buttonStyle,
             data-attr={dataAttr}
         >
             <a className={'cursor-pointer ' + buttonClassName} style={{ ...buttonStyle }} onClick={open} href="#">
-                <CaretDownOutlined />
                 {title || <span>&hellip;</span>}
+                <DownOutlined style={{ marginLeft: '3px', color: 'rgba(0, 0, 0, 0.25)' }} />
             </a>
             <div
                 className={'dropdown-menu ' + (menuOpen && 'show')}

--- a/frontend/src/lib/components/Dropdown.js
+++ b/frontend/src/lib/components/Dropdown.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { CaretDownOutlined } from '@ant-design/icons'
 
 export function Dropdown({ className, style, 'data-attr': dataAttr, buttonStyle, children, buttonClassName, title }) {
     const [menuOpen, setMenuOpen] = useState(false)
@@ -26,6 +27,7 @@ export function Dropdown({ className, style, 'data-attr': dataAttr, buttonStyle,
             data-attr={dataAttr}
         >
             <a className={'cursor-pointer ' + buttonClassName} style={{ ...buttonStyle }} onClick={open} href="#">
+                <CaretDownOutlined />
                 {title || <span>&hellip;</span>}
             </a>
             <div

--- a/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
@@ -7,7 +7,7 @@ import { ActionFilterDropdown } from './ActionFilterDropdown'
 import { Tooltip } from 'antd'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { userLogic } from 'scenes/userLogic'
-import { CaretDownOutlined } from '@ant-design/icons'
+import { DownOutlined } from '@ant-design/icons'
 
 const determineFilterLabel = (visible, filter) => {
     if (visible) return 'Hide Filters'
@@ -62,18 +62,17 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 onClick={onClick}
                 style={{
                     fontWeight: 500,
-                    borderBottom: '1.5px dotted var(--blue)',
                 }}
             >
-                <CaretDownOutlined />
                 {name || 'Select action'}
+                <DownOutlined style={{ marginLeft: '3px', color: 'rgba(0, 0, 0, 0.25)' }} />
             </button>
             {!hideMathSelector && <MathSelector math={math} index={index} onMathSelect={onMathSelect} />}
             <div
                 className="btn btn-sm btn-light"
                 onClick={() => setEntityFilterVisible(!entityFilterVisible)}
                 data-attr={'show-prop-filter-' + index}
-                style={{ marginLeft: 16 }}
+                style={{ marginTop: '8px', marginLeft: 16 }}
             >
                 {determineFilterLabel(entityFilterVisible, filter)}
             </div>

--- a/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
@@ -57,12 +57,10 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
             <button
                 data-attr={'trend-element-subject-' + index}
                 ref={node}
-                className="filter-action"
+                className="filter-action btn btn-sm btn-light"
                 type="button"
                 onClick={onClick}
                 style={{
-                    border: 0,
-                    padding: 0,
                     fontWeight: 500,
                     borderBottom: '1.5px dotted var(--blue)',
                 }}

--- a/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
@@ -7,6 +7,7 @@ import { ActionFilterDropdown } from './ActionFilterDropdown'
 import { Tooltip } from 'antd'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { userLogic } from 'scenes/userLogic'
+import { CaretDownOutlined } from '@ant-design/icons'
 
 const determineFilterLabel = (visible, filter) => {
     if (visible) return 'Hide Filters'
@@ -66,6 +67,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                     borderBottom: '1.5px dotted var(--blue)',
                 }}
             >
+                <CaretDownOutlined />
                 {name || 'Select action'}
             </button>
             {!hideMathSelector && <MathSelector math={math} index={index} onMathSelect={onMathSelect} />}

--- a/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
@@ -53,7 +53,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
         value = entity.id || filter.id
     }
     return (
-        <div>
+        <div className="mt-2">
             <button
                 data-attr={'trend-element-subject-' + index}
                 ref={node}
@@ -72,7 +72,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 className="btn btn-sm btn-light"
                 onClick={() => setEntityFilterVisible(!entityFilterVisible)}
                 data-attr={'show-prop-filter-' + index}
-                style={{ marginTop: '8px', marginLeft: 16 }}
+                style={{ marginLeft: 10, marginRight: 10 }}
             >
                 {determineFilterLabel(entityFilterVisible, filter)}
             </div>
@@ -80,7 +80,6 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 onClick={onClose}
                 style={{
                     float: 'none',
-                    marginLeft: 8,
                     position: 'absolute',
                     marginTop: 3,
                 }}
@@ -117,7 +116,7 @@ function MathSelector(props) {
         <Dropdown
             title={items[items.map(i => i.toLowerCase()).indexOf(props.math)] || 'Total'}
             buttonClassName="btn btn-sm btn-light"
-            style={{ marginLeft: 32 }}
+            style={{ marginLeft: 16 }}
             data-attr={'math-selector-' + props.index}
         >
             <Tooltip

--- a/frontend/src/scenes/trends/Trends.js
+++ b/frontend/src/scenes/trends/Trends.js
@@ -46,7 +46,7 @@ function _Trends() {
             <PeopleModal visible={showingPeople} />
             <h1 className="page-header">Trends</h1>
             <Row gutter={16}>
-                <Col xs={24} xl={6}>
+                <Col xs={24} xl={7}>
                     <Card>
                         <div className="card-body px-4">
                             <Tabs
@@ -117,7 +117,7 @@ function _Trends() {
                         </div>
                     </Card>
                 </Col>
-                <Col xs={24} xl={18}>
+                <Col xs={24} xl={17}>
                     <Card
                         title={
                             <div className="float-right pt-1 pb-1">


### PR DESCRIPTION
This just adds some clarity that these are drop down menus. 

There is a bug that needs fixing not related to this for $pageviews dropdown not looking like DAU Total dropdown.

![image](https://user-images.githubusercontent.com/391319/83698620-be168800-a5b6-11ea-96ec-437f4605ea53.png)


## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [x] Cypress E2E tests (if applicable)
