### PR TITLE
Whitelist kea-typegen folder in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !yarn.lock
 !webpack.config.js
 !postcss.config.js
+!.kearc
 !frontend/src
 !frontend/types
 !frontend/public

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 !webpack.config.js
 !postcss.config.js
 !.kearc
+!tsconfig.json
 !frontend/src
 !frontend/types
 !frontend/public

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,4 +11,5 @@
 !webpack.config.js
 !postcss.config.js
 !frontend/src
+!frontend/types
 !frontend/public

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir /code/frontend/dist
 
 COPY . /code/
 
-RUN DEBUG="true" DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN DEBUG='true' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 EXPOSE 8000
 EXPOSE 8234

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir /code/frontend/dist
 
 COPY . /code/
 
-RUN DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN DEBUG="true" DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 EXPOSE 8000
 EXPOSE 8234

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -13,6 +13,8 @@ COPY yarn.lock /code/
 COPY webpack.config.js /code/
 COPY postcss.config.js /code/
 COPY babel.config.js /code/
+COPY tsconfig.json /code/
+COPY .kearc /code/
 COPY frontend/ /code/frontend
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_12.x  | bash - \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir /code/frontend/dist
 
 COPY . /code/
 
-RUN DEBUG='true' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN DEBUG=1 DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 EXPOSE 8000
 EXPOSE 8234

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 
 COPY . /code/
 
-RUN DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN SECRET_KEY='unsafe secret key for preview only' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 RUN /etc/init.d/postgresql start\
     && DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog REDIS_URL='redis:///' python manage.py migrate\

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -38,6 +38,8 @@ COPY yarn.lock /code/
 COPY webpack.config.js /code/
 COPY postcss.config.js /code/
 COPY babel.config.js /code/
+COPY tsconfig.json /code/
+COPY .kearc /code/
 COPY frontend/ /code/frontend
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_12.x  | bash - \

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 
 COPY . /code/
 
-RUN SECRET_KEY='unsafe secret key for preview only' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN SECRET_KEY='unsafe secret key for collectstatic only' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 RUN /etc/init.d/postgresql start\
     && DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog REDIS_URL='redis:///' python manage.py migrate\

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -14,6 +14,8 @@ COPY yarn.lock /code/
 COPY webpack.config.js /code/
 COPY postcss.config.js /code/
 COPY babel.config.js /code/
+COPY tsconfig.json /code/
+COPY .kearc /code/
 COPY frontend/ /code/frontend
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_12.x  | bash - \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 
 COPY . /code/
 
-RUN DEBUG=1 DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN SECRET_KEY='unsafe secret key for collectstatic only'  DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 EXPOSE 8000
 CMD ["./bin/docker"]

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 
 COPY . /code/
 
-RUN DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN DEBUG=1 DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 EXPOSE 8000
 CMD ["./bin/docker"]


### PR DESCRIPTION
## Changes

- I only saw after the PR was merged that in master all commits also get a docker test. This was failing. I hope the following change restores order to the republic.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
