### PR TITLE
Fix compare being parsed as string

### DIFF
--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -32,7 +32,7 @@ class Filter(PropertyMixin):
     shown_as: Optional[str] = None
     breakdown: Optional[str] = None
     breakdown_type: Optional[str] = None
-    _compare: Optional[bool] = None
+    _compare: Optional[Union[bool, str]] = None
     funnel_id: Optional[int] = None
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None,) -> None:

--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -32,7 +32,7 @@ class Filter(PropertyMixin):
     shown_as: Optional[str] = None
     breakdown: Optional[str] = None
     breakdown_type: Optional[str] = None
-    compare: Optional[bool] = None
+    _compare: Optional[bool] = None
     funnel_id: Optional[int] = None
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None,) -> None:

--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from distutils.util import strtobool
 from typing import Any, Dict, List, Optional, Union
 
 from dateutil.relativedelta import relativedelta
@@ -55,7 +56,7 @@ class Filter(PropertyMixin):
         self.shown_as = data.get("shown_as")
         self.breakdown = data.get("breakdown")
         self.breakdown_type = data.get("breakdown_type")
-        self.compare = data.get("compare")
+        self.compare = bool(strtobool(data.get("compare", "false")))
 
         if data.get("actions"):
             self.entities.extend(

--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -56,7 +56,7 @@ class Filter(PropertyMixin):
         self.shown_as = data.get("shown_as")
         self.breakdown = data.get("breakdown")
         self.breakdown_type = data.get("breakdown_type")
-        self.compare = bool(strtobool(data.get("compare", "false")))
+        self._compare = data.get("compare", "false")
 
         if data.get("actions"):
             self.entities.extend(
@@ -82,6 +82,15 @@ class Filter(PropertyMixin):
             "breakdown_type": self.breakdown_type,
             "compare": self.compare,
         }
+
+    @property
+    def compare(self) -> bool:
+        if isinstance(self._compare, bool):
+            return self._compare
+        elif isinstance(self._compare, str):
+            return bool(strtobool(self._compare))
+        else:
+            return False
 
     @property
     def actions(self) -> List[Entity]:

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -123,7 +123,7 @@ class TestTrends(BaseTest):
     def test_trends_compare(self):
         self._create_events()
         with freeze_time("2020-01-04T13:00:01Z"):
-            response = Trends().run(Filter(data={"compare": True}), self.team)
+            response = Trends().run(Filter(data={"compare": "true"}), self.team)
 
         self.assertEqual(response[0]["label"], "sign up - current")
         self.assertEqual(response[0]["labels"][4], "day 4")
@@ -136,6 +136,15 @@ class TestTrends(BaseTest):
         self.assertEqual(response[1]["data"][4], 1.0)
         self.assertEqual(response[1]["labels"][5], "day 5")
         self.assertEqual(response[1]["data"][5], 0.0)
+
+        with freeze_time("2020-01-04T13:00:01Z"):
+            no_compare_response = Trends().run(Filter(data={"compare": "false"}), self.team)
+
+        self.assertEqual(no_compare_response[0]["label"], "sign up")
+        self.assertEqual(no_compare_response[0]["labels"][4], "Wed. 1 January")
+        self.assertEqual(no_compare_response[0]["data"][4], 3.0)
+        self.assertEqual(no_compare_response[0]["labels"][5], "Thu. 2 January")
+        self.assertEqual(no_compare_response[0]["data"][5], 1.0)
 
     def test_property_filtering(self):
         self._create_events()


### PR DESCRIPTION
## Changes

filter.compare was parsed as a string so even if it said 'false' it was executing the compare logic

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
