### PR TITLE
Wait for PostHog to start serving requests before running cypress

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,5 +21,5 @@ jobs:
 
       - name: Cypress run
         run: |
-          python cypress/wait.py 
+          python3 cypress/wait.py 
           yarn run cypress run --config-file cypress.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: 12
       - run: yarn install
-      
+
       - name: Prepare server
         run: docker-compose -f docker-compose.e2e.yml up -d
       - name: Check running containers
@@ -21,5 +21,5 @@ jobs:
 
       - name: Cypress run
         run: |
-          sleep 60
+          python cypress/wait.py 
           yarn run cypress run --config-file cypress.json

--- a/cypress/wait.py
+++ b/cypress/wait.py
@@ -1,15 +1,18 @@
+import datetime
+import http.client
 import time
-
-import requests
 
 
 def main():
     print("Waiting to run tests until PostHog is up and serving requests")
     booted = False
-    while not booted:
+    ts = datetime.datetime.now()
+    while not booted and (datetime.datetime.now() - ts).seconds < 240:
         try:
-            r = requests.get("http://127.0.0.1:8000/_health/")
-            if r.status_code == 200:
+            conn = http.client.HTTPConnection("127.0.0.1", 8000)
+            conn.request("GET", "/_health/")
+            r = conn.getresponse()
+            if r.status == 200:
                 booted = True
                 print("PostHog is alive! Proceeding")
                 continue

--- a/cypress/wait.py
+++ b/cypress/wait.py
@@ -8,7 +8,7 @@ def main():
     booted = False
     while not booted:
         try:
-            r = requests.get("http://127.0.0.1:8000/static/main.js")
+            r = requests.get("http://127.0.0.1:8000/_health/")
             if r.status_code == 200:
                 booted = True
                 print("PostHog is alive! Proceeding")

--- a/cypress/wait.py
+++ b/cypress/wait.py
@@ -17,7 +17,8 @@ def main():
                 print("PostHog is alive! Proceeding")
                 continue
             else:
-                print("PostHog is still building frontend. Sleeping for 1 second")
+                # recieved not 200 from PostHog, but service is up
+                print("PostHog is still booting. Sleeping for 1 second")
         except:
             print("PostHog is still booting. Sleeping for 1 second")
         time.sleep(1)

--- a/cypress/wait.py
+++ b/cypress/wait.py
@@ -1,0 +1,24 @@
+import time
+
+import requests
+
+
+def main():
+    print("Waiting to run tests until PostHog is up and serving requests")
+    booted = False
+    while not booted:
+        try:
+            r = requests.get("http://127.0.0.1:8000/static/main.js")
+            if r.status_code == 200:
+                booted = True
+                print("PostHog is alive! Proceeding")
+                continue
+            else:
+                print("PostHog is still building frontend. Sleeping for 1 second")
+        except:
+            print("PostHog is still booting. Sleeping for 1 second")
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Simply replaces the sleep for 60 seconds to wait for the health endpoint is up on PostHog