### PR TITLE
Fix breakdown filters sentry error

### DIFF
--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -29,7 +29,7 @@ class Filter(PropertyMixin):
     display: Optional[str] = None
     selector: Optional[str] = None
     shown_as: Optional[str] = None
-    breakdown: Optional[str] = None
+    breakdown: Optional[Union[str, List[Union[str, int]]]] = None
     breakdown_type: Optional[str] = None
     compare: Optional[bool] = None
     funnel_id: Optional[int] = None
@@ -53,7 +53,7 @@ class Filter(PropertyMixin):
         self.display = data.get("display")
         self.selector = data.get("selector")
         self.shown_as = data.get("shown_as")
-        self.breakdown = data.get("breakdown")
+        self.breakdown = self._parse_breakdown(data)
         self.breakdown_type = data.get("breakdown_type")
         self.compare = data.get("compare")
 
@@ -66,6 +66,15 @@ class Filter(PropertyMixin):
                 [Entity({**entity, "type": TREND_FILTER_TYPE_EVENTS}) for entity in data.get("events", [])]
             )
         self.entities = sorted(self.entities, key=lambda entity: entity.order if entity.order else -1)
+
+    def _parse_breakdown(self, data: Dict[str, Any]) -> Optional[Union[str, List[Union[str, int]]]]:
+        breakdown = data.get("breakdown")
+        if not isinstance(breakdown, str):
+            return breakdown
+        try:
+            return json.loads(breakdown)
+        except (TypeError, json.decoder.JSONDecodeError):
+            return breakdown
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/posthog/queries/trends.py
+++ b/posthog/queries/trends.py
@@ -171,14 +171,14 @@ def aggregate_by_interval(
     if breakdown:
         if filter.breakdown_type == "cohort":
             cohort_annotations = add_cohort_annotations(
-                team_id, json.loads(filter.breakdown) if filter.breakdown else []
+                team_id, filter.breakdown if filter.breakdown and isinstance(filter.breakdown, list) else []
             )
             values.extend(cohort_annotations.keys())
             filtered_events = filtered_events.annotate(**cohort_annotations)
             breakdown = "cohorts"
         elif filter.breakdown_type == "person":
             person_annotations = add_person_properties_annotations(
-                team_id, filter.breakdown if filter.breakdown else ""
+                team_id, filter.breakdown if filter.breakdown and isinstance(filter.breakdown, str) else ""
             )
             filtered_events = filtered_events.annotate(**person_annotations)
             values.append(breakdown)


### PR DESCRIPTION
## Changes

Fixes [this Sentry error](https://sentry.io/organizations/posthog/issues/1816854506/?project=1899813&referrer=alert_email). In the filter we were storing cohort breakdowns as a JSON string, but in the database they were stored as a list, causing this error. I _think_ this only caused issues with caching.

To reproduce
1. Create a dashboard item where you break down by multiple cohorts
2. Clear cache
3. Caching won't work

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
