### PR TITLE
fix: handle the case of invalid json gracefully

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import secrets
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -80,16 +80,17 @@ def get_decide(request: HttpRequest):
                 request.user.temporary_token = secrets.token_urlsafe(32)
                 request.user.save()
 
-    try:
-        _load_data(request.POST["data"])
-    except json.decoder.JSONDecodeError:
-        return cors_response(
-            request,
-            JsonResponse(
-                {"code": "validation", "message": "Malformed request data. Make sure you're sending valid JSON.",},
-                status=400,
-            ),
-        )
+    if request.method == "POST":
+        try:
+            _load_data(request.POST["data"])
+        except json.decoder.JSONDecodeError:
+            return cors_response(
+                request,
+                JsonResponse(
+                    {"code": "validation", "message": "Malformed request data. Make sure you're sending valid JSON.",},
+                    status=400,
+                ),
+            )
 
     response["featureFlags"] = feature_flags(request)
     return cors_response(request, JsonResponse(response))


### PR DESCRIPTION
This changes the behaviour how invalid json is handled in the `/decide`-endpoint instead of failing hard by throwing a 500 internal server error it instead will throw a 400 Bad Request error instead to make the Developer Experience better

fixes #1576

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
