### PR TITLE
Clean up DEBUG warning in settings.py

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -338,7 +338,7 @@ if TEST:
 if DEBUG and not TEST:
     print_warning(
         (
-            "️Environment variable DEBUG is set - PostHog is running in development mode!",
-            "Absolutely unset DEBUG if this is supposed to be a production environment!",
+            "️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT mode!",
+            "Be sure to unset DEBUG if this is supposed to be a PRODUCTION environment!",
         )
     )

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -12,9 +12,10 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import ast
 import os
+import shutil
 import sys
 from distutils.util import strtobool
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import dj_database_url
 import sentry_sdk
@@ -45,6 +46,11 @@ def get_bool_from_env(name: str, default_value: bool) -> bool:
         except ValueError as e:
             raise ValueError(f"{value} is an invalid value for {name}, expected boolean") from e
     return default_value
+
+
+def print_warning(warning_lines: Sequence[str]):
+    highlight_length = min(max(map(len, warning_lines)) // 2, shutil.get_terminal_size().columns)
+    print("\n".join(("", "🔻" * highlight_length, *warning_lines, "🔺" * highlight_length, "",)))
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -98,8 +104,6 @@ TRUST_ALL_PROXIES = os.environ.get("TRUST_ALL_PROXIES", False)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("SECRET_KEY", "6(@hkxrx07e*z3@6ls#uwajz6v@#8-%mmvs8-_y7c_c^l5c0m$")
-
-# SECURITY WARNING: don't run with debug turned on in production!
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "*"))
 
@@ -331,9 +335,10 @@ if TEST:
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     }
 
-
 if DEBUG and not TEST:
-    print("🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰")
-    print("️🧰 🔧 Running PostHog in __development mode__! DEBUG=1 🔧 🧰")
-    print("️🧰 ⚠️ Please update your config if this is a live site ⚠️ 🧰")
-    print("🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰🧰")
+    print_warning(
+        (
+            "️Environment variable DEBUG is set - PostHog is running in development mode!",
+            "Absolutely unset DEBUG if this is supposed to be a production environment!",
+        )
+    )


### PR DESCRIPTION
## Changes

A cleaner development mode terminal warning.

![DEBUG](https://user-images.githubusercontent.com/4550621/89196887-21b73480-d5ab-11ea-8167-516fb44e3dc9.png)
