### PR TITLE
1139-Fix regex for event filter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -24,7 +24,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     onChange={(_, new_key) =>
                         setFilter(
                             index,
-                            new_key.value.replace(/^(event_|person_|element_)/i, ''),
+                            new_key.value.replace(/^(event_|person_|element_)/gi, ''),
                             undefined,
                             operator,
                             new_key.type

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -24,7 +24,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     onChange={(_, new_key) =>
                         setFilter(
                             index,
-                            new_key.value.replace(/event_|person_|element_/i, ''),
+                            new_key.value.replace(/^(event_|person_|element_)/i, ''),
                             undefined,
                             operator,
                             new_key.type

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -24,7 +24,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     onChange={(_, new_key) =>
                         setFilter(
                             index,
-                            new_key.value.replace(/event_|person_|element_/gi, ''),
+                            new_key.value.replace(/event_|person_|element_/i, ''),
                             undefined,
                             operator,
                             new_key.type


### PR DESCRIPTION
## Changes
- fixes #1139 (regex was being called globally when we really just wanted to remove the prefix/first instance)

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
