### PR TITLE
Pinning the dev Dockerfile PostgreSQL and Redis to the production ver

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     db:
-        image: postgres:alpine
+        image: postgres-11:alpine
         container_name: posthog_db
         environment:
             POSTGRES_USER: posthog
@@ -11,7 +11,7 @@ services:
         ports:
             - '5439:5432'
     redis:
-        image: 'redis:alpine'
+        image: 'redis-5:alpine'
         container_name: posthog_redis
         ports:
             - '6379:6379'


### PR DESCRIPTION
## Changes

Matching the production versions locally to make sure Redis 5.x  and PostgreSQL 11.x is used.

[Related change to the docs](https://github.com/PostHog/posthog.com/pull/517)

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
