### PR TITLE
When DEBUG, include posthog.js with local posthog host

### DIFF
--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -2,10 +2,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" href="/static/favicon-32x32.png" sizes="32x32"/>
 <link rel="icon" href="/static/favicon-192x192.png" sizes="192x192"/>
-{% if not opt_out_capture and not debug %}
+{% if not opt_out_capture %}
     <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('sTMFPsFhdP1Ssg', {api_host: 'https://app.posthog.com'})
+    posthog.init('{{js_posthog_apikey}}', {api_host: '{{js_posthog_host}}'})
     </script>
 {% endif %}
 {% if sentry_dsn %}

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -5,7 +5,7 @@
 {% if not opt_out_capture %}
     <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('{{js_posthog_apikey}}', {api_host: '{{js_posthog_host}}'})
+    posthog.init('{{js_posthog_apikey}}', {api_host: {{js_posthog_host}}})
     </script>
 {% endif %}
 {% if sentry_dsn %}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -162,6 +162,7 @@ def render_template(template_name: str, request: HttpRequest, context=None) -> H
     template = get_template(template_name)
     try:
         context["opt_out_capture"] = request.user.team.opt_out_capture
+        context["js_posthog_apikey"] = request.user.team.api_token
     except (Team.DoesNotExist, AttributeError):
         team = Team.objects.all()
         # if there's one team on the instance, and they've set opt_out
@@ -185,6 +186,12 @@ def render_template(template_name: str, request: HttpRequest, context=None) -> H
         context["debug"] = True
         context["git_rev"] = get_git_commit()
         context["git_branch"] = get_git_branch()
+
+    if settings.DEBUG:
+        context["js_posthog_host"] = "http://localhost:8000"
+    else:
+        context["js_posthog_apikey"] = "sTMFPsFhdP1Ssg"
+        context["js_posthog_host"] = "https://app.posthog.com"
 
     html = template.render(context, request=request)
     return HttpResponse(html)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -188,10 +188,10 @@ def render_template(template_name: str, request: HttpRequest, context=None) -> H
         context["git_branch"] = get_git_branch()
 
     if settings.DEBUG:
-        context["js_posthog_host"] = "http://localhost:8000"
+        context["js_posthog_host"] = "window.location.origin"
     else:
         context["js_posthog_apikey"] = "sTMFPsFhdP1Ssg"
-        context["js_posthog_host"] = "https://app.posthog.com"
+        context["js_posthog_host"] = "'https://app.posthog.com'"
 
     html = template.render(context, request=request)
     return HttpResponse(html)


### PR DESCRIPTION
## Changes

This was initially included in session recording project, but removed in
https://github.com/PostHog/posthog/pull/1837

Wins of doing it this way:
- Less noisy data in production.
  - Slack thread by @paolodamico: https://posthog.slack.com/archives/C018RGRS10S/p1602486169005700
- Can develop/dogfood feature flags for development.
  - Used in session recording - can "merge" half-complete solutions that
    are not yet ready for release
- Can possibly mock feature flags in cypress tests
- Session recording can be done in localhost now :)

Downsides:
- If feature flags are not cleaned up, this may cause drift between
  local checkouts and production.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
