### PR TITLE
Upgrade Sentry

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -20,7 +20,9 @@ from typing import List, Optional, Sequence
 import dj_database_url
 import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
+from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
 
 VERSION = "1.12.1"
 
@@ -86,7 +88,9 @@ SECURE_SSL_REDIRECT = secure_cookies
 if not DEBUG and not TEST:
     if os.environ.get("SENTRY_DSN"):
         sentry_sdk.init(
-            dsn=os.environ["SENTRY_DSN"], integrations=[DjangoIntegration()], request_bodies="always",
+            dsn=os.environ["SENTRY_DSN"],
+            integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],
+            request_bodies="always",
         )
 
 if get_bool_from_env("DISABLE_SECURE_SSL_REDIRECT", False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ requests==2.22.0
 requests-oauthlib==1.3.0
 ruamel.yaml==0.16.10
 ruamel.yaml.clib==0.2.0
-sentry-sdk==0.14.3
+sentry-sdk==0.16.5
 six==1.14.0
 social-auth-app-django==3.1.0
 social-auth-core==3.3.3


### PR DESCRIPTION
## Changes

This updates `sentry-sdk` from 0.14.3 to 0.16.5 and enables `CeleryIntegration` plus `RedisIntegration` in addition to `DjangoIntegration`. Should somewhat enhance backend error reports.