### PR TITLE
Fix timestamp on session list

### DIFF
--- a/frontend/src/scenes/sessions/sessionsTableLogic.js
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.js
@@ -40,7 +40,8 @@ export const sessionsTableLogic = kea({
     listeners: ({ values, actions }) => ({
         fetchNextSessions: async () => {
             const response = await api.get(
-                'api/event/sessions/?' + toParams({ date_from: values.selectedDate, offset: values.offset })
+                'api/event/sessions/?' +
+                    toParams({ date_from: values.selectedDate.toISOString(), offset: values.offset })
             )
             if (response.offset) actions.setOffset(response.offset)
             else actions.setOffset(null)

--- a/frontend/src/scenes/sessions/sessionsTableLogic.js
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.js
@@ -4,12 +4,12 @@ import moment from 'moment'
 import { toParams } from 'lib/utils'
 
 export const sessionsTableLogic = kea({
-    loaders: ({ actions }) => ({
+    loaders: ({ actions, values }) => ({
         sessions: {
             __default: [],
             loadSessions: async (selectedDate) => {
                 const response = await api.get(
-                    'api/event/sessions' + (selectedDate ? '/?date_from=' + selectedDate.toISOString() : '')
+                    'api/event/sessions' + (selectedDate ? '/?date_from=' + values.selectedDateURLparam : '')
                 )
                 if (response.offset) actions.setOffset(response.offset)
                 if (response.date_from) actions.setDate(moment(response.date_from).startOf('day'))
@@ -37,11 +37,13 @@ export const sessionsTableLogic = kea({
         ],
         selectedDate: [moment().startOf('day'), { dateChanged: (_, { date }) => date, setDate: (_, { date }) => date }],
     }),
+    selectors: ({ selectors }) => ({
+        selectedDateURLparam: [() => [selectors.selectedDate], (selectedDate) => selectedDate.toISOString()],
+    }),
     listeners: ({ values, actions }) => ({
         fetchNextSessions: async () => {
             const response = await api.get(
-                'api/event/sessions/?' +
-                    toParams({ date_from: values.selectedDate.toISOString(), offset: values.offset })
+                'api/event/sessions/?' + toParams({ date_from: values.selectedDateURLparam, offset: values.offset })
             )
             if (response.offset) actions.setOffset(response.offset)
             else actions.setOffset(null)

--- a/frontend/src/scenes/sessions/sessionsTableLogic.js
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.js
@@ -51,6 +51,7 @@ export const sessionsTableLogic = kea({
         },
         dateChanged: ({ date }) => {
             actions.loadSessions(date)
+            actions.setOffset(null)
         },
     }),
     events: ({ actions }) => ({

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -391,12 +391,7 @@ class EventViewSet(viewsets.ModelViewSet):
         return result
 
     def _session_list(
-        self,
-        base_query: str,
-        params: Tuple[Any, ...],
-        team: Team,
-        date_filter: Dict[str, datetime],
-        request: request.Request,
+        self, base_query: str, params: Tuple[Any, ...], team: Team, request: request.Request,
     ) -> List[Dict[str, Any]]:
         session_list = "SELECT * FROM (SELECT global_session_id, properties, start_time, length, sessions.distinct_id, event_count, events from\
                                 (SELECT\

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -386,7 +386,7 @@ class EventViewSet(viewsets.ModelViewSet):
         elif session_type == "dist":
             result = self._session_dist(all_sessions, sessions_sql_params)
         else:
-            result = self._session_list(all_sessions, sessions_sql_params, team, date_filter, request)
+            result = self._session_list(all_sessions, sessions_sql_params, team, request)
 
         return result
 


### PR DESCRIPTION
## Changes
- addresses #1277 session list timestamps were off because of inconsistency in parsing moment object

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
