### PR TITLE
Remove samesite middleware

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -57,13 +57,3 @@ class AllowIP(object):
         return HttpResponse(
             "Your IP is not allowed. Check your ALLOWED_IP_BLOCKS settings. If you are behind a proxy, you need to set TRUSTED_PROXIES. See https://posthog.com/docs/deployment/running-behind-proxy"
         )
-
-
-class SameSiteSessionMiddleware(SessionMiddleware):
-    def process_response(self, request, response):
-        response = super(SameSiteSessionMiddleware, self).process_response(request, response)
-
-        if settings.SESSION_COOKIE_NAME in response.cookies:
-            response.cookies[settings.SESSION_COOKIE_NAME]["samesite"] = "None"
-
-        return response

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -130,7 +130,6 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
-    "posthog.middleware.SameSiteSessionMiddleware",  # keep this at the top
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.AllowIP",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
## Changes

Alternative to #1383

Removes `SameSite=None` from the session cookies.

It was used to let the toolbar know we're around... you go on your site and it shows up with helpful information.

There seem to be problems with it, including complexities managing a 1:1 mapping between running behind "https" and the "Secure" flag on the cookie that's needed in many of the latest browsers.

We should/could use another cookie to signal we're logged in and make the session cookie foolproof by keeping it local (default `SameSite=Lax` that django gives to all other cookies)

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
