### PR TITLE
Closes #944 hide math selector on funnels

### DIFF
--- a/frontend/src/scenes/funnels/EditFunnel.js
+++ b/frontend/src/scenes/funnels/EditFunnel.js
@@ -50,6 +50,7 @@ function _EditFunnel({ funnelId }) {
                         filters={funnel.filters}
                         setFilters={filters => setFunnel({ filters }, false)}
                         typeKey={`EditFunnel-${funnel.id || 'new'}`}
+                        hideMathSelector={true}
                     />
                     <br />
                     <hr />

--- a/frontend/src/scenes/trends/ActionFilter/ActionFilter.js
+++ b/frontend/src/scenes/trends/ActionFilter/ActionFilter.js
@@ -4,7 +4,7 @@ import { entityFilterLogic } from './entityFilterLogic'
 import { ActionFilterRow } from './ActionFilterRow'
 import { Button } from 'antd'
 
-export function ActionFilter({ setFilters, filters, typeKey }) {
+export function ActionFilter({ setFilters, filters, typeKey, hideMathSelector }) {
     const logic = entityFilterLogic({ setFilters, filters, typeKey })
 
     const { localFilters } = useValues(logic)
@@ -20,7 +20,13 @@ export function ActionFilter({ setFilters, filters, typeKey }) {
         <div>
             {localFilters &&
                 localFilters.map((filter, index) => (
-                    <ActionFilterRow logic={logic} filter={filter} index={index} key={index} />
+                    <ActionFilterRow
+                        logic={logic}
+                        filter={filter}
+                        index={index}
+                        key={index}
+                        hideMathSelector={hideMathSelector}
+                    />
                 ))}
             <Button
                 type="primary"

--- a/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/trends/ActionFilter/ActionFilterRow.js
@@ -19,7 +19,7 @@ const determineFilterLabel = (visible, filter) => {
     return 'Add Filters'
 }
 
-export function ActionFilterRow({ logic, filter, index }) {
+export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
     const node = useRef()
     const { selectedFilter, entities } = useValues(logic)
     const { selectFilter, updateFilterMath, removeLocalFilter, updateFilterProperty } = useActions(logic)
@@ -68,11 +68,12 @@ export function ActionFilterRow({ logic, filter, index }) {
             >
                 {name || 'Select action'}
             </button>
-            <MathSelector math={math} index={index} onMathSelect={onMathSelect} />
+            {!hideMathSelector && <MathSelector math={math} index={index} onMathSelect={onMathSelect} />}
             <div
                 className="btn btn-sm btn-light"
                 onClick={() => setEntityFilterVisible(!entityFilterVisible)}
                 data-attr={'show-prop-filter-' + index}
+                style={{ marginLeft: 16 }}
             >
                 {determineFilterLabel(entityFilterVisible, filter)}
             </div>
@@ -117,7 +118,7 @@ function MathSelector(props) {
         <Dropdown
             title={items[items.map(i => i.toLowerCase()).indexOf(props.math)] || 'Total'}
             buttonClassName="btn btn-sm btn-light"
-            style={{ marginLeft: 32, marginRight: 16 }}
+            style={{ marginLeft: 32 }}
             data-attr={'math-selector-' + props.index}
         >
             <Tooltip


### PR DESCRIPTION
## Changes

- Per #944, the math selector on funnels doesn't actually do anything.
Even if we do allow users to toggle between Uniques/totals, it would be over the entire funnel, not individual entities.
-
-

## Checklist
- [x] Cypress E2E tests (if applicable)
