### PR TITLE
Add monitoring of celery queue size to statsd

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -8,6 +8,7 @@ from celery.schedules import crontab
 
 from django.conf import settings
 from django.db import connection
+from django_statsd import utils
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
@@ -69,8 +70,9 @@ def redis_heartbeat():
 
 @app.task()
 def redis_task_queue_length():
+    g = utils.get_client("production_celery", class_=statsd.Gauge)
     llen = redis_instance.llen("celery")
-    statsd.Gauge("celery_queue_depth", llen)
+    g.increment("celery_queue_depth", llen)
 
 
 @app.task

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -5,7 +5,6 @@ import redis
 import statsd
 from celery import Celery
 from celery.schedules import crontab
-
 from django.conf import settings
 from django.db import connection
 from django_statsd import utils
@@ -33,14 +32,6 @@ redis_instance = redis.from_url(settings.REDIS_URL, db=0)
 
 # How frequently do we want to calculate action -> event relationships if async is enabled
 ACTION_EVENT_MAPPING_INTERVAL_MINUTES = 10
-
-
-def celery_queue_length(queue="celery") -> int:
-    if settings.REDIS_URL:
-        redis_instance = redis.from_url(settings.REDIS_URL, db=0)
-    else:
-        return 0
-    return redis_instance.llen(queue)
 
 
 @app.on_after_configure.connect

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,12 +1,11 @@
 import os
 import time
-from datetime import datetime
-from typing import Optional
 
 import redis
-from celery import Celery, group
+import statsd
+from celery import Celery
 from celery.schedules import crontab
-from dateutil import parser
+
 from django.conf import settings
 from django.db import connection
 
@@ -35,10 +34,19 @@ redis_instance = redis.from_url(settings.REDIS_URL, db=0)
 ACTION_EVENT_MAPPING_INTERVAL_MINUTES = 10
 
 
+def celery_queue_length(queue="celery") -> int:
+    if settings.REDIS_URL:
+        redis_instance = redis.from_url(settings.REDIS_URL, db=0)
+    else:
+        return 0
+    return redis_instance.llen(queue)
+
+
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     # Heartbeat every 10sec to make sure the worker is alive
     sender.add_periodic_task(10.0, redis_heartbeat.s(), name="10 sec heartbeat", priority=0)
+    sender.add_periodic_task(1.0, redis_task_queue_length.s(), name="1 sec redis metric", priority=0)
     sender.add_periodic_task(
         crontab(day_of_week="mon,fri"), update_event_partitions.s(),  # check twice a week
     )
@@ -57,6 +65,12 @@ def setup_periodic_tasks(sender, **kwargs):
 @app.task
 def redis_heartbeat():
     redis_instance.set("POSTHOG_HEARTBEAT", int(time.time()))
+
+
+@app.task()
+def redis_task_queue_length():
+    llen = redis_instance.llen("celery")
+    statsd.Gauge("celery_queue_depth", llen)
 
 
 @app.task

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -2,12 +2,12 @@ import os
 import time
 
 import redis
-import statsd
+import statsd  # type: ignore
 from celery import Celery
 from celery.schedules import crontab
 from django.conf import settings
 from django.db import connection
-from django_statsd import utils
+from django_statsd import utils  # type: ignore
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -321,11 +321,3 @@ def get_redis_heartbeat() -> Union[str, int]:
     if worker_heartbeat and (worker_heartbeat == 0 or worker_heartbeat < 300):
         return worker_heartbeat
     return "offline"
-
-
-def get_celery_queue_length(queue="celery") -> int:
-    if settings.REDIS_URL:
-        redis_instance = redis.from_url(settings.REDIS_URL, db=0)
-    else:
-        return 0
-    return redis_instance.llen(queue)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -321,3 +321,11 @@ def get_redis_heartbeat() -> Union[str, int]:
     if worker_heartbeat and (worker_heartbeat == 0 or worker_heartbeat < 300):
         return worker_heartbeat
     return "offline"
+
+
+def get_celery_queue_length(queue="celery") -> int:
+    if settings.REDIS_URL:
+        redis_instance = redis.from_url(settings.REDIS_URL, db=0)
+    else:
+        return 0
+    return redis_instance.llen(queue)


### PR DESCRIPTION
This is definitely something we need to track for the health of our events ingestion pipeline