### PR TITLE
Annotation fixes #1248 and more

### DIFF
--- a/frontend/src/lib/components/Annotations/annotationsLogic.js
+++ b/frontend/src/lib/components/Annotations/annotationsLogic.js
@@ -10,7 +10,7 @@ export const annotationsLogic = kea({
     key: (props) => (props.pageKey ? `${props.pageKey}_annotations` : 'annotations_default'),
     connect: {
         actions: [annotationsModel, ['loadGlobalAnnotations', 'deleteGlobalAnnotation', 'createGlobalAnnotation']],
-        values: [annotationsModel, ['globalAnnotations']],
+        values: [annotationsModel, ['activeGlobalAnnotations']],
     },
     actions: () => ({
         createAnnotation: (content, date_marker, apply_all = false) => ({
@@ -93,8 +93,8 @@ export const annotationsLogic = kea({
     }),
     selectors: ({ selectors }) => ({
         annotationsList: [
-            () => [selectors.annotationsToCreate, selectors.annotations, selectors.globalAnnotations],
-            (annotationsToCreate, annotations, globalAnnotations) => {
+            () => [selectors.annotationsToCreate, selectors.annotations, selectors.activeGlobalAnnotations],
+            (annotationsToCreate, annotations, activeGlobalAnnotations) => {
                 const result = [
                     ...annotationsToCreate.map((val) => ({
                         ...val,
@@ -104,7 +104,7 @@ export const annotationsLogic = kea({
                         ...val,
                         id: parseInt(val.id),
                     })),
-                    ...globalAnnotations.map((val) => ({
+                    ...activeGlobalAnnotations.map((val) => ({
                         ...val,
                         id: parseInt(val.id),
                     })),

--- a/frontend/src/models/annotationsModel.js
+++ b/frontend/src/models/annotationsModel.js
@@ -40,6 +40,14 @@ export const annotationsModel = kea({
             },
         },
     }),
+    selectors: ({ selectors }) => ({
+        activeGlobalAnnotations: [
+            () => [selectors.globalAnnotations],
+            (globalAnnotations) => {
+                return globalAnnotations.filter((annotation) => !annotation.deleted)
+            },
+        ],
+    }),
     listeners: ({ actions }) => ({
         createGlobalAnnotation: async ({ dashboard_item, content, date_marker, created_at }) => {
             await api.create('api/annotation', {

--- a/frontend/src/scenes/annotations/AnnotationsTable.tsx
+++ b/frontend/src/scenes/annotations/AnnotationsTable.tsx
@@ -6,7 +6,7 @@ import 'lib/components/Annotations/AnnotationMarker.scss'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import moment from 'moment'
 import { annotationsModel } from '~/models/annotationsModel'
-import { DeleteOutlined } from '@ant-design/icons'
+import { DeleteOutlined, RedoOutlined } from '@ant-design/icons'
 
 const { TextArea } = Input
 
@@ -17,7 +17,9 @@ interface Props {
 export function AnnotationsTable(props: Props): JSX.Element {
     const { logic } = props
     const { annotations, annotationsLoading, next, loadingNext } = useValues(logic)
-    const { loadAnnotations, updateAnnotation, deleteAnnotation, loadAnnotationsNext } = useActions(logic)
+    const { loadAnnotations, updateAnnotation, deleteAnnotation, loadAnnotationsNext, restoreAnnotation } = useActions(
+        logic
+    )
     const { createGlobalAnnotation } = useActions(annotationsModel)
     const [open, setOpen] = useState(false)
     const [selectedAnnotation, setSelected] = useState(null)
@@ -55,6 +57,12 @@ export function AnnotationsTable(props: Props): JSX.Element {
                 )
             },
             ellipsis: true,
+        },
+        {
+            title: 'Date Marker',
+            render: function RenderDateMarker(annotation): JSX.Element {
+                return <span>{moment(annotation.date_marker).format('YYYY-MM-DD')}</span>
+            },
         },
         {
             title: 'Last Updated',
@@ -145,6 +153,10 @@ export function AnnotationsTable(props: Props): JSX.Element {
                     deleteAnnotation(selectedAnnotation.id)
                     closeModal()
                 }}
+                onRestore={(): void => {
+                    restoreAnnotation(selectedAnnotation.id)
+                    closeModal()
+                }}
                 annotation={selectedAnnotation}
             ></CreateAnnotationModal>
         </div>
@@ -155,6 +167,7 @@ interface CreateAnnotationModalProps {
     visible: boolean
     onCancel: () => void
     onDelete: () => void
+    onRestore: () => void
     onSubmit: (input: string, date: moment.Moment) => void
     annotation?: any
 }
@@ -206,12 +219,21 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
             ) : (
                 <Row justify="space-between">
                     <span>Change existing annotation text</span>
-                    <DeleteOutlined
-                        className="clickable"
-                        onClick={(): void => {
-                            props.onDelete()
-                        }}
-                    ></DeleteOutlined>
+                    {!props.annotation?.deleted ? (
+                        <DeleteOutlined
+                            className="clickable"
+                            onClick={(): void => {
+                                props.onDelete()
+                            }}
+                        />
+                    ) : (
+                        <RedoOutlined
+                            className="clickable"
+                            onClick={(): void => {
+                                props.onRestore()
+                            }}
+                        />
+                    )}
                 </Row>
             )}
             <br></br>

--- a/frontend/src/scenes/annotations/annotationsTableLogic.js
+++ b/frontend/src/scenes/annotations/annotationsTableLogic.js
@@ -34,6 +34,7 @@ export const annotationsTableLogic = kea({
     actions: () => ({
         updateAnnotation: (id, content) => ({ id, content }),
         deleteAnnotation: (id) => ({ id }),
+        restoreAnnotation: (id) => ({ id }),
         loadAnnotationsNext: () => true,
         setNext: (next) => ({ next }),
         appendAnnotations: (annotations) => ({ annotations }),
@@ -41,6 +42,10 @@ export const annotationsTableLogic = kea({
     listeners: ({ actions, values }) => ({
         updateAnnotation: async ({ id, content }) => {
             await api.update(`api/annotation/${id}`, { content })
+        },
+        restoreAnnotation: async ({ id }) => {
+            await api.update(`api/annotation/${id}`, { deleted: false })
+            actions.loadAnnotations({})
         },
         deleteAnnotation: ({ id }) => {
             deleteWithUndo({


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixed: #1284 out of time range annotations were causing gutter to load unnecessarily
- fixed: global annotations were being loaded even when deleted as a result of #1258 
- added ability to revive annotations that were deleted

*If this affects the front-end, include screenshots.*  
![2020-07-28 10 55 57](https://user-images.githubusercontent.com/13127476/88682707-f9b66580-d0c0-11ea-85f1-27a5c2320327.gif)

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
