### PR TITLE
Upgrade simmer to version that works with colons ":" in class names.

### DIFF
--- a/frontend/src/editor/index.js
+++ b/frontend/src/editor/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
-import Simmer from 'simmerjs'
+import Simmer from '@mariusandra/simmerjs'
 import root from 'react-shadow'
 import { ActionEdit } from '~/scenes/actions/ActionEdit'
 import Draggable from 'react-draggable'

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -3,7 +3,7 @@ import '~/toolbar/styles.scss'
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Simmer from 'simmerjs'
+import Simmer from '@mariusandra/simmerjs'
 import { getContext } from 'kea'
 import { Provider } from 'react-redux'
 import { initKea } from '~/initKea'

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -1,4 +1,4 @@
-import Simmer from 'simmerjs'
+import Simmer from '@mariusandra/simmerjs'
 import { cssEscape } from 'lib/utils/cssEscape'
 import { ActionStepType, ElementType } from '~/types'
 import { ActionStepForm, BoxColor } from '~/toolbar/types'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@babel/core": "^7.10.4",
         "@babel/runtime": "^7.10.4",
         "@mariusandra/react-grid-layout": "0.18.3",
+        "@mariusandra/simmerjs": "0.5.6-posthog-2",
         "antd": "^4.1.1",
         "babel-preset-nano-react-app": "^0.1.0",
         "bootstrap": "^4.4.1",
@@ -56,7 +57,6 @@
         "redux": "^4.0.5",
         "reselect": "^4.0.0",
         "sass": "^1.26.2",
-        "simmerjs": "^0.5.6",
         "styled-components": "^5.0.1"
     },
     "devDependencies": {

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -53,6 +53,10 @@ class SelectorPart(object):
     direct_descendant = False
     unique_order = 0
 
+    def _unescape_class(self, class_name):
+        # separate all double slashes "\\" (replace them with "\") and remove all single slashes between them
+        return "\\".join([p.replace("\\", "") for p in class_name.split("\\\\")])
+
     def __init__(self, tag: str, direct_descendant: bool):
         self.direct_descendant = direct_descendant
         self.data: Dict[str, Union[str, List]] = {}
@@ -71,7 +75,7 @@ class SelectorPart(object):
         if "." in tag:
             parts = tag.split(".")
             # strip all slashes that are not followed by another slash
-            self.data["attr_class__contains"] = [re.sub("\\\\(?!\\\\)", "", p) for p in parts[1:]]
+            self.data["attr_class__contains"] = [self._unescape_class(p) for p in parts[1:]]
             tag = parts[0]
         if tag:
             self.data["tag_name"] = tag

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -70,7 +70,8 @@ class SelectorPart(object):
             tag = parts[0]
         if "." in tag:
             parts = tag.split(".")
-            self.data["attr_class__contains"] = parts[1:]
+            # strip all slashes that are not followed by another slash
+            self.data["attr_class__contains"] = [re.sub("\\\\(?!\\\\)", "", p) for p in parts[1:]]
             tag = parts[0]
         if tag:
             self.data["tag_name"] = tag

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -154,6 +154,23 @@ class TestFilterByActions(BaseTest):
         self.assertEqual(events[0], event1)
         self.assertEqual(len(events), 1)
 
+    def test_with_class_with_escaped_symbols(self):
+        Person.objects.create(distinct_ids=["whatever"], team=self.team)
+        action1 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(action=action1, selector="a.nav-link\\:b\\@ld", tag_name="a")
+        event1 = Event.objects.create(
+            team=self.team,
+            distinct_id="whatever",
+            elements=[
+                Element(tag_name="span", attr_class=None, order=0),
+                Element(tag_name="a", attr_class=["nav-link:b@ld"], order=1),
+            ],
+        )
+
+        events = Event.objects.filter_by_action(action1)
+        self.assertEqual(events[0], event1)
+        self.assertEqual(len(events), 1)
+
     def test_attributes(self):
         Person.objects.create(distinct_ids=["whatever"], team=self.team)
 

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -157,13 +157,30 @@ class TestFilterByActions(BaseTest):
     def test_with_class_with_escaped_symbols(self):
         Person.objects.create(distinct_ids=["whatever"], team=self.team)
         action1 = Action.objects.create(team=self.team)
-        ActionStep.objects.create(action=action1, selector="a.nav-link\\:b\\@ld", tag_name="a")
+        ActionStep.objects.create(action=action1, selector="a.na\\\\v-link\\:b\\@ld", tag_name="a")
         event1 = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
             elements=[
                 Element(tag_name="span", attr_class=None, order=0),
-                Element(tag_name="a", attr_class=["nav-link:b@ld"], order=1),
+                Element(tag_name="a", attr_class=["na\\v-link:b@ld"], order=1),
+            ],
+        )
+
+        events = Event.objects.filter_by_action(action1)
+        self.assertEqual(events[0], event1)
+        self.assertEqual(len(events), 1)
+
+    def test_with_class_with_escaped_slashes(self):
+        Person.objects.create(distinct_ids=["whatever"], team=self.team)
+        action1 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(action=action1, selector="a.na\\\\\\\\\\\\v-link\\:b\\@ld", tag_name="a")
+        event1 = Event.objects.create(
+            team=self.team,
+            distinct_id="whatever",
+            elements=[
+                Element(tag_name="span", attr_class=None, order=0),
+                Element(tag_name="a", attr_class=["na\\\\\\v-link:b@ld"], order=1),
             ],
         )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,17 @@
     react-draggable "^4.0.0"
     react-resizable "^1.10.0"
 
+"@mariusandra/simmerjs@0.5.6-posthog-2":
+  version "0.5.6-posthog-2"
+  resolved "https://registry.yarnpkg.com/@mariusandra/simmerjs/-/simmerjs-0.5.6-posthog-2.tgz#17efdf40e40e9770fdf9ac4448d4b4d779171af4"
+  integrity sha512-PfDnFBCvUidNlPJoAom7FCoLKXL9h5WAfC7mkftI1swQ0RFHeCOqRvlfvwUHM8lsCD56alL2a8o4PTbl6dg4IQ==
+  dependencies:
+    lodash.difference "^4.5.0"
+    lodash.flatmap "^4.5.0"
+    lodash.isfunction "^3.0.8"
+    lodash.take "^4.1.1"
+    lodash.takeright "^4.1.1"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -9214,17 +9225,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-simmerjs@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/simmerjs/-/simmerjs-0.5.6.tgz#4bba4fd4cbac18d889037aa199dd742dd1402b96"
-  integrity sha512-Z00zGHUp2IVSDUuni6gzBxVVQwAEZ7jVHnqL97+2RaHVWTYKfgCNyCvgm68Uc1M6X84hjatxvtOc24Y9ECLPWQ==
-  dependencies:
-    lodash.difference "^4.5.0"
-    lodash.flatmap "^4.5.0"
-    lodash.isfunction "^3.0.8"
-    lodash.take "^4.1.1"
-    lodash.takeright "^4.1.1"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
## Changes

- This PR closes #1368 
- I [fixed the bug](https://github.com/gmmorris/simmerjs/pull/19) in Simmer and sent a PR
- This PR upgrades to [my own version](https://github.com/mariusandra/simmerjs/tree/local-release) of the simmer npm package that already contains the fix (plus adds types), so we could use it immediately.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
