### PR TITLE
LOCAL_HTTPS support (with HMR) through ngrok and JS_URL

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -71,6 +71,10 @@ if not DEBUG and not TEST:
             dsn=os.environ["SENTRY_DSN"], integrations=[DjangoIntegration()], request_bodies="always",
         )
 
+if get_bool_from_env("LOCAL_HTTPS", False):
+    SECURE_SSL_REDIRECT = False
+    SESSION_COOKIE_SECURE = True
+
 if get_bool_from_env("DISABLE_SECURE_SSL_REDIRECT", False):
     SECURE_SSL_REDIRECT = False
     SESSION_COOKIE_SECURE = False

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,8 @@ function createEntry(entry) {
             publicPath:
                 process.env.NODE_ENV === 'production'
                     ? '/static/'
+                    : process.env.JS_URL
+                    ? `${process.env.JS_URL}${process.env.JS_URL.endsWith('/') ? '' : '/'}static/`
                     : process.env.IS_PORTER
                     ? `https://${process.env.PORTER_WEBPACK_HOST}/static/`
                     : `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerHost}:8234/static/`,
@@ -162,9 +164,12 @@ function createEntry(entry) {
             port: 8234,
             noInfo: true,
             stats: 'minimal',
-            public: process.env.IS_PORTER
-                ? `https://${process.env.PORTER_WEBPACK_HOST}`
-                : `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerHost}:8234`,
+            disableHostCheck: !!process.env.LOCAL_HTTPS,
+            public: process.env.JS_URL
+                ? new URL(process.env.JS_URL).host
+                : process.env.IS_PORTER
+                ? `${process.env.PORTER_WEBPACK_HOST}`
+                : `${webpackDevServerHost}:8234`,
             allowedHosts: process.env.IS_PORTER
                 ? [`${process.env.PORTER_WEBPACK_HOST}`, `${process.env.PORTER_SERVER_HOST}`]
                 : [],
@@ -204,7 +209,7 @@ function createEntry(entry) {
                 ? [
                       new MiniCssExtractPlugin({
                           filename: '[name].css',
-                          ignoreOrder: true
+                          ignoreOrder: true,
                       }),
                       new HtmlWebpackPlugin({
                           alwaysWriteToDisk: true,


### PR DESCRIPTION
## Changes

When this is merged, to start a local HTTPS setup run the following commands.

I'll make a PR for the docs once it's merged. Could this replace the existing and more complicated local HTTPS instructions?

The steps:

#### 1. Start ngrok tunnel to 8234 (webpack dev server)

```
ngrok http 8234
```

![2020-07-28 16 41 54](https://user-images.githubusercontent.com/53387/88680940-53368880-d0f1-11ea-9e38-6ff624dbbee0.gif)

#### 2. Copy the URL and start webpack

```
export WEBPACK_HOT_RELOAD_HOST=0.0.0.0
export LOCAL_HTTPS=1
export JS_URL=https://68f83839843a.ngrok.io
yarn start
```

#### 3. Copy the URL and start the server

```
export DEBUG=1
export LOCAL_HTTPS=1
export JS_URL=https://68f83839843a.ngrok.io
python manage.py runserver
```

#### 4. Start a ngrok tunnel to 8000

```
ngrok http 8000
```

Do what you need with the URL that is returned to you in the browser!

![image](https://user-images.githubusercontent.com/53387/88681162-8f69e900-d0f1-11ea-8597-987456b521f5.png)


#### 5. Tips & Tricks

If testing the toolbar, make sure to add whatever ngrok urls to the list in `/setup`.

Also, watch out, network requests can be slow through ngrok:

![2020-07-28 16 36 36](https://user-images.githubusercontent.com/53387/88680912-4b76e400-d0f1-11ea-84f2-a740ebe0a704.gif)

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
