### PR TITLE
Added warning for changing feature flag key

### DIFF
--- a/frontend/src/scenes/experiments/EditFeatureFlag.js
+++ b/frontend/src/scenes/experiments/EditFeatureFlag.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Input, Button, Form, Switch, Slider } from 'antd'
 import { kea, useActions, useValues } from 'kea'
 import { slugify } from 'lib/utils'
@@ -36,6 +36,8 @@ function Snippet({ flagKey }) {
     )
 }
 
+const noop = () => {}
+
 export function EditFeatureFlag({ featureFlag, logic, isNew }) {
     const [form] = Form.useForm()
     const { updateFeatureFlag, createFeatureFlag } = useActions(logic)
@@ -43,6 +45,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
     const _editLogic = editLogic({ featureFlag })
     const { filters, rollout_percentage } = useValues(_editLogic)
     const { setFilters, setRolloutPercentage } = useActions(_editLogic)
+    const [hasKeyChanged, setHasKeyChanged] = useState(false)
 
     let submitDisabled = rollout_percentage === null && (!filters?.properties || filters.properties.length === 0)
     return (
@@ -50,6 +53,13 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
             layout="vertical"
             form={form}
             initialValues={featureFlag}
+            onValuesChange={
+                !isNew
+                    ? (changedValues) => {
+                          if (changedValues.key) setHasKeyChanged(changedValues.key !== featureFlag.key)
+                      }
+                    : noop
+            }
             onFinish={(values) => {
                 const updatedFlag = { ...featureFlag, ...values, rollout_percentage, filters }
                 if (isNew) {
@@ -73,7 +83,25 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                 />
             </Form.Item>
 
-            <Form.Item name="key" label="Key" rules={[{ required: true }]}>
+            <Form.Item
+                name="key"
+                label="Key"
+                rules={[{ required: true }]}
+                validateStatus={!!rollout_percentage && hasKeyChanged ? 'warning' : ''}
+                help={
+                    !!rollout_percentage && hasKeyChanged ? (
+                        <small>
+                            Changing this key will
+                            <a href="https://posthog.com/docs/features/feature-flags">
+                                {' '}
+                                affect the persistence of your flag.
+                            </a>
+                        </small>
+                    ) : (
+                        ' '
+                    )
+                }
+            >
                 <Input data-attr="feature-flag-key" />
             </Form.Item>
 

--- a/frontend/src/scenes/experiments/EditFeatureFlag.js
+++ b/frontend/src/scenes/experiments/EditFeatureFlag.js
@@ -92,7 +92,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                     !!rollout_percentage && hasKeyChanged ? (
                         <small>
                             Changing this key will
-                            <a href="https://posthog.com/docs/features/feature-flags">
+                            <a href="https://posthog.com/docs/features/feature-flags#feature-flag-persistence">
                                 {' '}
                                 affect the persistence of your flag.
                             </a>


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

I wanted to make the warning only appear when necessary, so it only appears when rollout percentage is on, and when the key actually changes. Wanted to keep it short so I'll now add a note about this to the Docs and link it back here. 

EDIT: "Add note on feature flag persistence" (https://github.com/PostHog/posthog.com/pull/409)

<img width="394" alt="Screenshot 2020-09-11 at 14 17 04" src="https://user-images.githubusercontent.com/38760734/92936654-e1649500-f439-11ea-9926-981fe1c89a94.png">
<img width="393" alt="Screenshot 2020-09-11 at 14 17 12" src="https://user-images.githubusercontent.com/38760734/92936656-e295c200-f439-11ea-9f6e-ebd8f5a46902.png">


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
