### PR TITLE
Disable web snippet on DEBUG instances

### DIFF
--- a/frontend/src/scenes/sceneLogic.js
+++ b/frontend/src/scenes/sceneLogic.js
@@ -124,7 +124,7 @@ export const sceneLogic = kea({
     },
     listeners: ({ values, actions }) => ({
         setScene: () => {
-            window.posthog && posthog?.capture('$pageview')
+            window.posthog && window.posthog?.capture('$pageview')
         },
         loadScene: async ({ scene, params = {} }, breakpoint) => {
             if (values.scene === scene) {

--- a/frontend/src/scenes/sceneLogic.js
+++ b/frontend/src/scenes/sceneLogic.js
@@ -124,7 +124,7 @@ export const sceneLogic = kea({
     },
     listeners: ({ values, actions }) => ({
         setScene: () => {
-            window.posthog && window.posthog.capture('$pageview')
+            window.posthog && posthog?.capture('$pageview')
         },
         loadScene: async ({ scene, params = {} }, breakpoint) => {
             if (values.scene === scene) {

--- a/frontend/src/scenes/sceneLogic.js
+++ b/frontend/src/scenes/sceneLogic.js
@@ -124,7 +124,7 @@ export const sceneLogic = kea({
     },
     listeners: ({ values, actions }) => ({
         setScene: () => {
-            window.posthog && window.posthog?.capture('$pageview')
+            window.posthog?.capture('$pageview')
         },
         loadScene: async ({ scene, params = {} }, breakpoint) => {
             if (values.scene === scene) {

--- a/frontend/src/scenes/setup/Setup.js
+++ b/frontend/src/scenes/setup/Setup.js
@@ -23,7 +23,7 @@ export const Setup = hot(_Setup)
 function _Setup() {
     const { user } = useValues(userLogic)
     const { location } = useValues(router)
-    const showSessionRecord = window.posthog && window.posthog.isFeatureEnabled('session-recording-player')
+    const showSessionRecord = window.posthog && posthog?.isFeatureEnabled('session-recording-player')
 
     useAnchor(location.hash)
 

--- a/frontend/src/scenes/setup/Setup.js
+++ b/frontend/src/scenes/setup/Setup.js
@@ -23,7 +23,7 @@ export const Setup = hot(_Setup)
 function _Setup() {
     const { user } = useValues(userLogic)
     const { location } = useValues(router)
-    const showSessionRecord = window.posthog && window.posthog?.isFeatureEnabled('session-recording-player')
+    const showSessionRecord = window.posthog?.isFeatureEnabled('session-recording-player')
 
     useAnchor(location.hash)
 

--- a/frontend/src/scenes/setup/Setup.js
+++ b/frontend/src/scenes/setup/Setup.js
@@ -23,7 +23,7 @@ export const Setup = hot(_Setup)
 function _Setup() {
     const { user } = useValues(userLogic)
     const { location } = useValues(router)
-    const showSessionRecord = window.posthog && posthog?.isFeatureEnabled('session-recording-player')
+    const showSessionRecord = window.posthog && window.posthog?.isFeatureEnabled('session-recording-player')
 
     useAnchor(location.hash)
 

--- a/frontend/src/scenes/users/Person.js
+++ b/frontend/src/scenes/users/Person.js
@@ -132,7 +132,7 @@ function _Person({ _: distinctId, id }) {
                     key="events"
                     data-attr="people-types-tab"
                 />
-                {window.posthog && window.posthog.isFeatureEnabled('session-recording-player') && (
+                {window.posthog && posthog?.isFeatureEnabled('session-recording-player') && (
                     <TabPane
                         tab={<span data-attr="people-types-tab">Sessions By Day</span>}
                         key="sessions"

--- a/frontend/src/scenes/users/Person.js
+++ b/frontend/src/scenes/users/Person.js
@@ -132,7 +132,7 @@ function _Person({ _: distinctId, id }) {
                     key="events"
                     data-attr="people-types-tab"
                 />
-                {window.posthog && posthog?.isFeatureEnabled('session-recording-player') && (
+                {window.posthog && window.posthog?.isFeatureEnabled('session-recording-player') && (
                     <TabPane
                         tab={<span data-attr="people-types-tab">Sessions By Day</span>}
                         key="sessions"

--- a/frontend/src/scenes/users/Person.js
+++ b/frontend/src/scenes/users/Person.js
@@ -132,7 +132,7 @@ function _Person({ _: distinctId, id }) {
                     key="events"
                     data-attr="people-types-tab"
                 />
-                {window.posthog && window.posthog?.isFeatureEnabled('session-recording-player') && (
+                {window.posthog?.isFeatureEnabled('session-recording-player') && (
                     <TabPane
                         tab={<span data-attr="people-types-tab">Sessions By Day</span>}
                         key="sessions"

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -2,7 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" href="/static/favicon-32x32.png" sizes="32x32"/>
 <link rel="icon" href="/static/favicon-192x192.png" sizes="192x192"/>
-{% if not opt_out_capture %}
+{% if not opt_out_capture and not debug %}
     <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init('sTMFPsFhdP1Ssg', {api_host: 'https://app.posthog.com'})


### PR DESCRIPTION
## Changes

We disabled Python analytics on DEBUG instances, but forgot to do the same with the web snippet, resulting in frontend events causing noise in our data. This fixes that.
