### PR TITLE
Fix property filtering null values

### DIFF
--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -55,6 +55,7 @@ class Property:
             return Q(
                 ~Q(**{"properties__{}__{}".format(self.key, self.operator[4:]): value})
                 | ~Q(properties__has_key=self.key)
+                | Q(**{"properties__{}".format(self.key): None})
             )
         return Q(**{"properties__{}{}".format(self.key, f"__{self.operator}" if self.operator else ""): value})
 

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -95,11 +95,13 @@ class TestPropertiesToQ(BaseTest):
         Event.objects.create(
             team=self.team, event="$pageview", properties={"$current_url": "https://whatever.com"},
         )
+        event3 = Event.objects.create(team=self.team, event="$pageview", properties={"$current_url": None},)
         filter = Filter(data={"properties": {"$current_url__not_icontains": "whatever.com"}})
-        events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
+        events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk)).order_by("id")
         self.assertEqual(events[0], event1)
         self.assertEqual(events[1], event2)
-        self.assertEqual(len(events), 2)
+        self.assertEqual(events[2], event3)
+        self.assertEqual(len(events), 3)
 
     def test_multiple(self):
         event2 = Event.objects.create(


### PR DESCRIPTION
## Changes

If any property was filtered with not_contains, it ignored any values that were null. For example:

Filtering `email does not contain posthog.com` wouldn't match `{"email": null}`, but it should.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
