### PR TITLE
Clear up `dau` label and description

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -16,18 +16,18 @@ const MATHS = {
             <>
                 Total event volume.
                 <br />
-                If a user performs an event 3 times on a given day, it counts as 3.
+                If a user performs an event 3 times in a given day/week/month, it counts as 3.
             </>
         ),
         onProperty: false,
     },
     dau: {
-        name: 'Unique',
+        name: 'Active users',
         description: (
             <>
-                Unique active users.
+                Users active in the time interval.
                 <br />
-                If a user performs an event 3 times on a given day, it counts only as 1.
+                If a user performs an event 3 times in a given day/week/month, it counts only as 1.
             </>
         ),
         onProperty: false,


### PR DESCRIPTION
## Changes

There's already been #1453, but "Unique" as a label for `dau` may be not entirely clear as well, as at first glance it looks like it may mean unique _events_. "Active users" introduced here should be clearly related to "Daily Active Users".