### PR TITLE
Add makemigrations to PR checklist and make it more specific

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 
 ## Checklist
 
-- [ ] All querysets/queries filter by Team (if applicable)
-- [ ] Backend tests (if applicable)
-- [ ] Cypress E2E tests (if applicable)
+- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
+- [ ] Django `makemigrations` ran (if this PR affects any models)
+- [ ] Backend tests (if this PR affects the backend)
+- [ ] Cypress E2E tests (if this PR affects the front and/or backend)


### PR DESCRIPTION
## Changes

Added `makemigrations` to PR checklist to ensure no missing migrations.
Also replaced "(if applicable)" with more specific guidance.