### PR TITLE
Replace uuid4 and uuid1_macless with UUIDT

### DIFF
--- a/ee/clickhouse/models/clickhouse.py
+++ b/ee/clickhouse/models/clickhouse.py
@@ -1,5 +1,5 @@
-from posthog.models.utils import uuid1_macless
+from posthog.models.utils import UUIDT
 
 
 def generate_clickhouse_uuid() -> str:
-    return str(uuid1_macless())
+    return str(UUIDT())

--- a/ee/clickhouse/models/element.py
+++ b/ee/clickhouse/models/element.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from typing import List, Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from rest_framework import serializers
 
@@ -13,6 +13,7 @@ from posthog.cache import get_cached_value, set_cached_value
 from posthog.models.element import Element
 from posthog.models.element_group import hash_elements
 from posthog.models.team import Team
+from posthog.models.utils import UUIDT
 
 
 def create_element(
@@ -21,7 +22,7 @@ def create_element(
     if not timestamp:
         timestamp = datetime.datetime.now()
     data = {
-        "uuid": str(uuid4()),
+        "uuid": str(UUIDT()),
         "event_uuid": str(event_uuid),
         "created_at": timestamp.isoformat(),
         "text": element.text or "",

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -1,7 +1,7 @@
 import datetime
 import json
-from typing import Any, Dict, List, Optional, Union
-from uuid import UUID, uuid4
+from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -28,6 +28,7 @@ from ee.kafka.topics import KAFKA_OMNI_PERSON, KAFKA_PERSON, KAFKA_PERSON_UNIQUE
 from posthog import settings
 from posthog.ee import check_ee_enabled
 from posthog.models.person import Person, PersonDistinctId
+from posthog.models.utils import UUIDT
 
 if settings.EE_AVAILABLE and check_ee_enabled():
 
@@ -60,7 +61,7 @@ def emit_omni_person(
     timestamp: Optional[datetime.datetime] = None,
 ) -> UUID:
     if not uuid:
-        uuid = uuid4()
+        uuid = UUIDT()
 
     if not timestamp:
         timestamp = datetime.datetime.now()
@@ -90,7 +91,7 @@ def create_person(
     if uuid:
         uuid = str(uuid)
     else:
-        uuid = str(uuid4())
+        uuid = str(UUIDT())
     if not timestamp:
         timestamp = datetime.datetime.now()
 

--- a/ee/clickhouse/models/test/test_element.py
+++ b/ee/clickhouse/models/test/test_element.py
@@ -1,16 +1,15 @@
-import uuid
-
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.element import create_elements, get_all_elements, get_elements_by_elements_hash
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.api.test.base import BaseTest
 from posthog.models import Element
+from posthog.models.utils import UUIDT
 
 
 class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
     def test_create_elements(self) -> None:
         elements_hash_1 = create_elements(
-            event_uuid=uuid.uuid4(),
+            event_uuid=UUIDT(),
             team=self.team,
             elements=[
                 Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
@@ -24,7 +23,7 @@ class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(get_all_elements()), 4)
 
         elements_hash_2 = create_elements(
-            event_uuid=uuid.uuid4(),
+            event_uuid=UUIDT(),
             team=self.team,
             elements=[
                 Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
@@ -61,7 +60,7 @@ class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(get_all_elements()), 0)
 
         create_elements(
-            event_uuid=uuid.uuid4(),
+            event_uuid=UUIDT(),
             team=self.team,
             elements=[
                 Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),
@@ -75,7 +74,7 @@ class TestClickhouseElement(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(get_all_elements()), 4)
 
         create_elements(
-            event_uuid=uuid.uuid4(),
+            event_uuid=UUIDT(),
             team=self.team,
             elements=[
                 Element(tag_name="a", href="/a-url", nth_child=1, nth_of_type=0),

--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -1,6 +1,6 @@
 import datetime
-from typing import Dict, List, Optional, Union
-from uuid import UUID, uuid4
+from typing import Dict, Optional
+from uuid import UUID
 
 from celery import shared_task
 
@@ -10,6 +10,7 @@ from ee.clickhouse.models.person import emit_omni_person
 from posthog.ee import check_ee_enabled
 from posthog.models.element import Element
 from posthog.models.team import Team
+from posthog.models.utils import UUIDT
 from posthog.tasks.process_event import handle_timestamp, store_names_and_properties
 
 
@@ -82,8 +83,8 @@ if check_ee_enabled():
         distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str],
     ) -> None:
         properties = data.get("properties", None)
-        person_uuid = uuid4()
-        event_uuid = uuid4()
+        person_uuid = UUIDT()
+        event_uuid = UUIDT()
         ts = handle_timestamp(data, now, sent_at)
 
         if data["event"] == "$create_alias":

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -21,7 +21,7 @@ from posthog.models import (
     PersonDistinctId,
     Team,
 )
-from posthog.models.utils import uuid1_macless
+from posthog.models.utils import UUIDT
 from posthog.utils import render_template
 
 
@@ -38,7 +38,7 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
         if index > 0 and index % 14 == 0:
             days_ago -= 1
 
-        distinct_id = str(uuid1_macless())
+        distinct_id = str(UUIDT())
         distinct_ids.append(PersonDistinctId(team=team, person=person, distinct_id=distinct_id))
         date = now() - relativedelta(days=days_ago)
         browser = random.choice(["Chrome", "Safari", "Firefox"])

--- a/posthog/management/commands/create_bulk_events.py
+++ b/posthog/management/commands/create_bulk_events.py
@@ -24,7 +24,7 @@ from posthog.models import (
     PersonDistinctId,
     Team,
 )
-from posthog.models.utils import uuid1_macless
+from posthog.models.utils import UUIDT
 
 
 def clean_csv_value(value: Optional[any]) -> str:
@@ -131,7 +131,7 @@ class Command(BaseCommand):
         demo_data_index = 0
 
         for index, person in enumerate(Person.objects.filter(team=team)):
-            distinct_id = str(uuid1_macless())
+            distinct_id = str(UUIDT())
             distinct_ids.append(PersonDistinctId(team=team, person=person, distinct_id=distinct_id))
 
             if index % 3 == 0:

--- a/posthog/migrations/0083_auto_20200826_1504.py
+++ b/posthog/migrations/0083_auto_20200826_1504.py
@@ -4,13 +4,13 @@ import uuid
 
 from django.db import migrations, models
 
-from posthog.models.utils import uuid1_macless
+from posthog.models.utils import UUIDT
 
 
 def create_uuid(apps, schema_editor):
     Team = apps.get_model("posthog", "Team")
     for team in Team.objects.all():
-        team.uuid = uuid1_macless()
+        team.uuid = UUIDT()
         team.save()
 
 

--- a/posthog/migrations/0085_org_models.py
+++ b/posthog/migrations/0085_org_models.py
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
                 (
                     "id",
                     models.UUIDField(
-                        default=posthog.models.utils.uuid1_macless, editable=False, primary_key=True, serialize=False,
+                        default=posthog.models.utils.UUIDT, editable=False, primary_key=True, serialize=False,
                     ),
                 ),
                 ("name", models.CharField(max_length=64)),
@@ -121,7 +121,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="team",
             name="uuid",
-            field=models.UUIDField(default=posthog.models.utils.uuid1_macless, editable=False, unique=True),
+            field=models.UUIDField(default=posthog.models.utils.UUIDT, editable=False, unique=True),
         ),
         migrations.AlterField(
             model_name="user",
@@ -139,7 +139,7 @@ class Migration(migrations.Migration):
                 (
                     "id",
                     models.UUIDField(
-                        default=posthog.models.utils.uuid1_macless, editable=False, primary_key=True, serialize=False,
+                        default=posthog.models.utils.UUIDT, editable=False, primary_key=True, serialize=False,
                     ),
                 ),
                 ("level", models.PositiveSmallIntegerField(choices=[(1, "member"), (8, "administrator")], default=1),),
@@ -171,7 +171,7 @@ class Migration(migrations.Migration):
                 (
                     "id",
                     models.UUIDField(
-                        default=posthog.models.utils.uuid1_macless, editable=False, primary_key=True, serialize=False,
+                        default=posthog.models.utils.UUIDT, editable=False, primary_key=True, serialize=False,
                     ),
                 ),
                 ("uses", models.PositiveIntegerField(default=0)),

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -1,6 +1,3 @@
-import hashlib
-import uuid as uuidlib
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from django.contrib.postgres.fields import ArrayField, JSONField
@@ -14,7 +11,7 @@ from .action_step import ActionStep
 from .dashboard import Dashboard
 from .dashboard_item import DashboardItem
 from .personal_api_key import PersonalAPIKey
-from .utils import generate_random_token, sane_repr, uuid1_macless
+from .utils import UUIDT, generate_random_token, sane_repr
 
 TEAM_CACHE: Dict[str, "Team"] = {}
 
@@ -108,7 +105,7 @@ class Team(models.Model):
     anonymize_ips: models.BooleanField = models.BooleanField(default=False)
     completed_snippet_onboarding: models.BooleanField = models.BooleanField(default=False)
     ingested_event: models.BooleanField = models.BooleanField(default=False)
-    uuid: models.UUIDField = models.UUIDField(default=uuid1_macless, editable=False, unique=True)
+    uuid: models.UUIDField = models.UUIDField(default=UUIDT, editable=False, unique=True)
 
     # DEPRECATED: replaced with env variable OPT_OUT_CAPTURE and User field anonymized_data
     # However, we still honor teams that have set this previously

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -1,26 +1,54 @@
 import secrets
 import uuid
-from collections import namedtuple
-from typing import Callable, Sequence
+from collections import defaultdict, namedtuple
+from time import time
+from typing import Callable, Dict, Optional
 
 from django.db import models
 
 
-def uuid1_macless() -> uuid.UUID:
-    """Time-based UUID v1 using random 48 bits rather than the real MAC address, for more randomness and security.
+class UUIDT(uuid.UUID):
+    """UUID (mostly) sortable by generation time.
     
-    For primary keys, this is superior to incremented integers
-    (as they can reveal sensitive business information about usage volumes and patterns) and to UUID v4
-    (as the complete randomness of v4 makes it less useful for indexing or possibly sorting).
+    This doesn't adhere to any official UUID version spec, but it is superior as a primary key:
+    to incremented integers (as they can reveal sensitive business information about usage volumes and patterns),
+    to UUID v4 (as the complete randomness of v4 makes its indexing performance suboptimal),
+    and to UUID v1 (as despite being time-based it can't be used practically for sorting by generation time).
+
+    This is loosely based on Segment's KSUID (https://github.com/segmentio/ksuid) and on Twitter's snowflake ID
+    (https://blog.twitter.com/engineering/en_us/a/2010/announcing-snowflake.html).
     """
-    return uuid.uuid1(secrets.randbits(48) | 0x010000000000)  # https://tools.ietf.org/html/rfc4122#section-4.5
+
+    current_series_per_ms: Dict[int, int] = defaultdict(int)
+
+    def __init__(self, unix_time_ms: Optional[int] = None) -> None:
+        if unix_time_ms is None:
+            unix_time_ms = int(time() * 1000)
+        time_component = unix_time_ms.to_bytes(6, "big", signed=False)  # 48 bits for time
+        series_component = self.get_series(unix_time_ms).to_bytes(2, "big", signed=False)  # 16 bits for series
+        random_component = secrets.token_bytes(8)  # 64 bits for gibberish
+        bytes = time_component + series_component + random_component
+        assert len(bytes) == 16
+        super().__init__(bytes=bytes)
+
+    @classmethod
+    def get_series(cls, unix_time_ms: int) -> int:
+        """Get per-millisecond series integer in range [0-65536)."""
+        series = cls.current_series_per_ms[unix_time_ms]
+        if len(cls.current_series_per_ms) > 10_000:
+            # clear class dict periodically
+            cls.current_series_per_ms.clear()
+            cls.current_series_per_ms[unix_time_ms] = series
+        cls.current_series_per_ms[unix_time_ms] += 1
+        cls.current_series_per_ms[unix_time_ms] %= 65_536
+        return series
 
 
 class UUIDModel(models.Model):
     class Meta:
         abstract = True
 
-    id: models.UUIDField = models.UUIDField(primary_key=True, default=uuid1_macless, editable=False)
+    id: models.UUIDField = models.UUIDField(primary_key=True, default=UUIDT, editable=False)
 
 
 def sane_repr(*attrs: str) -> Callable[[object], str]:

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -15,6 +15,9 @@ class UUIDT(uuid.UUID):
     to UUID v4 (as the complete randomness of v4 makes its indexing performance suboptimal),
     and to UUID v1 (as despite being time-based it can't be used practically for sorting by generation time).
 
+    Order can be messed up if system clock is changed or if more than 65 536 IDs are generated per millisecond
+    (that's over 5 trillion events per day), but it should be largely safe to assume that these are time-sortable.
+
     Anatomy:
     - 4 bytes - Unix time milliseconds unsigned integer
     - 2 bytes - autoincremented per-millisecond series unsigned integer

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -20,7 +20,7 @@ class UUIDT(uuid.UUID):
 
     Anatomy:
     - 6 bytes - Unix time milliseconds unsigned integer
-    - 2 bytes - leftmost 2 bytes of hardware address (MAC with random fallback)
+    - 2 bytes - autoincremented series unsigned integer (per millisecond, rolls over to 0 after reaching 65 535 UUIDs in one ms)
     - 8 bytes - securely random gibberish
 
     Loosely based on Segment's KSUID (https://github.com/segmentio/ksuid) and on Twitter's snowflake ID


### PR DESCRIPTION
## Changes

This replaces `uuid4` and `uuid1_macless` with `UUIDT`, which consists of:
- 6 bytes - Unix time milliseconds unsigned integer (will fail in 10 895 CE)
- 2 bytes - autoincremented series unsigned integer (per millisecond, rolls over to 0 after reaching 65 535 UUIDs in one ms)
- 8 bytes - securely random gibberish
    
`UUIDT` doesn't adhere to any particular UUID version spec, but it is superior as a primary key:
to incremented integers (as they can reveal sensitive business information about usage volumes and patterns),
to UUID v4 (as the complete randomness of v4 can make its indexing performance suboptimal),
and to UUID v1 (as despite being time-based it can't be used practically for sorting by generation time).

Order can be messed up if system clock is changed or if more than 65 536 IDs are generated per millisecond (that's over 5 trillion events per day), but it should be largely safe to assume that these are sorted.

Loosely based on [Segment's KSUID](https://github.com/segmentio/ksuid) and on [Twitter's snowflake ID](https://blog.twitter.com/engineering/en_us/a/2010/announcing-snowflake.html).