### PR TITLE
Added rr-block class to sensitive elements

### DIFF
--- a/frontend/src/lib/components/CopyToClipboard.tsx
+++ b/frontend/src/lib/components/CopyToClipboard.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Tooltip, Input } from 'antd'
 import { CopyOutlined } from '@ant-design/icons'
 import { copyToClipboard } from 'lib/utils'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 interface InlineProps {
     children: JSX.Element | string
@@ -27,7 +28,7 @@ export function CopyToClipboardInline({
     return (
         <Tooltip title="Click to copy">
             <span
-                className={isValueSensitive ? 'ph-no-capture' : undefined}
+                className={isValueSensitive ? 'ph-no-capture ' + rrwebBlockClass : ''}
                 style={{ cursor: 'pointer' }}
                 onClick={() => {
                     copyToClipboard(explicitValue ?? children.toString(), description)
@@ -50,7 +51,7 @@ export function CopyToClipboardInput({
 }: InputProps): JSX.Element {
     return (
         <Input
-            className={isValueSensitive ? 'ph-no-capture' : undefined}
+            className={isValueSensitive ? 'ph-no-capture ' + rrwebBlockClass : ''}
             type="text"
             value={value}
             placeholder={placeholder || 'nothing to show here'}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -5,6 +5,7 @@ import { PropertyValue } from './PropertyValue'
 import { PropertyKeyInfo, keyMapping } from 'lib/components/PropertyKeyInfo'
 import { cohortsModel } from '../../../models/cohortsModel'
 import { useValues, useActions } from 'kea'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 const { TabPane } = Tabs
 
@@ -23,6 +24,7 @@ function PropertyPaneContents({
         <>
             <div className={displayOperatorAndValue ? 'col-4 pl-0' : 'col p-0'}>
                 <Select
+                    className={rrwebBlockClass}
                     showSearch
                     autoFocus={!propkey}
                     defaultOpen={!propkey}
@@ -154,6 +156,7 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
     return (
         <>
             <Select
+                className={rrwebBlockClass}
                 style={{ width: '100%' }}
                 showSearch
                 optionFilterProp="children"

--- a/frontend/src/lib/utils/rrwebBlockClass.tsx
+++ b/frontend/src/lib/utils/rrwebBlockClass.tsx
@@ -1,0 +1,3 @@
+const rrwebBlockClass: string = 'rr-block'
+
+export default rrwebBlockClass

--- a/frontend/src/scenes/annotations/AnnotationsTable.tsx
+++ b/frontend/src/scenes/annotations/AnnotationsTable.tsx
@@ -6,6 +6,7 @@ import { humanFriendlyDetailedTime } from 'lib/utils'
 import moment from 'moment'
 import { annotationsModel } from '~/models/annotationsModel'
 import { DeleteOutlined, RedoOutlined } from '@ant-design/icons'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 const { TextArea } = Input
 
@@ -50,7 +51,10 @@ export function AnnotationsTable(props: Props): JSX.Element {
                 const { created_by } = annotation
 
                 return (
-                    <Link to={`/person/${encodeURIComponent(created_by.id)}`} className="ph-no-capture">
+                    <Link
+                        to={`/person/${encodeURIComponent(created_by.id)}`}
+                        className={rrwebBlockClass + ' ph-no-capture'}
+                    >
                         {created_by?.name || created_by?.email}
                     </Link>
                 )

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -15,6 +15,8 @@ import { EventName } from 'scenes/actions/EventName'
 
 import { eventToName, toParams } from 'lib/utils'
 
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
+
 export function EventsTable({
     fixedFilters,
     filtersEnabled = true,
@@ -96,7 +98,10 @@ export function EventsTable({
             render: function renderPerson({ event }) {
                 if (!event) return { props: { colSpan: 0 } }
                 return showLinkToPerson ? (
-                    <Link to={`/person/${encodeURIComponent(event.distinct_id)}${search}`} className="ph-no-capture">
+                    <Link
+                        to={`/person/${encodeURIComponent(event.distinct_id)}${search}`}
+                        className={'ph-no-capture ' + rrwebBlockClass}
+                    >
                         {event.person}
                     </Link>
                 ) : (
@@ -112,7 +117,12 @@ export function EventsTable({
                 let param = event.properties['$current_url'] ? '$current_url' : '$screen_name'
                 if (filtersEnabled)
                     return (
-                        <FilterPropertyLink property={param} value={event.properties[param]} filters={{ properties }} />
+                        <FilterPropertyLink
+                            className={'ph-no-capture ' + rrwebBlockClass}
+                            property={param}
+                            value={event.properties[param]}
+                            filters={{ properties }}
+                        />
                     )
                 return <Property value={event.properties[param]} />
             },
@@ -173,7 +183,7 @@ export function EventsTable({
                 loading={isLoading}
                 columns={columns}
                 size="small"
-                className="ph-no-capture"
+                className={rrwebBlockClass + ' ph-no-capture'}
                 locale={{
                     emptyText: (
                         <span>

--- a/frontend/src/scenes/experiments/EditFeatureFlag.js
+++ b/frontend/src/scenes/experiments/EditFeatureFlag.js
@@ -4,6 +4,7 @@ import { kea, useActions, useValues } from 'kea'
 import { slugify } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 const editLogic = kea({
     actions: () => ({
@@ -72,6 +73,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
             <Form.Item
                 name="name"
                 label="Name"
+                className={rrwebBlockClass}
                 rules={[
                     { required: true, message: 'Please give your feature flag a name, like "experimental feature".' },
                 ]}
@@ -109,7 +111,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                 <Switch />
             </Form.Item>
 
-            <Form.Item label="Filter by user properties">
+            <Form.Item className={rrwebBlockClass} label="Filter by user properties">
                 <PropertyFilters
                     pageKey="feature-flag"
                     propertyFilters={filters?.properties}

--- a/frontend/src/scenes/experiments/FeatureFlags.js
+++ b/frontend/src/scenes/experiments/FeatureFlags.js
@@ -5,6 +5,7 @@ import { featureFlagLogic } from './featureFlagLogic'
 import { Table, Switch, Drawer, Button } from 'antd'
 import moment from 'moment'
 import { EditFeatureFlag } from './EditFeatureFlag'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 export const FeatureFlags = hot(_FeatureFlags)
 function _FeatureFlags() {
@@ -68,7 +69,7 @@ function _FeatureFlags() {
                     onClick: () => setOpenFeatureFlag(featureFlag),
                 })}
                 size="small"
-                rowClassName="cursor-pointer"
+                rowClassName={'cursor-pointer ' + rrwebBlockClass}
                 data-attr="feature-flag-table"
             />
             {openFeatureFlag && (

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -10,6 +10,7 @@ import moment from 'moment'
 import { SessionType } from '~/types'
 import { CaretLeftOutlined, CaretRightOutlined } from '@ant-design/icons'
 import SessionsPlayerButton from './SessionsPlayerButton'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -27,7 +28,10 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
             key: 'person',
             render: function RenderSession(session: SessionType) {
                 return (
-                    <Link to={`/person/${encodeURIComponent(session.distinct_id)}`} className="ph-no-capture">
+                    <Link
+                        to={`/person/${encodeURIComponent(session.distinct_id)}`}
+                        className={rrwebBlockClass + ' ph-no-capture'}
+                    >
                         {session.properties?.email || session.distinct_id}
                     </Link>
                 )

--- a/frontend/src/scenes/team/Team.js
+++ b/frontend/src/scenes/team/Team.js
@@ -5,6 +5,7 @@ import { Table, Modal } from 'antd'
 import { useValues, useActions } from 'kea'
 import { teamLogic } from './teamLogic'
 import { DeleteOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 function Team({ user }) {
     const logic = teamLogic()
@@ -84,7 +85,12 @@ function Team({ user }) {
                         <Spin />
                     </Row>
                 ) : (
-                    <Table dataSource={userDataMarked} columns={columns} rowKey="distinct_id" />
+                    <Table
+                        dataSource={userDataMarked}
+                        className={rrwebBlockClass}
+                        columns={columns}
+                        rowKey="distinct_id"
+                    />
                 )}
             </div>
         </>

--- a/frontend/src/scenes/users/Cohorts.js
+++ b/frontend/src/scenes/users/Cohorts.js
@@ -8,6 +8,7 @@ import { ExportOutlined, DeleteOutlined, InfoCircleOutlined } from '@ant-design/
 import { cohortsModel } from '../../models/cohortsModel'
 import { useValues, useActions } from 'kea'
 import { hot } from 'react-hot-loader/root'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 export const Cohorts = hot(_Cohorts)
 function _Cohorts() {
@@ -19,7 +20,11 @@ function _Cohorts() {
             dataIndex: 'name',
             key: 'name',
             render: function RenderName(_, cohort) {
-                return <Link to={'/people?cohort=' + cohort.id}>{cohort.name}</Link>
+                return (
+                    <Link className={rrwebBlockClass} to={'/people?cohort=' + cohort.id}>
+                        {cohort.name}
+                    </Link>
+                )
             },
         },
         {

--- a/frontend/src/scenes/users/PeopleTable.js
+++ b/frontend/src/scenes/users/PeopleTable.js
@@ -4,6 +4,7 @@ import { Link } from 'lib/components/Link'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { DeleteOutlined } from '@ant-design/icons'
 import { deletePersonData } from 'lib/utils'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 export function PeopleTable({ people, loading, actions, onChange }) {
     let columns = [
@@ -13,7 +14,10 @@ export function PeopleTable({ people, loading, actions, onChange }) {
             key: 'name',
             render: function RenderName(_, person) {
                 return (
-                    <Link to={'/person/' + encodeURIComponent(person.distinct_ids[0])} className="ph-no-capture">
+                    <Link
+                        to={'/person/' + encodeURIComponent(person.distinct_ids[0])}
+                        className={'ph-no-capture ' + rrwebBlockClass}
+                    >
                         {person.name}
                     </Link>
                 )


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Adds the `rr-block` class to prevent session recordings from capturing sensitive data.

This could of course be set on posthog-js to be `ph-no-capture` but there are things that I think PostHog should capture that rrweb shouldn't and vice-versa.

However, the way it was added as a centralized export allows the class to be changed very easily.


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
