### PR TITLE
Try running review apps in production mode

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,9 +8,6 @@
             "scripts": {
                 "postdeploy": "python manage.py setup_dev"
             },
-            "env": {
-                "DEBUG": true
-            },
             "buildpacks": [
                 { "url": "heroku/nodejs" },
                 { "url": "https://github.com/timgl/heroku-buildpack-python.git" }


### PR DESCRIPTION
## Changes

GitHub+Heroku review apps are running in DEBUG mode, but we are doing that during development anyway. There's more value in having production-like review apps, making, for instance, judging impact of added dependencies easier.
