### PR TITLE
Fix styling of URL list

### DIFF
--- a/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
+++ b/frontend/src/lib/components/AppEditorLink/EditAppUrls.js
@@ -12,7 +12,7 @@ export function EditAppUrls({ actionId = null, allowNavigation = false }) {
 
     return (
         <div>
-            <List bordered style={{ marginTop: '1rem', background: '#fff' }}>
+            <List bordered style={{ background: '#fff', overflow: 'hidden', wordBreak: 'break-all' }}>
                 {appUrls.map((url, index) => (
                     <UrlRow
                         key={`${index},${url}`}

--- a/frontend/src/toolbar/styles.scss
+++ b/frontend/src/toolbar/styles.scss
@@ -110,8 +110,6 @@
     z-index: 2147483031 !important;
 }
 .ant-list-item {
-    overflow: hidden;
-    word-break: break-all;
     &:hover {
         background: #f0f0f0;
     }

--- a/frontend/src/toolbar/styles.scss
+++ b/frontend/src/toolbar/styles.scss
@@ -110,6 +110,8 @@
     z-index: 2147483031 !important;
 }
 .ant-list-item {
+    overflow: hidden;
+    word-break: break-all;
     &:hover {
         background: #f0f0f0;
     }


### PR DESCRIPTION
## Changes

Simple fix for top margin and and string breaking on URL list (used in Launch Toolbar and New Action).

Before | After
--- | ---
<img width="1065" alt="Before" src="https://user-images.githubusercontent.com/4550621/91496914-44dcb780-e8bd-11ea-8aa9-a70af63c7a2b.png"> | <img width="484" alt="After" src="https://user-images.githubusercontent.com/4550621/91496919-46a67b00-e8bd-11ea-879f-5a2197b4cb20.png">

