### PR TITLE
Improve event properties display

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { PropertyKeyInfo } from './PropertyKeyInfo'
 import { Table, Tooltip } from 'antd'
 import { EditOutlined, NumberOutlined, CalendarOutlined, BulbOutlined, StopOutlined } from '@ant-design/icons'
+import { isURL } from 'lib/utils'
 
 type HandledType = 'string' | 'string, parsable as datetime' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
 type Type = HandledType | 'symbol' | 'object' | 'function'
@@ -20,18 +21,23 @@ const typeToIcon: Record<string, JSX.Element> = {
     null: <StopOutlined style={iconStyle} />,
 }
 
-function PropertyDisplay({ properties }: { properties: any }): JSX.Element {
-    let propertiesType: Type = typeof properties
-    if (properties === null) propertiesType = 'null'
-    else if (propertiesType === 'string' && moment(properties).isValid())
-        propertiesType = 'string, parsable as datetime'
-    return typeToIcon[propertiesType] ? (
+function ValueDisplay({ value }: { value: any }): JSX.Element {
+    let valueType: Type = typeof value
+    if (value === null) valueType = 'null'
+    else if (valueType === 'string' && moment(value).isValid()) valueType = 'string, parsable as datetime'
+    return typeToIcon[valueType] ? (
         <>
-            <Tooltip title={`Property of type ${propertiesType}.`}>{typeToIcon[propertiesType]}</Tooltip>
-            {String(properties)}
+            <Tooltip title={`Property of type ${valueType}.`}>{typeToIcon[valueType]}</Tooltip>
+            {isURL(value) ? (
+                <a href={value} target="_blank" rel="noopener noreferrer">
+                    {String(value)}
+                </a>
+            ) : (
+                String(value)
+            )}
         </>
     ) : (
-        properties
+        value
     )
 }
 
@@ -73,7 +79,8 @@ export function PropertiesTable({ properties }: { properties: any }): JSX.Elemen
                 dataSource={Object.entries(properties)}
             />
         )
-    return <PropertyDisplay properties={properties} />
+    // if none of above, it's a value
+    return <ValueDisplay value={properties} />
 }
 
 PropertiesTable.propTypes = {

--- a/frontend/src/lib/components/PropertyKeyInfo.js
+++ b/frontend/src/lib/components/PropertyKeyInfo.js
@@ -109,7 +109,17 @@ export const keyMapping = {
             description: 'Keys of the feature flags that were active while this event was sent.',
             examples: ['beta-feature'],
         },
-        // Events we maybe hide entirely from the list
+        $device: {
+            label: 'Device',
+            description: 'The mobile device that was used.',
+            examples: ['iPad', 'iPhone', 'Android'],
+        },
+        $sentry_url: {
+            label: 'Sentry URL',
+            description: 'Direct link to the exception in Sentry',
+            examples: ['https://sentry.io/...'],
+        },
+        // Events we hide entirely from the list
         $had_persisted_distinct_id: {
             label: '$had_persisted_distinct_id',
             description: '',

--- a/frontend/src/lib/components/PropertyKeyInfo.js
+++ b/frontend/src/lib/components/PropertyKeyInfo.js
@@ -3,6 +3,11 @@ import { Popover } from 'antd'
 
 export const keyMapping = {
     event: {
+        $timestamp: {
+            label: 'Timestamp',
+            description: 'Time the event happened.',
+            examples: [new Date().toISOString()],
+        },
         $browser: {
             label: 'Browser',
             description: 'Name of the browser the user has used.',
@@ -120,23 +125,47 @@ export const keyMapping = {
             examples: ['https://sentry.io/...'],
         },
         // Events we hide entirely from the list
+        $snapshot_data: {
+            label: 'Snapshot data',
+            description: 'JSON object used for session recordings.',
+            hide: true,
+        },
         $had_persisted_distinct_id: {
             label: '$had_persisted_distinct_id',
             description: '',
+            hide: true,
         },
         $device: {
             label: 'Device',
             description: 'The mobile device that was used.',
             examples: ['iPad', 'iPhone', 'Android'],
         },
+        $had_persisted_distinct_id: {
+            label: '$had_persisted_distinct_id',
+            description: '',
+            hide: true,
+        },
+        $sentry_event_id: {
+            label: 'Sentry Event ID',
+            description: 'This is the Sentry key for an event.',
+            examples: ['byroc2ar9ee4ijqp'],
+            hide: true,
+        },
+        $sentry_exception: {
+            label: 'Sentry exception',
+            description: 'Raw Sentry exception data',
+            hide: true,
+        },
         $ce_version: {
             label: '$ce_version',
             description: '',
+            hide: true,
         },
         $anon_distinct_id: {
             label: 'Anon Distinct ID',
             description: 'If the user was previously anonymous, their anonymous ID will be set here.',
             examples: ['16ff262c4301e5-0aa346c03894bc-39667c0e-1aeaa0-16ff262c431767'],
+            hide: true,
         },
         $event_type: {
             label: 'Event Type',
@@ -147,15 +176,18 @@ export const keyMapping = {
         $insert_id: {
             label: 'Insert ID',
             description: 'Unique insert ID for the event.',
+            hide: true,
         },
         $time: {
             label: 'Time',
             description: 'Time as given by the client.',
+            hide: true,
         },
         $device_id: {
             label: 'Device ID',
             description: 'Unique ID for that device, consistent even if users are logging in/out.',
             examples: ['16ff262c4301e5-0aa346c03894bc-39667c0e-1aeaa0-16ff262c431767'],
+            hide: true,
         },
     },
     element: {

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -362,6 +362,7 @@ export function stripHTTP(url) {
 
 export function isURL(string) {
     if (!string) return false
+    // https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
     var expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi
     var regex = new RegExp(expression)
     return string.match && string.match(regex)

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -360,6 +360,13 @@ export function stripHTTP(url) {
     return url
 }
 
+export function isURL(string) {
+    if (!string) return false
+    var expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi
+    var regex = new RegExp(expression)
+    return string.match && string.match(regex)
+}
+
 export const eventToName = (event) => {
     if (event.event !== '$autocapture') return event.event
     let name = ''

--- a/frontend/src/scenes/events/EventDetails.js
+++ b/frontend/src/scenes/events/EventDetails.js
@@ -1,17 +1,25 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import moment from 'moment'
 import { EventElements } from 'scenes/events/EventElements'
 import { Tabs, Button } from 'antd'
 
 import { createActionFromEvent } from './createActionFromEvent'
+import { keyMapping } from 'lib/components/PropertyKeyInfo'
 const { TabPane } = Tabs
 
 export function EventDetails({ event }) {
-    let displayableEventProperties = {}
+    const [showHiddenProps, setShowHiddenProps] = useState(false)
 
+    let displayableEventProperties = {}
+    let hiddenPropsCount = 0
     for (let key of Object.keys(event.properties)) {
-        if (key !== '$snapshot_data') displayableEventProperties[key] = event.properties[key]
+        if (keyMapping.event[key] && keyMapping.event[key].hide) {
+            hiddenPropsCount += 1
+        }
+        if (!keyMapping.event[key] || showHiddenProps || !keyMapping.event[key].hide) {
+            displayableEventProperties[key] = event.properties[key]
+        }
     }
 
     return (
@@ -32,10 +40,21 @@ export function EventDetails({ event }) {
                 <TabPane tab="Properties" key="properties">
                     <PropertiesTable
                         properties={{
-                            Timestamp: moment(event.timestamp).toISOString(),
+                            $timestamp: moment(event.timestamp).toISOString(),
                             ...displayableEventProperties,
                         }}
                     />
+                    {hiddenPropsCount > 0 && (
+                        <small>
+                            <Button
+                                style={{ margin: '8px 0 0 8px' }}
+                                type="link"
+                                onClick={() => setShowHiddenProps(!showHiddenProps)}
+                            >
+                                {hiddenPropsCount} hidden properties. Click to {showHiddenProps ? 'hide' : 'show'}.
+                            </Button>
+                        </small>
+                    )}
                 </TabPane>
                 {event.elements && event.elements.length > 0 && (
                     <TabPane tab="Elements" key="elements">

--- a/frontend/src/scenes/events/EventDetails.js
+++ b/frontend/src/scenes/events/EventDetails.js
@@ -11,14 +11,14 @@ const { TabPane } = Tabs
 export function EventDetails({ event }) {
     const [showHiddenProps, setShowHiddenProps] = useState(false)
 
-    let displayableEventProperties = {}
+    let displayedEventProperties = {}
     let hiddenPropsCount = 0
     for (let key of Object.keys(event.properties)) {
         if (keyMapping.event[key] && keyMapping.event[key].hide) {
             hiddenPropsCount += 1
         }
-        if (!keyMapping.event[key] || showHiddenProps || !keyMapping.event[key].hide) {
-            displayableEventProperties[key] = event.properties[key]
+        if (!keyMapping.event[key] || !keyMapping.event[key].hide || showHiddenProps) {
+            displayedEventProperties[key] = event.properties[key]
         }
     }
 
@@ -41,7 +41,7 @@ export function EventDetails({ event }) {
                     <PropertiesTable
                         properties={{
                             $timestamp: moment(event.timestamp).toISOString(),
-                            ...displayableEventProperties,
+                            ...displayedEventProperties,
                         }}
                     />
                     {hiddenPropsCount > 0 && (

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -185,7 +185,7 @@ export function EventsTable({
                 pagination={{ pageSize: 99999, hideOnSinglePage: true }}
                 rowKey={(row) => (row.event ? row.event.id + '-' + row.event.actionId : row.date_break)}
                 rowClassName={(row) => {
-                    if (row.event) return 'event-row'
+                    if (row.event) return 'event-row ' + (row.event.event === '$exception' && 'event-row-is-exception')
                     if (row.date_break) return 'event-day-separator'
                     if (row.new_events) return 'event-row-new'
                 }}

--- a/frontend/src/style/events.scss
+++ b/frontend/src/style/events.scss
@@ -12,4 +12,7 @@
     .event-new-events {
         background-color: $gray-300;
     }
+    .event-row-is-exception {
+        background-color: lighten($danger, 40%);
+    }
 }


### PR DESCRIPTION
## Changes

- Makes URLs clickable
- Hide a handful of properties that aren't relevant (with option to show them, see toggle)
![image](https://user-images.githubusercontent.com/1727427/95449185-b1d77880-0964-11eb-80f7-c0cdd2069214.png)
- Make an exception event red in the events list
![image](https://user-images.githubusercontent.com/1727427/95449228-c1ef5800-0964-11eb-9872-c0787a5c287b.png)


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
