### PR TITLE
Refined toolbar styles

### DIFF
--- a/frontend/src/toolbar/button/Circle.js
+++ b/frontend/src/toolbar/button/Circle.js
@@ -158,8 +158,6 @@ export function Circle({
                                         : {}),
                                     whiteSpace: 'nowrap',
                                     color: 'white',
-                                    textShadow:
-                                        'black 0px 0px 1px, black 0px 0px 2px, rgba(0, 0, 0, 0.25) 0px 0.3px 0.7px, rgba(0, 0, 0, 0.18) 0px 0.8px 1.6px, rgba(0, 0, 0, 0.15) 0px 1.5px 3px, rgba(0, 0, 0, 0.125) 0px 2.7px 5.4px, rgba(0, 0, 0, 0.1) 0px 5px 10px, rgba(0, 0, 0, 0.07) 0px 12px 24px',
                                     pointerEvents: 'none',
                                     zIndex,
                                     ...labelStyle,

--- a/frontend/src/toolbar/button/Circle.js
+++ b/frontend/src/toolbar/button/Circle.js
@@ -119,7 +119,6 @@ export function Circle({
                                 marginTop: -width / 2,
                                 borderRadius: width / 2,
                                 background: 'white',
-                                boxShadow: '0 0 13px 4px rgba(0, 0, 0, 0.3)',
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'center',
@@ -160,7 +159,7 @@ export function Circle({
                                     whiteSpace: 'nowrap',
                                     color: 'white',
                                     textShadow:
-                                        'rgb(0, 0, 0) 0px 0px 2px, rgba(0,0,0,1) 0 0 2px, rgba(0,0,0,1) 0 0 10px, rgba(255,255,255,0.8) 0 0 40px, rgba(0,0,0,0.8) 0 0 20px',
+                                        'black 0px 0px 1px, black 0px 0px 2px, rgba(0, 0, 0, 0.25) 0px 0.3px 0.7px, rgba(0, 0, 0, 0.18) 0px 0.8px 1.6px, rgba(0, 0, 0, 0.15) 0px 1.5px 3px, rgba(0, 0, 0, 0.125) 0px 2.7px 5.4px, rgba(0, 0, 0, 0.1) 0px 5px 10px, rgba(0, 0, 0, 0.07) 0px 12px 24px',
                                     pointerEvents: 'none',
                                     zIndex,
                                     ...labelStyle,

--- a/frontend/src/toolbar/button/ToolbarButton.scss
+++ b/frontend/src/toolbar/button/ToolbarButton.scss
@@ -25,10 +25,6 @@
 
 .toolbar-info-windows {
     position: fixed;
-
-    .circle-label {
-        font-weight: 500;
-    }
     width: 300px;
     left: 0;
     top: 0;
@@ -37,6 +33,13 @@
         0 2.7px 5.4px rgba(0, 0, 0, 0.125), 0 5px 10px rgba(0, 0, 0, 0.101), 0 12px 24px rgba(0, 0, 0, 0.07);
     opacity: 1;
     transition: opacity ease 0.5s;
+
+    .circle-label {
+        font-weight: 700;
+        text-shadow: black 0 0 1px, black 0 0 2px, rgba(0, 0, 0, 0.25) 0 0.3px 0.7px, rgba(0, 0, 0, 0.18) 0 0.8px 1.6px,
+            rgba(0, 0, 0, 0.15) 0 1.5px 3px, rgba(0, 0, 0, 0.125) 0 2.7px 5.4px, rgba(0, 0, 0, 0.1) 0 5px 10px,
+            rgba(0, 0, 0, 0.07) 0 12px 24px;
+    }
 
     .toolbar-block {
         max-height: 80vh;

--- a/frontend/src/toolbar/button/ToolbarButton.scss
+++ b/frontend/src/toolbar/button/ToolbarButton.scss
@@ -21,6 +21,13 @@
                 0 20.1px 40.1px rgba(0, 0, 0, 0.101), 0 48px 96px rgba(0, 0, 0, 0.07);
         }
     }
+
+    .circle-label {
+        font-weight: 700;
+        text-shadow: black 0 0 1px, black 0 0 2px, rgba(0, 0, 0, 0.25) 0 0.3px 0.7px, rgba(0, 0, 0, 0.18) 0 0.8px 1.6px,
+            rgba(0, 0, 0, 0.15) 0 1.5px 3px, rgba(0, 0, 0, 0.125) 0 2.7px 5.4px, rgba(0, 0, 0, 0.1) 0 5px 10px,
+            rgba(0, 0, 0, 0.07) 0 12px 24px;
+    }
 }
 
 .toolbar-info-windows {
@@ -33,13 +40,6 @@
         0 2.7px 5.4px rgba(0, 0, 0, 0.125), 0 5px 10px rgba(0, 0, 0, 0.101), 0 12px 24px rgba(0, 0, 0, 0.07);
     opacity: 1;
     transition: opacity ease 0.5s;
-
-    .circle-label {
-        font-weight: 700;
-        text-shadow: black 0 0 1px, black 0 0 2px, rgba(0, 0, 0, 0.25) 0 0.3px 0.7px, rgba(0, 0, 0, 0.18) 0 0.8px 1.6px,
-            rgba(0, 0, 0, 0.15) 0 1.5px 3px, rgba(0, 0, 0, 0.125) 0 2.7px 5.4px, rgba(0, 0, 0, 0.1) 0 5px 10px,
-            rgba(0, 0, 0, 0.07) 0 12px 24px;
-    }
 
     .toolbar-block {
         max-height: 80vh;

--- a/frontend/src/toolbar/button/ToolbarButton.scss
+++ b/frontend/src/toolbar/button/ToolbarButton.scss
@@ -11,8 +11,14 @@
     }
 
     .circle-button {
+        transition: box-shadow 0.2s ease;
+        box-shadow: 0 0.3px 0.7px rgba(0, 0, 0, 0.25), 0 0.8px 1.7px rgba(0, 0, 0, 0.18),
+            0 1.5px 3.1px rgba(0, 0, 0, 0.149), 0 2.7px 5.4px rgba(0, 0, 0, 0.125), 0 5px 10px rgba(0, 0, 0, 0.101),
+            0 12px 24px rgba(0, 0, 0, 0.07);
         &:hover {
-            box-shadow: 0 0 13px 4px rgba(0, 0, 0, 0.5) !important;
+            box-shadow: 0 1.3px 2.7px rgba(0, 0, 0, 0.25), 0 3.2px 6.4px rgba(0, 0, 0, 0.18),
+                0 6px 12px rgba(0, 0, 0, 0.149), 0 10.7px 21.4px rgba(0, 0, 0, 0.125),
+                0 20.1px 40.1px rgba(0, 0, 0, 0.101), 0 48px 96px rgba(0, 0, 0, 0.07);
         }
     }
 }
@@ -23,7 +29,8 @@
     left: 0;
     top: 0;
     z-index: 2147483020;
-    box-shadow: hsla(4, 30%, 27%, 0.6) 0px 3px 10px 2px;
+    box-shadow: 0 0.3px 0.7px rgba(0, 0, 0, 0.25), 0 0.8px 1.7px rgba(0, 0, 0, 0.18), 0 1.5px 3.1px rgba(0, 0, 0, 0.149),
+        0 2.7px 5.4px rgba(0, 0, 0, 0.125), 0 5px 10px rgba(0, 0, 0, 0.101), 0 12px 24px rgba(0, 0, 0, 0.07);
     opacity: 1;
     transition: opacity ease 0.5s;
 

--- a/frontend/src/toolbar/button/ToolbarButton.scss
+++ b/frontend/src/toolbar/button/ToolbarButton.scss
@@ -25,6 +25,10 @@
 
 .toolbar-info-windows {
     position: fixed;
+
+    .circle-label {
+        font-weight: 500;
+    }
     width: 300px;
     left: 0;
     top: 0;

--- a/frontend/src/toolbar/dockUtils.js
+++ b/frontend/src/toolbar/dockUtils.js
@@ -4,8 +4,8 @@ export function applyDockBodyStyles(htmlStyle, bodyStyle, zoom, padding, deferTr
     // htmlStyle.background = 'hsl(231, 17%, 22%)'
     htmlStyle.background = 'linear-gradient(to right, hsla(234, 17%, 94%, 1) 71%, hsla(234, 17%, 99%, 1) 100%)'
     bodyStyle.boxShadow = 'hsl(219, 14%, 76%) 30px 30px 70px, hsl(219, 14%, 76%) 8px 8px 10px'
-    if (!Object.keys(bodyStyle).some((styleKey) => styleKey.startsWith('background'))) {
-        // if there's no body background, set to white to avoid transparency
+    if (!bodyStyle.background && !bodyStyle.backgroundColor && !bodyStyle.backgroundImage) {
+        // if body background is not set, set to white to avoid transparency
         bodyStyle.backgroundColor = 'white'
     }
     bodyStyle.width = `100vw`

--- a/frontend/src/toolbar/dockUtils.js
+++ b/frontend/src/toolbar/dockUtils.js
@@ -4,7 +4,8 @@ export function applyDockBodyStyles(htmlStyle, bodyStyle, zoom, padding, deferTr
     // htmlStyle.background = 'hsl(231, 17%, 22%)'
     htmlStyle.background = 'linear-gradient(to right, hsla(234, 17%, 94%, 1) 71%, hsla(234, 17%, 99%, 1) 100%)'
     bodyStyle.boxShadow = 'hsl(219, 14%, 76%) 30px 30px 70px, hsl(219, 14%, 76%) 8px 8px 10px'
-    if (!bodyStyle.backgroundColor) {
+    if (!Object.keys(bodyStyle).some((styleKey) => styleKey.startsWith('background'))) {
+        // if there's no body background, set to white to avoid transparency
         bodyStyle.backgroundColor = 'white'
     }
     bodyStyle.width = `100vw`

--- a/frontend/src/toolbar/styles.scss
+++ b/frontend/src/toolbar/styles.scss
@@ -1,5 +1,6 @@
 .toolbar-block {
     background: white;
+    color: black;
     font-size: 14px;
     padding: 20px;
     &.no-padding {


### PR DESCRIPTION
## Changes

Improved some toolbar styles, in particular shadows.

![Old shadows](https://user-images.githubusercontent.com/4550621/87668698-dad4dc80-c76c-11ea-9347-e8eba3290dbe.png)
![New shadows](https://user-images.githubusercontent.com/4550621/87668701-dd373680-c76c-11ea-9c1c-c7bf142f4c82.png)

Styles are kind of a mess in the toolbar, I think it'd be good to decide upon styling practically only in .css or only in .js and stick to that, because it's not very maintainable the current way.