### PR TITLE
Downgrade react dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-datepicker": "^2.13.0",
-        "react-dom": "^16.13.1",
+        "react-dom": "^16.12.0",
         "react-draggable": "^4.2.0",
         "react-redux": "^7.2.0",
         "react-shadow": "^17.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8055,7 +8055,7 @@ react-datepicker@^2.13.0:
     react-onclickoutside "^6.9.0"
     react-popper "^1.3.4"
 
-react-dom@^16.13.1:
+react-dom@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==


### PR DESCRIPTION
## Changes

On app, when navigating from a random user to "insights" i get the following error.
![image](https://user-images.githubusercontent.com/1727427/92114516-3f1d2f80-edf1-11ea-9afa-4dd318bb3b11.png)

https://sentry.io/organizations/posthog/issues/1872377025/?project=1899813&query=is%3Aunresolved

I _think_ it's related to react-dom but couldn't reproduce locally

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
