### PR TITLE
Nicer API Failure Errors

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -15,83 +15,76 @@ function getCookie(name) {
 }
 
 class Api {
-    get(url) {
+    async get(url) {
         if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') == -1 && url[url.length - 1] != '/' ? '/' : '')
+            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }
-        return fetch(url).then((response) => {
-            if (!response.ok) {
-                return response.json().then((data) => {
-                    throw { status: response.status, ...data }
-                })
-            }
-            return response.json()
-        })
+        const response = await fetch(url)
+
+        if (!response.ok) {
+            const data = await response.json()
+            throw { status: response.status, ...data }
+        }
+        return response.json()
     }
-    update(url, data) {
+    async update(url, data) {
         if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') == -1 && url[url.length - 1] != '/' ? '/' : '')
+            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }
-        return fetch(url, {
+        const response = await fetch(url, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': getCookie('csrftoken'),
             },
             body: JSON.stringify(data),
-        }).then((response) => {
-            if (!response.ok) {
-                return response.json().then((data) => {
-                    if (Array.isArray(data)) {
-                        throw data
-                    }
-                    throw { status: response.status, ...data }
-                })
-            }
-            return response.json()
         })
-    }
-    create(url, data) {
-        if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') == -1 && url[url.length - 1] != '/' ? '/' : '')
+        if (!response.ok) {
+            const data = await response.json()
+            if (Array.isArray(data)) {
+                throw data
+            }
+            throw { status: response.status, ...data }
         }
-        return fetch(url, {
+        return response.json()
+    }
+    async create(url, data) {
+        if (url.indexOf('http') !== 0) {
+            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
+        }
+        const response = await fetch(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': getCookie('csrftoken'),
             },
             body: JSON.stringify(data),
-        }).then((response) => {
-            if (!response.ok) {
-                return response.json().then((data) => {
-                    if (Array.isArray(data)) {
-                        throw data
-                    }
-                    throw { status: response.status, ...data }
-                })
-            }
-            return response.json()
         })
-    }
-    delete(url) {
-        if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') == -1 && url[url.length - 1] != '/' ? '/' : '')
+        if (!response.ok) {
+            const data = await response.json()
+            if (Array.isArray(data)) {
+                throw data
+            }
+            throw { status: response.status, ...data }
         }
-        return fetch(url, {
+        return response.json()
+    }
+    async delete(url) {
+        if (url.indexOf('http') !== 0) {
+            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
+        }
+        const response = await fetch(url, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'X-CSRFToken': getCookie('csrftoken'),
             },
-        }).then((response) => {
-            if (!response.ok) {
-                return response.json().then((data) => {
-                    throw { status: response.status, ...data }
-                })
-            }
-            return response
         })
+        if (!response.ok) {
+            const data = await response.json()
+            throw { status: response.status, ...data }
+        }
+        return response
     }
 }
 let api = new Api()

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -14,6 +14,14 @@ function getCookie(name) {
     return cookieValue
 }
 
+async function getJSONOrThrow(response) {
+    try {
+        return await response.json()
+    } catch (e) {
+        throw new Error('Something went wrong when parsing the response from the server.')
+    }
+}
+
 class Api {
     async get(url) {
         if (url.indexOf('http') !== 0) {
@@ -22,10 +30,10 @@ class Api {
         const response = await fetch(url)
 
         if (!response.ok) {
-            const data = await response.json()
+            const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }
-        return response.json()
+        return await getJSONOrThrow(response)
     }
     async update(url, data) {
         if (url.indexOf('http') !== 0) {
@@ -40,13 +48,13 @@ class Api {
             body: JSON.stringify(data),
         })
         if (!response.ok) {
-            const data = await response.json()
+            const data = await getJSONOrThrow(response)
             if (Array.isArray(data)) {
                 throw data
             }
             throw { status: response.status, ...data }
         }
-        return response.json()
+        return await getJSONOrThrow(response)
     }
     async create(url, data) {
         if (url.indexOf('http') !== 0) {
@@ -61,13 +69,13 @@ class Api {
             body: JSON.stringify(data),
         })
         if (!response.ok) {
-            const data = await response.json()
+            const data = await getJSONOrThrow(response)
             if (Array.isArray(data)) {
                 throw data
             }
             throw { status: response.status, ...data }
         }
-        return response.json()
+        return await getJSONOrThrow(response)
     }
     async delete(url) {
         if (url.indexOf('http') !== 0) {
@@ -81,7 +89,7 @@ class Api {
             },
         })
         if (!response.ok) {
-            const data = await response.json()
+            const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }
         return response


### PR DESCRIPTION
## Changes

This PR add a little bit more information for the case when we are unable to parse the JSON from the server.

Before:
![2020-09-10 13 32 07](https://user-images.githubusercontent.com/53387/92724277-9c256200-f36a-11ea-91dd-56fbebc96be8.gif)

After:
![2020-09-10 13 31 20](https://user-images.githubusercontent.com/53387/92724183-7b5d0c80-f36a-11ea-83bc-337404f9d5d9.gif)

I also converted `api.js` to use `async`/`await`.

This could obviously be further improved.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
