### PR TITLE
Fixes silent fail on empty capture request 

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -124,7 +124,16 @@ def get_event(request):
             ),
         )
     if not data:
-        return cors_response(request, HttpResponse("1"))
+        return cors_response(
+            request,
+            JsonResponse(
+                {
+                    "code": "validation",
+                    "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request.",
+                },
+                status=400,
+            ),
+        )
     sent_at = _get_sent_at(data, request)
     token = _get_token(data, request)
     if not token:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -119,7 +119,7 @@ def get_event(request):
         return cors_response(
             request,
             JsonResponse(
-                {"code": "validation", "message": "Invalid formatting. Make sure you're passing correct JSON.",},
+                {"code": "validation", "message": "Invalid formatting. Make sure you're sending valid JSON.",},
                 status=400,
             ),
         )
@@ -129,7 +129,7 @@ def get_event(request):
             JsonResponse(
                 {
                     "code": "validation",
-                    "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request.",
+                    "message": "No data found. Make sure to use a POST request when sending the payload in the body of the request.",
                 },
                 status=400,
             ),

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -108,9 +108,33 @@ class TestCapture(BaseTest):
 
     @patch("posthog.models.team.TEAM_CACHE", {})
     @patch("posthog.tasks.process_event.process_event.delay")
-    def test_ignore_empty_request(self, patch_process_event):
+    def test_empty_request_returns_an_error(self, patch_process_event):
+        """
+        Empty requests that fail silently cause confusion as to whether they were successful or not.
+        """
+
+        # Empty GET
         response = self.client.get("/e/?data=", content_type="application/json", HTTP_ORIGIN="https://localhost",)
-        self.assertEqual(response.content, b"1")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "code": "validation",
+                "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request.",
+            },
+        )
+        self.assertEqual(patch_process_event.call_count, 0)
+
+        # Empty POST
+        response = self.client.post("/e/", {}, content_type="application/json", HTTP_ORIGIN="https://localhost",)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "code": "validation",
+                "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request.",
+            },
+        )
         self.assertEqual(patch_process_event.call_count, 0)
 
     @patch("posthog.models.team.TEAM_CACHE", {})

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -120,7 +120,7 @@ class TestCapture(BaseTest):
             response.json(),
             {
                 "code": "validation",
-                "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request.",
+                "message": "No data found. Make sure to use a POST request when sending the payload in the body of the request.",
             },
         )
         self.assertEqual(patch_process_event.call_count, 0)
@@ -132,7 +132,7 @@ class TestCapture(BaseTest):
             response.json(),
             {
                 "code": "validation",
-                "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request.",
+                "message": "No data found. Make sure to use a POST request when sending the payload in the body of the request.",
             },
         )
         self.assertEqual(patch_process_event.call_count, 0)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -55,7 +55,8 @@ class AllowIP(object):
         if ip and any(ip_address(ip) in ip_network(block, strict=False) for block in self.ip_blocks):
             return response
         return HttpResponse(
-            "Your IP is not allowed. Check your ALLOWED_IP_BLOCKS settings. If you are behind a proxy, you need to set TRUSTED_PROXIES. See https://posthog.com/docs/deployment/running-behind-proxy"
+            "Your IP is not allowed. Check your ALLOWED_IP_BLOCKS settings. If you are behind a proxy, you need to set TRUSTED_PROXIES. See https://posthog.com/docs/deployment/running-behind-proxy",
+            status=403,
         )
 
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1,4 +1,5 @@
 import json
+import urllib
 from typing import Dict
 
 from django.conf import settings
@@ -24,7 +25,7 @@ class TestSignup(TestCase):
                 "api_key": "tokenABC123",
                 "batch": [{"type": "capture", "event": "user signed up", "distinct_id": "2"}],
             }
-            req_body_qs: str = f"?data={json.dumps(req_body)}"
+            req_body_qs: str = f"?data={urllib.parse.quote_plus(json.dumps(req_body))}"
 
             # not in list
             response = self.client.get("/", REMOTE_ADDR="10.0.0.1")
@@ -40,11 +41,11 @@ class TestSignup(TestCase):
             response = self.client.get("/", REMOTE_ADDR="192.168.0.2")
             self.assertIn(b"IP is not allowed", response.content)
 
-            response = self.client.get(f"/capture{req_body_qs}", REMOTE_ADDR="192.168.0.1")
-            self.assertEqual(b'{"status": 1}', response.content)
+            # response = self.client.get(f"/capture{req_body_qs}", REMOTE_ADDR="192.168.0.1")
+            # self.assertEqual(b'{"status": 1}', response.content)
 
-            response = self.client.get(f"/capture{req_body_qs}", REMOTE_ADDR="192.168.0.2")
-            self.assertEqual(b'{"status": 1}', response.content)
+            # response = self.client.get(f"/capture{req_body_qs}", REMOTE_ADDR="192.168.0.2")
+            # self.assertEqual(b'{"status": 1}', response.content)
 
             # /24 block
             response = self.client.get("/", REMOTE_ADDR="127.0.0.1")

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -21,13 +21,16 @@ class TestSignup(TestCase):
         self.REQ_BODY_QS: str = f"?data={json.dumps(self.REQ_BODY)}"
 
     def test_ip_range(self):
+        """
+        Also test that capture endpoint is not restrictied by ALLOWED_IP_BLOCKS
+        """
         with self.settings(ALLOWED_IP_BLOCKS=["192.168.0.0/31", "127.0.0.0/25", "128.0.0.1"]):
             # not in list
             response = self.client.get("/", REMOTE_ADDR="10.0.0.1")
             self.assertIn(b"IP is not allowed", response.content)
 
             response = self.client.post(
-                f"/batch/", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="10.0.0.1",
+                "/capture", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="10.0.0.1",
             )
             self.assertEqual(b'{"status": 1}', response.content)
 
@@ -39,12 +42,12 @@ class TestSignup(TestCase):
             self.assertIn(b"IP is not allowed", response.content)
 
             response = self.client.post(
-                f"/batch/", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="192.168.0.1",
+                "/capture", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="192.168.0.1",
             )
             self.assertEqual(b'{"status": 1}', response.content)
 
             response = self.client.post(
-                f"/batch/", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="192.168.0.2",
+                "/capture", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="192.168.0.2",
             )
             self.assertEqual(b'{"status": 1}', response.content)
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -26,7 +26,9 @@ class TestSignup(TestCase):
             response = self.client.get("/", REMOTE_ADDR="10.0.0.1")
             self.assertIn(b"IP is not allowed", response.content)
 
-            response = self.client.get(f"/batch/{self.REQ_BODY_QS}", REMOTE_ADDR="10.0.0.1")
+            response = self.client.post(
+                f"/batch/", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="10.0.0.1",
+            )
             self.assertEqual(b'{"status": 1}', response.content)
 
             # /31 block
@@ -36,10 +38,14 @@ class TestSignup(TestCase):
             response = self.client.get("/", REMOTE_ADDR="192.168.0.2")
             self.assertIn(b"IP is not allowed", response.content)
 
-            response = self.client.get(f"/batch/{self.REQ_BODY_QS}", REMOTE_ADDR="192.168.0.1")
+            response = self.client.post(
+                f"/batch/", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="192.168.0.1",
+            )
             self.assertEqual(b'{"status": 1}', response.content)
 
-            response = self.client.get(f"/batch/{self.REQ_BODY_QS}", REMOTE_ADDR="192.168.0.2")
+            response = self.client.post(
+                f"/batch/", self.REQ_BODY, content_type="application/json", REMOTE_ADDR="192.168.0.2",
+            )
             self.assertEqual(b'{"status": 1}', response.content)
 
             # /24 block

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -23,6 +23,7 @@ class TestSignup(TestCase):
 
             # not in list
             response = self.client.get("/", REMOTE_ADDR="10.0.0.1")
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertIn(b"IP is not allowed", response.content)
 
             response = self.client.get("/batch/", REMOTE_ADDR="10.0.0.1",)
@@ -40,9 +41,11 @@ class TestSignup(TestCase):
 
             # /31 block
             response = self.client.get("/", REMOTE_ADDR="192.168.0.1")
+            self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertNotIn(b"IP is not allowed", response.content)
 
             response = self.client.get("/", REMOTE_ADDR="192.168.0.2")
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertIn(b"IP is not allowed", response.content)
 
             response = self.client.get("/batch/", REMOTE_ADDR="192.168.0.1")
@@ -53,16 +56,20 @@ class TestSignup(TestCase):
 
             # /24 block
             response = self.client.get("/", REMOTE_ADDR="127.0.0.1")
+            self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertNotIn(b"IP is not allowed", response.content)
 
             response = self.client.get("/", REMOTE_ADDR="127.0.0.100")
+            self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertNotIn(b"IP is not allowed", response.content)
 
             response = self.client.get("/", REMOTE_ADDR="127.0.0.200")
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertIn(b"IP is not allowed", response.content)
 
             # precise ip
             response = self.client.get("/", REMOTE_ADDR="128.0.0.1")
+            self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertNotIn(b"IP is not allowed", response.content)
 
             response = self.client.get("/", REMOTE_ADDR="128.0.0.2")


### PR DESCRIPTION
## Changes

Closes #1407. The problem was that if you accidentally sent a `GET` request to `/capture` with the data/payload on the request body (or a `POST` request without the `Content-Type = application/json` header & the `data` key), you would get a _successful response_, while the request was malformed and therefore ignored. Further the success response in this case was just a `1` instead of a `{ "status": 1 }` response when the request was actually properly formed.

This PR introduces a change that will return an error response if you send a request to `/capture` with an empty payload (probably due to a mistake with how the request was constructed). Sample error response:

```json
{
    "code": "validation",
    "message": "No data provided. Make sure to use a POST request when sending the payload in the body of the request."
}
```

**This PR does NOT introduce changes to the frontend.**

## Checklist

- [ ] **N/A.** All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [X] Backend tests (if this PR affects the backend)
- [ ] **N/A.** Cypress E2E tests (if this PR affects the front and/or backend)
