### PR TITLE
Fixed broken Cypress tests (+ made it all much faster!)

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -17,7 +17,7 @@ describe('Dashboards', () => {
         cy.get('[data-attr=share-dashboard-link]')
             .invoke('val')
             .then((link) => {
-                cy.wait(500)
+                cy.wait(200)
                 cy.visit(link)
             })
     })

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -4,18 +4,18 @@ describe('Events', () => {
     })
 
     it('Events loaded', () => {
-        cy.get('[data-attr=events-table').should('exist')
+        cy.get('[data-attr=events-table]').should('exist')
     })
 
     it('Click on an event', () => {
         cy.get('[data-attr=events-table] .event-row:first-child td:first-child').click()
-        cy.get('[data-attr=event-details').should('exist')
+        cy.get('[data-attr=event-details]').should('exist')
     })
 
     it('All events route works', () => {
         cy.get('[data-attr=menu-item-all-events]').click()
 
-        cy.get('[data-attr=events-table').should('exist')
+        cy.get('[data-attr=events-table]').should('exist')
     })
 
     it('Apply 1 overall filter', () => {
@@ -23,13 +23,13 @@ describe('Events', () => {
         cy.get('[data-attr=prop-filter-event-0]').click()
         cy.get('[data-attr=prop-val]').click()
         cy.get('[data-attr=prop-val-0]').click()
-        cy.get('[data-attr=events-table').should('exist')
+        cy.get('[data-attr=events-table]').should('exist')
     })
 
     it('Filter by event', () => {
         cy.get('[data-attr=event-filter-trigger]').click()
         cy.get('[data-attr=event-name-box]').click()
         cy.get('[data-attr=prop-val-0]').click()
-        cy.get('[data-attr=events-table').should('exist')
+        cy.get('[data-attr=events-table]').should('exist')
     })
 })

--- a/cypress/integration/funnels.js
+++ b/cypress/integration/funnels.js
@@ -34,8 +34,8 @@ describe('Funnels', () => {
         cy.get('[data-attr=add-action-event-button]').click()
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.contains('Pageviews').click()
-
-        cy.get('[data-attr=save-funnel-button]').click()
+        cy.wait(500)
+        cy.get('[data-attr=save-funnel-button]', { timeout: 7000 }).click()
 
         cy.get('[data-attr=funnel-viz]').should('exist')
     })

--- a/cypress/integration/funnels.js
+++ b/cypress/integration/funnels.js
@@ -34,7 +34,6 @@ describe('Funnels', () => {
         cy.get('[data-attr=add-action-event-button]').click()
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.contains('Pageviews').click()
-        cy.wait(500)
         cy.get('[data-attr=save-funnel-button]', { timeout: 7000 }).click()
 
         cy.get('[data-attr=funnel-viz]').should('exist')

--- a/cypress/integration/live_actions.js
+++ b/cypress/integration/live_actions.js
@@ -5,7 +5,7 @@ describe('Live Actions', () => {
     })
 
     it('Live actions loaded', () => {
-        cy.get('[data-attr=events-table').should('exist')
+        cy.get('[data-attr=events-table]').should('exist')
     })
 
     it('Apply 1 overall filter', () => {
@@ -14,6 +14,6 @@ describe('Live Actions', () => {
         cy.get('[data-attr=prop-val]').click()
         cy.get('[data-attr=prop-val-0]').click()
 
-        cy.get('[data-attr=events-table').should('exist')
+        cy.get('[data-attr=events-table]').should('exist')
     })
 })

--- a/cypress/integration/trends_elements.js
+++ b/cypress/integration/trends_elements.js
@@ -110,7 +110,6 @@ describe('Trends actions & events', () => {
         cy.get('form > .ant-select > .ant-select-selector').click()
         cy.get(':nth-child(1) > .ant-select-item-option-content').click()
         cy.contains('Add panel to dashboard').click()
-        cy.wait(500) // not ideal but toast has a delay render
         cy.get('[data-attr=success-toast]', { timeout: 7000 }).should('exist')
     })
 })

--- a/cypress/integration/trends_elements.js
+++ b/cypress/integration/trends_elements.js
@@ -110,6 +110,7 @@ describe('Trends actions & events', () => {
         cy.get('form > .ant-select > .ant-select-selector').click()
         cy.get(':nth-child(1) > .ant-select-item-option-content').click()
         cy.contains('Add panel to dashboard').click()
+        cy.wait(300) // not ideal but toast has a delay render
         cy.get('[data-attr=success-toast]', { timeout: 7000 }).should('exist')
     })
 })

--- a/cypress/integration/trends_elements.js
+++ b/cypress/integration/trends_elements.js
@@ -106,8 +106,11 @@ describe('Trends actions & events', () => {
 
     it('Save to dashboard', () => {
         cy.get('[data-attr=save-to-dashboard-button]').click()
+        cy.get('.ant-input').type('Pageviews')
+        cy.get('form > .ant-select > .ant-select-selector').click()
+        cy.get(':nth-child(1) > .ant-select-item-option-content').click()
         cy.contains('Add panel to dashboard').click()
-        cy.wait(700) // not ideal but toast has a delay render
-        cy.get('[data-attr=success-toast]').should('exist')
+        cy.wait(500) // not ideal but toast has a delay render
+        cy.get('[data-attr=success-toast]', { timeout: 7000 }).should('exist')
     })
 })

--- a/cypress/integration/trends_sessions.js
+++ b/cypress/integration/trends_sessions.js
@@ -36,7 +36,6 @@ describe('Trends sessions', () => {
     it('Save to dashboard', () => {
         cy.get('[data-attr=save-to-dashboard-button]').click()
         cy.contains('Add panel to dashboard').click()
-        cy.wait(700) // not ideal but toast has a delay render
         cy.get('[data-attr=success-toast]').should('exist')
     })
 })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -7,19 +7,13 @@ beforeEach(() => {
     cy.visit('/')
 
     cy.url().then((url) => {
-        if (url.includes('setup_admin')) {
-            cy.get('#inputCompany').type('company').should('have.value', 'company')
-
-            cy.get('#inputName').type('name').should('have.value', 'name')
-
-            cy.get('#inputEmail').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
-
-            cy.get('#inputPassword').type('Test1234').should('have.value', 'Test1234')
-
-            cy.get('.btn').click()
-
-            cy.visit('/demo')
-            cy.visit('/')
+        if (url.includes('preflight')) {
+            cy.get('.text-center > .ant-btn-default').click()
+            cy.get('[style="margin-bottom: 64px;"] > .ant-btn').click()
+            cy.wait(200)
+            setupAdmin()
+        } else if (url.includes('setup_admin')) {
+            setupAdmin()
         } else if (url.includes('login')) {
             cy.get('#inputEmail').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
 
@@ -27,8 +21,8 @@ beforeEach(() => {
 
             cy.get('.btn').click()
         }
-        cy.wait(2000)
-        cy.get('body').then(($body) => {
+        cy.wait(200)
+        cy.get('body', { timeout: 7000 }).then(($body) => {
             if ($body.find('[data-attr=select-platform-Web]').length) {
                 cy.get('[data-attr=select-platform-Web]').click()
                 cy.get('[data-attr=wizard-step-counter]').should('contain', 'Step 2')
@@ -39,6 +33,21 @@ beforeEach(() => {
         })
     })
 })
+
+const setupAdmin = () => {
+    cy.get('#inputCompany', { timeout: 7000 }).type('company').should('have.value', 'company')
+
+    cy.get('#inputName').type('name').should('have.value', 'name')
+
+    cy.get('#inputEmail').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
+
+    cy.get('#inputPassword').type('Test1234').should('have.value', 'Test1234')
+
+    cy.get('.btn').click()
+
+    cy.visit('/demo')
+    cy.visit('/')
+}
 
 Cypress.on('uncaught:exception', () => {
     return false

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,6 +21,7 @@ beforeEach(() => {
 
             cy.get('.btn').click()
         }
+        cy.wait(200)
         cy.get('body', { timeout: 7000 }).then(($body) => {
             if ($body.find('[data-attr=select-platform-Web]').length) {
                 cy.get('[data-attr=select-platform-Web]').click()

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,7 +21,6 @@ beforeEach(() => {
 
             cy.get('.btn').click()
         }
-        cy.wait(200)
         cy.get('body', { timeout: 7000 }).then(($body) => {
             if ($body.find('[data-attr=select-platform-Web]').length) {
                 cy.get('[data-attr=select-platform-Web]').click()


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

All of our Cypress tests were failing after the Preflight PR got merged because that added a new page before signup that wasn't accounted for.

There were also minor changes which broke some tests, and those are also now fixed.

Lastly, we had a `cy.wait(2000)` at login that was slowing down this process significantly.

We should prioritize passing something like `{timeout: 7000}` to `cy.get` instead of waits. Timeouts mean Cypress will try to get that element until the time runs out, but, if it finds it before, it continues. Default value is 4000ms. 6000 or 7000 should be good for most cases. 

There are times when waiting is necessary, because a wrong click can close a dropdown, for instance. However, we should keep Cypress `wait` calls as few as possible, and with low numbers. 

Simply getting rid of the 2000ms wait is a **major** improvement in speed, but there's more that can be done. I think there's things to do that could speed this up more, plus some of our tests are not that great, as they will fail sometimes and succeed others (i.e. they are maybe too dependent on things happening within a short time frame).

## Checklist

- [x] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [x] Backend tests (if this PR affects the backend)
- [x] Cypress E2E tests (if this PR affects the front and/or backend)
