### PR TITLE
Retention table event filtering fix

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -19,7 +19,7 @@ export function RetentionTable({ logic }) {
         },
     ]
 
-    if (!retentionLoading) {
+    if (!retentionLoading && retention.data) {
         retention.data[0].values.forEach((_, dayIndex) => {
             columns.push({
                 title: retention.data[dayIndex].label,

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -194,10 +194,9 @@ class EventManager(models.QuerySet):
 
     def query_retention(self, filters, team, event="$pageview") -> models.QuerySet:
         filtered_events = (
-            Event.objects.add_person_id(team_id=team.id)
+            Event.objects.filter_by_event_with_people(event=event, team_id=team.id)
             .filter(filters.date_filter_Q)
             .filter(filters.properties_to_Q(team_id=team.pk))
-            .filter(event=event)
         )
 
         first_date = (
@@ -228,7 +227,6 @@ class EventManager(models.QuerySet):
                 full_query, (filters.date_from,) + events_query_params + first_date_params,
             )
             data = namedtuplefetchall(cursor)
-
         return data
 
     def create(self, site_url: Optional[str] = None, *args: Any, **kwargs: Any):


### PR DESCRIPTION
## Changes
- previously the filtering for retention metric wasn't directly filtering out events based on team. instead `add_person_id` was indirectly filtering for the team but this kept the query really slow

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
