### PR TITLE
Fix upside down Changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 #### Bugfixes
 
 - Actually include the version bump when you push a release! 🐛
-- Add flutter docs and reorder flow (#1134)[https://github.com/PostHog/posthog/pull/1134]
-- Black all the things! (#1136)[https://github.com/PostHog/posthog/pull/1136]
+- Add flutter docs and reorder flow [#1134](https://github.com/PostHog/posthog/pull/1134)
+- Black all the things! [#1136](https://github.com/PostHog/posthog/pull/1136)
 
 ### 1.10.0 - Wednesday 1 July 2020
 


### PR DESCRIPTION
## Changes

Rushed the bump in version too quick yesterday, lead to upside down markdown links!