### PR TITLE
Add interval selection to sessions

### DIFF
--- a/frontend/src/lib/components/IntervalFilter.js
+++ b/frontend/src/lib/components/IntervalFilter.js
@@ -31,7 +31,11 @@ export function IntervalFilter({ filters, setFilters, disabled = false }) {
         >
             {Object.entries(intervalMapping).map(([key, value]) => {
                 return (
-                    <Select.Option key={key} value={key}>
+                    <Select.Option
+                        key={key}
+                        value={key}
+                        disabled={(key === 'minute' || key === 'hour') && !!filters.session}
+                    >
                         {value}
                     </Select.Option>
                 )

--- a/frontend/src/lib/components/IntervalFilter.js
+++ b/frontend/src/lib/components/IntervalFilter.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { disableMinuteFor, disableHourFor } from '../../scenes/trends/trendsLogic'
+import { disableMinuteFor, disableHourFor } from 'scenes/trends/trendsLogic'
 import { Select } from 'antd'
 
 let intervalMapping = {

--- a/frontend/src/scenes/trends/Trends.js
+++ b/frontend/src/scenes/trends/Trends.js
@@ -136,11 +136,11 @@ function _Trends() {
                     <Card
                         title={
                             <div className="float-right pt-1 pb-1">
-                                <IntervalFilter setFilters={setFilters} filters={filters} disabled={filters.session} />
+                                <IntervalFilter setFilters={setFilters} filters={filters} />
                                 <ChartFilter
                                     displayMap={displayMap}
                                     filters={filters}
-                                    onChange={display => {
+                                    onChange={(display) => {
                                         if (display === ACTIONS_TABLE || display === ACTIONS_PIE_CHART)
                                             clearAnnotationsToCreate()
                                         setDisplay(display)


### PR DESCRIPTION
## Changes

- we previously had interval selection disabled for sessions. added support for that
-
-

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
