### PR TITLE
Disable heartbeats in DEBUG

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,7 +1,6 @@
 import os
 import time
 
-import posthoganalytics
 import redis
 import statsd  # type: ignore
 from celery import Celery
@@ -38,10 +37,12 @@ statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_P
 
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
-    sender.add_periodic_task(1.0, redis_celery_queue_depth.s(), name="1 sec queue probe", priority=0)
+    if not settings.DEBUG:
+        sender.add_periodic_task(1.0, redis_celery_queue_depth.s(), name="1 sec queue probe", priority=0)
+        # Heartbeat every 10sec to make sure the worker is alive
+        sender.add_periodic_task(10.0, redis_heartbeat.s(), name="10 sec heartbeat", priority=0)
 
-    # Heartbeat every 10sec to make sure the worker is alive
-    sender.add_periodic_task(10.0, redis_heartbeat.s(), name="10 sec heartbeat", priority=0)
+    # update events table partitions twice a week
     sender.add_periodic_task(
         crontab(day_of_week="mon,fri"), update_event_partitions.s(),  # check twice a week
     )


### PR DESCRIPTION
## Changes

These heartbeat logs make PostHog stdout horribly messy to read and it doesn't seem like they are actually needed in a DEBUG setting. This disables them in DEBUG mode.
