### PR TITLE
Fix funnel query generation when applying element filters (solves #1089)

### DIFF
--- a/posthog/api/test/test_funnel.py
+++ b/posthog/api/test/test_funnel.py
@@ -33,6 +33,22 @@ class TestCreateFunnel(BaseTest):
         self.assertEqual(funnels.get_steps()[0]['order'], 0)
         self.assertEqual(funnels.get_steps()[1]['order'], 1)
 
+    def test_create_funnel_element_filters(self):
+        self.client.post('/api/funnel/', data={
+            'name': 'Whatever',
+            'filters': {
+                'events': [
+                    {
+                        'id': '$autocapture', 'name': '$autocapture', 'type': 'events', 'order': 0,
+                        'properties': [{ 'key': 'text', 'type': 'element', 'value': 'Sign up' }]
+                    }
+                ]
+            }
+        }, content_type='application/json').json()
+        funnels = Funnel.objects.get()
+        self.assertEqual(funnels.filters['events'][0]['id'], '$autocapture')
+        self.assertEqual(funnels.get_steps()[0]['order'], 0)
+
     def test_delete_funnel(self):
         funnel = Funnel.objects.create(team=self.team)
         response = self.client.patch('/api/funnel/%s/' % funnel.pk, data={'deleted': True, 'steps': []}, content_type='application/json').json()


### PR DESCRIPTION
## Changes

This is a fix for funnel Postgres query generation, which resulted in invalid queries when applying element (CSS, tag etc.) filters, as referenced in #1089 for CSS selector filters specifically.

## Checklist
- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [x] Cypress E2E tests (if applicable)
