### PR TITLE
Revert "Fix old editor toolbar (#1114)"

### DIFF
--- a/frontend/src/editor/index.js
+++ b/frontend/src/editor/index.js
@@ -4,13 +4,9 @@ import Simmer from 'simmerjs'
 import root from 'react-shadow'
 import { ActionEdit } from '~/scenes/actions/ActionEdit'
 import Draggable from 'react-draggable'
-import { connect, getContext } from 'kea'
+import { getContext } from 'kea'
 import { Provider } from 'react-redux'
 import { hot } from 'react-hot-loader/root'
-import { initKea } from '~/initKea'
-import { userLogic } from 'scenes/userLogic'
-
-initKea()
 
 window.simmer = new Simmer(window, { depth: 8 })
 
@@ -190,7 +186,8 @@ class _App extends Component {
         )
     }
 }
-const App = hot(connect([userLogic])(_App))
+
+const App = hot(_App)
 
 window.ph_load_editor = function(editorParams) {
     let container = document.createElement('div')

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -335,6 +335,7 @@ export class ActionStep extends Component {
                                 </p>
                             ),
                         ]}
+
                         {step.event === '$autocapture' && (
                             <this.AutocaptureFields step={step} isEditor={isEditor} actionId={actionId} />
                         )}
@@ -367,18 +368,16 @@ export class ActionStep extends Component {
                                 )}
                             </div>
                         )}
-                        {!isEditor ? (
-                            <PropertyFilters
-                                propertyFilters={step.properties}
-                                pageKey={'action-edit'}
-                                onChange={properties => {
-                                    this.sendStep({
-                                        ...this.props.step, // Not sure why, but the normal 'step' variable does not work here
-                                        properties,
-                                    })
-                                }}
-                            />
-                        ) : null}
+                        <PropertyFilters
+                            propertyFilters={step.properties}
+                            pageKey={'action-edit'}
+                            onChange={properties => {
+                                this.sendStep({
+                                    ...this.props.step, // Not sure why, but the normal 'step' variable does not work here
+                                    properties,
+                                })
+                            }}
+                        />
                     </div>
                 </div>
             </div>

--- a/frontend/src/scenes/userLogic.js
+++ b/frontend/src/scenes/userLogic.js
@@ -28,13 +28,13 @@ export const userLogic = kea({
     selectors: ({ selectors }) => ({
         eventProperties: [
             () => [selectors.user],
-            user => user?.team.event_properties.map(property => ({ value: property, label: property })) || [],
+            user => user.team.event_properties.map(property => ({ value: property, label: property })),
         ],
         eventNames: [() => [selectors.user], user => user.team.event_names],
         customEventNames: [
             () => [selectors.user],
             user => {
-                const eventNames = user?.team.event_names || []
+                const eventNames = user.team.event_names
                 const regex = new RegExp('^[^$].*')
                 const filtered = eventNames.filter(event => event.match(regex))
                 return filtered
@@ -47,7 +47,7 @@ export const userLogic = kea({
                     { label: 'Custom events', options: [] },
                     { label: 'PostHog events', options: [] },
                 ]
-                user?.team.event_names.forEach(name => {
+                user.team.event_names.forEach(name => {
                     let format = { label: name, value: name }
                     if (posthogEvents.indexOf(name) > -1) return data[1].options.push(format)
                     data[0].options.push(format)


### PR DESCRIPTION
This reverts commit 0720c6e7a33536be5ad8e5025cc78a83f1369adf.

## Changes

Reverts #1114 . Somehow deploys are now broken after that.

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
