### PR TITLE
Added Github Action to create and deploy DigitalOcean images

### DIFF
--- a/.github/workflows/auto-image.yml
+++ b/.github/workflows/auto-image.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+name: Create DigitalOcean Image
+
+jobs:
+  build:
+    name: Create and deploy DigitalOcean image
+    runs-on: hashicorp/packer:1.5.5
+    steps:
+      - name: Build and deploy Image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+        run: |
+          git clone https://github.com/posthog/deployment.git \
+          && cd deployment/packer/digitalocean/single_node \
+          && packer build digitalocean.json


### PR DESCRIPTION
## Changes

- New github action triggered when a new tag in the form of a new version is created which runs deployment scripts to DigitalOcean.
- Also can be expanded to other platforms in the future.

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
