### PR TITLE
Improve Django commands for development

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "environments": {
         "review": {
             "scripts": {
-                "postdeploy": "python manage.py setup_review"
+                "postdeploy": "python manage.py setup_dev"
             },
             "env": {
                 "DEBUG": true

--- a/posthog/management/commands/api_keys.py
+++ b/posthog/management/commands/api_keys.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+
+from posthog.models import Team
+
+
+class Command(BaseCommand):
+    help = "Get team API keys through command line instead of having to go through settings"
+
+    def handle(self, *args, **options):
+        for team in Team.objects.all():
+            print(f"{team.name + ' ' if team.name else ''}(ID {team.id}) - {team.api_token}")

--- a/posthog/management/commands/setup_dev.py
+++ b/posthog/management/commands/setup_dev.py
@@ -8,7 +8,7 @@ from posthog.models import User
 
 
 class Command(BaseCommand):
-    help = "Set up review instance with demo data"
+    help = "Set up the instance for development/review with demo data"
 
     def handle(self, *args, **options):
         organization, team, user = User.objects.bootstrap(


### PR DESCRIPTION
## Changes

This renames command `setup_review` to `setup_dev` and adds command `api_keys`, which allows for checking team API keys through CLI instead of having to log into the web app. Resolves #1719.