### PR TITLE
Noop on celery worker if ee is not enabled

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -17,10 +17,11 @@ from posthog.settings import (
     TEST,
 )
 
-if not TEST and CLICKHOUSE_ASYNC:
-    if PRIMARY_DB != CLICKHOUSE:
-        ch_client = Client(host="localhost")
-    else:
+if PRIMARY_DB != CLICKHOUSE:
+    ch_client = Client(host="localhost")
+    ch_sync_client = SyncClient(host="localhost")
+else:
+    if not TEST and CLICKHOUSE_ASYNC:
         ch_client = Client(
             host=CLICKHOUSE_HOST,
             database=CLICKHOUSE_DATABASE,
@@ -30,19 +31,15 @@ if not TEST and CLICKHOUSE_ASYNC:
             verify=CLICKHOUSE_VERIFY,
         )
 
-    @async_to_sync
-    async def async_execute(query, args=None):
-        loop = asyncio.get_event_loop()
-        task = loop.create_task(ch_client.execute(query, args))
-        # we return this in case we want to cancel it
-        return task
+        @async_to_sync
+        async def async_execute(query, args=None):
+            loop = asyncio.get_event_loop()
+            task = loop.create_task(ch_client.execute(query, args))
+            # we return this in case we want to cancel it
+            return task
 
-
-else:
-    # if this is a test use the sync client
-    if PRIMARY_DB != CLICKHOUSE:
-        ch_client = SyncClient(host="localhost")
     else:
+        # if this is a test use the sync client
         ch_client = SyncClient(
             host=CLICKHOUSE_HOST,
             database=CLICKHOUSE_DATABASE,
@@ -52,14 +49,10 @@ else:
             verify=CLICKHOUSE_VERIFY,
         )
 
-    def async_execute(query, args=None):
-        task = ch_client.execute(query, args)
-        return task
+        def async_execute(query, args=None):
+            task = ch_client.execute(query, args)
+            return task
 
-
-if PRIMARY_DB != CLICKHOUSE:
-    ch_sync_client = SyncClient(host="localhost")
-else:
     ch_sync_client = SyncClient(
         host=CLICKHOUSE_HOST,
         database=CLICKHOUSE_DATABASE,
@@ -69,6 +62,5 @@ else:
         verify=CLICKHOUSE_VERIFY,
     )
 
-
-def sync_execute(query, args=None):
-    return ch_sync_client.execute(query, args)
+    def sync_execute(query, args=None):
+        return ch_sync_client.execute(query, args)

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -20,6 +20,14 @@ from posthog.settings import (
 if PRIMARY_DB != CLICKHOUSE:
     ch_client = Client(host="localhost")
     ch_sync_client = SyncClient(host="localhost")
+
+    def async_execute(query, args=None):
+        return
+
+    def sync_execute(query, args=None):
+        return
+
+
 else:
     if not TEST and CLICKHOUSE_ASYNC:
         ch_client = Client(


### PR DESCRIPTION
We have a ton of attempts at saving to clickhouse even when `PRIMARY_DB` is postgres. Having celery workers noop if Clickhouse is not enabled.

![image](https://user-images.githubusercontent.com/391319/92296060-5f2e1b00-eee5-11ea-82e2-8074ae3baf0e.png)
