### PR TITLE
Kea TypeGen 0.1

### DIFF
--- a/frontend/src/lib/components/Annotations/annotationsLogicType.ts
+++ b/frontend/src/lib/components/Annotations/annotationsLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface annotationsLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface annotationsLogicType extends Logic {
     actionCreators: {
         createAnnotation: (
             content: any,
@@ -9,7 +10,12 @@ export interface annotationsLogicType {
             apply_all?: any
         ) => {
             type: 'create annotation (lib.components.Annotations.annotationsLogic)'
-            payload: { content: any; date_marker: any; created_at: Moment; apply_all: boolean }
+            payload: {
+                content: any
+                date_marker: any
+                created_at: Moment
+                apply_all: boolean
+            }
         }
         createAnnotationNow: (
             content: any,
@@ -17,13 +23,20 @@ export interface annotationsLogicType {
             apply_all?: any
         ) => {
             type: 'create annotation now (lib.components.Annotations.annotationsLogic)'
-            payload: { content: any; date_marker: any; created_at: Moment; apply_all: boolean }
+            payload: {
+                content: any
+                date_marker: any
+                created_at: Moment
+                apply_all: boolean
+            }
         }
         deleteAnnotation: (
             id: any
         ) => {
             type: 'delete annotation (lib.components.Annotations.annotationsLogic)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         clearAnnotationsToCreate: () => {
             type: 'clear annotations to create (lib.components.Annotations.annotationsLogic)'
@@ -35,13 +48,17 @@ export interface annotationsLogicType {
             dates: any
         ) => {
             type: 'update diff type (lib.components.Annotations.annotationsLogic)'
-            payload: { dates: any }
+            payload: {
+                dates: any
+            }
         }
         setDiffType: (
             type: any
         ) => {
             type: 'set diff type (lib.components.Annotations.annotationsLogic)'
-            payload: { type: any }
+            payload: {
+                type: any
+            }
         }
         loadAnnotations: ({
             before,
@@ -51,11 +68,11 @@ export interface annotationsLogicType {
             payload: any
         }
         loadAnnotationsSuccess: (
-            annotations: never[]
+            annotations: any[]
         ) => {
             type: 'load annotations success (lib.components.Annotations.annotationsLogic)'
             payload: {
-                annotations: never[]
+                annotations: any[]
             }
         }
         loadAnnotationsFailure: (
@@ -97,60 +114,114 @@ export interface annotationsLogicType {
         updateDiffType: (dates: any) => void
         setDiffType: (type: any) => void
         loadAnnotations: ({ before, after }: any) => void
-        loadAnnotationsSuccess: (annotations: never[]) => void
+        loadAnnotationsSuccess: (annotations: any[]) => void
         loadAnnotationsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        annotations: any[]
+        annotationsLoading: boolean
+        annotationsToCreate: any[]
+        diffType: string
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: string
+    listeners: {
+        createAnnotationNow: ((
+            payload: {
+                content: any
+                date_marker: any
+                created_at: Moment
+                apply_all: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'create annotation now (lib.components.Annotations.annotationsLogic)'
+                payload: {
+                    content: any
+                    date_marker: any
+                    created_at: Moment
+                    apply_all: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        deleteAnnotation: ((
+            payload: {
+                id: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'delete annotation (lib.components.Annotations.annotationsLogic)'
+                payload: {
+                    id: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateDiffType: ((
+            payload: {
+                dates: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update diff type (lib.components.Annotations.annotationsLogic)'
+                payload: {
+                    dates: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['lib', 'components', 'Annotations', 'annotationsLogic']
     pathString: 'lib.components.Annotations.annotationsLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
-        annotations: never[]
+        annotations: any[]
         annotationsLoading: boolean
-        annotationsToCreate: never[]
+        annotationsToCreate: any[]
         diffType: string
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
-        annotations: (state: never[], action: any, fullState: any) => never[]
+        annotations: (state: any[], action: any, fullState: any) => any[]
         annotationsLoading: (state: boolean, action: any, fullState: any) => boolean
-        annotationsToCreate: (state: never[], action: any, fullState: any) => never[]
+        annotationsToCreate: (state: any[], action: any, fullState: any) => any[]
         diffType: (state: string, action: any, fullState: any) => string
     }
     selector: (
         state: any
     ) => {
-        annotations: never[]
+        annotations: any[]
         annotationsLoading: boolean
-        annotationsToCreate: never[]
+        annotationsToCreate: any[]
         diffType: string
     }
     selectors: {
-        annotations: (state: any, props: any) => never[]
+        annotations: (state: any, props: any) => any[]
         annotationsLoading: (state: any, props: any) => boolean
-        annotationsToCreate: (state: any, props: any) => never[]
+        annotationsToCreate: (state: any, props: any) => any[]
         diffType: (state: any, props: any) => string
         annotationsList: (state: any, props: any) => any[]
         groupedAnnotations: (state: any, props: any) => Dictionary<any[]>
     }
+    sharedListeners: {}
     values: {
-        annotations: never[]
+        annotations: any[]
         annotationsLoading: boolean
-        annotationsToCreate: never[]
+        annotationsToCreate: any[]
         diffType: string
         annotationsList: any[]
         groupedAnnotations: Dictionary<any[]>
     }
     _isKea: true
+    _isKeaWithKey: true
     __keaTypeGenInternalSelectorTypes: {
         annotationsList: (arg1: any, arg2: any, arg3: any) => any[]
         groupedAnnotations: (arg1: any, arg2: any) => Dictionary<any[]>

--- a/frontend/src/lib/components/AppEditorLink/appUrlsLogicType.ts
+++ b/frontend/src/lib/components/AppEditorLink/appUrlsLogicType.ts
@@ -1,43 +1,53 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface appUrlsLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface appUrlsLogicType extends Logic {
     actionCreators: {
         addUrl: (
             value: any
         ) => {
             type: 'add url (lib.components.AppEditorLink.appUrlsLogic)'
-            payload: { value: any }
+            payload: {
+                value: any
+            }
         }
         addUrlAndGo: (
             value: any
         ) => {
             type: 'add url and go (lib.components.AppEditorLink.appUrlsLogic)'
-            payload: { value: any }
+            payload: {
+                value: any
+            }
         }
         removeUrl: (
             index: any
         ) => {
             type: 'remove url (lib.components.AppEditorLink.appUrlsLogic)'
-            payload: { index: any }
+            payload: {
+                index: any
+            }
         }
         updateUrl: (
             index: any,
             value: any
         ) => {
             type: 'update url (lib.components.AppEditorLink.appUrlsLogic)'
-            payload: { index: any; value: any }
+            payload: {
+                index: any
+                value: any
+            }
         }
         loadSuggestions: () => {
             type: 'load suggestions (lib.components.AppEditorLink.appUrlsLogic)'
             payload: any
         }
         loadSuggestionsSuccess: (
-            suggestions: never[]
+            suggestions: any[]
         ) => {
             type: 'load suggestions success (lib.components.AppEditorLink.appUrlsLogic)'
             payload: {
-                suggestions: never[]
+                suggestions: any[]
             }
         }
         loadSuggestionsFailure: (
@@ -73,49 +83,108 @@ export interface appUrlsLogicType {
         removeUrl: (index: any) => void
         updateUrl: (index: any, value: any) => void
         loadSuggestions: () => void
-        loadSuggestionsSuccess: (suggestions: never[]) => void
+        loadSuggestionsSuccess: (suggestions: any[]) => void
         loadSuggestionsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        suggestions: any[]
+        suggestionsLoading: boolean
+        appUrls: (state: any) => string[]
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        addUrlAndGo: ((
+            payload: {
+                value: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'add url and go (lib.components.AppEditorLink.appUrlsLogic)'
+                payload: {
+                    value: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        removeUrl: ((
+            payload: {
+                index: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'remove url (lib.components.AppEditorLink.appUrlsLogic)'
+                payload: {
+                    index: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateUrl: ((
+            payload: {
+                index: any
+                value: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update url (lib.components.AppEditorLink.appUrlsLogic)'
+                payload: {
+                    index: any
+                    value: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['lib', 'components', 'AppEditorLink', 'appUrlsLogic']
     pathString: 'lib.components.AppEditorLink.appUrlsLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
-        suggestions: never[]
+        suggestions: any[]
         suggestionsLoading: boolean
-        appUrls: string[]
+        appUrls: (state: any) => string[]
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
-        suggestions: (state: never[], action: any, fullState: any) => never[]
+        suggestions: (state: any[], action: any, fullState: any) => any[]
         suggestionsLoading: (state: boolean, action: any, fullState: any) => boolean
-        appUrls: (state: string[], action: any, fullState: any) => string[]
+        appUrls: (state: (state: any) => string[], action: any, fullState: any) => (state: any) => string[]
     }
     selector: (
         state: any
     ) => {
-        suggestions: never[]
+        suggestions: any[]
         suggestionsLoading: boolean
-        appUrls: string[]
+        appUrls: (state: any) => string[]
     }
     selectors: {
-        suggestions: (state: any, props: any) => never[]
+        suggestions: (state: any, props: any) => any[]
         suggestionsLoading: (state: any, props: any) => boolean
-        appUrls: (state: any, props: any) => string[]
+        appUrls: (state: any, props: any) => (state: any) => string[]
+    }
+    sharedListeners: {
+        saveAppUrls: (
+            payload: any,
+            breakpoint: BreakPointFunction,
+            action: {
+                type: string
+                payload: any
+            },
+            previousState: any
+        ) => void | Promise<void>
     }
     values: {
-        suggestions: never[]
+        suggestions: any[]
         suggestionsLoading: boolean
-        appUrls: string[]
+        appUrls: (state: any) => string[]
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogicType.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogicType.ts
@@ -1,13 +1,16 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface chartFilterLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface chartFilterLogicType extends Logic {
     actionCreators: {
         setChartFilter: (
             filter: any
         ) => {
             type: 'set chart filter (lib.components.ChartFilter.chartFilterLogic)'
-            payload: { filter: any }
+            payload: {
+                filter: any
+            }
         }
     }
     actionKeys: {
@@ -19,15 +22,16 @@ export interface chartFilterLogicType {
     actions: {
         setChartFilter: (filter: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        chartFilter: 'ActionsLineGraph'
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['lib', 'components', 'ChartFilter', 'chartFilterLogic']
     pathString: 'lib.components.ChartFilter.chartFilterLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -35,7 +39,7 @@ export interface chartFilterLogicType {
     ) => {
         chartFilter: 'ActionsLineGraph'
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         chartFilter: (state: 'ActionsLineGraph', action: any, fullState: any) => 'ActionsLineGraph'
     }
@@ -47,8 +51,10 @@ export interface chartFilterLogicType {
     selectors: {
         chartFilter: (state: any, props: any) => 'ActionsLineGraph'
     }
+    sharedListeners: {}
     values: {
         chartFilter: 'ActionsLineGraph'
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogicType.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogicType.ts
@@ -1,13 +1,16 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface compareFilterLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface compareFilterLogicType extends Logic {
     actionCreators: {
         setCompare: (
             compare: any
         ) => {
             type: 'set compare (lib.components.CompareFilter.compareFilterLogic)'
-            payload: { compare: any }
+            payload: {
+                compare: any
+            }
         }
     }
     actionKeys: {
@@ -19,15 +22,16 @@ export interface compareFilterLogicType {
     actions: {
         setCompare: (compare: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        compare: boolean
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['lib', 'components', 'CompareFilter', 'compareFilterLogic']
     pathString: 'lib.components.CompareFilter.compareFilterLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -35,7 +39,7 @@ export interface compareFilterLogicType {
     ) => {
         compare: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         compare: (state: boolean, action: any, fullState: any) => boolean
     }
@@ -47,8 +51,10 @@ export interface compareFilterLogicType {
     selectors: {
         compare: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         compare: boolean
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/lib/components/DateFilter/dateFilterLogicType.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogicType.ts
@@ -1,14 +1,18 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface dateFilterLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface dateFilterLogicType extends Logic {
     actionCreators: {
         setDates: (
             dateFrom: any,
             dateTo: any
         ) => {
             type: 'set dates (lib.components.DateFilter.dateFilterLogic)'
-            payload: { dateFrom: any; dateTo: any }
+            payload: {
+                dateFrom: any
+                dateTo: any
+            }
         }
     }
     actionKeys: {
@@ -20,15 +24,16 @@ export interface dateFilterLogicType {
     actions: {
         setDates: (dateFrom: any, dateTo: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        dates: {}
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['lib', 'components', 'DateFilter', 'dateFilterLogic']
     pathString: 'lib.components.DateFilter.dateFilterLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -36,7 +41,7 @@ export interface dateFilterLogicType {
     ) => {
         dates: {}
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         dates: (state: {}, action: any, fullState: any) => {}
     }
@@ -48,8 +53,10 @@ export interface dateFilterLogicType {
     selectors: {
         dates: (state: any, props: any) => {}
     }
+    sharedListeners: {}
     values: {
         dates: {}
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogicType.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogicType.ts
@@ -1,19 +1,24 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface intervalFilterLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface intervalFilterLogicType extends Logic {
     actionCreators: {
         setIntervalFilter: (
             filter: any
         ) => {
             type: 'set interval filter (lib.components.IntervalFilter.intervalFilterLogic)'
-            payload: { filter: any }
+            payload: {
+                filter: any
+            }
         }
         setDateFrom: (
             dateFrom: any
         ) => {
             type: 'set date from (lib.components.IntervalFilter.intervalFilterLogic)'
-            payload: { dateFrom: any }
+            payload: {
+                dateFrom: any
+            }
         }
     }
     actionKeys: {
@@ -28,15 +33,17 @@ export interface intervalFilterLogicType {
         setIntervalFilter: (filter: any) => void
         setDateFrom: (dateFrom: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        interval: null
+        dateFrom: null
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['lib', 'components', 'IntervalFilter', 'intervalFilterLogic']
     pathString: 'lib.components.IntervalFilter.intervalFilterLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -45,7 +52,7 @@ export interface intervalFilterLogicType {
         interval: null
         dateFrom: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         interval: (state: null, action: any, fullState: any) => null
         dateFrom: (state: null, action: any, fullState: any) => null
@@ -60,9 +67,11 @@ export interface intervalFilterLogicType {
         interval: (state: any, props: any) => null
         dateFrom: (state: any, props: any) => null
     }
+    sharedListeners: {}
     values: {
         interval: null
         dateFrom: null
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogicType.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface propertyFilterLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface propertyFilterLogicType extends Logic {
     actionCreators: {
         loadEventProperties: () => {
             type: 'load event properties (lib.components.PropertyFilters.propertyFilterLogic)'
@@ -13,13 +14,17 @@ export interface propertyFilterLogicType {
             properties: any
         ) => {
             type: 'set properties (lib.components.PropertyFilters.propertyFilterLogic)'
-            payload: { properties: any }
+            payload: {
+                properties: any
+            }
         }
         update: (
             filters: any
         ) => {
             type: 'update (lib.components.PropertyFilters.propertyFilterLogic)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
         setFilter: (
             index: any,
@@ -29,13 +34,21 @@ export interface propertyFilterLogicType {
             type: any
         ) => {
             type: 'set filter (lib.components.PropertyFilters.propertyFilterLogic)'
-            payload: { index: any; key: any; value: any; operator: any; type: any }
+            payload: {
+                index: any
+                key: any
+                value: any
+                operator: any
+                type: any
+            }
         }
         setFilters: (
             filters: any
         ) => {
             type: 'set filters (lib.components.PropertyFilters.propertyFilterLogic)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
         newFilter: () => {
             type: 'new filter (lib.components.PropertyFilters.propertyFilterLogic)'
@@ -47,7 +60,9 @@ export interface propertyFilterLogicType {
             index: any
         ) => {
             type: 'remove (lib.components.PropertyFilters.propertyFilterLogic)'
-            payload: { index: any }
+            payload: {
+                index: any
+            }
         }
         loadPersonProperties: () => {
             type: 'load person properties (lib.components.PropertyFilters.propertyFilterLogic)'
@@ -106,15 +121,21 @@ export interface propertyFilterLogicType {
         loadPersonPropertiesSuccess: (personProperties: any) => void
         loadPersonPropertiesFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        personProperties: any
+        personPropertiesLoading: boolean
+        eventProperties: any[]
+        filters: any
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: any
+    listeners: {}
     path: ['lib', 'components', 'PropertyFilters', 'propertyFilterLogic']
     pathString: 'lib.components.PropertyFilters.propertyFilterLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -122,14 +143,14 @@ export interface propertyFilterLogicType {
     ) => {
         personProperties: any
         personPropertiesLoading: boolean
-        eventProperties: never[]
+        eventProperties: any[]
         filters: any
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         personProperties: (state: any, action: any, fullState: any) => any
         personPropertiesLoading: (state: boolean, action: any, fullState: any) => boolean
-        eventProperties: (state: never[], action: any, fullState: any) => never[]
+        eventProperties: (state: any[], action: any, fullState: any) => any[]
         filters: (state: any, action: any, fullState: any) => any
     }
     selector: (
@@ -137,20 +158,22 @@ export interface propertyFilterLogicType {
     ) => {
         personProperties: any
         personPropertiesLoading: boolean
-        eventProperties: never[]
+        eventProperties: any[]
         filters: any
     }
     selectors: {
         personProperties: (state: any, props: any) => any
         personPropertiesLoading: (state: any, props: any) => boolean
-        eventProperties: (state: any, props: any) => never[]
+        eventProperties: (state: any, props: any) => any[]
         filters: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
         personProperties: any
         personPropertiesLoading: boolean
-        eventProperties: never[]
+        eventProperties: any[]
         filters: any
     }
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModalType.ts
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModalType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface saveToDashboardModalLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface saveToDashboardModalLogicType extends Logic {
     actionCreators: {
         addNewDashboard: () => {
             type: 'add new dashboard (lib.components.SaveToDashboard.SaveToDashboardModal)'
@@ -19,20 +20,35 @@ export interface saveToDashboardModalLogicType {
     actions: {
         addNewDashboard: () => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {}
+    events: {}
+    key: undefined
+    listeners: {
+        addNewDashboard: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'add new dashboard (lib.components.SaveToDashboard.SaveToDashboardModal)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['lib', 'components', 'SaveToDashboard', 'SaveToDashboardModal']
     pathString: 'lib.components.SaveToDashboard.SaveToDashboardModal'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (state: any, action: () => any, fullState: any) => {}
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {}
     selector: (state: any) => {}
     selectors: {}
+    sharedListeners: {}
     values: {}
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/lib/logic/promptType.ts
+++ b/frontend/src/lib/logic/promptType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface promptType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface promptType extends Logic {
     actionCreators: {
         prompt: ({
             title,
@@ -12,7 +13,14 @@ export interface promptType {
             failure,
         }: any) => {
             type: 'prompt (lib.logic.prompt)'
-            payload: { title: any; placeholder: any; value: any; error: any; success: any; failure: any }
+            payload: {
+                title: any
+                placeholder: any
+                value: any
+                error: any
+                success: any
+                failure: any
+            }
         }
     }
     actionKeys: {
@@ -24,20 +32,47 @@ export interface promptType {
     actions: {
         prompt: ({ title, placeholder, value, error, success, failure }: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {}
+    events: {
+        beforeUnmount: () => void
+    }
+    key: any
+    listeners: {
+        prompt: ((
+            payload: {
+                title: any
+                placeholder: any
+                value: any
+                error: any
+                success: any
+                failure: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'prompt (lib.logic.prompt)'
+                payload: {
+                    title: any
+                    placeholder: any
+                    value: any
+                    error: any
+                    success: any
+                    failure: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['lib', 'logic', 'prompt']
     pathString: 'lib.logic.prompt'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (state: any, action: () => any, fullState: any) => {}
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {}
     selector: (state: any) => {}
     selectors: {}
+    sharedListeners: {}
     values: {}
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/models/actionsModelType.ts
+++ b/frontend/src/models/actionsModelType.ts
@@ -1,18 +1,19 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface actionsModelType {
-    key: any
+import { Logic } from 'kea'
+
+export interface actionsModelType extends Logic {
     actionCreators: {
         loadActions: () => {
             type: 'load actions (models.actionsModel)'
             payload: any
         }
         loadActionsSuccess: (
-            actions: never[]
+            actions: any[]
         ) => {
             type: 'load actions success (models.actionsModel)'
             payload: {
-                actions: never[]
+                actions: any[]
             }
         }
         loadActionsFailure: (
@@ -36,48 +37,54 @@ export interface actionsModelType {
     }
     actions: {
         loadActions: () => void
-        loadActionsSuccess: (actions: never[]) => void
+        loadActionsSuccess: (actions: any[]) => void
         loadActionsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        actions: any[]
+        actionsLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {}
     path: ['models', 'actionsModel']
     pathString: 'models.actionsModel'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
-        actions: never[]
+        actions: any[]
         actionsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
-        actions: (state: never[], action: any, fullState: any) => never[]
+        actions: (state: any[], action: any, fullState: any) => any[]
         actionsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        actions: never[]
+        actions: any[]
         actionsLoading: boolean
     }
     selectors: {
-        actions: (state: any, props: any) => never[]
+        actions: (state: any, props: any) => any[]
         actionsLoading: (state: any, props: any) => boolean
         actionsGrouped: (state: any, props: any) => { label: string; options: never[] }[]
     }
+    sharedListeners: {}
     values: {
-        actions: never[]
+        actions: any[]
         actionsLoading: boolean
         actionsGrouped: { label: string; options: never[] }[]
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         actionsGrouped: (arg1: any) => { label: string; options: never[] }[]
     }

--- a/frontend/src/models/annotationsModelType.ts
+++ b/frontend/src/models/annotationsModelType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface annotationsModelType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface annotationsModelType extends Logic {
     actionCreators: {
         createGlobalAnnotation: (
             content: any,
@@ -9,24 +10,31 @@ export interface annotationsModelType {
             dashboard_item: any
         ) => {
             type: 'create global annotation (models.annotationsModel)'
-            payload: { content: any; date_marker: any; created_at: Moment; dashboard_item: any }
+            payload: {
+                content: any
+                date_marker: any
+                created_at: Moment
+                dashboard_item: any
+            }
         }
         deleteGlobalAnnotation: (
             id: any
         ) => {
             type: 'delete global annotation (models.annotationsModel)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         loadGlobalAnnotations: () => {
             type: 'load global annotations (models.annotationsModel)'
             payload: any
         }
         loadGlobalAnnotationsSuccess: (
-            globalAnnotations: never[]
+            globalAnnotations: any[]
         ) => {
             type: 'load global annotations success (models.annotationsModel)'
             payload: {
-                globalAnnotations: never[]
+                globalAnnotations: any[]
             }
         }
         loadGlobalAnnotationsFailure: (
@@ -56,48 +64,87 @@ export interface annotationsModelType {
         createGlobalAnnotation: (content: any, date_marker: any, dashboard_item: any) => void
         deleteGlobalAnnotation: (id: any) => void
         loadGlobalAnnotations: () => void
-        loadGlobalAnnotationsSuccess: (globalAnnotations: never[]) => void
+        loadGlobalAnnotationsSuccess: (globalAnnotations: any[]) => void
         loadGlobalAnnotationsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        globalAnnotations: any[]
+        globalAnnotationsLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        createGlobalAnnotation: ((
+            payload: {
+                content: any
+                date_marker: any
+                created_at: Moment
+                dashboard_item: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'create global annotation (models.annotationsModel)'
+                payload: {
+                    content: any
+                    date_marker: any
+                    created_at: Moment
+                    dashboard_item: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        deleteGlobalAnnotation: ((
+            payload: {
+                id: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'delete global annotation (models.annotationsModel)'
+                payload: {
+                    id: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['models', 'annotationsModel']
     pathString: 'models.annotationsModel'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
-        globalAnnotations: never[]
+        globalAnnotations: any[]
         globalAnnotationsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
-        globalAnnotations: (state: never[], action: any, fullState: any) => never[]
+        globalAnnotations: (state: any[], action: any, fullState: any) => any[]
         globalAnnotationsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        globalAnnotations: never[]
+        globalAnnotations: any[]
         globalAnnotationsLoading: boolean
     }
     selectors: {
-        globalAnnotations: (state: any, props: any) => never[]
+        globalAnnotations: (state: any, props: any) => any[]
         globalAnnotationsLoading: (state: any, props: any) => boolean
         activeGlobalAnnotations: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
-        globalAnnotations: never[]
+        globalAnnotations: any[]
         globalAnnotationsLoading: boolean
         activeGlobalAnnotations: any
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         activeGlobalAnnotations: (arg1: any) => any
     }

--- a/frontend/src/models/cohortsModelType.ts
+++ b/frontend/src/models/cohortsModelType.ts
@@ -1,13 +1,16 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface cohortsModelType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface cohortsModelType extends Logic {
     actionCreators: {
         setPollTimeout: (
             pollTimeout: any
         ) => {
             type: 'set poll timeout (models.cohortsModel)'
-            payload: { pollTimeout: any }
+            payload: {
+                pollTimeout: any
+            }
         }
         loadCohorts: () => {
             type: 'load cohorts (models.cohortsModel)'
@@ -48,15 +51,35 @@ export interface cohortsModelType {
         loadCohortsSuccess: (cohorts: any) => void
         loadCohortsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        cohorts: any
+        cohortsLoading: boolean
+        pollTimeout: null
+    }
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: undefined
+    listeners: {
+        loadCohortsSuccess: ((
+            payload: {
+                cohorts: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load cohorts success (models.cohortsModel)'
+                payload: {
+                    cohorts: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['models', 'cohortsModel']
     pathString: 'models.cohortsModel'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -66,7 +89,7 @@ export interface cohortsModelType {
         cohortsLoading: boolean
         pollTimeout: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         cohorts: (state: any, action: any, fullState: any) => any
         cohortsLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -84,10 +107,12 @@ export interface cohortsModelType {
         cohortsLoading: (state: any, props: any) => boolean
         pollTimeout: (state: any, props: any) => null
     }
+    sharedListeners: {}
     values: {
         cohorts: any
         cohortsLoading: boolean
         pollTimeout: null
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/models/dashboardsModelType.ts
+++ b/frontend/src/models/dashboardsModelType.ts
@@ -1,25 +1,32 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface dashboardsModelType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface dashboardsModelType extends Logic {
     actionCreators: {
         delayedDeleteDashboard: (
             id: any
         ) => {
             type: 'delayed delete dashboard (models.dashboardsModel)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         setLastVisitedDashboardId: (
             id: any
         ) => {
             type: 'set last visited dashboard id (models.dashboardsModel)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         updateDashboardItem: (
             item: any
         ) => {
             type: 'update dashboard item (models.dashboardsModel)'
-            payload: { item: any }
+            payload: {
+                item: any
+            }
         }
         loadDashboards: () => {
             type: 'load dashboards (models.dashboardsModel)'
@@ -283,15 +290,63 @@ export interface dashboardsModelType {
         unpinDashboardSuccess: (dashboard: any) => void
         unpinDashboardFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        rawDashboards: {}
+        rawDashboardsLoading: boolean
+        dashboard: any
+        dashboardLoading: boolean
+        redirect: boolean
+        lastVisitedDashboardId: null
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        addDashboardSuccess: ((
+            payload: {
+                dashboard: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'add dashboard success (models.dashboardsModel)'
+                payload: {
+                    dashboard: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        restoreDashboardSuccess: ((
+            payload: {
+                dashboard: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'restore dashboard success (models.dashboardsModel)'
+                payload: {
+                    dashboard: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        deleteDashboardSuccess: ((
+            payload: {
+                dashboard: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'delete dashboard success (models.dashboardsModel)'
+                payload: {
+                    dashboard: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['models', 'dashboardsModel']
     pathString: 'models.dashboardsModel'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -304,7 +359,7 @@ export interface dashboardsModelType {
         redirect: boolean
         lastVisitedDashboardId: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         rawDashboards: (state: {}, action: any, fullState: any) => {}
         rawDashboardsLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -334,6 +389,7 @@ export interface dashboardsModelType {
         dashboardsLoading: (state: any, props: any) => any
         pinnedDashboards: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
         rawDashboards: {}
         rawDashboardsLoading: boolean
@@ -346,6 +402,7 @@ export interface dashboardsModelType {
         pinnedDashboards: any
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         dashboards: (arg1: any) => any[]
         dashboardsLoading: (arg1: any) => any

--- a/frontend/src/models/funnelsModelType.ts
+++ b/frontend/src/models/funnelsModelType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface funnelsModelType {
-    key: any
+import { Logic } from 'kea'
+
+export interface funnelsModelType extends Logic {
     actionCreators: {
         loadFunnels: () => {
             type: 'load funnels (models.funnelsModel)'
@@ -39,15 +40,19 @@ export interface funnelsModelType {
         loadFunnelsSuccess: (funnels: any) => void
         loadFunnelsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        funnels: any
+        funnelsLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {}
     path: ['models', 'funnelsModel']
     pathString: 'models.funnelsModel'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -56,7 +61,7 @@ export interface funnelsModelType {
         funnels: any
         funnelsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         funnels: (state: any, action: any, fullState: any) => any
         funnelsLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -71,9 +76,11 @@ export interface funnelsModelType {
         funnels: (state: any, props: any) => any
         funnelsLoading: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         funnels: any
         funnelsLoading: boolean
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/actions/ActionType.ts
+++ b/frontend/src/scenes/actions/ActionType.ts
@@ -1,25 +1,32 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface actionLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface actionLogicType extends Logic {
     actionCreators: {
         checkIsFinished: (
             action: any
         ) => {
             type: 'check is finished (scenes.actions.Action)'
-            payload: { action: any }
+            payload: {
+                action: any
+            }
         }
         setPollTimeout: (
             pollTimeout: any
         ) => {
             type: 'set poll timeout (scenes.actions.Action)'
-            payload: { pollTimeout: any }
+            payload: {
+                pollTimeout: any
+            }
         }
         setIsComplete: (
             isComplete: any
         ) => {
             type: 'set is complete (scenes.actions.Action)'
-            payload: { isComplete: any }
+            payload: {
+                isComplete: any
+            }
         }
         loadAction: () => {
             type: 'load action (scenes.actions.Action)'
@@ -66,15 +73,36 @@ export interface actionLogicType {
         loadActionSuccess: (action: any) => void
         loadActionFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        pollTimeout: null
+        isComplete: boolean
+        action: any
+        actionLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: any
+    listeners: {
+        checkIsFinished: ((
+            payload: {
+                action: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'check is finished (scenes.actions.Action)'
+                payload: {
+                    action: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'actions', 'Action']
     pathString: 'scenes.actions.Action'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -85,7 +113,7 @@ export interface actionLogicType {
         action: any
         actionLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         pollTimeout: (state: null, action: any, fullState: any) => null
         isComplete: (state: boolean, action: any, fullState: any) => boolean
@@ -106,6 +134,7 @@ export interface actionLogicType {
         action: (state: any, props: any) => any
         actionLoading: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         pollTimeout: null
         isComplete: boolean
@@ -113,4 +142,5 @@ export interface actionLogicType {
         actionLoading: boolean
     }
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/scenes/actions/actionEditLogicType.ts
+++ b/frontend/src/scenes/actions/actionEditLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface actionEditLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface actionEditLogicType extends Logic {
     actionCreators: {
         saveAction: () => {
             type: 'save action (scenes.actions.actionEditLogic)'
@@ -13,19 +14,25 @@ export interface actionEditLogicType {
             action: any
         ) => {
             type: 'set action (scenes.actions.actionEditLogic)'
-            payload: { action: any }
+            payload: {
+                action: any
+            }
         }
         setCreateNew: (
             createNew: any
         ) => {
             type: 'set create new (scenes.actions.actionEditLogic)'
-            payload: { createNew: any }
+            payload: {
+                createNew: any
+            }
         }
         actionAlreadyExists: (
             actionId: any
         ) => {
             type: 'action already exists (scenes.actions.actionEditLogic)'
-            payload: { actionId: any }
+            payload: {
+                actionId: any
+            }
         }
         loadAction: () => {
             type: 'load action (scenes.actions.actionEditLogic)'
@@ -75,15 +82,35 @@ export interface actionEditLogicType {
         loadActionSuccess: (action: any) => void
         loadActionFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        action: any
+        actionLoading: boolean
+        errorActionId: null
+        createNew: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: any
+    listeners: {
+        saveAction: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'save action (scenes.actions.actionEditLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'actions', 'actionEditLogic']
     pathString: 'scenes.actions.actionEditLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -94,7 +121,7 @@ export interface actionEditLogicType {
         errorActionId: null
         createNew: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         action: (state: any, action: any, fullState: any) => any
         actionLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -115,6 +142,7 @@ export interface actionEditLogicType {
         errorActionId: (state: any, props: any) => null
         createNew: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         action: any
         actionLoading: boolean
@@ -122,4 +150,5 @@ export interface actionEditLogicType {
         createNew: boolean
     }
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/scenes/annotations/annotationsTableLogicType.ts
+++ b/frontend/src/scenes/annotations/annotationsTableLogicType.ts
@@ -1,18 +1,19 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface annotationsTableLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface annotationsTableLogicType extends Logic {
     actionCreators: {
         loadAnnotations: () => {
             type: 'load annotations (scenes.annotations.annotationsTableLogic)'
             payload: any
         }
         loadAnnotationsSuccess: (
-            annotations: never[]
+            annotations: any[]
         ) => {
             type: 'load annotations success (scenes.annotations.annotationsTableLogic)'
             payload: {
-                annotations: never[]
+                annotations: any[]
             }
         }
         loadAnnotationsFailure: (
@@ -28,19 +29,26 @@ export interface annotationsTableLogicType {
             content: any
         ) => {
             type: 'update annotation (scenes.annotations.annotationsTableLogic)'
-            payload: { id: any; content: any }
+            payload: {
+                id: any
+                content: any
+            }
         }
         deleteAnnotation: (
             id: any
         ) => {
             type: 'delete annotation (scenes.annotations.annotationsTableLogic)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         restoreAnnotation: (
             id: any
         ) => {
             type: 'restore annotation (scenes.annotations.annotationsTableLogic)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         loadAnnotationsNext: () => {
             type: 'load annotations next (scenes.annotations.annotationsTableLogic)'
@@ -50,13 +58,17 @@ export interface annotationsTableLogicType {
             next: any
         ) => {
             type: 'set next (scenes.annotations.annotationsTableLogic)'
-            payload: { next: any }
+            payload: {
+                next: any
+            }
         }
         appendAnnotations: (
             annotations: any
         ) => {
             type: 'append annotations (scenes.annotations.annotationsTableLogic)'
-            payload: { annotations: any }
+            payload: {
+                annotations: any
+            }
         }
     }
     actionKeys: {
@@ -83,7 +95,7 @@ export interface annotationsTableLogicType {
     }
     actions: {
         loadAnnotations: () => void
-        loadAnnotationsSuccess: (annotations: never[]) => void
+        loadAnnotationsSuccess: (annotations: any[]) => void
         loadAnnotationsFailure: (error: string) => void
         updateAnnotation: (id: any, content: any) => void
         deleteAnnotation: (id: any) => void
@@ -92,28 +104,85 @@ export interface annotationsTableLogicType {
         setNext: (next: any) => void
         appendAnnotations: (annotations: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        annotations: any[]
+        annotationsLoading: boolean
+        next: null
+        loadingNext: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        updateAnnotation: ((
+            payload: {
+                id: any
+                content: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update annotation (scenes.annotations.annotationsTableLogic)'
+                payload: {
+                    id: any
+                    content: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        restoreAnnotation: ((
+            payload: {
+                id: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'restore annotation (scenes.annotations.annotationsTableLogic)'
+                payload: {
+                    id: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        deleteAnnotation: ((
+            payload: {
+                id: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'delete annotation (scenes.annotations.annotationsTableLogic)'
+                payload: {
+                    id: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        loadAnnotationsNext: ((
+            payload: boolean,
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load annotations next (scenes.annotations.annotationsTableLogic)'
+                payload: boolean
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'annotations', 'annotationsTableLogic']
     pathString: 'scenes.annotations.annotationsTableLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
-        annotations: never[]
+        annotations: any[]
         annotationsLoading: boolean
         next: null
         loadingNext: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
-        annotations: (state: never[], action: any, fullState: any) => never[]
+        annotations: (state: any[], action: any, fullState: any) => any[]
         annotationsLoading: (state: boolean, action: any, fullState: any) => boolean
         next: (state: null, action: any, fullState: any) => null
         loadingNext: (state: boolean, action: any, fullState: any) => boolean
@@ -121,22 +190,24 @@ export interface annotationsTableLogicType {
     selector: (
         state: any
     ) => {
-        annotations: never[]
+        annotations: any[]
         annotationsLoading: boolean
         next: null
         loadingNext: boolean
     }
     selectors: {
-        annotations: (state: any, props: any) => never[]
+        annotations: (state: any, props: any) => any[]
         annotationsLoading: (state: any, props: any) => boolean
         next: (state: any, props: any) => null
         loadingNext: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
-        annotations: never[]
+        annotations: any[]
         annotationsLoading: boolean
         next: null
         loadingNext: boolean
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/dashboard/dashboardLogicType.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface dashboardLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface dashboardLogicType extends Logic {
     actionCreators: {
         addNewDashboard: () => {
             type: 'add new dashboard (scenes.dashboard.dashboardLogic)'
@@ -19,20 +20,27 @@ export interface dashboardLogicType {
             id: any
         ) => {
             type: 'rename dashboard item (scenes.dashboard.dashboardLogic)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         renameDashboardItemSuccess: (
             item: any
         ) => {
             type: 'rename dashboard item success (scenes.dashboard.dashboardLogic)'
-            payload: { item: any }
+            payload: {
+                item: any
+            }
         }
         setIsSharedDashboard: (
             id: any,
             isShared: any
         ) => {
             type: 'set is shared dashboard (scenes.dashboard.dashboardLogic)'
-            payload: { id: any; isShared: any }
+            payload: {
+                id: any
+                isShared: any
+            }
         }
         duplicateDashboardItem: (
             id: any,
@@ -40,26 +48,37 @@ export interface dashboardLogicType {
             move?: any
         ) => {
             type: 'duplicate dashboard item (scenes.dashboard.dashboardLogic)'
-            payload: { id: any; dashboardId: any; move: boolean }
+            payload: {
+                id: any
+                dashboardId: any
+                move: boolean
+            }
         }
         duplicateDashboardItemSuccess: (
             item: any
         ) => {
             type: 'duplicate dashboard item success (scenes.dashboard.dashboardLogic)'
-            payload: { item: any }
+            payload: {
+                item: any
+            }
         }
         updateLayouts: (
             layouts: any
         ) => {
             type: 'update layouts (scenes.dashboard.dashboardLogic)'
-            payload: { layouts: any }
+            payload: {
+                layouts: any
+            }
         }
         updateContainerWidth: (
             containerWidth: any,
             columns: any
         ) => {
             type: 'update container width (scenes.dashboard.dashboardLogic)'
-            payload: { containerWidth: any; columns: any }
+            payload: {
+                containerWidth: any
+                columns: any
+            }
         }
         saveLayouts: () => {
             type: 'save layouts (scenes.dashboard.dashboardLogic)'
@@ -72,7 +91,10 @@ export interface dashboardLogicType {
             color: any
         ) => {
             type: 'update item color (scenes.dashboard.dashboardLogic)'
-            payload: { id: any; color: any }
+            payload: {
+                id: any
+                color: any
+            }
         }
         enableDragging: () => {
             type: 'enable dragging (scenes.dashboard.dashboardLogic)'
@@ -96,18 +118,20 @@ export interface dashboardLogicType {
             id: any
         ) => {
             type: 'refresh dashboard item (scenes.dashboard.dashboardLogic)'
-            payload: { id: any }
+            payload: {
+                id: any
+            }
         }
         loadDashboardItems: () => {
             type: 'load dashboard items (scenes.dashboard.dashboardLogic)'
             payload: any
         }
         loadDashboardItemsSuccess: (
-            allItems: never[]
+            allItems: any[]
         ) => {
             type: 'load dashboard items success (scenes.dashboard.dashboardLogic)'
             payload: {
-                allItems: never[]
+                allItems: any[]
             }
         }
         loadDashboardItemsFailure: (
@@ -176,32 +200,205 @@ export interface dashboardLogicType {
         disableDragging: () => void
         refreshDashboardItem: (id: any) => void
         loadDashboardItems: () => void
-        loadDashboardItemsSuccess: (allItems: never[]) => void
+        loadDashboardItemsSuccess: (allItems: any[]) => void
         loadDashboardItemsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
-    path: ['scenes', 'dashboard', 'dashboardLogic']
-    pathString: 'scenes.dashboard.dashboardLogic'
-    propTypes: any
-    props: Record<string, any>
-    reducer: (
-        state: any,
-        action: () => any,
-        fullState: any
-    ) => {
-        allItems: never[]
+    constants: {}
+    defaults: {
+        allItems: any[]
         allItemsLoading: boolean
         draggingEnabled: () => 'off' | 'on'
         containerWidth: null
         columns: null
     }
-    reducerOptions: any
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: any
+    listeners: {
+        addNewDashboard: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'add new dashboard (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setIsSharedDashboard: ((
+            payload: {
+                id: any
+                isShared: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set is shared dashboard (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    id: any
+                    isShared: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        renameDashboard: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'rename dashboard (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        renameDashboardItem: ((
+            payload: {
+                id: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'rename dashboard item (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    id: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateLayouts: ((
+            payload: {
+                layouts: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update layouts (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    layouts: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        saveLayouts: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'save layouts (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateItemColor: ((
+            payload: {
+                id: any
+                color: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update item color (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    id: any
+                    color: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        duplicateDashboardItem: ((
+            payload: {
+                id: any
+                dashboardId: any
+                move: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'duplicate dashboard item (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    id: any
+                    dashboardId: any
+                    move: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        enableWobblyDragging: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'enable wobbly dragging (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        enableDragging: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'enable dragging (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        disableDragging: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'disable dragging (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        refreshDashboardItem: ((
+            payload: {
+                id: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'refresh dashboard item (scenes.dashboard.dashboardLogic)'
+                payload: {
+                    id: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
+    path: ['scenes', 'dashboard', 'dashboardLogic']
+    pathString: 'scenes.dashboard.dashboardLogic'
+    props: Record<string, unknown>
+    reducer: (
+        state: any,
+        action: () => any,
+        fullState: any
+    ) => {
+        allItems: any[]
+        allItemsLoading: boolean
+        draggingEnabled: () => 'off' | 'on'
+        containerWidth: null
+        columns: null
+    }
+    reducerOptions: {}
     reducers: {
-        allItems: (state: never[], action: any, fullState: any) => never[]
+        allItems: (state: any[], action: any, fullState: any) => any[]
         allItemsLoading: (state: boolean, action: any, fullState: any) => boolean
         draggingEnabled: (state: () => 'off' | 'on', action: any, fullState: any) => () => 'off' | 'on'
         containerWidth: (state: null, action: any, fullState: any) => null
@@ -210,14 +407,14 @@ export interface dashboardLogicType {
     selector: (
         state: any
     ) => {
-        allItems: never[]
+        allItems: any[]
         allItemsLoading: boolean
         draggingEnabled: () => 'off' | 'on'
         containerWidth: null
         columns: null
     }
     selectors: {
-        allItems: (state: any, props: any) => never[]
+        allItems: (state: any, props: any) => any[]
         allItemsLoading: (state: any, props: any) => boolean
         draggingEnabled: (state: any, props: any) => () => 'off' | 'on'
         containerWidth: (state: any, props: any) => null
@@ -232,8 +429,9 @@ export interface dashboardLogicType {
         layout: (state: any, props: any) => any
         layoutForItem: (state: any, props: any) => {}
     }
+    sharedListeners: {}
     values: {
-        allItems: never[]
+        allItems: any[]
         allItemsLoading: boolean
         draggingEnabled: () => 'off' | 'on'
         containerWidth: null
@@ -249,6 +447,7 @@ export interface dashboardLogicType {
         layoutForItem: {}
     }
     _isKea: true
+    _isKeaWithKey: true
     __keaTypeGenInternalSelectorTypes: {
         items: (arg1: any) => any
         itemsLoading: (arg1: any) => any

--- a/frontend/src/scenes/dashboard/dashboardsLogicType.ts
+++ b/frontend/src/scenes/dashboard/dashboardsLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface dashboardsLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface dashboardsLogicType extends Logic {
     actionCreators: {
         addNewDashboard: () => {
             type: 'add new dashboard (scenes.dashboard.dashboardsLogic)'
@@ -19,26 +20,41 @@ export interface dashboardsLogicType {
     actions: {
         addNewDashboard: () => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {}
+    events: {}
+    key: undefined
+    listeners: {
+        addNewDashboard: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'add new dashboard (scenes.dashboard.dashboardsLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'dashboard', 'dashboardsLogic']
     pathString: 'scenes.dashboard.dashboardsLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (state: any, action: () => any, fullState: any) => {}
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {}
     selector: (state: any) => {}
     selectors: {
         dashboards: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
         dashboards: any
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         dashboards: (arg1: any) => any
     }

--- a/frontend/src/scenes/events/eventsTableLogicType.ts
+++ b/frontend/src/scenes/events/eventsTableLogicType.ts
@@ -1,19 +1,24 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface eventsTableLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface eventsTableLogicType extends Logic {
     actionCreators: {
         setProperties: (
             properties: any
         ) => {
             type: 'set properties (scenes.events.eventsTableLogic)'
-            payload: { properties: any }
+            payload: {
+                properties: any
+            }
         }
         fetchEvents: (
             nextParams?: any
         ) => {
             type: 'fetch events (scenes.events.eventsTableLogic)'
-            payload: { nextParams: any }
+            payload: {
+                nextParams: any
+            }
         }
         fetchEventsSuccess: (
             events: any,
@@ -21,7 +26,11 @@ export interface eventsTableLogicType {
             isNext?: any
         ) => {
             type: 'fetch events success (scenes.events.eventsTableLogic)'
-            payload: { events: any; hasNext: boolean; isNext: boolean }
+            payload: {
+                events: any
+                hasNext: boolean
+                isNext: boolean
+            }
         }
         fetchNextEvents: () => {
             type: 'fetch next events (scenes.events.eventsTableLogic)'
@@ -45,25 +54,33 @@ export interface eventsTableLogicType {
             events: any
         ) => {
             type: 'poll events success (scenes.events.eventsTableLogic)'
-            payload: { events: any }
+            payload: {
+                events: any
+            }
         }
         prependNewEvents: (
             events: any
         ) => {
             type: 'prepend new events (scenes.events.eventsTableLogic)'
-            payload: { events: any }
+            payload: {
+                events: any
+            }
         }
         setSelectedEvent: (
             selectedEvent: any
         ) => {
             type: 'set selected event (scenes.events.eventsTableLogic)'
-            payload: { selectedEvent: any }
+            payload: {
+                selectedEvent: any
+            }
         }
         setPollTimeout: (
             pollTimeout: any
         ) => {
             type: 'set poll timeout (scenes.events.eventsTableLogic)'
-            payload: { pollTimeout: any }
+            payload: {
+                pollTimeout: any
+            }
         }
         setDelayedLoading: () => {
             type: 'set delayed loading (scenes.events.eventsTableLogic)'
@@ -75,7 +92,9 @@ export interface eventsTableLogicType {
             event: any
         ) => {
             type: 'set event filter (scenes.events.eventsTableLogic)'
-            payload: { event: any }
+            payload: {
+                event: any
+            }
         }
     }
     actionKeys: {
@@ -120,45 +139,138 @@ export interface eventsTableLogicType {
         setDelayedLoading: () => void
         setEventFilter: (event: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        initialPathname: (state: any) => any
+        properties: any[]
+        eventFilter: boolean
+        isLoading: boolean
+        isLoadingNext: boolean
+        events: any[]
+        hasNext: boolean
+        orderBy: string
+        selectedEvent: null
+        newEvents: any[]
+        highlightEvents: {}
+        pollTimeout: null
+    }
+    events: {
+        beforeUnmount: () => void
+    }
+    key: string
+    listeners: {
+        setProperties: ((
+            payload: {
+                properties: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set properties (scenes.events.eventsTableLogic)'
+                payload: {
+                    properties: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        flipSort: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'flip sort (scenes.events.eventsTableLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setEventFilter: ((
+            payload: {
+                event: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set event filter (scenes.events.eventsTableLogic)'
+                payload: {
+                    event: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        fetchNextEvents: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'fetch next events (scenes.events.eventsTableLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        fetchEvents: ((
+            payload: {
+                nextParams: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'fetch events (scenes.events.eventsTableLogic)'
+                payload: {
+                    nextParams: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        pollEvents: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'poll events (scenes.events.eventsTableLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'events', 'eventsTableLogic']
     pathString: 'scenes.events.eventsTableLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: any[]
         eventFilter: boolean
         isLoading: boolean
         isLoadingNext: boolean
-        events: never[]
+        events: any[]
         hasNext: boolean
         orderBy: string
         selectedEvent: null
-        newEvents: never[]
+        newEvents: any[]
         highlightEvents: {}
         pollTimeout: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         initialPathname: (state: (state: any) => any, action: any, fullState: any) => (state: any) => any
-        properties: (state: never[], action: any, fullState: any) => never[]
+        properties: (state: any[], action: any, fullState: any) => any[]
         eventFilter: (state: boolean, action: any, fullState: any) => boolean
         isLoading: (state: boolean, action: any, fullState: any) => boolean
         isLoadingNext: (state: boolean, action: any, fullState: any) => boolean
-        events: (state: never[], action: any, fullState: any) => never[]
+        events: (state: any[], action: any, fullState: any) => any[]
         hasNext: (state: boolean, action: any, fullState: any) => boolean
         orderBy: (state: string, action: any, fullState: any) => string
         selectedEvent: (state: null, action: any, fullState: any) => null
-        newEvents: (state: never[], action: any, fullState: any) => never[]
+        newEvents: (state: any[], action: any, fullState: any) => any[]
         highlightEvents: (state: {}, action: any, fullState: any) => {}
         pollTimeout: (state: null, action: any, fullState: any) => null
     }
@@ -166,51 +278,53 @@ export interface eventsTableLogicType {
         state: any
     ) => {
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: any[]
         eventFilter: boolean
         isLoading: boolean
         isLoadingNext: boolean
-        events: never[]
+        events: any[]
         hasNext: boolean
         orderBy: string
         selectedEvent: null
-        newEvents: never[]
+        newEvents: any[]
         highlightEvents: {}
         pollTimeout: null
     }
     selectors: {
         initialPathname: (state: any, props: any) => (state: any) => any
-        properties: (state: any, props: any) => never[]
+        properties: (state: any, props: any) => any[]
         eventFilter: (state: any, props: any) => boolean
         isLoading: (state: any, props: any) => boolean
         isLoadingNext: (state: any, props: any) => boolean
-        events: (state: any, props: any) => never[]
+        events: (state: any, props: any) => any[]
         hasNext: (state: any, props: any) => boolean
         orderBy: (state: any, props: any) => string
         selectedEvent: (state: any, props: any) => null
-        newEvents: (state: any, props: any) => never[]
+        newEvents: (state: any, props: any) => any[]
         highlightEvents: (state: any, props: any) => {}
         pollTimeout: (state: any, props: any) => null
         propertiesForUrl: (state: any, props: any) => '' | { properties: any }
         eventsFormatted: (state: any, props: any) => any[]
     }
+    sharedListeners: {}
     values: {
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: any[]
         eventFilter: boolean
         isLoading: boolean
         isLoadingNext: boolean
-        events: never[]
+        events: any[]
         hasNext: boolean
         orderBy: string
         selectedEvent: null
-        newEvents: never[]
+        newEvents: any[]
         highlightEvents: {}
         pollTimeout: null
         propertiesForUrl: '' | { properties: any }
         eventsFormatted: any[]
     }
     _isKea: true
+    _isKeaWithKey: true
     __keaTypeGenInternalSelectorTypes: {
         propertiesForUrl: (arg1: any) => '' | { properties: any }
         eventsFormatted: (arg1: any, arg2: any) => any[]

--- a/frontend/src/scenes/experiments/EditFeatureFlagType.ts
+++ b/frontend/src/scenes/experiments/EditFeatureFlagType.ts
@@ -1,19 +1,24 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface editLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface editLogicType extends Logic {
     actionCreators: {
         setRolloutPercentage: (
             rollout_percentage: any
         ) => {
             type: 'set rollout percentage (scenes.experiments.EditFeatureFlag)'
-            payload: { rollout_percentage: any }
+            payload: {
+                rollout_percentage: any
+            }
         }
         setFilters: (
             filters: any
         ) => {
             type: 'set filters (scenes.experiments.EditFeatureFlag)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
     }
     actionKeys: {
@@ -28,15 +33,17 @@ export interface editLogicType {
         setRolloutPercentage: (rollout_percentage: any) => void
         setFilters: (filters: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        filters: any
+        rollout_percentage: any
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['scenes', 'experiments', 'EditFeatureFlag']
     pathString: 'scenes.experiments.EditFeatureFlag'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -45,7 +52,7 @@ export interface editLogicType {
         filters: any
         rollout_percentage: any
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         filters: (state: any, action: any, fullState: any) => any
         rollout_percentage: (state: any, action: any, fullState: any) => any
@@ -60,9 +67,11 @@ export interface editLogicType {
         filters: (state: any, props: any) => any
         rollout_percentage: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
         filters: any
         rollout_percentage: any
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/experiments/featureFlagLogicType.ts
+++ b/frontend/src/scenes/experiments/featureFlagLogicType.ts
@@ -1,25 +1,29 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface featureFlagLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface featureFlagLogicType extends Logic {
     actionCreators: {
         setFunnel: (
             funnel: any,
             update: any
         ) => {
             type: 'set funnel (scenes.experiments.featureFlagLogic)'
-            payload: { funnel: any; update: any }
+            payload: {
+                funnel: any
+                update: any
+            }
         }
         loadFeatureFlags: () => {
             type: 'load feature flags (scenes.experiments.featureFlagLogic)'
             payload: any
         }
         loadFeatureFlagsSuccess: (
-            featureFlags: never[]
+            featureFlags: any[]
         ) => {
             type: 'load feature flags success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: any[]
             }
         }
         loadFeatureFlagsFailure: (
@@ -37,11 +41,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         updateFeatureFlagSuccess: (
-            featureFlags: never[]
+            featureFlags: any[]
         ) => {
             type: 'update feature flag success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: any[]
             }
         }
         updateFeatureFlagFailure: (
@@ -59,11 +63,11 @@ export interface featureFlagLogicType {
             payload: any
         }
         createFeatureFlagSuccess: (
-            featureFlags: never[]
+            featureFlags: any[]
         ) => {
             type: 'create feature flag success (scenes.experiments.featureFlagLogic)'
             payload: {
-                featureFlags: never[]
+                featureFlags: any[]
             }
         }
         createFeatureFlagFailure: (
@@ -102,50 +106,92 @@ export interface featureFlagLogicType {
     actions: {
         setFunnel: (funnel: any, update: any) => void
         loadFeatureFlags: () => void
-        loadFeatureFlagsSuccess: (featureFlags: never[]) => void
+        loadFeatureFlagsSuccess: (featureFlags: any[]) => void
         loadFeatureFlagsFailure: (error: string) => void
         updateFeatureFlag: (featureFlag: any) => void
-        updateFeatureFlagSuccess: (featureFlags: never[]) => void
+        updateFeatureFlagSuccess: (featureFlags: any[]) => void
         updateFeatureFlagFailure: (error: string) => void
         createFeatureFlag: (featureFlag: any) => void
-        createFeatureFlagSuccess: (featureFlags: never[]) => void
+        createFeatureFlagSuccess: (featureFlags: any[]) => void
         createFeatureFlagFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        featureFlags: any[]
+        featureFlagsLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: any
+    listeners: {
+        updateFeatureFlag: ((
+            payload: any,
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update feature flag (scenes.experiments.featureFlagLogic)'
+                payload: any
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateFeatureFlagSuccess: ((
+            payload: {
+                featureFlags: any[]
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update feature flag success (scenes.experiments.featureFlagLogic)'
+                payload: {
+                    featureFlags: any[]
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        createFeatureFlagSuccess: ((
+            payload: {
+                featureFlags: any[]
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'create feature flag success (scenes.experiments.featureFlagLogic)'
+                payload: {
+                    featureFlags: any[]
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'experiments', 'featureFlagLogic']
     pathString: 'scenes.experiments.featureFlagLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
         fullState: any
     ) => {
-        featureFlags: never[]
+        featureFlags: any[]
         featureFlagsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
-        featureFlags: (state: never[], action: any, fullState: any) => never[]
+        featureFlags: (state: any[], action: any, fullState: any) => any[]
         featureFlagsLoading: (state: boolean, action: any, fullState: any) => boolean
     }
     selector: (
         state: any
     ) => {
-        featureFlags: never[]
+        featureFlags: any[]
         featureFlagsLoading: boolean
     }
     selectors: {
-        featureFlags: (state: any, props: any) => never[]
+        featureFlags: (state: any, props: any) => any[]
         featureFlagsLoading: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
-        featureFlags: never[]
+        featureFlags: any[]
         featureFlagsLoading: boolean
     }
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/scenes/funnels/funnelLogicType.ts
+++ b/frontend/src/scenes/funnels/funnelLogicType.ts
@@ -1,14 +1,18 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface funnelLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface funnelLogicType extends Logic {
     actionCreators: {
         setFunnel: (
             funnel: any,
             update: any
         ) => {
             type: 'set funnel (scenes.funnels.funnelLogic)'
-            payload: { funnel: any; update: any }
+            payload: {
+                funnel: any
+                update: any
+            }
         }
         clearFunnel: () => {
             type: 'clear funnel (scenes.funnels.funnelLogic)'
@@ -191,15 +195,105 @@ export interface funnelLogicType {
         loadPeopleSuccess: (people: any) => void
         loadPeopleFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        funnel: {
+            filters: {}
+        }
+        funnelLoading: boolean
+        stepsWithCount: any
+        stepsWithCountLoading: boolean
+        people: any
+        peopleLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: any
+    listeners: {
+        loadStepsWithCountSuccess: ((
+            payload: {
+                stepsWithCount: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load steps with count success (scenes.funnels.funnelLogic)'
+                payload: {
+                    stepsWithCount: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setFunnel: ((
+            payload: {
+                funnel: any
+                update: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set funnel (scenes.funnels.funnelLogic)'
+                payload: {
+                    funnel: any
+                    update: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        loadFunnelSuccess: ((
+            payload: {
+                funnel: {
+                    filters: {}
+                }
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load funnel success (scenes.funnels.funnelLogic)'
+                payload: {
+                    funnel: {
+                        filters: {}
+                    }
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateFunnelSuccess: ((
+            payload: {
+                funnel: {
+                    filters: {}
+                }
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update funnel success (scenes.funnels.funnelLogic)'
+                payload: {
+                    funnel: {
+                        filters: {}
+                    }
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        createFunnelSuccess: ((
+            payload: {
+                funnel: {
+                    filters: {}
+                }
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'create funnel success (scenes.funnels.funnelLogic)'
+                payload: {
+                    funnel: {
+                        filters: {}
+                    }
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'funnels', 'funnelLogic']
     pathString: 'scenes.funnels.funnelLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -214,7 +308,7 @@ export interface funnelLogicType {
         people: any
         peopleLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         funnel: (
             state: {
@@ -258,6 +352,7 @@ export interface funnelLogicType {
         peopleSorted: (state: any, props: any) => any
         isStepsEmpty: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         funnel: {
             filters: {}
@@ -271,6 +366,7 @@ export interface funnelLogicType {
         isStepsEmpty: boolean
     }
     _isKea: true
+    _isKeaWithKey: true
     __keaTypeGenInternalSelectorTypes: {
         peopleSorted: (arg1: any, arg2: any) => any
         isStepsEmpty: (arg1: any) => boolean

--- a/frontend/src/scenes/funnels/funnelVizLogicType.ts
+++ b/frontend/src/scenes/funnels/funnelVizLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface funnelVizLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface funnelVizLogicType extends Logic {
     actionCreators: {
         loadResults: (
             refresh?: any
@@ -41,15 +42,17 @@ export interface funnelVizLogicType {
         loadResultsSuccess: (results: any) => void
         loadResultsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        results: any
+        resultsLoading: boolean
+    }
+    events: {}
+    key: any
+    listeners: {}
     path: ['scenes', 'funnels', 'funnelVizLogic']
     pathString: 'scenes.funnels.funnelVizLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -58,7 +61,7 @@ export interface funnelVizLogicType {
         results: any
         resultsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         results: (state: any, action: any, fullState: any) => any
         resultsLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -73,9 +76,11 @@ export interface funnelVizLogicType {
         results: (state: any, props: any) => any
         resultsLoading: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         results: any
         resultsLoading: boolean
     }
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogicType.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogicType.ts
@@ -1,31 +1,49 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface entityFilterLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface entityFilterLogicType extends Logic {
     actionCreators: {
         selectFilter: (
             filter: any
         ) => {
             type: 'select filter (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { filter: any }
+            payload: {
+                filter: any
+            }
         }
         updateFilterMath: (
             filter: any
         ) => {
             type: 'update filter math (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { type: any; value: any; math: any; math_property: any; index: any }
+            payload: {
+                type: any
+                value: any
+                math: any
+                math_property: any
+                index: any
+            }
         }
         updateFilter: (
             filter: any
         ) => {
             type: 'update filter (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { type: any; index: any; value: any; name: any }
+            payload: {
+                type: any
+                index: any
+                value: any
+                name: any
+            }
         }
         removeLocalFilter: (
             filter: any
         ) => {
             type: 'remove local filter (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { value: any; type: any; index: any }
+            payload: {
+                value: any
+                type: any
+                index: any
+            }
         }
         addFilter: () => {
             type: 'add filter (scenes.insights.ActionFilter.entityFilterLogic)'
@@ -37,19 +55,26 @@ export interface entityFilterLogicType {
             filter: any
         ) => {
             type: 'update filter property (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { properties: any; index: any }
+            payload: {
+                properties: any
+                index: any
+            }
         }
         setFilters: (
             filters: any
         ) => {
             type: 'set filters (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
         setLocalFilters: (
             filters: any
         ) => {
             type: 'set local filters (scenes.insights.ActionFilter.entityFilterLogic)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
     }
     actionKeys: {
@@ -82,15 +107,118 @@ export interface entityFilterLogicType {
         setFilters: (filters: any) => void
         setLocalFilters: (filters: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        selectedFilter: null
+        localFilters: any[]
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: any
+    listeners: {
+        updateFilter: ((
+            payload: {
+                type: any
+                index: any
+                value: any
+                name: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update filter (scenes.insights.ActionFilter.entityFilterLogic)'
+                payload: {
+                    type: any
+                    index: any
+                    value: any
+                    name: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateFilterProperty: ((
+            payload: {
+                properties: any
+                index: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update filter property (scenes.insights.ActionFilter.entityFilterLogic)'
+                payload: {
+                    properties: any
+                    index: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        updateFilterMath: ((
+            payload: {
+                type: any
+                value: any
+                math: any
+                math_property: any
+                index: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update filter math (scenes.insights.ActionFilter.entityFilterLogic)'
+                payload: {
+                    type: any
+                    value: any
+                    math: any
+                    math_property: any
+                    index: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        removeLocalFilter: ((
+            payload: {
+                value: any
+                type: any
+                index: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'remove local filter (scenes.insights.ActionFilter.entityFilterLogic)'
+                payload: {
+                    value: any
+                    type: any
+                    index: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        addFilter: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'add filter (scenes.insights.ActionFilter.entityFilterLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setFilters: ((
+            payload: {
+                filters: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set filters (scenes.insights.ActionFilter.entityFilterLogic)'
+                payload: {
+                    filters: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'insights', 'ActionFilter', 'entityFilterLogic']
     pathString: 'scenes.insights.ActionFilter.entityFilterLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -99,7 +227,7 @@ export interface entityFilterLogicType {
         selectedFilter: null
         localFilters: any[]
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         selectedFilter: (state: null, action: any, fullState: any) => null
         localFilters: (state: any[], action: any, fullState: any) => any[]
@@ -117,6 +245,7 @@ export interface entityFilterLogicType {
         entities: (state: any, props: any) => { [x: string]: any }
         filters: (state: any, props: any) => { [x: string]: any }
     }
+    sharedListeners: {}
     values: {
         selectedFilter: null
         localFilters: any[]
@@ -125,6 +254,7 @@ export interface entityFilterLogicType {
         filters: { [x: string]: any }
     }
     _isKea: true
+    _isKeaWithKey: true
     __keaTypeGenInternalSelectorTypes: {
         entities: (arg1: any, arg2: any) => { [x: string]: any }
         filters: (arg1: any) => { [x: string]: any }

--- a/frontend/src/scenes/insights/insightLogicType.ts
+++ b/frontend/src/scenes/insights/insightLogicType.ts
@@ -1,32 +1,42 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface insightLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface insightLogicType extends Logic {
     actionCreators: {
         setActiveView: (
             type: any
         ) => {
             type: 'set active view (scenes.insights.insightLogic)'
-            payload: { type: any }
+            payload: {
+                type: any
+            }
         }
         updateActiveView: (
             type: any
         ) => {
             type: 'update active view (scenes.insights.insightLogic)'
-            payload: { type: any }
+            payload: {
+                type: any
+            }
         }
         setCachedUrl: (
             type: any,
             url: any
         ) => {
             type: 'set cached url (scenes.insights.insightLogic)'
-            payload: { type: any; url: any }
+            payload: {
+                type: any
+                url: any
+            }
         }
         setAllFilters: (
             filters: any
         ) => {
             type: 'set all filters (scenes.insights.insightLogic)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
     }
     actionKeys: {
@@ -47,15 +57,18 @@ export interface insightLogicType {
         setCachedUrl: (type: any, url: any) => void
         setAllFilters: (filters: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        cachedUrls: {}
+        activeView: string
+        allFilters: {}
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['scenes', 'insights', 'insightLogic']
     pathString: 'scenes.insights.insightLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -65,7 +78,7 @@ export interface insightLogicType {
         activeView: string
         allFilters: {}
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         cachedUrls: (state: {}, action: any, fullState: any) => {}
         activeView: (state: string, action: any, fullState: any) => string
@@ -83,10 +96,12 @@ export interface insightLogicType {
         activeView: (state: any, props: any) => string
         allFilters: (state: any, props: any) => {}
     }
+    sharedListeners: {}
     values: {
         cachedUrls: {}
         activeView: string
         allFilters: {}
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/insights/trendsLogicType.ts
+++ b/frontend/src/scenes/insights/trendsLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface trendsLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface trendsLogicType extends Logic {
     actionCreators: {
         loadResults: (
             refresh?: any
@@ -10,11 +11,11 @@ export interface trendsLogicType {
             payload: any
         }
         loadResultsSuccess: (
-            results: never[]
+            results: any[]
         ) => {
             type: 'load results success (scenes.insights.trendsLogic)'
             payload: {
-                results: never[]
+                results: any[]
             }
         }
         loadResultsFailure: (
@@ -31,13 +32,19 @@ export interface trendsLogicType {
             fromUrl?: any
         ) => {
             type: 'set filters (scenes.insights.trendsLogic)'
-            payload: { filters: any; mergeFilters: boolean; fromUrl: boolean }
+            payload: {
+                filters: any
+                mergeFilters: boolean
+                fromUrl: boolean
+            }
         }
         setDisplay: (
             display: any
         ) => {
             type: 'set display (scenes.insights.trendsLogic)'
-            payload: { display: any }
+            payload: {
+                display: any
+            }
         }
         loadPeople: (
             action: any,
@@ -46,7 +53,12 @@ export interface trendsLogicType {
             breakdown_value: any
         ) => {
             type: 'load people (scenes.insights.trendsLogic)'
-            payload: { action: any; label: any; day: any; breakdown_value: any }
+            payload: {
+                action: any
+                label: any
+                day: any
+                breakdown_value: any
+            }
         }
         loadMorePeople: () => {
             type: 'load more people (scenes.insights.trendsLogic)'
@@ -58,13 +70,17 @@ export interface trendsLogicType {
             status: any
         ) => {
             type: 'set loading more people (scenes.insights.trendsLogic)'
-            payload: { status: any }
+            payload: {
+                status: any
+            }
         }
         setShowingPeople: (
             isShowing: any
         ) => {
             type: 'set showing people (scenes.insights.trendsLogic)'
-            payload: { isShowing: any }
+            payload: {
+                isShowing: any
+            }
         }
         setPeople: (
             people: any,
@@ -76,7 +92,15 @@ export interface trendsLogicType {
             next: any
         ) => {
             type: 'set people (scenes.insights.trendsLogic)'
-            payload: { people: any; count: any; action: any; label: any; day: any; breakdown_value: any; next: any }
+            payload: {
+                people: any
+                count: any
+                action: any
+                label: any
+                day: any
+                breakdown_value: any
+                next: any
+            }
         }
     }
     actionKeys: {
@@ -105,7 +129,7 @@ export interface trendsLogicType {
     }
     actions: {
         loadResults: (refresh?: any) => void
-        loadResultsSuccess: (results: never[]) => void
+        loadResultsSuccess: (results: any[]) => void
         loadResultsFailure: (error: string) => void
         setFilters: (filters: any, mergeFilters?: any, fromUrl?: any) => void
         setDisplay: (display: any) => void
@@ -115,29 +139,34 @@ export interface trendsLogicType {
         setShowingPeople: (isShowing: any) => void
         setPeople: (people: any, count: any, action: any, label: any, day: any, breakdown_value: any, next: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
-    path: ['scenes', 'insights', 'trendsLogic']
-    pathString: 'scenes.insights.trendsLogic'
-    propTypes: any
-    props: Record<string, any>
-    reducer: (
-        state: any,
-        action: () => any,
-        fullState: any
-    ) => {
-        results: never[]
+    constants: {}
+    defaults: {
+        results: any[]
         resultsLoading: boolean
         filters: any
         people: null
         showingPeople: boolean
     }
-    reducerOptions: any
+    events: {}
+    key: any
+    listeners: {}
+    path: ['scenes', 'insights', 'trendsLogic']
+    pathString: 'scenes.insights.trendsLogic'
+    props: Record<string, unknown>
+    reducer: (
+        state: any,
+        action: () => any,
+        fullState: any
+    ) => {
+        results: any[]
+        resultsLoading: boolean
+        filters: any
+        people: null
+        showingPeople: boolean
+    }
+    reducerOptions: {}
     reducers: {
-        results: (state: never[], action: any, fullState: any) => never[]
+        results: (state: any[], action: any, fullState: any) => any[]
         resultsLoading: (state: boolean, action: any, fullState: any) => boolean
         filters: (state: any, action: any, fullState: any) => any
         people: (state: null, action: any, fullState: any) => null
@@ -146,14 +175,14 @@ export interface trendsLogicType {
     selector: (
         state: any
     ) => {
-        results: never[]
+        results: any[]
         resultsLoading: boolean
         filters: any
         people: null
         showingPeople: boolean
     }
     selectors: {
-        results: (state: any, props: any) => never[]
+        results: (state: any, props: any) => any[]
         resultsLoading: (state: any, props: any) => boolean
         filters: (state: any, props: any) => any
         people: (state: any, props: any) => null
@@ -162,8 +191,9 @@ export interface trendsLogicType {
         peopleAction: (state: any, props: any) => any
         peopleDay: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
-        results: never[]
+        results: any[]
         resultsLoading: boolean
         filters: any
         people: null
@@ -173,6 +203,7 @@ export interface trendsLogicType {
         peopleDay: any
     }
     _isKea: true
+    _isKeaWithKey: true
     __keaTypeGenInternalSelectorTypes: {
         peopleAction: (arg1: any, arg2: any) => any
         peopleDay: (arg1: any) => any

--- a/frontend/src/scenes/paths/pathsLogicType.ts
+++ b/frontend/src/scenes/paths/pathsLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface pathsLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface pathsLogicType extends Logic {
     actionCreators: {
         loadPaths: (
             _: any
@@ -33,7 +34,9 @@ export interface pathsLogicType {
             properties: any
         ) => {
             type: 'set properties (scenes.paths.pathsLogic)'
-            payload: { properties: any }
+            payload: {
+                properties: any
+            }
         }
         setFilter: (
             filter: any
@@ -63,15 +66,50 @@ export interface pathsLogicType {
         setProperties: (properties: any) => void
         setFilter: (filter: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        paths: {
+            nodes: never[]
+            links: never[]
+        }
+        pathsLoading: boolean
+        initialPathname: (state: any) => any
+        filter: {
+            type: string
+        }
+        properties: {}
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        setProperties: ((
+            payload: {
+                properties: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set properties (scenes.paths.pathsLogic)'
+                payload: {
+                    properties: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setFilter: ((
+            payload: any,
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set filter (scenes.paths.pathsLogic)'
+                payload: any
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'paths', 'pathsLogic']
     pathString: 'scenes.paths.pathsLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -88,7 +126,7 @@ export interface pathsLogicType {
         }
         properties: {}
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         paths: (
             state: {
@@ -147,6 +185,7 @@ export interface pathsLogicType {
         properties: (state: any, props: any) => {}
         propertiesForUrl: (state: any, props: any) => '' | { insight: string }
     }
+    sharedListeners: {}
     values: {
         paths: {
             nodes: never[]
@@ -161,6 +200,7 @@ export interface pathsLogicType {
         propertiesForUrl: '' | { insight: string }
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         propertiesForUrl: (arg1: any, arg2: any) => '' | { insight: string }
     }

--- a/frontend/src/scenes/retention/retentionTableLogicType.ts
+++ b/frontend/src/scenes/retention/retentionTableLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface retentionTableLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface retentionTableLogicType extends Logic {
     actionCreators: {
         loadRetention: () => {
             type: 'load retention (scenes.retention.retentionTableLogic)'
@@ -45,39 +46,53 @@ export interface retentionTableLogicType {
             properties: any
         ) => {
             type: 'set properties (scenes.retention.retentionTableLogic)'
-            payload: { properties: any }
+            payload: {
+                properties: any
+            }
         }
         setFilters: (
             filters: any
         ) => {
             type: 'set filters (scenes.retention.retentionTableLogic)'
-            payload: { filters: any }
+            payload: {
+                filters: any
+            }
         }
         loadMore: (
             selectedIndex: any
         ) => {
             type: 'load more (scenes.retention.retentionTableLogic)'
-            payload: { selectedIndex: any }
+            payload: {
+                selectedIndex: any
+            }
         }
         loadMorePeople: (
             selectedIndex: any,
             peopleIds: any
         ) => {
             type: 'load more people (scenes.retention.retentionTableLogic)'
-            payload: { selectedIndex: any; peopleIds: any }
+            payload: {
+                selectedIndex: any
+                peopleIds: any
+            }
         }
         updatePeople: (
             selectedIndex: any,
             people: any
         ) => {
             type: 'update people (scenes.retention.retentionTableLogic)'
-            payload: { selectedIndex: any; people: any }
+            payload: {
+                selectedIndex: any
+                people: any
+            }
         }
         updateRetention: (
             retention: any
         ) => {
             type: 'update retention (scenes.retention.retentionTableLogic)'
-            payload: { retention: any }
+            payload: {
+                retention: any
+            }
         }
     }
     actionKeys: {
@@ -122,15 +137,80 @@ export interface retentionTableLogicType {
         updatePeople: (selectedIndex: any, people: any) => void
         updateRetention: (retention: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        retention: {}
+        retentionLoading: boolean
+        people: {}
+        peopleLoading: boolean
+        initialPathname: (state: any) => any
+        properties: any[]
+        filters: {}
+        loadingMore: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        setProperties: ((
+            payload: {
+                properties: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set properties (scenes.retention.retentionTableLogic)'
+                payload: {
+                    properties: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setFilters: ((
+            payload: {
+                filters: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set filters (scenes.retention.retentionTableLogic)'
+                payload: {
+                    filters: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        loadMore: ((
+            payload: {
+                selectedIndex: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load more (scenes.retention.retentionTableLogic)'
+                payload: {
+                    selectedIndex: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        loadMorePeople: ((
+            payload: {
+                selectedIndex: any
+                peopleIds: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load more people (scenes.retention.retentionTableLogic)'
+                payload: {
+                    selectedIndex: any
+                    peopleIds: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'retention', 'retentionTableLogic']
     pathString: 'scenes.retention.retentionTableLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -141,18 +221,18 @@ export interface retentionTableLogicType {
         people: {}
         peopleLoading: boolean
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: any[]
         filters: {}
         loadingMore: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         retention: (state: {}, action: any, fullState: any) => {}
         retentionLoading: (state: boolean, action: any, fullState: any) => boolean
         people: (state: {}, action: any, fullState: any) => {}
         peopleLoading: (state: boolean, action: any, fullState: any) => boolean
         initialPathname: (state: (state: any) => any, action: any, fullState: any) => (state: any) => any
-        properties: (state: never[], action: any, fullState: any) => never[]
+        properties: (state: any[], action: any, fullState: any) => any[]
         filters: (state: {}, action: any, fullState: any) => {}
         loadingMore: (state: boolean, action: any, fullState: any) => boolean
     }
@@ -164,7 +244,7 @@ export interface retentionTableLogicType {
         people: {}
         peopleLoading: boolean
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: any[]
         filters: {}
         loadingMore: boolean
     }
@@ -174,25 +254,27 @@ export interface retentionTableLogicType {
         people: (state: any, props: any) => {}
         peopleLoading: (state: any, props: any) => boolean
         initialPathname: (state: any, props: any) => (state: any) => any
-        properties: (state: any, props: any) => never[]
+        properties: (state: any, props: any) => any[]
         filters: (state: any, props: any) => {}
         loadingMore: (state: any, props: any) => boolean
         propertiesForUrl: (state: any, props: any) => '' | { properties: any }
         startEntity: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
         retention: {}
         retentionLoading: boolean
         people: {}
         peopleLoading: boolean
         initialPathname: (state: any) => any
-        properties: never[]
+        properties: any[]
         filters: {}
         loadingMore: boolean
         propertiesForUrl: '' | { properties: any }
         startEntity: any
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         propertiesForUrl: (arg1: any) => '' | { properties: any }
         startEntity: (arg1: any) => any

--- a/frontend/src/scenes/sceneLogicType.ts
+++ b/frontend/src/scenes/sceneLogicType.ts
@@ -1,28 +1,38 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface sceneLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface sceneLogicType extends Logic {
     actionCreators: {
         loadScene: (
             scene: any,
             params: any
         ) => {
             type: 'load scene (scenes.sceneLogic)'
-            payload: { scene: any; params: any }
+            payload: {
+                scene: any
+                params: any
+            }
         }
         setScene: (
             scene: any,
             params: any
         ) => {
             type: 'set scene (scenes.sceneLogic)'
-            payload: { scene: any; params: any }
+            payload: {
+                scene: any
+                params: any
+            }
         }
         setLoadedScene: (
             scene: any,
             loadedScene: any
         ) => {
             type: 'set loaded scene (scenes.sceneLogic)'
-            payload: { scene: any; loadedScene: any }
+            payload: {
+                scene: any
+                loadedScene: any
+            }
         }
     }
     actionKeys: {
@@ -40,15 +50,57 @@ export interface sceneLogicType {
         setScene: (scene: any, params: any) => void
         setLoadedScene: (scene: any, loadedScene: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        scene: null
+        params: {}
+        loadedScenes: {
+            404: {
+                component: () => Element
+            }
+            '4xx': {
+                component: () => Element
+            }
+        }
+        loadingScene: null
+    }
+    events: {}
+    key: undefined
+    listeners: {
+        setScene: ((
+            payload: {
+                scene: any
+                params: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set scene (scenes.sceneLogic)'
+                payload: {
+                    scene: any
+                    params: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        loadScene: ((
+            payload: {
+                scene: any
+                params: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load scene (scenes.sceneLogic)'
+                payload: {
+                    scene: any
+                    params: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'sceneLogic']
     pathString: 'scenes.sceneLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -60,10 +112,13 @@ export interface sceneLogicType {
             404: {
                 component: () => Element
             }
+            '4xx': {
+                component: () => Element
+            }
         }
         loadingScene: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         scene: (state: null, action: any, fullState: any) => null
         params: (state: {}, action: any, fullState: any) => {}
@@ -72,11 +127,17 @@ export interface sceneLogicType {
                 404: {
                     component: () => Element
                 }
+                '4xx': {
+                    component: () => Element
+                }
             },
             action: any,
             fullState: any
         ) => {
             404: {
+                component: () => Element
+            }
+            '4xx': {
                 component: () => Element
             }
         }
@@ -89,6 +150,9 @@ export interface sceneLogicType {
         params: {}
         loadedScenes: {
             404: {
+                component: () => Element
+            }
+            '4xx': {
                 component: () => Element
             }
         }
@@ -104,9 +168,13 @@ export interface sceneLogicType {
             404: {
                 component: () => Element
             }
+            '4xx': {
+                component: () => Element
+            }
         }
         loadingScene: (state: any, props: any) => null
     }
+    sharedListeners: {}
     values: {
         scene: null
         params: {}
@@ -114,8 +182,12 @@ export interface sceneLogicType {
             404: {
                 component: () => Element
             }
+            '4xx': {
+                component: () => Element
+            }
         }
         loadingScene: null
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/sessions/sessionsTableLogicType.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface sessionsTableLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface sessionsTableLogicType extends Logic {
     actionCreators: {
         loadSessions: (
             selectedDate: any
@@ -10,11 +11,11 @@ export interface sessionsTableLogicType {
             payload: any
         }
         loadSessionsSuccess: (
-            sessions: never[]
+            sessions: any[]
         ) => {
             type: 'load sessions success (scenes.sessions.sessionsTableLogic)'
             payload: {
-                sessions: never[]
+                sessions: any[]
             }
         }
         loadSessionsFailure: (
@@ -29,7 +30,9 @@ export interface sessionsTableLogicType {
             offset: any
         ) => {
             type: 'set offset (scenes.sessions.sessionsTableLogic)'
-            payload: { offset: any }
+            payload: {
+                offset: any
+            }
         }
         fetchNextSessions: () => {
             type: 'fetch next sessions (scenes.sessions.sessionsTableLogic)'
@@ -41,19 +44,25 @@ export interface sessionsTableLogicType {
             sessions: any
         ) => {
             type: 'append new sessions (scenes.sessions.sessionsTableLogic)'
-            payload: { sessions: any }
+            payload: {
+                sessions: any
+            }
         }
         dateChanged: (
             date: any
         ) => {
             type: 'date changed (scenes.sessions.sessionsTableLogic)'
-            payload: { date: any }
+            payload: {
+                date: any
+            }
         }
         setDate: (
             date: any
         ) => {
             type: 'set date (scenes.sessions.sessionsTableLogic)'
-            payload: { date: any }
+            payload: {
+                date: any
+            }
         }
     }
     actionKeys: {
@@ -78,7 +87,7 @@ export interface sessionsTableLogicType {
     }
     actions: {
         loadSessions: (selectedDate: any) => void
-        loadSessionsSuccess: (sessions: never[]) => void
+        loadSessionsSuccess: (sessions: any[]) => void
         loadSessionsFailure: (error: string) => void
         setOffset: (offset: any) => void
         fetchNextSessions: () => void
@@ -86,29 +95,63 @@ export interface sessionsTableLogicType {
         dateChanged: (date: any) => void
         setDate: (date: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
-    path: ['scenes', 'sessions', 'sessionsTableLogic']
-    pathString: 'scenes.sessions.sessionsTableLogic'
-    propTypes: any
-    props: Record<string, any>
-    reducer: (
-        state: any,
-        action: () => any,
-        fullState: any
-    ) => {
-        sessions: never[]
+    constants: {}
+    defaults: {
+        sessions: any[]
         sessionsLoading: boolean
         isLoadingNext: boolean
         offset: null
         selectedDate: Moment
     }
-    reducerOptions: any
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        fetchNextSessions: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'fetch next sessions (scenes.sessions.sessionsTableLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        dateChanged: ((
+            payload: {
+                date: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'date changed (scenes.sessions.sessionsTableLogic)'
+                payload: {
+                    date: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
+    path: ['scenes', 'sessions', 'sessionsTableLogic']
+    pathString: 'scenes.sessions.sessionsTableLogic'
+    props: Record<string, unknown>
+    reducer: (
+        state: any,
+        action: () => any,
+        fullState: any
+    ) => {
+        sessions: any[]
+        sessionsLoading: boolean
+        isLoadingNext: boolean
+        offset: null
+        selectedDate: Moment
+    }
+    reducerOptions: {}
     reducers: {
-        sessions: (state: never[], action: any, fullState: any) => never[]
+        sessions: (state: any[], action: any, fullState: any) => any[]
         sessionsLoading: (state: boolean, action: any, fullState: any) => boolean
         isLoadingNext: (state: boolean, action: any, fullState: any) => boolean
         offset: (state: null, action: any, fullState: any) => null
@@ -117,22 +160,23 @@ export interface sessionsTableLogicType {
     selector: (
         state: any
     ) => {
-        sessions: never[]
+        sessions: any[]
         sessionsLoading: boolean
         isLoadingNext: boolean
         offset: null
         selectedDate: Moment
     }
     selectors: {
-        sessions: (state: any, props: any) => never[]
+        sessions: (state: any, props: any) => any[]
         sessionsLoading: (state: any, props: any) => boolean
         isLoadingNext: (state: any, props: any) => boolean
         offset: (state: any, props: any) => null
         selectedDate: (state: any, props: any) => Moment
         selectedDateURLparam: (state: any, props: any) => any
     }
+    sharedListeners: {}
     values: {
-        sessions: never[]
+        sessions: any[]
         sessionsLoading: boolean
         isLoadingNext: boolean
         offset: null
@@ -140,6 +184,7 @@ export interface sessionsTableLogicType {
         selectedDateURLparam: any
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         selectedDateURLparam: (arg1: any) => any
     }

--- a/frontend/src/scenes/setup/DeleteDemoDataType.ts
+++ b/frontend/src/scenes/setup/DeleteDemoDataType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface deleteDemoDataLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface deleteDemoDataLogicType extends Logic {
     actionCreators: {
         deleteDemoData: () => {
             type: 'delete demo data (scenes.setup.DeleteDemoData)'
@@ -28,15 +29,16 @@ export interface deleteDemoDataLogicType {
         deleteDemoData: () => void
         demoDataDeleted: () => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        isDeleted: boolean
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['scenes', 'setup', 'DeleteDemoData']
     pathString: 'scenes.setup.DeleteDemoData'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -44,7 +46,7 @@ export interface deleteDemoDataLogicType {
     ) => {
         isDeleted: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         isDeleted: (state: boolean, action: any, fullState: any) => boolean
     }
@@ -56,8 +58,10 @@ export interface deleteDemoDataLogicType {
     selectors: {
         isDeleted: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         isDeleted: boolean
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/setup/WebhookIntegrationType.ts
+++ b/frontend/src/scenes/setup/WebhookIntegrationType.ts
@@ -1,22 +1,25 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface logicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface logicType extends Logic {
     actionCreators: {
         setEditedWebhook: (
             webhook: any
         ) => {
-            type: 'set edited webhook (scenes.setup.SlackIntegration)'
-            payload: { webhook: any }
+            type: 'set edited webhook (scenes.setup.WebhookIntegration)'
+            payload: {
+                webhook: any
+            }
         }
         saveWebhook: () => {
-            type: 'save webhook (scenes.setup.SlackIntegration)'
+            type: 'save webhook (scenes.setup.WebhookIntegration)'
             payload: {
                 value: boolean
             }
         }
         testAndSaveWebhook: () => {
-            type: 'test and save webhook (scenes.setup.SlackIntegration)'
+            type: 'test and save webhook (scenes.setup.WebhookIntegration)'
             payload: {
                 value: boolean
             }
@@ -24,21 +27,23 @@ export interface logicType {
         setError: (
             error: any
         ) => {
-            type: 'set error (scenes.setup.SlackIntegration)'
-            payload: { error: any }
+            type: 'set error (scenes.setup.WebhookIntegration)'
+            payload: {
+                error: any
+            }
         }
     }
     actionKeys: {
-        'set edited webhook (scenes.setup.SlackIntegration)': 'setEditedWebhook'
-        'save webhook (scenes.setup.SlackIntegration)': 'saveWebhook'
-        'test and save webhook (scenes.setup.SlackIntegration)': 'testAndSaveWebhook'
-        'set error (scenes.setup.SlackIntegration)': 'setError'
+        'set edited webhook (scenes.setup.WebhookIntegration)': 'setEditedWebhook'
+        'save webhook (scenes.setup.WebhookIntegration)': 'saveWebhook'
+        'test and save webhook (scenes.setup.WebhookIntegration)': 'testAndSaveWebhook'
+        'set error (scenes.setup.WebhookIntegration)': 'setError'
     }
     actionTypes: {
-        setEditedWebhook: 'set edited webhook (scenes.setup.SlackIntegration)'
-        saveWebhook: 'save webhook (scenes.setup.SlackIntegration)'
-        testAndSaveWebhook: 'test and save webhook (scenes.setup.SlackIntegration)'
-        setError: 'set error (scenes.setup.SlackIntegration)'
+        setEditedWebhook: 'set edited webhook (scenes.setup.WebhookIntegration)'
+        saveWebhook: 'save webhook (scenes.setup.WebhookIntegration)'
+        testAndSaveWebhook: 'test and save webhook (scenes.setup.WebhookIntegration)'
+        setError: 'set error (scenes.setup.WebhookIntegration)'
     }
     actions: {
         setEditedWebhook: (webhook: any) => void
@@ -46,15 +51,19 @@ export interface logicType {
         testAndSaveWebhook: () => void
         setError: (error: any) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
-    path: ['scenes', 'setup', 'SlackIntegration']
-    pathString: 'scenes.setup.SlackIntegration'
-    propTypes: any
-    props: Record<string, any>
+    constants: {}
+    defaults: {
+        editedWebhook: (state: any) => string | undefined
+        isSaving: boolean
+        isSaved: boolean
+        error: null
+    }
+    events: {}
+    key: undefined
+    listeners: {}
+    path: ['scenes', 'setup', 'WebhookIntegration']
+    pathString: 'scenes.setup.WebhookIntegration'
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -65,7 +74,7 @@ export interface logicType {
         isSaved: boolean
         error: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         editedWebhook: (
             state: (state: any) => string | undefined,
@@ -90,6 +99,7 @@ export interface logicType {
         isSaved: (state: any, props: any) => boolean
         error: (state: any, props: any) => null
     }
+    sharedListeners: {}
     values: {
         editedWebhook: (state: any) => string | undefined
         isSaving: boolean
@@ -97,6 +107,7 @@ export interface logicType {
         error: null
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalReducerActions: {
         __computed: (
             user: UserType,

--- a/frontend/src/scenes/team/teamLogicType.ts
+++ b/frontend/src/scenes/team/teamLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface teamLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface teamLogicType extends Logic {
     actionCreators: {
         loadUsers: () => {
             type: 'load users (scenes.team.teamLogic)'
@@ -66,15 +67,19 @@ export interface teamLogicType {
         deleteUserSuccess: (users: {}) => void
         deleteUserFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        users: {}
+        usersLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {}
     path: ['scenes', 'team', 'teamLogic']
     pathString: 'scenes.team.teamLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -83,7 +88,7 @@ export interface teamLogicType {
         users: {}
         usersLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         users: (state: {}, action: any, fullState: any) => {}
         usersLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -98,9 +103,11 @@ export interface teamLogicType {
         users: (state: any, props: any) => {}
         usersLoading: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         users: {}
         usersLoading: boolean
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/scenes/userLogicType.ts
+++ b/frontend/src/scenes/userLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface userLogicType<UserType, EventProperty> {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface userLogicType<UserType, EventProperty> extends Logic {
     actionCreators: {
         loadUser: () => {
             type: 'load user (scenes.userLogic)'
@@ -14,28 +15,40 @@ export interface userLogicType<UserType, EventProperty> {
             updateKey?: string
         ) => {
             type: 'set user (scenes.userLogic)'
-            payload: { user: UserType | null; updateKey: string | undefined }
+            payload: {
+                user: UserType | null
+                updateKey: string | undefined
+            }
         }
         userUpdateRequest: (
             update: Partial<UserType>,
             updateKey?: string
         ) => {
             type: 'user update request (scenes.userLogic)'
-            payload: { update: Partial<UserType>; updateKey: string | undefined }
+            payload: {
+                update: Partial<UserType>
+                updateKey: string | undefined
+            }
         }
         userUpdateSuccess: (
             user: UserType,
             updateKey?: string
         ) => {
             type: 'user update success (scenes.userLogic)'
-            payload: { user: UserType; updateKey: string | undefined }
+            payload: {
+                user: UserType
+                updateKey: string | undefined
+            }
         }
         userUpdateFailure: (
             error: string,
             updateKey?: string
         ) => {
             type: 'user update failure (scenes.userLogic)'
-            payload: { updateKey: string | undefined; error: string }
+            payload: {
+                updateKey: string | undefined
+                error: string
+            }
         }
     }
     actionKeys: {
@@ -59,15 +72,47 @@ export interface userLogicType<UserType, EventProperty> {
         userUpdateSuccess: (user: UserType, updateKey?: string) => void
         userUpdateFailure: (error: string, updateKey?: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        user: UserType | null
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        loadUser: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'load user (scenes.userLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        userUpdateRequest: ((
+            payload: {
+                update: Partial<UserType>
+                updateKey: string | undefined
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'user update request (scenes.userLogic)'
+                payload: {
+                    update: Partial<UserType>
+                    updateKey: string | undefined
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'userLogic']
     pathString: 'scenes.userLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -75,7 +120,7 @@ export interface userLogicType<UserType, EventProperty> {
     ) => {
         user: UserType | null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         user: (state: UserType | null, action: any, fullState: any) => UserType | null
     }
@@ -91,6 +136,7 @@ export interface userLogicType<UserType, EventProperty> {
         customEventNames: (state: any, props: any) => string[]
         eventNamesGrouped: (state: any, props: any) => { label: string; options: EventProperty[] }[]
     }
+    sharedListeners: {}
     values: {
         user: UserType | null
         eventProperties: EventProperty[]
@@ -99,6 +145,7 @@ export interface userLogicType<UserType, EventProperty> {
         eventNamesGrouped: { label: string; options: EventProperty[] }[]
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         eventProperties: (arg1: UserType | null) => EventProperty[]
         eventNames: (arg1: UserType | null) => string[]

--- a/frontend/src/scenes/users/cohortLogicType.ts
+++ b/frontend/src/scenes/users/cohortLogicType.ts
@@ -1,37 +1,48 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface cohortLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface cohortLogicType extends Logic {
     actionCreators: {
         saveCohort: (
             cohort: any
         ) => {
             type: 'save cohort (scenes.users.cohortLogic)'
-            payload: { cohort: any }
+            payload: {
+                cohort: any
+            }
         }
         setCohort: (
             cohort: any
         ) => {
             type: 'set cohort (scenes.users.cohortLogic)'
-            payload: { cohort: any }
+            payload: {
+                cohort: any
+            }
         }
         checkIsFinished: (
             cohort: any
         ) => {
             type: 'check is finished (scenes.users.cohortLogic)'
-            payload: { cohort: any }
+            payload: {
+                cohort: any
+            }
         }
         setToastId: (
             toastId: any
         ) => {
             type: 'set toast id (scenes.users.cohortLogic)'
-            payload: { toastId: any }
+            payload: {
+                toastId: any
+            }
         }
         setPollTimeout: (
             pollTimeout: any
         ) => {
             type: 'set poll timeout (scenes.users.cohortLogic)'
-            payload: { pollTimeout: any }
+            payload: {
+                pollTimeout: any
+            }
         }
         loadPersonProperties: () => {
             type: 'load person properties (scenes.users.cohortLogic)'
@@ -84,15 +95,50 @@ export interface cohortLogicType {
         loadPersonPropertiesSuccess: (personProperties: any) => void
         loadPersonPropertiesFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        personProperties: any
+        personPropertiesLoading: boolean
+        pollTimeout: null
+        cohort: null
+        toastId: null
+    }
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: any
+    listeners: {
+        saveCohort: ((
+            payload: {
+                cohort: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'save cohort (scenes.users.cohortLogic)'
+                payload: {
+                    cohort: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        checkIsFinished: ((
+            payload: {
+                cohort: any
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'check is finished (scenes.users.cohortLogic)'
+                payload: {
+                    cohort: any
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['scenes', 'users', 'cohortLogic']
     pathString: 'scenes.users.cohortLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -104,7 +150,7 @@ export interface cohortLogicType {
         cohort: null
         toastId: null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         personProperties: (state: any, action: any, fullState: any) => any
         personPropertiesLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -128,6 +174,17 @@ export interface cohortLogicType {
         cohort: (state: any, props: any) => null
         toastId: (state: any, props: any) => null
     }
+    sharedListeners: {
+        pollIsFinished: (
+            payload: any,
+            breakpoint: BreakPointFunction,
+            action: {
+                type: string
+                payload: any
+            },
+            previousState: any
+        ) => void | Promise<void>
+    }
     values: {
         personProperties: any
         personPropertiesLoading: boolean
@@ -136,4 +193,5 @@ export interface cohortLogicType {
         toastId: null
     }
     _isKea: true
+    _isKeaWithKey: true
 }

--- a/frontend/src/toolbar/actions/actionsLogicType.ts
+++ b/frontend/src/toolbar/actions/actionsLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface actionsLogicType<ActionType> {
-    key: any
+import { Logic } from 'kea'
+
+export interface actionsLogicType<ActionType> extends Logic {
     actionCreators: {
         getActions: (
             _?: any
@@ -111,15 +112,17 @@ export interface actionsLogicType<ActionType> {
         deleteActionSuccess: (allActions: ActionType[]) => void
         deleteActionFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        allActions: ActionType[]
+        allActionsLoading: boolean
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['toolbar', 'actions', 'actionsLogic']
     pathString: 'toolbar.actions.actionsLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -128,7 +131,7 @@ export interface actionsLogicType<ActionType> {
         allActions: ActionType[]
         allActionsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         allActions: (state: ActionType[], action: any, fullState: any) => ActionType[]
         allActionsLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -146,6 +149,7 @@ export interface actionsLogicType<ActionType> {
         actionsForCurrentUrl: (state: any, props: any) => ActionType[]
         actionCount: (state: any, props: any) => number
     }
+    sharedListeners: {}
     values: {
         allActions: ActionType[]
         allActionsLoading: boolean
@@ -154,6 +158,7 @@ export interface actionsLogicType<ActionType> {
         actionCount: number
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         sortedActions: (arg1: ActionType[]) => ActionType[]
         actionsForCurrentUrl: (arg1: ActionType[], arg2: string) => ActionType[]

--- a/frontend/src/toolbar/actions/actionsTabLogicType.ts
+++ b/frontend/src/toolbar/actions/actionsTabLogicType.ts
@@ -1,44 +1,58 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdFieldData> {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdFieldData> extends Logic {
     actionCreators: {
         setForm: (
             form: FormInstance
         ) => {
             type: 'set form (toolbar.actions.actionsTabLogic)'
-            payload: { form: FormInstance }
+            payload: {
+                form: FormInstance
+            }
         }
         selectAction: (
             id: number | null
         ) => {
             type: 'select action (toolbar.actions.actionsTabLogic)'
-            payload: { id: number | null }
+            payload: {
+                id: number | null
+            }
         }
         newAction: (
             element?: HTMLElement
         ) => {
             type: 'new action (toolbar.actions.actionsTabLogic)'
-            payload: { element: HTMLElement | null }
+            payload: {
+                element: HTMLElement | null
+            }
         }
         inspectForElementWithIndex: (
             index: number | null
         ) => {
             type: 'inspect for element with index (toolbar.actions.actionsTabLogic)'
-            payload: { index: number | null }
+            payload: {
+                index: number | null
+            }
         }
         inspectElementSelected: (
             element: HTMLElement,
             index: number | null
         ) => {
             type: 'inspect element selected (toolbar.actions.actionsTabLogic)'
-            payload: { element: HTMLElement; index: number | null }
+            payload: {
+                element: HTMLElement
+                index: number | null
+            }
         }
         setEditingFields: (
             editingFields: AntdFieldData[]
         ) => {
             type: 'set editing fields (toolbar.actions.actionsTabLogic)'
-            payload: { editingFields: AntdFieldData[] }
+            payload: {
+                editingFields: AntdFieldData[]
+            }
         }
         incrementCounter: () => {
             type: 'increment counter (toolbar.actions.actionsTabLogic)'
@@ -50,7 +64,9 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
             formValues: ActionForm
         ) => {
             type: 'save action (toolbar.actions.actionsTabLogic)'
-            payload: { formValues: ActionForm }
+            payload: {
+                formValues: ActionForm
+            }
         }
         deleteAction: () => {
             type: 'delete action (toolbar.actions.actionsTabLogic)'
@@ -74,7 +90,9 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
             showActionsTooltip: boolean
         ) => {
             type: 'set show actions tooltip (toolbar.actions.actionsTabLogic)'
-            payload: { showActionsTooltip: boolean }
+            payload: {
+                showActionsTooltip: boolean
+            }
         }
     }
     actionKeys: {
@@ -119,15 +137,145 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
         hideButtonActions: () => void
         setShowActionsTooltip: (showActionsTooltip: boolean) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        buttonActionsVisible: boolean
+        selectedActionId: number | 'new' | null
+        newActionForElement: HTMLElement | null
+        inspectingElement: number | null
+        editingFields: AntdFieldData[] | null
+        form: FormInstance | null
+        counter: number
+        showActionsTooltip: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        selectAction: ((
+            payload: {
+                id: number | null
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'select action (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    id: number | null
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        inspectElementSelected: ((
+            payload: {
+                element: HTMLElement
+                index: number | null
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'inspect element selected (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    element: HTMLElement
+                    index: number | null
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        saveAction: ((
+            payload: {
+                formValues: ActionForm
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'save action (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    formValues: ActionForm
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        deleteAction: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'delete action (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        showButtonActions: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'show button actions (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        hideButtonActions: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'hide button actions (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        'get actions success (toolbar.actions.actionsLogic)': ((
+            payload: {
+                allActions: ActionType[]
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'get actions success (toolbar.actions.actionsLogic)'
+                payload: {
+                    allActions: ActionType[]
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setShowActionsTooltip: ((
+            payload: {
+                showActionsTooltip: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set show actions tooltip (toolbar.actions.actionsTabLogic)'
+                payload: {
+                    showActionsTooltip: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        'set tab (toolbar.toolbarTabLogic)': ((
+            payload: {
+                tab: string
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set tab (toolbar.toolbarTabLogic)'
+                payload: {
+                    tab: string
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['toolbar', 'actions', 'actionsTabLogic']
     pathString: 'toolbar.actions.actionsTabLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -142,7 +290,7 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
         counter: number
         showActionsTooltip: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         buttonActionsVisible: (state: boolean, action: any, fullState: any) => boolean
         selectedActionId: (state: number | 'new' | null, action: any, fullState: any) => number | 'new' | null
@@ -178,6 +326,7 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
         initialValuesForForm: (state: any, props: any) => ActionForm
         selectedEditedAction: (state: any, props: any) => ActionForm
     }
+    sharedListeners: {}
     values: {
         buttonActionsVisible: boolean
         selectedActionId: number | 'new' | null
@@ -192,6 +341,7 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
         selectedEditedAction: ActionForm
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         selectedAction: (arg1: number | 'new' | null, arg2: HTMLElement | null, arg3: ActionType[]) => ActionType | null
         initialValuesForForm: (arg1: ActionType | null) => ActionForm
@@ -203,5 +353,23 @@ export interface actionsTabLogicType<ActionType, ActionForm, FormInstance, AntdF
             arg5: number | null,
             arg6: number
         ) => ActionForm
+    }
+    __keaTypeGenInternalReducerActions: {
+        'get actions success (toolbar.actions.actionsLogic)': (
+            allActions: ActionType[]
+        ) => {
+            type: 'get actions success (toolbar.actions.actionsLogic)'
+            payload: {
+                allActions: ActionType[]
+            }
+        }
+        'set tab (toolbar.toolbarTabLogic)': (
+            tab: ToolbarTab | string
+        ) => {
+            type: 'set tab (toolbar.toolbarTabLogic)'
+            payload: {
+                tab: string
+            }
+        }
     }
 }

--- a/frontend/src/toolbar/button/toolbarButtonLogicType.ts
+++ b/frontend/src/toolbar/button/toolbarButtonLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface toolbarButtonLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface toolbarButtonLogicType extends Logic {
     actionCreators: {
         showHeatmapInfo: () => {
             type: 'show heatmap info (toolbar.button.toolbarButtonLogic)'
@@ -43,35 +44,49 @@ export interface toolbarButtonLogicType {
             percentage: number
         ) => {
             type: 'set extension percentage (toolbar.button.toolbarButtonLogic)'
-            payload: { percentage: number }
+            payload: {
+                percentage: number
+            }
         }
         saveDragPosition: (
             x: number,
             y: number
         ) => {
             type: 'save drag position (toolbar.button.toolbarButtonLogic)'
-            payload: { x: number; y: number }
+            payload: {
+                x: number
+                y: number
+            }
         }
         saveHeatmapPosition: (
             x: number,
             y: number
         ) => {
             type: 'save heatmap position (toolbar.button.toolbarButtonLogic)'
-            payload: { x: number; y: number }
+            payload: {
+                x: number
+                y: number
+            }
         }
         saveActionsPosition: (
             x: number,
             y: number
         ) => {
             type: 'save actions position (toolbar.button.toolbarButtonLogic)'
-            payload: { x: number; y: number }
+            payload: {
+                x: number
+                y: number
+            }
         }
         saveStatsPosition: (
             x: number,
             y: number
         ) => {
             type: 'save stats position (toolbar.button.toolbarButtonLogic)'
-            payload: { x: number; y: number }
+            payload: {
+                x: number
+                y: number
+            }
         }
     }
     actionKeys: {
@@ -113,15 +128,51 @@ export interface toolbarButtonLogicType {
         saveActionsPosition: (x: number, y: number) => void
         saveStatsPosition: (x: number, y: number) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        windowHeight: number
+        windowWidth: number
+        heatmapInfoVisible: boolean
+        actionsInfoVisible: boolean
+        statsVisible: boolean
+        extensionPercentage: number
+        lastDragPosition: null | {
+            x: number
+            y: number
+        }
+        heatmapPosition: {
+            x: number
+            y: number
+        }
+        actionsPosition: {
+            x: number
+            y: number
+        }
+        statsPosition: {
+            x: number
+            y: number
+        }
+    }
+    events: {}
+    key: undefined
+    listeners: {
+        hideActionsInfo: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'hide actions info (toolbar.button.toolbarButtonLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['toolbar', 'button', 'toolbarButtonLogic']
     pathString: 'toolbar.button.toolbarButtonLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -150,7 +201,11 @@ export interface toolbarButtonLogicType {
             y: number
         }
     }
-    reducerOptions: any
+    reducerOptions: {
+        lastDragPosition: {
+            persist: boolean
+        }
+    }
     reducers: {
         windowHeight: (state: number, action: any, fullState: any) => number
         windowWidth: (state: number, action: any, fullState: any) => number
@@ -277,6 +332,7 @@ export interface toolbarButtonLogicType {
         actionsWindowVisible: (state: any, props: any) => boolean
         statsExtensionPercentage: (state: any, props: any) => number
     }
+    sharedListeners: {}
     values: {
         windowHeight: number
         windowWidth: number
@@ -314,6 +370,7 @@ export interface toolbarButtonLogicType {
         statsExtensionPercentage: number
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         dragPosition: (
             arg1: {

--- a/frontend/src/toolbar/dockLogicType.ts
+++ b/frontend/src/toolbar/dockLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface dockLogicType<ToolbarMode, ToolbarAnimationState> {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface dockLogicType<ToolbarMode, ToolbarAnimationState> extends Logic {
     actionCreators: {
         button: () => {
             type: 'button (toolbar.dockLogic)'
@@ -62,7 +63,12 @@ export interface dockLogicType<ToolbarMode, ToolbarAnimationState> {
             update?: boolean
         ) => {
             type: 'set mode (toolbar.dockLogic)'
-            payload: { mode: ToolbarMode; update: boolean; windowWidth: number; windowHeight: number }
+            payload: {
+                mode: ToolbarMode
+                update: boolean
+                windowWidth: number
+                windowHeight: number
+            }
         }
     }
     actionKeys: {
@@ -101,15 +107,100 @@ export interface dockLogicType<ToolbarMode, ToolbarAnimationState> {
         hideButtonAnimated: () => void
         setMode: (mode: ToolbarMode, update?: boolean) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        windowWidth: number
+        windowHeight: number
+        windowScroll: number
+        mode: ToolbarMode
+        lastMode: ToolbarMode
+        dockStatus: ToolbarAnimationState
+        buttonStatus: ToolbarAnimationState
+    }
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: undefined
+    listeners: {
+        button: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'button (toolbar.dockLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        dock: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'dock (toolbar.dockLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        hideButton: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'hide button (toolbar.dockLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        update: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'update (toolbar.dockLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setMode: ((
+            payload: {
+                mode: ToolbarMode
+                update: boolean
+                windowWidth: number
+                windowHeight: number
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set mode (toolbar.dockLogic)'
+                payload: {
+                    mode: ToolbarMode
+                    update: boolean
+                    windowWidth: number
+                    windowHeight: number
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['toolbar', 'dockLogic']
     pathString: 'toolbar.dockLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: {
+        shadowRef: string
+        padding: string
+    }
     reducer: (
         state: any,
         action: () => any,
@@ -123,7 +214,11 @@ export interface dockLogicType<ToolbarMode, ToolbarAnimationState> {
         dockStatus: ToolbarAnimationState
         buttonStatus: ToolbarAnimationState
     }
-    reducerOptions: any
+    reducerOptions: {
+        lastMode: {
+            persist: boolean
+        }
+    }
     reducers: {
         windowWidth: (state: number, action: any, fullState: any) => number
         windowHeight: (state: number, action: any, fullState: any) => number
@@ -161,6 +256,7 @@ export interface dockLogicType<ToolbarMode, ToolbarAnimationState> {
         domPadding: (state: any, props: any) => number
         dockTopMargin: (state: any, props: any) => number
     }
+    sharedListeners: {}
     values: {
         windowWidth: number
         windowHeight: number
@@ -179,6 +275,7 @@ export interface dockLogicType<ToolbarMode, ToolbarAnimationState> {
         dockTopMargin: number
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         isAnimating: (arg1: ToolbarAnimationState, arg2: ToolbarAnimationState) => boolean
         padding: (arg1: number) => number

--- a/frontend/src/toolbar/elements/elementsLogicType.ts
+++ b/frontend/src/toolbar/elements/elementsLogicType.ts
@@ -1,5 +1,7 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
+import { Logic, BreakPointFunction } from 'kea'
+
 export interface elementsLogicType<
     ToolbarTab,
     ToolbarMode,
@@ -10,8 +12,7 @@ export interface elementsLogicType<
     ActionElementWithMetadata,
     ActionElementMap,
     ElementMap
-> {
-    key: any
+> extends Logic {
     actionCreators: {
         enableInspect: () => {
             type: 'enable inspect (toolbar.elements.elementsLogic)'
@@ -29,13 +30,17 @@ export interface elementsLogicType<
             element: HTMLElement | null
         ) => {
             type: 'select element (toolbar.elements.elementsLogic)'
-            payload: { element: HTMLElement | null }
+            payload: {
+                element: HTMLElement | null
+            }
         }
         createAction: (
             element: HTMLElement
         ) => {
             type: 'create action (toolbar.elements.elementsLogic)'
-            payload: { element: HTMLElement }
+            payload: {
+                element: HTMLElement
+            }
         }
         updateRects: () => {
             type: 'update rects (toolbar.elements.elementsLogic)'
@@ -47,19 +52,25 @@ export interface elementsLogicType<
             element: HTMLElement | null
         ) => {
             type: 'set hover element (toolbar.elements.elementsLogic)'
-            payload: { element: HTMLElement | null }
+            payload: {
+                element: HTMLElement | null
+            }
         }
         setHighlightElement: (
             element: HTMLElement | null
         ) => {
             type: 'set highlight element (toolbar.elements.elementsLogic)'
-            payload: { element: HTMLElement | null }
+            payload: {
+                element: HTMLElement | null
+            }
         }
         setSelectedElement: (
             element: HTMLElement | null
         ) => {
             type: 'set selected element (toolbar.elements.elementsLogic)'
-            payload: { element: HTMLElement | null }
+            payload: {
+                element: HTMLElement | null
+            }
         }
     }
     actionKeys: {
@@ -92,15 +103,64 @@ export interface elementsLogicType<
         setHighlightElement: (element: HTMLElement | null) => void
         setSelectedElement: (element: HTMLElement | null) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        inspectEnabledRaw: boolean
+        rectUpdateCounter: number
+        hoverElement: HTMLElement | null
+        highlightElement: HTMLElement | null
+        selectedElement: HTMLElement | null
+        enabledLast: null | 'inspect' | 'heatmap'
+    }
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: undefined
+    listeners: {
+        enableInspect: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'enable inspect (toolbar.elements.elementsLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        selectElement: ((
+            payload: {
+                element: HTMLElement | null
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'select element (toolbar.elements.elementsLogic)'
+                payload: {
+                    element: HTMLElement | null
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        createAction: ((
+            payload: {
+                element: HTMLElement
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'create action (toolbar.elements.elementsLogic)'
+                payload: {
+                    element: HTMLElement
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['toolbar', 'elements', 'elementsLogic']
     pathString: 'toolbar.elements.elementsLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -113,7 +173,7 @@ export interface elementsLogicType<
         selectedElement: HTMLElement | null
         enabledLast: null | 'inspect' | 'heatmap'
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         inspectEnabledRaw: (state: boolean, action: any, fullState: any) => boolean
         rectUpdateCounter: (state: number, action: any, fullState: any) => number
@@ -188,6 +248,7 @@ export interface elementsLogicType<
             count?: number | undefined
         } | null
     }
+    sharedListeners: {}
     values: {
         inspectEnabledRaw: boolean
         rectUpdateCounter: number
@@ -236,6 +297,7 @@ export interface elementsLogicType<
         } | null
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         inspectEnabled: (
             arg1: ToolbarMode,

--- a/frontend/src/toolbar/elements/heatmapLogicType.ts
+++ b/frontend/src/toolbar/elements/heatmapLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionStepType> {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionStepType> extends Logic {
     actionCreators: {
         enableHeatmap: () => {
             type: 'enable heatmap (toolbar.elements.heatmapLogic)'
@@ -19,7 +20,9 @@ export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionS
             showHeatmapTooltip: boolean
         ) => {
             type: 'set show heatmap tooltip (toolbar.elements.heatmapLogic)'
-            payload: { showHeatmapTooltip: boolean }
+            payload: {
+                showHeatmapTooltip: boolean
+            }
         }
         resetEvents: () => {
             type: 'reset events (toolbar.elements.heatmapLogic)'
@@ -101,15 +104,88 @@ export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionS
         getEventsSuccess: (events: ElementsEventType[]) => void
         getEventsFailure: (error: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        heatmapEnabled: boolean
+        heatmapLoading: boolean
+        showHeatmapTooltip: boolean
+        events: ElementsEventType[]
+        eventsLoading: boolean
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        'set href (toolbar.stats.currentPageLogic)': ((
+            payload: {
+                href: string
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set href (toolbar.stats.currentPageLogic)'
+                payload: {
+                    href: string
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        enableHeatmap: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'enable heatmap (toolbar.elements.heatmapLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        disableHeatmap: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'disable heatmap (toolbar.elements.heatmapLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        getEventsSuccess: ((
+            payload: {
+                events: ElementsEventType[]
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'get events success (toolbar.elements.heatmapLogic)'
+                payload: {
+                    events: ElementsEventType[]
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        setShowHeatmapTooltip: ((
+            payload: {
+                showHeatmapTooltip: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'set show heatmap tooltip (toolbar.elements.heatmapLogic)'
+                payload: {
+                    showHeatmapTooltip: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['toolbar', 'elements', 'heatmapLogic']
     pathString: 'toolbar.elements.heatmapLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -121,7 +197,7 @@ export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionS
         events: ElementsEventType[]
         eventsLoading: boolean
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         heatmapEnabled: (state: boolean, action: any, fullState: any) => boolean
         heatmapLoading: (state: boolean, action: any, fullState: any) => boolean
@@ -160,6 +236,7 @@ export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionS
         clickCount: (state: any, props: any) => number
         highestClickCount: (state: any, props: any) => number
     }
+    sharedListeners: {}
     values: {
         heatmapEnabled: boolean
         heatmapLoading: boolean
@@ -180,6 +257,7 @@ export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionS
         highestClickCount: number
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         elements: (arg1: ElementsEventType[]) => CountedHTMLElement[]
         countedElements: (
@@ -222,5 +300,15 @@ export interface heatmapLogicType<ElementsEventType, CountedHTMLElement, ActionS
                 actionStep?: ActionStepType | undefined
             }[]
         ) => number
+    }
+    __keaTypeGenInternalReducerActions: {
+        'set href (toolbar.stats.currentPageLogic)': (
+            href: string
+        ) => {
+            type: 'set href (toolbar.stats.currentPageLogic)'
+            payload: {
+                href: string
+            }
+        }
     }
 }

--- a/frontend/src/toolbar/stats/currentPageLogicType.ts
+++ b/frontend/src/toolbar/stats/currentPageLogicType.ts
@@ -1,13 +1,16 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface currentPageLogicType {
-    key: any
+import { Logic } from 'kea'
+
+export interface currentPageLogicType extends Logic {
     actionCreators: {
         setHref: (
             href: string
         ) => {
             type: 'set href (toolbar.stats.currentPageLogic)'
-            payload: { href: string }
+            payload: {
+                href: string
+            }
         }
     }
     actionKeys: {
@@ -19,15 +22,19 @@ export interface currentPageLogicType {
     actions: {
         setHref: (href: string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        href: string
+    }
+    events: {
+        afterMount: () => void
+        beforeUnmount: () => void
+    }
+    key: undefined
+    listeners: {}
     path: ['toolbar', 'stats', 'currentPageLogic']
     pathString: 'toolbar.stats.currentPageLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -35,7 +42,7 @@ export interface currentPageLogicType {
     ) => {
         href: string
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         href: (state: string, action: any, fullState: any) => string
     }
@@ -47,8 +54,10 @@ export interface currentPageLogicType {
     selectors: {
         href: (state: any, props: any) => string
     }
+    sharedListeners: {}
     values: {
         href: string
     }
     _isKea: true
+    _isKeaWithKey: false
 }

--- a/frontend/src/toolbar/toolbarLogicType.ts
+++ b/frontend/src/toolbar/toolbarLogicType.ts
@@ -1,7 +1,8 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface toolbarLogicType {
-    key: any
+import { Logic, BreakPointFunction } from 'kea'
+
+export interface toolbarLogicType extends Logic {
     actionCreators: {
         authenticate: () => {
             type: 'authenticate (toolbar.toolbarLogic)'
@@ -28,15 +29,49 @@ export interface toolbarLogicType {
         authenticate: () => void
         logout: () => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        rawApiURL: string
+        rawJsURL: string
+        temporaryToken: string | null
+        actionId: number | null
+        userIntent: string | null
+    }
+    events: {
+        afterMount: () => void
+    }
+    key: undefined
+    listeners: {
+        authenticate: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'authenticate (toolbar.toolbarLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+        logout: ((
+            payload: {
+                value: boolean
+            },
+            breakpoint: BreakPointFunction,
+            action: {
+                type: 'logout (toolbar.toolbarLogic)'
+                payload: {
+                    value: boolean
+                }
+            },
+            previousState: any
+        ) => void | Promise<void>)[]
+    }
     path: ['toolbar', 'toolbarLogic']
     pathString: 'toolbar.toolbarLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -48,7 +83,7 @@ export interface toolbarLogicType {
         actionId: number | null
         userIntent: string | null
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         rawApiURL: (state: string, action: any, fullState: any) => string
         rawJsURL: (state: string, action: any, fullState: any) => string
@@ -75,6 +110,7 @@ export interface toolbarLogicType {
         jsURL: (state: any, props: any) => string
         isAuthenticated: (state: any, props: any) => boolean
     }
+    sharedListeners: {}
     values: {
         rawApiURL: string
         rawJsURL: string
@@ -86,6 +122,7 @@ export interface toolbarLogicType {
         isAuthenticated: boolean
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalSelectorTypes: {
         apiURL: (arg1: string) => string
         jsURL: (arg1: string) => string

--- a/frontend/src/toolbar/toolbarTabLogicType.ts
+++ b/frontend/src/toolbar/toolbarTabLogicType.ts
@@ -1,13 +1,16 @@
 // Auto-generated with kea-typegen. DO NOT EDIT!
 
-export interface toolbarTabLogicType<ToolbarTab> {
-    key: any
+import { Logic } from 'kea'
+
+export interface toolbarTabLogicType<ToolbarTab> extends Logic {
     actionCreators: {
         setTab: (
             tab: ToolbarTab | string
         ) => {
             type: 'set tab (toolbar.toolbarTabLogic)'
-            payload: { tab: string }
+            payload: {
+                tab: string
+            }
         }
     }
     actionKeys: {
@@ -19,15 +22,16 @@ export interface toolbarTabLogicType<ToolbarTab> {
     actions: {
         setTab: (tab: ToolbarTab | string) => void
     }
-    cache: Record<string, any>
-    connections: any
-    constants: any
-    defaults: any
-    events: any
+    constants: {}
+    defaults: {
+        tab: ToolbarTab
+    }
+    events: {}
+    key: undefined
+    listeners: {}
     path: ['toolbar', 'toolbarTabLogic']
     pathString: 'toolbar.toolbarTabLogic'
-    propTypes: any
-    props: Record<string, any>
+    props: Record<string, unknown>
     reducer: (
         state: any,
         action: () => any,
@@ -35,7 +39,7 @@ export interface toolbarTabLogicType<ToolbarTab> {
     ) => {
         tab: ToolbarTab
     }
-    reducerOptions: any
+    reducerOptions: {}
     reducers: {
         tab: (state: ToolbarTab, action: any, fullState: any) => ToolbarTab
     }
@@ -47,10 +51,12 @@ export interface toolbarTabLogicType<ToolbarTab> {
     selectors: {
         tab: (state: any, props: any) => ToolbarTab
     }
+    sharedListeners: {}
     values: {
         tab: ToolbarTab
     }
     _isKea: true
+    _isKeaWithKey: false
     __keaTypeGenInternalReducerActions: {
         'button (toolbar.dockLogic)': () => {
             type: 'button (toolbar.dockLogic)'

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "editor": "^1.0.0",
         "eslint-plugin-cypress": "^2.11.1",
         "funnel-graph-js": "^1.4.1",
-        "kea": "^2.2.0-beta.5",
+        "kea": "^2.2.0-rc.2",
         "kea-loaders": "^0.3.0",
         "kea-localstorage": "^1.0.2",
         "kea-router": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "html-webpack-harddisk-plugin": "^1.0.1",
         "html-webpack-plugin": "^4.3.0",
         "husky": ">=4",
-        "kea-typegen": "^0.0.35",
+        "kea-typegen": "^0.1.0",
         "lint-staged": ">=10",
         "mini-css-extract-plugin": "^0.9.0",
         "nodemon": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,10 +6125,10 @@ kea-router@^0.4.0:
   dependencies:
     url-pattern "^1.0.3"
 
-kea-typegen@^0.0.35:
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-0.0.35.tgz#a481e56280a7f8d9a2cdd1945e68b76dba938b49"
-  integrity sha512-TXSRppYBHo8WcoyYr780GZ3Y3BWkAApBYITYbc+6Q96mrGS/FSmPWxM/Elk9vLZ+3rcpiAN1fF1Gcnunzl2nPg==
+kea-typegen@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-0.1.0.tgz#dcbe0ddecc434d0194e614ba2710566b3e1f9e76"
+  integrity sha512-2dBFI8H5W3jCowJHnd76bQV9bZNoYnu4pxhFjIdnHkRTdgLtQeWlLDq23M95+nBZnNhKDC3RurKGjbVGJbcacg==
   dependencies:
     "@wessberg/ts-clone-node" "0.3.8"
     prettier "^2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6139,7 +6139,7 @@ kea-window-values@^0.0.1:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-0.0.1.tgz#918eee6647507e2d3d5d19466b9561261e7bc8d7"
   integrity sha512-60SfOqHrmnCC8hSD2LALMJemYcohQ8tGcTHlA5u4rQy0l0wFFE4gqH1WbKd+73j9m4f6zdoOk07rwJf+P8maiQ==
 
-kea@^2.2.0-beta.5:
+kea@^2.2.0-rc.2:
   version "2.2.0-rc.2"
   resolved "https://registry.yarnpkg.com/kea/-/kea-2.2.0-rc.2.tgz#1c04110dca4b4c475fb0b0f40a5bfbe609058d40"
   integrity sha512-N1ytphLYPeUmrqpal78mdZextJkO2Gzj8LQI3bahM/NagYSX8biAYS6FhJeGJfaySChkBf2zbL2hvfrScKap3A==


### PR DESCRIPTION
## Changes

The used version of kea (beta5) was complaining that the logic types were not correct and were missing properties. The solution was to update to the lastest versions of kea and typegen.

- Update from kea 2.2.0-beta.5 to 2.2.0-rc.2 and typegen to 0.1 (released more than a week ago)
- Update all logic types to typegen 0.1

I understand these huge typegen PRs are quite the hassle. This is probably the last one for a while though. I promise to keep any changes like this to a minimum.


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
