### PR TITLE
Fix cypress test for team

### DIFF
--- a/cypress/integration/auth.js
+++ b/cypress/integration/auth.js
@@ -29,7 +29,7 @@ describe('Auth', () => {
     })
 
     it('Sign up using team link', () => {
-        cy.get('[data-attr=menu-item-settings]').click()
+        cy.get('[data-attr=menu-item-team]').click()
         cy.get('[data-attr=copy-invite-to-clipboard-input]')
             .invoke('val')
             .then((link) => {
@@ -50,7 +50,7 @@ describe('Auth', () => {
     })
 
     it('Sign up using team link with updates', () => {
-        cy.get('[data-attr=menu-item-settings]').click()
+        cy.get('[data-attr=menu-item-team]').click()
         cy.get('[data-attr=copy-invite-to-clipboard-input]')
             .invoke('val')
             .then((link) => {


### PR DESCRIPTION
## Changes

*Please describe.*  
Cypress tests were failing because auth tests need to refer to team tab now to get the url

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
