### PR TITLE
SameSite cookie Secure fix with DISABLE_SECURE_SSL_REDIRECT=True

### DIFF
--- a/bin/start-https
+++ b/bin/start-https
@@ -4,7 +4,7 @@ set -e
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 export IS_BEHIND_PROXY=1
-export LOCAL_HTTPS=1
+export DISABLE_SECURE_SSL_REDIRECT=1
 ./bin/start-worker &
 ./bin/start-backend &
 ./bin/start-frontend-https &

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -76,13 +76,9 @@ if not DEBUG and not TEST:
             dsn=os.environ["SENTRY_DSN"], integrations=[DjangoIntegration()], request_bodies="always",
         )
 
-if get_bool_from_env("LOCAL_HTTPS", False):
-    SECURE_SSL_REDIRECT = False
-    SESSION_COOKIE_SECURE = True
-
 if get_bool_from_env("DISABLE_SECURE_SSL_REDIRECT", False):
     SECURE_SSL_REDIRECT = False
-    SESSION_COOKIE_SECURE = False
+    SESSION_COOKIE_SECURE = True
 
 if get_bool_from_env("IS_BEHIND_PROXY", False):
     USE_X_FORWARDED_HOST = True

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,9 @@ function createEntry(entry) {
                     ? `${process.env.JS_URL}${process.env.JS_URL.endsWith('/') ? '' : '/'}static/`
                     : process.env.IS_PORTER
                     ? `https://${process.env.PORTER_WEBPACK_HOST}/static/`
-                    : `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerHost}:8234/static/`,
+                    : `http${
+                          process.env.DISABLE_SECURE_SSL_REDIRECT ? 's' : ''
+                      }://${webpackDevServerHost}:8234/static/`,
         },
         resolve: {
             extensions: ['.js', '.ts', '.tsx'],
@@ -164,7 +166,7 @@ function createEntry(entry) {
             port: 8234,
             noInfo: true,
             stats: 'minimal',
-            disableHostCheck: !!process.env.LOCAL_HTTPS,
+            disableHostCheck: !!process.env.DISABLE_SECURE_SSL_REDIRECT,
             public: process.env.JS_URL
                 ? new URL(process.env.JS_URL).host
                 : process.env.IS_PORTER


### PR DESCRIPTION
It appears that the latest Chrome started to block cookies that are `SameSite=None`, if the `Secure` flag is not set. This was the case for our session cookie under some configurations in PostHog 0.12.0.

This PR attempts to fix that. Ideally it should be released as `0.12.1` ASAP.

The problem is that when running over https, a cookie must be set `Secure`. When not running over https, the cookie must **not** be set `Secure`. This was not happening if you ran PostHog behind a https proxy and had `DISABLE_SECURE_SSL_REDIRECT=True`. 

## Changes

- sets `SESSION_COOKIE_SECURE = True` on `DISABLE_SECURE_SSL_REDIRECT` (was: `False`)
- replace `LOCAL_HTTPS` with `DISABLE_SECURE_SSL_REDIRECT` (from #1290)
- provides a solution to #1376 if released as a patch version

## TODO

Update the docs about local https


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
