### PR TITLE
Added warning for unset SECRET_KEY

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,6 +89,7 @@ jobs:
               if: steps.yarn-build-cache.outputs.cache-hit != 'true'
             - name: Boot PostHog
               env:
+                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
                   REDIS_URL: 'redis://localhost'
                   DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
                   DISABLE_SECURE_SSL_REDIRECT: 1

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -47,11 +47,13 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Check for missing migrations
         env:
+          SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
           DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
           REDIS_URL: 'redis://localhost'
         run: python manage.py makemigrations --check --dry-run
       - name: Run tests
         env:
+          SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
           DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
         run: |
           mkdir -p frontend/dist
@@ -61,6 +63,7 @@ jobs:
           python manage.py test --keepdb -v 2
       - name: Typechecking
         env:
+          SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
           DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
           REDIS_URL: 'redis://localhost'
         run: |

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -110,8 +110,7 @@ TRUST_ALL_PROXIES = os.environ.get("TRUST_ALL_PROXIES", False)
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
-DEFAULT_SECRET_KEY = "6(@hkxrx07e*z3@6ls#uwajz6v@#8-%mmvs8-_y7c_c^l5c0m$"
-DEFAULT_DOCKER_KEY = "<randomly generated secret key>"
+DEFAULT_SECRET_KEY = "<randomly generated secret key>"
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
@@ -365,7 +364,7 @@ if DEBUG and not TEST:
         )
     )
 
-if not DEBUG and not TEST and (SECRET_KEY == DEFAULT_SECRET_KEY or SECRET_KEY == DEFAULT_DOCKER_KEY):
+if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
     print_warning(
         (
             "You are using the default SECRET_KEY in a production environment!",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -111,6 +111,7 @@ TRUST_ALL_PROXIES = os.environ.get("TRUST_ALL_PROXIES", False)
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 DEFAULT_SECRET_KEY = "6(@hkxrx07e*z3@6ls#uwajz6v@#8-%mmvs8-_y7c_c^l5c0m$"
+DEFAULT_DOCKER_KEY = "<randomly generated secret key>"
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
@@ -364,7 +365,7 @@ if DEBUG and not TEST:
         )
     )
 
-if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
+if not DEBUG and not TEST and (SECRET_KEY == DEFAULT_SECRET_KEY or SECRET_KEY == DEFAULT_DOCKER_KEY):
     print_warning(
         (
             "You are using the default SECRET_KEY in a production environment!",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -367,12 +367,12 @@ if DEBUG and not TEST:
 if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
     print_warning(
         (
-            "You have not set a unique SECRET_KEY!",
+            "You are using the default SECRET_KEY in a production environment!",
             "For the safety of your instance, you must generate and set a unique key.",
-            "More information: https://posthog.com/docs/deployment/securing-posthog#secret-key",
+            "More information on https://posthog.com/docs/deployment/securing-posthog#secret-key",
         )
     )
-    sys.exit("[ERROR] SECRET_KEY missing. Process finished with exit code 1.\n")
+    sys.exit("[ERROR] Default SECRET_KEY in production. Stopping Django server…\n")
 
 
 def show_toolbar(request):

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -368,10 +368,11 @@ if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
     print_warning(
         (
             "You have not set a unique SECRET_KEY!",
-            "For the safety of your instance, you should consider generating and setting a unique key.",
+            "For the safety of your instance, you must generate and set a unique key.",
             "More information: https://posthog.com/docs/deployment/securing-posthog#secret-key",
         )
     )
+    sys.exit("[ERROR] SECRET_KEY missing. Process finished with exit code 1.\n")
 
 
 def show_toolbar(request):

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -110,8 +110,10 @@ TRUST_ALL_PROXIES = os.environ.get("TRUST_ALL_PROXIES", False)
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
+DEFAULT_SECRET_KEY = "6(@hkxrx07e*z3@6ls#uwajz6v@#8-%mmvs8-_y7c_c^l5c0m$"
+
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY", "6(@hkxrx07e*z3@6ls#uwajz6v@#8-%mmvs8-_y7c_c^l5c0m$")
+SECRET_KEY = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "*"))
 
@@ -359,6 +361,15 @@ if DEBUG and not TEST:
         (
             "️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT mode!",
             "Be sure to unset DEBUG if this is supposed to be a PRODUCTION environment!",
+        )
+    )
+
+if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
+    print_warning(
+        (
+            "You have not set a unique SECRET_KEY!",
+            "For the safety of your instance, you should consider generating and setting a unique key.",
+            "More information: https://posthog.com/docs/deployment/securing-posthog#secret-key",
         )
     )
 


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.* 

Currently, if the user doesn't set a `SECRET_KEY`, we just fall back to a default key. This seems ok but it isn't. We're open source, so that default key is public knowledge. 

In my view, we should actually consider exiting if the user hasn't set their own `SECRET_KEY`. Nevertheless, at least a warning is in order. However, if the user is in `TEST` or `DEBUG` mode the warning is suppressed. 

Here's [some reading](https://martinfowler.com/articles/session-secret.html) on the topic.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
