### PR TITLE
fix tags for redis & postgres in docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     db:
-        image: postgres-11:alpine
+        image: postgres:11-alpine
         container_name: posthog_db
         environment:
             POSTGRES_USER: posthog
@@ -11,7 +11,7 @@ services:
         ports:
             - '5439:5432'
     redis:
-        image: 'redis-5:alpine'
+        image: 'redis:5-alpine'
         container_name: posthog_redis
         ports:
             - '6379:6379'


### PR DESCRIPTION
## Changes

docker compose was failing because the tags used for postgres & redis were slightly wrong

## Checklist

- [] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [] Backend tests (if this PR affects the backend)
- [] Cypress E2E tests (if this PR affects the front and/or backend)
