### PR TITLE
Add regex matching to actions and filters (closes #1150)

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -94,7 +94,7 @@ function PropertyPaneContents({
                 </Select>
             </div>
             {displayOperatorAndValue && (
-                <div className={isOperatorFlag(operator) ? 'col-8 p-0' : 'col-3 pl-0'}>
+                <div className={isOperatorFlag(operator) ? 'col-8 p-0' : 'col-4 pl-0'}>
                     <Select
                         style={{ width: '100%' }}
                         defaultActiveFirstOption
@@ -126,7 +126,7 @@ function PropertyPaneContents({
                 </div>
             )}
             {displayOperatorAndValue && !isOperatorFlag(operator) && (
-                <div className="col-5 p-0">
+                <div className="col-4 p-0">
                     <PropertyValue
                         type={type}
                         key={propkey}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -191,6 +191,7 @@ export const operatorMap = {
     icontains: '∋ contains',
     not_icontains: "∌ doesn't contain",
     regex: '∼ matches regex',
+    not_regex: "≁ doesn't match regex",
     gt: '> greater than',
     lt: '< lower than',
     is_set: '✓ is set',

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -190,7 +190,7 @@ export const operatorMap = {
     is_not: "≠ doesn't equal",
     icontains: '∋ contains',
     not_icontains: "∌ doesn't contain",
-    regex: '~ regex matches',
+    regex: '∼ matches regex',
     gt: '> greater than',
     lt: '< lower than',
     is_set: '✓ is set',

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -190,6 +190,7 @@ export const operatorMap = {
     is_not: "≠ doesn't equal",
     icontains: '∋ contains',
     not_icontains: "∌ doesn't contain",
+    regex: '~ regex matches',
     gt: '> greater than',
     lt: '< lower than',
     is_set: '✓ is set',

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -303,14 +303,14 @@ export class ActionStep extends Component {
                     type="button"
                     className={'btn btn-sm ' + (step.url_matching == 'regex' ? 'btn-secondary' : 'btn-light')}
                 >
-                    regex matches
+                    matches regex
                 </button>
                 <button
                     onClick={() => this.sendStep({ ...step, url_matching: 'exact' })}
                     type="button"
                     className={'btn btn-sm ' + (step.url_matching == 'exact' ? 'btn-secondary' : 'btn-light')}
                 >
-                    exactly matches
+                    matches exactly
                 </button>
             </div>
         )

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -4,6 +4,26 @@ import { AppEditorLink } from '../../lib/components/AppEditorLink/AppEditorLink'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import PropTypes from 'prop-types'
 
+const MATCHING_NOTES = {
+    contains: (
+        <>
+            Use <code>%</code> for wildcard, for example: <code>/user/%/edit</code>.
+        </>
+    ),
+    regex: (
+        <>
+            <a
+                href="https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP"
+                target="_blank"
+                rel="noreferrer"
+            >
+                PostgreSQL regular expression syntax
+            </a>{' '}
+            applies.
+        </>
+    ),
+}
+
 let getSafeText = (el) => {
     if (!el.childNodes || !el.childNodes.length) return
     let elText = ''
@@ -17,6 +37,7 @@ let getSafeText = (el) => {
     })
     return elText
 }
+
 export class ActionStep extends Component {
     constructor(props) {
         super(props)
@@ -278,6 +299,13 @@ export class ActionStep extends Component {
                     contains
                 </button>
                 <button
+                    onClick={() => this.sendStep({ ...step, url_matching: 'regex' })}
+                    type="button"
+                    className={'btn btn-sm ' + (step.url_matching == 'regex' ? 'btn-secondary' : 'btn-light')}
+                >
+                    regex matches
+                </button>
+                <button
                     onClick={() => this.sendStep({ ...step, url_matching: 'exact' })}
                     type="button"
                     className={'btn btn-sm ' + (step.url_matching == 'exact' ? 'btn-secondary' : 'btn-light')}
@@ -361,9 +389,9 @@ export class ActionStep extends Component {
                                     extra_options={<this.URLMatching step={step} isEditor={isEditor} />}
                                     label="URL"
                                 />
-                                {(!step.url_matching || step.url_matching == 'contains') && (
+                                {step.url_matching && step.url_matching in MATCHING_NOTES && (
                                     <small style={{ display: 'block', marginTop: -12 }}>
-                                        Use '%' for wildcard, for example: /user/%/edit
+                                        {MATCHING_NOTES[step.url_matching]}
                                     </small>
                                 )}
                             </div>

--- a/frontend/src/scenes/actions/ActionsTable.js
+++ b/frontend/src/scenes/actions/ActionsTable.js
@@ -41,7 +41,14 @@ export function ActionsTable() {
                                         case '$autocapture':
                                             return 'Autocapture'
                                         case '$pageview':
-                                            return 'URL matches ' + step.url
+                                            switch (step.url_matching) {
+                                                case 'regex':
+                                                    return 'Page view URL regex matches'
+                                                case 'exact':
+                                                    return 'Page view URL exactly matches'
+                                                default:
+                                                    return 'Page view URL contains'
+                                            }
                                         default:
                                             return 'Event: ' + step.event
                                     }

--- a/frontend/src/scenes/actions/ActionsTable.js
+++ b/frontend/src/scenes/actions/ActionsTable.js
@@ -43,9 +43,9 @@ export function ActionsTable() {
                                         case '$pageview':
                                             switch (step.url_matching) {
                                                 case 'regex':
-                                                    return 'Page view URL regex matches'
+                                                    return 'Page view URL matches regex'
                                                 case 'exact':
-                                                    return 'Page view URL exactly matches'
+                                                    return 'Page view URL matches exactly'
                                                 default:
                                                     return 'Page view URL contains'
                                             }

--- a/frontend/src/scenes/trends/ActionSelectInfo.js
+++ b/frontend/src/scenes/trends/ActionSelectInfo.js
@@ -53,7 +53,12 @@ export class ActionSelectInfo extends Component {
                                         )}
                                         {step.url && (
                                             <li>
-                                                URL {step.url_matching == 'contains' ? 'contains' : 'matches'}{' '}
+                                                URL{' '}
+                                                {step.url_matching === 'regex'
+                                                    ? 'regex matches'
+                                                    : step.url_matching === 'exact'
+                                                    ? 'exactly matches'
+                                                    : 'contains'}{' '}
                                                 <pre>{step.url}</pre>
                                             </li>
                                         )}

--- a/frontend/src/scenes/trends/ActionSelectInfo.js
+++ b/frontend/src/scenes/trends/ActionSelectInfo.js
@@ -55,9 +55,9 @@ export class ActionSelectInfo extends Component {
                                             <li>
                                                 URL{' '}
                                                 {step.url_matching === 'regex'
-                                                    ? 'regex matches'
+                                                    ? 'matches regex'
                                                     : step.url_matching === 'exact'
-                                                    ? 'exactly matches'
+                                                    ? 'matches exactly'
                                                     : 'contains'}{' '}
                                                 <pre>{step.url}</pre>
                                             </li>

--- a/posthog/models/action_step.py
+++ b/posthog/models/action_step.py
@@ -3,11 +3,13 @@ from django.contrib.postgres.fields import JSONField
 
 
 class ActionStep(models.Model):
-    EXACT = "exact"
     CONTAINS = "contains"
+    REGEX = "regex"
+    EXACT = "exact"
     URL_MATCHING = [
-        (EXACT, EXACT),
         (CONTAINS, CONTAINS),
+        (REGEX, REGEX),
+        (EXACT, EXACT),
     ]
     action: models.ForeignKey = models.ForeignKey("Action", related_name="steps", on_delete=models.CASCADE)
     tag_name: models.CharField = models.CharField(max_length=400, null=True, blank=True)

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -134,11 +134,13 @@ class EventManager(models.QuerySet):
     def filter_by_url(self, action_step: ActionStep, subquery: QuerySet):
         if not action_step.url:
             return subquery
-        url_exact = action_step.url_matching == ActionStep.EXACT
-        return subquery.extra(
-            where=["properties ->> '$current_url' {} %s".format("=" if url_exact else "LIKE")],
-            params=[action_step.url if url_exact else "%{}%".format(action_step.url)],
-        )
+        if action_step.url_matching == ActionStep.EXACT:
+            where, param = "properties->>'$current_url' = %s", action_step.url
+        elif action_step.url_matching == ActionStep.REGEX:
+            where, param = "properties->>'$current_url' ~ %s", action_step.url
+        else:
+            where, param = "properties->>'$current_url' LIKE %s", f"%{action_step.url}%"
+        return subquery.extra(where=[where], params=[param])
 
     def filter_by_event(self, action_step):
         if not action_step.event:
@@ -178,7 +180,7 @@ class EventManager(models.QuerySet):
                     pk=OuterRef("id"),
                     **self.filter_by_event(step),
                     **self.filter_by_element(model_to_dict(step), team_id=action.team_id),
-                    **self.filter_by_period(start, end)
+                    **self.filter_by_period(start, end),
                 )
                 .only("id")
             )

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -45,13 +45,16 @@ class Property:
         value = self._parse_value(self.value)
         if self.operator == "is_not":
             return Q(~Q(**{"properties__{}".format(self.key): value}) | ~Q(properties__has_key=self.key))
-        if self.operator == "not_icontains":
-            return Q(~Q(**{"properties__{}__icontains".format(self.key): value}) | ~Q(properties__has_key=self.key))
         if self.operator == "is_set":
             return Q(**{"properties__{}__isnull".format(self.key): False})
         if self.operator == "is_not_set":
             return Q(**{"properties__{}__isnull".format(self.key): True})
-        return Q(**{"properties__{}{}".format(self.key, "__{}".format(self.operator) if self.operator else ""): value})
+        if self.operator.startswith("not_"):
+            return Q(
+                ~Q(**{"properties__{}__{}".format(self.key, self.operator[4:]): value})
+                | ~Q(properties__has_key=self.key)
+            )
+        return Q(**{"properties__{}{}".format(self.key, f"__{self.operator}" if self.operator else ""): value})
 
 
 class PropertyMixin:

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -49,7 +49,7 @@ class Property:
             return Q(**{"properties__{}__isnull".format(self.key): False})
         if self.operator == "is_not_set":
             return Q(**{"properties__{}__isnull".format(self.key): True})
-        if self.operator.startswith("not_"):
+        if isinstance(self.operator, str) and self.operator.startswith("not_"):
             return Q(
                 ~Q(**{"properties__{}__{}".format(self.key, self.operator[4:]): value})
                 | ~Q(properties__has_key=self.key)

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -203,6 +203,11 @@ class TestFilterByActions(BaseTest):
             action=action3, url="https://posthog.com/%/123", url_matching=ActionStep.CONTAINS,
         )
 
+        action4 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(
+            action=action4, url="/123$", url_matching=ActionStep.REGEX,
+        )
+
         event1 = Event.objects.create(team=self.team, distinct_id="whatever")
         event2 = Event.objects.create(
             team=self.team,
@@ -220,6 +225,10 @@ class TestFilterByActions(BaseTest):
         self.assertEqual(len(events), 1)
 
         events = Event.objects.filter_by_action(action3)
+        self.assertEqual(events[0], event2)
+        self.assertEqual(len(events), 1)
+
+        events = Event.objects.filter_by_action(action4)
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -47,6 +47,15 @@ class TestPropertiesToQ(BaseTest):
         events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events.get(), event2)
 
+    def test_regex(self):
+        Event.objects.create(team=self.team, event="$pageview")
+        event2 = Event.objects.create(
+            team=self.team, event="$pageview", properties={"$current_url": "https://whatever.com"},
+        )
+        filter = Filter(data={"properties": {"$current_url__regex": "\.com$"}})
+        events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
+        self.assertEqual(events.get(), event2)
+
     def test_is_not(self):
         event1 = Event.objects.create(team=self.team, event="$pageview")
         event2 = Event.objects.create(


### PR DESCRIPTION
## Changes

Per feature request (#1150), this adds regex matching.

![Trends](https://user-images.githubusercontent.com/4550621/87724943-a426b280-c7bc-11ea-8f34-8dafad0ea429.png)
![Action](https://user-images.githubusercontent.com/4550621/87724952-a6890c80-c7bc-11ea-90b9-d1ed277a3f27.png)

## Checklist

- [x] All querysets/queries filter by Team (if applicable)
- [x] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
