### PR TITLE
Avoid throwing uncaught error when creating cohorts

### DIFF
--- a/frontend/src/scenes/users/Cohort.js
+++ b/frontend/src/scenes/users/Cohort.js
@@ -5,7 +5,6 @@ import { cohortLogic } from './cohortLogic'
 import { Button } from 'antd'
 
 import { useValues, useActions } from 'kea'
-import { router } from 'kea-router'
 
 const isSubmitDisabled = (cohorts) => {
     if (cohorts && cohorts.groups) return !cohorts.groups.some((group) => Object.keys(group).length)
@@ -36,7 +35,6 @@ export function Cohort({ onChange }) {
                             onClick={() => {
                                 setCohort({ id: false, groups: [] })
                                 onChange()
-                                router.actions.push(`${this.props.location.pathname}`)
                             }}
                         />
                         {cohort.name || 'New Cohort'}


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/1665112291/?project=1899813&query=is%3Aunresolved+frontend&sort=user&statsPeriod=14d

This was introduced in commit 8e6b4f56b5eb32962dc0d624c56ffe85d629a96b
when moving from classes to functional components.

A lot of the Cohorts/People UX is weird, creating a separate issue on
this.

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
