### PR TITLE
Changed Tab Colors on ActionFilter Dropdown

### DIFF
--- a/frontend/src/lib/components/ActionSelectTab.js
+++ b/frontend/src/lib/components/ActionSelectTab.js
@@ -8,7 +8,7 @@ export function ActionSelectTab({ entityType, chooseEntityType, allTypes }) {
                 <div
                     key={index}
                     style={{
-                        backgroundColor: entityType == type ? '#eeeeee' : 'white',
+                        backgroundColor: entityType == type ? 'white' : '#eeeeee',
                         flex: 1,
                         display: 'flex',
                         justifyContent: 'center',


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Super tiny UX change in the Trends page. 

Active tab used to be the one with faint color ('Events' is active tab):

<img width="387" alt="Screenshot 2020-08-22 at 10 00 13" src="https://user-images.githubusercontent.com/38760734/90956626-9c62c980-e45e-11ea-8f4b-228907b7a1b7.png">

I changed that to be:

<img width="382" alt="Screenshot 2020-08-22 at 09 59 55" src="https://user-images.githubusercontent.com/38760734/90956647-bc928880-e45e-11ea-919a-09bd38e9e1bc.png">

When I first used those tabs, I was very confused for a sec, trying to click the active one multiple times.


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
