### PR TITLE
Closes #1177 N+1 queries when loading live actions

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -211,7 +211,7 @@ class EventViewSet(viewsets.ModelViewSet):
         for event in events:
             if event.pk in ids_seen:
                 continue
-            ids_seen.append(event.pkm)
+            ids_seen.append(event.pk)
             for action in event.action_set.all():
                 event.action = action
                 matches.append(event)

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -212,9 +212,11 @@ class EventViewSet(viewsets.ModelViewSet):
             if event.pk in ids_seen:
                 continue
             ids_seen.append(event.pk)
-            for action in event.action_set.filter(deleted=False):
-                event.action = action
-                matches.append(event)
+            for action in event.action_set.all():
+                # do not use .filter(), because it causes N+1 query problem. Filter just in memory
+                if not action.deleted:
+                    event.action = action
+                    matches.append(event)
         prefetched_events = self._prefetch_events(matches)
         return response.Response(
             {"next": len(events) > 100, "results": [self._serialize_actions(event) for event in prefetched_events],}


### PR DESCRIPTION
## Changes

- filter in-memory, instead of generation n+1 queries 

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
