### PR TITLE
Fix sessions team filtering

### DIFF
--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -92,7 +92,7 @@ class Sessions(BaseQuery):
             SELECT *,\
                 SUM(new_session) OVER (ORDER BY distinct_id, timestamp) AS global_session_id,\
                 SUM(new_session) OVER (PARTITION BY distinct_id ORDER BY timestamp) AS user_session_id\
-                FROM (SELECT id, distinct_id, event, elements_hash, timestamp, properties, CASE WHEN EXTRACT('EPOCH' FROM (timestamp - previous_timestamp)) >= (60 * 30)\
+                FROM (SELECT id, team_id, distinct_id, event, elements_hash, timestamp, properties, CASE WHEN EXTRACT('EPOCH' FROM (timestamp - previous_timestamp)) >= (60 * 30)\
                     OR previous_timestamp IS NULL \
                     THEN 1 ELSE 0 END AS new_session \
                     FROM ({}) AS inner_sessions\
@@ -122,10 +122,10 @@ class Sessions(BaseQuery):
                                     MIN(timestamp) as start_time,\
                                     array_agg(json_build_object( 'id', id, 'event', event, 'timestamp', timestamp, 'properties', properties, 'elements_hash', elements_hash) ORDER BY timestamp) as events\
                                         FROM ({}) as count GROUP BY 1) as sessions\
-                                        LEFT OUTER JOIN posthog_persondistinctid ON posthog_persondistinctid.distinct_id = sessions.distinct_id\
+                                        LEFT OUTER JOIN posthog_persondistinctid ON posthog_persondistinctid.distinct_id = sessions.distinct_id AND posthog_persondistinctid.team_id = {}\
                                         LEFT OUTER JOIN posthog_person ON posthog_person.id = posthog_persondistinctid.person_id\
                                         ORDER BY start_time DESC) as ordered_sessions OFFSET %s LIMIT 50".format(
-            base_query
+            base_query, team.pk
         )
 
         with connection.cursor() as cursor:

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -121,11 +121,11 @@ class Sessions(BaseQuery):
                                     EXTRACT('EPOCH' FROM (MAX(timestamp) - MIN(timestamp))) AS length,\
                                     MIN(timestamp) as start_time,\
                                     array_agg(json_build_object( 'id', id, 'event', event, 'timestamp', timestamp, 'properties', properties, 'elements_hash', elements_hash) ORDER BY timestamp) as events\
-                                        FROM ({}) as count GROUP BY 1) as sessions\
-                                        LEFT OUTER JOIN posthog_persondistinctid ON posthog_persondistinctid.distinct_id = sessions.distinct_id AND posthog_persondistinctid.team_id = {}\
+                                        FROM ({base_query}) as count GROUP BY 1) as sessions\
+                                        LEFT OUTER JOIN posthog_persondistinctid ON posthog_persondistinctid.distinct_id = sessions.distinct_id AND posthog_persondistinctid.team_id = {team_id}\
                                         LEFT OUTER JOIN posthog_person ON posthog_person.id = posthog_persondistinctid.person_id\
                                         ORDER BY start_time DESC) as ordered_sessions OFFSET %s LIMIT 50".format(
-            base_query, team.pk
+            base_query=base_query, team_id=team.id
         )
 
         with connection.cursor() as cursor:

--- a/posthog/queries/test/test_sessions.py
+++ b/posthog/queries/test/test_sessions.py
@@ -1,7 +1,7 @@
 from freezegun import freeze_time
 
 from posthog.api.test.base import BaseTest
-from posthog.models import Event, Filter
+from posthog.models import Event, Filter, Person, Team
 from posthog.queries.sessions import Sessions
 
 
@@ -21,7 +21,10 @@ def sessions_test_factory(sessions, event_factory):
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
                 event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-
+            team_2 = Team.objects.create()
+            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            # Test team leakage
+            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = sessions().run(Filter(data={"events": [], "session": None}), self.team)
 


### PR DESCRIPTION
## Changes

We weren't correctly filtering by team when joining on persondistinctid

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
