### PR TITLE
Merge people with the same e-mails

### DIFF
--- a/posthog/management/commands/merge_distinct_emails.py
+++ b/posthog/management/commands/merge_distinct_emails.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
                 email = row[0]
                 print("Merging email: {}".format(email))
 
-                people = Person.objects.filter(team=team, properties__email=email)
+                people = Person.objects.filter(team=team, properties__email=email).order_by("pk")
                 first_person = people[0]
                 other_people = people[1:]
 

--- a/posthog/management/commands/merge_distinct_emails.py
+++ b/posthog/management/commands/merge_distinct_emails.py
@@ -1,0 +1,58 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from posthog.models import Person, PersonDistinctId, Team
+
+
+class Command(BaseCommand):
+    help = "Merge users who have the same e-mail, but a different distinct_id"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team_id", nargs="+", type=int, help="specify the team id eg. --team_id 1")
+
+    def handle(self, *args, **options):
+        if not options["team_id"]:
+            print("The argument --team_id is required")
+            exit(1)
+
+        for team in Team.objects.filter(pk__in=options["team_id"]):
+            self._merge_team(team)
+
+    def _merge_team(self, team):
+        team_id = team.id
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                select properties->>'email', team_id, count(*)
+                from posthog_person
+                where properties->>'email' is not null and properties->>'email' != '' and team_id = %s
+                group by properties->>'email', team_id
+                HAVING count(*) > 1
+                order by count(*) desc;
+                """,
+                [team_id],
+            )
+
+            for row in cursor.fetchall():
+                email = row[0]
+                print("Merging email: {}".format(email))
+
+                people = Person.objects.filter(team=team, properties__email=email)
+                first_person = people[0]
+                other_people = people[1:]
+
+                # merge the properties
+                for other_person in other_people:
+                    first_person.properties = {**other_person.properties, **first_person.properties}
+                first_person.save()
+
+                # merge the distinct_ids
+                for other_person in other_people:
+                    other_person_distinct_ids = PersonDistinctId.objects.filter(person=other_person, team_id=team_id)
+
+                    for person_distinct_id in other_person_distinct_ids:
+                        person_distinct_id.person = first_person
+                        person_distinct_id.save()
+
+                    other_person.delete()


### PR DESCRIPTION
## Changes

This is the first part of #1350 

This adds a management script that merges users whose properties share the same email.

I ran the command locally many times and also copied part of it to `manage.py shell` in heroku to merge my own user:

Before:

<img width="1208" alt="Screenshot 2020-08-04 at 16 28 07" src="https://user-images.githubusercontent.com/53387/89306670-7a9cd080-d670-11ea-82cc-2321fe28d6d2.png">


After:

![image](https://user-images.githubusercontent.com/53387/89306700-85effc00-d670-11ea-8a95-90a9aa779a7b.png)



## Checklist

- [x] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
