### PR TITLE
Fix and test Team.event_properties_numerical

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -227,34 +227,43 @@ function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAv
             buttonClassName="btn btn-sm btn-light ml-2"
             data-attr={`math-selector-${index}`}
         >
-            {MATH_ENTRIES.map(([key, { name, description, onProperty }]) => (
-                <Tooltip
-                    placement="right"
-                    title={
-                        onProperty ? (
-                            <>
-                                {description}
-                                <br />
-                                {numericalNotice}
-                            </>
-                        ) : (
-                            description
-                        )
-                    }
-                    key={`math-${key}`}
-                >
-                    <div>
-                        <button
-                            className="dropdown-item"
-                            disabled={onProperty && !areEventPropertiesNumericalAvailable}
-                            onClick={() => onMathSelect(index, key)}
-                            data-attr={`math-${key}-${index}`}
-                        >
-                            {name}
-                        </button>
-                    </div>
-                </Tooltip>
-            ))}
+            {MATH_ENTRIES.map(([key, { name, description, onProperty }]) => {
+                const disabled = onProperty && !areEventPropertiesNumericalAvailable
+                return (
+                    <Tooltip
+                        placement="right"
+                        title={
+                            onProperty ? (
+                                <>
+                                    {description}
+                                    <br />
+                                    {numericalNotice}
+                                </>
+                            ) : (
+                                description
+                            )
+                        }
+                        key={`math-${key}`}
+                    >
+                        <div>
+                            <button
+                                className="dropdown-item"
+                                disabled={disabled}
+                                onClick={
+                                    disabled
+                                        ? () => {
+                                              onMathSelect(index, key)
+                                          }
+                                        : undefined
+                                }
+                                data-attr={`math-${key}-${index}`}
+                            >
+                                {name}
+                            </button>
+                        </div>
+                    </Tooltip>
+                )
+            })}
         </Dropdown>
     )
 }

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -251,10 +251,10 @@ function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAv
                                 disabled={disabled}
                                 onClick={
                                     disabled
-                                        ? () => {
+                                        ? undefined
+                                        : () => {
                                               onMathSelect(index, key)
                                           }
-                                        : undefined
                                 }
                                 data-attr={`math-${key}-${index}`}
                             >

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -77,7 +77,6 @@ const MATHS = {
         onProperty: true,
     },
 }
-const MATH_ENTRIES = Object.entries(MATHS)
 
 const determineFilterLabel = (visible, filter) => {
     if (visible) return 'Hide filters'
@@ -93,7 +92,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
     const node = useRef()
     const { selectedFilter, entities } = useValues(logic)
     const { selectFilter, updateFilterMath, removeLocalFilter, updateFilterProperty } = useActions(logic)
-    const { eventProperties, eventPropertiesNumerical } = useValues(userLogic)
+    const { eventProperties } = useValues(userLogic)
     const [entityFilterVisible, setEntityFilterVisible] = useState(false)
 
     let entity, name, value
@@ -154,16 +153,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 {name || 'Select action'}
                 <DownOutlined style={{ marginLeft: '3px', color: 'rgba(0, 0, 0, 0.25)' }} />
             </button>
-            {!hideMathSelector && (
-                <MathSelector
-                    math={math}
-                    index={index}
-                    onMathSelect={onMathSelect}
-                    areEventPropertiesNumericalAvailable={
-                        eventPropertiesNumerical && eventPropertiesNumerical.length > 0
-                    }
-                />
-            )}
+            {!hideMathSelector && <MathSelector math={math} index={index} onMathSelect={onMathSelect} />}
             {!hideMathSelector && MATHS[math]?.onProperty && (
                 <MathPropertySelector
                     name={name}
@@ -171,7 +161,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                     mathProperty={mathProperty}
                     index={index}
                     onMathPropertySelect={onMathPropertySelect}
-                    properties={eventPropertiesNumerical}
+                    properties={eventProperties}
                 />
             )}
             <div
@@ -216,54 +206,25 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
     )
 }
 
-function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAvailable }) {
-    const numericalNotice = `This can only be used on on properties that have at least one number type occurence in your events.${
-        areEventPropertiesNumericalAvailable ? '' : ' None have been found yet!'
-    }`
-
+function MathSelector(props) {
     return (
         <Dropdown
-            title={MATHS[math || 'total']?.name}
+            title={MATHS[props.math || 'total']?.name}
             buttonClassName="btn btn-sm btn-light ml-2"
-            data-attr={`math-selector-${index}`}
+            data-attr={`math-selector-${props.index}`}
         >
-            {MATH_ENTRIES.map(([key, { name, description, onProperty }]) => {
-                const disabled = onProperty && !areEventPropertiesNumericalAvailable
-                return (
-                    <Tooltip
-                        placement="right"
-                        title={
-                            onProperty ? (
-                                <>
-                                    {description}
-                                    <br />
-                                    {numericalNotice}
-                                </>
-                            ) : (
-                                description
-                            )
-                        }
-                        key={`math-${key}`}
+            {Object.entries(MATHS).map(([key, value]) => (
+                <Tooltip placement="right" title={value.description} key={`math-${key}`}>
+                    <a
+                        href="#"
+                        className="dropdown-item"
+                        onClick={() => props.onMathSelect(props.index, key)}
+                        data-attr={`math-${key}-${props.index}`}
                     >
-                        <div>
-                            <button
-                                className="dropdown-item"
-                                disabled={disabled}
-                                onClick={
-                                    disabled
-                                        ? undefined
-                                        : () => {
-                                              onMathSelect(index, key)
-                                          }
-                                }
-                                data-attr={`math-${key}-${index}`}
-                            >
-                                {name}
-                            </button>
-                        </div>
-                    </Tooltip>
-                )
-            })}
+                        {value.name}
+                    </a>
+                </Tooltip>
+            ))}
         </Dropdown>
     )
 }

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -77,6 +77,7 @@ const MATHS = {
         onProperty: true,
     },
 }
+const MATH_ENTRIES = Object.entries(MATHS)
 
 const determineFilterLabel = (visible, filter) => {
     if (visible) return 'Hide filters'
@@ -92,7 +93,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
     const node = useRef()
     const { selectedFilter, entities } = useValues(logic)
     const { selectFilter, updateFilterMath, removeLocalFilter, updateFilterProperty } = useActions(logic)
-    const { eventProperties } = useValues(userLogic)
+    const { eventProperties, eventPropertiesNumerical } = useValues(userLogic)
     const [entityFilterVisible, setEntityFilterVisible] = useState(false)
 
     let entity, name, value
@@ -153,7 +154,16 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 {name || 'Select action'}
                 <DownOutlined style={{ marginLeft: '3px', color: 'rgba(0, 0, 0, 0.25)' }} />
             </button>
-            {!hideMathSelector && <MathSelector math={math} index={index} onMathSelect={onMathSelect} />}
+            {!hideMathSelector && (
+                <MathSelector
+                    math={math}
+                    index={index}
+                    onMathSelect={onMathSelect}
+                    areEventPropertiesNumericalAvailable={
+                        eventPropertiesNumerical && eventPropertiesNumerical.length > 0
+                    }
+                />
+            )}
             {!hideMathSelector && MATHS[math]?.onProperty && (
                 <MathPropertySelector
                     name={name}
@@ -161,7 +171,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                     mathProperty={mathProperty}
                     index={index}
                     onMathPropertySelect={onMathPropertySelect}
-                    properties={eventProperties}
+                    properties={eventPropertiesNumerical}
                 />
             )}
             <div
@@ -206,23 +216,43 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
     )
 }
 
-function MathSelector(props) {
+function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAvailable }) {
+    const numericalNotice = `This can only be used on on properties that have at least one number type occurence in your events.${
+        areEventPropertiesNumericalAvailable ? '' : ' None have been found yet!'
+    }`
+
     return (
         <Dropdown
-            title={MATHS[props.math || 'total']?.name}
+            title={MATHS[math || 'total']?.name}
             buttonClassName="btn btn-sm btn-light ml-2"
-            data-attr={`math-selector-${props.index}`}
+            data-attr={`math-selector-${index}`}
         >
-            {Object.entries(MATHS).map(([key, value]) => (
-                <Tooltip placement="right" title={value.description} key={`math-${key}`}>
-                    <a
-                        href="#"
-                        className="dropdown-item"
-                        onClick={() => props.onMathSelect(props.index, key)}
-                        data-attr={`math-${key}-${props.index}`}
-                    >
-                        {value.name}
-                    </a>
+            {MATH_ENTRIES.map(([key, { name, description, onProperty }]) => (
+                <Tooltip
+                    placement="right"
+                    title={
+                        onProperty ? (
+                            <>
+                                {description}
+                                <br />
+                                {numericalNotice}
+                            </>
+                        ) : (
+                            description
+                        )
+                    }
+                    key={`math-${key}`}
+                >
+                    <div>
+                        <button
+                            className="dropdown-item"
+                            disabled={onProperty && !areEventPropertiesNumericalAvailable}
+                            onClick={() => onMathSelect(index, key)}
+                            data-attr={`math-${key}-${index}`}
+                        >
+                            {name}
+                        </button>
+                    </div>
                 </Tooltip>
             ))}
         </Dropdown>

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -43,6 +43,13 @@ export const userLogic = kea<userLogicType<UserType, EventProperty>>({
                     (property: string) => ({ value: property, label: property } as EventProperty)
                 ) || ([] as EventProperty[]),
         ],
+        eventPropertiesNumerical: [
+            () => [selectors.user],
+            (user) =>
+                user?.team.event_properties_numerical.map(
+                    (property: string) => ({ value: property, label: property } as EventProperty)
+                ) || ([] as EventProperty[]),
+        ],
         eventNames: [() => [selectors.user], (user) => user?.team.event_names || []],
         customEventNames: [
             () => [selectors.user],

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -43,13 +43,6 @@ export const userLogic = kea<userLogicType<UserType, EventProperty>>({
                     (property: string) => ({ value: property, label: property } as EventProperty)
                 ) || ([] as EventProperty[]),
         ],
-        eventPropertiesNumerical: [
-            () => [selectors.user],
-            (user) =>
-                user?.team.event_properties_numerical.map(
-                    (property: string) => ({ value: property, label: property } as EventProperty)
-                ) || ([] as EventProperty[]),
-        ],
         eventNames: [() => [selectors.user], (user) => user?.team.event_names || []],
         customEventNames: [
             () => [selectors.user],
@@ -89,7 +82,9 @@ export const userLogic = kea<userLogicType<UserType, EventProperty>>({
 
                     const PostHog = (window as any).posthog
                     if (PostHog) {
-                        PostHog.identify(user.distinct_id)
+                        PostHog.identify(user.distinct_id, {
+                            email: user.anonymize_data ? null : user.email,
+                        })
                         PostHog.register({
                             posthog_version: user.posthog_version,
                             has_slack_webhook: !!user.team?.slack_incoming_webhook,

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -10,7 +10,8 @@ from django.conf import settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from posthog.models import PersonalAPIKey
+from posthog.models import PersonalAPIKey, Team
+from posthog.tasks.process_event import _capture
 
 from .base import BaseTest
 

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -153,8 +153,8 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                             timestamp=date + relativedelta(seconds=60),
                         )
                     )
-    Team.event_properties_numerical.append("purchase")
-    Team.save()
+    team.event_properties_numerical.append("purchase")
+    team.save()
     PersonDistinctId.objects.bulk_create(distinct_ids)
     Event.objects.bulk_create(events)
 

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -137,6 +137,15 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                     )
                     events.append(
                         Event(
+                            event="purchase",
+                            team=team,
+                            distinct_id=distinct_id,
+                            properties={"cost": 10},
+                            timestamp=date + relativedelta(seconds=60),
+                        )
+                    )
+                    events.append(
+                        Event(
                             event="$pageview",
                             team=team,
                             distinct_id=distinct_id,
@@ -144,7 +153,8 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                             timestamp=date + relativedelta(seconds=60),
                         )
                     )
-
+    Team.event_properties_numerical.append("purchase")
+    Team.save()
     PersonDistinctId.objects.bulk_create(distinct_ids)
     Event.objects.bulk_create(events)
 

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -140,7 +140,7 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                             event="purchase",
                             team=team,
                             distinct_id=distinct_id,
-                            properties={"cost": 10},
+                            properties={"price": 10},
                             timestamp=date + relativedelta(seconds=60),
                         )
                     )

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -66,11 +66,11 @@ def _store_names_and_properties(team: Team, event: str, properties: Dict) -> Non
     if event not in team.event_names:
         save = True
         team.event_names.append(event)
-    for key in properties.keys():
+    for key, value in properties.items():
         if key not in team.event_properties:
             team.event_properties.append(key)
             save = True
-        if isinstance(key, Number) and key not in team.event_properties_numerical:
+        if isinstance(value, Number) and key not in team.event_properties_numerical:
             team.event_properties_numerical.append(key)
             save = True
     if save:

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -628,7 +628,7 @@ class TestIdentify(TransactionTestCase):
         person_after_event = Person.objects.get(team=self.team, persondistinctid__distinct_id=distinct_id)
         self.assertTrue(person_after_event.is_identified)
 
-    def test_team_event_properties(self):
+    def test_team_event_properties(self) -> None:
         self.assertListEqual(self.team.event_properties_numerical, [])
         process_event(
             "xxx",

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -28,7 +28,7 @@ class ProcessEvent(BaseTest):
         ActionStep.objects.create(action=action2, selector="a", event="$autocapture")
         team_id = self.team.pk
 
-        with self.assertNumQueries(29):
+        with self.assertNumQueries(30):
             process_event(
                 2,
                 "",

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -627,3 +627,18 @@ class TestIdentify(TransactionTestCase):
         )
         person_after_event = Person.objects.get(team=self.team, persondistinctid__distinct_id=distinct_id)
         self.assertTrue(person_after_event.is_identified)
+
+    def test_team_event_properties(self):
+        self.assertListEqual(self.team.event_properties_numerical, [])
+        process_event(
+            "xxx",
+            "",
+            "",
+            {"event": "purchase", "properties": {"price": 299.99, "name": "AirPods Pro"},},
+            self.team.pk,
+            now().isoformat(),
+            now().isoformat(),
+        )
+        self.team.refresh_from_db()
+        self.assertListEqual(self.team.event_properties, ["price", "name", "$ip"])
+        self.assertListEqual(self.team.event_properties_numerical, ["price"])

--- a/posthog/test/test_demo.py
+++ b/posthog/test/test_demo.py
@@ -9,7 +9,7 @@ class TestDemo(BaseTest):
 
     def test_create_demo_data(self):
         self.client.get("/demo")
-        self.assertEqual(Event.objects.count(), 190)
+        self.assertEqual(Event.objects.count(), 192)
         self.assertEqual(Person.objects.count(), 100)
         self.assertEqual(Action.objects.count(), 3)
 
@@ -23,7 +23,7 @@ class TestDemo(BaseTest):
 
     def test_delete_demo_data(self):
         self.client.get("/demo")
-        self.assertEqual(Event.objects.count(), 190)
+        self.assertEqual(Event.objects.count(), 192)
         Person.objects.create(team=self.team, distinct_ids=["random_real_person"])
         response = self.client.delete("/delete_demo_data/").json()
         self.assertEqual(response["status"], "ok")


### PR DESCRIPTION
## Changes

Ad discovered in #1536, `Team.event_properties_numerical` wasn't updated in event processing. This fixes that and adds testing of `event_properties` and `event_properties_numerical`.

## Checklist

- [x] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [x] Backend tests (if this PR affects the backend)