### PR TITLE
Copy correct babel file in docker images

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ COPY package.json /code/
 COPY yarn.lock /code/
 COPY webpack.config.js /code/
 COPY postcss.config.js /code/
-COPY .babelrc /code/
+COPY babel.config.js /code/
 COPY frontend/ /code/frontend
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_12.x  | bash - \

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -37,7 +37,7 @@ COPY package.json /code/
 COPY yarn.lock /code/
 COPY webpack.config.js /code/
 COPY postcss.config.js /code/
-COPY .babelrc /code/
+COPY babel.config.js /code/
 COPY frontend/ /code/frontend
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_12.x  | bash - \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -13,7 +13,7 @@ COPY package.json /code/
 COPY yarn.lock /code/
 COPY webpack.config.js /code/
 COPY postcss.config.js /code/
-COPY .babelrc /code/
+COPY babel.config.js /code/
 COPY frontend/ /code/frontend
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_12.x  | bash - \


### PR DESCRIPTION
## Changes

- We were still copying .babelrc which caused docker images to fail
- This copies babel.config.js instead 

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
