### PR TITLE
Search for cohorts that contain the given distinctIDs for feature flags

### DIFF
--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -44,7 +44,12 @@ class Property:
             return value
 
     def property_to_Q(self) -> Q:
+        from .cohort import CohortPeople
+
         value = self._parse_value(self.value)
+        if self.type == "cohort":
+            return Q(Exists(CohortPeople.objects.filter(cohort_id=int(value), person_id=OuterRef("id"),).only("id")))
+
         if self.operator == "is_not":
             return Q(~Q(**{"properties__{}".format(self.key): value}) | ~Q(properties__has_key=self.key))
         if self.operator == "is_set":

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from posthog.api.test.base import BaseTest
-from posthog.models import Element, Event, Filter, Person, Property
+from posthog.models import Cohort, CohortPeople, Element, Event, Filter, Person, Property
 
 
 class TestFilter(BaseTest):
@@ -136,6 +136,18 @@ class TestPropertiesToQ(BaseTest):
         events = Event.objects.add_person_id(self.team.pk).filter(filter.properties_to_Q(team_id=self.team.pk))
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
+
+    def test_cohort_properties(self):
+        person1_distinct_id = "person1"
+        person1 = Person.objects.create(team=self.team, distinct_ids=[person1_distinct_id], properties={"group": 1})
+        cohort1 = Cohort.objects.create(team=self.team, name="cohort1", people=[person1])
+
+        matched_person = (
+            Person.objects.filter(team_id=self.team.pk, persondistinctid__distinct_id=person1_distinct_id)
+            .filter(Filter(data=self.filters).properties_to_Q(team_id=self.team.pk, is_person_query=True))
+            .exists()
+        )
+        self.assertTrue(matched_person)
 
     def test_boolean_filters(self):
         event1 = Event.objects.create(team=self.team, event="$pageview")

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -137,7 +137,7 @@ class TestPropertiesToQ(BaseTest):
         self.assertEqual(events[0], event2)
         self.assertEqual(len(events), 1)
 
-    def test_cohort_properties(self):
+    def test_person_cohort_properties(self):
         person1_distinct_id = "person1"
         person1 = Person.objects.create(team=self.team, distinct_ids=[person1_distinct_id], properties={"group": 1})
         cohort1 = Cohort.objects.create(team=self.team, groups={}, name="cohort1")

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from posthog.api.test.base import BaseTest
-from posthog.models import Cohort, CohortPeople, Element, Event, Filter, Person, Property
+from posthog.models import Cohort, Element, Event, Filter, Person
 
 
 class TestFilter(BaseTest):

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -140,11 +140,14 @@ class TestPropertiesToQ(BaseTest):
     def test_cohort_properties(self):
         person1_distinct_id = "person1"
         person1 = Person.objects.create(team=self.team, distinct_ids=[person1_distinct_id], properties={"group": 1})
-        cohort1 = Cohort.objects.create(team=self.team, name="cohort1", people=[person1])
+        cohort1 = Cohort.objects.create(team=self.team, groups={}, name="cohort1")
+        cohort1.people.add(person1)
+
+        filters = {"cohort": [{"key": "1", "value": "true"}]}
 
         matched_person = (
             Person.objects.filter(team_id=self.team.pk, persondistinctid__distinct_id=person1_distinct_id)
-            .filter(Filter(data=self.filters).properties_to_Q(team_id=self.team.pk, is_person_query=True))
+            .filter(Filter(data=filters).properties_to_Q(team_id=self.team.pk, is_person_query=True))
             .exists()
         )
         self.assertTrue(matched_person)


### PR DESCRIPTION
## Changes

Shout out to @EDsCODE for the help on the Django ORM side. The filtering is insane. 🤯

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
