### PR TITLE
Add "no TLS in production" warning bar (closes #1422)

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -18,7 +18,7 @@
     {% endif %}
   </head>
   <body>
-    {% include "debug-bar.html" %}
+    {% include "bottom-notice.html" %}
     <script>
         if (typeof Object.entries === 'undefined') {
             let div = document.createElement("div");

--- a/frontend/src/layout.ejs
+++ b/frontend/src/layout.ejs
@@ -119,7 +119,7 @@ color: var(--blue)
   </head>
   <body>
 
-        {% include "debug-bar.html" %}
+        {% include "bottom-notice.html" %}
         {% block content %}
         {% endblock %}
 

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -313,7 +313,7 @@ label.disabled {
     background: var(--success) !important;
 }
 
-.bottom-bar {
+.bottom-notice {
     z-index: 1000000000;
     display: flex;
     flex-direction: row;
@@ -326,6 +326,7 @@ label.disabled {
     font-size: 0.75rem;
     line-height: 1.5rem;
     &#tls-bar div {
+        height: auto;
         background: #f00;
     }
     div {

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -325,9 +325,20 @@ label.disabled {
     color: #fff;
     font-size: 0.75rem;
     line-height: 1.5rem;
-    &#tls-bar div {
+    &.warning div {
         height: auto;
         background: #f00;
+    }
+    &.tricolor {
+        div:nth-child(1) {
+            background: #1d4aff;
+        }
+        div:nth-child(2) {
+            background: #f54e00;
+        }
+        div:nth-child(3) {
+            background: #f9bd2b;
+        }
     }
     div {
         flex-basis: 0;
@@ -337,15 +348,6 @@ label.disabled {
     }
     span {
         display: none;
-    }
-    div:nth-child(1) {
-        background: #1d4aff;
-    }
-    div:nth-child(2) {
-        background: #f54e00;
-    }
-    div:nth-child(3) {
-        background: #f9bd2b;
     }
     button {
         border: none;

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -313,7 +313,7 @@ label.disabled {
     background: var(--success) !important;
 }
 
-#debug-bar {
+.bottom-bar {
     z-index: 1000000000;
     display: flex;
     flex-direction: row;
@@ -325,6 +325,9 @@ label.disabled {
     color: #fff;
     font-size: 0.75rem;
     line-height: 1.5rem;
+    &#tls-bar div {
+        background: #f00;
+    }
     div {
         flex-basis: 0;
         flex-grow: 1;

--- a/posthog/templates/bottom-notice.html
+++ b/posthog/templates/bottom-notice.html
@@ -1,5 +1,5 @@
 {% if debug %}
-    <div id="debug-bar" class="bottom-notice">
+    <div class="bottom-notice tricolor">
         <div><span>Current branch: </span><b><code>{{ git_branch|default:"unknown" }}</code></b><span>.</span></div>
         <div><span>PostHog running in </span><b><code>DEBUG</code></b> mode!</div>
         <div><span>Current revision: </span><b><code>{{ git_rev|default:"unknown" }}</code></b><span>.</span></div>
@@ -8,12 +8,15 @@
         </button>
     </div>
 {% else %}
-    <div id="tls-bar" class="bottom-notice" style="display: none">
-        <div>PostHog dangerously running in&nbsp;<b><code>PRODUCTION</code></b>&nbsp;mode without&nbsp;TLS! Use a&nbsp;valid TLS&nbsp;certificate and&nbsp;route&nbsp;to&nbsp;<code>https://</code>.</div>
-    </div>
     <script>
-        const bar = document.getElementById('tls-bar')
-        if (location.protocol !== 'https:') bar.style = ''
-        else bar.remove()
+        if (location.protocol !== 'https:') {
+            const element = document.createElement('div')
+            element.className = 'bottom-notice warning'
+            element.innerHTML = (
+                '<div>PostHog dangerously running in&nbsp;<b><code>PRODUCTION</code></b>&nbsp;mode without&nbsp;TLS! ' +
+                'Use a&nbsp;valid TLS&nbsp;certificate and&nbsp;route&nbsp;to&nbsp;<code>https://</code>.</div>'
+            )
+            document.body.prepend(element)
+        }
     </script>
 {% endif %}

--- a/posthog/templates/bottom-notice.html
+++ b/posthog/templates/bottom-notice.html
@@ -1,15 +1,15 @@
 {% if debug %}
-    <div id="debug-bar" class="bottom-bar">
+    <div id="debug-bar" class="bottom-notice">
         <div><span>Current branch: </span><b><code>{{ git_branch|default:"unknown" }}</code></b><span>.</span></div>
         <div><span>PostHog running in </span><b><code>DEBUG</code></b> mode!</div>
         <div><span>Current revision: </span><b><code>{{ git_rev|default:"unknown" }}</code></b><span>.</span></div>
-        <button title="Close debug bar" onclick="document.getElementById('debug-bar').remove()">
+        <button title="Close debug bar" onclick="document.getElementById('bottom-notice').remove()">
             <code>×</code>
         </button>
     </div>
 {% else %}
-    <div id="tls-bar" class="bottom-bar" style="display: none">
-        <div>PostHog dangerously running in <b><code>PRODUCTION</code></b> mode without TLS! Use a valid TLS certificate and route to <code>https://</code>.</div>
+    <div id="tls-bar" class="bottom-notice" style="display: none">
+        <div>PostHog dangerously running in&nbsp;<b><code>PRODUCTION</code></b>&nbsp;mode without&nbsp;TLS! Use a&nbsp;valid TLS&nbsp;certificate and&nbsp;route&nbsp;to&nbsp;<code>https://</code>.</div>
     </div>
     <script>
         const bar = document.getElementById('tls-bar')

--- a/posthog/templates/debug-bar.html
+++ b/posthog/templates/debug-bar.html
@@ -1,4 +1,4 @@
-{% if x %}
+{% if debug %}
     <div id="debug-bar" class="bottom-bar">
         <div><span>Current branch: </span><b><code>{{ git_branch|default:"unknown" }}</code></b><span>.</span></div>
         <div><span>PostHog running in </span><b><code>DEBUG</code></b> mode!</div>
@@ -7,9 +7,9 @@
             <code>×</code>
         </button>
     </div>
-{% else %}}
+{% else %}
     <div id="tls-bar" class="bottom-bar" style="display: none">
-        <div>PostHog running in dangerously <b><code>PRODUCTION</code></b> mode without TLS! Always route to <code>https://</code> with a valid TLS certificate.</div>
+        <div>PostHog dangerously running in <b><code>PRODUCTION</code></b> mode without TLS! Use a valid TLS certificate and route to <code>https://</code>.</div>
     </div>
     <script>
         const bar = document.getElementById('tls-bar')

--- a/posthog/templates/debug-bar.html
+++ b/posthog/templates/debug-bar.html
@@ -1,5 +1,5 @@
-{% if debug %}
-    <div id="debug-bar">
+{% if x %}
+    <div id="debug-bar" class="bottom-bar">
         <div><span>Current branch: </span><b><code>{{ git_branch|default:"unknown" }}</code></b><span>.</span></div>
         <div><span>PostHog running in </span><b><code>DEBUG</code></b> mode!</div>
         <div><span>Current revision: </span><b><code>{{ git_rev|default:"unknown" }}</code></b><span>.</span></div>
@@ -7,4 +7,13 @@
             <code>×</code>
         </button>
     </div>
+{% else %}}
+    <div id="tls-bar" class="bottom-bar" style="display: none">
+        <div>PostHog running in dangerously <b><code>PRODUCTION</code></b> mode without TLS! Always route to <code>https://</code> with a valid TLS certificate.</div>
+    </div>
+    <script>
+        const bar = document.getElementById('tls-bar')
+        if (location.protocol !== 'https:') bar.style = ''
+        else bar.remove()
+    </script>
 {% endif %}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -110,7 +110,7 @@ def render_template(template_name: str, request: HttpRequest, context=None) -> H
     if os.environ.get("SENTRY_DSN"):
         context["sentry_dsn"] = os.environ["SENTRY_DSN"]
 
-    if settings.DEBUG:
+    if settings.DEBUG and not settings.TEST:
         context["debug"] = True
         context["version"] = settings.VERSION
         try:


### PR DESCRIPTION
## Changes

A simple bar warning that TLS is a must in production, as suggested by Marius.

![TLS bar](https://user-images.githubusercontent.com/4550621/90335657-b3c13300-dfd6-11ea-9170-7ee4e3fbefb5.png)
