### PR TITLE
Identify email in frontend

### DIFF
--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -82,7 +82,9 @@ export const userLogic = kea<userLogicType<UserType, EventProperty>>({
 
                     const PostHog = (window as any).posthog
                     if (PostHog) {
-                        PostHog.identify(user.distinct_id)
+                        PostHog.identify(user.distinct_id, {
+                            email: user.anonymize_data ? null : user.email,
+                        })
                         PostHog.register({
                             posthog_version: user.posthog_version,
                             has_slack_webhook: !!user.team?.slack_incoming_webhook,


### PR DESCRIPTION
## Changes

In some cases identifying in the backend wasn't working (or was so long ago that we weren't sending the correct information). Doing this in the frontend gives us another failsafe.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
