### PR TITLE
Changed tone on action creation buttons

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -186,7 +186,7 @@ export class ActionStep extends Component {
                                 () => this.sendStep({ ...step, event: '$autocapture' })
                             )
                         }
-                        className={'btn ' + (step.event === '$autocapture' ? 'btn-secondary' : 'btn-light action-btn')}
+                        className={'btn ' + (step.event === '$autocapture' ? 'btn-secondary' : 'btn-light btn-action')}
                     >
                         Frontend element
                     </button>
@@ -199,7 +199,7 @@ export class ActionStep extends Component {
                             step.event !== '$autocapture' &&
                             step.event !== '$pageview'
                                 ? 'btn-secondary'
-                                : 'btn-light action-btn')
+                                : 'btn-light btn-action')
                         }
                     >
                         Custom event
@@ -220,7 +220,7 @@ export class ActionStep extends Component {
                                 })
                             )
                         }}
-                        className={'btn ' + (step.event === '$pageview' ? 'btn-secondary' : 'btn-light action-btn')}
+                        className={'btn ' + (step.event === '$pageview' ? 'btn-secondary' : 'btn-light btn-action')}
                         data-attr="action-step-pageview"
                     >
                         Page view

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -186,7 +186,7 @@ export class ActionStep extends Component {
                                 () => this.sendStep({ ...step, event: '$autocapture' })
                             )
                         }
-                        className={'btn ' + (step.event === '$autocapture' ? 'btn-secondary' : 'btn-light')}
+                        className={'btn ' + (step.event === '$autocapture' ? 'btn-secondary' : 'btn-light action-btn')}
                     >
                         Frontend element
                     </button>
@@ -199,7 +199,7 @@ export class ActionStep extends Component {
                             step.event !== '$autocapture' &&
                             step.event !== '$pageview'
                                 ? 'btn-secondary'
-                                : 'btn-light')
+                                : 'btn-light action-btn')
                         }
                     >
                         Custom event
@@ -220,7 +220,7 @@ export class ActionStep extends Component {
                                 })
                             )
                         }}
-                        className={'btn ' + (step.event === '$pageview' ? 'btn-secondary' : 'btn-light')}
+                        className={'btn ' + (step.event === '$pageview' ? 'btn-secondary' : 'btn-light action-btn')}
                         data-attr="action-step-pageview"
                     >
                         Page view

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -421,3 +421,7 @@ label.disabled {
         font-weight: bold;
     }
 }
+
+.action-btn {
+    background-color: #f0f0f0 !important;
+}

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -422,6 +422,6 @@ label.disabled {
     }
 }
 
-.action-btn {
+.btn-action {
     background-color: #f0f0f0 !important;
 }


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

I agreed with @paolodamico on his first point from #1529. 

### Before
<img width="1190" alt="before" src="https://user-images.githubusercontent.com/38760734/91636778-94180a80-e9d9-11ea-95fd-0004485c47cc.png">

### After
<img width="1205" alt="after" src="https://user-images.githubusercontent.com/38760734/91636788-a09c6300-e9d9-11ea-9348-82771cb95503.png">


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
