### PR TITLE
Fixed Start Times for Session View

### DIFF
--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -286,9 +286,14 @@ export function humanFriendlyDiff(from, to) {
 
 export function humanFriendlyDetailedTime(date, withSeconds = false) {
     let formatString = 'MMMM Do YYYY h:mm'
-    if (moment().diff(date, 'days') == 0) {
+    const today = moment().startOf('day')
+    const yesterday = today
+        .clone()
+        .subtract(1, 'days')
+        .startOf('day')
+    if (moment(date).isSame(today, 'd')) {
         formatString = '[Today] h:mm'
-    } else if (moment().diff(date, 'days') == 1) {
+    } else if (moment(date).isSame(yesterday, 'd')) {
         formatString = '[Yesterday] h:mm'
     }
     if (withSeconds) formatString += ':s a'

--- a/frontend/src/scenes/App.js
+++ b/frontend/src/scenes/App.js
@@ -28,6 +28,7 @@ const urlBackgroundMap = {
     '/dashboard': 'https://posthog.s3.eu-west-2.amazonaws.com/graphs.png',
     '/dashboard/1': 'https://posthog.s3.eu-west-2.amazonaws.com/graphs.png',
     '/events': 'https://posthog.s3.eu-west-2.amazonaws.com/preview-actions.png',
+    '/sessions': 'https://posthog.s3.eu-west-2.amazonaws.com/preview-actions.png',
     '/actions': 'https://posthog.s3.eu-west-2.amazonaws.com/preview-actions.png',
     '/actions/live': 'https://posthog.s3.eu-west-2.amazonaws.com/preview-actions.png',
     '/trends': 'https://posthog.s3.eu-west-2.amazonaws.com/preview-action-trends.png',

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -275,6 +275,9 @@ class EventViewSet(viewsets.ModelViewSet):
 
     def calculate_sessions(self, events: QuerySet, session_type: Optional[str], date_filter: Dict[str, datetime], team: Team, request: request.Request) -> List[Dict[str, Any]]:
 
+        if not events:
+            return []
+            
         # format date filter for session view
         _date_gte = Q()
         if session_type is None:


### PR DESCRIPTION
## Changes
- Addresses #1038 
- add default prompt to sessions page when no events have been sent

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
