### PR TITLE
Add check for misformed JSON

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -113,7 +113,16 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
 @csrf_exempt
 def get_event(request):
     now = timezone.now()
-    data = _load_data(request)
+    try:
+        data = _load_data(request)
+    except TypeError:
+        return cors_response(
+            request,
+            JsonResponse(
+                {"code": "validation", "message": "Invalid formatting. Make sure you're passing correct JSON.",},
+                status=400,
+            ),
+        )
     if not data:
         return cors_response(request, HttpResponse("1"))
     sent_at = _get_sent_at(data, request)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -384,3 +384,9 @@ class TestCapture(BaseTest):
         timediff = arguments["sent_at"].timestamp() - tomorrow_sent_at.timestamp()
         self.assertLess(abs(timediff), 1)
         self.assertEqual(arguments["data"]["timestamp"], tomorrow.isoformat())
+
+    def test_incorrect_json(self):
+        response = self.client.post(
+            "/capture/", '{"event": "incorrect json with trailing comma",}', content_type="application/json"
+        )
+        self.assertEqual(response.json()["code"], "validation")


### PR DESCRIPTION
## Changes

If you sent incorrectly formatted JSON you'd get a 500 page. Give a more descriptive error messag einstead

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
