### PR TITLE
Fix selector attributes

### DIFF
--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -66,7 +66,7 @@ class SelectorPart(object):
             self.data["attr_id"] = result[3]
             tag = result[1]
         if result and "[" in tag:
-            self.data["attributes__{}".format(result[2])] = result[3]
+            self.data["attributes__attr__{}".format(result[2])] = result[3]
             tag = result[1]
         if "nth-child(" in tag:
             parts = tag.split(":nth-child(")
@@ -138,6 +138,9 @@ class EventManager(models.QuerySet):
         if not filter:
             return {}
         groups = groups.filter(**filter)
+        import ipdb
+
+        ipdb.set_trace()
         return {"elements_hash__in": groups.values_list("hash", flat=True)}
 
     def filter_by_url(self, action_step: ActionStep, subquery: QuerySet):

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -80,6 +80,21 @@ class SelectorPart(object):
         if tag:
             self.data["tag_name"] = tag
 
+    @property
+    def extra_query(self) -> Dict[str, List[Union[str, List[str]]]]:
+        where: List[Union[str, List[str]]] = []
+        params: List[Union[str, List[str]]] = []
+        for key, value in self.data.items():
+            if "attr__" in key:
+                where.append("(attributes ->> 'attr__{}') = %s".format(key.split("attr__")[1]))
+            else:
+                if "__contains" in key:
+                    where.append("{} @> %s::varchar(200)[]".format(key.replace("__contains", "")))
+                else:
+                    where.append("{} = %s".format(key))
+            params.append(value)
+        return {"where": where, "params": params}
+
 
 class Selector(object):
     parts: List[SelectorPart] = []
@@ -105,9 +120,10 @@ class EventManager(models.QuerySet):
         subqueries = {}
         for index, tag in enumerate(selector.parts):
             subqueries["match_{}".format(index)] = Subquery(
-                Element.objects.filter(group_id=OuterRef("pk"), **tag.data)
+                Element.objects.filter(group_id=OuterRef("pk"))
                 .values("order")
                 .order_by("order")
+                .extra(**tag.extra_query)  # type: ignore
                 # If there's two of the same element, for the second one we need to shift one
                 [tag.unique_order : tag.unique_order + 1]
             )
@@ -137,10 +153,8 @@ class EventManager(models.QuerySet):
 
         if not filter:
             return {}
-        groups = groups.filter(**filter)
-        import ipdb
 
-        ipdb.set_trace()
+        groups = groups.filter(**filter)
         return {"elements_hash__in": groups.values_list("hash", flat=True)}
 
     def filter_by_url(self, action_step: ActionStep, subquery: QuerySet):

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -190,24 +190,14 @@ class TestFilterByActions(BaseTest):
 
     def test_attributes(self):
         Person.objects.create(distinct_ids=["whatever"], team=self.team)
-
         event1 = Event.objects.create(
-            team=self.team,
-            distinct_id="whatever",
-            elements=[
-                Element(tag_name="span", order=0),
-                Element(tag_name="a", order=1, attributes={"attr__data-id": "123"}),
-            ],
-        )
-
-        event2 = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
             elements=[Element(tag_name="button", order=0, attributes={"attr__data-id": "123"})],
         )
 
         action1 = Action.objects.create(team=self.team)
-        ActionStep.objects.create(action=action1, selector='a[data-id="123"]')
+        ActionStep.objects.create(action=action1, selector='[data-id="123"]')
         action1.calculate_events()
 
         events = Event.objects.filter_by_action(action1)
@@ -387,18 +377,7 @@ class TestActions(BaseTest):
         event = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
-            elements=[Element(order=0, tag_name="a", attributes={"data-id": "whatever"})],
-        )
-        self.assertEqual(event.actions, [action])
-
-    def test_attributes_2(self):
-        action = Action.objects.create(team=self.team, name="watch movie")
-        ActionStep.objects.create(action=action, selector='[data-attr="select-platform-Web"]')
-        Person.objects.create(distinct_ids=["watched_movie"], team=self.team)
-        event = Event.objects.create(
-            team=self.team,
-            distinct_id="whatever",
-            elements=[Element(order=0, tag_name="button", attributes={"data-attr": "select-platform-Web"})],
+            elements=[Element(order=0, tag_name="a", attributes={"attr__data-id": "whatever"})],
         )
         self.assertEqual(event.actions, [action])
 
@@ -526,7 +505,11 @@ class TestSelectors(BaseTest):
         )
         self.assertEqual(
             selector1.parts[1].__dict__,
-            {"data": {"tag_name": "div", "attributes__data-id": "5"}, "direct_descendant": True, "unique_order": 0,},
+            {
+                "data": {"tag_name": "div", "attributes__attr__data-id": "5"},
+                "direct_descendant": True,
+                "unique_order": 0,
+            },
         )
 
     def test_selector_id(self):

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -196,14 +196,14 @@ class TestFilterByActions(BaseTest):
             distinct_id="whatever",
             elements=[
                 Element(tag_name="span", order=0),
-                Element(tag_name="a", order=1, attributes={"data-id": "123"}),
+                Element(tag_name="a", order=1, attributes={"attr__data-id": "123"}),
             ],
         )
 
         event2 = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
-            elements=[Element(tag_name="button", order=0, attributes={"data-id": "123"})],
+            elements=[Element(tag_name="button", order=0, attributes={"attr__data-id": "123"})],
         )
 
         action1 = Action.objects.create(team=self.team)
@@ -388,6 +388,17 @@ class TestActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[Element(order=0, tag_name="a", attributes={"data-id": "whatever"})],
+        )
+        self.assertEqual(event.actions, [action])
+
+    def test_attributes_2(self):
+        action = Action.objects.create(team=self.team, name="watch movie")
+        ActionStep.objects.create(action=action, selector='[data-attr="select-platform-Web"]')
+        Person.objects.create(distinct_ids=["watched_movie"], team=self.team)
+        event = Event.objects.create(
+            team=self.team,
+            distinct_id="whatever",
+            elements=[Element(order=0, tag_name="button", attributes={"data-attr": "select-platform-Web"})],
         )
         self.assertEqual(event.actions, [action])
 


### PR DESCRIPTION
## Changes

Closes #1409. Filtering selectors with attributes wasn't working, because we are storing all attributes with the `attr__` prefix. I  had to use Django's "extra" function as using normal filtering didn't work.

## Checklist

- [x] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [x] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
