### PR TITLE
Universal secret key auto generation with backwards compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 .yalc
 yalc.lock
 cypress/screenshots/*
+secret_key.txt

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
             IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
-            SECRET_KEY: '<randomly generated secret key>'
+            SECRET_KEY: 'rofl'
             DEBUG: 'true'
         depends_on:
             - db
@@ -48,7 +48,7 @@ services:
             IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
-            SECRET_KEY: '<randomly generated secret key>'
+            SECRET_KEY: 'rofl'
             DEBUG: 'true'
         depends_on:
             - db

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -23,7 +23,6 @@ services:
             IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
-            SECRET_KEY: '<randomly generated secret key>'
             DEBUG: 1
             DISABLE_SECURE_SSL_REDIRECT: 1
             OPT_OUT_CAPTURE: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
             IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
-            SECRET_KEY: '<randomly generated secret key>'
         depends_on:
             - db
             - redis

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Sequence
 import dj_database_url
 import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
+from django.core.management.utils import get_random_secret_key
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -115,7 +116,20 @@ TRUST_ALL_PROXIES = os.environ.get("TRUST_ALL_PROXIES", False)
 DEFAULT_SECRET_KEY = "<randomly generated secret key>"
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
+SECRET_KEY = os.environ.get("SECRET_KEY")
+
+if not SECRET_KEY:
+    _secrets_file = os.path.join(BASE_DIR, "secret_key.txt")
+
+    # Create secret_key.txt and populate if does not exist or is empty
+    if not os.path.exists(_secrets_file) or os.path.getsize(_secrets_file) == 0:
+        with open(_secrets_file, "w") as f:
+            f.write(get_random_secret_key())
+
+    with open(_secrets_file) as f:
+        SECRET_KEY = f.read()
+
+    del _secrets_file
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "*"))
 


### PR DESCRIPTION
## Changes

- Secret keys are now automatically generated on first boot.
- If the `SECRET_KEY` environment variable exists, it will be preferred to the stored secret key.
- Old deployments of PostHog should be able to deploy this update and retain their old secret key by following the documentation in the PR below.
- https://github.com/PostHog/posthog.com/pull/347
## Checklist

- [N/A] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [N/A] Backend tests (if this PR affects the backend)
- [N/A] Cypress E2E tests (if this PR affects the front and/or backend)
