### PR TITLE
GitHub templates update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,25 +6,27 @@ labels: bug
 
 ---
 
-**Describe the bug**
+### Bug description
 
 
 
-**To Reproduce**
+### How to reproduce
+
 1. 
 2. 
 3. 
 
-**Expected behavior**
+### Expected behavior
 
 
 
-**Screenshots**
+### Screenshots
 
 
 
-**Hosted or self hosted?:**
-- hosted/self-hosted
-- (if self-hosted) what version?
+### Environment
 
-**Additional context**
+- PostHog cloud or self-managed?
+- PostHog version/commit
+
+### Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,4 +23,4 @@ assignees: ''
 
 
 
-#### *Thank* you for your feature request – we love each and every one!
+#### *Thank you* for your feature request – we love each and every one!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,20 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe
 
 
-**Describe the solution you'd like**
+
+### Describe the solution you'd like
 
 
-**Describe alternatives you've considered**
+
+### Describe alternatives you've considered
 
 
-**Additional context**
+
+### Additional context
 
 
-***Thank*** you for your feature request - we love each and every one!
+
+#### *Thank* you for your feature request – we love each and every one!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 -
 
 ## Checklist
+
 - [ ] All querysets/queries filter by Team (if applicable)
 - [ ] Backend tests (if applicable)
 - [ ] Cypress E2E tests (if applicable)


### PR DESCRIPTION
## Changes

Updated GitHub templates, in particular issue ones, now a bit cleaner than before and reflecting current nomenclature (e.g. hosted/self-hosted → cloud/self-managed).

![Issue template changes](https://user-images.githubusercontent.com/4550621/87306555-77eb0780-c518-11ea-8d71-c821fbad48dc.png)
