### PR TITLE
Fix moving from sessions to trends

### DIFF
--- a/cypress/integration/trends_sessions.js
+++ b/cypress/integration/trends_sessions.js
@@ -5,6 +5,14 @@ describe('Trends sessions', () => {
         cy.contains('Sessions').click()
     })
 
+    it('Navigate from distributed sessions to /trends', () => {
+        cy.get('[data-attr=sessions-filter]').click()
+        cy.get('[data-attr=sessions-filter-distribution]').click()
+        cy.get('[data-attr=trend-table-graph]').should('exist')
+        cy.contains('Actions & Events').click()
+        cy.get('[data-attr=trend-line-graph] canvas').should('exist')
+    })
+
     it('Sessions exists', () => {
         // then
         cy.get('[data-attr=trend-line-graph]').should('exist')

--- a/frontend/src/lib/components/SessionsFilter.js
+++ b/frontend/src/lib/components/SessionsFilter.js
@@ -10,9 +10,12 @@ export function SessionFilter(props) {
             value={value}
             dropdownMatchSelectWidth={false}
             onChange={onChange}
+            data-attr="sessions-filter"
         >
             <Select.Option value="avg">Average Session Length</Select.Option>
-            <Select.Option value="dist">Distribution of Session Lengths</Select.Option>
+            <Select.Option value="dist" data-attr="sessions-filter-distribution">
+                Distribution of Session Lengths
+            </Select.Option>
         </Select>
     )
 }

--- a/frontend/src/scenes/trends/trendsLogic.js
+++ b/frontend/src/scenes/trends/trendsLogic.js
@@ -229,6 +229,7 @@ export const trendsLogic = kea({
                 return // don't use the URL if on the dashboard
             }
             actions.setCachedUrl(values.activeView, window.location.pathname + window.location.search)
+            actions.loadResultsSuccess([])
             const cachedUrl = values.cachedUrls[type]
             if (cachedUrl) {
                 return cachedUrl

--- a/frontend/src/scenes/trends/trendsLogic.js
+++ b/frontend/src/scenes/trends/trendsLogic.js
@@ -94,6 +94,7 @@ export const trendsLogic = kea({
     loaders: ({ values }) => ({
         results: {
             __default: [],
+            setActiveView: () => [],
             loadResults: async (refresh = false, breakpoint) => {
                 let response
                 if (values.activeView === ViewType.SESSIONS) {
@@ -229,7 +230,6 @@ export const trendsLogic = kea({
                 return // don't use the URL if on the dashboard
             }
             actions.setCachedUrl(values.activeView, window.location.pathname + window.location.search)
-            actions.loadResultsSuccess([])
             const cachedUrl = values.cachedUrls[type]
             if (cachedUrl) {
                 return cachedUrl


### PR DESCRIPTION
## Changes

- This happened if you were on "Distribution of session lengths" and changes tabs back to events
- Caused this sentry error: https://sentry.io/organizations/posthog/issues/1730337811/?referrer=slack
-

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [x] Cypress E2E tests (if applicable)
