### PR TITLE
Update async events to clickhouse to use python 3.6 api

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -6,6 +6,7 @@ from clickhouse_driver import Client as SyncClient  # type: ignore
 
 from posthog.settings import (
     CLICKHOUSE,
+    CLICKHOUSE_ASYNC,
     CLICKHOUSE_CA,
     CLICKHOUSE_DATABASE,
     CLICKHOUSE_HOST,
@@ -16,7 +17,7 @@ from posthog.settings import (
     TEST,
 )
 
-if not TEST:
+if not TEST and CLICKHOUSE_ASYNC:
     if PRIMARY_DB != CLICKHOUSE:
         ch_client = Client(host="localhost")
     else:
@@ -31,7 +32,8 @@ if not TEST:
 
     @async_to_sync
     async def async_execute(query, args=None):
-        task = asyncio.create_task(ch_client.execute(query, args))
+        loop = asyncio.get_event_loop()
+        task = loop.create_task(ch_client.execute(query, args))
         # we return this in case we want to cancel it
         return task
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -116,6 +116,7 @@ CLICKHOUSE_SECURE = get_bool_from_env("CLICKHOUSE_SECURE", True)
 CLICKHOUSE_VERIFY = get_bool_from_env("CLICKHOUSE_VERIFY", True)
 CLICKHOUSE_REPLICATION = get_bool_from_env("CLICKHOUSE_REPLICATION", False)
 CLICKHOUSE_ENABLE_STORAGE_POLICY = get_bool_from_env("CLICKHOUSE_ENABLE_STORAGE_POLICY", False)
+CLICKHOUSE_ASYNC = get_bool_from_env("CLICKHOUSE_ASYNC", False)
 
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"


### PR DESCRIPTION

Problem:
`asyncio.create_task(<coro>)` is not available in 3.6 which is what heroku is running

Solution:
```
loop = asyncio.get_event_loop()
loop.create_task(<coro>)
```
 🤷‍♀️