### PR TITLE
Fix chart sizing in Safari (solves #1045)

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.js
+++ b/frontend/src/scenes/dashboard/DashboardItem.js
@@ -244,14 +244,12 @@ export function DashboardItem({
                 </div>
                 <div className="dashboard-item-content">
                     {Element ? (
-                        <div className="graph-container">
-                            <Element
-                                dashboardItemId={item.id}
-                                filters={filters}
-                                color={color}
-                                theme={color === 'white' ? 'light' : 'dark'}
-                            />
-                        </div>
+                        <Element
+                            dashboardItemId={item.id}
+                            filters={filters}
+                            color={color}
+                            theme={color === 'white' ? 'light' : 'dark'}
+                        />
                     ) : (
                         <Loading />
                     )}

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -55,14 +55,13 @@
         }
     }
     .dashboard-item-content {
-        padding: 8px 15px 15px 15px;
+        margin: 8px 15px 15px 15px;
         overflow: hidden;
         flex-grow: 1;
         position: relative;
         .graph-container {
             width: 100%;
             height: 100%;
-            position: relative;
         }
     }
     .dashboard-item-container.table .dashboard-item-content {


### PR DESCRIPTION
## Changes

Safari was reluctant to properly size graph containers. Pie charts were mentioned in particular in #1045 – which were completely broken – but the same issue affected somewhat other charts too. It took some tinkering to figure out the browser's problem, but should be fixed now. Using Safari 13.1.1.

Before:
![before](https://user-images.githubusercontent.com/4550621/86005545-16ee0a80-ba15-11ea-8a1c-96ba7e9c374b.png)

After:
![after](https://user-images.githubusercontent.com/4550621/86005573-1c4b5500-ba15-11ea-97f8-7dbfa76b6439.png)

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
