### PR TITLE
WIP: Added proposed solution for auto SECRET_KEY setup (#1358)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log
 .yalc
 yalc.lock
 cypress/screenshots/*
+.key

--- a/bin/docker-dev-web
+++ b/bin/docker-dev-web
@@ -1,6 +1,18 @@
 #!/bin/bash
 
 set -e
+
+KEY_FILE="$(pwd)/.key"
+key="$(openssl rand -hex 32)"
+
+if test -f "$KEY_FILE"; then
+    key="$(cat $KEY_FILE)"
+else
+    echo $key > $KEY_FILE
+fi
+
+export SECRET_KEY=$key
+
 python manage.py migrate
 
 python manage.py runserver 0.0.0.0:8000 & ./bin/start-frontend 0.0.0.0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,6 @@ services:
       IS_DOCKER: "true"
       DATABASE_URL: "postgres://posthog:posthog@db:5432/posthog"
       REDIS_URL: "redis://redis:6379/"
-      SECRET_KEY: "<randomly generated secret key>"
       DEBUG: "true"
     depends_on:
       - db


### PR DESCRIPTION
## Changes

*Please describe.*  

When updating the Docs and going through deployment on the various cloud providers, I noticed that it can be easy to skip the `SECRET_KEY` generation process, as it has to be done manually and the instructions are hidden away on the Docs. 

I set updating the Docs to make this process clear as one of my priorities but then started to consider how this could be done in a more automatic way, hence this PR. 

This might not be the best solution, but I'm just hoping to bring in a discussion about what the solution could look like. 

I only set this up for the development environment for now to get feedback.

The idea is to auto-generate a the key and store it in a `.key` file. If it's the first time the user is deploying, this file will be created based on the output of `openssl rand -hex 32`. Otherwise, the key will be pulled from the existing file. 

Based on #1358.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
