### PR TITLE
Attempt to fix chunk loading errors

### DIFF
--- a/frontend/src/layout/Error404.tsx
+++ b/frontend/src/layout/Error404.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { HedgehogOverlay } from 'lib/components/HedgehogOverlay/HedgehogOverlay'
 
-export function Error404() {
+export function Error404(): JSX.Element {
     return (
         <div>
             <h2>Error 404</h2>

--- a/frontend/src/layout/ErrorNetwork.tsx
+++ b/frontend/src/layout/ErrorNetwork.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { HedgehogOverlay } from 'lib/components/HedgehogOverlay/HedgehogOverlay'
 import { Button } from 'antd'
 import { ReloadOutlined } from '@ant-design/icons'
 
@@ -13,7 +12,6 @@ export function ErrorNetwork(): JSX.Element {
                     <ReloadOutlined /> Reload the page!
                 </Button>
             </p>
-            <HedgehogOverlay type="sad" />
         </div>
     )
 }

--- a/frontend/src/layout/ErrorNetwork.tsx
+++ b/frontend/src/layout/ErrorNetwork.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { HedgehogOverlay } from 'lib/components/HedgehogOverlay/HedgehogOverlay'
+import { Button } from 'antd'
+import { ReloadOutlined } from '@ant-design/icons'
+
+export function ErrorNetwork(): JSX.Element {
+    return (
+        <div>
+            <h2>Network Error</h2>
+            <p>There was an issue loading the requested resource.</p>
+            <p>
+                <Button onClick={() => window.location.reload()}>
+                    <ReloadOutlined /> Reload the page!
+                </Button>
+            </p>
+            <HedgehogOverlay type="sad" />
+        </div>
+    )
+}


### PR DESCRIPTION
## Changes

If we detect a "chunk loading error", do one of two things:

- If this is the first page the user opened, show a "network error" image (screenshot below)
- If this is not the first page (e.g. the user clicked something to load a new page), do a browser reload. Hopefully that will load in the new JS and it'll be a seamless transition.

<img width="1217" alt="Screenshot 2020-08-03 at 17 18 00" src="https://user-images.githubusercontent.com/53387/89198551-aa36d480-d5ad-11ea-89ce-e639be06685d.png">

This hog should only show up if the first page you open somehow doesn't load.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
