### PR TITLE
Dashboard pie label

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.js
+++ b/frontend/src/scenes/dashboard/DashboardItem.js
@@ -87,6 +87,7 @@ export function DashboardItem({
     dashboards,
     enableWobblyDragging,
     index,
+    layout,
     onRefresh,
 }) {
     const [initialLoaded, setInitialLoaded] = useState(false)
@@ -120,7 +121,7 @@ export function DashboardItem({
     return (
         <div
             key={item.id}
-            className={`dashboard-item ${item.color || 'white'}`}
+            className={`dashboard-item ${item.color || 'white'} di-width-${layout?.w || 0} di-height-${layout?.h || 0}`}
             {...longPressProps}
             data-attr={'dashboard-item-' + index}
         >

--- a/frontend/src/scenes/dashboard/DashboardItems.js
+++ b/frontend/src/scenes/dashboard/DashboardItems.js
@@ -1,6 +1,6 @@
 import './DashboardItems.scss'
 
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { Responsive, WidthProvider } from '@mariusandra/react-grid-layout'
 
@@ -13,12 +13,13 @@ const noop = () => {}
 
 export function DashboardItems({ logic }) {
     const { dashboards } = useValues(dashboardsModel)
-    const { dashboard, items, layouts, breakpoints, cols, draggingEnabled } = useValues(logic)
+    const { dashboard, items, layouts, layoutForItem, breakpoints, cols, draggingEnabled } = useValues(logic)
     const {
         loadDashboardItems,
         renameDashboardItem,
         refreshDashboardItem,
         updateLayouts,
+        updateContainerWidth,
         updateItemColor,
         duplicateDashboardItem,
         enableWobblyDragging,
@@ -26,6 +27,7 @@ export function DashboardItems({ logic }) {
 
     // make sure the dashboard takes up the right size
     useEffect(() => triggerResizeAfterADelay(), [])
+    const [resizingItem, setResizingItem] = useState(null)
 
     // can not click links when dragging and 250ms after
     const isDragging = useRef(false)
@@ -46,10 +48,17 @@ export function DashboardItems({ logic }) {
                 updateLayouts(layouts)
                 triggerResize()
             }}
+            onWidthChange={(containerWidth, _, cols) => {
+                updateContainerWidth(containerWidth, cols)
+            }}
             breakpoints={breakpoints}
             resizeHandles={['s', 'e', 'se']}
             cols={cols}
             onResize={(layout, oldItem, newItem) => {
+                if (!resizingItem || resizingItem.w !== newItem.w || resizingItem.h !== newItem.h) {
+                    setResizingItem(newItem)
+                }
+
                 // Trigger the resize event for funnels, as they won't update their dimensions
                 // when their container is resized and must be recalculated.
                 // Skip this for other types as it slows down the interactions a bit.
@@ -58,7 +67,10 @@ export function DashboardItems({ logic }) {
                     triggerResize()
                 }
             }}
-            onResizeStop={triggerResizeAfterADelay}
+            onResizeStop={() => {
+                setResizingItem(null)
+                triggerResizeAfterADelay()
+            }}
             onDrag={() => {
                 isDragging.current = true
                 window.clearTimeout(dragEndTimeout.current)
@@ -77,6 +89,9 @@ export function DashboardItems({ logic }) {
                         key={item.id}
                         dashboardId={dashboard.id}
                         item={item}
+                        layout={
+                            resizingItem?.i?.toString() === item.id.toString() ? resizingItem : layoutForItem[item.id]
+                        }
                         loadDashboardItems={loadDashboardItems}
                         renameDashboardItem={renameDashboardItem}
                         duplicateDashboardItem={duplicateDashboardItem}

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -21,6 +21,7 @@ export const dashboardLogic = kea({
         duplicateDashboardItem: (id, dashboardId, move = false) => ({ id, dashboardId, move }),
         duplicateDashboardItemSuccess: (item) => ({ item }),
         updateLayouts: (layouts) => ({ layouts }),
+        updateContainerWidth: (containerWidth, columns) => ({ containerWidth, columns }),
         saveLayouts: true,
         updateItemColor: (id, color) => ({ id, color }),
         enableDragging: true,
@@ -84,6 +85,18 @@ export const dashboardLogic = kea({
                 disableDragging: () => 'off',
             },
         ],
+        containerWidth: [
+            null,
+            {
+                updateContainerWidth: (_, { containerWidth }) => containerWidth,
+            },
+        ],
+        columns: [
+            null,
+            {
+                updateContainerWidth: (_, { columns }) => columns,
+            },
+        ],
     }),
 
     selectors: ({ props, selectors }) => ({
@@ -95,6 +108,13 @@ export const dashboardLogic = kea({
         ],
         breakpoints: [() => [], () => ({ lg: 1600, sm: 940, xs: 480, xxs: 0 })],
         cols: [() => [], () => ({ lg: 24, sm: 12, xs: 6, xxs: 2 })],
+        sizeKey: [
+            (s) => [s.columns, s.cols],
+            (columns, cols) => {
+                const [size] = Object.entries(cols).find(([, value]) => value === columns) || []
+                return size
+            },
+        ],
         layouts: [
             () => [selectors.items, selectors.cols],
             (items, cols) => {
@@ -165,6 +185,19 @@ export const dashboardLogic = kea({
                     allLayouts[col] = cleanLayouts
                 })
                 return allLayouts
+            },
+        ],
+        layout: [(s) => [s.layouts, s.sizeKey], (layouts, sizeKey) => layouts[sizeKey]],
+        layoutForItem: [
+            (s) => [s.layout],
+            (layout) => {
+                const layoutForItem = {}
+                if (layout) {
+                    for (const obj of layout) {
+                        layoutForItem[obj.i] = obj
+                    }
+                }
+                return layoutForItem
             },
         ],
     }),

--- a/frontend/src/scenes/trends/ActionsPie.js
+++ b/frontend/src/scenes/trends/ActionsPie.js
@@ -1,3 +1,5 @@
+import './ActionsPie.scss'
+
 import React, { useEffect, useState } from 'react'
 import { Loading } from 'lib/utils'
 import { LineGraph } from './LineGraph'
@@ -43,32 +45,20 @@ export function ActionsPie({ dashboardItemId, filters: filtersParam, color }) {
 
     return data && !resultsLoading ? (
         data[0] && data[0].labels ? (
-            <div
-                style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '80%',
-                }}
-            >
-                <h1
-                    style={{
-                        position: 'absolute',
-                        margin: '0 auto',
-                        left: '50%',
-                        top: '100%',
-                        fontSize: '1.5rem',
-                        pointerEvents: 'none',
-                    }}
-                >
-                    <div style={{ marginLeft: '-50%', marginTop: 5 }}>Total: {total}</div>
+            <div className="actions-pie-component">
+                <div className="pie-chart">
+                    <LineGraph
+                        data-attr="trend-pie-graph"
+                        color={color}
+                        type="doughnut"
+                        datasets={data}
+                        labels={data[0].labels}
+                    />
+                </div>
+                <h1>
+                    <span className="label">Total: </span>
+                    {total}
                 </h1>
-                <LineGraph
-                    data-attr="trend-pie-graph"
-                    color={color}
-                    type="doughnut"
-                    datasets={data}
-                    labels={data[0].labels}
-                />
             </div>
         ) : (
             <p style={{ textAlign: 'center', marginTop: '4rem' }}>We couldn't find any matching actions.</p>

--- a/frontend/src/scenes/trends/ActionsPie.scss
+++ b/frontend/src/scenes/trends/ActionsPie.scss
@@ -1,22 +1,39 @@
 .actions-pie-component {
-    position: relative;
+    position: absolute;
     width: 100%;
     height: 100%;
 
     .pie-chart {
-        position: absolute;
+        position: relative;
         width: 100%;
-        height: calc(100% - 30px);
+        height: calc(100% - 100px);
+        transition: height 0.5s;
     }
-
     h1 {
         position: absolute;
         bottom: 0;
         width: 100%;
-        font-size: 18px;
+        font-size: 56px;
+        transition: font-size 0.5s;
         margin: 0;
         text-align: center;
         line-height: 1.3em;
+    }
+    @media (max-width: 700px) {
+        .pie-chart {
+            height: calc(100% - 60px);
+        }
+        h1 {
+            font-size: 48px;
+        }
+    }
+    @media (max-width: 500px) {
+        .pie-chart {
+            height: calc(100% - 50px);
+        }
+        h1 {
+            font-size: 32px;
+        }
     }
 }
 

--- a/frontend/src/scenes/trends/ActionsPie.scss
+++ b/frontend/src/scenes/trends/ActionsPie.scss
@@ -1,0 +1,114 @@
+.actions-pie-component {
+    position: relative;
+    width: 100%;
+    height: 100%;
+
+    .pie-chart {
+        position: absolute;
+        width: 100%;
+        height: calc(100% - 30px);
+    }
+
+    h1 {
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        font-size: 18px;
+        margin: 0;
+        text-align: center;
+        line-height: 1.3em;
+    }
+}
+
+.dashboard-item.di-width-1,
+.dashboard-item.di-width-2 {
+    .actions-pie-component {
+        .pie-chart {
+            height: calc(100% - 20px);
+        }
+
+        h1 {
+            font-size: 16px;
+            .label {
+                display: none;
+            }
+        }
+    }
+}
+
+.dashboard-item.di-width-3,
+.dashboard-item.di-width-4 {
+    .actions-pie-component {
+        .pie-chart {
+            height: calc(100% - 30px);
+        }
+
+        h1 {
+            font-size: 24px;
+            .label {
+                display: none;
+            }
+        }
+    }
+}
+
+.dashboard-item.di-width-5,
+.dashboard-item.di-width-6 {
+    .actions-pie-component {
+        .pie-chart {
+            height: calc(100% - 40px);
+        }
+
+        h1 {
+            font-size: 36px;
+        }
+    }
+}
+.dashboard-item.di-width-7,
+.dashboard-item.di-width-8,
+.dashboard-item.di-width-9,
+.dashboard-item.di-width-10 {
+    .actions-pie-component {
+        .pie-chart {
+            height: calc(100% - 70px);
+        }
+
+        h1 {
+            font-size: 48px;
+        }
+    }
+}
+.dashboard-item.di-width-11,
+.dashboard-item.di-width-12,
+.dashboard-item.di-width-13,
+.dashboard-item.di-width-14,
+.dashboard-item.di-width-15,
+.dashboard-item.di-width-16 {
+    .actions-pie-component {
+        .pie-chart {
+            height: calc(100% - 100px);
+        }
+
+        h1 {
+            font-size: 64px;
+        }
+    }
+}
+.dashboard-item.di-width-17,
+.dashboard-item.di-width-18,
+.dashboard-item.di-width-19,
+.dashboard-item.di-width-20,
+.dashboard-item.di-width-21,
+.dashboard-item.di-width-22,
+.dashboard-item.di-width-23,
+.dashboard-item.di-width-24 {
+    .actions-pie-component {
+        .pie-chart {
+            height: calc(100% - 130px);
+        }
+
+        h1 {
+            font-size: 96px;
+        }
+    }
+}


### PR DESCRIPTION
## Changes

This is how it looks like now:

![2020-07-14 14 53 07](https://user-images.githubusercontent.com/53387/87428104-20b16980-c5e2-11ea-8f90-c7f8435f84f5.gif)

On the trends page it's not ideal, but good enough. The issue with the height was there before this PR. (The height of the chart area is at `70vh` on /trends... so it looks weird on a smaller resolution when everything is in 1 column.)

The label's position/size should be fine though:

![2020-07-14 14 54 11](https://user-images.githubusercontent.com/53387/87428169-3c1c7480-c5e2-11ea-8245-efce19e5ca88.gif)


## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
