### PR TITLE
Better posthog-foss syncing

### DIFF
--- a/.github/workflows/posthog-foss.yml
+++ b/.github/workflows/posthog-foss.yml
@@ -1,12 +1,16 @@
-name: Sync posthog/posthog-foss
+name: PostHog FOSS
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   repo-sync:
+    name: Sync posthog-foss with posthog
     runs-on: ubuntu-latest
     steps:
-    - name: repo-sync
+    - name: Sync repositories 1 to 1
       uses: ungless/git-sync@master # tag syncing is not currently part of wei/git-sync
       with:
         source_repo: "https://${{ secrets.SYNC_GITHUB_TOKEN }}@github.com/posthog/posthog.git"
@@ -19,12 +23,12 @@ jobs:
         repository: "posthog/posthog-foss"
         ref: master
         token: ${{ secrets.SYNC_GITHUB_TOKEN }} # SYNC_GITHUB_TOKEN is a PAT token with the workflows scope which is not in GITHUB_TOKEN
-    - name: Remove ee/
+    - name: Remove all non-FOSS parts
       uses: EndBug/add-and-commit@v4
       with:
         author_name: PostHog Bot
         author_email: hey@posthog.com
-        message: "SYNC: Remove ee/"
+        message: "Remove all non-FOSS parts"
         remove: "-r ee/"
       env: 
         GITHUB_TOKEN: ${{ secrets.SYNC_GITHUB_TOKEN }}

--- a/.github/workflows/sync-foss.yml
+++ b/.github/workflows/sync-foss.yml
@@ -1,0 +1,30 @@
+name: Sync posthog/posthog-foss
+
+on: push
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: repo-sync
+      uses: ungless/git-sync@master # tag syncing is not currently part of wei/git-sync
+      with:
+        source_repo: "https://${{ secrets.SYNC_GITHUB_TOKEN }}@github.com/posthog/posthog.git"
+        source_branch: "master"
+        destination_repo: "https://${{ secrets.SYNC_GITHUB_TOKEN }}@github.com/posthog/posthog-foss.git"
+        destination_branch: "master"
+    - name: Checkout posthog-foss
+      uses: actions/checkout@v2
+      with:
+        repository: "posthog/posthog-foss"
+        ref: master
+        token: ${{ secrets.SYNC_GITHUB_TOKEN }} # SYNC_GITHUB_TOKEN is a PAT token with the workflows scope which is not in GITHUB_TOKEN
+    - name: Remove ee/
+      uses: EndBug/add-and-commit@v4
+      with:
+        author_name: PostHog Bot
+        author_email: hey@posthog.com
+        message: "SYNC: Remove ee/"
+        remove: "-r ee/"
+      env: 
+        GITHUB_TOKEN: ${{ secrets.SYNC_GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- this is FAR better way of syncing `posthog/posthog` with `posthog/posthog-foss`.
- this happens on `push` to `master`, unlike the previous approach which ran on cron


## Needed for merge

- [x] Remove `SYNC_GITHUB_TOKEN` from `posthog/posthog-foss`
- [x] Add `SYNC_GITHUB_TOKEN` secret to `posthog/posthog`
- [x] Disable all actions in https://github.com/posthog/posthog-foss