### PR TITLE
Fix toolbar fade container click block

### DIFF
--- a/frontend/src/lib/components/Fade/Fade.tsx
+++ b/frontend/src/lib/components/Fade/Fade.tsx
@@ -4,11 +4,13 @@ import React, { useEffect, useState } from 'react'
 export function Fade({
     visible,
     children,
+    className,
     style = {},
     ...props
 }: {
     visible: boolean
     children: React.ReactNode
+    className: string
     style?: React.CSSProperties
 }): JSX.Element | null {
     const [shouldRender, setShouldRender] = useState(visible)
@@ -27,7 +29,7 @@ export function Fade({
 
     return shouldRender ? (
         <div
-            className="fade-component-container"
+            className={`fade-component-container${className ? ` ${className}` : ''}`}
             style={{ animation: `${visible ? 'fadeComponentFadeIn' : 'fadeComponentFadeOut'} 0.3s`, ...style }}
             onAnimationEnd={onAnimationEnd}
             {...props}

--- a/frontend/src/toolbar/ToolbarContainer.tsx
+++ b/frontend/src/toolbar/ToolbarContainer.tsx
@@ -11,7 +11,7 @@ function _ToolbarContainer(): JSX.Element {
     const { buttonVisible } = useValues(toolbarLogic)
 
     return (
-        <Fade visible={buttonVisible} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
+        <Fade visible={buttonVisible} className="toolbar-global-fade-container">
             <Elements />
             <DraggableButton />
         </Fade>

--- a/frontend/src/toolbar/styles.scss
+++ b/frontend/src/toolbar/styles.scss
@@ -42,3 +42,15 @@
 .Toastify__toast-container {
     z-index: 2147483040;
 }
+
+.toolbar-global-fade-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    > * {
+        pointer-events: auto;
+    }
+}


### PR DESCRIPTION
## Changes

Fixes a bug where if the toolbar is open you can't click anything anymore on your site

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
