### PR TITLE
Report all non-DRF exceptions to sentry

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -406,6 +406,10 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 100,
 }
 
+EXCEPTIONS_HOG = {
+    "EXCEPTION_REPORTING": "posthog.utils.exception_reporting",
+}
+
 # Email
 EMAIL_HOST = os.environ.get("EMAIL_HOST")
 EMAIL_PORT = os.environ.get("EMAIL_PORT", "25")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -20,7 +20,8 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
 from django.utils import timezone
-from sentry_sdk import push_scope
+from rest_framework.exceptions import APIException
+from sentry_sdk import capture_exception, push_scope
 
 
 def absolute_uri(url: Optional[str] = None) -> str:
@@ -50,6 +51,14 @@ def get_previous_week(at_date: Optional[datetime.datetime] = None) -> Tuple[date
     )  # very start of the previous Monday
 
     return (period_start, period_end)
+
+
+def exception_reporting(exception: BaseException, context: Dict) -> None:
+    """
+    Determines which exceptions to report to Sentry and sends them.
+    """
+    if not isinstance(exception, APIException):
+        capture_exception(exception)
 
 
 def relative_date_parse(input: str) -> datetime.datetime:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ django-redis==4.12.1
 django-statsd==2.5.2
 djangorestframework==3.11.0
 djangorestframework-csv==2.1.0
-drf-exceptions-hog==0.0.1
+drf-exceptions-hog==0.0.2
 fakeredis==1.4.3
 future==0.18.2
 gunicorn==20.0.4


### PR DESCRIPTION
## Changes

- Will now report all non-DRF exceptions (not inheriting from `APIException`) to Sentry as before implementing https://github.com/posthog/drf-exceptions-hog.