### PR TITLE
Closes #975 add prroperties to person and fix pagination

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -135,14 +135,14 @@ class EventViewSet(viewsets.ModelViewSet):
 
         reverse = request.GET.get('orderBy', '-timestamp') != '-timestamp'
         if len(events) > 100:
-            next_url: Union[bool, str] = '{}{}{}={}'.format(
+            next_url: Union[bool, str] = request.build_absolute_uri('{}{}{}={}'.format(
                 path,
                 '&' if '?' in path else '?',
                 'after' if reverse else 'before',
                 events[99].timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-            )
+            ))
         else:
-            next_url = False
+            next_url = None
 
         return response.Response({
             'next': next_url,

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Lag
 from django.db.models.expressions import Window
 from django.db import connection
 from django.utils.timezone import now
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional
 from django.utils.timezone import now
 import json
 import pandas as pd
@@ -135,7 +135,7 @@ class EventViewSet(viewsets.ModelViewSet):
 
         reverse = request.GET.get('orderBy', '-timestamp') != '-timestamp'
         if len(events) > 100:
-            next_url: Union[bool, str] = request.build_absolute_uri('{}{}{}={}'.format(
+            next_url: Optional[str] = request.build_absolute_uri('{}{}{}={}'.format(
                 path,
                 '&' if '?' in path else '?',
                 'after' if reverse else 'before',

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -268,7 +268,7 @@ class TestEvents(TransactionBaseTest):
             events.append(Event(team=self.team, event='some event', distinct_id='1'))
         Event.objects.bulk_create(events)
         response = self.client.get('/api/event/?distinct_id=1').json()
-        self.assertIn('distinct_id=1', response['next'])
+        self.assertIn('http://testserver/api/event/?distinct_id=1&before=', response['next'])
 
         page2 = self.client.get(response['next']).json()
         self.assertEqual(len(page2['results']), 50)


### PR DESCRIPTION
## Changes

- Add properties filter to person
- Make pagination url consistent between /event and everything else
-

## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
