### PR TITLE
Toolbar `__posthog` state param and JS_URL setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "kea-router": "^0.4.0",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "1.2.4",
+        "posthog-js": "1.3.1",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
         "react-datepicker": "^2.13.0",

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -63,8 +63,8 @@ def get_decide(request: HttpRequest):
             if request.user.toolbar_mode == "toolbar":
                 editor_params["toolbarVersion"] = "toolbar"
 
-            if settings.DEBUG:
-                editor_params["jsURL"] = "http://localhost:8234/"
+            if settings.JS_URL:
+                editor_params["jsURL"] = settings.JS_URL
 
             response["editorParams"] = editor_params
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -98,8 +98,9 @@ def redirect_to_site(request):
         "apiURL": request.build_absolute_uri("/"),
         "userIntent": request.GET.get("userIntent"),
     }
-    if settings.DEBUG:
-        params["jsURL"] = "http://localhost:8234/"
+
+    if settings.JS_URL:
+        params["jsURL"] = settings.JS_URL
 
     if use_new_toolbar:
         params["action"] = "ph_authorize"

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -83,6 +83,7 @@ def redirect_to_site(request):
 
     team = request.user.team_set.get()
     app_url = request.GET.get("appUrl") or (team.app_urls and team.app_urls[0])
+    use_new_toolbar = request.user.toolbar_mode == "toolbar"
 
     if not app_url:
         return HttpResponse(status=404)
@@ -99,12 +100,17 @@ def redirect_to_site(request):
     }
     if settings.DEBUG:
         params["jsURL"] = "http://localhost:8234/"
-    if request.user.toolbar_mode == "toolbar":
+
+    if use_new_toolbar:
+        params["action"] = "ph_authorize"
         params["toolbarVersion"] = "toolbar"
 
     state = urllib.parse.quote(json.dumps(params))
 
-    return redirect("{}#state={}".format(app_url, state))
+    if use_new_toolbar:
+        return redirect("{}#__posthog={}".format(app_url, state))
+    else:
+        return redirect("{}#state={}".format(app_url, state))
 
 
 @require_http_methods(["PATCH"])

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -56,6 +56,11 @@ TEST = "test" in sys.argv
 
 SITE_URL = os.environ.get("SITE_URL", "http://localhost:8000")
 
+if DEBUG:
+    JS_URL = os.environ.get("JS_URL", "http://localhost:8234/")
+else:
+    JS_URL = os.environ.get("JS_URL", "")
+
 SECURE_SSL_REDIRECT = False
 
 if not DEBUG and not TEST:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7735,10 +7735,10 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-posthog-js@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.2.4.tgz#ff6589fa2a192d3e6f10ec0c326b144a91e8f5d0"
-  integrity sha512-wpZ/conZxzJzArpLLQEQ0pk0MWjueL3S5ikPBd9IwsNbFTb1cO6kCRag/BckdWg3k4kE6zTr4F5hGbD5C8BpXg==
+posthog-js@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.3.1.tgz#970acec1423eaa5dba0d2603410c9c70294e16da"
+  integrity sha512-Oqvk7ifPCXFhcM8k3l2vnO7OZJtq5A8M3kPjnywVY/oMX0XXu8Nf/9DF45ZYExSaVb06N8fuLAzyPpIv5cQzmg==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Changes

This fixes the problem with the toolbar not loading if some other JS script likes to clear your `state` hash parameter before array.js even loads.

- Upgrade `posthog-js` to 1.3.1 which supports the changes here.
- Use the new params (`__posthog` instead of `state` and `ph_authorize` for the action) when initing the toolbar.
- Add `JS_URL` to settings to manually set Webpack HMR path (can be used to override if running with DEBUG=1)

## Checklist
- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
