### PR TITLE
Closes #1180 worker fails if timestamp is invalid

### DIFF
--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -1,13 +1,13 @@
-from celery import shared_task
-from django.core import serializers
-from posthog.models import Person, Element, Event, Team, PersonDistinctId
+import datetime
 from typing import Union, Dict, Optional
-from dateutil.relativedelta import relativedelta
+
+from celery import shared_task
 from dateutil import parser
+from dateutil.relativedelta import relativedelta
+from django.db import IntegrityError
 from sentry_sdk import capture_exception
 
-from django.db import IntegrityError
-import datetime
+from posthog.models import Person, Element, Event, Team, PersonDistinctId
 
 
 def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_failed: bool = True,) -> None:
@@ -164,7 +164,7 @@ def _handle_timestamp(data: dict, now: str, sent_at: Optional[str]) -> Union[dat
                 capture_exception(e)
 
         return data["timestamp"]
-    now_datetime = parser.isoparse(now)
+    now_datetime = parser.parse(now)
     if data.get("offset"):
         return now_datetime - relativedelta(microseconds=data["offset"] * 1000)
     return now_datetime


### PR DESCRIPTION
## Changes

- use `parser.parse()` instead of `parser. isoparse()`
- optimize imports

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
