### PR TITLE
Disable weekly status report on PostHog Cloud

### DIFF
--- a/ee/api/license.py
+++ b/ee/api/license.py
@@ -26,7 +26,7 @@ class LicenseViewSet(viewsets.ModelViewSet):
     serializer_class = LicenseSerializer
 
     def get_queryset(self) -> QuerySet:
-        if hasattr(settings, "MULTI_TENANCY"):
+        if getattr(settings, "MULTI_TENANCY", False):
             return License.objects.none()
 
         return super().get_queryset()

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -89,7 +89,7 @@ def user(request):
             "posthog_version": VERSION,
             "available_features": request.user.available_features,
             "billing_plan": request.user.billing_plan,
-            "is_multi_tenancy": hasattr(settings, "MULTI_TENANCY"),
+            "is_multi_tenancy": getattr(settings, "MULTI_TENANCY", False),
             "ee_available": request.user.ee_available,
         }
     )

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -9,9 +9,6 @@ from celery.schedules import crontab
 from django.conf import settings
 from django.db import connection
 
-from posthog.models.user import MULTI_TENANCY_MISSING
-from posthog.settings import STATSD_HOST, STATSD_PORT, STATSD_PREFIX
-
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 
@@ -36,7 +33,7 @@ redis_instance = redis.from_url(settings.REDIS_URL, db=0)
 # How frequently do we want to calculate action -> event relationships if async is enabled
 ACTION_EVENT_MAPPING_INTERVAL_MINUTES = 10
 
-statsd.Connection.set_defaults(host=STATSD_HOST, port=STATSD_PORT)
+statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
 
 
 @app.on_after_configure.connect
@@ -48,7 +45,7 @@ def setup_periodic_tasks(sender, **kwargs):
         crontab(day_of_week="mon,fri"), update_event_partitions.s(),  # check twice a week
     )
     # send weekly status report on non-PostHog Cloud instances
-    if MULTI_TENANCY_MISSING:
+    if not getattr(settings, "MULTI_TENANCY", False):
         sender.add_periodic_task(crontab(day_of_week="mon"), status_report.s())
     sender.add_periodic_task(15 * 60, calculate_cohort.s(), name="debug")
     sender.add_periodic_task(600, check_cached_items.s(), name="check dashboard items")
@@ -70,7 +67,7 @@ def redis_heartbeat():
 @app.task
 def redis_celery_queue_depth():
     try:
-        g = statsd.Gauge("%s_posthog_celery" % (STATSD_PREFIX,))
+        g = statsd.Gauge("%s_posthog_celery" % (settings.STATSD_PREFIX,))
         llen = redis_instance.llen("celery")
         g.send("queue_depth", llen)
     except:

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 def is_email_restricted_from_signup(email: str) -> bool:
-    if not hasattr(settings, "RESTRICT_SIGNUPS"):
+    if not getattr(settings, "RESTRICT_SIGNUPS", False):
         return False
 
     restricted_signups: Union[str, bool] = settings.RESTRICT_SIGNUPS


### PR DESCRIPTION
## Changes

As discussed with @paolodamico, PostHog Cloud's Postgres DB chokes on instance report queries, as they analyze all events and Postgres just doesn't handle this scale well.