### PR TITLE
Prevent refresh when no property is added

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.js
+++ b/frontend/src/scenes/events/eventsTableLogic.js
@@ -182,7 +182,10 @@ export const eventsTableLogic = kea({
                 return
             }
 
-            if (!objectsEqual(searchParams.properties || {}, values.properties)) {
+            if (
+                !objectsEqual(searchParams?.properties, []) &&
+                !objectsEqual(searchParams.properties || {}, values.properties)
+            ) {
                 actions.setProperties(searchParams.properties || {})
             }
         },


### PR DESCRIPTION
## Changes
Small change that stops this:

![2020-07-27 16 38 06](https://user-images.githubusercontent.com/13127476/88589740-975d5680-d027-11ea-80ab-3a9cf6ba8771.gif)


## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
