### PR TITLE
Fixes #1431 : Filter submit events correctly when creating a new action

### DIFF
--- a/frontend/src/scenes/events/createActionFromEvent.js
+++ b/frontend/src/scenes/events/createActionFromEvent.js
@@ -47,6 +47,10 @@ export async function createActionFromEvent(event, increment) {
     }
     if (increment) actionData.name = actionData.name + ' ' + increment
 
+    if (event.properties.$event_type === 'submit') {
+        actionData.steps[0].properties = [{ key: '$event_type', value: 'submit' }]
+    }
+
     let action = false
     try {
         action = await api.create('api/action', actionData)


### PR DESCRIPTION
#832  Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Checks if event type is submit and adds property to filter by =submit when creating a new action

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
