### PR TITLE
Improve tracking of development instances (resolves #1518)

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,13 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* global require, module, process */
+/* eslint-env node */
+
+const plugins = [require('autoprefixer')] // postCSS modules here
+
+if (process.env.NODE_ENV === 'production') plugins.push(require('cssnano'))
 
 module.exports = {
-    plugins:
-        process.env.NODE_ENV === 'production'
-            ? [
-                  require('autoprefixer'),
-                  require('cssnano'),
-                  // More postCSS modules here if needed
-              ]
-            : [require('autoprefixer')],
+    plugins,
 }

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -11,5 +11,13 @@ class PostHogConfig(AppConfig):
 
     def ready(self):
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
-        if settings.TEST or os.environ.get("OPT_OUT_CAPTURE"):
+        if settings.DEBUG:
+            if os.getenv("RUN_MAIN") == "true":
+                first_team = self.get_model("Team").objects.first()
+                if first_team is not None:
+                    first_user = first_team.users.first()
+                    if first_user is not None:
+                        posthoganalytics.capture(first_user.distinct_id, "development server launched")
+            posthoganalytics.disabled = True
+        elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE"):
             posthoganalytics.disabled = True

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -18,8 +18,8 @@ class PostHogConfig(AppConfig):
             if os.getenv("RUN_MAIN") == "true":
                 # MAC addresses are 6 bits long, so overflow shouldn't happen
                 # hashing here as we don't care about the actual address, just it being rather consistent
-                mac_address_hash = hashlib.md5(uuid.getnode().to_bytes(6, "little")).hexdigest()
-                posthoganalytics.capture(mac_address_hash, "development server launched")
+                mac_address_hash = hashlib.md5(uuid.getnode().to_bytes(6, "little"))
+                posthoganalytics.capture(mac_address_hash.hexdigest(), "development server launched")
             posthoganalytics.disabled = True
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE"):
             posthoganalytics.disabled = True

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -1,4 +1,6 @@
+import hashlib
 import os
+import uuid
 
 import posthoganalytics
 from django.apps import AppConfig
@@ -12,12 +14,12 @@ class PostHogConfig(AppConfig):
     def ready(self):
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
         if settings.DEBUG:
+            # log development server launch to posthog
             if os.getenv("RUN_MAIN") == "true":
-                first_team = self.get_model("Team").objects.first()
-                if first_team is not None:
-                    first_user = first_team.users.first()
-                    if first_user is not None:
-                        posthoganalytics.capture(first_user.distinct_id, "development server launched")
+                # MAC addresses are 6 bits long, so overflow shouldn't happen
+                # hashing here as we don't care about the actual address, just it being rather consistent
+                mac_address_hash = hashlib.md5(uuid.getnode().to_bytes(6, "little")).hexdigest()
+                posthoganalytics.capture(mac_address_hash, "development server launched")
             posthoganalytics.disabled = True
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE"):
             posthoganalytics.disabled = True


### PR DESCRIPTION
## Changes

This will disable `posthoganalytics` when `DEBUG` is truthy, after sending only one event: "development instance launched". The user distinct ID user here is the one of the first user of the first team (presumably the person setting up the instance). The downside is that first there has to be a user, so completely fresh instances with no user yet aren't reported due to lack of distinct ID. Maybe there's a solution to this.

<img width="1245" alt="Screen Shot 2020-08-27 at 00 46 34" src="https://user-images.githubusercontent.com/4550621/91364638-8018b100-e7ff-11ea-8656-325a3ed4e607.png">
