### PR TITLE
Add authorization screen for toolbar

### DIFF
--- a/posthog/templates/authorize_and_redirect.html
+++ b/posthog/templates/authorize_and_redirect.html
@@ -1,0 +1,18 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+    <form class="form-signin" method="post" action="/login">
+        Do you want to give the PostHog toolbar on <strong>{{ redirect_url }}</strong> access to your PostHog data?
+        <br /><br />
+        With the toolbar, you'll be able to
+        <ul>
+            <li>See aggregated stats</li>
+            <li>See heatmaps</li>
+            <li>Create new actions</li>
+        </ul>
+        <a href='/api/user/redirect_to_site/?appUrl={{ redirect_url}}' class="btn btn-lg btn-primary btn-block" type="submit">
+            Authorize
+            <strong>{{ domain }}</strong>
+        </a>
+    </form>
+{% endblock %}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -8,6 +8,7 @@ from django.contrib.auth import authenticate, login, views as auth_views, decora
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from django.template.loader import render_to_string
+from urllib.parse import urlparse
 
 from .api import router, capture, user
 from .models import Team, User
@@ -136,6 +137,20 @@ def social_create_user(strategy, details, backend, user=None, *args, **kwargs):
 def logout(request):
     return auth_views.logout_then_login(request)
 
+def authorize_and_redirect(request):
+    if not request.GET.get('redirect'):
+        return HttpResponse("You need to pass a url to ?redirect=", status=401)
+    url = request.GET['redirect']
+    return render_template(
+        'authorize_and_redirect.html',
+        request=request,
+        context={
+
+            'domain': urlparse(url).hostname,
+            'redirect_url': url,
+        }
+    )
+
 urlpatterns = [
     path('_health/', health),
     path('_stats/', stats),
@@ -147,6 +162,7 @@ urlpatterns = [
     path('api/user/redirect_to_site/', user.redirect_to_site),
     path('api/user/change_password/', user.change_password),
     path('api/user/test_slack_webhook/', user.test_slack_webhook),
+    path('authorize_and_redirect/', decorators.login_required(authorize_and_redirect)),
     path('decide/', capture.get_decide),
     path('engage/', capture.get_event),
     path('engage', capture.get_event),


### PR DESCRIPTION
## Changes

- Screen you can send users to to authorize any URL
![image](https://user-images.githubusercontent.com/1727427/84488258-39a3c380-aca0-11ea-8049-c0c35f31db00.png)
-
-

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
