### PR TITLE
Make "new version" less threatening

### DIFF
--- a/frontend/src/layout/LatestVersion.js
+++ b/frontend/src/layout/LatestVersion.js
@@ -4,7 +4,7 @@ import api from './../lib/api'
 import { Button } from 'antd'
 import { ChangelogModal } from '~/layout/ChangelogModal'
 import { userLogic } from 'scenes/userLogic'
-import { CheckOutlined, WarningOutlined } from '@ant-design/icons'
+import { CheckOutlined, BulbOutlined } from '@ant-design/icons'
 
 export function LatestVersion() {
     const { user } = useValues(userLogic)
@@ -47,13 +47,13 @@ export function LatestVersion() {
                                 <Button
                                     type="link"
                                     onClick={() => setChangelogOpen(true)}
-                                    style={{ color: 'var(--red)' }}
+                                    style={{ color: 'hsla(42, 90%, 37%, 1)' }}
                                 >
                                     <span className="hide-when-small">
-                                        <WarningOutlined /> New version available
+                                        <BulbOutlined /> New version available
                                     </span>
                                     <span className="show-when-small">
-                                        <WarningOutlined /> Upgrade!
+                                        <BulbOutlined /> Upgrade!
                                     </span>
                                 </Button>
                             )}


### PR DESCRIPTION
## Changes

Closes #1154

This improves the look of the "new version available" field, making it less threatening:

<img width="693" alt="Screenshot 2020-07-15 at 13 45 54" src="https://user-images.githubusercontent.com/53387/87541620-d1327280-c6a1-11ea-9290-f648c2a8ef8b.png">

<img width="359" alt="Screenshot 2020-07-15 at 13 46 08" src="https://user-images.githubusercontent.com/53387/87541610-cd9eeb80-c6a1-11ea-89fc-6cc1defba17a.png">


## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
