### PR TITLE
Demo data erroring on dashboard fixed

### DIFF
--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -180,6 +180,7 @@ def _create_funnel(team: Team, base_url: str) -> None:
         dashboard=dashboard,
         name="HogFlix signup -> watching movie",
         type="FunnelViz",
+        funnel_id=funnel.pk,
         filters={"funnel_id": funnel.pk},
     )
 


### PR DESCRIPTION
## Changes
- fixed `loadResults` errors being raised due to null value in API request with demo funnels on dashboards.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
