### PR TITLE
Don't show warning during tests

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -332,7 +332,7 @@ if TEST:
     }
 
 
-if DEBUG:
+if DEBUG and not TEST:
     print("🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰")
     print("️🧰 🔧 Running PostHog in __development mode__! DEBUG=1 🔧 🧰")
     print("️🧰 ⚠️ Please update your config if this is a live site ⚠️ 🧰")


### PR DESCRIPTION
## Changes

Warnings were bugging me running tests locally :)

## Checklist

- [ ] All querysets/queries filter by Team (if applicable)
- [ ] Backend tests (if applicable)
- [ ] Cypress E2E tests (if applicable)
