### PR TITLE
Fixes billing/licensing issues

### DIFF
--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -93,5 +93,5 @@ class Team(models.Model):
         if self.name:
             return self.name
         if self.app_urls and self.app_urls[0]:
-            return self.app_urls.join(", ")
+            return ", ".join(self.app_urls)
         return str(self.pk)

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -115,9 +115,12 @@ class User(AbstractUser):
         if EE_MISSING:
             return None
 
-        # If we're on multi-tenancy grab the team's plan
+        # If we're on multi-tenancy grab the team's price
         if not MULTI_TENANCY_MISSING:
-            return None
+            try:
+                return TeamBilling.objects.get(team=self.team).price_id
+            except TeamBilling.DoesNotExist:
+                return None
         # Otherwise, try to find a valid license on this instance
         license = License.objects.filter(valid_until__gte=now()).first()
         if license:

--- a/posthog/test/test_team_model.py
+++ b/posthog/test/test_team_model.py
@@ -5,24 +5,24 @@ from ..models.team import Team
 
 class TestTeam(TestCase):
     def test_team_str(self):
-        # 1. Use the team.name by default
+        # Use the team.name by default
         team: Team = Team.objects.create(name="The Mighty Library")
         self.assertEqual(str(team), "The Mighty Library")
 
-        # 2. If the team has no name:
+        # If the team has no name:
 
-        # 2.1 Team has one app_url
+        # Team has one app_url
         team = Team.objects.create(app_urls=["app.posthog.com"])
         self.assertEqual(str(team), "app.posthog.com")
 
-        # 2.2 Team has multiple app_urls
+        # Team has multiple app_urls
         team = Team.objects.create(app_urls=["app.posthog.com", "custom.posthog.com"])
         self.assertEqual(str(team), "app.posthog.com, custom.posthog.com")
 
-        # 2.3 Team has empty app_url
+        # Team has empty app_url
         team = Team.objects.create(app_urls=[""])
         self.assertEqual(str(team), str(team.pk))
 
-        # 2.3 Team has no app_urls
+        # Team has no app_urls
         team = Team.objects.create(app_urls=[])
         self.assertEqual(str(team), str(team.pk))

--- a/posthog/test/test_team_model.py
+++ b/posthog/test/test_team_model.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from ..models.team import Team
+
+
+class TestTeam(TestCase):
+    def test_team_str(self):
+        # 1. Use the team.name by default
+        team: Team = Team.objects.create(name="The Mighty Library")
+        self.assertEqual(str(team), "The Mighty Library")
+
+        # 2. If the team has no name:
+
+        # 2.1 Team has one app_url
+        team = Team.objects.create(app_urls=["app.posthog.com"])
+        self.assertEqual(str(team), "app.posthog.com")
+
+        # 2.2 Team has multiple app_urls
+        team = Team.objects.create(app_urls=["app.posthog.com", "custom.posthog.com"])
+        self.assertEqual(str(team), "app.posthog.com, custom.posthog.com")
+
+        # 2.3 Team has empty app_url
+        team = Team.objects.create(app_urls=[""])
+        self.assertEqual(str(team), str(team.pk))
+
+        # 2.3 Team has no app_urls
+        team = Team.objects.create(app_urls=[])
+        self.assertEqual(str(team), str(team.pk))

--- a/posthog/test/test_user_model.py
+++ b/posthog/test/test_user_model.py
@@ -17,11 +17,11 @@ class TestUser(BaseTest):
         self.assertFalse(self.user.feature_available("whatever"))
 
     @patch("posthog.models.user.MULTI_TENANCY_MISSING", False)
-    @patch("posthog.models.user.License.PLANS", {"enterprise": ["whatever"]})
+    @patch("posthog.models.user.License.PLANS", {"price_1234567890": ["whatever"]})
     @patch("posthog.models.user.TeamBilling")
     def test_feature_available_multi_tenancy(self, patch_team_billing):
-        patch_team_billing.objects.get().plan = "enterprise"
-        self.assertFalse(self.user.feature_available("whatever"))
+        patch_team_billing.objects.get().price_id = "price_1234567890"
+        self.assertTrue(self.user.feature_available("whatever"))
 
     @patch("posthog.models.user.License.PLANS", {"enterprise": ["whatever"]})
     @patch("ee.models.license.requests.post")


### PR DESCRIPTION
**Warning:** Absolutely requires merging https://github.com/PostHog/posthog-production/pull/10 first.

## Changes

- Reintroduces `multi_tenancy` licensing from #1390 (reverted on #1435) but fixing the bugs that caused the failure last Aug 14th (https://sentry.io/organizations/posthog/issues/1841058328).
- Fixes broken test, all tests now passing 100%.
- Fixes issue with `str` method of `Team` model (bug https://sentry.io/organizations/posthog/issues/1841030886/)


## Checklist

- [X] **N/A**. All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [X] Backend tests (if this PR affects the backend)
- [X] **N/A**. Cypress E2E tests (if this PR affects the front and/or backend)
