### PR TITLE
Hide message format and make optional

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -132,26 +132,30 @@ export function ActionEdit({ actionId, apiURL, onSave, user, isEditor, simmer, s
                             <Link to="/setup#webhook">
                                 {slackEnabled ? 'Configure' : 'Enable'} this integration in Setup.
                             </Link>
-                            <Input
-                                addonBefore="Message format"
-                                placeholder="try: [action.name] triggered by [user.name]"
-                                value={action.slack_message_format}
-                                onChange={(e) => {
-                                    setAction({ ...action, slack_message_format: e.target.value })
-                                    setEdited(true)
-                                }}
-                                disabled={!slackEnabled || !action.post_to_slack}
-                                data-attr="edit-slack-message-format"
-                            />
-                            <small>
-                                <a
-                                    href="https://posthog.com/docs/integrations/message-formatting/"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    See documentation on how to format webhook messages.
-                                </a>
-                            </small>
+                            {action.post_to_slack && (
+                                <>
+                                    <Input
+                                        addonBefore="Message format (optional)"
+                                        placeholder="try: [action.name] triggered by [user.name]"
+                                        value={action.slack_message_format}
+                                        onChange={(e) => {
+                                            setAction({ ...action, slack_message_format: e.target.value })
+                                            setEdited(true)
+                                        }}
+                                        disabled={!slackEnabled || !action.post_to_slack}
+                                        data-attr="edit-slack-message-format"
+                                    />
+                                    <small>
+                                        <a
+                                            href="https://posthog.com/docs/integrations/message-formatting/"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            See documentation on how to format webhook messages.
+                                        </a>
+                                    </small>
+                                </>
+                            )}
                         </div>
                     </div>
                 ) : (


### PR DESCRIPTION
## Changes
Having the message format always visible made the interface even more cluttered. This PR will only show the message format if you're sending a slack message.
![image](https://user-images.githubusercontent.com/1727427/89901065-dcb38380-dbe4-11ea-84c1-eb375352d5ce.png)
![image](https://user-images.githubusercontent.com/1727427/89901099-e76e1880-dbe4-11ea-888f-2adbbc37b40c.png)


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
