### PR TITLE
Element stats performance improvement

### DIFF
--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -1,5 +1,8 @@
 from .base import BaseTest
 from posthog.models import Element, ElementGroup, Team, Event
+from django.utils.timezone import now
+from dateutil.relativedelta import relativedelta
+
 import json
 
 class TestElement(BaseTest):
@@ -28,6 +31,9 @@ class TestElement(BaseTest):
         ]
         event1 = Event.objects.create(team=self.team, elements=elements, event='$autocapture', properties={'$current_url': 'http://example.com/demo'})
         Event.objects.create(team=self.team, elements=elements, event='$autocapture', properties={'$current_url': 'http://example.com/demo'})
+        # make sure we only load last 7 days by default
+        Event.objects.create(timestamp=now() - relativedelta(days=8), team=self.team, elements=elements, event='$autocapture', properties={'$current_url': 'http://example.com/demo'})
+
         Event.objects.create(team=self.team, event='$autocapture', properties={'$current_url': 'http://example.com/something_else'}, elements=[
             Element(tag_name='img', order=0)
         ])


### PR DESCRIPTION
## Changes

-Make sure we only grab the top 100 events
- Make sure we only load the last week of data by default
- add date_from and date_to query params

## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- ~Cypress E2E tests (if applicable)~
