### PR TITLE
Fix password validation and improve minimums notice (closes #1197)

### DIFF
--- a/posthog/templates/registration/password_reset_confirm.html
+++ b/posthog/templates/registration/password_reset_confirm.html
@@ -15,8 +15,7 @@
         </div>
         <div class='field'>
             <small id="passwordHelpBlock" class="form-text text-muted">
-                Your password must be at least 8 characters long and must contain at least 1 lowercase letter,
-                1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
+                Your password must be at least 8 characters long and must contain at least 1 lowercase letter, 1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
             </small>
             <input
                 pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[!-~]{8,}$" type="password" name='new_password2'

--- a/posthog/templates/registration/password_reset_confirm.html
+++ b/posthog/templates/registration/password_reset_confirm.html
@@ -14,7 +14,14 @@
             <label for="inputPassword1">Password</label>
         </div>
         <div class='field'>
-            <input type="password" name='new_password2' id="inputPassword1" placeholder="" required>
+            <small id="passwordHelpBlock" class="form-text text-muted">
+                Your password must be at least 8 characters long and must contain at least 1 lowercase letter,
+                1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
+            </small>
+            <input
+                pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[!-~]{8,}$" type="password" name='new_password2'
+                id="inputPassword1" placeholder="" required
+            >
             <label for="inputPassword1">Password (again)</label>
         </div>
         <button class="btn btn-lg btn-primary btn-block" type="submit">Reset password</button>

--- a/posthog/templates/setup_admin.html
+++ b/posthog/templates/setup_admin.html
@@ -26,9 +26,13 @@
             </div>
             <div class='field'>
                 <small id="passwordHelpBlock" class="form-text text-muted">
-                    Your password must be 8-20 characters long and must contain an uppercase letter and a number.
+                    Your password must be at least 8 characters long and must contain at least 1 lowercase letter,
+                    1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
                 </small>
-                <input pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$" type="password" name='password' id="inputPassword" placeholder="" required>
+                <input
+                    pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[!-~]{8,}$" type="password" name='password'
+                    id="inputPassword" placeholder="" required
+                >
                 <label for="inputPassword">Password</label>
             </div>
             <p>

--- a/posthog/templates/setup_admin.html
+++ b/posthog/templates/setup_admin.html
@@ -26,8 +26,7 @@
             </div>
             <div class='field'>
                 <small id="passwordHelpBlock" class="form-text text-muted">
-                    Your password must be at least 8 characters long and must contain at least 1 lowercase letter,
-                    1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
+                    Your password must be at least 8 characters long and must contain at least 1 lowercase letter, 1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
                 </small>
                 <input
                     pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[!-~]{8,}$" type="password" name='password'

--- a/posthog/templates/signup_to_team.html
+++ b/posthog/templates/signup_to_team.html
@@ -21,9 +21,13 @@
             </div>
             <div class='field'>
                 <small id="passwordHelpBlock" class="form-text text-muted">
-                    Your password must be 8-20 characters long and must contain an uppercase letter and a number.
+                    Your password must be at least 8 characters long and must contain at least 1 lowercase letter,
+                    1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
                 </small>
-                <input pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$" type="password" name='password' id="inputPassword" placeholder="" required>
+                <input
+                    pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[!-~]{8,}$" type="password" name='password'
+                    id="inputPassword" placeholder="" required
+                >
                 <label for="inputPassword">Password</label>
             </div>
             <p>

--- a/posthog/templates/signup_to_team.html
+++ b/posthog/templates/signup_to_team.html
@@ -21,8 +21,7 @@
             </div>
             <div class='field'>
                 <small id="passwordHelpBlock" class="form-text text-muted">
-                    Your password must be at least 8 characters long and must contain at least 1 lowercase letter,
-                    1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
+                    Your password must be at least 8 characters long and must contain at least 1 lowercase letter, 1 uppercase letter, and 1 digit. We strongly recommend at least 1 special character as well.
                 </small>
                 <input
                     pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[!-~]{8,}$" type="password" name='password'


### PR DESCRIPTION
## Changes

Made all characters with ASCII codes between ! (33) and ~ (126) allowed client-side (essentially [all ASCII characters barring control ones](https://www.rapidtables.com/code/text/ascii-table.html), so: letters, numbers, special characters). Also made password requirements clearer.

One thing where this isn't updated though is the cloud offering account creation page. Couldn't locate it in code, did I miss it in this repo?

## Checklist

- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [x] Cypress E2E tests (if applicable)
