### PR TITLE
Adds support for Default Dashboards (#1694)

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -22,14 +22,6 @@ describe('Dashboards', () => {
             })
     })
 
-    it('Create dashboard', () => {
-        cy.get('[data-attr="new-dashboard"]').click({ force: true })
-
-        cy.get('[data-attr=modal-prompt]').clear().type('Test Dashboard')
-        cy.contains('OK').click()
-        cy.contains('Test Dashboard').should('exist')
-    })
-
     it('Click on a dashboard item dropdown and view graph', () => {
         cy.get('[data-attr=dashboard-name-0]').click()
         cy.get('[data-attr=dashboard-item-0-dropdown]').click()

--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -22,6 +22,27 @@ describe('Dashboards', () => {
             })
     })
 
+    it('Create an empty dashboard', () => {
+        cy.get('[data-attr="new-dashboard"]').click()
+        cy.get('[data-attr=dashboard-name]').clear().type('YDefault')
+        cy.get('button').contains('Create').click()
+
+        cy.contains('YDefault').should('exist')
+        cy.contains('There are no panels').should('exist')
+    })
+
+    it('Create dashboard from a template', () => {
+        cy.get('[data-attr="new-dashboard"]').click()
+        cy.get('[data-attr=dashboard-name]').clear().type('XDefault')
+        cy.get('[data-attr=copy-from-template]').click()
+        cy.get('[data-attr=dashboard-select-2]').click()
+
+        cy.get('button').contains('Create').click()
+
+        cy.contains('XDefault').should('exist')
+        cy.get('.dashboard-item').its('length').should('be.gte', 2)
+    })
+
     it('Click on a dashboard item dropdown and view graph', () => {
         cy.get('[data-attr=dashboard-name-0]').click()
         cy.get('[data-attr=dashboard-item-0-dropdown]').click()

--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -26,8 +26,8 @@ export const dashboardsModel = kea({
         // We're not using this loader as a reducer per se, but just calling it `dashboard`
         // to have the right payload ({ dashboard }) in the Success actions
         dashboard: {
-            addDashboard: async ({ name, show = false }) => {
-                const result = await api.create('api/dashboard', { name, pinned: true })
+            addDashboard: async ({ name, show = false, copyFromTemplate }) => {
+                const result = await api.create('api/dashboard', { name, pinned: true, copyFromTemplate })
                 if (show) router.actions.push(`/dashboard/${result.id}`)
                 return result
             },

--- a/frontend/src/scenes/dashboard/Dashboards.js
+++ b/frontend/src/scenes/dashboard/Dashboards.js
@@ -1,30 +1,47 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { Button, Spin } from 'antd'
+import { Button, Card, Col, Drawer, Row, Spin } from 'antd'
 import { dashboardsLogic } from 'scenes/dashboard/dashboardsLogic'
 import { Link } from 'lib/components/Link'
 import { PlusOutlined } from '@ant-design/icons'
 import { Table } from 'antd'
-import { PushpinFilled, PushpinOutlined, DeleteOutlined } from '@ant-design/icons'
+import { PushpinFilled, PushpinOutlined, DeleteOutlined, AppstoreAddOutlined } from '@ant-design/icons'
 import { hot } from 'react-hot-loader/root'
+import { NewDashboard } from 'scenes/dashboard/NewDashboard'
 
 export const Dashboards = hot(_Dashboards)
 function _Dashboards() {
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { deleteDashboard, unpinDashboard, pinDashboard } = useActions(dashboardsModel)
+    const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard } = useActions(dashboardsModel)
     const { dashboards } = useValues(dashboardsLogic)
-    const { addNewDashboard } = useActions(dashboardsLogic)
+    const [openNewDashboard, setOpenNewDashboard] = useState(false)
 
     return (
         <div>
             <div style={{ marginBottom: 20 }}>
-                <Button data-attr={'new-dashboard'} onClick={addNewDashboard} style={{ float: 'right' }}>
+                <Button
+                    data-attr={'new-dashboard'}
+                    onClick={() => setOpenNewDashboard(true)}
+                    style={{ float: 'right' }}
+                >
                     <PlusOutlined style={{ verticalAlign: 'baseline' }} />
                     New Dashboard
                 </Button>
                 <h1 className="page-header">Dashboards</h1>
             </div>
+
+            {openNewDashboard && (
+                <Drawer
+                    title={'New Dashboard'}
+                    width={400}
+                    onClose={() => setOpenNewDashboard(false)}
+                    destroyOnClose={true}
+                    visible={true}
+                >
+                    <NewDashboard model={dashboardsModel} />
+                </Drawer>
+            )}
 
             {dashboardsLoading ? (
                 <Spin />
@@ -70,9 +87,66 @@ function _Dashboards() {
                     />
                 </Table>
             ) : (
-                <p>
-                    You have no dashboards. <Link onClick={addNewDashboard}>Click here to add one!</Link>
-                </p>
+                <div>
+                    <p>Create your first dashboard:</p>
+
+                    <Row gutter={24}>
+                        <Col xs={24} xl={6} gutter={24}>
+                            <Card
+                                title="Empty"
+                                size="small"
+                                style={{ cursor: 'pointer' }}
+                                onClick={() =>
+                                    addDashboard({
+                                        name: 'New Dashboard',
+                                        show: true,
+                                        copyFromTemplate: '',
+                                    })
+                                }
+                            >
+                                <div style={{ textAlign: 'center', fontSize: 40 }}>
+                                    <AppstoreAddOutlined />
+                                </div>
+                            </Card>
+                        </Col>
+                        <Col xs={24} xl={6} gutter={24}>
+                            <Card
+                                title="App Default"
+                                size="small"
+                                style={{ cursor: 'pointer' }}
+                                onClick={() =>
+                                    addDashboard({
+                                        name: 'Default App Dashboard',
+                                        show: true,
+                                        copyFromTemplate: 'DEFAULT_APP',
+                                    })
+                                }
+                            >
+                                <div style={{ textAlign: 'center', fontSize: 40 }}>
+                                    <AppstoreAddOutlined />
+                                </div>
+                            </Card>
+                        </Col>
+                        <Col s={24} xl={6} gutter={24}>
+                            <Card
+                                title="Web Default"
+                                size="small"
+                                style={{ cursor: 'pointer' }}
+                                onClick={() =>
+                                    addDashboard({
+                                        name: 'Default Web Dashboard',
+                                        show: true,
+                                        copyFromTemplate: 'DEFAULT_WEB',
+                                    })
+                                }
+                            >
+                                <div style={{ textAlign: 'center', fontSize: 40 }} data-attr="new-action-pageview">
+                                    <AppstoreAddOutlined />
+                                </div>
+                            </Card>
+                        </Col>
+                    </Row>
+                </div>
             )}
         </div>
     )

--- a/frontend/src/scenes/dashboard/NewDashboard.js
+++ b/frontend/src/scenes/dashboard/NewDashboard.js
@@ -32,10 +32,16 @@ export function NewDashboard({ dashboard, model }) {
             </Form.Item>
 
             <Form.Item name="copyFromTemplate" label="Start from" className={rrwebBlockClass}>
-                <Select data-attr="copyFromTemplate" style={{ width: '100%' }} defaultValue={''}>
-                    <Select.Option value="">Empty Dashboard</Select.Option>
-                    <Select.Option value="DEFAULT_APP">Default Dashboard - App</Select.Option>
-                    <Select.Option value="DEFAULT_WEB">Default Dashboard - Web</Select.Option>
+                <Select data-attr="copy-from-template" style={{ width: '100%' }} defaultValue={''}>
+                    <Select.Option data-attr="dashboard-select-1" value="">
+                        Empty Dashboard
+                    </Select.Option>
+                    <Select.Option data-attr="dashboard-select-2" value="DEFAULT_APP">
+                        Default Dashboard - App
+                    </Select.Option>
+                    <Select.Option data-attr="dashboard-select-3" value="DEFAULT_WEB">
+                        Default Dashboard - Web
+                    </Select.Option>
                 </Select>
             </Form.Item>
 

--- a/frontend/src/scenes/dashboard/NewDashboard.js
+++ b/frontend/src/scenes/dashboard/NewDashboard.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Input, Button, Form, Select } from 'antd'
+import { useActions } from 'kea'
+import { slugify } from 'lib/utils'
+import { SaveOutlined } from '@ant-design/icons'
+import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
+
+export function NewDashboard({ dashboard, model }) {
+    const [form] = Form.useForm()
+    const { addDashboard } = useActions(model)
+
+    return (
+        <Form
+            layout="vertical"
+            form={form}
+            initialValues={dashboard}
+            onFinish={(values) => {
+                addDashboard(values)
+            }}
+        >
+            <Form.Item
+                name="name"
+                label="Dashboard name"
+                className={rrwebBlockClass}
+                rules={[{ required: true, message: 'Please give your dashboard a name.' }]}
+            >
+                <Input
+                    autoFocus={true}
+                    onChange={(e) => form.setFieldsValue({ key: slugify(e.target.value) })}
+                    data-attr="dashboard-name"
+                />
+            </Form.Item>
+
+            <Form.Item name="copyFromTemplate" label="Start from" className={rrwebBlockClass}>
+                <Select data-attr="copyFromTemplate" style={{ width: '100%' }} defaultValue={''}>
+                    <Select.Option value="">Empty Dashboard</Select.Option>
+                    <Select.Option value="DEFAULT_APP">Default Dashboard - App</Select.Option>
+                    <Select.Option value="DEFAULT_WEB">Default Dashboard - Web</Select.Option>
+                </Select>
+            </Form.Item>
+
+            <br />
+
+            <Form.Item>
+                <Button icon={<SaveOutlined />} htmlType="submit" type="primary" data-attr="dashboard-submit">
+                    Create
+                </Button>
+            </Form.Item>
+        </Form>
+    )
+}

--- a/frontend/src/scenes/dashboard/dashboardsLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardsLogic.js
@@ -1,7 +1,6 @@
 import { kea } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { router } from 'kea-router'
-import { prompt } from 'lib/logic/prompt'
 
 export const dashboardsLogic = kea({
     actions: () => ({
@@ -19,16 +18,6 @@ export const dashboardsLogic = kea({
     }),
 
     listeners: () => ({
-        addNewDashboard: async () => {
-            prompt({ key: `new-dashboard-dashboards` }).actions.prompt({
-                title: 'New dashboard',
-                placeholder: 'Please enter a name',
-                value: '',
-                error: 'You must enter name',
-                success: (name) => dashboardsModel.actions.addDashboard({ name }),
-            })
-        },
-
         [dashboardsModel.actions.addDashboardSuccess]: ({ dashboard }) => {
             router.actions.push(`/dashboard/${dashboard.id}`)
         },

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -1,9 +1,9 @@
 import secrets
 from distutils.util import strtobool
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from django.core.cache import cache
-from django.db.models import Prefetch, Q, QuerySet
+from django.db.models import Prefetch, QuerySet
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now

--- a/posthog/default_dashboards.py
+++ b/posthog/default_dashboards.py
@@ -1,0 +1,73 @@
+from django.utils.timezone import now
+
+from posthog.constants import TREND_FILTER_TYPE_EVENTS, TRENDS_LINEAR
+from posthog.models import Dashboard, DashboardItem
+
+DEFAULT_DASHBOARD_APP = "DEFAULT_APP"
+DEFAULT_DASHBOARD_WEB = "DEFAULT_WEB"
+
+
+def create_default_app_dashboard_items(dashboard: Dashboard):
+    DashboardItem.objects.create(
+        team=dashboard.team,
+        dashboard=dashboard,
+        name="Views this week",
+        type=TRENDS_LINEAR,
+        filters={TREND_FILTER_TYPE_EVENTS: [{"id": "$pageview", "type": TREND_FILTER_TYPE_EVENTS}]},
+        last_refresh=now(),
+    )
+
+    DashboardItem.objects.create(
+        team=dashboard.team,
+        dashboard=dashboard,
+        name="Most popular phones this week",
+        type="ActionsTable",
+        filters={
+            TREND_FILTER_TYPE_EVENTS: [{"id": "$pageview", "type": TREND_FILTER_TYPE_EVENTS}],
+            "display": "ActionsTable",
+            "breakdown": "$browser",
+        },
+        last_refresh=now(),
+    )
+
+    DashboardItem.objects.create(
+        team=dashboard.team,
+        dashboard=dashboard,
+        name="Daily Active Users",
+        type=TRENDS_LINEAR,
+        filters={TREND_FILTER_TYPE_EVENTS: [{"id": "$pageview", "math": "dau", "type": TREND_FILTER_TYPE_EVENTS}]},
+        last_refresh=now(),
+    )
+    return dashboard
+
+
+def create_default_web_dashboard_items(dashboard: Dashboard):
+    DashboardItem.objects.create(
+        team=dashboard.team,
+        dashboard=dashboard,
+        name="Pageviews this week",
+        type=TRENDS_LINEAR,
+        filters={TREND_FILTER_TYPE_EVENTS: [{"id": "$pageview", "type": TREND_FILTER_TYPE_EVENTS}]},
+        last_refresh=now(),
+    )
+    DashboardItem.objects.create(
+        team=dashboard.team,
+        dashboard=dashboard,
+        name="Most popular browsers this week",
+        type="ActionsTable",
+        filters={
+            TREND_FILTER_TYPE_EVENTS: [{"id": "$pageview", "type": TREND_FILTER_TYPE_EVENTS}],
+            "display": "ActionsTable",
+            "breakdown": "$browser",
+        },
+        last_refresh=now(),
+    )
+    DashboardItem.objects.create(
+        team=dashboard.team,
+        dashboard=dashboard,
+        name="Daily Active Users",
+        type=TRENDS_LINEAR,
+        filters={TREND_FILTER_TYPE_EVENTS: [{"id": "$pageview", "math": "dau", "type": TREND_FILTER_TYPE_EVENTS}]},
+        last_refresh=now(),
+    )
+    return dashboard


### PR DESCRIPTION
## Changes

Users can now create new Dashboards from predefined defaults.

Enables the creation of Default Dashboards like https://github.com/PostHog/posthog/issues/1694

Users without any Dashboards are offered with a selection of choices, including an Empty Dashboard.

The same default templates are now also part of the generic "New Dashboard" dialog.

Dashboard items are only an example, not meant to be part of the actual Default Dashboard template. They can be redefined in `default_dashboards.py`.

![Default dashboards](https://user-images.githubusercontent.com/140952/96181243-fd28f280-0f33-11eb-907f-8b886238ad04.gif)


## Checklist

- [X] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [X] Cypress E2E tests (if this PR affects the front and/or backend)
