### PR TITLE
Always yarn install because of caching bug

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,6 @@ jobs:
             - name: Yarn install deps
               run: |
                   yarn install --frozen-lockfile
-              if: steps.yarn-dep-cache.outputs.cache-hit != 'true'
             - uses: actions/cache@v1
               name: Setup Yarn build cache
               id: yarn-build-cache


### PR DESCRIPTION
Quick fix for caching bug in actions for yarn install. This addresses the intermittent issue where when running `yarn build` the build fails finding dep `mini-css-extract-plugin`.

For now we will just always install yarn deps. Will fix this later.