### PR TITLE
Adds to #1010 add high prio to heartbeat

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -30,7 +30,7 @@ redis_instance = redis.from_url(settings.REDIS_URL, db=0)
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     # Heartbeat every 10sec to make sure the worker is alive
-    sender.add_periodic_task(10.0, redis_heartbeat.s(), name='10 sec heartbeat')
+    sender.add_periodic_task(10.0, redis_heartbeat.s(), name='10 sec heartbeat', priority=0)
     sender.add_periodic_task(
         crontab(day_of_week='mon,fri'), # check twice a week
         update_event_partitions.s(),


### PR DESCRIPTION
## Changes

- Attempts to fix #1010 by adding a higher prio to the worker
- See this thread: https://github.com/celery/celery/issues/4028 redis priority support is poorly documented and there seems to be some confusion around how it actually works.
-

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
