### PR TITLE
Add None to getattr in event pipeline

### DIFF
--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -266,7 +266,7 @@ class EventManager(models.QuerySet):
 
         by_dates = {}
         for row in data:
-            people = sorted(row.people, key=lambda p: scores[round(row.first_date, 1)][int(p)], reverse=True)
+            people = sorted(row.people, key=lambda p: scores[round(row.first_date, 1)][int(p)], reverse=True,)
 
             random_key = "".join(
                 random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(10)
@@ -412,7 +412,7 @@ class Event(models.Model):
                 events = namedtuplefetchall(cursor)
 
         event = [event for event in events][0]
-        filtered_actions = [action for action in actions if getattr(event, "action_{}".format(action.pk))]
+        filtered_actions = [action for action in actions if getattr(event, "action_{}".format(action.pk), None)]
         return filtered_actions
 
     created_at: models.DateTimeField = models.DateTimeField(auto_now_add=True, null=True, blank=True)


### PR DESCRIPTION
## Changes

Fixes [this](https://sentry.io/organizations/posthog/issues/1769576442/?project=1899813&query=is%3Aunresolved) sentry error where getattr had no default return so the action matching event condition was failling

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
