### PR TITLE
Toolbar Instrumentation (& posthog-js-lite)

### DIFF
--- a/frontend/src/toolbar/ToolbarApp.js
+++ b/frontend/src/toolbar/ToolbarApp.js
@@ -1,16 +1,24 @@
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { dockLogic } from '~/toolbar/dockLogic'
 import { useSecondRender } from 'lib/hooks/useSecondRender'
 import root from 'react-shadow'
 import { ToolbarContainer } from '~/toolbar/ToolbarContainer'
 import { useMountedLogic } from 'kea'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
+import { posthog } from '~/toolbar/posthog'
 
 export function ToolbarApp(props) {
     useMountedLogic(toolbarLogic(props))
 
     const shadowRef = useRef(null)
     useMountedLogic(dockLogic({ shadowRef }))
+
+    useEffect(() => {
+        if (props.instrument) {
+            posthog.identify(null, { email: props.userEmail })
+            posthog.optIn()
+        }
+    }, [])
 
     // this runs after the shadow root has been added to the dom
     const didRender = useSecondRender(() => {

--- a/frontend/src/toolbar/dockLogic.js
+++ b/frontend/src/toolbar/dockLogic.js
@@ -6,6 +6,7 @@ import {
     updateDockToolbarVariables,
 } from '~/toolbar/dockUtils'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
+import { posthog } from '~/toolbar/posthog'
 
 // props:
 // - shadowRef: shadowRoot ref
@@ -120,12 +121,14 @@ export const dockLogic = kea({
             window.addEventListener('resize', cache.onScrollResize)
             window.requestAnimationFrame(() => {
                 if (toolbarLogic.values.isAuthenticated) {
+                    posthog.capture('Toolbar Authenticated')
                     if (values.lastMode === 'dock') {
                         actions.dock()
                     } else {
                         actions.button()
                     }
                 } else {
+                    posthog.capture('Toolbar Pre-Authorize')
                     actions.button()
                 }
             })
@@ -138,12 +141,15 @@ export const dockLogic = kea({
 
     listeners: ({ actions, values, props }) => ({
         button: () => {
+            posthog.capture('Toolbar Button Mode')
             values.mode !== 'button' && actions.setMode('button', false)
         },
         dock: () => {
+            posthog.capture('Toolbar Dock Mode')
             values.mode !== 'dock' && actions.setMode('dock', false)
         },
         hideButton: () => {
+            posthog.capture('Toolbar Closed')
             values.mode !== '' && actions.setMode('', false)
         },
         update: () => {

--- a/frontend/src/toolbar/index.js
+++ b/frontend/src/toolbar/index.js
@@ -18,13 +18,7 @@ window.ph_load_editor = function (editorParams) {
 
     ReactDOM.render(
         <Provider store={getContext().store}>
-            <ToolbarApp
-                jsURL={editorParams.jsURL || editorParams.apiURL}
-                apiURL={editorParams.apiURL}
-                temporaryToken={editorParams.temporaryToken}
-                actionId={editorParams.actionId}
-                userIntent={editorParams.userIntent}
-            />
+            <ToolbarApp {...editorParams} jsURL={editorParams.jsURL || editorParams.apiURL} />
         </Provider>,
         container
     )

--- a/frontend/src/toolbar/posthog.js
+++ b/frontend/src/toolbar/posthog.js
@@ -1,0 +1,16 @@
+import { browserPostHog } from 'posthog-js-lite/dist/src/targets/browser'
+
+const apiKey = 'sTMFPsFhdP1Ssg'
+const apiHost = 'https://app.posthog.com'
+
+// const apiKey = '8jVz0YZ2YPtP7eL1I5l5RQIp-WcuFeD3pZO8c0YDMx4'
+// const apiHost = 'http://localhost:8000'
+
+function setupPostHog() {
+    const posthog = browserPostHog(apiKey, {
+        apiHost: apiHost,
+        optedIn: false, // must call .optIn() before any events are sent
+    })
+    return posthog
+}
+export const posthog = setupPostHog()

--- a/frontend/src/toolbar/posthog.js
+++ b/frontend/src/toolbar/posthog.js
@@ -3,9 +3,6 @@ import { browserPostHog } from 'posthog-js-lite/dist/src/targets/browser'
 const apiKey = 'sTMFPsFhdP1Ssg'
 const apiHost = 'https://app.posthog.com'
 
-// const apiKey = '8jVz0YZ2YPtP7eL1I5l5RQIp-WcuFeD3pZO8c0YDMx4'
-// const apiHost = 'http://localhost:8000'
-
 function setupPostHog() {
     const posthog = browserPostHog(apiKey, {
         apiHost: apiHost,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
         "posthog-js": "1.3.1",
+        "posthog-js-lite": "file:.yalc/posthog-js-lite",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
         "react-datepicker": "^2.13.0",
@@ -102,8 +103,8 @@
         }
     },
     "lint-staged": {
-        "*.{js,css,scss}": "prettier --write",
-        "*.js": "eslint",
+        "*.{ts,js,css,scss}": "prettier --write",
+        "*.{ts,js}": "eslint",
         "*.py": "black -l 120"
     },
     "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
         "posthog-js": "1.3.1",
-        "posthog-js-lite": "file:.yalc/posthog-js-lite",
+        "posthog-js-lite": "^0.0.1",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
         "react-datepicker": "^2.13.0",

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -106,6 +106,10 @@ def redirect_to_site(request):
         params["action"] = "ph_authorize"
         params["toolbarVersion"] = "toolbar"
 
+    if not settings.TEST and not os.environ.get("OPT_OUT_CAPTURE"):
+        params["instrument"] = True
+        params["userEmail"] = request.user.email
+
     state = urllib.parse.quote(json.dumps(params))
 
     if use_new_toolbar:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7735,6 +7735,11 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.26, postcss@^7.0
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+posthog-js-lite@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.1.tgz#e32eebc8e5203947bc90bc794615627d7ffe7d28"
+  integrity sha512-CUfSRT/kjKLhGz23iS1YznFNYG/hkwESGzqAae6oFY2ncIXUppTeYvsQ/SM7QTajQEIHP6uUzjgDeaTQum7VWw==
+
 posthog-js@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.3.1.tgz#970acec1423eaa5dba0d2603410c9c70294e16da"


### PR DESCRIPTION
## Changes

This PR adds instrumentation to the toolbar. Very simple for now - just to see if people opened it and/or clicked to the dock mode. I'll add more later events, but just want to get this PR out in the open.

The complicated part of this PR was creating a new library: [posthog-js-lite](https://github.com/PostHog/posthog-js-lite), which is:

- The beginning of a reimplementation of the JS/Browser integration using modern tooling (should be compiled to something that works with IE11+... I don't think we should go lower)
- Currently working: capture & identify calls (incl. setting properties), the rest are for later
- Payload compression with LZ64
- Opt in & opt out
- 10kb, so small enough to embed in a script
- Can run with multiple instances on one page (no clash with window.posthog)
- Runs in a browser and uses `fetch` unlike posthog-node, which needs axios to run

Still a lot to do, but this will solve the issue of toolbar instrumentation!

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
