### PR TITLE
hide url controls on checkbox check event

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -20,6 +20,14 @@ let getSafeText = (el) => {
 }
 
 export class ActionStep extends Component {
+    isUrlChecked = (step) => {
+        return step?.selection?.indexOf('url') !== -1 ? true : false
+    }
+    ckbContainer = {
+        display: 'flex',
+        minHeight: '31px',
+        alignItems: 'center',
+    }
     constructor(props) {
         super(props)
         this.state = {
@@ -138,8 +146,9 @@ export class ActionStep extends Component {
                         {selectorError ? 'Invalid selector' : `Matches ${matches} elements`}
                     </small>
                 )}
-                <label>
+                <label style={this.ckbContainer}>
                     <input
+                        style={{ marginRight: '4px' }}
                         type="checkbox"
                         name="selection"
                         checked={this.state.selection.indexOf(props.item) > -1}
@@ -271,7 +280,13 @@ export class ActionStep extends Component {
     }
     URLMatching = ({ step, isEditor }) => {
         return (
-            <div className="btn-group" style={{ margin: isEditor ? '4px 0 0 8px' : '0 0 0 8px' }}>
+            <div
+                className="btn-group"
+                style={{
+                    margin: isEditor ? '4px 0 0 8px' : '0 0 0 8px',
+                    display: this.isUrlChecked(step) ? 'block' : 'none',
+                }}
+            >
                 <button
                     onClick={() => this.sendStep({ ...step, url_matching: 'contains' })}
                     type="button"


### PR DESCRIPTION
## Changes

when editing page viewaction, there are some unnecessary buttons displayed when the url checkbox is unchecked,
![url-fix](https://user-images.githubusercontent.com/6637499/93535846-81498380-f950-11ea-8597-cac10c854bfe.gif)


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
