### PR TITLE
Remove function call to see impact on performance

### DIFF
--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -131,18 +131,13 @@ def _capture(
         **({"elements": elements_list} if elements_list else {})
     )
     store_names_and_properties(team=team, event=event, properties=properties)
-    check_created_person(team_id=team_id, distinct_id=distinct_id)
-
-
-def check_created_person(team_id: int, distinct_id: str) -> None:
     if not Person.objects.distinct_ids_exist(team_id=team_id, distinct_ids=[str(distinct_id)]):
         # Catch race condition where in between getting and creating,
         # another request already created this user
         try:
             Person.objects.create(team_id=team_id, distinct_ids=[str(distinct_id)])
         except IntegrityError:
-            return
-    return
+            pass
 
 
 def get_or_create_person(team_id: int, distinct_id: str) -> Tuple[Person, bool]:


### PR DESCRIPTION
I have a hunch that adding a simple function call is 2x-ing the 50 percentile time to capture an event.
![image](https://user-images.githubusercontent.com/391319/92677825-8156dd00-f2d9-11ea-9a63-9d36259dff13.png)
