### PR TITLE
Clickhouse Deduplicated Elements

### DIFF
--- a/ee/clickhouse/demo.py
+++ b/ee/clickhouse/demo.py
@@ -43,17 +43,12 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
             demo_data_index += 1
             elements = [
                 Element(
-                    tag_name="a",
-                    href="/demo/1",
-                    attr_class=["btn", "btn-success"],
-                    attr_id="sign-up",
-                    text="Sign up",
-                    order=0,
+                    tag_name="a", href="/demo/1", attr_class=["btn", "btn-success"], attr_id="sign-up", text="Sign up",
                 ),
-                Element(tag_name="form", attr_class=["form"], order=1),
-                Element(tag_name="div", attr_class=["container"], order=2),
-                Element(tag_name="body", order=3),
-                Element(tag_name="html", order=4),
+                Element(tag_name="form", attr_class=["form"]),
+                Element(tag_name="div", attr_class=["container"]),
+                Element(tag_name="body"),
+                Element(tag_name="html"),
             ]
             element_hash = create_elements(elements=elements, team=team)
             create_event(
@@ -76,11 +71,11 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
             if index % 4 == 0:
 
                 elements = [
-                    Element(tag_name="button", attr_class=["btn", "btn-success"], text="Sign up!", order=0,),
-                    Element(tag_name="form", attr_class=["form"], order=1),
-                    Element(tag_name="div", attr_class=["container"], order=2),
-                    Element(tag_name="body", order=3),
-                    Element(tag_name="html", order=4),
+                    Element(tag_name="button", attr_class=["btn", "btn-success"], text="Sign up!",),
+                    Element(tag_name="form", attr_class=["form"]),
+                    Element(tag_name="div", attr_class=["container"]),
+                    Element(tag_name="body"),
+                    Element(tag_name="html"),
                 ]
                 element_hash = create_elements(elements=elements, team=team)
                 create_event(
@@ -108,11 +103,11 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
                 if index % 5 == 0:
 
                     elements = [
-                        Element(tag_name="button", attr_class=["btn", "btn-success"], text="Pay $10", order=0,),
-                        Element(tag_name="form", attr_class=["form"], order=1),
-                        Element(tag_name="div", attr_class=["container"], order=2),
-                        Element(tag_name="body", order=3),
-                        Element(tag_name="html", order=4),
+                        Element(tag_name="button", attr_class=["btn", "btn-success"], text="Pay $10",),
+                        Element(tag_name="form", attr_class=["form"]),
+                        Element(tag_name="div", attr_class=["container"]),
+                        Element(tag_name="body"),
+                        Element(tag_name="html"),
                     ]
                     element_hash = create_elements(elements=elements, team=team)
 

--- a/ee/clickhouse/demo.py
+++ b/ee/clickhouse/demo.py
@@ -50,14 +50,14 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
                 Element(tag_name="body"),
                 Element(tag_name="html"),
             ]
-            element_hash = create_elements(elements=elements, team=team)
+            elements_hash = create_elements(elements=elements, team=team)
             create_event(
                 team=team,
                 distinct_id=distinct_id,
                 event="$autocapture",
                 properties={"$current_url": base_url, "$browser": browser, "$lib": "web", "$event_type": "click",},
                 timestamp=date + relativedelta(seconds=14),
-                element_hash=element_hash,
+                elements_hash=elements_hash,
             )
 
             create_event(
@@ -77,7 +77,7 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
                     Element(tag_name="body"),
                     Element(tag_name="html"),
                 ]
-                element_hash = create_elements(elements=elements, team=team)
+                elements_hash = create_elements(elements=elements, team=team)
                 create_event(
                     team=team,
                     event="$autocapture",
@@ -89,7 +89,7 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
                         "$event_type": "click",
                     },
                     timestamp=date + relativedelta(seconds=29),
-                    element_hash=element_hash,
+                    elements_hash=elements_hash,
                 )
 
                 create_event(
@@ -109,7 +109,7 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
                         Element(tag_name="body"),
                         Element(tag_name="html"),
                     ]
-                    element_hash = create_elements(elements=elements, team=team)
+                    elements_hash = create_elements(elements=elements, team=team)
 
                     create_event(
                         team=team,
@@ -122,7 +122,7 @@ def create_anonymous_users_ch(team: Team, base_url: str) -> None:
                             "$event_type": "click",
                         },
                         timestamp=date + relativedelta(seconds=59),
-                        element_hash=element_hash,
+                        elements_hash=elements_hash,
                     )
 
                     create_event(

--- a/ee/clickhouse/migrations/0004_elements.py
+++ b/ee/clickhouse/migrations/0004_elements.py
@@ -1,7 +1,6 @@
 from infi.clickhouse_orm import migrations  # type: ignore
 
 from ee.clickhouse.sql.elements import (
-    ELEMENT_GROUP_TABLE_SQL,
     ELEMENTS_PROPERTIES_MAT,
     ELEMENTS_TABLE_SQL,
     ELEMENTS_WITH_ARRAY_PROPS,
@@ -10,7 +9,6 @@ from ee.clickhouse.sql.elements import (
 
 operations = [
     migrations.RunSQL(ELEMENTS_TABLE_SQL),
-    migrations.RunSQL(ELEMENT_GROUP_TABLE_SQL),
     migrations.RunSQL(ELEMENTS_WITH_ARRAY_PROPS),
     migrations.RunSQL(ELEMENTS_WITH_ARRAY_PROPS_MAT),
     migrations.RunSQL(ELEMENTS_PROPERTIES_MAT),

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from ee.clickhouse.client import async_execute, sync_execute
 from ee.clickhouse.sql.elements import GET_ALL_ELEMENTS_SQL, GET_ELEMENTS_BY_ELEMENTS_HASH_SQL, INSERT_ELEMENTS_SQL
+from posthog.cache import get_cache_key, set_cache_key
 from posthog.models.element import Element
 from posthog.models.element_group import hash_elements
 from posthog.models.team import Team
@@ -30,17 +31,21 @@ def create_element(element: Element, team: Team, elements_hash: str) -> None:
     )
 
 
-def create_elements(elements: List[Element], team: Team) -> str:
+def create_elements(elements: List[Element], team: Team, use_cache: bool = True) -> str:
     # create group
     for index, element in enumerate(elements):
         element.order = index
     elements_hash = hash_elements(elements)
 
-    # TODO: check if such a hash already exists
+    if use_cache and get_cache_key("@ch/elements/{}".format(elements_hash)):
+        return elements_hash
 
     # create elements
     for index, element in enumerate(elements):
         create_element(element=element, team=team, elements_hash=elements_hash)
+
+    if use_cache:
+        set_cache_key("@ch/elements/{}".format(elements_hash), "1")
 
     return elements_hash
 

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -43,13 +43,15 @@ def create_element(element: Element, team: Team, group_id: UUID) -> None:
 
 
 def create_elements(elements: List[Element], team: Team) -> str:
-
     # create group
+    for index, element in enumerate(elements):
+        element.order = index
+
     element_hash = hash_elements(elements)
     group_id = create_element_group(element_hash=element_hash, team=team)
 
     # create elements
-    for element in elements:
+    for index, element in enumerate(elements):
         create_element(element=element, team=team, group_id=group_id)
 
     return element_hash

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -73,7 +73,7 @@ class ClickhouseElementSerializer(serializers.Serializer):
     order = serializers.SerializerMethodField()
     team_id = serializers.SerializerMethodField()
     created_at = serializers.SerializerMethodField()
-    group_id = serializers.SerializerMethodField()
+    elements_hash = serializers.SerializerMethodField()
 
     def get_id(self, element):
         return element[0]
@@ -111,5 +111,5 @@ class ClickhouseElementSerializer(serializers.Serializer):
     def get_created_at(self, element):
         return element[11]
 
-    def get_group_id(self, element):
+    def get_elements_hash(self, element):
         return element[12]

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -57,14 +57,22 @@ def create_elements(elements: List[Element], team: Team) -> str:
     return elements_hash
 
 
-def get_element_group_by_hash(elements_hash: str):
-    result = sync_execute(GET_ELEMENT_GROUP_BY_HASH_SQL, {"elements_hash": elements_hash})
+def get_element_group_by_hash(elements_hash: str, team_id: int):
+    result = sync_execute(GET_ELEMENT_GROUP_BY_HASH_SQL, {"elements_hash": elements_hash, "team_id": team_id})
     return ClickhouseElementGroupSerializer(result, many=True).data
 
 
-def get_elements_by_group(group_id: UUID):
-    result = sync_execute(GET_ELEMENT_BY_GROUP_SQL, {"group_id": group_id})
+def get_elements_by_group(group_id: UUID, team_id: int):
+    result = sync_execute(GET_ELEMENT_BY_GROUP_SQL, {"group_id": group_id, "team_id": team_id})
     return ClickhouseElementSerializer(result, many=True).data
+
+
+def get_elements_by_elements_hash(elements_hash: str, team_id: int):
+    elements_group = get_element_group_by_hash(elements_hash, team_id)
+    if len(elements_group) > 0:
+        return get_elements_by_group(elements_group[0]["id"], team_id)
+
+    return []
 
 
 def get_elements():
@@ -112,7 +120,7 @@ class ClickhouseElementSerializer(serializers.Serializer):
         return element[7]
 
     def get_attributes(self, element):
-        return element[8]
+        return json.loads(element[8])
 
     def get_order(self, element):
         return element[9]

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -17,9 +17,9 @@ from posthog.models.element_group import hash_elements
 from posthog.models.team import Team
 
 
-def create_element_group(team: Team, element_hash: str) -> UUID:
+def create_element_group(team: Team, elements_hash: str) -> UUID:
     id = uuid4()
-    async_execute(INSERT_ELEMENT_GROUP_SQL, {"id": id, "element_hash": element_hash, "team_id": team.pk})
+    async_execute(INSERT_ELEMENT_GROUP_SQL, {"id": id, "elements_hash": elements_hash, "team_id": team.pk})
     return id
 
 
@@ -47,14 +47,14 @@ def create_elements(elements: List[Element], team: Team) -> str:
     for index, element in enumerate(elements):
         element.order = index
 
-    element_hash = hash_elements(elements)
-    group_id = create_element_group(element_hash=element_hash, team=team)
+    elements_hash = hash_elements(elements)
+    group_id = create_element_group(elements_hash=elements_hash, team=team)
 
     # create elements
     for index, element in enumerate(elements):
         create_element(element=element, team=team, group_id=group_id)
 
-    return element_hash
+    return elements_hash
 
 
 def get_element_group_by_hash(elements_hash: str):

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from ee.clickhouse.client import async_execute, sync_execute
 from ee.clickhouse.sql.elements import GET_ALL_ELEMENTS_SQL, GET_ELEMENTS_BY_ELEMENTS_HASH_SQL, INSERT_ELEMENTS_SQL
-from posthog.cache import get_cache_key, set_cache_key
+from posthog.cache import get_cached_value, set_cached_value
 from posthog.models.element import Element
 from posthog.models.element_group import hash_elements
 from posthog.models.team import Team
@@ -37,7 +37,7 @@ def create_elements(elements: List[Element], team: Team, use_cache: bool = True)
         element.order = index
     elements_hash = hash_elements(elements)
 
-    if use_cache and get_cache_key("@ch/elements/{}".format(elements_hash)):
+    if use_cache and get_cached_value(team.pk, "elements/{}".format(elements_hash)):
         return elements_hash
 
     # create elements
@@ -45,7 +45,7 @@ def create_elements(elements: List[Element], team: Team, use_cache: bool = True)
         create_element(element=element, team=team, elements_hash=elements_hash)
 
     if use_cache:
-        set_cache_key("@ch/elements/{}".format(elements_hash), "1")
+        set_cached_value(team.pk, "elements/{}".format(elements_hash), "1")
 
     return elements_hash
 

--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -19,7 +19,7 @@ def create_event(
     distinct_id: str,
     timestamp: Optional[Union[datetime, str]] = None,
     properties: Optional[Dict] = {},
-    element_hash: Optional[str] = "",
+    elements_hash: Optional[str] = "",
     elements: Optional[List[Element]] = None,
 ) -> None:
 
@@ -33,8 +33,8 @@ def create_event(
         timestamp = timestamp.astimezone(pytz.utc)
 
     # TODO: don't create same group twice?
-    if elements and not element_hash:
-        element_hash = create_elements(elements=elements, team=team)
+    if elements and not elements_hash:
+        elements_hash = create_elements(elements=elements, team=team)
 
     async_execute(
         INSERT_EVENT_SQL,
@@ -44,7 +44,7 @@ def create_event(
             "timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
             "team_id": team.pk,
             "distinct_id": distinct_id,
-            "element_hash": element_hash,
+            "elements_hash": elements_hash,
         },
     )
 

--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -32,7 +32,6 @@ def create_event(
     else:
         timestamp = timestamp.astimezone(pytz.utc)
 
-    # TODO: don't create same group twice?
     if elements and not elements_hash:
         elements_hash = create_elements(elements=elements, team=team)
 

--- a/ee/clickhouse/models/test/test_element.py
+++ b/ee/clickhouse/models/test/test_element.py
@@ -15,6 +15,7 @@ class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
                 Element(tag_name="div", nth_child=0, nth_of_type=0),
                 Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
             ],
+            use_cache=False,
         )
 
         self.assertEqual(len(get_all_elements()), 4)
@@ -27,6 +28,7 @@ class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
                 Element(tag_name="div", nth_child=0, nth_of_type=0),
                 Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
             ],
+            use_cache=False,
         )
 
         self.assertEqual(elements_hash_1, elements_hash_2)
@@ -49,4 +51,33 @@ class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
 
         self.assertGreater(len(get_all_elements()), 4)
         sync_execute("OPTIMIZE TABLE elements FINAL")
+        self.assertEqual(len(get_all_elements()), 4)
+
+    def test_create_cache(self) -> None:
+        self.assertEqual(len(get_all_elements()), 0)
+
+        create_elements(
+            team=self.team,
+            elements=[
+                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
+                Element(tag_name="button", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
+            ],
+            use_cache=True,
+        )
+
+        self.assertEqual(len(get_all_elements()), 4)
+
+        create_elements(
+            team=self.team,
+            elements=[
+                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
+                Element(tag_name="button", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
+            ],
+            use_cache=True,
+        )
+
         self.assertEqual(len(get_all_elements()), 4)

--- a/ee/clickhouse/models/test/test_element.py
+++ b/ee/clickhouse/models/test/test_element.py
@@ -1,0 +1,52 @@
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.element import create_elements, get_all_elements, get_elements_by_elements_hash
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.api.test.base import BaseTest
+from posthog.models import Element
+
+
+class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
+    def test_create_elements(self) -> None:
+        elements_hash_1 = create_elements(
+            team=self.team,
+            elements=[
+                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
+                Element(tag_name="button", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
+            ],
+        )
+
+        self.assertEqual(len(get_all_elements()), 4)
+
+        elements_hash_2 = create_elements(
+            team=self.team,
+            elements=[
+                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
+                Element(tag_name="button", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
+            ],
+        )
+
+        self.assertEqual(elements_hash_1, elements_hash_2)
+
+        self.assertGreater(len(get_all_elements(final=False)), 4)
+        self.assertEqual(len(get_all_elements(final=True)), 4)
+
+        elements = get_elements_by_elements_hash(elements_hash=elements_hash_1, team_id=self.team.pk)
+        self.assertEqual(len(elements), 4)
+
+        self.assertEqual(elements[0]["tag_name"], "a")
+        self.assertEqual(elements[1]["tag_name"], "button")
+        self.assertEqual(elements[2]["tag_name"], "div")
+        self.assertEqual(elements[3]["tag_name"], "div")
+
+        self.assertEqual(elements[0]["order"], 0)
+        self.assertEqual(elements[1]["order"], 1)
+        self.assertEqual(elements[2]["order"], 2)
+        self.assertEqual(elements[3]["order"], 3)
+
+        self.assertGreater(len(get_all_elements()), 4)
+        sync_execute("OPTIMIZE TABLE elements FINAL")
+        self.assertEqual(len(get_all_elements()), 4)

--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -92,7 +92,6 @@ def _capture_ee(
                 nth_child=el.get("nth_child"),
                 nth_of_type=el.get("nth_of_type"),
                 attributes={key: value for key, value in el.items() if key.startswith("attr__")},
-                order=index,
             )
             for index, el in enumerate(elements)
         ]

--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -106,7 +106,7 @@ def _capture_ee(
     store_names_and_properties(team=team, event=event, properties=properties)
 
     # determine/create elements
-    element_hash = create_elements(elements_list, team)
+    elements_hash = create_elements(elements_list, team)
 
     # # determine create events
     create_event(
@@ -114,7 +114,7 @@ def _capture_ee(
         properties=properties,
         timestamp=timestamp,
         team=team,
-        element_hash=element_hash,
+        elements_hash=elements_hash,
         distinct_id=distinct_id,
     )
 

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -140,6 +140,7 @@ class ClickhousePaths(BaseQuery):
               AND target_event IS NOT NULL
             GROUP BY source_event, target_event
             ORDER BY event_count DESC, source_event, target_event
+            LIMIT 20
         """
 
         final_query = count_query.format(

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -103,8 +103,7 @@ class ClickhousePaths(BaseQuery):
             marked_session_start="{} = %(start_point)s".format(start_comparator)
             if filter and filter.start_point
             else "new_session",
-            element_joins="JOIN elements_group ON elements_group.elements_hash = events.elements_hash\
-            JOIN elements ON (elements.group_id = elements_group.id AND elements.order = toInt32(0))"
+            element_joins="JOIN elements ON (elements.elements_hash = events.elements_hash AND elements.order = toInt32(0))"
             if event == AUTOCAPTURE_EVENT
             else "",
             excess_row_filter=excess_row_filter,

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -57,7 +57,7 @@ class ClickhousePaths(BaseQuery):
                            person_id,
                            events.id AS event_id,
                            {path_type} AS path_type
-                    FROM events
+                    FROM events_with_array_props_view AS events
                     JOIN person_distinct_id ON person_distinct_id.distinct_id = events.distinct_id
                     {element_joins}
                     WHERE events.team_id = %(team_id)s 

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -43,18 +43,10 @@ class ClickhousePaths(BaseQuery):
         for i in range(query_depth):
             if i > 0:
                 use_row += " or "
-            use_row += "(neighbor(new_session, {}, 0) = 1 and neighbor(person_id, {}) == person_id)".format(-i, -i)
+            use_row += "neighbor(new_session, {}, 0) = 1".format(-i)
+            if filter and filter.start_point:
+                use_row += " or neighbor(marked_session_start, {}, 0) = 1".format(-i)
         use_row += ")"
-
-        if filter and filter.start_point:
-            use_row += " or ("
-            for i in range(query_depth):
-                if i > 0:
-                    use_row += " or "
-                use_row += "(neighbor(marked_session_start, {}, 0) = 1 and neighbor(person_id, {}) == person_id)".format(
-                    -i, -i
-                )
-            use_row += ")"
 
         # new_session = this is 1 when the event is from a new session or
         #                       0 if it's less than 30min after and for the same person_id as the previous event

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -1,10 +1,251 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.queries.util import parse_timestamps
+from posthog.constants import AUTOCAPTURE_EVENT, CUSTOM_EVENT, SCREEN_EVENT
 from posthog.models.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.base import BaseQuery
+from posthog.utils import relative_date_parse, request_to_date_query
 
 
 class ClickhousePaths(BaseQuery):
+    # def _determine_path_type(self, requested_type=None):
+    #     # Default
+    #     event: Optional[str] = "$pageview"
+    #     event_filter = {"event": event}
+    #     path_type = "properties->> '$current_url'"
+    #     start_comparator = "{} ~".format(path_type)
+    #
+    #     # determine requested type
+    #     if requested_type:
+    #         if requested_type == SCREEN_EVENT:
+    #             event = SCREEN_EVENT
+    #             event_filter = {"event": event}
+    #             path_type = "properties->> '$screen_name'"
+    #             start_comparator = "{} ~".format(path_type)
+    #         elif requested_type == AUTOCAPTURE_EVENT:
+    #             event = AUTOCAPTURE_EVENT
+    #             event_filter = {"event": event}
+    #             path_type = "tag_name_source"
+    #             start_comparator = "group_id ="
+    #         elif requested_type == CUSTOM_EVENT:
+    #             event = None
+    #             event_filter = {}
+    #             path_type = "event"
+    #             start_comparator = "event ="
+    #     return event, path_type, event_filter, start_comparator
+    #
+    # def _apply_start_point(self, start_comparator: str, query_string: str, start_point: str) -> str:
+    #     marked = "\
+    #         SELECT *, CASE WHEN {} '{}' THEN timestamp ELSE NULL END as mark from ({}) as sessionified\
+    #     ".format(
+    #         start_comparator, start_point, query_string
+    #     )
+    #
+    #     marked_plus = "\
+    #         SELECT *, MIN(mark) OVER (\
+    #                 PARTITION BY distinct_id\
+    #                 , session ORDER BY timestamp\
+    #                 ) AS max from ({}) as marked order by session\
+    #     ".format(
+    #         marked
+    #     )
+    #
+    #     sessionified = "\
+    #         SELECT * FROM ({}) as something where timestamp >= max \
+    #     ".format(
+    #         marked_plus
+    #     )
+    #     return sessionified
+    #
+    # def _add_elements(self, query_string: str) -> str:
+    #     element = 'SELECT \'<\'|| e."tag_name" || \'> \'  || e."text" as tag_name_source, e."text" as text_source FROM "posthog_element" e JOIN \
+    #                 ( SELECT group_id, MIN("posthog_element"."order") as minOrder FROM "posthog_element" GROUP BY group_id) e2 ON e.order = e2.minOrder AND e.group_id = e2.group_id where e.group_id = v2.group_id'
+    #     element_group = 'SELECT g."id" as group_id FROM "posthog_elementgroup" g where v1."elements_hash" = g."hash"'
+    #     sessions_sql = "SELECT * FROM ({}) as v1 JOIN LATERAL ({}) as v2 on true JOIN LATERAL ({}) as v3 on true".format(
+    #         query_string, element_group, element
+    #     )
+    #     return sessions_sql
+
+    def calculate_paths(self, filter: Filter, team: Team):
+        # date_query = request_to_date_query({"date_from": filter._date_from, "date_to": filter._date_to}, exact=False)
+        # resp = []
+        # event, path_type, event_filter, start_comparator = self._determine_path_type(
+        #     filter.path_type if filter else None
+        # )
+        #
+        # sessions = (
+        #     Event.objects.add_person_id(team.pk)
+        #     .filter(team=team, **(event_filter), **date_query)
+        #     .filter(~Q(event__in=["$autocapture", "$pageview", "$identify", "$pageleave"]) if event is None else Q())
+        #     .filter(filter.properties_to_Q(team_id=team.pk) if filter and filter.properties else Q())
+        #     .annotate(
+        #         previous_timestamp=Window(
+        #             expression=Lag("timestamp", default=None),
+        #             partition_by=F("distinct_id"),
+        #             order_by=F("timestamp").asc(),
+        #         )
+        #     )
+        # )
+
+        # sessions_sql, sessions_sql_params = sessions.query.sql_with_params()
+
+        SESSIONS_QUERY = """
+            -- 2
+                SELECT distinct_id,
+                         event_id,
+                         timestamp,
+                         path_type,
+                         neighbor(distinct_id, -1) as possible_prev_distinct_id,
+                         neighbor(event_id, -1)       as possible_prev_event_id,
+                         neighbor(timestamp, -1)   as possible_prev_timestamp,
+                         if(possible_prev_distinct_id != distinct_id or
+                            dateDiff('minute', toDateTime(timestamp), toDateTime(possible_prev_timestamp)) > 30, 1,
+                            0)                     as new_session
+                  FROM (
+            -- 1
+                        SELECT timestamp,
+                               distinct_id,
+                               id as event_id,
+                               JSONExtractString(properties, %(property)s) as path_type
+                        FROM events
+                        WHERE team_id = %(team_id)s
+                          and event = %(event)s
+                        GROUP BY distinct_id, timestamp, event_id, properties
+                        ORDER BY distinct_id, timestamp
+            -- /1
+
+                           )
+            -- /2
+        """
+
+        # if event == "$autocapture":
+        #     sessions_sql = self._add_elements(query_string=sessions_sql)
+
+        # events_notated = "\
+        # SELECT *, CASE WHEN EXTRACT('EPOCH' FROM (timestamp - previous_timestamp)) >= (60 * 30) OR previous_timestamp IS NULL THEN 1 ELSE 0 END AS new_session\
+        # FROM ({}) AS inner_sessions\
+        # ".format(
+        #     sessions_sql
+        # )
+
+        # sessionified = "\
+        # SELECT events_notated.*, SUM(new_session) OVER (\
+        #     ORDER BY distinct_id\
+        #             ,timestamp\
+        #     ) AS session\
+        # FROM ({}) as events_notated\
+        # ".format(
+        #     events_notated
+        # )
+        #
+        # if filter and filter.start_point:
+        #     sessionified = self._apply_start_point(
+        #         start_comparator=start_comparator, query_string=sessionified, start_point=filter.start_point,
+        #     )
+        #
+        # final = "\
+        # SELECT {} as path_type, id, sessionified.session\
+        #     ,ROW_NUMBER() OVER (\
+        #             PARTITION BY distinct_id\
+        #             ,session ORDER BY timestamp\
+        #             ) AS event_number\
+        # FROM ({}) as sessionified\
+        # ".format(
+        #     path_type, sessionified
+        # )
+        #
+        # counts = "\
+        # SELECT event_number || '_' || path_type as target_event, id as target_id, LAG(event_number || '_' || path_type, 1) OVER (\
+        #     PARTITION BY session\
+        #     ) AS source_event , LAG(id, 1) OVER (\
+        #     PARTITION BY session\
+        #     ) AS source_id from \
+        # ({}) as final\
+        # where event_number <= 4\
+        # ".format(
+        #     final
+        # )
+
+        # cursor = connection.cursor()
+        # cursor.execute(
+        #     "\
+        # SELECT source_event, target_event, MAX(target_id), MAX(source_id), count(*) from ({}) as counts\
+        # where source_event is not null and target_event is not null\
+        # group by source_event, target_event order by count desc limit 20\
+        # ".format(
+        #         counts
+        #     ),
+        #     sessions_sql_params,
+        # )
+        # rows = cursor.fetchall()
+
+        AGGREGATE_QUERY = """
+            -- 4
+            SELECT concat(toString(group_index), '_', path_type) as target_event,
+                   event_id as target_event_id,
+                   if(group_index > 1, neighbor(concat(toString(group_index), '_', path_type), -1), null) as source_event,
+                   if(group_index > 1, neighbor(event_id, -1), null)       as source_event_id
+            FROM (
+            -- 3
+                  SELECT distinct_id,
+                         event_id,
+                         timestamp,
+                         path_type,
+                         arraySum(arraySlice(gids, 1, idx))                 AS gid,
+                         indexOf(arrayReverse(arraySlice(gids, 1, idx)), 1) as group_index
+                  FROM (
+                        SELECT groupArray(timestamp)   as timestamps,
+                               groupArray(path_type)   as path_types,
+                               groupArray(event_id)       as event_ids,
+                               groupArray(distinct_id) as distinct_ids,
+                               groupArray(new_session) AS gids
+                        FROM ({sessions_query})
+                       )
+                      ARRAY JOIN
+                       distinct_ids as distinct_id,
+                       event_ids as event_id,
+                       timestamps as timestamp,
+                       path_types as path_type,
+                       arrayEnumerate(gids) AS idx
+            -- /3
+                )
+            -- /4
+        """
+
+        COUNT_QUERY = """
+            -- 5
+            SELECT 
+                source_event, 
+                any(source_event_id) as source_event_id, 
+                target_event, 
+                any(target_event_id) as target_event_id, 
+                count(*) as event_count
+            from (
+                {aggregate_query}
+            ) 
+            where source_event is not null and target_event is not null
+            group by source_event, target_event
+            order by event_count desc, source_event, target_event
+            -- /5
+        """
+
+        FINAL_QUERY = COUNT_QUERY.format(aggregate_query=AGGREGATE_QUERY.format(sessions_query=SESSIONS_QUERY))
+
+        params = {"team_id": team.pk, "property": "$current_url", "event": "$pageview"}
+
+        resp: List[Dict[str, str]] = []
+
+        rows = sync_execute(FINAL_QUERY, params)
+
+        for row in rows:
+            resp.append(
+                {"source": row[0], "target": row[2], "target_id": row[3], "source_id": row[1], "value": row[4],}
+            )
+
+        resp = sorted(resp, key=lambda x: x["value"], reverse=True)
+        return resp
+
     def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
-        return []
+        return self.calculate_paths(filter=filter, team=team)

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1,0 +1,9 @@
+from ee.clickhouse.models.event import create_event
+from ee.clickhouse.models.person import create_person
+from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.queries.test.test_paths import paths_test_factory
+
+
+class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePaths, create_event, create_person)):  # type: ignore
+    pass

--- a/ee/clickhouse/sql/actions.py
+++ b/ee/clickhouse/sql/actions.py
@@ -34,9 +34,7 @@ ELEMENT_ACTION_FILTER = """
 (
     SELECT id FROM events WHERE 
     elements_hash IN (
-        SELECT elements_hash FROM elements_group WHERE id IN (
-            SELECT group_id from elements WHERE {element_filter}
-        ) 
+        SELECT elements_hash FROM elements WHERE {element_filter} GROUP BY elements_hash
     ) {event_filter}
 )
 """

--- a/ee/clickhouse/sql/clickhouse.py
+++ b/ee/clickhouse/sql/clickhouse.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from posthog.settings import CLICKHOUSE_ENABLE_STORAGE_POLICY, CLICKHOUSE_REPLICATION
 
 STORAGE_POLICY = "SETTINGS storage_policy = 'hot_to_cold'" if CLICKHOUSE_ENABLE_STORAGE_POLICY else ""
@@ -8,7 +10,10 @@ TABLE_ENGINE = (
 )
 
 
-def table_engine(table: str) -> str:
+def table_engine(table: str, engine_type: Optional[str] = None) -> str:
+    if engine_type == "Replacing" and not CLICKHOUSE_REPLICATION:
+        return "ReplacingMergeTree(created_at)"
+
     return TABLE_ENGINE.format(table=table)
 
 

--- a/ee/clickhouse/sql/elements.py
+++ b/ee/clickhouse/sql/elements.py
@@ -69,11 +69,11 @@ INSERT INTO elements_group SELECT %(id)s, %(elements_hash)s, %(team_id)s
 """
 
 GET_ELEMENT_GROUP_BY_HASH_SQL = """
-SELECT * FROM elements_group where elements_hash = %(elements_hash)s
+SELECT * FROM elements_group where elements_hash = %(elements_hash)s and team_id=%(team_id)s
 """
 
 GET_ELEMENT_BY_GROUP_SQL = """
-SELECT * FROM elements where group_id = %(group_id)s order by order ASC
+SELECT * FROM elements where group_id = %(group_id)s and team_id=%(team_id)s order by order ASC
 """
 
 GET_ELEMENTS_SQL = """

--- a/ee/clickhouse/sql/elements.py
+++ b/ee/clickhouse/sql/elements.py
@@ -139,3 +139,16 @@ array_attribute_values as value
 from elements_with_array_props_view
 ARRAY JOIN array_attribute_keys, array_attribute_values
 """
+
+ELEMENT_TAG_COUNT = """
+SELECT concat('<', elements.tag_name, '> ', elements.text) AS tag_name,
+       events.elements_hash as tag_hash,
+       count(*) as tag_count
+FROM events
+JOIN elements_group ON elements_group.elements_hash = events.elements_hash
+JOIN elements ON (elements.group_id = elements_group.id AND elements.order = toInt32(0))
+WHERE events.team_id = %(team_id)s AND event = '$autocapture'
+GROUP BY tag_name, tag_hash
+ORDER BY tag_count desc, tag_name
+LIMIT %(limit)s
+"""

--- a/ee/clickhouse/sql/elements.py
+++ b/ee/clickhouse/sql/elements.py
@@ -65,7 +65,7 @@ ORDER BY (team_id, id)
 
 
 INSERT_ELEMENT_GROUP_SQL = """
-INSERT INTO elements_group SELECT %(id)s, %(element_hash)s, %(team_id)s
+INSERT INTO elements_group SELECT %(id)s, %(elements_hash)s, %(team_id)s
 """
 
 GET_ELEMENT_GROUP_BY_HASH_SQL = """

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -37,7 +37,7 @@ SAMPLE BY id
 )
 
 INSERT_EVENT_SQL = """
-INSERT INTO events SELECT generateUUIDv4(), %(event)s, %(properties)s, %(timestamp)s, %(team_id)s, %(distinct_id)s, %(element_hash)s, now()
+INSERT INTO events SELECT generateUUIDv4(), %(event)s, %(properties)s, %(timestamp)s, %(team_id)s, %(distinct_id)s, %(elements_hash)s, now()
 """
 
 GET_EVENTS_SQL = """

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -119,6 +119,10 @@ WHERE id IN
 ) {conditions} {limit}
 """
 
+SELECT_ONE_EVENT_SQL = """
+SELECT * FROM events_with_array_props_view WHERE id = %(event_id)s AND team_id = %(team_id)s
+"""
+
 EVENT_PROP_CLAUSE = """
 SELECT event_id
 FROM events_properties_view AS ep

--- a/ee/clickhouse/test/test_process_event_ee.py
+++ b/ee/clickhouse/test/test_process_event_ee.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from django.utils.timezone import now
 
-from ee.clickhouse.models.element import get_element_group_by_hash, get_elements, get_elements_by_group
+from ee.clickhouse.models.element import get_all_elements, get_elements_by_elements_hash
 from ee.clickhouse.models.event import get_events
 from ee.clickhouse.models.person import create_person, get_person_by_distinct_id, get_person_distinct_ids, get_persons
 from ee.clickhouse.process_event import process_event_ee
@@ -46,8 +46,7 @@ class ClickhouseProcessEvent(ClickhouseTestMixin, BaseTest):
         events = get_events()
 
         self.assertEqual(events[0]["event"], "$autocapture")
-        group = get_element_group_by_hash(elements_hash=events[0]["elements_hash"], team_id=team_id)
-        elements = get_elements_by_group(group_id=group[0]["id"], team_id=team_id)
+        elements = get_elements_by_elements_hash(elements_hash=events[0]["elements_hash"], team_id=team_id)
         self.assertEqual(elements[0]["tag_name"], "a")
         self.assertEqual(elements[0]["attr_class"], ["btn", "btn-sm"])
         self.assertEqual(elements[1]["order"], 1)
@@ -460,7 +459,7 @@ class ClickhouseProcessEvent(ClickhouseTestMixin, BaseTest):
             now().isoformat(),
         )
 
-        elements = get_elements()
+        elements = get_all_elements()
 
         self.assertEqual(len(elements[0]["href"]), 2048)
         self.assertEqual(len(elements[0]["text"]), 400)

--- a/ee/clickhouse/test/test_process_event_ee.py
+++ b/ee/clickhouse/test/test_process_event_ee.py
@@ -46,8 +46,8 @@ class ClickhouseProcessEvent(ClickhouseTestMixin, BaseTest):
         events = get_events()
 
         self.assertEqual(events[0]["event"], "$autocapture")
-        group = get_element_group_by_hash(elements_hash=events[0]["elements_hash"])
-        elements = get_elements_by_group(group_id=group[0]["id"])
+        group = get_element_group_by_hash(elements_hash=events[0]["elements_hash"], team_id=team_id)
+        elements = get_elements_by_group(group_id=group[0]["id"], team_id=team_id)
         self.assertEqual(elements[0]["tag_name"], "a")
         self.assertEqual(elements[0]["attr_class"], ["btn", "btn-sm"])
         self.assertEqual(elements[1]["order"], 1)

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -1,10 +1,5 @@
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.sql.elements import (
-    DROP_ELEMENTS_GROUP_TABLE_SQL,
-    DROP_ELEMENTS_TABLE_SQL,
-    ELEMENT_GROUP_TABLE_SQL,
-    ELEMENTS_TABLE_SQL,
-)
+from ee.clickhouse.sql.elements import DROP_ELEMENTS_TABLE_SQL, ELEMENTS_TABLE_SQL
 from ee.clickhouse.sql.events import (
     DROP_EVENTS_TABLE_SQL,
     DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
@@ -27,13 +22,11 @@ class ClickhouseTestMixin:
     def tearDown(self):
         self._destroy_event_tables()
         sync_execute(DROP_ELEMENTS_TABLE_SQL)
-        sync_execute(DROP_ELEMENTS_GROUP_TABLE_SQL)
         sync_execute(DROP_PERSON_TABLE_SQL)
         sync_execute(DROP_PERSON_DISTINCT_ID_TABLE_SQL)
 
         self._create_event_tables()
         sync_execute(ELEMENTS_TABLE_SQL)
-        sync_execute(ELEMENT_GROUP_TABLE_SQL)
         sync_execute(PERSONS_TABLE_SQL)
         sync_execute(PERSONS_DISTINCT_ID_TABLE_SQL)
 

--- a/ee/clickhouse/views/__init__.py
+++ b/ee/clickhouse/views/__init__.py
@@ -1,4 +1,5 @@
 from .actions import ClickhouseActions
 from .events import ClickhouseEvents
 from .insights import ClickhouseInsights
+from .paths import ClickhousePathsViewSet
 from .person import ClickhousePerson

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.event import ClickhouseEventSerializer, determine_event_conditions
 from ee.clickhouse.models.property import get_property_values_for_key, parse_filter
-from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_EVENT_WITH_PROP_SQL
+from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_EVENT_WITH_PROP_SQL, SELECT_ONE_EVENT_SQL
 from posthog.models.filter import Filter
 from posthog.utils import convert_property_value
 
@@ -39,8 +39,11 @@ class ClickhouseEvents(viewsets.ViewSet):
         return Response({"next": None, "results": result})
 
     def retrieve(self, request, pk=None):
-        # TODO: implement retrieve event by id
-        return Response([])
+        # TODO: implement getting elements
+        team = request.user.team_set.get()
+        query_result = sync_execute(SELECT_ONE_EVENT_SQL, {"team_id": team.pk, "event_id": pk},)
+        result = ClickhouseEventSerializer(query_result[0], many=False).data
+        return Response(result)
 
     @action(methods=["GET"], detail=False)
     def values(self, request: Request) -> Response:

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -15,7 +17,6 @@ class ClickhouseEvents(viewsets.ViewSet):
     serializer_class = ClickhouseEventSerializer
 
     def list(self, request):
-
         team = request.user.team_set.get()
         filter = Filter(request=request)
         limit = "LIMIT 100" if not filter._date_from and not filter._date_to else ""
@@ -48,4 +49,4 @@ class ClickhouseEvents(viewsets.ViewSet):
         result = []
         if key:
             result = get_property_values_for_key(key, team)
-        return Response([{"name": convert_property_value(value[0])} for value in result])
+        return Response([{"name": json.loads(convert_property_value(value[0]))} for value in result])

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
 from ee.clickhouse.queries.clickhouse_sessions import ClickhouseSessions
 from ee.clickhouse.queries.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.clickhouse_trends import ClickhouseTrends
@@ -33,3 +34,10 @@ class ClickhouseInsights(InsightViewSet):
         filter = Filter(request=request)
         response = ClickhouseSessions().run(team=team, filter=filter)
         return Response({"result": response})
+
+    @action(methods=["GET"], detail=False)
+    def path(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        team = request.user.team_set.get()
+        filter = Filter(request=request)
+        resp = ClickhousePaths().run(filter=filter, team=team)
+        return Response(resp)

--- a/ee/clickhouse/views/paths.py
+++ b/ee/clickhouse/views/paths.py
@@ -1,0 +1,30 @@
+from django.db import connection
+from rest_framework import request, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
+from posthog.api.paths import PathsViewSet
+from posthog.models import Filter
+from posthog.utils import request_to_date_query
+
+
+# At the moment, paths don't support users changing distinct_ids midway through.
+# See: https://github.com/PostHog/posthog/issues/185
+class ClickhousePathsViewSet(PathsViewSet):
+    @action(methods=["GET"], detail=False)
+    def elements(self, request: request.Request):
+        return []
+
+    # FIXME: Timestamp is timezone aware timestamp, date range uses naive date.
+    # To avoid unexpected results should convert date range to timestamps with timezone.
+    def list(self, request):
+        team = request.user.team_set.get()
+        date_query = request_to_date_query(request.GET, exact=False)
+        filter = Filter(request=request)
+        start_point = request.GET.get("start")
+        request_type = request.GET.get("type", None)
+        resp = ClickhousePaths().run(
+            filter=filter, start_point=start_point, date_query=date_query, request_type=request_type, team=team
+        )
+        return Response(resp)

--- a/frontend/src/scenes/events/EventElements.js
+++ b/frontend/src/scenes/events/EventElements.js
@@ -5,7 +5,7 @@ function indent(n) {
 }
 
 export function EventElements({ event }) {
-    let elements = [...event.elements].reverse()
+    let elements = [...(event.elements || [])].reverse()
     elements = elements.slice(Math.max(elements.length - 10, 1))
 
     return (

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -57,7 +57,7 @@ export function Paths() {
     const { paths, filter, pathsLoading } = useValues(pathsLogic)
 
     const [modalVisible, setModalVisible] = useState(false)
-    const [eventelements, setEventelements] = useState(null)
+    const [event, setEvent] = useState(null)
 
     useEffect(() => {
         renderPaths()
@@ -191,9 +191,9 @@ export function Paths() {
             .on('click', async (node) => {
                 if (filter.path_type == AUTOCAPTURE) {
                     setModalVisible(true)
-                    setEventelements(null)
+                    setEvent(null)
                     let result = await api.get('api/event/' + node.id)
-                    setEventelements(result)
+                    setEvent(result)
                 }
             })
             .style('cursor', filter.path_type == AUTOCAPTURE ? 'pointer' : 'auto')
@@ -238,7 +238,7 @@ export function Paths() {
                     </Button>,
                 ]}
                 bodyStyle={
-                    !eventelements
+                    !event
                         ? {
                               alignItems: 'center',
                               justifyContent: 'center',
@@ -246,7 +246,7 @@ export function Paths() {
                         : {}
                 }
             >
-                {eventelements ? <EventElements event={eventelements}></EventElements> : <Spin />}
+                {event ? <EventElements event={event}></EventElements> : <Spin />}
             </Modal>
         </div>
     )

--- a/frontend/src/scenes/paths/pathsLogic.js
+++ b/frontend/src/scenes/paths/pathsLogic.js
@@ -2,7 +2,6 @@ import { kea } from 'kea'
 import { toParams, objectsEqual } from 'lib/utils'
 import api from 'lib/api'
 import { router } from 'kea-router'
-import lo from 'lodash'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
 
@@ -102,19 +101,18 @@ export const pathsLogic = kea({
                 let result = {
                     insight: ViewType.PATHS,
                 }
-                if (!lo.isEmpty(properties)) {
+                if (properties && properties.length > 0) {
                     result['properties'] = properties
                 }
 
-                if (!lo.isEmpty(filter)) {
+                if (filter && Object.keys(filter).length > 0) {
                     result = {
                         ...result,
                         ...filter,
                     }
                 }
 
-                if (lo.isEmpty(result)) return ''
-                return result
+                return Object.keys(result).length === 0 ? '' : result
             },
         ],
     }),

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -44,20 +44,27 @@ router.register(r"funnel", funnel.FunnelViewSet)
 router.register(r"dashboard", dashboard.DashboardsViewSet)
 router.register(r"dashboard_item", dashboard.DashboardItemsViewSet)
 router.register(r"cohort", cohort.CohortViewSet)
-router.register(r"paths", paths.PathsViewSet, basename="paths")
 router.register(r"personal_api_keys", personal_api_key.PersonalAPIKeyViewSet, basename="personal_api_keys")
 router.register(r"team/user", team_user.TeamUserViewSet)
 
 if check_ee_enabled():
     try:
-        from ee.clickhouse.views import ClickhouseActions, ClickhouseEvents, ClickhouseInsights, ClickhousePerson
+        from ee.clickhouse.views import (
+            ClickhouseActions,
+            ClickhouseEvents,
+            ClickhouseInsights,
+            ClickhousePathsViewSet,
+            ClickhousePerson,
+        )
 
         # router.register(r"action", ClickhouseActions, basename="action")
         # router.register(r"event", ClickhouseEvents, basename="event")
         router.register(r"insight", ClickhouseInsights, basename="insight")
+        router.register(r"paths", ClickhousePathsViewSet, basename="paths")
         # router.register(r"person", ClickhousePerson, basename="person")
 
     except ImportError:
         print("Clickhouse enabled but missing enterprise capabilities. Defaulting to postgres")
 else:
     router.register(r"insight", insight.InsightViewSet)
+    router.register(r"paths", paths.PathsViewSet, basename="paths")

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -35,7 +35,6 @@ def api_not_found(request):
 
 router = OptionalTrailingSlashRouter()
 router.register(r"annotation", annotation.AnnotationsViewSet)
-router.register(r"event", event.EventViewSet)
 router.register(r"element", element.ElementViewSet)
 router.register(r"person", person.PersonViewSet)
 router.register(r"action", action.ActionViewSet)
@@ -58,7 +57,7 @@ if check_ee_enabled():
         )
 
         # router.register(r"action", ClickhouseActions, basename="action")
-        # router.register(r"event", ClickhouseEvents, basename="event")
+        router.register(r"event", ClickhouseEvents, basename="event")
         router.register(r"insight", ClickhouseInsights, basename="insight")
         router.register(r"paths", ClickhousePathsViewSet, basename="paths")
         # router.register(r"person", ClickhousePerson, basename="person")
@@ -67,4 +66,5 @@ if check_ee_enabled():
         print("Clickhouse enabled but missing enterprise capabilities. Defaulting to postgres")
 else:
     router.register(r"insight", insight.InsightViewSet)
+    router.register(r"event", event.EventViewSet)
     router.register(r"paths", paths.PathsViewSet, basename="paths")

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -8,8 +8,6 @@ from posthog.queries import paths
 from posthog.utils import dict_from_cursor_fetchall, request_to_date_query
 
 
-# At the moment, paths don't support users changing distinct_ids midway through.
-# See: https://github.com/PostHog/posthog/issues/185
 class PathsViewSet(viewsets.ViewSet):
     @action(methods=["GET"], detail=False)
     def elements(self, request: request.Request):
@@ -21,7 +19,7 @@ class PathsViewSet(viewsets.ViewSet):
         elements_readble = '\
             SELECT tag_name_source as name, group_id as id FROM (SELECT \'<\' || e."tag_name" || \'> \'  || e."text" as tag_name_source, e."text" as text_source, e.group_id FROM "posthog_element" e\
                 JOIN ( SELECT group_id, MIN("posthog_element"."order") as minOrder FROM "posthog_element" GROUP BY group_id) e2 ON e.order = e2.minOrder AND e.group_id = e2.group_id) as element\
-                JOIN (SELECT id, hash, count FROM posthog_elementgroup  as g JOIN (SELECT count(*), elements_hash from ({}) as a group by elements_hash) as e on g.hash = e.elements_hash) as outer_group ON element.group_id = outer_group.id  where text_source <> \'\' order by count DESC limit 20\
+                JOIN (SELECT id, hash, count FROM posthog_elementgroup  as g JOIN (SELECT count(*), elements_hash from ({}) as a group by elements_hash) as e on g.hash = e.elements_hash) as outer_group ON element.group_id = outer_group.id  where text_source <> \'\' order by count DESC, name limit 20\
         '.format(
             all_events_SQL
         )

--- a/posthog/api/test/base.py
+++ b/posthog/api/test/base.py
@@ -1,6 +1,7 @@
 from django.test import Client, TestCase, TransactionTestCase
 from rest_framework.test import APITestCase
 
+from posthog.cache import clear_cache
 from posthog.models import Team, User
 
 
@@ -17,6 +18,7 @@ class TestMixin:
 
     def setUp(self):
         super().setUp()  # type: ignore
+        clear_cache()
         self.team: Team = Team.objects.create(api_token="token123")
         if self.TESTS_API:
             self.client = Client()

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -28,7 +28,7 @@ class TestCreateAction(BaseTest):
         Event.objects.create(
             team=self.team,
             event="$autocapture",
-            elements=[Element(tag_name="button", order=0, text="sign up NOW"), Element(tag_name="div", order=1),],
+            elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div"),],
         )
         response = self.client.post(
             "/api/action/",
@@ -63,7 +63,7 @@ class TestCreateAction(BaseTest):
             team=self.team,
             event="$autocapture",
             properties={"$browser": "Chrome"},
-            elements=[Element(tag_name="button", order=0, text="sign up NOW"), Element(tag_name="div", order=1),],
+            elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div"),],
         )
         response = self.client.patch(
             "/api/action/%s/" % action.pk,

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -11,6 +11,18 @@ from .base import BaseTest
 class TestElement(BaseTest):
     TESTS_API = True
 
+    def test_element_automatic_order(self):
+        elements = [
+            Element(tag_name="a", href="https://posthog.com/about", text="click here"),
+            Element(tag_name="span"),
+            Element(tag_name="div"),
+        ]
+        ElementGroup.objects.create(team=self.team, elements=elements)
+
+        self.assertEqual(elements[0].order, 0)
+        self.assertEqual(elements[1].order, 1)
+        self.assertEqual(elements[2].order, 2)
+
     def test_event_property_values(self):
         group = ElementGroup.objects.create(
             team=self.team, elements=[Element(tag_name="a", href="https://posthog.com/about", text="click here")],

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -67,7 +67,7 @@ class TestElement(BaseTest):
             team=self.team,
             event="$autocapture",
             properties={"$current_url": "http://example.com/something_else"},
-            elements=[Element(tag_name="img", order=0)],
+            elements=[Element(tag_name="img")],
         )
 
         with self.assertNumQueries(6):

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -20,7 +20,7 @@ class TestEvents(TransactionBaseTest):
             team=self.team,
             distinct_id="2",
             properties={"$ip": "8.8.8.8"},
-            elements=[Element(tag_name="button", text="something")],
+            elements=[Element(tag_name="button", text="something"), Element(tag_name="div")],
         )
         Event.objects.create(team=self.team, distinct_id="some-random-uid", properties={"$ip": "8.8.8.8"})
         Event.objects.create(team=self.team, distinct_id="some-other-one", properties={"$ip": "8.8.8.8"})
@@ -29,6 +29,8 @@ class TestEvents(TransactionBaseTest):
             response = self.client.get("/api/event/?distinct_id=2").json()
         self.assertEqual(response["results"][0]["person"], "tim@posthog.com")
         self.assertEqual(response["results"][0]["elements"][0]["tag_name"], "button")
+        self.assertEqual(response["results"][0]["elements"][0]["order"], 0)
+        self.assertEqual(response["results"][0]["elements"][1]["order"], 1)
 
     def test_filter_events_by_event_name(self):
         person = Person.objects.create(
@@ -100,9 +102,8 @@ class TestEvents(TransactionBaseTest):
                     text="Watch now",
                     attr_id="something",
                     href="/movie",
-                    order=0,
                 ),
-                Element(tag_name="div", href="/movie", order=1),
+                Element(tag_name="div", href="/movie"),
             ],
         )
         return sign_up
@@ -140,10 +141,7 @@ class TestEvents(TransactionBaseTest):
             distinct_id="stopped_after_pay",
             properties={"$current_url": "http://whatever.com"},
             team=self.team,
-            elements=[
-                Element(tag_name="blabla", href="/moviedd", order=0),
-                Element(tag_name="blabla", href="/moviedd", order=1),
-            ],
+            elements=[Element(tag_name="blabla", href="/moviedd"), Element(tag_name="blabla", href="/moviedd"),],
         )
         last_event = Event.objects.create(
             distinct_id="stopped_after_pay", properties={"$current_url": "http://whatever.com"}, team=self.team,

--- a/posthog/cache.py
+++ b/posthog/cache.py
@@ -13,7 +13,7 @@ elif settings.REDIS_URL:
 
 
 def get_cache_key(team_id: int, key: str) -> str:
-    "@c/{}/{}".format(team_id, key)
+    return "@c/{}/{}".format(team_id, key)
 
 
 def get_cached_value(team_id: int, key: str) -> Optional[str]:

--- a/posthog/cache.py
+++ b/posthog/cache.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import fakeredis
 import redis
 from django.conf import settings
@@ -10,15 +12,19 @@ elif settings.REDIS_URL:
     redis_instance = redis.from_url(settings.REDIS_URL, db=0)
 
 
-def get_cache_key(key: str):
-    return redis_instance.get(key)
+def get_cache_key(team_id: int, key: str) -> str:
+    "@c/{}/{}".format(team_id, key)
 
 
-def set_cache_key(key: str, value: str):
-    return redis_instance.set(key, value)
+def get_cached_value(team_id: int, key: str) -> Optional[str]:
+    return redis_instance.get(get_cache_key(team_id, key))
 
 
-def clear_cache():
+def set_cached_value(team_id: int, key: str, value: str) -> None:
+    redis_instance.set(get_cache_key(team_id, key), value)
+
+
+def clear_cache() -> None:
     if not settings.TEST and not settings.DEBUG:
         raise ("Can only clear redis cache in TEST or DEBUG mode!")
 

--- a/posthog/cache.py
+++ b/posthog/cache.py
@@ -1,0 +1,25 @@
+import fakeredis
+import redis
+from django.conf import settings
+
+redis_instance = None
+
+if settings.TEST:
+    redis_instance = fakeredis.FakeStrictRedis()
+elif settings.REDIS_URL:
+    redis_instance = redis.from_url(settings.REDIS_URL, db=0)
+
+
+def get_cache_key(key: str):
+    return redis_instance.get(key)
+
+
+def set_cache_key(key: str, value: str):
+    return redis_instance.set(key, value)
+
+
+def clear_cache():
+    if not settings.TEST and not settings.DEBUG:
+        raise ("Can only clear redis cache in TEST or DEBUG mode!")
+
+    redis_instance.flushdb()

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -70,12 +70,11 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                         attr_class=["btn", "btn-success"],
                         attr_id="sign-up",
                         text="Sign up",
-                        order=0,
                     ),
-                    Element(tag_name="form", attr_class=["form"], order=1),
-                    Element(tag_name="div", attr_class=["container"], order=2),
-                    Element(tag_name="body", order=3),
-                    Element(tag_name="html", order=4),
+                    Element(tag_name="form", attr_class=["form"]),
+                    Element(tag_name="div", attr_class=["container"]),
+                    Element(tag_name="body"),
+                    Element(tag_name="html"),
                 ],
             )
             events.append(
@@ -100,11 +99,11 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                     },
                     timestamp=date + relativedelta(seconds=29),
                     elements=[
-                        Element(tag_name="button", attr_class=["btn", "btn-success"], text="Sign up!", order=0,),
-                        Element(tag_name="form", attr_class=["form"], order=1),
-                        Element(tag_name="div", attr_class=["container"], order=2),
-                        Element(tag_name="body", order=3),
-                        Element(tag_name="html", order=4),
+                        Element(tag_name="button", attr_class=["btn", "btn-success"], text="Sign up!",),
+                        Element(tag_name="form", attr_class=["form"]),
+                        Element(tag_name="div", attr_class=["container"]),
+                        Element(tag_name="body"),
+                        Element(tag_name="html"),
                     ],
                 )
                 events.append(
@@ -129,11 +128,11 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                         },
                         timestamp=date + relativedelta(seconds=59),
                         elements=[
-                            Element(tag_name="button", attr_class=["btn", "btn-success"], text="Pay $10", order=0,),
-                            Element(tag_name="form", attr_class=["form"], order=1),
-                            Element(tag_name="div", attr_class=["container"], order=2),
-                            Element(tag_name="body", order=3),
-                            Element(tag_name="html", order=4),
+                            Element(tag_name="button", attr_class=["btn", "btn-success"], text="Pay $10",),
+                            Element(tag_name="form", attr_class=["form"]),
+                            Element(tag_name="div", attr_class=["container"]),
+                            Element(tag_name="body"),
+                            Element(tag_name="html"),
                         ],
                     )
                     events.append(

--- a/posthog/models/element_group.py
+++ b/posthog/models/element_group.py
@@ -22,6 +22,8 @@ class ElementGroupManager(models.Manager):
     def create(self, *args: Any, **kwargs: Any):
         elements = kwargs.pop("elements")
         with transaction.atomic():
+            for index, element in enumerate(elements):
+                element.order = index
             kwargs["hash"] = hash_elements(elements)
             try:
                 with transaction.atomic():
@@ -30,9 +32,8 @@ class ElementGroupManager(models.Manager):
                 return ElementGroup.objects.get(
                     hash=kwargs["hash"], team_id=kwargs["team"].pk if kwargs.get("team") else kwargs["team_id"],
                 )
-            for element in elements:
+            for index, element in enumerate(elements):
                 element.group = group
-            for element in elements:
                 setattr(element, "pk", None)
             Element.objects.bulk_create(elements)
             return group

--- a/posthog/queries/paths.py
+++ b/posthog/queries/paths.py
@@ -52,7 +52,7 @@ class Paths(BaseQuery):
 
         marked_plus = "\
             SELECT *, MIN(mark) OVER (\
-                    PARTITION BY distinct_id\
+                    PARTITION BY person_id\
                     , session ORDER BY timestamp\
                     ) AS max from ({}) as marked order by session\
         ".format(
@@ -94,7 +94,7 @@ class Paths(BaseQuery):
             .annotate(
                 previous_timestamp=Window(
                     expression=Lag("timestamp", default=None),
-                    partition_by=F("distinct_id"),
+                    partition_by=F("person_id"),
                     order_by=F("timestamp").asc(),
                 )
             )
@@ -114,7 +114,7 @@ class Paths(BaseQuery):
 
         sessionified = "\
         SELECT events_notated.*, SUM(new_session) OVER (\
-            ORDER BY distinct_id\
+            ORDER BY person_id\
                     ,timestamp\
             ) AS session\
         FROM ({}) as events_notated\
@@ -130,7 +130,7 @@ class Paths(BaseQuery):
         final = "\
         SELECT {} as path_type, id, sessionified.session\
             ,ROW_NUMBER() OVER (\
-                    PARTITION BY distinct_id\
+                    PARTITION BY person_id\
                     ,session ORDER BY timestamp\
                     ) AS event_number\
         FROM ({}) as sessionified\

--- a/posthog/queries/paths.py
+++ b/posthog/queries/paths.py
@@ -85,7 +85,11 @@ class Paths(BaseQuery):
         sessions = (
             Event.objects.add_person_id(team.pk)
             .filter(team=team, **(event_filter), **date_query)
-            .filter(~Q(event__in=["$autocapture", "$pageview", "$identify", "$pageleave"]) if event is None else Q())
+            .filter(
+                ~Q(event__in=["$autocapture", "$pageview", "$identify", "$pageleave", "$screen"])
+                if event is None
+                else Q()
+            )
             .filter(filter.properties_to_Q(team_id=team.pk) if filter and filter.properties else Q())
             .annotate(
                 previous_timestamp=Window(

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -196,10 +196,10 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team,
                 distinct_id="person_1",
                 elements=[
-                    Element(tag_name="a", text="hello", href="/a-url", nth_child=1, nth_of_type=0, order=0,),
-                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=1),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3, attr_id="nested",),
+                    Element(tag_name="a", text="hello", href="/a-url", nth_child=1, nth_of_type=0),
+                    Element(tag_name="button", nth_child=0, nth_of_type=0),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
                 ],
             )
 
@@ -208,10 +208,10 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team,
                 distinct_id="person_1",
                 elements=[
-                    Element(tag_name="a", text="goodbye", nth_child=2, nth_of_type=0, order=0, attr_id="someId",),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
+                    Element(tag_name="a", text="goodbye", nth_child=2, nth_of_type=0, attr_id="someId",),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0),
                     # make sure elements don't get double counted if they're part of the same event
-                    Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=2),
+                    Element(href="/a-url-2", nth_child=0, nth_of_type=0),
                 ],
             )
 
@@ -221,10 +221,10 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team,
                 distinct_id="person_2",
                 elements=[
-                    Element(tag_name="a", text="hello1", href="/a-url", nth_child=1, nth_of_type=0, order=0,),
-                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=1),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3, attr_id="nested",),
+                    Element(tag_name="a", text="hello1", href="/a-url", nth_child=1, nth_of_type=0,),
+                    Element(tag_name="button", nth_child=0, nth_of_type=0),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
                 ],
             )
 
@@ -233,10 +233,10 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team,
                 distinct_id="person_2",
                 elements=[
-                    Element(tag_name="a", text="goodbye1", nth_child=2, nth_of_type=0, order=0, attr_id="someId",),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
+                    Element(tag_name="a", text="goodbye1", nth_child=2, nth_of_type=0, attr_id="someId",),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0),
                     # make sure elements don't get double counted if they're part of the same event
-                    Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=2),
+                    Element(href="/a-url-2", nth_child=0, nth_of_type=0),
                 ],
             )
             response = paths().run(team=self.team, filter=Filter(data={"path_type": "$autocapture"}))

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -402,11 +402,11 @@ def paths_test_factory(paths, event_factory, person_factory):
 
             self.assertEqual(len(response), 5)
 
-            self.assertTrue(response[0].items() > {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
-            self.assertTrue(response[1].items() > {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
-            self.assertTrue(response[2].items() > {"source": "2_/", "target": "3_/about", "value": 1}.items())
-            self.assertTrue(response[3].items() > {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
-            self.assertTrue(response[4].items() > {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
+            self.assertTrue(response[0].items() >= {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
+            self.assertTrue(response[1].items() >= {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
+            self.assertTrue(response[2].items() >= {"source": "2_/", "target": "3_/about", "value": 1}.items())
+            self.assertTrue(response[3].items() >= {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
+            self.assertTrue(response[4].items() >= {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
 
         def test_paths_in_window(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person_1"])

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -360,25 +360,33 @@ def paths_test_factory(paths, event_factory, person_factory):
                 properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
             )
 
+            person_factory(team_id=self.team.pk, distinct_ids=["person_5"])
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_5", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/about"}, distinct_id="person_5", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_5", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/help"}, distinct_id="person_5", event="$pageview", team=self.team,
+            )
+
             response = self.client.get("/api/paths/?type=%24pageview&start=%2Fpricing").json()
 
             response = paths().run(
                 team=self.team, filter=Filter(data={"path_type": "$pageview", "start_point": "/pricing"}),
             )
 
-            self.assertEqual(len(response), 3)
+            self.assertEqual(len(response), 5)
 
-            self.assertEqual(response[0]["source"], "1_/pricing")
-            self.assertEqual(response[0]["target"], "2_/")
-            self.assertEqual(response[0]["value"], 1)
-
-            self.assertEqual(response[1]["source"], "1_/pricing")
-            self.assertEqual(response[1]["target"], "2_/about")
-            self.assertEqual(response[1]["value"], 1)
-
-            self.assertEqual(response[2]["source"], "2_/")
-            self.assertEqual(response[2]["target"], "3_/about")
-            self.assertEqual(response[2]["value"], 1)
+            self.assertTrue(response[0].items() > {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
+            self.assertTrue(response[1].items() > {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
+            self.assertTrue(response[2].items() > {"source": "2_/", "target": "3_/about", "value": 1}.items())
+            self.assertTrue(response[3].items() > {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
+            self.assertTrue(response[4].items() > {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
 
         def test_paths_in_window(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person_1"])

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -363,6 +363,8 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team, filter=Filter(data={"path_type": "$pageview", "start_point": "/pricing"}),
             )
 
+            self.assertGreaterEqual(len(response), 0)
+
             for item in response:
                 self.assertEqual(item["source"], "1_/pricing")
 

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -348,6 +348,9 @@ def paths_test_factory(paths, event_factory, person_factory):
             event_factory(
                 properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
             )
+            event_factory(
+                properties={"$current_url": "/about"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
 
             person_factory(team_id=self.team.pk, distinct_ids=["person_4"])
             event_factory(
@@ -363,10 +366,19 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team, filter=Filter(data={"path_type": "$pageview", "start_point": "/pricing"}),
             )
 
-            self.assertGreaterEqual(len(response), 0)
+            self.assertEqual(len(response), 3)
 
-            for item in response:
-                self.assertEqual(item["source"], "1_/pricing")
+            self.assertEqual(response[0]["source"], "1_/pricing")
+            self.assertEqual(response[0]["target"], "2_/")
+            self.assertEqual(response[0]["value"], 1)
+
+            self.assertEqual(response[1]["source"], "1_/pricing")
+            self.assertEqual(response[1]["target"], "2_/about")
+            self.assertEqual(response[1]["value"], 1)
+
+            self.assertEqual(response[2]["source"], "2_/")
+            self.assertEqual(response[2]["target"], "3_/about")
+            self.assertEqual(response[2]["value"], 1)
 
         def test_paths_in_window(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person_1"])

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -8,386 +8,393 @@ from posthog.queries.paths import Paths
 from posthog.utils import request_to_date_query
 
 
-class TestPaths(BaseTest):
-    TESTS_API = True
+def paths_test_factory(paths, event_factory, person_factory):
+    class TestPaths(BaseTest):
+        TESTS_API = True
 
-    def test_current_url_paths_and_logic(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=["person_1"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
-        )
-
-        person2 = Person.objects.create(team=self.team, distinct_ids=["person_2"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_2", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_3"])
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_4"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
-        )
-        filter = Filter(data={"date_from": "-7d"})
-        response = Paths().run(team=self.team, filter=filter)
-        self.assertEqual(response[0]["source"], "1_/", response)
-        self.assertEqual(response[0]["target"], "2_/pricing")
-        self.assertEqual(response[0]["value"], 2)
-
-        self.assertEqual(response[1]["source"], "1_/")
-        self.assertEqual(response[1]["target"], "2_/about")
-        self.assertEqual(response[1]["value"], 1)
-
-        self.assertEqual(response[2]["source"], "1_/pricing")
-        self.assertEqual(response[2]["target"], "2_/")
-        self.assertEqual(response[2]["value"], 1)
-
-        self.assertEqual(response[3]["source"], "2_/pricing", response[3])
-        self.assertEqual(response[3]["target"], "3_/about")
-        self.assertEqual(response[3]["value"], 1)
-
-        date_from = now() - relativedelta(days=7)
-        response = self.client.get("/api/paths/?date_from=" + date_from.strftime("%Y-%m-%d")).json()
-        self.assertEqual(len(response), 4)
-
-        date_to = now() + relativedelta(days=7)
-        response = self.client.get("/api/paths/?date_to=" + date_to.strftime("%Y-%m-%d")).json()
-        self.assertEqual(len(response), 4)
-
-        date_from = now() + relativedelta(days=7)
-        response = self.client.get("/api/paths/?date_from=" + date_from.strftime("%Y-%m-%d")).json()
-        self.assertEqual(len(response), 0)
-
-        date_to = now() - relativedelta(days=7)
-        response = self.client.get("/api/paths/?date_to=" + date_to.strftime("%Y-%m-%d")).json()
-        self.assertEqual(len(response), 0)
-
-        date_from = now() - relativedelta(days=7)
-        date_to = now() + relativedelta(days=7)
-
-        date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
-
-        filter = Filter(data={**date_params})
-        response = Paths().run(team=self.team, filter=filter)
-        self.assertEqual(len(response), 4)
-
-        date_from = now() + relativedelta(days=7)
-        date_to = now() - relativedelta(days=7)
-        date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
-        filter = Filter(data={**date_params})
-        response = Paths().run(team=self.team, filter=filter)
-        self.assertEqual(len(response), 0)
-
-    def test_custom_event_paths(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=["person_1"])
-        Event.objects.create(distinct_id="person_1", event="custom_event_1", team=self.team)
-        Event.objects.create(distinct_id="person_1", event="custom_event_3", team=self.team)
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
-        )  # should be ignored
-
-        person2 = Person.objects.create(team=self.team, distinct_ids=["person_2"])
-        Event.objects.create(distinct_id="person_2", event="custom_event_1", team=self.team)
-        Event.objects.create(distinct_id="person_2", event="custom_event_2", team=self.team)
-        Event.objects.create(distinct_id="person_2", event="custom_event_3", team=self.team)
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_3"])
-        Event.objects.create(distinct_id="person_3", event="custom_event_2", team=self.team)
-        Event.objects.create(distinct_id="person_3", event="custom_event_1", team=self.team)
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_4"])
-        Event.objects.create(distinct_id="person_4", event="custom_event_1", team=self.team)
-        Event.objects.create(distinct_id="person_4", event="custom_event_2", team=self.team)
-
-        response = Paths().run(team=self.team, filter=Filter(data={"path_type": "custom_event"}))
-
-        self.assertEqual(response[0]["source"], "1_custom_event_1", response)
-        self.assertEqual(response[0]["target"], "2_custom_event_2")
-        self.assertEqual(response[0]["value"], 2)
-
-        self.assertEqual(response[1]["source"], "1_custom_event_1")
-        self.assertEqual(response[1]["target"], "2_custom_event_3")
-        self.assertEqual(response[1]["value"], 1)
-
-        self.assertEqual(response[2]["source"], "1_custom_event_2")
-        self.assertEqual(response[2]["target"], "2_custom_event_1")
-        self.assertEqual(response[2]["value"], 1)
-
-        self.assertEqual(response[3]["source"], "2_custom_event_2", response[3])
-        self.assertEqual(response[3]["target"], "3_custom_event_3")
-        self.assertEqual(response[3]["value"], 1)
-
-    def test_screen_paths(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=["person_1"])
-        Event.objects.create(
-            properties={"$screen_name": "/"}, distinct_id="person_1", event="$screen", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team,
-        )
-
-        person2 = Person.objects.create(team=self.team, distinct_ids=["person_2"])
-        Event.objects.create(
-            properties={"$screen_name": "/"}, distinct_id="person_2", event="$screen", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$screen_name": "/pricing"}, distinct_id="person_2", event="$screen", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$screen_name": "/about"}, distinct_id="person_2", event="$screen", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_3"])
-        Event.objects.create(
-            properties={"$screen_name": "/pricing"}, distinct_id="person_3", event="$screen", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$screen_name": "/"}, distinct_id="person_3", event="$screen", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_4"])
-        Event.objects.create(
-            properties={"$screen_name": "/"}, distinct_id="person_4", event="$screen", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$screen_name": "/pricing"}, distinct_id="person_4", event="$screen", team=self.team,
-        )
-
-        response = Paths().run(team=self.team, filter=Filter(data={"path_type": "$screen"}))
-        self.assertEqual(response[0]["source"], "1_/", response)
-        self.assertEqual(response[0]["target"], "2_/pricing")
-        self.assertEqual(response[0]["value"], 2)
-
-        self.assertEqual(response[1]["source"], "1_/")
-        self.assertEqual(response[1]["target"], "2_/about")
-        self.assertEqual(response[1]["value"], 1)
-
-        self.assertEqual(response[2]["source"], "1_/pricing")
-        self.assertEqual(response[2]["target"], "2_/")
-        self.assertEqual(response[2]["value"], 1)
-
-        self.assertEqual(response[3]["source"], "2_/pricing", response[3])
-        self.assertEqual(response[3]["target"], "3_/about")
-        self.assertEqual(response[3]["value"], 1)
-
-    def test_autocapture_paths(self):
-        Person.objects.create(team=self.team, distinct_ids=["person_1"])
-        Event.objects.create(
-            event="$autocapture",
-            team=self.team,
-            distinct_id="person_1",
-            elements=[
-                Element(tag_name="a", text="hello", href="/a-url", nth_child=1, nth_of_type=0, order=1,),
-                Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
-            ],
-        )
-
-        Event.objects.create(
-            event="$autocapture",
-            team=self.team,
-            distinct_id="person_1",
-            elements=[
-                Element(tag_name="a", text="goodbye", nth_child=2, nth_of_type=0, order=0, attr_id="someId",),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
-                # make sure elements don't get double counted if they're part of the same event
-                Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=2),
-            ],
-        )
-
-        Person.objects.create(team=self.team, distinct_ids=["person_2"])
-        Event.objects.create(
-            event="$autocapture",
-            team=self.team,
-            distinct_id="person_2",
-            elements=[
-                Element(tag_name="a", text="hello1", href="/a-url", nth_child=1, nth_of_type=0, order=1,),
-                Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
-            ],
-        )
-
-        Event.objects.create(
-            event="$autocapture",
-            team=self.team,
-            distinct_id="person_2",
-            elements=[
-                Element(tag_name="a", text="goodbye1", nth_child=2, nth_of_type=0, order=0, attr_id="someId",),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
-                # make sure elements don't get double counted if they're part of the same event
-                Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=2),
-            ],
-        )
-        response = Paths().run(team=self.team, filter=Filter(data={"path_type": "$autocapture"}))
-
-        self.assertEqual(response[0]["source"], "1_<a> hello")
-        self.assertEqual(response[0]["target"], "2_<a> goodbye")
-        self.assertEqual(response[0]["value"], 1)
-
-        self.assertEqual(response[1]["source"], "1_<a> hello1")
-        self.assertEqual(response[1]["target"], "2_<a> goodbye1")
-        self.assertEqual(response[1]["value"], 1)
-
-        elements = self.client.get("/api/paths/elements/").json()
-        self.assertEqual(elements[0]["name"], "<a> hello")
-        self.assertEqual(elements[1]["name"], "<a> goodbye")
-        self.assertEqual(len(elements), 4)
-
-    def test_paths_properties_filter(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=["person_1"])
-        Event.objects.create(
-            properties={"$current_url": "/", "$browser": "Chrome"},
-            distinct_id="person_1",
-            event="$pageview",
-            team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/about", "$browser": "Chrome"},
-            distinct_id="person_1",
-            event="$pageview",
-            team=self.team,
-        )
-
-        person2 = Person.objects.create(team=self.team, distinct_ids=["person_2"])
-        Event.objects.create(
-            properties={"$current_url": "/", "$browser": "Chrome"},
-            distinct_id="person_2",
-            event="$pageview",
-            team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/pricing", "$browser": "Chrome"},
-            distinct_id="person_2",
-            event="$pageview",
-            team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/about", "$browser": "Chrome"},
-            distinct_id="person_2",
-            event="$pageview",
-            team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_3"])
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_4"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
-        )
-
-        filter = Filter(data={"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]})
-
-        response = Paths().run(team=self.team, filter=filter)
-
-        self.assertEqual(response[0]["source"], "1_/")
-        self.assertEqual(response[0]["target"], "2_/about")
-        self.assertEqual(response[0]["value"], 1)
-
-        self.assertEqual(response[1]["source"], "1_/")
-        self.assertEqual(response[1]["target"], "2_/pricing")
-        self.assertEqual(response[1]["value"], 1)
-
-        self.assertEqual(response[2]["source"], "2_/pricing")
-        self.assertEqual(response[2]["target"], "3_/about")
-        self.assertEqual(response[2]["value"], 1)
-
-    def test_paths_start(self):
-        person1 = Person.objects.create(team=self.team, distinct_ids=["person_1"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
-        )
-
-        person2 = Person.objects.create(team=self.team, distinct_ids=["person_2"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_2", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_3"])
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
-        )
-
-        person3 = Person.objects.create(team=self.team, distinct_ids=["person_4"])
-        Event.objects.create(
-            properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
-        )
-        Event.objects.create(
-            properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
-        )
-
-        response = self.client.get("/api/paths/?type=%24pageview&start=%2Fpricing").json()
-
-        response = Paths().run(
-            team=self.team, filter=Filter(data={"path_type": "$pageview", "start_point": "/pricing"}),
-        )
-
-        for item in response:
-            self.assertEqual(item["source"], "1_/pricing")
-
-    def test_paths_in_window(self):
-        Person.objects.create(team=self.team, distinct_ids=["person_1"])
-
-        with freeze_time("2020-04-14T03:25:34.000Z"):
-            Event.objects.create(
+        def test_current_url_paths_and_logic(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+            event_factory(
                 properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
             )
-        with freeze_time("2020-04-14T03:30:34.000Z"):
-            Event.objects.create(
+            event_factory(
                 properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
             )
 
-        with freeze_time("2020-04-15T03:25:34.000Z"):
-            Event.objects.create(
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_2", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_4"])
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
+            )
+            filter = Filter(data={"date_from": "-7d"})
+            response = paths().run(team=self.team, filter=filter)
+            self.assertEqual(response[0]["source"], "1_/", response)
+            self.assertEqual(response[0]["target"], "2_/pricing")
+            self.assertEqual(response[0]["value"], 2)
+
+            self.assertEqual(response[1]["source"], "1_/")
+            self.assertEqual(response[1]["target"], "2_/about")
+            self.assertEqual(response[1]["value"], 1)
+
+            self.assertEqual(response[2]["source"], "1_/pricing")
+            self.assertEqual(response[2]["target"], "2_/")
+            self.assertEqual(response[2]["value"], 1)
+
+            self.assertEqual(response[3]["source"], "2_/pricing", response[3])
+            self.assertEqual(response[3]["target"], "3_/about")
+            self.assertEqual(response[3]["value"], 1)
+
+            date_from = now() - relativedelta(days=7)
+            response = self.client.get("/api/paths/?date_from=" + date_from.strftime("%Y-%m-%d")).json()
+            self.assertEqual(len(response), 4)
+
+            date_to = now() + relativedelta(days=7)
+            response = self.client.get("/api/paths/?date_to=" + date_to.strftime("%Y-%m-%d")).json()
+            self.assertEqual(len(response), 4)
+
+            date_from = now() + relativedelta(days=7)
+            response = self.client.get("/api/paths/?date_from=" + date_from.strftime("%Y-%m-%d")).json()
+            self.assertEqual(len(response), 0)
+
+            date_to = now() - relativedelta(days=7)
+            response = self.client.get("/api/paths/?date_to=" + date_to.strftime("%Y-%m-%d")).json()
+            self.assertEqual(len(response), 0)
+
+            date_from = now() - relativedelta(days=7)
+            date_to = now() + relativedelta(days=7)
+
+            date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
+
+            filter = Filter(data={**date_params})
+            response = paths().run(team=self.team, filter=filter)
+            self.assertEqual(len(response), 4)
+
+            date_from = now() + relativedelta(days=7)
+            date_to = now() - relativedelta(days=7)
+            date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
+            filter = Filter(data={**date_params})
+            response = paths().run(team=self.team, filter=filter)
+            self.assertEqual(len(response), 0)
+
+        def test_custom_event_paths(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+            event_factory(distinct_id="person_1", event="custom_event_1", team=self.team)
+            event_factory(distinct_id="person_1", event="custom_event_3", team=self.team)
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
+            )  # should be ignored
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            event_factory(distinct_id="person_2", event="custom_event_1", team=self.team)
+            event_factory(distinct_id="person_2", event="custom_event_2", team=self.team)
+            event_factory(distinct_id="person_2", event="custom_event_3", team=self.team)
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
+            event_factory(distinct_id="person_3", event="custom_event_2", team=self.team)
+            event_factory(distinct_id="person_3", event="custom_event_1", team=self.team)
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_4"])
+            event_factory(distinct_id="person_4", event="custom_event_1", team=self.team)
+            event_factory(distinct_id="person_4", event="custom_event_2", team=self.team)
+
+            response = paths().run(team=self.team, filter=Filter(data={"path_type": "custom_event"}))
+
+            self.assertEqual(response[0]["source"], "1_custom_event_1", response)
+            self.assertEqual(response[0]["target"], "2_custom_event_2")
+            self.assertEqual(response[0]["value"], 2)
+
+            self.assertEqual(response[1]["source"], "1_custom_event_1")
+            self.assertEqual(response[1]["target"], "2_custom_event_3")
+            self.assertEqual(response[1]["value"], 1)
+
+            self.assertEqual(response[2]["source"], "1_custom_event_2")
+            self.assertEqual(response[2]["target"], "2_custom_event_1")
+            self.assertEqual(response[2]["value"], 1)
+
+            self.assertEqual(response[3]["source"], "2_custom_event_2", response[3])
+            self.assertEqual(response[3]["target"], "3_custom_event_3")
+            self.assertEqual(response[3]["value"], 1)
+
+        def test_screen_paths(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+            event_factory(
+                properties={"$screen_name": "/"}, distinct_id="person_1", event="$screen", team=self.team,
+            )
+            event_factory(
+                properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            event_factory(
+                properties={"$screen_name": "/"}, distinct_id="person_2", event="$screen", team=self.team,
+            )
+            event_factory(
+                properties={"$screen_name": "/pricing"}, distinct_id="person_2", event="$screen", team=self.team,
+            )
+            event_factory(
+                properties={"$screen_name": "/about"}, distinct_id="person_2", event="$screen", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
+            event_factory(
+                properties={"$screen_name": "/pricing"}, distinct_id="person_3", event="$screen", team=self.team,
+            )
+            event_factory(
+                properties={"$screen_name": "/"}, distinct_id="person_3", event="$screen", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_4"])
+            event_factory(
+                properties={"$screen_name": "/"}, distinct_id="person_4", event="$screen", team=self.team,
+            )
+            event_factory(
+                properties={"$screen_name": "/pricing"}, distinct_id="person_4", event="$screen", team=self.team,
+            )
+
+            response = paths().run(team=self.team, filter=Filter(data={"path_type": "$screen"}))
+            self.assertEqual(response[0]["source"], "1_/", response)
+            self.assertEqual(response[0]["target"], "2_/pricing")
+            self.assertEqual(response[0]["value"], 2)
+
+            self.assertEqual(response[1]["source"], "1_/")
+            self.assertEqual(response[1]["target"], "2_/about")
+            self.assertEqual(response[1]["value"], 1)
+
+            self.assertEqual(response[2]["source"], "1_/pricing")
+            self.assertEqual(response[2]["target"], "2_/")
+            self.assertEqual(response[2]["value"], 1)
+
+            self.assertEqual(response[3]["source"], "2_/pricing", response[3])
+            self.assertEqual(response[3]["target"], "3_/about")
+            self.assertEqual(response[3]["value"], 1)
+
+        def test_autocapture_paths(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+            event_factory(
+                event="$autocapture",
+                team=self.team,
+                distinct_id="person_1",
+                elements=[
+                    Element(tag_name="a", text="hello", href="/a-url", nth_child=1, nth_of_type=0, order=1,),
+                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
+                ],
+            )
+
+            event_factory(
+                event="$autocapture",
+                team=self.team,
+                distinct_id="person_1",
+                elements=[
+                    Element(tag_name="a", text="goodbye", nth_child=2, nth_of_type=0, order=0, attr_id="someId",),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
+                    # make sure elements don't get double counted if they're part of the same event
+                    Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=2),
+                ],
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            event_factory(
+                event="$autocapture",
+                team=self.team,
+                distinct_id="person_2",
+                elements=[
+                    Element(tag_name="a", text="hello1", href="/a-url", nth_child=1, nth_of_type=0, order=1,),
+                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
+                ],
+            )
+
+            event_factory(
+                event="$autocapture",
+                team=self.team,
+                distinct_id="person_2",
+                elements=[
+                    Element(tag_name="a", text="goodbye1", nth_child=2, nth_of_type=0, order=0, attr_id="someId",),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
+                    # make sure elements don't get double counted if they're part of the same event
+                    Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=2),
+                ],
+            )
+            response = paths().run(team=self.team, filter=Filter(data={"path_type": "$autocapture"}))
+
+            self.assertEqual(response[0]["source"], "1_<a> hello")
+            self.assertEqual(response[0]["target"], "2_<a> goodbye")
+            self.assertEqual(response[0]["value"], 1)
+
+            self.assertEqual(response[1]["source"], "1_<a> hello1")
+            self.assertEqual(response[1]["target"], "2_<a> goodbye1")
+            self.assertEqual(response[1]["value"], 1)
+
+            elements = self.client.get("/api/paths/elements/").json()
+            self.assertEqual(elements[0]["name"], "<a> hello")
+            self.assertEqual(elements[1]["name"], "<a> goodbye")
+            self.assertEqual(len(elements), 4)
+
+        def test_paths_properties_filter(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+            event_factory(
+                properties={"$current_url": "/", "$browser": "Chrome"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/about", "$browser": "Chrome"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            event_factory(
+                properties={"$current_url": "/", "$browser": "Chrome"},
+                distinct_id="person_2",
+                event="$pageview",
+                team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing", "$browser": "Chrome"},
+                distinct_id="person_2",
+                event="$pageview",
+                team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/about", "$browser": "Chrome"},
+                distinct_id="person_2",
+                event="$pageview",
+                team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_4"])
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
+            )
+
+            filter = Filter(data={"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]})
+
+            response = paths().run(team=self.team, filter=filter)
+
+            self.assertEqual(response[0]["source"], "1_/")
+            self.assertEqual(response[0]["target"], "2_/about")
+            self.assertEqual(response[0]["value"], 1)
+
+            self.assertEqual(response[1]["source"], "1_/")
+            self.assertEqual(response[1]["target"], "2_/pricing")
+            self.assertEqual(response[1]["value"], 1)
+
+            self.assertEqual(response[2]["source"], "2_/pricing")
+            self.assertEqual(response[2]["target"], "3_/about")
+            self.assertEqual(response[2]["value"], 1)
+
+        def test_paths_start(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+            event_factory(
                 properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
             )
-        with freeze_time("2020-04-15T03:30:34.000Z"):
-            Event.objects.create(
+            event_factory(
                 properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
             )
 
-        response = Paths().run(team=self.team, filter=Filter(data={"date_from": "2020-04-13"}))
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_2", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
+            )
 
-        self.assertEqual(response[0]["source"], "1_/")
-        self.assertEqual(response[0]["target"], "2_/about")
-        self.assertEqual(response[0]["value"], 2)
+            person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["person_4"])
+            event_factory(
+                properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
+            )
+            event_factory(
+                properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
+            )
+
+            response = self.client.get("/api/paths/?type=%24pageview&start=%2Fpricing").json()
+
+            response = paths().run(
+                team=self.team, filter=Filter(data={"path_type": "$pageview", "start_point": "/pricing"}),
+            )
+
+            for item in response:
+                self.assertEqual(item["source"], "1_/pricing")
+
+        def test_paths_in_window(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"])
+
+            with freeze_time("2020-04-14T03:25:34.000Z"):
+                event_factory(
+                    properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
+                )
+            with freeze_time("2020-04-14T03:30:34.000Z"):
+                event_factory(
+                    properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
+                )
+
+            with freeze_time("2020-04-15T03:25:34.000Z"):
+                event_factory(
+                    properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
+                )
+            with freeze_time("2020-04-15T03:30:34.000Z"):
+                event_factory(
+                    properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
+                )
+
+            response = paths().run(team=self.team, filter=Filter(data={"date_from": "2020-04-13"}))
+
+            self.assertEqual(response[0]["source"], "1_/")
+            self.assertEqual(response[0]["target"], "2_/about")
+            self.assertEqual(response[0]["value"], 2)
+
+    return TestPaths
+
+
+class DjangoPathsTest(paths_test_factory(Paths, Event.objects.create, Person.objects.create)):  # type: ignore
+    pass

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -21,15 +21,15 @@ def paths_test_factory(paths, event_factory, person_factory):
                 properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
             )
 
-            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
             event_factory(
-                properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
+                properties={"$current_url": "/"}, distinct_id="person_2a", event="$pageview", team=self.team,
             )
             event_factory(
-                properties={"$current_url": "/pricing"}, distinct_id="person_2", event="$pageview", team=self.team,
+                properties={"$current_url": "/pricing"}, distinct_id="person_2b", event="$pageview", team=self.team,
             )
             event_factory(
-                properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
+                properties={"$current_url": "/about"}, distinct_id="person_2a", event="$pageview", team=self.team,
             )
 
             person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
@@ -145,15 +145,15 @@ def paths_test_factory(paths, event_factory, person_factory):
                 properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team,
             )
 
-            person_factory(team_id=self.team.pk, distinct_ids=["person_2"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
             event_factory(
-                properties={"$screen_name": "/"}, distinct_id="person_2", event="$screen", team=self.team,
+                properties={"$screen_name": "/"}, distinct_id="person_2b", event="$screen", team=self.team,
             )
             event_factory(
-                properties={"$screen_name": "/pricing"}, distinct_id="person_2", event="$screen", team=self.team,
+                properties={"$screen_name": "/pricing"}, distinct_id="person_2a", event="$screen", team=self.team,
             )
             event_factory(
-                properties={"$screen_name": "/about"}, distinct_id="person_2", event="$screen", team=self.team,
+                properties={"$screen_name": "/about"}, distinct_id="person_2b", event="$screen", team=self.team,
             )
 
             person_factory(team_id=self.team.pk, distinct_ids=["person_3"])
@@ -360,18 +360,18 @@ def paths_test_factory(paths, event_factory, person_factory):
                 properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
             )
 
-            person_factory(team_id=self.team.pk, distinct_ids=["person_5"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person_5a", "person_5b"])
             event_factory(
-                properties={"$current_url": "/pricing"}, distinct_id="person_5", event="$pageview", team=self.team,
+                properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team,
             )
             event_factory(
-                properties={"$current_url": "/about"}, distinct_id="person_5", event="$pageview", team=self.team,
+                properties={"$current_url": "/about"}, distinct_id="person_5b", event="$pageview", team=self.team,
             )
             event_factory(
-                properties={"$current_url": "/pricing"}, distinct_id="person_5", event="$pageview", team=self.team,
+                properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team,
             )
             event_factory(
-                properties={"$current_url": "/help"}, distinct_id="person_5", event="$pageview", team=self.team,
+                properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team,
             )
 
             response = self.client.get("/api/paths/?type=%24pageview&start=%2Fpricing").json()

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -196,10 +196,10 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team,
                 distinct_id="person_1",
                 elements=[
-                    Element(tag_name="a", text="hello", href="/a-url", nth_child=1, nth_of_type=0, order=1,),
-                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
+                    Element(tag_name="a", text="hello", href="/a-url", nth_child=1, nth_of_type=0, order=0,),
+                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=1),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3, attr_id="nested",),
                 ],
             )
 
@@ -221,10 +221,10 @@ def paths_test_factory(paths, event_factory, person_factory):
                 team=self.team,
                 distinct_id="person_2",
                 elements=[
-                    Element(tag_name="a", text="hello1", href="/a-url", nth_child=1, nth_of_type=0, order=1,),
-                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
-                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
+                    Element(tag_name="a", text="hello1", href="/a-url", nth_child=1, nth_of_type=0, order=0,),
+                    Element(tag_name="button", nth_child=0, nth_of_type=0, order=1),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
+                    Element(tag_name="div", nth_child=0, nth_of_type=0, order=3, attr_id="nested",),
                 ],
             )
 

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -101,7 +101,6 @@ def _capture(
                 nth_child=el.get("nth_child"),
                 nth_of_type=el.get("nth_of_type"),
                 attributes={key: value for key, value in el.items() if key.startswith("attr__")},
-                order=index,
             )
             for index, el in enumerate(elements)
         ]

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -14,10 +14,10 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0, order=1),
-                Element(tag_name="button", nth_child=0, nth_of_type=0, order=2),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=4, attr_id="nested",),
+                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0, order=0),
+                Element(tag_name="button", nth_child=0, nth_of_type=0, order=1),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, order=3, attr_id="nested",),
             ],
         )
 
@@ -230,7 +230,7 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             properties={"$current_url": "https://posthog.com/feedback/123"},
-            elements=[Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0, order=1,)],
+            elements=[Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0, order=0,)],
         )
 
         events = Event.objects.filter_by_action(action1)
@@ -286,8 +286,8 @@ class TestFilterByActions(BaseTest):
 class TestElementGroup(BaseTest):
     def test_create_elements(self):
         elements = [
-            Element(tag_name="button", text="Sign up!"),
-            Element(tag_name="div"),
+            Element(tag_name="button", text="Sign up!", order=0,),
+            Element(tag_name="div", order=1,),
         ]
         group1 = ElementGroup.objects.create(team=self.team, elements=elements)
         elements = list(Element.objects.all())
@@ -295,9 +295,9 @@ class TestElementGroup(BaseTest):
         self.assertEqual(elements[1].tag_name, "div")
 
         elements = [
-            Element(tag_name="button", text="Sign up!"),
+            Element(tag_name="button", text="Sign up!", order=0,),
             # make sure we remove events if we can
-            Element(tag_name="div", event=Event.objects.create(team=self.team)),
+            Element(tag_name="div", event=Event.objects.create(team=self.team), order=1,),
         ]
         group2 = ElementGroup.objects.create(team=self.team, elements=elements)
         self.assertEqual(Element.objects.count(), 2)

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -14,10 +14,10 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0, order=0),
-                Element(tag_name="button", nth_child=0, nth_of_type=0, order=1),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=3, attr_id="nested",),
+                Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
+                Element(tag_name="button", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0, attr_id="nested",),
             ],
         )
 
@@ -26,15 +26,15 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="a", nth_child=2, nth_of_type=0, order=0, attr_id="someId"),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=2),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=3),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=4),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=5),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=6),
+                Element(tag_name="a", nth_child=2, nth_of_type=0, attr_id="someId"),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
                 # make sure elements don't get double counted if they're part of the same event
-                Element(href="/a-url-2", nth_child=0, nth_of_type=0, order=7),
+                Element(href="/a-url-2", nth_child=0, nth_of_type=0),
             ],
         )
 
@@ -45,8 +45,8 @@ class TestFilterByActions(BaseTest):
             team=team2,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="a", nth_child=2, nth_of_type=0, order=0, attr_id="someId"),
-                Element(tag_name="div", nth_child=0, nth_of_type=0, order=1),
+                Element(tag_name="a", nth_child=2, nth_of_type=0, attr_id="someId"),
+                Element(tag_name="div", nth_child=0, nth_of_type=0),
             ],
         )
 
@@ -101,22 +101,22 @@ class TestFilterByActions(BaseTest):
         event1 = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
-            elements=[Element(tag_name="a", href="/a-url", text="some_text", nth_child=0, nth_of_type=0, order=0,)],
+            elements=[Element(tag_name="a", href="/a-url", text="some_text", nth_child=0, nth_of_type=0,)],
         )
 
         event2 = Event.objects.create(
             team=self.team,
             distinct_id="whatever2",
-            elements=[Element(tag_name="a", href="/a-url", text="some_text", nth_child=0, nth_of_type=0, order=0,)],
+            elements=[Element(tag_name="a", href="/a-url", text="some_text", nth_child=0, nth_of_type=0,)],
         )
 
         event3 = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="a", href="/a-url-2", text="some_other_text", nth_child=0, nth_of_type=0, order=0,),
+                Element(tag_name="a", href="/a-url-2", text="some_other_text", nth_child=0, nth_of_type=0,),
                 # make sure elements don't get double counted if they're part of the same event
-                Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0, order=1,),
+                Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0,),
             ],
         )
 
@@ -124,9 +124,9 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever2",
             elements=[
-                Element(tag_name="a", href="/a-url-2", text="some_other_text", nth_child=0, nth_of_type=0, order=0,),
+                Element(tag_name="a", href="/a-url-2", text="some_other_text", nth_child=0, nth_of_type=0,),
                 # make sure elements don't get double counted if they're part of the same event
-                Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0, order=1,),
+                Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0,),
             ],
         )
 
@@ -145,8 +145,8 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="span", attr_class=None, order=0),
-                Element(tag_name="a", attr_class=["active", "nav-link"], order=1),
+                Element(tag_name="span", attr_class=None),
+                Element(tag_name="a", attr_class=["active", "nav-link"]),
             ],
         )
 
@@ -162,8 +162,8 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="span", attr_class=None, order=0),
-                Element(tag_name="a", attr_class=["na\\v-link:b@ld"], order=1),
+                Element(tag_name="span", attr_class=None),
+                Element(tag_name="a", attr_class=["na\\v-link:b@ld"]),
             ],
         )
 
@@ -179,8 +179,8 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             elements=[
-                Element(tag_name="span", attr_class=None, order=0),
-                Element(tag_name="a", attr_class=["na\\\\\\v-link:b@ld"], order=1),
+                Element(tag_name="span", attr_class=None),
+                Element(tag_name="a", attr_class=["na\\\\\\v-link:b@ld"]),
             ],
         )
 
@@ -193,7 +193,7 @@ class TestFilterByActions(BaseTest):
         event1 = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
-            elements=[Element(tag_name="button", order=0, attributes={"attr__data-id": "123"})],
+            elements=[Element(tag_name="button", attributes={"attr__data-id": "123"})],
         )
 
         action1 = Action.objects.create(team=self.team)
@@ -230,7 +230,7 @@ class TestFilterByActions(BaseTest):
             team=self.team,
             distinct_id="whatever",
             properties={"$current_url": "https://posthog.com/feedback/123"},
-            elements=[Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0, order=0,)],
+            elements=[Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0,)],
         )
 
         events = Event.objects.filter_by_action(action1)
@@ -286,8 +286,8 @@ class TestFilterByActions(BaseTest):
 class TestElementGroup(BaseTest):
     def test_create_elements(self):
         elements = [
-            Element(tag_name="button", text="Sign up!", order=0,),
-            Element(tag_name="div", order=1,),
+            Element(tag_name="button", text="Sign up!",),
+            Element(tag_name="div",),
         ]
         group1 = ElementGroup.objects.create(team=self.team, elements=elements)
         elements = list(Element.objects.all())
@@ -295,9 +295,9 @@ class TestElementGroup(BaseTest):
         self.assertEqual(elements[1].tag_name, "div")
 
         elements = [
-            Element(tag_name="button", text="Sign up!", order=0,),
+            Element(tag_name="button", text="Sign up!",),
             # make sure we remove events if we can
-            Element(tag_name="div", event=Event.objects.create(team=self.team), order=1,),
+            Element(tag_name="div", event=Event.objects.create(team=self.team),),
         ]
         group2 = ElementGroup.objects.create(team=self.team, elements=elements)
         self.assertEqual(Element.objects.count(), 2)
@@ -308,6 +308,7 @@ class TestElementGroup(BaseTest):
         group3 = ElementGroup.objects.create(team=team2, elements=elements)
         group3_duplicate = ElementGroup.objects.create(team_id=team2.pk, elements=elements)
         self.assertNotEqual(group2, group3)
+        self.assertEqual(group3, group3_duplicate)
         self.assertEqual(ElementGroup.objects.count(), 2)
 
 
@@ -333,9 +334,8 @@ class TestActions(BaseTest):
                     text="Watch now",
                     attr_id="something",
                     href="/movie",
-                    order=0,
                 ),
-                Element(tag_name="div", href="/movie", order=1),
+                Element(tag_name="div", href="/movie"),
             ],
         )
         return event
@@ -377,7 +377,7 @@ class TestActions(BaseTest):
         event = Event.objects.create(
             team=self.team,
             distinct_id="whatever",
-            elements=[Element(order=0, tag_name="a", attributes={"attr__data-id": "whatever"})],
+            elements=[Element(tag_name="a", attributes={"attr__data-id": "whatever"})],
         )
         self.assertEqual(event.actions, [action])
 
@@ -396,7 +396,7 @@ class TestActions(BaseTest):
             event="$autocapture",
             distinct_id="user_paid",
             team=self.team,
-            elements=[Element(tag_name="a", attr_class=None, order=0)],
+            elements=[Element(tag_name="a", attr_class=None)],
         )
         # This would error when attr_class wasn't set.
         self.assertEqual(event.actions, [])

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -37,7 +37,7 @@ class TestSelectors(BaseTest):
         event1 = Event.objects.create(
             team=self.team,
             event="$autocapture",
-            elements=[Element.objects.create(tag_name="a", order=0), Element.objects.create(tag_name="div", order=1),],
+            elements=[Element.objects.create(tag_name="a"), Element.objects.create(tag_name="div"),],
         )
         event2 = Event.objects.create(team=self.team, event="$autocapture")
         filter = Filter(data={"properties": [{"key": "selector", "value": "div > a", "type": "element"}]})

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ django-redis==4.12.1
 django-statsd==2.5.2
 djangorestframework==3.11.0
 djangorestframework-csv==2.1.0
+fakeredis==1.4.3
 future==0.18.2
 gunicorn==20.0.4
 idna==2.8
@@ -65,6 +66,7 @@ sentry-sdk==0.16.5
 six==1.14.0
 social-auth-app-django==3.1.0
 social-auth-core==3.3.3
+sortedcontainers==2.2.2
 sqlparse==0.3.0
 tenacity==6.1.0
 traitlets==4.3.3

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,6 +1,7 @@
 # To compile, run:
 #    pip-compile requirements/dev.in
 
+fakeredis
 flake8
 flake8-bugbear
 flake8-colors

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,7 +1,6 @@
 # To compile, run:
 #    pip-compile requirements/dev.in
 
-fakeredis
 flake8
 flake8-bugbear
 flake8-colors

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,6 +18,7 @@ django-stubs==1.5.0       # via -r requirements/dev.in, djangorestframework-stub
 django==3.0.6             # via django-debug-toolbar, django-stubs
 djangorestframework-stubs==1.1.0  # via -r requirements/dev.in
 entrypoints==0.3          # via flake8
+fakeredis==1.4.3          # via -r requirements/dev.in
 flake8-bugbear==20.1.4    # via -r requirements/dev.in
 flake8-colors==0.1.6      # via -r requirements/dev.in
 flake8-commas==2.0.0      # via -r requirements/dev.in
@@ -50,8 +51,10 @@ pygments==2.6.1           # via ipython
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via freezegun
 pytz==2020.1              # via django
+redis==3.5.3              # via fakeredis
 regex==2020.6.8           # via black
-six==1.14.0               # via flake8-print, freezegun, packaging, pip-tools, python-dateutil, traitlets
+six==1.14.0               # via fakeredis, flake8-print, freezegun, packaging, pip-tools, python-dateutil, traitlets
+sortedcontainers==2.2.2   # via fakeredis
 sqlparse==0.3.1           # via django, django-debug-toolbar
 tblib==1.6.0              # via -r requirements/dev.in
 toml==0.10.1              # via black

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,6 @@ django-stubs==1.5.0       # via -r requirements/dev.in, djangorestframework-stub
 django==3.0.6             # via django-debug-toolbar, django-stubs
 djangorestframework-stubs==1.1.0  # via -r requirements/dev.in
 entrypoints==0.3          # via flake8
-fakeredis==1.4.3          # via -r requirements/dev.in
 flake8-bugbear==20.1.4    # via -r requirements/dev.in
 flake8-colors==0.1.6      # via -r requirements/dev.in
 flake8-commas==2.0.0      # via -r requirements/dev.in
@@ -51,10 +50,8 @@ pygments==2.6.1           # via ipython
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via freezegun
 pytz==2020.1              # via django
-redis==3.5.3              # via fakeredis
 regex==2020.6.8           # via black
-six==1.14.0               # via fakeredis, flake8-print, freezegun, packaging, pip-tools, python-dateutil, traitlets
-sortedcontainers==2.2.2   # via fakeredis
+six==1.14.0               # via flake8-print, freezegun, packaging, pip-tools, python-dateutil, traitlets
 sqlparse==0.3.1           # via django, django-debug-toolbar
 tblib==1.6.0              # via -r requirements/dev.in
 toml==0.10.1              # via black


### PR DESCRIPTION
## Changes

- Use ReplacingMergeTree for elements
- Remove element_groups
- Use elements_hash as a virtual "pk"
- Refactor events query to match
- Use Redis to avoid inserting duplicate elements

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
