### PR TITLE
Don't use exceptions_hog when DEBUGging, adjust DEBUG and TEST

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -402,7 +402,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated",],
-    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    "EXCEPTION_HANDLER": "rest_framework.views.exception_handler" if DEBUG else "exceptions_hog.exception_handler",
     "PAGE_SIZE": 100,
 }
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -57,8 +57,8 @@ def print_warning(warning_lines: Sequence[str]):
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DEBUG = get_bool_from_env("DEBUG", False)
-TEST = "test" in sys.argv  # type: bool
+TEST: bool = "test" in sys.argv or get_bool_from_env("TEST", False)
+DEBUG: bool = not TEST and get_bool_from_env("DEBUG", False)
 
 # Canonical base URL (used for email links)
 SITE_URL = os.environ.get("SITE_URL", "http://localhost:8000")


### PR DESCRIPTION
## Changes

`exceptions_hog` hides errors, rightly so in production but annoyingly when debugging. This fixes that and improves DEBUG and TEST settings detection.
