### PR TITLE
StatsD attempt v2. Now with more optionality!

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -128,30 +128,23 @@ INSTALLED_APPS = [
     "social_django",
 ]
 
-if STATSD_HOST:
-    MIDDLEWARE = [
-        "django_statsd.middleware.StatsdMiddleware",
-    ]
-else:
-    MIDDLEWARE = []
 
-MIDDLEWARE.extend(
-    [
-        "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
-        "django.middleware.security.SecurityMiddleware",
-        "posthog.middleware.AllowIP",
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "corsheaders.middleware.CorsMiddleware",
-        "django.middleware.common.CommonMiddleware",
-        "django.middleware.csrf.CsrfViewMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.messages.middleware.MessageMiddleware",
-        "django.middleware.clickjacking.XFrameOptionsMiddleware",
-        "whitenoise.middleware.WhiteNoiseMiddleware",
-    ]
-)
+MIDDLEWARE = [
+    "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
+    "django.middleware.security.SecurityMiddleware",
+    "posthog.middleware.AllowIP",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+]
 
 if STATSD_HOST:
+    MIDDLEWARE.insert(0, "django_statsd.middleware.StatsdMiddleware")
     MIDDLEWARE.append("django_statsd.middleware.StatsdMiddlewareTimer")
 
 # Load debug_toolbar if we can (DEBUG and Dev modes)

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -107,6 +107,11 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "6(@hkxrx07e*z3@6ls#uwajz6v@#8-%mmvs8-
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "*"))
 
+# Metrics - StatsD
+STATSD_HOST = os.environ.get("STATSD_HOST", None)
+STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
+STATSD_PREFIX = os.environ.get("STATSD_PREFIX", None)
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -123,21 +128,31 @@ INSTALLED_APPS = [
     "social_django",
 ]
 
-MIDDLEWARE = [
-    "django_statsd.middleware.StatsdMiddleware",
-    "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
-    "django.middleware.security.SecurityMiddleware",
-    "posthog.middleware.AllowIP",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
-    "django_statsd.middleware.StatsdMiddlewareTimer",
-]
+if STATSD_HOST:
+    MIDDLEWARE = [
+        "django_statsd.middleware.StatsdMiddleware",
+    ]
+else:
+    MIDDLEWARE = []
+
+MIDDLEWARE.extend(
+    [
+        "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
+        "django.middleware.security.SecurityMiddleware",
+        "posthog.middleware.AllowIP",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "corsheaders.middleware.CorsMiddleware",
+        "django.middleware.common.CommonMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
+    ]
+)
+
+if STATSD_HOST:
+    MIDDLEWARE.append("django_statsd.middleware.StatsdMiddlewareTimer")
 
 # Load debug_toolbar if we can (DEBUG and Dev modes)
 try:
@@ -331,11 +346,6 @@ CACHES = {
         "KEY_PREFIX": "posthog",
     }
 }
-
-# Metrics - StatsD
-STATSD_HOST = os.environ.get("STATSD_HOST", "127.0.0.1")
-STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
-STATSD_PREFIX = os.environ.get("STATSD_PREFIX", "debug")
 
 if TEST:
     CACHES["default"] = {

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -124,6 +124,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_statsd.middleware.StatsdMiddleware",
     "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.AllowIP",
@@ -135,6 +136,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django_statsd.middleware.StatsdMiddlewareTimer",
 ]
 
 # Load debug_toolbar if we can (DEBUG and Dev modes)
@@ -329,6 +331,10 @@ CACHES = {
         "KEY_PREFIX": "posthog",
     }
 }
+
+# Metrics - StatsD
+STATSD_HOST = os.environ.get("STATSD_HOST", "127.0.0.1")
+STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
 
 if TEST:
     CACHES["default"] = {

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -335,6 +335,7 @@ CACHES = {
 # Metrics - StatsD
 STATSD_HOST = os.environ.get("STATSD_HOST", "127.0.0.1")
 STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
+STATSD_PREFIX = os.environ.get("STATSD_PREFIX", "debug")
 
 if TEST:
     CACHES["default"] = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ django-cors-headers==3.2.1
 django-extensions==2.2.9
 django-loginas==0.3.8
 django-redis==4.12.1
+django-statsd==2.5.2
 djangorestframework==3.11.0
 djangorestframework-csv==2.1.0
 future==0.18.2


### PR DESCRIPTION
Summary:
Now we will only inject the middleware into the django app if `STATSD_HOST` is set in the environmental vars.

This treats the noisy logs that can happen if you boot up Posthog without any local statsd service setup.