### PR TITLE
Change h1 of Live Actions page to "Live Actions" instead of "Events"

### DIFF
--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -15,7 +15,7 @@ import { EventName } from 'scenes/actions/EventName'
 
 import { eventToName, toParams } from 'lib/utils'
 
-export function EventsTable({ fixedFilters, filtersEnabled = true, logic, isLiveActions }) {
+export function EventsTable({ fixedFilters, filtersEnabled = true, logic, isLiveActions = false }) {
     const {
         properties,
         eventsFormatted,
@@ -145,7 +145,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, logic, isLive
 
     return (
         <div className="events" data-attr="events-table">
-            <h1 className="page-header">Events</h1>
+            <h1 className="page-header">{isLiveActions ? 'Live Actions' : 'Events'}</h1>
             {filtersEnabled ? <PropertyFilters pageKey={isLiveActions ? 'LiveActionsTable' : 'EventsTable'} /> : null}
             <Tooltip title="Up to 100,000 latest events.">
                 <Button


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Tiny thing I came across while taking screenshots

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
