### PR TITLE
Add DEBUG=1 notice to server

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -244,21 +244,9 @@ if not REDIS_URL and os.environ.get("POSTHOG_REDIS_HOST", ""):
     )
 
 if not REDIS_URL:
-    print("⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️")
-    print("️⚠️ 🚨🚨🚨 PostHog warning! 🚨🚨🚨")
-    print("⚠️")
-    print("️⚠️ The environment variable REDIS_URL or POSTHOG_REDIS_HOST is not configured!")
-    print("⚠️ Redis will be mandatory in the next versions of PostHog (1.1.0+).")
-    print("⚠️ Please configure it now to avoid future surprises!")
-    print("⚠️")
-    print("⚠️ See here for more information!")
-    print("⚠️ --> https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011")
-    print("⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️")
-
     raise ImproperlyConfigured(
         f'The environment var "REDIS_URL" or "POSTHOG_REDIS_HOST" is absolutely required to run this software. If you\'re upgrading from an earlier version of PostHog, see here: https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011'
     )
-
 
 CELERY_BROKER_URL = REDIS_URL  # celery connects to redis
 CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # sleep max 30sec before checking for new periodic events
@@ -339,3 +327,10 @@ if TEST:
     CACHES["default"] = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     }
+
+
+if DEBUG:
+    print("🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰")
+    print("️🧰 🔧 Running PostHog in __development mode__! DEBUG=1 🔧 🧰")
+    print("️🧰 ⚠️ Please update your config if this is a live site ⚠️ 🧰")
+    print("🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰")


### PR DESCRIPTION
## Changes

Running PostHog with `DEBUG=1` in production and behind a HTTPS proxy (e.g. nginx) causes issues with the toolbar. Under these conditions the `Secure` flag will be removed from the session cookie, causing browsers to either display a warning like so:

![image](https://user-images.githubusercontent.com/53387/88673230-a821d100-d0e8-11ea-9ea9-6ae8ed70a543.png)

... or (soon?) to not acknowledge to cookie at all. This is especially the case with [SameSite=None](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) cookies that we use to get the session ID when running the toolbar on someone's site.

When `DEBUG=1` is set, then `settings.SESSION_COOKIE_SECURE` is not set as we are assumed to run on HTTP. That is correct behavior, as turning on `Secure` when over HTTP would cause the session cookie to be ignored.

This PR adds a warning message that shows when PostHog is running with `DEBUG=1`. We should dissuade users from doing this in production. Hopefully those affected will act accordingly.

![image](https://user-images.githubusercontent.com/53387/88672825-347fc400-d0e8-11ea-9148-204c86586439.png)

I'll make a separate PR for "running development over https" (probably via ngrok) later.


## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
