### PR TITLE
Fix dashboard funnels on Safari

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -55,6 +55,7 @@
         }
     }
     .dashboard-item-content {
+        height: 100%;
         margin: 8px 15px 15px 15px;
         overflow: hidden;
         flex-grow: 1;


### PR DESCRIPTION
## Changes

A fix to funnels not rendering on Safari.

| Before | After |
| - | - |
| <img width="543" alt="Before" src="https://user-images.githubusercontent.com/4550621/90869645-cc479980-e398-11ea-9b55-3b5f23c98dc2.png"> | <img width="543" alt="After" src="https://user-images.githubusercontent.com/4550621/90869800-06b13680-e399-11ea-896e-a5a09d929f79.png"> |

