### PR TITLE
Test if any filters exist and if they do make sure there are properties to filter on for decide endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -32,7 +32,12 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
     # Simple flags are ones that only have rollout_percentage
     #  That means server side libraries are able to gate these flags without calling to the server
     def get_is_simple_flag(self, feature_flag: FeatureFlag):
-        return not feature_flag.filters
+        filters = feature_flag.filters
+        if not filters:
+            return True
+        if not feature_flag.filters.get("properties", []):
+            return True
+        return False
 
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> FeatureFlag:
         request = self.context["request"]

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -35,7 +35,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         filters = feature_flag.filters
         if not filters:
             return True
-        if not feature_flag.filters.get("properties", []):
+        if not filters.get("properties", []):
             return True
         return False
 


### PR DESCRIPTION
## Changes
you can see with this example that the property filters are empty but it is still evaluating `is_simple_flag` to be False
```python
{'id': 71,
   'name': '[Clickhouse] retention endpoint',
   'key': 'ch-retention-endpoint',
   'rollout_percentage': 100,
   'filters': {'properties': []},
   'deleted': False,
   'active': True,
   'created_by': {'id': 218,
    'distinct_id': 'C8UGS3uhn4QTfUiZr1RyqTmtJ31AokcbotSpX2rafCQ',
    'first_name': 'Eric',
    'email': 'eric@posthog.com'},
   'created_at': '2020-09-28T12:24:55.162765Z',
   'is_simple_flag': False}
```
## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
