### PR TITLE
made shared_dashboards endpoint exempt from x-frame-options header

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -9,6 +9,7 @@ from django.db.models import Prefetch, QuerySet
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
+from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework import authentication, request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import AuthenticationFailed
@@ -188,6 +189,7 @@ class DashboardItemsViewSet(viewsets.ModelViewSet):
         return response.Response(serializer.data)
 
 
+@xframe_options_exempt
 def shared_dashboard(request: HttpRequest, share_token: str):
     dashboard = get_object_or_404(Dashboard, is_shared=True, share_token=share_token)
     return render_template(


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Allowing shared dashboards to be embedded into iframes for display on external websites.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
