### PR TITLE
Feat: Billing Message

### DIFF
--- a/frontend/src/lib/components/BillingToolbar.js
+++ b/frontend/src/lib/components/BillingToolbar.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { WarningOutlined } from '@ant-design/icons'
+
+const BillingToolbar = (props) => {
+    const { billingUrl } = props
+
+    return (
+        <>
+            {billingUrl && (
+                <div className="card">
+                    <div className="card-body">
+                        <WarningOutlined className="text-danger" /> Hey! You're about to reach your usage limit for the
+                        Free Plan.{' '}
+                        <a href={billingUrl} className="text-primary">
+                            <b>Upgrade now</b>
+                        </a>{' '}
+                        to the Growth Plan for $29/month and receive up to 500,000 events/month.
+                    </div>
+                </div>
+            )}
+        </>
+    )
+}
+
+export default BillingToolbar

--- a/frontend/src/lib/components/BillingToolbar.js
+++ b/frontend/src/lib/components/BillingToolbar.js
@@ -9,8 +9,8 @@ const BillingToolbar = (props) => {
             {billingUrl && (
                 <div className="card">
                     <div className="card-body">
-                        <WarningOutlined className="text-danger" /> Hey! You're about to reach your usage limit for the
-                        Free Plan.{' '}
+                        <WarningOutlined className="text-danger" /> Hey! You have reached your usage limit for the Free
+                        Plan.{' '}
                         <a href={billingUrl} className="text-primary">
                             <b>Upgrade now</b>
                         </a>{' '}

--- a/frontend/src/scenes/App.js
+++ b/frontend/src/scenes/App.js
@@ -11,6 +11,7 @@ import { Sidebar } from '~/layout/Sidebar'
 import { TopContent } from '~/layout/TopContent'
 import { SendEventsOverlay } from '~/layout/SendEventsOverlay'
 const OnboardingWizard = lazy(() => import('~/scenes/onboarding/onboardingWizard'))
+import BillingToolbar from 'lib/components/BillingToolbar'
 
 import { userLogic } from 'scenes/userLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -78,6 +79,9 @@ function App() {
                     <TopContent user={user} />
                 </div>
                 <Layout.Content className="pl-5 pr-5 pt-3" data-attr="layout-content">
+                    {user.billing?.should_setup_billing && (
+                        <BillingToolbar billingUrl={user.billing.subscription_url} />
+                    )}
                     {!user.has_events && image ? (
                         <SendEventsOverlay image={image} user={user} />
                     ) : (


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/958 for details.

**Depends on https://github.com/PostHog/posthog-production/pull/5**

## Changes

- Shows a prompt when the user should set-up billing (intended for `posthog-production`) based on a configuration value in the multi_tenancy application.
<img width="1137" alt="billing-toolbar" src="https://user-images.githubusercontent.com/5864173/86792452-1fa39980-c030-11ea-996d-5ed3d24f7784.png">

- Redirect to Stripe Checkout to set up billing.

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [X] Backend tests (if applicable)
- [X] Cypress E2E tests (if applicable)
