### PR TITLE
Fix session date filter

### DIFF
--- a/frontend/src/scenes/sessions/sessionsTableLogic.js
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.js
@@ -9,7 +9,13 @@ export const sessionsTableLogic = kea({
             __default: [],
             loadSessions: async (selectedDate) => {
                 const response = await api.get(
-                    'api/insight/session' + (selectedDate ? '/?date_from=' + values.selectedDateURLparam : '')
+                    'api/insight/session' +
+                        (selectedDate
+                            ? '/?date_from=' +
+                              values.selectedDateURLparam +
+                              '&date_to=' +
+                              moment(values.selectedDateURLparam).add(1, 'days').toISOString()
+                            : '')
                 )
                 if (response.offset) actions.setOffset(response.offset)
                 if (response.date_from) actions.setDate(moment(response.date_from).startOf('day'))


### PR DESCRIPTION
## Changes

Filtering on sessions didn't have a date_to filter, which meant that nothing would change if you selected a different day. 

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
