### PR TITLE
Bump settings.VERSION to 1.12.1 (resolves #1420)

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -22,7 +22,7 @@ import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
 from sentry_sdk.integrations.django import DjangoIntegration
 
-VERSION = "1.12.0"
+VERSION = "1.12.1"
 
 
 def get_env(key):


### PR DESCRIPTION
## Changes

It remained on 1.12.0, while our update server says 1.12.1 is the latest version.
