### PR TITLE
Add action table created by/at

### DIFF
--- a/frontend/src/scenes/actions/ActionsTable.js
+++ b/frontend/src/scenes/actions/ActionsTable.js
@@ -5,6 +5,7 @@ import { DeleteWithUndo } from 'lib/utils'
 import { useActions, useValues } from 'kea'
 import { actionsModel } from '../../models/actionsModel'
 import { NewActionButton } from './NewActionButton'
+import moment from 'moment'
 
 export function ActionsTable() {
     const { actions, actionsLoading } = useValues(actionsModel({ params: 'include_count=1' }))
@@ -57,6 +58,19 @@ export function ActionsTable() {
                         ))}
                     </span>
                 )
+            },
+        },
+        {
+            title: 'Created by',
+            render: function RenderCreatedBy(_, action) {
+                if (!action.created_by) return 'Unknown'
+                return action.created_by.first_name || action.created_by.email
+            },
+        },
+        {
+            title: 'Created at',
+            render: function RenderCreatedAt(_, action) {
+                return action.created_at ? moment(action.created_at).format('LLL') : '-'
             },
         },
         {

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -31,6 +31,7 @@ from rest_framework import authentication, request, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from posthog.api.user import UserSerializer
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, TRENDS_CUMULATIVE, TRENDS_STICKINESS
 from posthog.decorators import TRENDS_ENDPOINT, cached_function
 from posthog.models import (
@@ -73,6 +74,7 @@ class ActionStepSerializer(serializers.HyperlinkedModelSerializer):
 class ActionSerializer(serializers.HyperlinkedModelSerializer):
     steps = serializers.SerializerMethodField()
     count = serializers.SerializerMethodField()
+    created_by = UserSerializer(required=False, read_only=True)
 
     class Meta:
         model = Action
@@ -86,6 +88,7 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
             "deleted",
             "count",
             "is_calculating",
+            "created_by",
         ]
 
     def get_steps(self, action: Action):

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -92,7 +92,7 @@ class TestCreateAction(BaseTest):
         self.assertEqual(action.events.count(), 1)
 
         # test queries
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get("/api/action/")
 
         # test remove steps


### PR DESCRIPTION
## Changes

Little PR to add created by and at metadata to the actions table.
![image](https://user-images.githubusercontent.com/1727427/90055961-7448cd00-dcde-11ea-88ba-7c8981b41ba3.png)


## Checklist

- [x] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [x] Backend tests (if this PR affects the backend)
- [x] Cypress E2E tests (if this PR affects the front and/or backend)
