### PR TITLE
Get rid of caching in /decide endpoint

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -113,7 +113,7 @@ def get_event(request):
             ),
         )
 
-    team = Team.objects.get_cached_from_token(token, is_personal_api_key)
+    team = Team.objects.get_team_from_token(token, is_personal_api_key)
     if team is None:
         return cors_response(
             request,

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -54,7 +54,7 @@ def decide_editor_params(request: HttpRequest) -> Tuple[Dict[str, Any], bool]:
 
 
 # May raise exception if request body is malformed
-def find_team_by_token(request: HttpRequest, data_from_request: Dict[str, Any]) -> Union[Team, None]:
+def get_team_from_token(request: HttpRequest, data_from_request: Dict[str, Any]) -> Union[Team, None]:
     data = data_from_request["data"]
     if not data:
         return None
@@ -68,7 +68,7 @@ def find_team_by_token(request: HttpRequest, data_from_request: Dict[str, Any]) 
         is_personal_api_key = True
 
     if token:
-        return Team.objects.get_cached_from_token(token, is_personal_api_key)
+        return Team.objects.get_team_from_token(token, is_personal_api_key)
 
     return None
 
@@ -123,7 +123,7 @@ def get_decide(request: HttpRequest):
                 ),
             )
 
-        team = find_team_by_token(request, data_from_request)
+        team = get_team_from_token(request, data_from_request)
         if team:
             response["featureFlags"] = feature_flags(request, team, data_from_request["data"])
             response["sessionRecording"] = team.session_recording_opt_in

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -61,10 +61,7 @@ class TeamManager(models.Manager):
         )
         return team
 
-    def get_cached_from_token(self, token: str, is_personal_api_key: bool = False) -> Optional["Team"]:
-        team_from_cache = TEAM_CACHE.get(token)
-        if team_from_cache:
-            return team_from_cache
+    def get_team_from_token(self, token: str, is_personal_api_key: bool = False) -> Optional["Team"]:
         if not is_personal_api_key:
             try:
                 team = Team.objects.get(api_token=token)
@@ -85,7 +82,6 @@ class TeamManager(models.Manager):
                 team = personal_api_key.team
                 personal_api_key.last_used_at = timezone.now()
                 personal_api_key.save()
-        TEAM_CACHE[token] = team
         return team
 
 


### PR DESCRIPTION
The caching was causing `sessionRecording` to always be false => session
recording not to work.

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
