### PR TITLE
Fix compare sessions distribution bug

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -243,7 +243,7 @@ class EventViewSet(viewsets.ModelViewSet):
 
         # get compared period
         compare = request.GET.get('compare')
-        if compare and request.GET.get('date_from') != 'all':
+        if compare and request.GET.get('date_from') != 'all' and session_type == 'avg':
             calculated = self.calculate_sessions(events, session_type, date_filter)
             calculated = self._convert_to_comparison(calculated, 'current')
             compared_calculated = self._handle_compared(date_filter, session_type)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -255,12 +255,15 @@ class TestEvents(TransactionBaseTest):
             Event.objects.create(team=self.team, event='3rd action', distinct_id="2")
 
         response = self.client.get('/api/event/sessions/?session=distribution&date_from=all').json()
-        
-        for item in response:
+        compared_response = self.client.get('/api/event/sessions/?session=distribution&date_from=all&compare=true').json()
+
+        for index, item in enumerate(response):
             if item['label'] == '30-60 minutes' or item['label'] == '3-10 seconds':
                 self.assertEqual(item['count'], 2)
+                self.assertEqual(compared_response[index]['count'], 2)
             else:
                 self.assertEqual(item['count'], 1)
+                self.assertEqual(compared_response[index]['count'], 1)
 
     def test_pagination(self):
         events = []


### PR DESCRIPTION
## Changes
- temporary patch for bug where comparing trend session distribution was erroring

Followup should be #979 to make sessions on the trends page have better coverage

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
