### PR TITLE
Add highlight to experiments tab

### DIFF
--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -52,6 +52,7 @@ const sceneOverride = {
     editFunnel: 'funnels',
     person: 'people',
     dashboard: 'dashboards',
+    featureFlags: 'experiments',
 }
 
 // to show the open submenu


### PR DESCRIPTION
## Changes

*Please describe.*  
feature flags wouldn't highlight experiments before
*If this affects the front-end, include screenshots.*  
<img width="487" alt="Screen Shot 2020-07-29 at 9 46 17 AM" src="https://user-images.githubusercontent.com/13127476/88808052-647aa600-d180-11ea-9d06-5c2b9556b540.png">


## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
