### PR TITLE
Bugfix: Github actions can't use off the shelf docker images.

### DIFF
--- a/.github/workflows/auto-image.yml
+++ b/.github/workflows/auto-image.yml
@@ -8,13 +8,17 @@ name: Create DigitalOcean Image
 jobs:
   build:
     name: Create and deploy DigitalOcean image
-    runs-on: hashicorp/packer:1.5.5
+    runs-on: ubuntu-20.04
     steps:
       - name: Build and deploy Image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
         run: |
-          git clone https://github.com/posthog/deployment.git \
+          wget https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip
+          && unzip packer_1.6.0_linux_amd64.zip
+          && sudo mv packer /usr/bin/
+          && sudo chmod +x /usr/bin/packer
+          && git clone https://github.com/posthog/deployment.git \
           && cd deployment/packer/digitalocean/single_node \
           && packer build digitalocean.json


### PR DESCRIPTION
This updates the action to install packer manually