### PR TITLE
Update posthog-js to 1.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "kea-router": "^0.4.0",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "1.3.5",
+        "posthog-js": "1.3.8",
         "posthog-js-lite": "^0.0.1",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7811,10 +7811,10 @@ posthog-js-lite@^0.0.1:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.1.tgz#e32eebc8e5203947bc90bc794615627d7ffe7d28"
   integrity sha512-CUfSRT/kjKLhGz23iS1YznFNYG/hkwESGzqAae6oFY2ncIXUppTeYvsQ/SM7QTajQEIHP6uUzjgDeaTQum7VWw==
 
-posthog-js@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.3.5.tgz#46370bfa57f26b50c5d5ba1b4b1cd6ffa9a78ca8"
-  integrity sha512-1cskkroPfn8SDuc7Fbr/D0Fjjbm+Fhomb+ikcfy6ZUP3e1/2bxlnFFG7q4mXGVGwrt3E7usXI504lKAGJWnufw==
+posthog-js@1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.3.8.tgz#796c8b3c488ebabd5a0325b283e3bf7e2a56d286"
+  integrity sha512-XmdSKnHX7RvpUE5h71gkdiLbe5MHhOwXu9NgpnkaNLmF/JZn+jq2pEGPiTMJsGsTNHYTKPRa4F0dztZYjS4oEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Changes

Update `posthog-js` to 1.3.8, which includes some cookie fixes (`Secure` is set if running over https)

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
