### PR TITLE
Toolbar Action link to PostHog after save

### DIFF
--- a/frontend/src/toolbar/ToolbarApp.tsx
+++ b/frontend/src/toolbar/ToolbarApp.tsx
@@ -7,6 +7,7 @@ import { useMountedLogic } from 'kea'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { posthog } from '~/toolbar/posthog'
 import { EditorProps } from '~/types'
+import { Slide, ToastContainer } from 'react-toastify'
 
 export function ToolbarApp(props: EditorProps = {}): JSX.Element {
     useMountedLogic(toolbarLogic(props))
@@ -41,14 +42,11 @@ export function ToolbarApp(props: EditorProps = {}): JSX.Element {
 
     return (
         <>
-            <TypedShadowDiv id="__POSTHOG_TOOLBAR__" ref={shadowRef}>
+            <root.div id="__POSTHOG_TOOLBAR__" ref={shadowRef}>
                 <div id="posthog-toolbar-styles" />
                 {didRender ? <ToolbarContainer /> : null}
-            </TypedShadowDiv>
+                <ToastContainer autoClose={8000} transition={Slide} position="bottom-center" />
+            </root.div>
         </>
     )
-}
-
-function TypedShadowDiv(props: { id: string; ref: any; children: any }): JSX.Element {
-    return <root.div {...props} />
 }

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { kea } from 'kea'
 import api from 'lib/api'
 import { actionsLogic } from '~/toolbar/actions/actionsLogic'
@@ -176,7 +177,31 @@ export const actionsTabLogic = kea<actionsTabLogicType<ActionType, ActionForm, F
 
             actionsLogic.actions.updateAction({ action: response })
             actions.selectAction(null)
-            toast('Action saved!')
+
+            const insightsUrl = `insights?insight=TRENDS&interval=day&actions=${JSON.stringify([
+                { type: 'actions', id: response.id, order: 0, name: response.name },
+            ])}`
+
+            toast(
+                <>
+                    Action saved! Open it in PostHog:{' '}
+                    <a
+                        href={`${apiURL}${apiURL.endsWith('/') ? '' : '/'}${insightsUrl}`}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        Insights
+                    </a>{' '}
+                    -{' '}
+                    <a
+                        href={`${apiURL}${apiURL.endsWith('/') ? '' : '/'}action/${response.id}`}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        Actions
+                    </a>
+                </>
+            )
         },
         deleteAction: async () => {
             const { apiURL, temporaryToken } = toolbarLogic.values

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -1,3 +1,4 @@
+import 'react-toastify/dist/ReactToastify.css'
 import '~/toolbar/styles.scss'
 
 import React from 'react'
@@ -10,9 +11,7 @@ import { ToolbarApp } from '~/toolbar/ToolbarApp'
 import { EditorProps } from '~/types'
 
 initKea()
-
 ;(window as any)['simmer'] = new Simmer(window, { depth: 8 })
-
 ;(window as any)['ph_load_editor'] = function (editorParams: EditorProps) {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/frontend/src/toolbar/styles.scss
+++ b/frontend/src/toolbar/styles.scss
@@ -132,3 +132,7 @@
     position: fixed;
     z-index: 2147483020;
 }
+
+.Toastify__toast-container {
+    z-index: 2147483040;
+}


### PR DESCRIPTION
## Changes

This PR closes #1278. It's the simplest way I could add those links now without redoing a large part of the interface. 

- Fixes react-toastify for the toolbar
- Adds links to Actions & Insights pages in PostHog in the toast

![image](https://user-images.githubusercontent.com/53387/88938338-90338400-d285-11ea-921f-a908e355a9c7.png)

These links should go also in the actions table in some way... but that's outside the scope of this PR.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Django `makemigrations` ran (if this PR affects any models)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
