### PR TITLE
Fix texts too long

### DIFF
--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -95,7 +95,7 @@ def _capture(ip: str,
         del properties['$elements']
         elements_list = [
             Element(
-                text=el.get('$el_text'),
+                text=el['$el_text'][0:400] if el.get('$el_text') else None,
                 tag_name=el['tag_name'],
                 href=el['attr__href'][0:2048] if el.get('attr__href') else None,
                 attr_class=el['attr__class'].split(' ') if el.get('attr__class') else None,

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -277,18 +277,19 @@ class ProcessEvent(BaseTest):
             'key_on_old': 'old value'
         })
 
-    def test_long_href(self) -> None:
+    def test_long_htext(self) -> None:
         process_event('new_distinct_id', '', '', {
             'event': '$autocapture',
             'properties': {
                 'distinct_id': 'new_distinct_id',
                 'token': self.team.api_token,
                 '$elements': [
-                    {'tag_name': 'a', 'attr__href': 'a' * 2050, 'nth_child': 1, 'nth_of_type': 2, 'attr__class': 'btn btn-sm'},
+                    {'tag_name': 'a', '$el_text': 'a' * 2050, 'attr__href': 'a' * 2050, 'nth_child': 1, 'nth_of_type': 2, 'attr__class': 'btn btn-sm'},
                 ]
             }
         }, self.team.pk, now().isoformat(), now().isoformat())
         self.assertEqual(len(Element.objects.get().href), 2048)
+        self.assertEqual(len(Element.objects.get().text), 400)
 
 
 class TestIdentify(TransactionTestCase):


### PR DESCRIPTION
## Changes

- This fixes [a sentry error](https://sentry.io/organizations/posthog/issues/1612486295/?project=1899813&referrer=slack) caused by an elements text being too long. I'll also make sure we truncate this in posthog-js.
-
-

## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
