### PR TITLE
Increase number of concurrent celery workers in production

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-celery -A posthog worker
+celery -A posthog worker --concurrency=32


### PR DESCRIPTION
This corrects an issue on Heroku currently where we are IO bound on Clickhouse. We need to convert the inserts to be async but until then this will free up resources on the worker nodes to tend to the inserts.

Problem:
We are blocked processing events waiting on inserts to complete on ClickHouse.

Temporary Solution:
Increase concurrency of celery workers on worker nodes since worker boxes are not taxed at all on CPU or Memory. 
This should buy us time to refactor inserts to be async into Clickhouse.