### PR TITLE
Fix session label hover erroring

### DIFF
--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -204,7 +204,7 @@ export function LineGraph({
                                           return null
                                       var label = entityData.chartLabel || entityData.label || ''
                                       return (
-                                          formatLabel(label, entityData.action) +
+                                          (entityData.action ? formatLabel(label, entityData.action) : label) +
                                           ' - ' +
                                           tooltipItem.yLabel.toLocaleString()
                                       )


### PR DESCRIPTION
## Changes

*Please describe.*  
- The session label wasn't appearing on hover because it was erroring. The format label function expects an action but there's not supposed to be an action object for session graphs

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
