### PR TITLE
Use celery defaults for concurrency, bumping workers only increased latency of event processing

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-celery -A posthog worker --concurrency=32
+celery -A posthog worker


### PR DESCRIPTION
This reverts the last change which tested increasing concurrency to increase throughput.