### PR TITLE
Rework property filter operator is_set into is_set + is_not _set (solves #1097)

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Select } from 'antd'
-import { operatorMap, isOperatorNonparametric } from 'lib/utils'
+import { operatorMap, isOperatorFlag } from 'lib/utils'
 import { PropertyValue } from './PropertyValue'
 import { PropertyKeyInfo, keyMapping } from 'lib/components/PropertyKeyInfo'
 import { useValues, useActions } from 'kea'
@@ -79,7 +79,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
             </div>
 
             {key && (
-                <div className={`col-${isOperatorNonparametric(operator) ? 8 : 3} pl-0`}>
+                <div className={`col-${isOperatorFlag(operator) ? 8 : 3} pl-0`}>
                     <Select
                         style={{ width: '100%' }}
                         defaultActiveFirstOption
@@ -91,13 +91,13 @@ export function PropertyFilter({ index, onComplete, logic }) {
                         placeholder="Property key"
                         onChange={(_, new_operator) => {
                             let new_value = value
-                            if (isOperatorNonparametric(new_operator.value)) {
+                            if (isOperatorFlag(new_operator.value)) {
                                 // change value to induce reload
                                 new_value = new_operator.value
                                 onComplete()
                             } else {
-                                // clear value if switching from nonparametric to parametric
-                                if (isOperatorNonparametric(operator)) new_value = undefined
+                                // clear value if switching from nonparametric (flag) to parametric
+                                if (isOperatorFlag(operator)) new_value = undefined
                             }
                             setFilter(index, key, new_value, new_operator.value, type)
                         }}
@@ -110,7 +110,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     </Select>
                 </div>
             )}
-            {key && !isOperatorNonparametric(operator) && (
+            {key && !isOperatorFlag(operator) && (
                 <div className="col-5 pl-0">
                     <PropertyValue
                         type={type}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -86,7 +86,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                         labelInValue
                         value={{
                             value: operator || '=',
-                            label: operatorMap[operator || '='],
+                            label: operatorMap[operator || 'exact'],
                         }}
                         placeholder="Property key"
                         onChange={(_, new_operator) => {
@@ -104,7 +104,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     >
                         {Object.keys(operatorMap).map(operator => (
                             <Select.Option key={operator} value={operator}>
-                                {operatorMap[operator] || '= equals'}
+                                {operatorMap[operator || 'exact']}
                             </Select.Option>
                         ))}
                     </Select>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Select } from 'antd'
-import { operatorMap } from 'lib/utils'
+import { operatorMap, isOperatorNonparametric } from 'lib/utils'
 import { PropertyValue } from './PropertyValue'
 import { PropertyKeyInfo, keyMapping } from 'lib/components/PropertyKeyInfo'
 import { useValues, useActions } from 'kea'
@@ -9,6 +9,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
     const { eventProperties, personProperties, filters } = useValues(logic)
     const { setFilter } = useActions(logic)
     let { key, value, operator, type } = filters[index]
+
     return (
         <div className="row" style={{ margin: '0.5rem -15px', minWidth: key ? 700 : 400 }}>
             <div className={key ? 'col-4' : 'col'}>
@@ -78,20 +79,26 @@ export function PropertyFilter({ index, onComplete, logic }) {
             </div>
 
             {key && (
-                <div className="col-3 pl-0">
+                <div className={`col-${isOperatorNonparametric(operator) ? 8 : 3} pl-0`}>
                     <Select
                         style={{ width: '100%' }}
                         defaultActiveFirstOption
                         labelInValue
                         value={{
                             value: operator || '=',
-                            label: operatorMap[operator] || '= equals',
+                            label: operatorMap[operator || '='],
                         }}
                         placeholder="Property key"
                         onChange={(_, new_operator) => {
                             let new_value = value
-                            if (operator === 'is_set') new_value = undefined
-                            if (new_operator.value === 'is_set') new_value = 'true'
+                            if (isOperatorNonparametric(new_operator.value)) {
+                                // change value to induce reload
+                                new_value = new_operator.value
+                                onComplete()
+                            } else {
+                                // clear value if switching from nonparametric to parametric
+                                if (isOperatorNonparametric(operator)) new_value = undefined
+                            }
                             setFilter(index, key, new_value, new_operator.value, type)
                         }}
                     >
@@ -103,7 +110,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     </Select>
                 </div>
             )}
-            {key && (
+            {key && !isOperatorNonparametric(operator) && (
                 <div className="col-5 pl-0">
                     <PropertyValue
                         type={type}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -36,7 +36,7 @@ const FilterRow = React.memo(function FilterRow({ item, index, filters, logic, p
                             {keyMapping[type === 'element' ? 'element' : 'event'][key]?.label || key}{' '}
                             {isOperatorFlag(operator)
                                 ? operatorMap[operator]
-                                : `${operatorMap[operator || 'exact'].split(' ')[0]} ${value || ''}`}
+                                : `${(operatorMap[operator || 'exact'] || '?').split(' ')[0]} ${value || ''}`}
                         </span>
                     </Button>
                 ) : (

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -5,7 +5,7 @@ import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { Popover, Row } from 'antd'
-import { CloseButton, operatorMap } from 'lib/utils'
+import { CloseButton, operatorMap, isOperatorNonparametric } from 'lib/utils'
 import _ from 'lodash'
 
 const FilterRow = React.memo(function FilterRow({ item, index, filters, logic, pageKey }) {
@@ -34,7 +34,9 @@ const FilterRow = React.memo(function FilterRow({ item, index, filters, logic, p
                     <Button type="primary" shape="round" style={{ maxWidth: '85%' }}>
                         <span style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                             {keyMapping[type === 'element' ? 'element' : 'event'][key]?.label || key}{' '}
-                            {operatorMap[operator || 'exact'].split(' ')[0]} {value}
+                            {isOperatorNonparametric(operator)
+                                ? operatorMap[operator]
+                                : `${operatorMap[operator || 'exact'].split(' ')[0]} ${value || ''}`}
                         </span>
                     </Button>
                 ) : (

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -5,7 +5,7 @@ import { useValues, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { Popover, Row } from 'antd'
-import { CloseButton, operatorMap, isOperatorNonparametric } from 'lib/utils'
+import { CloseButton, operatorMap, isOperatorFlag } from 'lib/utils'
 import _ from 'lodash'
 
 const FilterRow = React.memo(function FilterRow({ item, index, filters, logic, pageKey }) {
@@ -34,7 +34,7 @@ const FilterRow = React.memo(function FilterRow({ item, index, filters, logic, p
                     <Button type="primary" shape="round" style={{ maxWidth: '85%' }}>
                         <span style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                             {keyMapping[type === 'element' ? 'element' : 'event'][key]?.label || key}{' '}
-                            {isOperatorNonparametric(operator)
+                            {isOperatorFlag(operator)
                                 ? operatorMap[operator]
                                 : `${operatorMap[operator || 'exact'].split(' ')[0]} ${value || ''}`}
                         </span>

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { Select } from 'antd'
 import api from '../../api'
-import { isOperatorNonparametric } from 'lib/utils'
+import { isOperatorFlag } from 'lib/utils'
 
 export function PropertyValue({
     propertyKey,
@@ -61,7 +61,7 @@ export function PropertyValue({
             loading={optionsCache[input] === 'loading'}
             onSearch={input => {
                 setInput(input)
-                if (!optionsCache[input] && !isOperatorNonparametric(operator)) loadPropertyValues(input)
+                if (!optionsCache[input] && !isOperatorFlag(operator)) loadPropertyValues(input)
             }}
             data-attr="prop-val"
             dropdownMatchSelectWidth={350}

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import api from '../../api'
 import { Select } from 'antd'
+import api from '../../api'
+import { isOperatorNonparametric } from 'lib/utils'
 
 export function PropertyValue({
     propertyKey,
@@ -46,7 +47,6 @@ export function PropertyValue({
     }, [propertyKey])
 
     let displayOptions
-    if (operator === 'is_set') displayOptions = ['true', 'false']
     displayOptions = ((options[propertyKey] && options[propertyKey].values) || []).filter(
         option => input === '' || (option && option.name?.toLowerCase().indexOf(input.toLowerCase()) > -1)
     )
@@ -61,7 +61,7 @@ export function PropertyValue({
             loading={optionsCache[input] === 'loading'}
             onSearch={input => {
                 setInput(input)
-                if (!optionsCache[input] && operator !== 'is_set') loadPropertyValues(input)
+                if (!optionsCache[input] && !isOperatorNonparametric(operator)) loadPropertyValues(input)
             }}
             data-attr="prop-val"
             dropdownMatchSelectWidth={350}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -196,7 +196,7 @@ export const operatorMap = {
     is_not_set: '✕ is not set',
 }
 
-export function isOperatorNonparametric(operator) {
+export function isOperatorFlag(operator) {
     // these filter operators can only be just set, no additional parameter
     return ['is_set', 'is_not_set'].includes(operator)
 }

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -193,6 +193,12 @@ export const operatorMap = {
     gt: '> greater than',
     lt: '< lower than',
     is_set: '✓ is set',
+    is_not_set: '✕ is not set',
+}
+
+export function isOperatorNonparametric(operator) {
+    // these filter operators can only be just set, no additional parameter
+    return ['is_set', 'is_not_set'].includes(operator)
 }
 
 export const formatProperty = property => {

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -44,7 +44,7 @@ class TestPerson(BaseTest):
 
         response = self.client.get(
             "/api/person/?properties=%s"
-            % json.dumps([{"key": "email", "operator": "is_set", "value": "true"}])
+            % json.dumps([{"key": "email", "operator": "is_set", "value": "is_set"}])
         ).json()
         self.assertEqual(len(response["results"]), 2)
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -44,7 +44,7 @@ class TestPerson(BaseTest):
 
         response = self.client.get(
             "/api/person/?properties=%s"
-            % json.dumps([{"key": "email", "operator": "is_set", "value": "is_set"}])
+            % json.dumps([{"key": "email", "operator": "is_set", "value": "true"}])
         ).json()
         self.assertEqual(len(response["results"]), 2)
 

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -51,7 +51,9 @@ class Property:
         if self.operator == 'not_icontains':
             return Q(~Q(**{'properties__{}__icontains'.format(self.key): value}) | ~Q(properties__has_key=self.key))
         if self.operator == 'is_set':
-            return Q(**{'properties__{}__isnull'.format(self.key): not value})
+            return Q(**{'properties__{}__isnull'.format(self.key): False})
+        if self.operator == 'is_not_set':
+            return Q(**{'properties__{}__isnull'.format(self.key): True})
         return Q(**{'properties__{}{}'.format(self.key, '__{}'.format(self.operator) if self.operator else ''): value})
 
 class PropertyMixin:

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -2,135 +2,229 @@ from posthog.api.test.base import BaseTest
 from posthog.models import Filter, Property, Event, Person, Element
 import json
 
+
 class TestFilter(BaseTest):
     def test_old_style_properties(self):
-        filter = Filter(data={
-            'properties': {
-                '$browser__is_not': 'IE7',
-                '$OS': 'Mac',
-            }
-        })
-        self.assertEqual(filter.properties[0].key, '$browser')
-        self.assertEqual(filter.properties[0].operator, 'is_not')
-        self.assertEqual(filter.properties[0].value, 'IE7')
-        self.assertEqual(filter.properties[0].type, 'event')
-        self.assertEqual(filter.properties[1].key, '$OS')
+        filter = Filter(data={"properties": {"$browser__is_not": "IE7", "$OS": "Mac",}})
+        self.assertEqual(filter.properties[0].key, "$browser")
+        self.assertEqual(filter.properties[0].operator, "is_not")
+        self.assertEqual(filter.properties[0].value, "IE7")
+        self.assertEqual(filter.properties[0].type, "event")
+        self.assertEqual(filter.properties[1].key, "$OS")
         self.assertEqual(filter.properties[1].operator, None)
-        self.assertEqual(filter.properties[1].value, 'Mac')
+        self.assertEqual(filter.properties[1].value, "Mac")
+
 
 class TestSelectors(BaseTest):
     def test_selectors(self):
-        event1 = Event.objects.create(team=self.team, event='$autocapture', elements=[
-            Element.objects.create(tag_name='a', order=0),
-            Element.objects.create(tag_name='div', order=1)
-        ])
-        event2 = Event.objects.create(team=self.team, event='$autocapture')
-        filter = Filter(data={
-            'properties': [{'key': 'selector', 'value': 'div > a', 'type': 'element'}]
-        })
+        event1 = Event.objects.create(
+            team=self.team,
+            event="$autocapture",
+            elements=[
+                Element.objects.create(tag_name="a", order=0),
+                Element.objects.create(tag_name="div", order=1),
+            ],
+        )
+        event2 = Event.objects.create(team=self.team, event="$autocapture")
+        filter = Filter(
+            data={
+                "properties": [
+                    {"key": "selector", "value": "div > a", "type": "element"}
+                ]
+            }
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.count(), 1)
 
+
 class TestPropertiesToQ(BaseTest):
     def test_simple(self):
-        Event.objects.create(team=self.team, event='$pageview')
-        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
-        filter = Filter(data={
-            'properties': {'$current_url': 'https://whatever.com'}
-        })
+        Event.objects.create(team=self.team, event="$pageview")
+        Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://whatever.com"},
+        )
+        filter = Filter(data={"properties": {"$current_url": "https://whatever.com"}})
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.count(), 1)
 
     def test_contains(self):
-        Event.objects.create(team=self.team, event='$pageview')
-        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
-        filter = Filter(data={
-            'properties': {'$current_url__icontains': 'whatever'}
-        })
+        Event.objects.create(team=self.team, event="$pageview")
+        event2 = Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://whatever.com"},
+        )
+        filter = Filter(data={"properties": {"$current_url__icontains": "whatever"}})
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.get(), event2)
 
     def test_is_not(self):
-        event1 = Event.objects.create(team=self.team, event='$pageview')
-        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com'})
-        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
-        filter = Filter(data={
-            'properties': {'$current_url__is_not': 'https://whatever.com'}
-        })
+        event1 = Event.objects.create(team=self.team, event="$pageview")
+        event2 = Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://something.com"},
+        )
+        Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://whatever.com"},
+        )
+        filter = Filter(
+            data={"properties": {"$current_url__is_not": "https://whatever.com"}}
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(events[1], event2)
         self.assertEqual(len(events), 2)
 
     def test_does_not_contain(self):
-        event1 = Event.objects.create(team=self.team, event='$pageview')
-        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com'})
-        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
-        filter = Filter(data={
-            'properties': {'$current_url__not_icontains': 'whatever.com'}
-        })
+        event1 = Event.objects.create(team=self.team, event="$pageview")
+        event2 = Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://something.com"},
+        )
+        Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://whatever.com"},
+        )
+        filter = Filter(
+            data={"properties": {"$current_url__not_icontains": "whatever.com"}}
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(events[1], event2)
         self.assertEqual(len(events), 2)
 
     def test_multiple(self):
-        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com', 'another_key': 'value'})
-        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com'})
-        filter = Filter(data={
-            'properties': {'$current_url__icontains': 'something.com', 'another_key': 'value'}
-        })
+        event2 = Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={
+                "$current_url": "https://something.com",
+                "another_key": "value",
+            },
+        )
+        Event.objects.create(
+            team=self.team,
+            event="$pageview",
+            properties={"$current_url": "https://something.com"},
+        )
+        filter = Filter(
+            data={
+                "properties": {
+                    "$current_url__icontains": "something.com",
+                    "another_key": "value",
+                }
+            }
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
     def test_user_properties(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=['person1'], properties={'group': 1})
-        person2 = Person.objects.create(team=self.team, distinct_ids=['person2'], properties={'group': 2})
-        event2 = Event.objects.create(team=self.team, distinct_id='person1', event='$pageview', properties={'$current_url': 'https://something.com', 'another_key': 'value'})
-        Event.objects.create(team=self.team, distinct_id='person2', event='$pageview', properties={'$current_url': 'https://something.com'})
-        filter = Filter(data={
-            'properties': [
-                {'key': 'group', 'value': 1, 'type': 'person'}
-            ] 
-        })
-        events = Event.objects.add_person_id(self.team.pk).filter(filter.properties_to_Q(team_id=self.team.pk))
+        person1 = Person.objects.create(
+            team=self.team, distinct_ids=["person1"], properties={"group": 1}
+        )
+        person2 = Person.objects.create(
+            team=self.team, distinct_ids=["person2"], properties={"group": 2}
+        )
+        event2 = Event.objects.create(
+            team=self.team,
+            distinct_id="person1",
+            event="$pageview",
+            properties={
+                "$current_url": "https://something.com",
+                "another_key": "value",
+            },
+        )
+        Event.objects.create(
+            team=self.team,
+            distinct_id="person2",
+            event="$pageview",
+            properties={"$current_url": "https://something.com"},
+        )
+        filter = Filter(
+            data={"properties": [{"key": "group", "value": 1, "type": "person"}]}
+        )
+        events = Event.objects.add_person_id(self.team.pk).filter(
+            filter.properties_to_Q(team_id=self.team.pk)
+        )
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
     def test_boolean_filters(self):
-        event1 = Event.objects.create(team=self.team, event='$pageview')
-        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'is_first_user': True})
-        filter = Filter(data={
-            'properties': [{'key': 'is_first_user', 'value': 'true'}]
-        })
+        event1 = Event.objects.create(team=self.team, event="$pageview")
+        event2 = Event.objects.create(
+            team=self.team, event="$pageview", properties={"is_first_user": True}
+        )
+        filter = Filter(
+            data={"properties": [{"key": "is_first_user", "value": "true"}]}
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
     def test_is_set(self):
-        event1 = Event.objects.create(team=self.team, event='$pageview')
-        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'is_first_user': True})
-        filter = Filter(data={
-            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'false'}]
-        })
+        event1 = Event.objects.create(team=self.team, event="$pageview")
+        event2 = Event.objects.create(
+            team=self.team, event="$pageview", properties={"is_first_user": True}
+        )
+        filter = Filter(
+            data={
+                "properties": [
+                    {
+                        "key": "is_first_user",
+                        "operator": "is_not_set",
+                        "value": "is_not_set",
+                    }
+                ]
+            }
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(len(events), 1)
 
-        filter = Filter(data={
-            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'true'}]
-        })
+        filter = Filter(
+            data={
+                "properties": [
+                    {"key": "is_first_user", "operator": "is_set", "value": "is_set"}
+                ]
+            }
+        )
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
 
     def test_json_object(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=['person1'], properties={'name': {'first_name': 'Mary', 'last_name': 'Smith'}})
-        event1 = Event.objects.create(team=self.team, distinct_id='person1', event='$pageview', properties={'$current_url': 'https://something.com'})
-        filter = Filter(data={
-            'properties': [
-                {'key': 'name', 'value': json.dumps({'first_name': 'Mary', 'last_name': 'Smith'}), 'type': 'person'}
-            ] 
-        })
-        events = Event.objects.add_person_id(self.team.pk).filter(filter.properties_to_Q(team_id=self.team.pk))
+        person1 = Person.objects.create(
+            team=self.team,
+            distinct_ids=["person1"],
+            properties={"name": {"first_name": "Mary", "last_name": "Smith"}},
+        )
+        event1 = Event.objects.create(
+            team=self.team,
+            distinct_id="person1",
+            event="$pageview",
+            properties={"$current_url": "https://something.com"},
+        )
+        filter = Filter(
+            data={
+                "properties": [
+                    {
+                        "key": "name",
+                        "value": json.dumps(
+                            {"first_name": "Mary", "last_name": "Smith"}
+                        ),
+                        "type": "person",
+                    }
+                ]
+            }
+        )
+        events = Event.objects.add_person_id(self.team.pk).filter(
+            filter.properties_to_Q(team_id=self.team.pk)
+        )
         self.assertEqual(events[0], event1)
         self.assertEqual(len(events), 1)

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -2,229 +2,135 @@ from posthog.api.test.base import BaseTest
 from posthog.models import Filter, Property, Event, Person, Element
 import json
 
-
 class TestFilter(BaseTest):
     def test_old_style_properties(self):
-        filter = Filter(data={"properties": {"$browser__is_not": "IE7", "$OS": "Mac",}})
-        self.assertEqual(filter.properties[0].key, "$browser")
-        self.assertEqual(filter.properties[0].operator, "is_not")
-        self.assertEqual(filter.properties[0].value, "IE7")
-        self.assertEqual(filter.properties[0].type, "event")
-        self.assertEqual(filter.properties[1].key, "$OS")
+        filter = Filter(data={
+            'properties': {
+                '$browser__is_not': 'IE7',
+                '$OS': 'Mac',
+            }
+        })
+        self.assertEqual(filter.properties[0].key, '$browser')
+        self.assertEqual(filter.properties[0].operator, 'is_not')
+        self.assertEqual(filter.properties[0].value, 'IE7')
+        self.assertEqual(filter.properties[0].type, 'event')
+        self.assertEqual(filter.properties[1].key, '$OS')
         self.assertEqual(filter.properties[1].operator, None)
-        self.assertEqual(filter.properties[1].value, "Mac")
-
+        self.assertEqual(filter.properties[1].value, 'Mac')
 
 class TestSelectors(BaseTest):
     def test_selectors(self):
-        event1 = Event.objects.create(
-            team=self.team,
-            event="$autocapture",
-            elements=[
-                Element.objects.create(tag_name="a", order=0),
-                Element.objects.create(tag_name="div", order=1),
-            ],
-        )
-        event2 = Event.objects.create(team=self.team, event="$autocapture")
-        filter = Filter(
-            data={
-                "properties": [
-                    {"key": "selector", "value": "div > a", "type": "element"}
-                ]
-            }
-        )
+        event1 = Event.objects.create(team=self.team, event='$autocapture', elements=[
+            Element.objects.create(tag_name='a', order=0),
+            Element.objects.create(tag_name='div', order=1)
+        ])
+        event2 = Event.objects.create(team=self.team, event='$autocapture')
+        filter = Filter(data={
+            'properties': [{'key': 'selector', 'value': 'div > a', 'type': 'element'}]
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.count(), 1)
 
-
 class TestPropertiesToQ(BaseTest):
     def test_simple(self):
-        Event.objects.create(team=self.team, event="$pageview")
-        Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://whatever.com"},
-        )
-        filter = Filter(data={"properties": {"$current_url": "https://whatever.com"}})
+        Event.objects.create(team=self.team, event='$pageview')
+        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
+        filter = Filter(data={
+            'properties': {'$current_url': 'https://whatever.com'}
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.count(), 1)
 
     def test_contains(self):
-        Event.objects.create(team=self.team, event="$pageview")
-        event2 = Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://whatever.com"},
-        )
-        filter = Filter(data={"properties": {"$current_url__icontains": "whatever"}})
+        Event.objects.create(team=self.team, event='$pageview')
+        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
+        filter = Filter(data={
+            'properties': {'$current_url__icontains': 'whatever'}
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.get(), event2)
 
     def test_is_not(self):
-        event1 = Event.objects.create(team=self.team, event="$pageview")
-        event2 = Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://something.com"},
-        )
-        Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://whatever.com"},
-        )
-        filter = Filter(
-            data={"properties": {"$current_url__is_not": "https://whatever.com"}}
-        )
+        event1 = Event.objects.create(team=self.team, event='$pageview')
+        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com'})
+        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
+        filter = Filter(data={
+            'properties': {'$current_url__is_not': 'https://whatever.com'}
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(events[1], event2)
         self.assertEqual(len(events), 2)
 
     def test_does_not_contain(self):
-        event1 = Event.objects.create(team=self.team, event="$pageview")
-        event2 = Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://something.com"},
-        )
-        Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://whatever.com"},
-        )
-        filter = Filter(
-            data={"properties": {"$current_url__not_icontains": "whatever.com"}}
-        )
+        event1 = Event.objects.create(team=self.team, event='$pageview')
+        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com'})
+        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://whatever.com'})
+        filter = Filter(data={
+            'properties': {'$current_url__not_icontains': 'whatever.com'}
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(events[1], event2)
         self.assertEqual(len(events), 2)
 
     def test_multiple(self):
-        event2 = Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={
-                "$current_url": "https://something.com",
-                "another_key": "value",
-            },
-        )
-        Event.objects.create(
-            team=self.team,
-            event="$pageview",
-            properties={"$current_url": "https://something.com"},
-        )
-        filter = Filter(
-            data={
-                "properties": {
-                    "$current_url__icontains": "something.com",
-                    "another_key": "value",
-                }
-            }
-        )
+        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com', 'another_key': 'value'})
+        Event.objects.create(team=self.team, event='$pageview', properties={'$current_url': 'https://something.com'})
+        filter = Filter(data={
+            'properties': {'$current_url__icontains': 'something.com', 'another_key': 'value'}
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
     def test_user_properties(self):
-        person1 = Person.objects.create(
-            team=self.team, distinct_ids=["person1"], properties={"group": 1}
-        )
-        person2 = Person.objects.create(
-            team=self.team, distinct_ids=["person2"], properties={"group": 2}
-        )
-        event2 = Event.objects.create(
-            team=self.team,
-            distinct_id="person1",
-            event="$pageview",
-            properties={
-                "$current_url": "https://something.com",
-                "another_key": "value",
-            },
-        )
-        Event.objects.create(
-            team=self.team,
-            distinct_id="person2",
-            event="$pageview",
-            properties={"$current_url": "https://something.com"},
-        )
-        filter = Filter(
-            data={"properties": [{"key": "group", "value": 1, "type": "person"}]}
-        )
-        events = Event.objects.add_person_id(self.team.pk).filter(
-            filter.properties_to_Q(team_id=self.team.pk)
-        )
+        person1 = Person.objects.create(team=self.team, distinct_ids=['person1'], properties={'group': 1})
+        person2 = Person.objects.create(team=self.team, distinct_ids=['person2'], properties={'group': 2})
+        event2 = Event.objects.create(team=self.team, distinct_id='person1', event='$pageview', properties={'$current_url': 'https://something.com', 'another_key': 'value'})
+        Event.objects.create(team=self.team, distinct_id='person2', event='$pageview', properties={'$current_url': 'https://something.com'})
+        filter = Filter(data={
+            'properties': [
+                {'key': 'group', 'value': 1, 'type': 'person'}
+            ] 
+        })
+        events = Event.objects.add_person_id(self.team.pk).filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
     def test_boolean_filters(self):
-        event1 = Event.objects.create(team=self.team, event="$pageview")
-        event2 = Event.objects.create(
-            team=self.team, event="$pageview", properties={"is_first_user": True}
-        )
-        filter = Filter(
-            data={"properties": [{"key": "is_first_user", "value": "true"}]}
-        )
+        event1 = Event.objects.create(team=self.team, event='$pageview')
+        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'is_first_user': True})
+        filter = Filter(data={
+            'properties': [{'key': 'is_first_user', 'value': 'true'}]
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
     def test_is_set(self):
-        event1 = Event.objects.create(team=self.team, event="$pageview")
-        event2 = Event.objects.create(
-            team=self.team, event="$pageview", properties={"is_first_user": True}
-        )
-        filter = Filter(
-            data={
-                "properties": [
-                    {
-                        "key": "is_first_user",
-                        "operator": "is_not_set",
-                        "value": "is_not_set",
-                    }
-                ]
-            }
-        )
+        event1 = Event.objects.create(team=self.team, event='$pageview')
+        event2 = Event.objects.create(team=self.team, event='$pageview', properties={'is_first_user': True})
+        filter = Filter(data={
+            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'false'}]
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(len(events), 1)
 
-        filter = Filter(
-            data={
-                "properties": [
-                    {"key": "is_first_user", "operator": "is_set", "value": "is_set"}
-                ]
-            }
-        )
+        filter = Filter(data={
+            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'true'}]
+        })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
 
     def test_json_object(self):
-        person1 = Person.objects.create(
-            team=self.team,
-            distinct_ids=["person1"],
-            properties={"name": {"first_name": "Mary", "last_name": "Smith"}},
-        )
-        event1 = Event.objects.create(
-            team=self.team,
-            distinct_id="person1",
-            event="$pageview",
-            properties={"$current_url": "https://something.com"},
-        )
-        filter = Filter(
-            data={
-                "properties": [
-                    {
-                        "key": "name",
-                        "value": json.dumps(
-                            {"first_name": "Mary", "last_name": "Smith"}
-                        ),
-                        "type": "person",
-                    }
-                ]
-            }
-        )
-        events = Event.objects.add_person_id(self.team.pk).filter(
-            filter.properties_to_Q(team_id=self.team.pk)
-        )
+        person1 = Person.objects.create(team=self.team, distinct_ids=['person1'], properties={'name': {'first_name': 'Mary', 'last_name': 'Smith'}})
+        event1 = Event.objects.create(team=self.team, distinct_id='person1', event='$pageview', properties={'$current_url': 'https://something.com'})
+        filter = Filter(data={
+            'properties': [
+                {'key': 'name', 'value': json.dumps({'first_name': 'Mary', 'last_name': 'Smith'}), 'type': 'person'}
+            ] 
+        })
+        events = Event.objects.add_person_id(self.team.pk).filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(len(events), 1)

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -108,18 +108,18 @@ class TestPropertiesToQ(BaseTest):
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
-    def test_is_set(self):
+    def test_is_not_set_and_is_set(self):
         event1 = Event.objects.create(team=self.team, event='$pageview')
         event2 = Event.objects.create(team=self.team, event='$pageview', properties={'is_first_user': True})
         filter = Filter(data={
-            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'false'}]
+            'properties': [{'key': 'is_first_user', 'operator': 'is_not_set', 'value': 'is_not_set'}]
         })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event1)
         self.assertEqual(len(events), 1)
 
         filter = Filter(data={
-            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'true'}]
+            'properties': [{'key': 'is_first_user', 'operator': 'is_set', 'value': 'is_set'}]
         })
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
 


### PR DESCRIPTION
## Changes
Reworked boolean property filter operator `is_set` into flags `is_set` and `is_not_set`. This solution is more elegant and user-friendly. Here's how it looks:

![ops](https://user-images.githubusercontent.com/4550621/85996873-151e4a00-ba09-11ea-99e2-374e0a17c0b8.png)

Note: There *may* be a backwards compatibility issue should a user share a link with value `false` set with operator `is_set` – after this rework the value is irrelevant in the case of flag operators (which at this point are `is_set` and `is_not_set`), while previously a falsy value resulted in `is_set` negation. This scenario doesn't seem *significantly* likely though, so in this implementation there's no backwards compatibility logic.

## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
