### PR TITLE
Fix cypress tests

### DIFF
--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -122,6 +122,9 @@ def demo(request):
         _create_anonymous_users(team=team, base_url=request.build_absolute_uri('/demo/'))
         _create_funnel(team=team, base_url=request.build_absolute_uri('/demo/'))
         _recalculate(team=team)
+    if '$pageview' not in team.event_names:
+        team.event_names.append('$pageview')
+        team.save()
     return render_template('demo.html', request=request, context={'api_token': team.api_token})
 
 def delete_demo_data(request):

--- a/posthog/test/test_demo.py
+++ b/posthog/test/test_demo.py
@@ -1,5 +1,5 @@
 from django.test import TestCase, Client
-from posthog.models import User, DashboardItem, Action, Person, Event, Funnel
+from posthog.models import User, DashboardItem, Action, Person, Event, Funnel, Team
 from posthog.api.test.base import BaseTest
 
 class TestDemo(BaseTest):
@@ -13,6 +13,7 @@ class TestDemo(BaseTest):
         self.assertEqual(Action.objects.count(), 3)
 
         self.assertEqual(Action.objects.all()[1].events.count(), 9)
+        self.assertIn('$pageview', Team.objects.get().event_names)
  
     def test_do_not_create_demo_data_if_already_exists(self):
         Event.objects.create(team=self.team, event='random event')


### PR DESCRIPTION
## Changes

- Visiting /demo inserts a bunch of events, but they don't automatically add `$pageview` to the event_names list on Teams. This makes sure that happens.
-
-

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
