### PR TITLE
Put process_event_ee back on celery with delay

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -172,7 +172,7 @@ def get_event(request):
             sent_at=sent_at,
         )
         if check_ee_enabled():
-            process_event_ee(
+            process_event_ee.delay(
                 distinct_id=distinct_id,
                 ip=get_ip_address(request),
                 site_url=request.build_absolute_uri("/")[:-1],


### PR DESCRIPTION
This was a leftover from debugging locally for Kafka production.