### PR TITLE
Random improvements (merge people, analytics)

### DIFF
--- a/frontend/src/scenes/App.js
+++ b/frontend/src/scenes/App.js
@@ -53,19 +53,19 @@ function App() {
     }, [location.pathname])
 
     useEffect(() => {
-        if (unauthenticatedRoutes.includes(scene) && user) replace('/')
+        // If user is already logged in, redirect away from unauthenticated routes like signup
+        if (user && unauthenticatedRoutes.includes(scene)) replace('/')
     }, [scene, user])
 
-    if (unauthenticatedRoutes.includes(scene) && !user) {
-        return (
-            <>
-                <Scene {...params} /> <ToastContainer autoClose={8000} transition={Slide} position="bottom-center" />
-            </>
-        )
-    }
-
     if (!user) {
-        return null
+        return (
+            unauthenticatedRoutes.includes(scene) && (
+                <>
+                    <Scene {...params} />{' '}
+                    <ToastContainer autoClose={8000} transition={Slide} position="bottom-center" />
+                </>
+            )
+        )
     }
 
     if (!user.team.completed_snippet_onboarding) {

--- a/frontend/src/scenes/App.js
+++ b/frontend/src/scenes/App.js
@@ -52,6 +52,10 @@ function App() {
     }, [location.pathname])
 
     if (unauthenticatedRoutes.includes(scene)) {
+        if (user) {
+            /* User is already logged in, redirect */
+            window.location.href = '/'
+        }
         return (
             <>
                 <Scene {...params} /> <ToastContainer autoClose={8000} transition={Slide} position="bottom-center" />

--- a/frontend/src/scenes/App.js
+++ b/frontend/src/scenes/App.js
@@ -3,7 +3,7 @@ import 'react-datepicker/dist/react-datepicker.css'
 import { hot } from 'react-hot-loader/root'
 
 import React, { useState, useEffect, lazy, Suspense } from 'react'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Layout, Spin } from 'antd'
 import { ToastContainer, Slide } from 'react-toastify'
 
@@ -42,6 +42,7 @@ function App() {
     const { user } = useValues(userLogic)
     const { scene, params, loadedScenes } = useValues(sceneLogic)
     const { location } = useValues(router)
+    const { replace } = useActions(router)
     const [sidebarCollapsed, setSidebarCollapsed] = useState(typeof window !== 'undefined' && window.innerWidth <= 991)
 
     const [image, setImage] = useState(null)
@@ -51,11 +52,11 @@ function App() {
         setImage(urlBackgroundMap[location.pathname])
     }, [location.pathname])
 
-    if (unauthenticatedRoutes.includes(scene)) {
-        if (user) {
-            /* User is already logged in, redirect */
-            window.location.href = '/'
-        }
+    useEffect(() => {
+        if (unauthenticatedRoutes.includes(scene) && user) replace('/')
+    }, [scene, user])
+
+    if (unauthenticatedRoutes.includes(scene) && !user) {
         return (
             <>
                 <Scene {...params} /> <ToastContainer autoClose={8000} transition={Slide} position="bottom-center" />

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -4,7 +4,7 @@ import posthoganalytics
 from django.apps import AppConfig
 from django.conf import settings
 
-from posthog.utils import get_machine_id
+from posthog.utils import get_git_branch, get_git_commit, get_machine_id
 from posthog.version import VERSION
 
 
@@ -18,7 +18,9 @@ class PostHogConfig(AppConfig):
             # log development server launch to posthog
             if os.getenv("RUN_MAIN") == "true":
                 posthoganalytics.capture(
-                    get_machine_id(), "development server launched", {"posthog_version": VERSION},
+                    get_machine_id(),
+                    "development server launched",
+                    {"posthog_version": VERSION, "git_rev": get_git_commit(), "git_branch": get_git_branch(),},
                 )
             posthoganalytics.disabled = True
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE"):

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -5,6 +5,7 @@ from django.apps import AppConfig
 from django.conf import settings
 
 from posthog.utils import get_machine_id
+from posthog.version import VERSION
 
 
 class PostHogConfig(AppConfig):
@@ -16,7 +17,9 @@ class PostHogConfig(AppConfig):
         if settings.DEBUG:
             # log development server launch to posthog
             if os.getenv("RUN_MAIN") == "true":
-                posthoganalytics.capture(get_machine_id(), "development server launched")
+                posthoganalytics.capture(
+                    get_machine_id(), "development server launched", {"posthog_version": VERSION},
+                )
             posthoganalytics.disabled = True
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE"):
             posthoganalytics.disabled = True

--- a/posthog/models/person.py
+++ b/posthog/models/person.py
@@ -38,9 +38,15 @@ class Person(models.Model):
     def merge_people(self, people_to_merge: List["Person"]):
         CohortPeople = apps.get_model(app_label="posthog", model_name="CohortPeople")
 
+        first_seen = self.created_at
+
         # merge the properties
         for other_person in people_to_merge:
             self.properties = {**other_person.properties, **self.properties}
+            if other_person.created_at < first_seen:
+                # Keep the oldest created_at (i.e. the first time we've seen this person)
+                first_seen = other_person.created_at
+        self.created_at = first_seen
         self.save()
 
         # merge the distinct_ids

--- a/posthog/test/test_person_model.py
+++ b/posthog/test/test_person_model.py
@@ -1,19 +1,28 @@
+import datetime
+
+import pytz
+
 from posthog.api.test.base import BaseTest
-from posthog.models import Action, ActionStep, Cohort, Element, Event, Person, Team
+from posthog.models import Action, ActionStep, Cohort, Event, Person
 
 
 class TestPerson(BaseTest):
     def test_merge_people(self):
-        person0 = Person.objects.create(distinct_ids=["person_0"], team=self.team, properties={"$os": "Microsoft"})
+        person0 = Person.objects.create(distinct_ids=["person_0"], team=self.team, properties={"$os": "Microsoft"},)
+        person0.created_at = datetime.datetime(2020, 1, 1, tzinfo=pytz.UTC)
+        person0.save()
 
-        person1 = Person.objects.create(distinct_ids=["person_1"], team=self.team, properties={"$os": "Chrome"})
+        person1 = Person.objects.create(distinct_ids=["person_1"], team=self.team, properties={"$os": "Chrome"},)
+        person1.created_at = datetime.datetime(2019, 7, 1, tzinfo=pytz.UTC)
+        person1.save()
+
         event1 = Event.objects.create(event="user signed up", team=self.team, distinct_id="person_1")
         action = Action.objects.create(team=self.team)
         ActionStep.objects.create(action=action, event="user signed up")
         action.calculate_events()
 
         person2 = Person.objects.create(
-            distinct_ids=["person_2"], team=self.team, properties={"$os": "Apple", "$browser": "MS Edge"}
+            distinct_ids=["person_2"], team=self.team, properties={"$os": "Apple", "$browser": "MS Edge"},
         )
         person3 = Person.objects.create(distinct_ids=["person_3"], team=self.team, properties={"$os": "PlayStation"})
 
@@ -27,7 +36,11 @@ class TestPerson(BaseTest):
 
         self.assertEqual(len(Person.objects.all()), 1)
 
-        person0 = Person.objects.get(pk=person0.pk)
+        person0.refresh_from_db()
         self.assertEqual(person0.properties, {"$os": "Microsoft", "$browser": "MS Edge"})
         self.assertEqual(person0.distinct_ids, ["person_0", "person_1", "person_2", "person_3"])
         self.assertEqual([p for p in cohort.people.all()], [person0])
+
+        self.assertEqual(
+            person0.created_at, datetime.datetime(2019, 7, 1, tzinfo=pytz.UTC),
+        )  # oldest time is kept


### PR DESCRIPTION
## Changes

This PR introduces the following random improvements:
- Redirect to home page (insights) when an authenticated user opens the `/signup` or `/preflight` pages which does not make sense to access once logged in. Fixes [POSTHOG-R2](https://sentry.io/organizations/posthog/issues/1893376375/).
- Abstracted `get_git_branch` & `get_git_commit` utilities.
- Adds version, commit & branch information to "development server launched" event.
- When calling the `merge_people` method on a `Person` instance, the method will now update the kept instance's `created_at` with the actually first seen date of the person (i.e. if another `Person` instance was created before the instance being kept, its `created_at` will be set to the `created_at` date of that older instance).

## Checklist

- [X] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [X] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
