### PR TITLE
Show upgrade warning if using a really old browser

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -17,8 +17,15 @@
         <script id="sentry-snippet">location.host.indexOf('127.0.0.1') == -1 && Sentry.init({ dsn: '{{sentry_dsn}}' });</script>
     {% endif %}
   </head>
-
   <body>
+    <script>
+        if (typeof Object.entries === 'undefined') {
+            let div = document.createElement("div");
+            div.style.color='#fef6f6'; div.style.background='#920c0c'; div.style.padding='5px 10px';
+            div.innerHTML = "You are using a really old browser. Please upgrade to fully enjoy PostHog!"
+            document.body.prepend(div);
+        }
+    </script>
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## Changes

In case the user is using a really old browser (tested by checking if it supports `Object.entries`), we show a warning message asking the user to upgrade.

![image](https://user-images.githubusercontent.com/53387/85000867-44a09d00-b153-11ea-924c-ce64b2813e3d.png)

This shows up no matter if the react bundle managed to load or not, as the error could be in initing the bundle for example.


## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
