### PR TITLE
Bugfix: Remove celerybeat.pid before starting docker worker

### DIFF
--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -14,6 +14,7 @@ then
   echo "⚠️ --> https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011"
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
+  rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
   ./bin/docker-worker-beat &
   ./bin/docker-worker-celery
 fi


### PR DESCRIPTION
This fixes a bug where celerybeat.pid is not cleaned up when you shut down docker-compose stack. This should be safe to remove since it is in the startup script for docker workers and there shouldn't be multiple docker celery beat workers running on one box unless you switch up the configs.