### PR TITLE
Close #1256: Add 80:8000 Docker Compose Port Mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     container_name: posthog_web
     ports:
       - "8000:8000"
+      - "80:8000"
     environment:
       IS_DOCKER: "true"
       DATABASE_URL: "postgres://posthog:posthog@db:5432/posthog"


### PR DESCRIPTION
## Changes

Added one line - an additional port mapping from host 80 to container 8000. 80 is the default HTTP port.