### PR TITLE
Fixes tests on multi_tenancy

### DIFF
--- a/posthog/test/test_user_model.py
+++ b/posthog/test/test_user_model.py
@@ -33,6 +33,7 @@ class TestUser(BaseTest):
 
     @patch("posthog.models.user.License.PLANS", {"enterprise": ["whatever"]})
     @patch("ee.models.license.requests.post")
+    @patch("posthog.models.user.MULTI_TENANCY_MISSING", True)
     def test_feature_available_self_hosted_has_license(self, patch_post):
         mock = Mock()
         mock.json.return_value = {"plan": "enterprise", "valid_until": now() + relativedelta(days=1)}


### PR DESCRIPTION
## Changes

- Enforces `MULTI_TENANCY_MISSING = True` in a specific test (`test_feature_available_self_hosted_has_license`) that was failing on github.com/posthog/posthog-production

## Checklist

- [X] **N/A.** All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [X] Backend tests (if this PR affects the backend)
- [X] **N/A.** Cypress E2E tests (if this PR affects the front and/or backend)
