### PR TITLE
Fix cohorts failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "kea-localstorage": "^1.0.2",
         "kea-router": "^0.3.0",
         "moment": "^2.24.0",
-        "posthog-js": "1.2.1",
+        "posthog-js": "1.2.2",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
         "react-datepicker": "^2.13.0",

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -74,32 +74,34 @@ class Cohort(models.Model):
         return filters
 
     def calculate_people(self):
-        self.is_calculating = True
-        self.save()
-        event_query, params = (
-            Person.objects.filter(self.people_filter(), team=self.team)
-            .distinct('pk')
-            .only("pk")
-            .query.sql_with_params()
-        )
-
-        query = """
-        DELETE FROM "posthog_cohortpeople" WHERE "cohort_id" = {};
-        INSERT INTO "posthog_cohortpeople" ("person_id", "cohort_id")
-        {}
-        ON CONFLICT DO NOTHING
-        """.format(
-            self.pk, event_query.replace('FROM "posthog_person"', ', {} FROM "posthog_person"'.format(self.pk), 1)
-        )
-
-        cursor = connection.cursor()
-        with transaction.atomic():
-            cursor.execute(query, params)
-
-            self.is_calculating = False
-            self.last_calculation = timezone.now()
+        try:
+            self.is_calculating = True
             self.save()
+            event_query, params = (
+                Person.objects.filter(self.people_filter(), team=self.team)
+                .distinct('pk')
+                .only("pk")
+                .query.sql_with_params()
+            )
 
+            query = """
+            DELETE FROM "posthog_cohortpeople" WHERE "cohort_id" = {};
+            INSERT INTO "posthog_cohortpeople" ("person_id", "cohort_id")
+            {}
+            ON CONFLICT DO NOTHING
+            """.format(
+                self.pk, event_query.replace('FROM "posthog_person"', ', {} FROM "posthog_person"'.format(self.pk), 1)
+            )
+
+            cursor = connection.cursor()
+            with transaction.atomic():
+                cursor.execute(query, params)
+
+                self.is_calculating = False
+                self.last_calculation = timezone.now()
+                self.save()
+        except:
+            capture_exception()
 
     def __str__(self):
         return self.name

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -7,6 +7,7 @@ from .action import Action
 from .event import Event
 from .filter import Filter
 from dateutil.relativedelta import relativedelta
+from sentry_sdk import capture_exception
 
 from typing import Any, Dict, Optional
 import json


### PR DESCRIPTION
## Changes

- We we're getting this Sentry error: https://sentry.io/organizations/posthog/issues/1717617599/?project=1899813&query=is%3Aunresolved
because I'd deleted an action that one of the cohorts relied on. In turn, this broke all cohort calculations that came after that cohort. This will at least capture those errors individually, rather than killing the entire process.
-
-

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
