### PR TITLE
Add display to filter todict

### DIFF
--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -80,6 +80,7 @@ class Filter(PropertyMixin):
             "breakdown": self.breakdown,
             "breakdown_type": self.breakdown_type,
             "compare": self.compare,
+            "display": self.display,
         }
 
     @property


### PR DESCRIPTION
## Changes

*Please describe.*  
Cumulative graph wasn't working. Fixed by adding it to the dict method for filters because it's used to determine cache key

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
