### PR TITLE
Add ph-no-capture to Toolbar

### DIFF
--- a/frontend/src/toolbar/ToolbarContainer.tsx
+++ b/frontend/src/toolbar/ToolbarContainer.tsx
@@ -28,7 +28,7 @@ function _ToolbarContainer(): JSX.Element {
             {showButton && windowWidth >= 0 ? <DraggableButton showInvisibleButton={showInvisibleButton} /> : null}
 
             {showDock ? (
-                <div id="dock-toolbar" className={showInvisibleDock ? 'toolbar-invisible' : ''}>
+                <div id="dock-toolbar" className={`ph-no-capture${showInvisibleDock ? ' toolbar-invisible' : ''}`}>
                     <div
                         className={`toolbar-close-button${dockStatus === 'complete' ? ' visible' : ''}`}
                         onClick={selectedElement ? () => setSelectedElement(null) : button}

--- a/frontend/src/toolbar/button/DraggableButton.tsx
+++ b/frontend/src/toolbar/button/DraggableButton.tsx
@@ -46,7 +46,7 @@ export function DraggableButton({ showInvisibleButton }: DraggableButtonProps): 
                     saveDragPosition(x, y)
                 }}
             >
-                <div id="button-toolbar" className={showInvisibleButton ? 'toolbar-invisible' : ''}>
+                <div id="button-toolbar" className={`ph-no-capture${showInvisibleButton ? ' toolbar-invisible' : ''}`}>
                     <ToolbarButton />
                 </div>
             </Draggable>


### PR DESCRIPTION
## Changes

Since PostHog/posthog-js#80 will make clicks inside shadow roots autocaptured – and Toolbar is all under a shadow root – I added `className="ph-no-capture"` to button and dock Toolbar components. This way Toolbar usage should not skew events data.

To be merged when the related posthog-js PR gets in.