### PR TITLE
Filter person on distinct id

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -61,7 +61,10 @@ class PersonViewSet(viewsets.ModelViewSet):
                     queryset = queryset.filter(properties__has_key=part.split(":")[1])
                 else:
                     contains.append(part)
-            queryset = queryset.filter(properties__icontains=" ".join(contains))
+            queryset = queryset.filter(
+                Q(properties__icontains=" ".join(contains))
+                | Q(persondistinctid__distinct_id__icontains=" ".join(contains))
+            )
         if request.GET.get("cohort"):
             queryset = queryset.filter(cohort__id=request.GET["cohort"])
         if request.GET.get("properties"):

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -21,6 +21,9 @@ class TestPerson(BaseTest):
         response = self.client.get("/api/person/?search=another@gm").json()
         self.assertEqual(len(response["results"]), 1)
 
+        response = self.client.get("/api/person/?search=_id_3").json()
+        self.assertEqual(len(response["results"]), 1)
+
     def test_properties(self):
         Person.objects.create(
             team=self.team, distinct_ids=["distinct_id"], properties={"email": "someone@gmail.com"},


### PR DESCRIPTION
## Changes

Allow searching users on distinct ID in all users screen

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
