### PR TITLE
Fix old editor toolbar

### DIFF
--- a/frontend/src/editor/index.js
+++ b/frontend/src/editor/index.js
@@ -4,9 +4,13 @@ import Simmer from 'simmerjs'
 import root from 'react-shadow'
 import { ActionEdit } from '~/scenes/actions/ActionEdit'
 import Draggable from 'react-draggable'
-import { getContext } from 'kea'
+import { connect, getContext } from 'kea'
 import { Provider } from 'react-redux'
 import { hot } from 'react-hot-loader/root'
+import { initKea } from '~/initKea'
+import { userLogic } from 'scenes/userLogic'
+
+initKea()
 
 window.simmer = new Simmer(window, { depth: 8 })
 
@@ -186,8 +190,7 @@ class _App extends Component {
         )
     }
 }
-
-const App = hot(_App)
+const App = hot(connect([userLogic])(_App))
 
 window.ph_load_editor = function(editorParams) {
     let container = document.createElement('div')

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -335,7 +335,6 @@ export class ActionStep extends Component {
                                 </p>
                             ),
                         ]}
-
                         {step.event === '$autocapture' && (
                             <this.AutocaptureFields step={step} isEditor={isEditor} actionId={actionId} />
                         )}
@@ -368,16 +367,18 @@ export class ActionStep extends Component {
                                 )}
                             </div>
                         )}
-                        <PropertyFilters
-                            propertyFilters={step.properties}
-                            pageKey={'action-edit'}
-                            onChange={properties => {
-                                this.sendStep({
-                                    ...this.props.step, // Not sure why, but the normal 'step' variable does not work here
-                                    properties,
-                                })
-                            }}
-                        />
+                        {!isEditor ? (
+                            <PropertyFilters
+                                propertyFilters={step.properties}
+                                pageKey={'action-edit'}
+                                onChange={properties => {
+                                    this.sendStep({
+                                        ...this.props.step, // Not sure why, but the normal 'step' variable does not work here
+                                        properties,
+                                    })
+                                }}
+                            />
+                        ) : null}
                     </div>
                 </div>
             </div>

--- a/frontend/src/scenes/userLogic.js
+++ b/frontend/src/scenes/userLogic.js
@@ -28,13 +28,13 @@ export const userLogic = kea({
     selectors: ({ selectors }) => ({
         eventProperties: [
             () => [selectors.user],
-            user => user.team.event_properties.map(property => ({ value: property, label: property })),
+            user => user?.team.event_properties.map(property => ({ value: property, label: property })) || [],
         ],
         eventNames: [() => [selectors.user], user => user.team.event_names],
         customEventNames: [
             () => [selectors.user],
             user => {
-                const eventNames = user.team.event_names
+                const eventNames = user?.team.event_names || []
                 const regex = new RegExp('^[^$].*')
                 const filtered = eventNames.filter(event => event.match(regex))
                 return filtered
@@ -47,7 +47,7 @@ export const userLogic = kea({
                     { label: 'Custom events', options: [] },
                     { label: 'PostHog events', options: [] },
                 ]
-                user.team.event_names.forEach(name => {
+                user?.team.event_names.forEach(name => {
                     let format = { label: name, value: name }
                     if (posthogEvents.indexOf(name) > -1) return data[1].options.push(format)
                     data[0].options.push(format)


### PR DESCRIPTION
## Changes

Makes the old editor toolbar work

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
