### PR TITLE
explicitly use python-statsd as statsd lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ pycparser==2.20
 PyJWT==1.7.1
 pyparsing==2.4.6
 python-dateutil==2.8.1
+python-statsd==2.1.0
 python3-openid==3.1.0
 pytz==2019.3
 redis==3.4.1


### PR DESCRIPTION
This is the statsd lib used by our statsd django middleware.
