### PR TITLE
Make sessions load

### DIFF
--- a/frontend/src/scenes/sessions/SessionsTable.js
+++ b/frontend/src/scenes/sessions/SessionsTable.js
@@ -18,7 +18,7 @@ export function SessionsTable({ logic }) {
             render: function RenderSession(session) {
                 return (
                     <Link to={`/person/${encodeURIComponent(session.distinct_id)}`} className="ph-no-capture">
-                        {session.properties.email || session.distinct_id}
+                        {session.properties?.email || session.distinct_id}
                     </Link>
                 )
             },

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -335,9 +335,6 @@ class EventViewSet(viewsets.ModelViewSet):
         request: request.Request,
     ) -> List[Dict[str, Any]]:
 
-        if not events:
-            return []
-
         # format date filter for session view
         _date_gte = Q()
         if session_type is None:
@@ -347,9 +344,8 @@ class EventViewSet(viewsets.ModelViewSet):
                     timestamp__lte=date_filter["timestamp__gte"] + relativedelta(days=1),
                 )
             else:
-                dt = events.order_by("-timestamp").values("timestamp")[0]["timestamp"]
-                if dt:
-                    dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+                dt = datetime.now()
+                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
                 _date_gte = Q(timestamp__gte=dt, timestamp__lte=dt + relativedelta(days=1))
 
         sessions = (

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -242,7 +242,8 @@ class TestEvents(TransactionBaseTest):
             Event.objects.create(team=self.team, event="4th action", distinct_id="1")
             Event.objects.create(team=self.team, event="4th action", distinct_id="2")
 
-        response = self.client.get("/api/event/sessions/").json()
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            response = self.client.get("/api/event/sessions/").json()
         self.assertEqual(len(response["result"]), 2)
         self.assertEqual(response["result"][0]["global_session_id"], 1)
 


### PR DESCRIPTION
## Changes
- original session implementation was causing events to evaluate when unneeded. removed this
- the query is still due for optimizations but this should atleast make things load properly

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
