### PR TITLE
Fix Heatmap broken CSS selector with button[href=]

### DIFF
--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -69,7 +69,7 @@ export function elementToSelector(element: ElementType): string {
             .map((a) => `.${cssEscape(a)}`)
             .join('')
     }
-    if (element.href) {
+    if (element.href && element.tag_name === 'a') {
         selector += `[href="${cssEscape(element.href)}"]`
     }
     if (element.nth_child) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "kea-router": "^0.4.0",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "1.4.2",
+        "posthog-js": "1.4.3",
         "posthog-js-lite": "^0.0.3",
         "prop-types": "^15.7.2",
         "react": ">= 16.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7830,10 +7830,10 @@ posthog-js-lite@^0.0.3:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.3.tgz#87e373706227a849c4e7c6b0cb2066a64ad5b6ed"
   integrity sha512-wEOs8DEjlFBwgd7l19grosaF7mTlliZ9G9pL0Qji189FDg2ukY5IegUxTyTs7gsTGt6WK9W47BF5yXA5+bwvZg==
 
-posthog-js@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.4.2.tgz#4cce9a8c9f25d657047178665bafbbd5cb104cb8"
-  integrity sha512-LEZV5cCih6CGhaXwgPcuOn1RKw5dajcE4ol/y+9Lmlp9+jPK32z7yo/djUPHILPxIV7HevsBd8nZk/6krcedqQ==
+posthog-js@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.4.3.tgz#d35d4680950cad5bde5cc6deb19e6f4985772ddf"
+  integrity sha512-Pi8+2B3Bx7hFjwPggZFkeGbKSLqso+cQc7XayeMDJ3Rqojs9kMklyLKWlEeVJv7IMxo6FFjW0fNcXNExjNKvrw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Changes

This makes a difference between these two elements being shown on the heatmap or not:

* shown (localhost)
![image](https://user-images.githubusercontent.com/53387/89908275-f9a08480-dbed-11ea-958c-904e8e64dfca.png)

* or not (live site):
![image](https://user-images.githubusercontent.com/53387/89908348-12109f00-dbee-11ea-9bed-aad33fd49dc5.png)

Possibly fixes many other pages.

Why?

The element that comes from the API is a button, but contains a "href"

![image](https://user-images.githubusercontent.com/53387/89908458-2f456d80-dbee-11ea-918f-404038c75861.png)

That's because posthog-js [is designed to send it like this](https://github.com/PostHog/posthog-js/blob/5d549aea33b1d8102e2dee3b4264eeca21244313/src/__tests__/autocapture.js#L488).

I also upgraded posthog-js to 1.4.3 [becuase of a problem](https://github.com/PostHog/posthog-js/issues/79).

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
