### PR TITLE
Upgrade to posthog-js 1.2.0 to support dynamic params.

### DIFF
--- a/frontend/src/toolbar/ToolbarContent.js
+++ b/frontend/src/toolbar/ToolbarContent.js
@@ -15,8 +15,8 @@ const tabComponents = {
 }
 
 export const ToolbarContent = hot(_ToolbarContent)
-function _ToolbarContent({ apiURL, temporaryToken, actionId, type, dockLogic }) {
-    const { tab, newTab } = useValues(toolbarTabLogic)
+function _ToolbarContent({ apiURL, temporaryToken, actionId, type, dockLogic, defaultTab }) {
+    const { tab, newTab } = useValues(toolbarTabLogic({ defaultTab }))
 
     const visible = tab ? { [tab]: 'visible' } : {}
     const invisible = newTab && tab ? { [newTab]: 'invisible' } : {}

--- a/frontend/src/toolbar/index.js
+++ b/frontend/src/toolbar/index.js
@@ -23,6 +23,7 @@ window.ph_load_editor = function(editorParams) {
                 apiURL={editorParams.apiURL}
                 temporaryToken={editorParams.temporaryToken}
                 actionId={editorParams.actionId}
+                defaultTab={editorParams.defaultTab}
                 startMinimized={editorParams.minimized}
             />
         </Provider>,

--- a/frontend/src/toolbar/toolbarTabLogic.js
+++ b/frontend/src/toolbar/toolbarTabLogic.js
@@ -6,9 +6,9 @@ export const toolbarTabLogic = kea({
         setTab: tab => ({ tab }),
         setTabs: (tab, newTab) => ({ tab, newTab }),
     }),
-    reducers: () => ({
+    reducers: ({ props }) => ({
         tab: [
-            'stats',
+            props.defaultTab || 'stats',
             {
                 setTabs: (_, { tab }) => tab,
             },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "kea-localstorage": "^1.0.2",
         "kea-router": "^0.3.0",
         "moment": "^2.24.0",
-        "posthog-js": "1.2.0",
+        "posthog-js": "1.2.1",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
         "react-datepicker": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "kea-localstorage": "^1.0.2",
         "kea-router": "^0.3.0",
         "moment": "^2.24.0",
-        "posthog-js": "1.1.0",
+        "posthog-js": "1.2.0",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
         "react-datepicker": "^2.13.0",

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -161,6 +161,7 @@ def parse_domain(url: str) -> Optional[str]:
 def get_decide(request):
     response = {
         'config': {'enable_collect_everything': True},
+        'editorParams': {},
         'isAuthenticated': False
     }
 
@@ -175,10 +176,13 @@ def get_decide(request):
 
         if (parse_domain(request.headers.get('Origin')) in permitted_domains) or (parse_domain(request.headers.get('Referer')) in permitted_domains):
             response['isAuthenticated'] = True
+            editor_params = {}
             if hasattr(settings, 'TOOLBAR_VERSION'):
-                response['toolbarVersion'] = settings.TOOLBAR_VERSION
+                editor_params['toolbarVersion'] = settings.TOOLBAR_VERSION
             if settings.DEBUG:
-                response['jsURL'] = 'http://localhost:8234/'
+                editor_params['jsURL'] = 'http://localhost:8234/'
+
+            response['editorParams'] = editor_params
 
             if not request.user.temporary_token:
                 request.user.temporary_token = secrets.token_urlsafe(32)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -327,18 +327,18 @@ class TestDecide(BaseTest):
         self.team.save()
         response = self.client.get('/decide/', HTTP_ORIGIN='https://example.com').json()
         self.assertEqual(response['isAuthenticated'], True)
-        self.assertEqual(response['toolbarVersion'], settings.TOOLBAR_VERSION)
+        self.assertEqual(response['editorParams']['toolbarVersion'], settings.TOOLBAR_VERSION)
 
     def test_user_on_evil_site(self):
         self.team.app_urls = ['https://example.com']
         self.team.save()
         response = self.client.get('/decide/', HTTP_ORIGIN='https://evilsite.com').json()
         self.assertEqual(response['isAuthenticated'], False)
-        self.assertIsNone(response.get('toolbarVersion', None))
+        self.assertIsNone(response['editorParams'].get('toolbarVersion', None))
 
     def test_user_on_local_host(self):
         self.team.app_urls = ['https://example.com']
         self.team.save()
         response = self.client.get('/decide/', HTTP_ORIGIN='http://127.0.0.1:8000').json()
         self.assertEqual(response['isAuthenticated'], True)
-        self.assertEqual(response['toolbarVersion'], settings.TOOLBAR_VERSION)
+        self.assertEqual(response['editorParams']['toolbarVersion'], settings.TOOLBAR_VERSION)

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -76,8 +76,7 @@ def redirect_to_site(request):
     request.user.save()
     params = {
         'action': 'mpeditor',
-        'token': team.api_token,  # TODO: remove when nobody is using posthog-js 1.1.2 or earlier anymore
-        'projectToken': team.api_token,
+        'token': team.api_token,
         'temporaryToken': request.user.temporary_token,
         'actionId': request.GET.get('actionId'),
         'defaultTab': 'actions',

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -76,9 +76,10 @@ def redirect_to_site(request):
     request.user.save()
     params = {
         'action': 'mpeditor',
-        'token': team.api_token,
+        'projectToken': team.api_token,
         'temporaryToken': request.user.temporary_token,
         'actionId': request.GET.get('actionId'),
+        'defaultTab': 'actions',
         'apiURL': request.build_absolute_uri('/'),
     }
     if settings.DEBUG:

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -76,6 +76,7 @@ def redirect_to_site(request):
     request.user.save()
     params = {
         'action': 'mpeditor',
+        'token': team.api_token,  # TODO: remove when nobody is using posthog-js 1.1.2 or earlier anymore
         'projectToken': team.api_token,
         'temporaryToken': request.user.temporary_token,
         'actionId': request.GET.get('actionId'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,10 +7066,10 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-posthog-js@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.2.0.tgz#d9d258b7787c826eafd311a64f83785614ba97ff"
-  integrity sha512-Bcq2/d3haFmuZrBqVbYXSjL2ndyVrI0PDqkFkQobc5WyXFEUEdK6xckcKg+SATh1MIg142zU7eC9RTMS0a4Qbw==
+posthog-js@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.2.1.tgz#b9b68a7014d560f2e695ba712eee1867291c997b"
+  integrity sha512-LsnSEMznRBERW6ikbbRmCTzWGQ1kr54CCTIDsle56gJ34P9YB5xY9Nvfr4CMwZGB/XVqZtY3l5w5C08exTiCyw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7066,10 +7066,10 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-posthog-js@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.1.0.tgz#156909007813ce187e6cbd6673ad9a4d93b73004"
-  integrity sha512-NCHULjFVsuDAJwlHyxMPcLAgX0WUs1rQsSDLyrs+zyxlKer3lOARSn+PKEhngwS2MNzo5X040S02PdKx1rm17Q==
+posthog-js@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.2.0.tgz#d9d258b7787c826eafd311a64f83785614ba97ff"
+  integrity sha512-Bcq2/d3haFmuZrBqVbYXSjL2ndyVrI0PDqkFkQobc5WyXFEUEdK6xckcKg+SATh1MIg142zU7eC9RTMS0a4Qbw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Changes

This PR adds a few things and might be good to get into the release.

- Upgrade to posthog-js 1.2.0, which supports sending various `editorParams` to the toolbar. Previously we had to whitelist, so when adding a new param (e.g. `defaultTab`), we had to release a new version of the JS snippet. This is no longer necessary.

- Update the posthog API to send data to the editor in the new format that splits out the editor params from the rest.

Related: if this is in, it's worth writing "upgrade to posthog-js 1.2.0 if using it npm" in the changelog.

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
