### PR TITLE
Fix syntaxerror on old browser notifications

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -7,7 +7,7 @@
     {% include "overlays.html" %}
     <script>
         if (typeof Object.entries === 'undefined') {
-            let div = document.createElement("div");
+            var div = document.createElement("div");
             div.style.color='#fef6f6'; div.style.background='#920c0c'; div.style.padding='5px 10px';
             div.innerHTML = "You are using a really old browser. Please upgrade to fully enjoy PostHog!"
             document.body.prepend(div);

--- a/frontend/src/shared_dashboard.ejs
+++ b/frontend/src/shared_dashboard.ejs
@@ -15,7 +15,7 @@
   <body>
     <script>
         if (typeof Object.entries === 'undefined') {
-            let div = document.createElement("div");
+            var div = document.createElement("div");
             div.style.color='#fef6f6'; div.style.background='#920c0c'; div.style.padding='5px 10px';
             div.innerHTML = "You are using a really old browser. Please upgrade to fully enjoy PostHog!"
             document.body.prepend(div);


### PR DESCRIPTION
Sentry: https://sentry.io/organizations/posthog/issues/1866056145/events/07430159d50a4c91a72c280a7921bf0d/?project=1899813&query=is%3Aunresolved&sort=user&statsPeriod=14d

I assume this was happening during parsing rather than during execution
- these are relatively new browsers

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
