### PR TITLE
Kea TypeGen 0.0.31

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "tabWidth": 4,
   "semi": false,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
 }

--- a/frontend/src/lib/components/Annotations/annotationsLogicType.ts
+++ b/frontend/src/lib/components/Annotations/annotationsLogicType.ts
@@ -51,11 +51,11 @@ export interface annotationsLogicType {
             payload: any
         }
         loadAnnotationsSuccess: (
-            annotations: never[]
+            annotations: undefined[]
         ) => {
             type: 'load annotations success (lib.components.Annotations.annotationsLogic)'
             payload: {
-                annotations: never[]
+                annotations: undefined[]
             }
         }
         loadAnnotationsFailure: (
@@ -138,11 +138,11 @@ export interface annotationsLogicType {
             payload: any
         }
         loadAnnotationsSuccess: (
-            annotations: never[]
+            annotations: undefined[]
         ) => {
             type: 'load annotations success (lib.components.Annotations.annotationsLogic)'
             payload: {
-                annotations: never[]
+                annotations: undefined[]
             }
         }
         loadAnnotationsFailure: (
@@ -168,38 +168,38 @@ export interface annotationsLogicType {
         action: () => any,
         fullState: any
     ) => {
-        annotations: never[]
+        annotations: undefined[]
         annotationsLoading: boolean
-        annotationsToCreate: never[]
+        annotationsToCreate: undefined[]
         diffType: string
     }
     reducerOptions: any
     reducers: {
-        annotations: (state: never[], action: any, fullState: any) => never[]
+        annotations: (state: undefined[], action: any, fullState: any) => undefined[]
         annotationsLoading: (state: boolean, action: any, fullState: any) => boolean
-        annotationsToCreate: (state: never[], action: any, fullState: any) => never[]
+        annotationsToCreate: (state: undefined[], action: any, fullState: any) => undefined[]
         diffType: (state: string, action: any, fullState: any) => string
     }
     selector: (
         state: any
     ) => {
-        annotations: never[]
+        annotations: undefined[]
         annotationsLoading: boolean
-        annotationsToCreate: never[]
+        annotationsToCreate: undefined[]
         diffType: string
     }
     selectors: {
-        annotations: (state: any, props: any) => never[]
+        annotations: (state: any, props: any) => undefined[]
         annotationsLoading: (state: any, props: any) => boolean
-        annotationsToCreate: (state: any, props: any) => never[]
+        annotationsToCreate: (state: any, props: any) => undefined[]
         diffType: (state: any, props: any) => string
         annotationsList: (state: any, props: any) => any[]
         groupedAnnotations: (state: any, props: any) => Dictionary<any[]>
     }
     values: {
-        annotations: never[]
+        annotations: undefined[]
         annotationsLoading: boolean
-        annotationsToCreate: never[]
+        annotationsToCreate: undefined[]
         diffType: string
         annotationsList: any[]
         groupedAnnotations: Dictionary<any[]>

--- a/frontend/src/lib/components/AppEditorLink/appUrlsLogicType.ts
+++ b/frontend/src/lib/components/AppEditorLink/appUrlsLogicType.ts
@@ -33,11 +33,11 @@ export interface appUrlsLogicType {
             payload: any
         }
         loadSuggestionsSuccess: (
-            suggestions: never[]
+            suggestions: undefined[]
         ) => {
             type: 'load suggestions success (lib.components.AppEditorLink.appUrlsLogic)'
             payload: {
-                suggestions: never[]
+                suggestions: undefined[]
             }
         }
         loadSuggestionsFailure: (
@@ -98,11 +98,11 @@ export interface appUrlsLogicType {
             payload: any
         }
         loadSuggestionsSuccess: (
-            suggestions: never[]
+            suggestions: undefined[]
         ) => {
             type: 'load suggestions success (lib.components.AppEditorLink.appUrlsLogic)'
             payload: {
-                suggestions: never[]
+                suggestions: undefined[]
             }
         }
         loadSuggestionsFailure: (
@@ -128,30 +128,30 @@ export interface appUrlsLogicType {
         action: () => any,
         fullState: any
     ) => {
-        suggestions: never[]
+        suggestions: undefined[]
         suggestionsLoading: boolean
         appUrls: string[]
     }
     reducerOptions: any
     reducers: {
-        suggestions: (state: never[], action: any, fullState: any) => never[]
+        suggestions: (state: undefined[], action: any, fullState: any) => undefined[]
         suggestionsLoading: (state: boolean, action: any, fullState: any) => boolean
         appUrls: (state: string[], action: any, fullState: any) => string[]
     }
     selector: (
         state: any
     ) => {
-        suggestions: never[]
+        suggestions: undefined[]
         suggestionsLoading: boolean
         appUrls: string[]
     }
     selectors: {
-        suggestions: (state: any, props: any) => never[]
+        suggestions: (state: any, props: any) => undefined[]
         suggestionsLoading: (state: any, props: any) => boolean
         appUrls: (state: any, props: any) => string[]
     }
     values: {
-        suggestions: never[]
+        suggestions: undefined[]
         suggestionsLoading: boolean
         appUrls: string[]
     }

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogicType.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogicType.ts
@@ -178,14 +178,14 @@ export interface propertyFilterLogicType {
     ) => {
         personProperties: any
         personPropertiesLoading: boolean
-        eventProperties: never[]
+        eventProperties: undefined[]
         filters: any
     }
     reducerOptions: any
     reducers: {
         personProperties: (state: any, action: any, fullState: any) => any
         personPropertiesLoading: (state: boolean, action: any, fullState: any) => boolean
-        eventProperties: (state: never[], action: any, fullState: any) => never[]
+        eventProperties: (state: undefined[], action: any, fullState: any) => undefined[]
         filters: (state: any, action: any, fullState: any) => any
     }
     selector: (
@@ -193,19 +193,19 @@ export interface propertyFilterLogicType {
     ) => {
         personProperties: any
         personPropertiesLoading: boolean
-        eventProperties: never[]
+        eventProperties: undefined[]
         filters: any
     }
     selectors: {
         personProperties: (state: any, props: any) => any
         personPropertiesLoading: (state: any, props: any) => boolean
-        eventProperties: (state: any, props: any) => never[]
+        eventProperties: (state: any, props: any) => undefined[]
         filters: (state: any, props: any) => any
     }
     values: {
         personProperties: any
         personPropertiesLoading: boolean
-        eventProperties: never[]
+        eventProperties: undefined[]
         filters: any
     }
     _isKea: true

--- a/frontend/src/models/actionsModelType.ts
+++ b/frontend/src/models/actionsModelType.ts
@@ -8,11 +8,11 @@ export interface actionsModelType {
             payload: any
         }
         loadActionsSuccess: (
-            actions: never[]
+            actions: undefined[]
         ) => {
             type: 'load actions success (models.actionsModel)'
             payload: {
-                actions: never[]
+                actions: undefined[]
             }
         }
         loadActionsFailure: (
@@ -40,11 +40,11 @@ export interface actionsModelType {
             payload: any
         }
         loadActionsSuccess: (
-            actions: never[]
+            actions: undefined[]
         ) => {
             type: 'load actions success (models.actionsModel)'
             payload: {
-                actions: never[]
+                actions: undefined[]
             }
         }
         loadActionsFailure: (
@@ -70,32 +70,32 @@ export interface actionsModelType {
         action: () => any,
         fullState: any
     ) => {
-        actions: never[]
+        actions: undefined[]
         actionsLoading: boolean
     }
     reducerOptions: any
     reducers: {
-        actions: (state: never[], action: any, fullState: any) => never[]
+        actions: (state: undefined[], action: any, fullState: any) => undefined[]
         actionsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        actions: never[]
+        actions: undefined[]
         actionsLoading: boolean
     }
     selectors: {
-        actions: (state: any, props: any) => never[]
+        actions: (state: any, props: any) => undefined[]
         actionsLoading: (state: any, props: any) => boolean
-        actionsGrouped: (state: any, props: any) => { label: string; options: never[] }[]
+        actionsGrouped: (state: any, props: any) => { label: string; options: any[] }[]
     }
     values: {
-        actions: never[]
+        actions: undefined[]
         actionsLoading: boolean
-        actionsGrouped: { label: string; options: never[] }[]
+        actionsGrouped: { label: string; options: any[] }[]
     }
     _isKea: true
     __keaTypeGenInternalSelectorTypes: {
-        actionsGrouped: (arg1: any) => { label: string; options: never[] }[]
+        actionsGrouped: (arg1: any) => { label: string; options: any[] }[]
     }
 }

--- a/frontend/src/models/annotationsModelType.ts
+++ b/frontend/src/models/annotationsModelType.ts
@@ -22,11 +22,11 @@ export interface annotationsModelType {
             payload: any
         }
         loadGlobalAnnotationsSuccess: (
-            globalAnnotations: never[]
+            globalAnnotations: undefined[]
         ) => {
             type: 'load global annotations success (models.annotationsModel)'
             payload: {
-                globalAnnotations: never[]
+                globalAnnotations: undefined[]
             }
         }
         loadGlobalAnnotationsFailure: (
@@ -72,11 +72,11 @@ export interface annotationsModelType {
             payload: any
         }
         loadGlobalAnnotationsSuccess: (
-            globalAnnotations: never[]
+            globalAnnotations: undefined[]
         ) => {
             type: 'load global annotations success (models.annotationsModel)'
             payload: {
-                globalAnnotations: never[]
+                globalAnnotations: undefined[]
             }
         }
         loadGlobalAnnotationsFailure: (
@@ -102,27 +102,32 @@ export interface annotationsModelType {
         action: () => any,
         fullState: any
     ) => {
-        globalAnnotations: never[]
+        globalAnnotations: undefined[]
         globalAnnotationsLoading: boolean
     }
     reducerOptions: any
     reducers: {
-        globalAnnotations: (state: never[], action: any, fullState: any) => never[]
+        globalAnnotations: (state: undefined[], action: any, fullState: any) => undefined[]
         globalAnnotationsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        globalAnnotations: never[]
+        globalAnnotations: undefined[]
         globalAnnotationsLoading: boolean
     }
     selectors: {
-        globalAnnotations: (state: any, props: any) => never[]
+        globalAnnotations: (state: any, props: any) => undefined[]
         globalAnnotationsLoading: (state: any, props: any) => boolean
+        activeGlobalAnnotations: (state: any, props: any) => any
     }
     values: {
-        globalAnnotations: never[]
+        globalAnnotations: undefined[]
         globalAnnotationsLoading: boolean
+        activeGlobalAnnotations: any
     }
     _isKea: true
+    __keaTypeGenInternalSelectorTypes: {
+        activeGlobalAnnotations: (arg1: any) => any
+    }
 }

--- a/frontend/src/scenes/annotations/annotationsTableLogicType.ts
+++ b/frontend/src/scenes/annotations/annotationsTableLogicType.ts
@@ -8,11 +8,11 @@ export interface annotationsTableLogicType {
             payload: any
         }
         loadAnnotationsSuccess: (
-            annotations: never[]
+            annotations: undefined[]
         ) => {
             type: 'load annotations success (scenes.annotations.annotationsTableLogic)'
             payload: {
-                annotations: never[]
+                annotations: undefined[]
             }
         }
         loadAnnotationsFailure: (
@@ -34,6 +34,12 @@ export interface annotationsTableLogicType {
             id: any
         ) => {
             type: 'delete annotation (scenes.annotations.annotationsTableLogic)'
+            payload: { id: any }
+        }
+        restoreAnnotation: (
+            id: any
+        ) => {
+            type: 'restore annotation (scenes.annotations.annotationsTableLogic)'
             payload: { id: any }
         }
         loadAnnotationsNext: () => {
@@ -59,6 +65,7 @@ export interface annotationsTableLogicType {
         'load annotations failure (scenes.annotations.annotationsTableLogic)': 'loadAnnotationsFailure'
         'update annotation (scenes.annotations.annotationsTableLogic)': 'updateAnnotation'
         'delete annotation (scenes.annotations.annotationsTableLogic)': 'deleteAnnotation'
+        'restore annotation (scenes.annotations.annotationsTableLogic)': 'restoreAnnotation'
         'load annotations next (scenes.annotations.annotationsTableLogic)': 'loadAnnotationsNext'
         'set next (scenes.annotations.annotationsTableLogic)': 'setNext'
         'append annotations (scenes.annotations.annotationsTableLogic)': 'appendAnnotations'
@@ -69,6 +76,7 @@ export interface annotationsTableLogicType {
         loadAnnotationsFailure: 'load annotations failure (scenes.annotations.annotationsTableLogic)'
         updateAnnotation: 'update annotation (scenes.annotations.annotationsTableLogic)'
         deleteAnnotation: 'delete annotation (scenes.annotations.annotationsTableLogic)'
+        restoreAnnotation: 'restore annotation (scenes.annotations.annotationsTableLogic)'
         loadAnnotationsNext: 'load annotations next (scenes.annotations.annotationsTableLogic)'
         setNext: 'set next (scenes.annotations.annotationsTableLogic)'
         appendAnnotations: 'append annotations (scenes.annotations.annotationsTableLogic)'
@@ -79,11 +87,11 @@ export interface annotationsTableLogicType {
             payload: any
         }
         loadAnnotationsSuccess: (
-            annotations: never[]
+            annotations: undefined[]
         ) => {
             type: 'load annotations success (scenes.annotations.annotationsTableLogic)'
             payload: {
-                annotations: never[]
+                annotations: undefined[]
             }
         }
         loadAnnotationsFailure: (
@@ -105,6 +113,12 @@ export interface annotationsTableLogicType {
             id: any
         ) => {
             type: 'delete annotation (scenes.annotations.annotationsTableLogic)'
+            payload: { id: any }
+        }
+        restoreAnnotation: (
+            id: any
+        ) => {
+            type: 'restore annotation (scenes.annotations.annotationsTableLogic)'
             payload: { id: any }
         }
         loadAnnotationsNext: () => {
@@ -138,14 +152,14 @@ export interface annotationsTableLogicType {
         action: () => any,
         fullState: any
     ) => {
-        annotations: never[]
+        annotations: undefined[]
         annotationsLoading: boolean
         next: null
         loadingNext: boolean
     }
     reducerOptions: any
     reducers: {
-        annotations: (state: never[], action: any, fullState: any) => never[]
+        annotations: (state: undefined[], action: any, fullState: any) => undefined[]
         annotationsLoading: (state: boolean, action: any, fullState: any) => boolean
         next: (state: null, action: any, fullState: any) => null
         loadingNext: (state: boolean, action: any, fullState: any) => boolean
@@ -153,19 +167,19 @@ export interface annotationsTableLogicType {
     selector: (
         state: any
     ) => {
-        annotations: never[]
+        annotations: undefined[]
         annotationsLoading: boolean
         next: null
         loadingNext: boolean
     }
     selectors: {
-        annotations: (state: any, props: any) => never[]
+        annotations: (state: any, props: any) => undefined[]
         annotationsLoading: (state: any, props: any) => boolean
         next: (state: any, props: any) => null
         loadingNext: (state: any, props: any) => boolean
     }
     values: {
-        annotations: never[]
+        annotations: undefined[]
         annotationsLoading: boolean
         next: null
         loadingNext: boolean

--- a/frontend/src/scenes/dashboard/dashboardLogicType.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogicType.ts
@@ -103,11 +103,11 @@ export interface dashboardLogicType {
             payload: any
         }
         loadDashboardItemsSuccess: (
-            allItems: never[]
+            allItems: undefined[]
         ) => {
             type: 'load dashboard items success (scenes.dashboard.dashboardLogic)'
             payload: {
-                allItems: never[]
+                allItems: undefined[]
             }
         }
         loadDashboardItemsFailure: (
@@ -260,11 +260,11 @@ export interface dashboardLogicType {
             payload: any
         }
         loadDashboardItemsSuccess: (
-            allItems: never[]
+            allItems: undefined[]
         ) => {
             type: 'load dashboard items success (scenes.dashboard.dashboardLogic)'
             payload: {
-                allItems: never[]
+                allItems: undefined[]
             }
         }
         loadDashboardItemsFailure: (
@@ -290,33 +290,33 @@ export interface dashboardLogicType {
         action: () => any,
         fullState: any
     ) => {
-        allItems: never[]
+        allItems: undefined[]
         allItemsLoading: boolean
-        draggingEnabled: () => 'off' | 'on'
+        draggingEnabled: () => 'on' | 'off'
         containerWidth: null
         columns: null
     }
     reducerOptions: any
     reducers: {
-        allItems: (state: never[], action: any, fullState: any) => never[]
+        allItems: (state: undefined[], action: any, fullState: any) => undefined[]
         allItemsLoading: (state: boolean, action: any, fullState: any) => boolean
-        draggingEnabled: (state: () => 'off' | 'on', action: any, fullState: any) => () => 'off' | 'on'
+        draggingEnabled: (state: () => 'on' | 'off', action: any, fullState: any) => () => 'on' | 'off'
         containerWidth: (state: null, action: any, fullState: any) => null
         columns: (state: null, action: any, fullState: any) => null
     }
     selector: (
         state: any
     ) => {
-        allItems: never[]
+        allItems: undefined[]
         allItemsLoading: boolean
-        draggingEnabled: () => 'off' | 'on'
+        draggingEnabled: () => 'on' | 'off'
         containerWidth: null
         columns: null
     }
     selectors: {
-        allItems: (state: any, props: any) => never[]
+        allItems: (state: any, props: any) => undefined[]
         allItemsLoading: (state: any, props: any) => boolean
-        draggingEnabled: (state: any, props: any) => () => 'off' | 'on'
+        draggingEnabled: (state: any, props: any) => () => 'on' | 'off'
         containerWidth: (state: any, props: any) => null
         columns: (state: any, props: any) => null
         items: (state: any, props: any) => any
@@ -324,15 +324,15 @@ export interface dashboardLogicType {
         dashboard: (state: any, props: any) => any
         breakpoints: (state: any, props: any) => { lg: number; sm: number; xs: number; xxs: number }
         cols: (state: any, props: any) => { lg: number; sm: number; xs: number; xxs: number }
-        sizeKey: (state: any, props: any) => string | undefined
+        sizeKey: (state: any, props: any) => string
         layouts: (state: any, props: any) => {}
         layout: (state: any, props: any) => any
         layoutForItem: (state: any, props: any) => {}
     }
     values: {
-        allItems: never[]
+        allItems: undefined[]
         allItemsLoading: boolean
-        draggingEnabled: () => 'off' | 'on'
+        draggingEnabled: () => 'on' | 'off'
         containerWidth: null
         columns: null
         items: any
@@ -340,7 +340,7 @@ export interface dashboardLogicType {
         dashboard: any
         breakpoints: { lg: number; sm: number; xs: number; xxs: number }
         cols: { lg: number; sm: number; xs: number; xxs: number }
-        sizeKey: string | undefined
+        sizeKey: string
         layouts: {}
         layout: any
         layoutForItem: {}
@@ -350,7 +350,7 @@ export interface dashboardLogicType {
         items: (arg1: any) => any
         itemsLoading: (arg1: any) => any
         dashboard: (arg1: any, arg2: any) => any
-        sizeKey: (arg1: any, arg2: any) => string | undefined
+        sizeKey: (arg1: any, arg2: any) => string
         layouts: (arg1: any, arg2: any) => {}
         layout: (arg1: any, arg2: any) => any
         layoutForItem: (arg1: any) => {}

--- a/frontend/src/scenes/events/eventsTableLogicType.ts
+++ b/frontend/src/scenes/events/eventsTableLogicType.ts
@@ -197,30 +197,30 @@ export interface eventsTableLogicType {
         fullState: any
     ) => {
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: undefined[]
         eventFilter: boolean
         isLoading: boolean
         isLoadingNext: boolean
-        events: never[]
+        events: undefined[]
         hasNext: boolean
         orderBy: string
         selectedEvent: null
-        newEvents: never[]
+        newEvents: undefined[]
         highlightEvents: {}
         pollTimeout: null
     }
     reducerOptions: any
     reducers: {
         initialPathname: (state: (state: any) => any, action: any, fullState: any) => (state: any) => any
-        properties: (state: never[], action: any, fullState: any) => never[]
+        properties: (state: undefined[], action: any, fullState: any) => undefined[]
         eventFilter: (state: boolean, action: any, fullState: any) => boolean
         isLoading: (state: boolean, action: any, fullState: any) => boolean
         isLoadingNext: (state: boolean, action: any, fullState: any) => boolean
-        events: (state: never[], action: any, fullState: any) => never[]
+        events: (state: undefined[], action: any, fullState: any) => undefined[]
         hasNext: (state: boolean, action: any, fullState: any) => boolean
         orderBy: (state: string, action: any, fullState: any) => string
         selectedEvent: (state: null, action: any, fullState: any) => null
-        newEvents: (state: never[], action: any, fullState: any) => never[]
+        newEvents: (state: undefined[], action: any, fullState: any) => undefined[]
         highlightEvents: (state: {}, action: any, fullState: any) => {}
         pollTimeout: (state: null, action: any, fullState: any) => null
     }
@@ -228,29 +228,29 @@ export interface eventsTableLogicType {
         state: any
     ) => {
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: undefined[]
         eventFilter: boolean
         isLoading: boolean
         isLoadingNext: boolean
-        events: never[]
+        events: undefined[]
         hasNext: boolean
         orderBy: string
         selectedEvent: null
-        newEvents: never[]
+        newEvents: undefined[]
         highlightEvents: {}
         pollTimeout: null
     }
     selectors: {
         initialPathname: (state: any, props: any) => (state: any) => any
-        properties: (state: any, props: any) => never[]
+        properties: (state: any, props: any) => undefined[]
         eventFilter: (state: any, props: any) => boolean
         isLoading: (state: any, props: any) => boolean
         isLoadingNext: (state: any, props: any) => boolean
-        events: (state: any, props: any) => never[]
+        events: (state: any, props: any) => undefined[]
         hasNext: (state: any, props: any) => boolean
         orderBy: (state: any, props: any) => string
         selectedEvent: (state: any, props: any) => null
-        newEvents: (state: any, props: any) => never[]
+        newEvents: (state: any, props: any) => undefined[]
         highlightEvents: (state: any, props: any) => {}
         pollTimeout: (state: any, props: any) => null
         propertiesForUrl: (state: any, props: any) => '' | { properties: any }
@@ -258,15 +258,15 @@ export interface eventsTableLogicType {
     }
     values: {
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: undefined[]
         eventFilter: boolean
         isLoading: boolean
         isLoadingNext: boolean
-        events: never[]
+        events: undefined[]
         hasNext: boolean
         orderBy: string
         selectedEvent: null
-        newEvents: never[]
+        newEvents: undefined[]
         highlightEvents: {}
         pollTimeout: null
         propertiesForUrl: '' | { properties: any }

--- a/frontend/src/scenes/experiments/featureFlagLogicType.ts
+++ b/frontend/src/scenes/experiments/featureFlagLogicType.ts
@@ -15,11 +15,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         loadFeatureFlagsSuccess: (
-            featureFlags: never[]
+            featureFlags: undefined[]
         ) => {
             type: 'load feature flags success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: undefined[]
             }
         }
         loadFeatureFlagsFailure: (
@@ -37,11 +37,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         updateFeatureFlagSuccess: (
-            featureFlags: never[]
+            featureFlags: undefined[]
         ) => {
             type: 'update feature flag success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: undefined[]
             }
         }
         updateFeatureFlagFailure: (
@@ -59,11 +59,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         createFeatureFlagSuccess: (
-            featureFlags: never[]
+            featureFlags: undefined[]
         ) => {
             type: 'create feature flag success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: undefined[]
             }
         }
         createFeatureFlagFailure: (
@@ -112,11 +112,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         loadFeatureFlagsSuccess: (
-            featureFlags: never[]
+            featureFlags: undefined[]
         ) => {
             type: 'load feature flags success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: undefined[]
             }
         }
         loadFeatureFlagsFailure: (
@@ -134,11 +134,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         updateFeatureFlagSuccess: (
-            featureFlags: never[]
+            featureFlags: undefined[]
         ) => {
             type: 'update feature flag success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: undefined[]
             }
         }
         updateFeatureFlagFailure: (
@@ -156,11 +156,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         createFeatureFlagSuccess: (
-            featureFlags: never[]
+            featureFlags: undefined[]
         ) => {
             type: 'create feature flag success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: undefined[]
             }
         }
         createFeatureFlagFailure: (
@@ -186,26 +186,26 @@ export interface featureFlagLogicType {
         action: () => any,
         fullState: any
     ) => {
-        featureFlags: never[]
+        featureFlags: undefined[]
         featureFlagsLoading: boolean
     }
     reducerOptions: any
     reducers: {
-        featureFlags: (state: never[], action: any, fullState: any) => never[]
+        featureFlags: (state: undefined[], action: any, fullState: any) => undefined[]
         featureFlagsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        featureFlags: never[]
+        featureFlags: undefined[]
         featureFlagsLoading: boolean
     }
     selectors: {
-        featureFlags: (state: any, props: any) => never[]
+        featureFlags: (state: any, props: any) => undefined[]
         featureFlagsLoading: (state: any, props: any) => boolean
     }
     values: {
-        featureFlags: never[]
+        featureFlags: undefined[]
         featureFlagsLoading: boolean
     }
     _isKea: true

--- a/frontend/src/scenes/funnels/funnelLogicType.ts
+++ b/frontend/src/scenes/funnels/funnelLogicType.ts
@@ -21,7 +21,9 @@ export interface funnelLogicType {
         }) => {
             type: 'load funnel success (scenes.funnels.funnelLogic)'
             payload: {
-                funnel: { filters: {} }
+                funnel: {
+                    filters: {}
+                }
             }
         }
         loadFunnelFailure: (
@@ -43,7 +45,9 @@ export interface funnelLogicType {
         }) => {
             type: 'update funnel success (scenes.funnels.funnelLogic)'
             payload: {
-                funnel: { filters: {} }
+                funnel: {
+                    filters: {}
+                }
             }
         }
         updateFunnelFailure: (
@@ -65,7 +69,9 @@ export interface funnelLogicType {
         }) => {
             type: 'create funnel success (scenes.funnels.funnelLogic)'
             payload: {
-                funnel: { filters: {} }
+                funnel: {
+                    filters: {}
+                }
             }
         }
         createFunnelFailure: (
@@ -177,7 +183,9 @@ export interface funnelLogicType {
         }) => {
             type: 'load funnel success (scenes.funnels.funnelLogic)'
             payload: {
-                funnel: { filters: {} }
+                funnel: {
+                    filters: {}
+                }
             }
         }
         loadFunnelFailure: (
@@ -199,7 +207,9 @@ export interface funnelLogicType {
         }) => {
             type: 'update funnel success (scenes.funnels.funnelLogic)'
             payload: {
-                funnel: { filters: {} }
+                funnel: {
+                    filters: {}
+                }
             }
         }
         updateFunnelFailure: (
@@ -221,7 +231,9 @@ export interface funnelLogicType {
         }) => {
             type: 'create funnel success (scenes.funnels.funnelLogic)'
             payload: {
-                funnel: { filters: {} }
+                funnel: {
+                    filters: {}
+                }
             }
         }
         createFunnelFailure: (
@@ -292,7 +304,9 @@ export interface funnelLogicType {
         action: () => any,
         fullState: any
     ) => {
-        funnel: { filters: {} }
+        funnel: {
+            filters: {}
+        }
         funnelLoading: boolean
         stepsWithCount: any
         stepsWithCountLoading: boolean
@@ -301,7 +315,15 @@ export interface funnelLogicType {
     }
     reducerOptions: any
     reducers: {
-        funnel: (state: { filters: {} }, action: any, fullState: any) => { filters: {} }
+        funnel: (
+            state: {
+                filters: {}
+            },
+            action: any,
+            fullState: any
+        ) => {
+            filters: {}
+        }
         funnelLoading: (state: boolean, action: any, fullState: any) => boolean
         stepsWithCount: (state: any, action: any, fullState: any) => any
         stepsWithCountLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -311,7 +333,9 @@ export interface funnelLogicType {
     selector: (
         state: any
     ) => {
-        funnel: { filters: {} }
+        funnel: {
+            filters: {}
+        }
         funnelLoading: boolean
         stepsWithCount: any
         stepsWithCountLoading: boolean
@@ -319,7 +343,12 @@ export interface funnelLogicType {
         peopleLoading: boolean
     }
     selectors: {
-        funnel: (state: any, props: any) => { filters: {} }
+        funnel: (
+            state: any,
+            props: any
+        ) => {
+            filters: {}
+        }
         funnelLoading: (state: any, props: any) => boolean
         stepsWithCount: (state: any, props: any) => any
         stepsWithCountLoading: (state: any, props: any) => boolean
@@ -329,7 +358,9 @@ export interface funnelLogicType {
         isStepsEmpty: (state: any, props: any) => boolean
     }
     values: {
-        funnel: { filters: {} }
+        funnel: {
+            filters: {}
+        }
         funnelLoading: boolean
         stepsWithCount: any
         stepsWithCountLoading: boolean

--- a/frontend/src/scenes/paths/pathsLogicType.ts
+++ b/frontend/src/scenes/paths/pathsLogicType.ts
@@ -15,7 +15,10 @@ export interface pathsLogicType {
         }) => {
             type: 'load paths success (scenes.paths.pathsLogic)'
             payload: {
-                paths: { nodes: undefined[]; links: undefined[] }
+                paths: {
+                    nodes: undefined[]
+                    links: undefined[]
+                }
             }
         }
         loadPathsFailure: (
@@ -66,7 +69,10 @@ export interface pathsLogicType {
         }) => {
             type: 'load paths success (scenes.paths.pathsLogic)'
             payload: {
-                paths: { nodes: undefined[]; links: undefined[] }
+                paths: {
+                    nodes: undefined[]
+                    links: undefined[]
+                }
             }
         }
         loadPathsFailure: (
@@ -104,46 +110,86 @@ export interface pathsLogicType {
         action: () => any,
         fullState: any
     ) => {
-        paths: { nodes: undefined[]; links: undefined[] }
+        paths: {
+            nodes: undefined[]
+            links: undefined[]
+        }
         pathsLoading: boolean
         initialPathname: (state: any) => any
-        filter: { type: string }
+        filter: {
+            type: string
+        }
         properties: {}
     }
     reducerOptions: any
     reducers: {
         paths: (
-            state: { nodes: undefined[]; links: undefined[] },
+            state: {
+                nodes: undefined[]
+                links: undefined[]
+            },
             action: any,
             fullState: any
-        ) => { nodes: undefined[]; links: undefined[] }
+        ) => {
+            nodes: undefined[]
+            links: undefined[]
+        }
         pathsLoading: (state: boolean, action: any, fullState: any) => boolean
         initialPathname: (state: (state: any) => any, action: any, fullState: any) => (state: any) => any
-        filter: (state: { type: string }, action: any, fullState: any) => { type: string }
+        filter: (
+            state: {
+                type: string
+            },
+            action: any,
+            fullState: any
+        ) => {
+            type: string
+        }
         properties: (state: {}, action: any, fullState: any) => {}
     }
     selector: (
         state: any
     ) => {
-        paths: { nodes: undefined[]; links: undefined[] }
+        paths: {
+            nodes: undefined[]
+            links: undefined[]
+        }
         pathsLoading: boolean
         initialPathname: (state: any) => any
-        filter: { type: string }
+        filter: {
+            type: string
+        }
         properties: {}
     }
     selectors: {
-        paths: (state: any, props: any) => { nodes: undefined[]; links: undefined[] }
+        paths: (
+            state: any,
+            props: any
+        ) => {
+            nodes: undefined[]
+            links: undefined[]
+        }
         pathsLoading: (state: any, props: any) => boolean
         initialPathname: (state: any, props: any) => (state: any) => any
-        filter: (state: any, props: any) => { type: string }
+        filter: (
+            state: any,
+            props: any
+        ) => {
+            type: string
+        }
         properties: (state: any, props: any) => {}
         propertiesForUrl: (state: any, props: any) => '' | { properties: any; filter: any }
     }
     values: {
-        paths: { nodes: undefined[]; links: undefined[] }
+        paths: {
+            nodes: undefined[]
+            links: undefined[]
+        }
         pathsLoading: boolean
         initialPathname: (state: any) => any
-        filter: { type: string }
+        filter: {
+            type: string
+        }
         properties: {}
         propertiesForUrl: '' | { properties: any; filter: any }
     }

--- a/frontend/src/scenes/paths/pathsLogicType.ts
+++ b/frontend/src/scenes/paths/pathsLogicType.ts
@@ -10,12 +10,12 @@ export interface pathsLogicType {
             payload: any
         }
         loadPathsSuccess: (paths: {
-            nodes: never[]
-            links: never[]
+            nodes: undefined[]
+            links: undefined[]
         }) => {
             type: 'load paths success (scenes.paths.pathsLogic)'
             payload: {
-                paths: { nodes: never[]; links: never[] }
+                paths: { nodes: undefined[]; links: undefined[] }
             }
         }
         loadPathsFailure: (
@@ -61,12 +61,12 @@ export interface pathsLogicType {
             payload: any
         }
         loadPathsSuccess: (paths: {
-            nodes: never[]
-            links: never[]
+            nodes: undefined[]
+            links: undefined[]
         }) => {
             type: 'load paths success (scenes.paths.pathsLogic)'
             payload: {
-                paths: { nodes: never[]; links: never[] }
+                paths: { nodes: undefined[]; links: undefined[] }
             }
         }
         loadPathsFailure: (
@@ -104,7 +104,7 @@ export interface pathsLogicType {
         action: () => any,
         fullState: any
     ) => {
-        paths: { nodes: never[]; links: never[] }
+        paths: { nodes: undefined[]; links: undefined[] }
         pathsLoading: boolean
         initialPathname: (state: any) => any
         filter: { type: string }
@@ -113,10 +113,10 @@ export interface pathsLogicType {
     reducerOptions: any
     reducers: {
         paths: (
-            state: { nodes: never[]; links: never[] },
+            state: { nodes: undefined[]; links: undefined[] },
             action: any,
             fullState: any
-        ) => { nodes: never[]; links: never[] }
+        ) => { nodes: undefined[]; links: undefined[] }
         pathsLoading: (state: boolean, action: any, fullState: any) => boolean
         initialPathname: (state: (state: any) => any, action: any, fullState: any) => (state: any) => any
         filter: (state: { type: string }, action: any, fullState: any) => { type: string }
@@ -125,14 +125,14 @@ export interface pathsLogicType {
     selector: (
         state: any
     ) => {
-        paths: { nodes: never[]; links: never[] }
+        paths: { nodes: undefined[]; links: undefined[] }
         pathsLoading: boolean
         initialPathname: (state: any) => any
         filter: { type: string }
         properties: {}
     }
     selectors: {
-        paths: (state: any, props: any) => { nodes: never[]; links: never[] }
+        paths: (state: any, props: any) => { nodes: undefined[]; links: undefined[] }
         pathsLoading: (state: any, props: any) => boolean
         initialPathname: (state: any, props: any) => (state: any) => any
         filter: (state: any, props: any) => { type: string }
@@ -140,7 +140,7 @@ export interface pathsLogicType {
         propertiesForUrl: (state: any, props: any) => '' | { properties: any; filter: any }
     }
     values: {
-        paths: { nodes: never[]; links: never[] }
+        paths: { nodes: undefined[]; links: undefined[] }
         pathsLoading: boolean
         initialPathname: (state: any) => any
         filter: { type: string }

--- a/frontend/src/scenes/retention/retentionTableLogicType.ts
+++ b/frontend/src/scenes/retention/retentionTableLogicType.ts
@@ -205,7 +205,7 @@ export interface retentionTableLogicType {
         people: {}
         peopleLoading: boolean
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: undefined[]
         filters: {}
         loadingMore: boolean
     }
@@ -216,7 +216,7 @@ export interface retentionTableLogicType {
         people: (state: {}, action: any, fullState: any) => {}
         peopleLoading: (state: boolean, action: any, fullState: any) => boolean
         initialPathname: (state: (state: any) => any, action: any, fullState: any) => (state: any) => any
-        properties: (state: never[], action: any, fullState: any) => never[]
+        properties: (state: undefined[], action: any, fullState: any) => undefined[]
         filters: (state: {}, action: any, fullState: any) => {}
         loadingMore: (state: boolean, action: any, fullState: any) => boolean
     }
@@ -228,7 +228,7 @@ export interface retentionTableLogicType {
         people: {}
         peopleLoading: boolean
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: undefined[]
         filters: {}
         loadingMore: boolean
     }
@@ -238,7 +238,7 @@ export interface retentionTableLogicType {
         people: (state: any, props: any) => {}
         peopleLoading: (state: any, props: any) => boolean
         initialPathname: (state: any, props: any) => (state: any) => any
-        properties: (state: any, props: any) => never[]
+        properties: (state: any, props: any) => undefined[]
         filters: (state: any, props: any) => {}
         loadingMore: (state: any, props: any) => boolean
         propertiesForUrl: (state: any, props: any) => '' | { properties: any }
@@ -250,7 +250,7 @@ export interface retentionTableLogicType {
         people: {}
         peopleLoading: boolean
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: undefined[]
         filters: {}
         loadingMore: boolean
         propertiesForUrl: '' | { properties: any }

--- a/frontend/src/scenes/sceneLogicType.ts
+++ b/frontend/src/scenes/sceneLogicType.ts
@@ -74,7 +74,11 @@ export interface sceneLogicType {
     ) => {
         scene: null
         params: {}
-        loadedScenes: { 404: { component: () => Element } }
+        loadedScenes: {
+            404: {
+                component: () => Element
+            }
+        }
         loadingScene: null
     }
     reducerOptions: any
@@ -82,10 +86,18 @@ export interface sceneLogicType {
         scene: (state: null, action: any, fullState: any) => null
         params: (state: {}, action: any, fullState: any) => {}
         loadedScenes: (
-            state: { 404: { component: () => Element } },
+            state: {
+                404: {
+                    component: () => Element
+                }
+            },
             action: any,
             fullState: any
-        ) => { 404: { component: () => Element } }
+        ) => {
+            404: {
+                component: () => Element
+            }
+        }
         loadingScene: (state: null, action: any, fullState: any) => null
     }
     selector: (
@@ -93,19 +105,34 @@ export interface sceneLogicType {
     ) => {
         scene: null
         params: {}
-        loadedScenes: { 404: { component: () => Element } }
+        loadedScenes: {
+            404: {
+                component: () => Element
+            }
+        }
         loadingScene: null
     }
     selectors: {
         scene: (state: any, props: any) => null
         params: (state: any, props: any) => {}
-        loadedScenes: (state: any, props: any) => { 404: { component: () => Element } }
+        loadedScenes: (
+            state: any,
+            props: any
+        ) => {
+            404: {
+                component: () => Element
+            }
+        }
         loadingScene: (state: any, props: any) => null
     }
     values: {
         scene: null
         params: {}
-        loadedScenes: { 404: { component: () => Element } }
+        loadedScenes: {
+            404: {
+                component: () => Element
+            }
+        }
         loadingScene: null
     }
     _isKea: true

--- a/frontend/src/scenes/sessions/sessionsTableLogicType.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogicType.ts
@@ -10,11 +10,11 @@ export interface sessionsTableLogicType {
             payload: any
         }
         loadSessionsSuccess: (
-            sessions: never[]
+            sessions: undefined[]
         ) => {
             type: 'load sessions success (scenes.sessions.sessionsTableLogic)'
             payload: {
-                sessions: never[]
+                sessions: undefined[]
             }
         }
         loadSessionsFailure: (
@@ -84,11 +84,11 @@ export interface sessionsTableLogicType {
             payload: any
         }
         loadSessionsSuccess: (
-            sessions: never[]
+            sessions: undefined[]
         ) => {
             type: 'load sessions success (scenes.sessions.sessionsTableLogic)'
             payload: {
-                sessions: never[]
+                sessions: undefined[]
             }
         }
         loadSessionsFailure: (
@@ -144,7 +144,7 @@ export interface sessionsTableLogicType {
         action: () => any,
         fullState: any
     ) => {
-        sessions: never[]
+        sessions: undefined[]
         sessionsLoading: boolean
         isLoadingNext: boolean
         offset: null
@@ -152,7 +152,7 @@ export interface sessionsTableLogicType {
     }
     reducerOptions: any
     reducers: {
-        sessions: (state: never[], action: any, fullState: any) => never[]
+        sessions: (state: undefined[], action: any, fullState: any) => undefined[]
         sessionsLoading: (state: boolean, action: any, fullState: any) => boolean
         isLoadingNext: (state: boolean, action: any, fullState: any) => boolean
         offset: (state: null, action: any, fullState: any) => null
@@ -161,25 +161,30 @@ export interface sessionsTableLogicType {
     selector: (
         state: any
     ) => {
-        sessions: never[]
+        sessions: undefined[]
         sessionsLoading: boolean
         isLoadingNext: boolean
         offset: null
         selectedDate: Moment
     }
     selectors: {
-        sessions: (state: any, props: any) => never[]
+        sessions: (state: any, props: any) => undefined[]
         sessionsLoading: (state: any, props: any) => boolean
         isLoadingNext: (state: any, props: any) => boolean
         offset: (state: any, props: any) => null
         selectedDate: (state: any, props: any) => Moment
+        selectedDateURLparam: (state: any, props: any) => any
     }
     values: {
-        sessions: never[]
+        sessions: undefined[]
         sessionsLoading: boolean
         isLoadingNext: boolean
         offset: null
         selectedDate: Moment
+        selectedDateURLparam: any
     }
     _isKea: true
+    __keaTypeGenInternalSelectorTypes: {
+        selectedDateURLparam: (arg1: any) => any
+    }
 }

--- a/frontend/src/scenes/setup/SlackIntegrationType.ts
+++ b/frontend/src/scenes/setup/SlackIntegrationType.ts
@@ -80,18 +80,14 @@ export interface logicType {
         action: () => any,
         fullState: any
     ) => {
-        editedWebhook: (state: any) => string | undefined
+        editedWebhook: (state: any) => string
         isSaving: boolean
         isSaved: boolean
         error: null
     }
     reducerOptions: any
     reducers: {
-        editedWebhook: (
-            state: (state: any) => string | undefined,
-            action: any,
-            fullState: any
-        ) => (state: any) => string | undefined
+        editedWebhook: (state: (state: any) => string, action: any, fullState: any) => (state: any) => string
         isSaving: (state: boolean, action: any, fullState: any) => boolean
         isSaved: (state: boolean, action: any, fullState: any) => boolean
         error: (state: null, action: any, fullState: any) => null
@@ -99,19 +95,19 @@ export interface logicType {
     selector: (
         state: any
     ) => {
-        editedWebhook: (state: any) => string | undefined
+        editedWebhook: (state: any) => string
         isSaving: boolean
         isSaved: boolean
         error: null
     }
     selectors: {
-        editedWebhook: (state: any, props: any) => (state: any) => string | undefined
+        editedWebhook: (state: any, props: any) => (state: any) => string
         isSaving: (state: any, props: any) => boolean
         isSaved: (state: any, props: any) => boolean
         error: (state: any, props: any) => null
     }
     values: {
-        editedWebhook: (state: any) => string | undefined
+        editedWebhook: (state: any) => string
         isSaving: boolean
         isSaved: boolean
         error: null
@@ -125,7 +121,7 @@ export interface logicType {
             type: 'user update success (scenes.userLogic)'
             payload: {
                 user: UserType
-                updateKey: string | undefined
+                updateKey: string
             }
         }
     }

--- a/frontend/src/scenes/trends/trendsLogicType.ts
+++ b/frontend/src/scenes/trends/trendsLogicType.ts
@@ -8,11 +8,11 @@ export interface trendsLogicType {
             payload: any
         }
         setActiveViewSuccess: (
-            results: never[]
+            results: undefined[]
         ) => {
             type: 'set active view success (scenes.trends.trendsLogic)'
             payload: {
-                results: never[]
+                results: undefined[]
             }
         }
         setActiveViewFailure: (
@@ -30,11 +30,11 @@ export interface trendsLogicType {
             payload: any
         }
         loadResultsSuccess: (
-            results: never[]
+            results: undefined[]
         ) => {
             type: 'load results success (scenes.trends.trendsLogic)'
             payload: {
-                results: never[]
+                results: undefined[]
             }
         }
         loadResultsFailure: (
@@ -152,11 +152,11 @@ export interface trendsLogicType {
             payload: any
         }
         setActiveViewSuccess: (
-            results: never[]
+            results: undefined[]
         ) => {
             type: 'set active view success (scenes.trends.trendsLogic)'
             payload: {
-                results: never[]
+                results: undefined[]
             }
         }
         setActiveViewFailure: (
@@ -174,11 +174,11 @@ export interface trendsLogicType {
             payload: any
         }
         loadResultsSuccess: (
-            results: never[]
+            results: undefined[]
         ) => {
             type: 'load results success (scenes.trends.trendsLogic)'
             payload: {
-                results: never[]
+                results: undefined[]
             }
         }
         loadResultsFailure: (
@@ -270,7 +270,7 @@ export interface trendsLogicType {
         action: () => any,
         fullState: any
     ) => {
-        results: never[]
+        results: undefined[]
         resultsLoading: boolean
         filters: any
         people: null
@@ -279,7 +279,7 @@ export interface trendsLogicType {
     }
     reducerOptions: any
     reducers: {
-        results: (state: never[], action: any, fullState: any) => never[]
+        results: (state: undefined[], action: any, fullState: any) => undefined[]
         resultsLoading: (state: boolean, action: any, fullState: any) => boolean
         filters: (state: any, action: any, fullState: any) => any
         people: (state: null, action: any, fullState: any) => null
@@ -289,7 +289,7 @@ export interface trendsLogicType {
     selector: (
         state: any
     ) => {
-        results: never[]
+        results: undefined[]
         resultsLoading: boolean
         filters: any
         people: null
@@ -297,7 +297,7 @@ export interface trendsLogicType {
         showingPeople: boolean
     }
     selectors: {
-        results: (state: any, props: any) => never[]
+        results: (state: any, props: any) => undefined[]
         resultsLoading: (state: any, props: any) => boolean
         filters: (state: any, props: any) => any
         people: (state: any, props: any) => null
@@ -309,7 +309,7 @@ export interface trendsLogicType {
         peopleDay: (state: any, props: any) => any
     }
     values: {
-        results: never[]
+        results: undefined[]
         resultsLoading: boolean
         filters: any
         people: null

--- a/frontend/src/scenes/userLogicType.ts
+++ b/frontend/src/scenes/userLogicType.ts
@@ -14,28 +14,28 @@ export interface userLogicType<UserType, EventProperty> {
             updateKey?: string
         ) => {
             type: 'set user (scenes.userLogic)'
-            payload: { user: UserType | null; updateKey: string | undefined }
+            payload: { user: UserType; updateKey: string }
         }
         userUpdateRequest: (
             update: Partial<UserType>,
             updateKey?: string
         ) => {
             type: 'user update request (scenes.userLogic)'
-            payload: { update: Partial<UserType>; updateKey: string | undefined }
+            payload: { update: Partial<UserType>; updateKey: string }
         }
         userUpdateSuccess: (
             user: UserType,
             updateKey?: string
         ) => {
             type: 'user update success (scenes.userLogic)'
-            payload: { user: UserType; updateKey: string | undefined }
+            payload: { user: UserType; updateKey: string }
         }
         userUpdateFailure: (
             error: string,
             updateKey?: string
         ) => {
             type: 'user update failure (scenes.userLogic)'
-            payload: { updateKey: string | undefined; error: string }
+            payload: { updateKey: string; error: string }
         }
     }
     actionKeys: {
@@ -64,28 +64,28 @@ export interface userLogicType<UserType, EventProperty> {
             updateKey?: string
         ) => {
             type: 'set user (scenes.userLogic)'
-            payload: { user: UserType | null; updateKey: string | undefined }
+            payload: { user: UserType; updateKey: string }
         }
         userUpdateRequest: (
             update: Partial<UserType>,
             updateKey?: string
         ) => {
             type: 'user update request (scenes.userLogic)'
-            payload: { update: Partial<UserType>; updateKey: string | undefined }
+            payload: { update: Partial<UserType>; updateKey: string }
         }
         userUpdateSuccess: (
             user: UserType,
             updateKey?: string
         ) => {
             type: 'user update success (scenes.userLogic)'
-            payload: { user: UserType; updateKey: string | undefined }
+            payload: { user: UserType; updateKey: string }
         }
         userUpdateFailure: (
             error: string,
             updateKey?: string
         ) => {
             type: 'user update failure (scenes.userLogic)'
-            payload: { updateKey: string | undefined; error: string }
+            payload: { updateKey: string; error: string }
         }
     }
     cache: Record<string, any>
@@ -129,9 +129,9 @@ export interface userLogicType<UserType, EventProperty> {
     }
     _isKea: true
     __keaTypeGenInternalSelectorTypes: {
-        eventProperties: (arg1: UserType | null) => EventProperty[]
-        eventNames: (arg1: UserType | null) => string[]
-        customEventNames: (arg1: UserType | null) => string[]
-        eventNamesGrouped: (arg1: UserType | null) => { label: string; options: EventProperty[] }[]
+        eventProperties: (arg1: UserType) => EventProperty[]
+        eventNames: (arg1: UserType) => string[]
+        customEventNames: (arg1: UserType) => string[]
+        eventNamesGrouped: (arg1: UserType) => { label: string; options: EventProperty[] }[]
     }
 }

--- a/frontend/src/toolbar/actions/actionsLogicType.ts
+++ b/frontend/src/toolbar/actions/actionsLogicType.ts
@@ -10,11 +10,11 @@ export interface actionsLogicType {
             payload: any
         }
         getActionsSuccess: (
-            allActions: never[]
+            allActions: undefined[]
         ) => {
             type: 'get actions success (toolbar.actions.actionsLogic)'
             payload: {
-                allActions: never[]
+                allActions: undefined[]
             }
         }
         getActionsFailure: (
@@ -32,11 +32,11 @@ export interface actionsLogicType {
             payload: any
         }
         updateActionSuccess: (
-            allActions: never[]
+            allActions: undefined[]
         ) => {
             type: 'update action success (toolbar.actions.actionsLogic)'
             payload: {
-                allActions: never[]
+                allActions: undefined[]
             }
         }
         updateActionFailure: (
@@ -54,11 +54,11 @@ export interface actionsLogicType {
             payload: any
         }
         deleteActionSuccess: (
-            allActions: never[]
+            allActions: undefined[]
         ) => {
             type: 'delete action success (toolbar.actions.actionsLogic)'
             payload: {
-                allActions: never[]
+                allActions: undefined[]
             }
         }
         deleteActionFailure: (
@@ -100,11 +100,11 @@ export interface actionsLogicType {
             payload: any
         }
         getActionsSuccess: (
-            allActions: never[]
+            allActions: undefined[]
         ) => {
             type: 'get actions success (toolbar.actions.actionsLogic)'
             payload: {
-                allActions: never[]
+                allActions: undefined[]
             }
         }
         getActionsFailure: (
@@ -122,11 +122,11 @@ export interface actionsLogicType {
             payload: any
         }
         updateActionSuccess: (
-            allActions: never[]
+            allActions: undefined[]
         ) => {
             type: 'update action success (toolbar.actions.actionsLogic)'
             payload: {
-                allActions: never[]
+                allActions: undefined[]
             }
         }
         updateActionFailure: (
@@ -144,11 +144,11 @@ export interface actionsLogicType {
             payload: any
         }
         deleteActionSuccess: (
-            allActions: never[]
+            allActions: undefined[]
         ) => {
             type: 'delete action success (toolbar.actions.actionsLogic)'
             payload: {
-                allActions: never[]
+                allActions: undefined[]
             }
         }
         deleteActionFailure: (
@@ -174,29 +174,29 @@ export interface actionsLogicType {
         action: () => any,
         fullState: any
     ) => {
-        allActions: never[]
+        allActions: undefined[]
         allActionsLoading: boolean
     }
     reducerOptions: any
     reducers: {
-        allActions: (state: never[], action: any, fullState: any) => never[]
+        allActions: (state: undefined[], action: any, fullState: any) => undefined[]
         allActionsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        allActions: never[]
+        allActions: undefined[]
         allActionsLoading: boolean
     }
     selectors: {
-        allActions: (state: any, props: any) => never[]
+        allActions: (state: any, props: any) => undefined[]
         allActionsLoading: (state: any, props: any) => boolean
         sortedActions: (state: any, props: any) => any[]
         actionsForCurrentUrl: (state: any, props: any) => any
         actionCount: (state: any, props: any) => any
     }
     values: {
-        allActions: never[]
+        allActions: undefined[]
         allActionsLoading: boolean
         sortedActions: any[]
         actionsForCurrentUrl: any

--- a/frontend/src/toolbar/button/toolbarButtonLogicType.ts
+++ b/frontend/src/toolbar/button/toolbarButtonLogicType.ts
@@ -191,9 +191,18 @@ export interface toolbarButtonLogicType {
         statsVisible: boolean
         extensionPercentage: number
         lastDragPosition: null
-        heatmapPosition: { x: number; y: number }
-        actionsPosition: { x: number; y: number }
-        statsPosition: { x: number; y: number }
+        heatmapPosition: {
+            x: number
+            y: number
+        }
+        actionsPosition: {
+            x: number
+            y: number
+        }
+        statsPosition: {
+            x: number
+            y: number
+        }
     }
     reducerOptions: any
     reducers: {
@@ -202,9 +211,39 @@ export interface toolbarButtonLogicType {
         statsVisible: (state: boolean, action: any, fullState: any) => boolean
         extensionPercentage: (state: number, action: any, fullState: any) => number
         lastDragPosition: (state: null, action: any, fullState: any) => null
-        heatmapPosition: (state: { x: number; y: number }, action: any, fullState: any) => { x: number; y: number }
-        actionsPosition: (state: { x: number; y: number }, action: any, fullState: any) => { x: number; y: number }
-        statsPosition: (state: { x: number; y: number }, action: any, fullState: any) => { x: number; y: number }
+        heatmapPosition: (
+            state: {
+                x: number
+                y: number
+            },
+            action: any,
+            fullState: any
+        ) => {
+            x: number
+            y: number
+        }
+        actionsPosition: (
+            state: {
+                x: number
+                y: number
+            },
+            action: any,
+            fullState: any
+        ) => {
+            x: number
+            y: number
+        }
+        statsPosition: (
+            state: {
+                x: number
+                y: number
+            },
+            action: any,
+            fullState: any
+        ) => {
+            x: number
+            y: number
+        }
     }
     selector: (
         state: any
@@ -214,9 +253,18 @@ export interface toolbarButtonLogicType {
         statsVisible: boolean
         extensionPercentage: number
         lastDragPosition: null
-        heatmapPosition: { x: number; y: number }
-        actionsPosition: { x: number; y: number }
-        statsPosition: { x: number; y: number }
+        heatmapPosition: {
+            x: number
+            y: number
+        }
+        actionsPosition: {
+            x: number
+            y: number
+        }
+        statsPosition: {
+            x: number
+            y: number
+        }
     }
     selectors: {
         heatmapInfoVisible: (state: any, props: any) => boolean
@@ -224,9 +272,27 @@ export interface toolbarButtonLogicType {
         statsVisible: (state: any, props: any) => boolean
         extensionPercentage: (state: any, props: any) => number
         lastDragPosition: (state: any, props: any) => null
-        heatmapPosition: (state: any, props: any) => { x: number; y: number }
-        actionsPosition: (state: any, props: any) => { x: number; y: number }
-        statsPosition: (state: any, props: any) => { x: number; y: number }
+        heatmapPosition: (
+            state: any,
+            props: any
+        ) => {
+            x: number
+            y: number
+        }
+        actionsPosition: (
+            state: any,
+            props: any
+        ) => {
+            x: number
+            y: number
+        }
+        statsPosition: (
+            state: any,
+            props: any
+        ) => {
+            x: number
+            y: number
+        }
         dragPosition: (state: any, props: any) => { x: number; y: number }
         toolbarListVerticalPadding: (state: any, props: any) => number
         dockButtonOnTop: (state: any, props: any) => boolean
@@ -246,9 +312,18 @@ export interface toolbarButtonLogicType {
         statsVisible: boolean
         extensionPercentage: number
         lastDragPosition: null
-        heatmapPosition: { x: number; y: number }
-        actionsPosition: { x: number; y: number }
-        statsPosition: { x: number; y: number }
+        heatmapPosition: {
+            x: number
+            y: number
+        }
+        actionsPosition: {
+            x: number
+            y: number
+        }
+        statsPosition: {
+            x: number
+            y: number
+        }
         dragPosition: { x: number; y: number }
         toolbarListVerticalPadding: number
         dockButtonOnTop: boolean

--- a/frontend/src/toolbar/elements/heatmapLogicType.ts
+++ b/frontend/src/toolbar/elements/heatmapLogicType.ts
@@ -26,11 +26,11 @@ export interface heatmapLogicType {
             payload: any
         }
         resetEventsSuccess: (
-            events: never[]
+            events: undefined[]
         ) => {
             type: 'reset events success (toolbar.elements.heatmapLogic)'
             payload: {
-                events: never[]
+                events: undefined[]
             }
         }
         resetEventsFailure: (
@@ -48,11 +48,11 @@ export interface heatmapLogicType {
             payload: any
         }
         getEventsSuccess: (
-            events: never[]
+            events: undefined[]
         ) => {
             type: 'get events success (toolbar.elements.heatmapLogic)'
             payload: {
-                events: never[]
+                events: undefined[]
             }
         }
         getEventsFailure: (
@@ -110,11 +110,11 @@ export interface heatmapLogicType {
             payload: any
         }
         resetEventsSuccess: (
-            events: never[]
+            events: undefined[]
         ) => {
             type: 'reset events success (toolbar.elements.heatmapLogic)'
             payload: {
-                events: never[]
+                events: undefined[]
             }
         }
         resetEventsFailure: (
@@ -132,11 +132,11 @@ export interface heatmapLogicType {
             payload: any
         }
         getEventsSuccess: (
-            events: never[]
+            events: undefined[]
         ) => {
             type: 'get events success (toolbar.elements.heatmapLogic)'
             payload: {
-                events: never[]
+                events: undefined[]
             }
         }
         getEventsFailure: (
@@ -165,7 +165,7 @@ export interface heatmapLogicType {
         heatmapEnabled: boolean
         heatmapLoading: boolean
         showHeatmapTooltip: boolean
-        events: never[]
+        events: undefined[]
         eventsLoading: boolean
     }
     reducerOptions: any
@@ -173,7 +173,7 @@ export interface heatmapLogicType {
         heatmapEnabled: (state: boolean, action: any, fullState: any) => boolean
         heatmapLoading: (state: boolean, action: any, fullState: any) => boolean
         showHeatmapTooltip: (state: boolean, action: any, fullState: any) => boolean
-        events: (state: never[], action: any, fullState: any) => never[]
+        events: (state: undefined[], action: any, fullState: any) => undefined[]
         eventsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
@@ -182,14 +182,14 @@ export interface heatmapLogicType {
         heatmapEnabled: boolean
         heatmapLoading: boolean
         showHeatmapTooltip: boolean
-        events: never[]
+        events: undefined[]
         eventsLoading: boolean
     }
     selectors: {
         heatmapEnabled: (state: any, props: any) => boolean
         heatmapLoading: (state: any, props: any) => boolean
         showHeatmapTooltip: (state: any, props: any) => boolean
-        events: (state: any, props: any) => never[]
+        events: (state: any, props: any) => undefined[]
         eventsLoading: (state: any, props: any) => boolean
         elements: (state: any, props: any) => any
         countedElements: (state: any, props: any) => any[]
@@ -201,7 +201,7 @@ export interface heatmapLogicType {
         heatmapEnabled: boolean
         heatmapLoading: boolean
         showHeatmapTooltip: boolean
-        events: never[]
+        events: undefined[]
         eventsLoading: boolean
         elements: any
         countedElements: any[]

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "html-webpack-harddisk-plugin": "^1.0.1",
         "html-webpack-plugin": "^4.3.0",
         "husky": ">=4",
-        "kea-typegen": "^0.0.31",
+        "kea-typegen": "^0.0.32",
         "lint-staged": ">=10",
         "mini-css-extract-plugin": "^0.9.0",
         "nodemon": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "build": "NODE_ENV=production webpack --config webpack.config.js && cp -a frontend/public/* frontend/dist/ && npm run copy-array",
         "prettier": "prettier --write \"./frontend/src/**/*.{js,css,scss}\"",
         "eslint": "eslint frontend/src",
-        "eslint:github-action": "yarn run eslint"
+        "eslint:github-action": "yarn run eslint",
+        "typegen:watch": "kea-typegen watch --path frontend/src"
     },
     "license": "MIT",
     "dependencies": {
@@ -41,7 +42,7 @@
         "kea-router": "^0.4.0",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "1.3.5",
+        "posthog-js": "file:.yalc/posthog-js",
         "posthog-js-lite": "^0.0.1",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",
@@ -84,7 +85,7 @@
         "html-webpack-harddisk-plugin": "^1.0.1",
         "html-webpack-plugin": "^4.3.0",
         "husky": ">=4",
-        "kea-typegen": "^0.0.29",
+        "kea-typegen": "^0.0.31",
         "lint-staged": ">=10",
         "mini-css-extract-plugin": "^0.9.0",
         "nodemon": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "kea-router": "^0.4.0",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "file:.yalc/posthog-js",
+        "posthog-js": "1.3.5",
         "posthog-js-lite": "^0.0.1",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6076,12 +6076,13 @@ kea-router@^0.4.0:
   dependencies:
     url-pattern "^1.0.3"
 
-kea-typegen@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-0.0.29.tgz#c92ec771ad3e3d2e097a99d48703111e4e6d28f7"
-  integrity sha512-FoqfCASBF3XBtFgNQOAFjHIP6wlXX+lX8XUmTB9UZX9vyCzAv4483WxelVbmeNfwEUy2doLqWzlDtYtrem983A==
+kea-typegen@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-0.0.31.tgz#4d46500fa2ce3391aff57eca277b6fcd96cf3b3e"
+  integrity sha512-gQli/CdkmxY9h5Gea6tvnotzOIRWNt9fFgnLsSVBAp1/NcOPfQ/BEDZg9MDZGLT3eD4jqyzo+zfrbLfUY9zWAg==
   dependencies:
     "@wessberg/ts-clone-node" "0.3.8"
+    prettier "^2.0.5"
     yargs "^15.4.0"
 
 kea-window-values@^0.0.1:
@@ -7780,10 +7781,8 @@ posthog-js-lite@^0.0.1:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.1.tgz#e32eebc8e5203947bc90bc794615627d7ffe7d28"
   integrity sha512-CUfSRT/kjKLhGz23iS1YznFNYG/hkwESGzqAae6oFY2ncIXUppTeYvsQ/SM7QTajQEIHP6uUzjgDeaTQum7VWw==
 
-posthog-js@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.3.5.tgz#46370bfa57f26b50c5d5ba1b4b1cd6ffa9a78ca8"
-  integrity sha512-1cskkroPfn8SDuc7Fbr/D0Fjjbm+Fhomb+ikcfy6ZUP3e1/2bxlnFFG7q4mXGVGwrt3E7usXI504lKAGJWnufw==
+"posthog-js@file:.yalc/posthog-js":
+  version "1.3.6-aa74521c"
 
 prelude-ls@^1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6076,10 +6076,10 @@ kea-router@^0.4.0:
   dependencies:
     url-pattern "^1.0.3"
 
-kea-typegen@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-0.0.31.tgz#4d46500fa2ce3391aff57eca277b6fcd96cf3b3e"
-  integrity sha512-gQli/CdkmxY9h5Gea6tvnotzOIRWNt9fFgnLsSVBAp1/NcOPfQ/BEDZg9MDZGLT3eD4jqyzo+zfrbLfUY9zWAg==
+kea-typegen@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-0.0.32.tgz#f2d5704f5a0eb78af318bbfdf29d8f1724575657"
+  integrity sha512-KXxoDuGwS7qMrvtP6dOFCfd5ynywDVPKgW7zyodZZ93Ieq6Z9avncxxG4YNmXoMRAo5VWeQlT01JG/Ckpi71cg==
   dependencies:
     "@wessberg/ts-clone-node" "0.3.8"
     prettier "^2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7781,8 +7781,10 @@ posthog-js-lite@^0.0.1:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.1.tgz#e32eebc8e5203947bc90bc794615627d7ffe7d28"
   integrity sha512-CUfSRT/kjKLhGz23iS1YznFNYG/hkwESGzqAae6oFY2ncIXUppTeYvsQ/SM7QTajQEIHP6uUzjgDeaTQum7VWw==
 
-"posthog-js@file:.yalc/posthog-js":
-  version "1.3.6-aa74521c"
+posthog-js@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.3.5.tgz#46370bfa57f26b50c5d5ba1b4b1cd6ffa9a78ca8"
+  integrity sha512-1cskkroPfn8SDuc7Fbr/D0Fjjbm+Fhomb+ikcfy6ZUP3e1/2bxlnFFG7q4mXGVGwrt3E7usXI504lKAGJWnufw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Changes

- This upgrades `kea-typegen` to `0.0.31`, which runs the generated types through prettier (v2) in case there's a prettier config file in the project.
- I also added a package.json script `typegen:watch` that does what it says.
- ... and I regenerated the types.

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
