### PR TITLE
Made 'Launch Toolbar' links open in a new tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,8 +29,8 @@ module.exports = {
     rules: {
         'react/prop-types': [0],
         'react/no-unescaped-entities': [0],
+        'react/jsx-no-target-blank': [0],
         'no-unused-vars': ['error', { ignoreRestSiblings: true }],
-        'react/jsx-no-target-blank': [2, { allowReferrer: true }],
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-empty-function': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         'react/prop-types': [0],
         'react/no-unescaped-entities': [0],
         'no-unused-vars': ['error', { ignoreRestSiblings: true }],
+        'react/jsx-no-target-blank': [2, { allowReferrer: true }],
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-empty-function': 'off',

--- a/frontend/src/lib/components/AppEditorLink/UrlRow.js
+++ b/frontend/src/lib/components/AppEditorLink/UrlRow.js
@@ -71,6 +71,8 @@ export function UrlRow({ actionId, url, saveUrl, deleteUrl, allowNavigation }) {
                     <a
                         data-attr="app-url-item"
                         href={appEditorUrl(actionId, editedValue)}
+                        target="_blank"
+                        rel="noreferrer noopener"
                         onClick={(e) => !allowNavigation && e.preventDefault()}
                     >
                         {editedValue}

--- a/frontend/src/lib/components/AppEditorLink/UrlRow.js
+++ b/frontend/src/lib/components/AppEditorLink/UrlRow.js
@@ -72,7 +72,7 @@ export function UrlRow({ actionId, url, saveUrl, deleteUrl, allowNavigation }) {
                         data-attr="app-url-item"
                         href={appEditorUrl(actionId, editedValue)}
                         target="_blank"
-                        rel="noreferrer noopener"
+                        rel="noopener"
                         onClick={(e) => !allowNavigation && e.preventDefault()}
                     >
                         {editedValue}


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Users shouldn't be leaving PostHog to use the Toolbar on their website. Made it so that URLs you have added open in a new tab when launching the toolbar.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
