### PR TITLE
Show CMD+K as "⌘K" instead of "⌘ + K"

### DIFF
--- a/frontend/src/layout/TopContent/CommandPaletteButton.tsx
+++ b/frontend/src/layout/TopContent/CommandPaletteButton.tsx
@@ -16,7 +16,7 @@ export function CommandPaletteButton(): JSX.Element {
             title={isPaletteShown ? 'Hide Command Palette' : 'Show Command Palette'}
         >
             <SearchOutlined size={1} style={{ marginRight: '0.5rem' }} />
-            {platformCommandControlKey()} + K
+            {platformCommandControlKey('K')}
         </span>
     )
 }

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -482,8 +482,8 @@ export function isMac(): boolean {
     return navigator.platform.includes('Mac')
 }
 
-export function platformCommandControlKey(): string {
-    return isMac() ? '⌘' : 'Ctrl'
+export function platformCommandControlKey(modifier: string): string {
+    return `${isMac() ? '⌘' : 'Ctrl + '}${modifier}`
 }
 
 export function groupBy<T>(items: T[], groupResolver: (item: T) => string | number): Record<string | number, T[]> {


### PR DESCRIPTION
## Changes

This has been bugging me for a while. On a Mac keyboard shortcuts are almost always shown without the "+"

Before:

<img width="417" alt="Screenshot 2020-10-15 at 13 38 32" src="https://user-images.githubusercontent.com/53387/96118753-3d648280-0eec-11eb-9065-70379563c995.png">

After:

<img width="396" alt="Screenshot 2020-10-15 at 13 40 55" src="https://user-images.githubusercontent.com/53387/96118760-3fc6dc80-0eec-11eb-9edc-c7c621478194.png">

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
