### PR TITLE
Add django-statsd for emitting performance metrics to statsd

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -331,6 +331,7 @@ CACHES = {
 # Metrics - StatsD
 STATSD_HOST = os.environ.get("STATSD_HOST", "127.0.0.1")
 STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
+STATSD_PREFIX = os.environ.get("STATSD_PREFIX", "debug")
 
 if TEST:
     CACHES["default"] = {

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -120,6 +120,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_statsd.middleware.StatsdMiddleware",
     "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.AllowIP",
@@ -131,6 +132,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django_statsd.middleware.StatsdMiddlewareTimer",
 ]
 
 # Load debug_toolbar if we can (DEBUG and Dev modes)
@@ -325,6 +327,10 @@ CACHES = {
         "KEY_PREFIX": "posthog",
     }
 }
+
+# Metrics - StatsD
+STATSD_HOST = os.environ.get("STATSD_HOST", "127.0.0.1")
+STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
 
 if TEST:
     CACHES["default"] = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ django-cors-headers==3.2.1
 django-extensions==2.2.9
 django-loginas==0.3.8
 django-redis==4.12.1
+django-statsd==2.5.2
 djangorestframework==3.11.0
 djangorestframework-csv==2.1.0
 future==0.18.2


### PR DESCRIPTION
## Changes

This adds automated metrics gathering for Django so that we have better visibility into what is going on under the hood.
![image](https://user-images.githubusercontent.com/391319/88992314-e6112780-d297-11ea-80f1-948ae4c59098.png)

Through injecting some simple middleware we get visibility into a good chunk of the app:
![image](https://user-images.githubusercontent.com/391319/88992341-fe814200-d297-11ea-9781-9cf076a2cd7d.png)

For further instrumentation check out:
https://django-stats.readthedocs.io/en/latest/
