### PR TITLE
fix sys.argv[1] check to not raise list index out of range

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -221,7 +221,7 @@ else:
 # Broker
 
 # The last case happens when someone upgrades Heroku but doesn't have Redis installed yet. Collectstatic gets called before we can provision Redis.
-if TEST or DEBUG or (sys.argv[1] and sys.argv[1] == "collectstatic"):
+if TEST or DEBUG or (len(sys.argv) > 1 and sys.argv[1] == "collectstatic"):
     REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost/")
 else:
     REDIS_URL = os.environ.get("REDIS_URL", "")


### PR DESCRIPTION
## Changes
- check the length of the list to avoid raising a list index out of range
- there are times where sys.argv[1] will not exist, for example: using uwsgi to deploy

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
