### PR TITLE
Typo in licenses.tsx

### DIFF
--- a/frontend/src/scenes/setup/Licenses.tsx
+++ b/frontend/src/scenes/setup/Licenses.tsx
@@ -48,7 +48,7 @@ function _Licenses(): JSX.Element {
             <p style={{ maxWidth: 600 }}>
                 <i>
                     Here you can add and manage your PostHog enterprise licenses. By adding a license key, you'll be
-                    able to unluck enterprise functionality in PostHog right away!
+                    able to unlock enterprise functionality in PostHog right away!
                     <br />
                     <br />
                     Contact <a href="mailto:sales@posthog.com">sales@posthog.com</a> to buy a license.


### PR DESCRIPTION
More unlock than unluck :)

## Changes

Currently: 
“Here you can add and manage your PostHog enterprise licenses. By adding a license key, you'll be able to unluck enterprise functionality in PostHog right away!”

Should be: 
"Here you can add and manage your PostHog enterprise licenses. By adding a license key, you'll be able to unlock enterprise functionality in PostHog right away!”

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
