### PR TITLE
Friendlier feedback command and flow navigation

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -76,7 +76,8 @@ export interface CommandFlow {
     icon?: any
     instruction?: string
     resolver: CommandResolver | CommandResultTemplate[] | CommandResultTemplate
-    scope: string
+    scope?: string
+    previousFlow?: CommandFlow | null
 }
 
 export interface CommandRegistrations {
@@ -118,6 +119,7 @@ export const commandPaletteLogic = kea<
         onMouseLeaveResult: true,
         executeResult: (result: CommandResult) => ({ result }),
         activateFlow: (flow: CommandFlow | null) => ({ flow }),
+        backFlow: true,
         registerCommand: (command: Command) => ({ command }),
         deregisterCommand: (commandKey: string) => ({ commandKey }),
         setCustomCommand: (commandKey: string) => ({ commandKey }),
@@ -138,6 +140,7 @@ export const commandPaletteLogic = kea<
                 setInput: () => 0,
                 executeResult: () => 0,
                 activateFlow: () => 0,
+                backFlow: () => 0,
                 onArrowUp: (previousIndex) => (previousIndex > 0 ? previousIndex - 1 : 0),
                 onArrowDown: (previousIndex, { maxIndex }) => (previousIndex < maxIndex ? previousIndex + 1 : maxIndex),
             },
@@ -145,11 +148,12 @@ export const commandPaletteLogic = kea<
         hoverResultIndex: [
             null as number | null,
             {
+                activateFlow: () => null,
+                backFlow: () => null,
                 onMouseEnterResult: (_, { index }) => index,
                 onMouseLeaveResult: () => null,
                 onArrowUp: () => null,
                 onArrowDown: () => null,
-                activateFlow: () => null,
             },
         ],
         input: [
@@ -157,13 +161,16 @@ export const commandPaletteLogic = kea<
             {
                 setInput: (_, { input }) => input,
                 activateFlow: () => '',
+                backFlow: () => '',
                 executeResult: () => '',
             },
         ],
         activeFlow: [
             null as CommandFlow | null,
             {
-                activateFlow: (_, { flow }) => flow,
+                activateFlow: (currentFlow, { flow }) =>
+                    flow ? { ...flow, scope: flow.scope ?? currentFlow?.scope, previousFlow: currentFlow } : null,
+                backFlow: (currentFlow) => currentFlow?.previousFlow ?? null,
             },
         ],
         rawCommandRegistrations: [

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -25,7 +25,7 @@ import {
     FunnelPlotOutlined,
     GatewayOutlined,
     InteractionOutlined,
-    MailOutlined,
+    ExclamationCircleOutlined,
     KeyOutlined,
     VideoCameraOutlined,
     SendOutlined,
@@ -627,28 +627,33 @@ export const commandPaletteLogic = kea<
                 resolver: {
                     icon: CommentOutlined,
                     display: 'Share Feedback',
-                    synonyms: ['send opinion', 'ask question', 'message posthog'],
+                    synonyms: ['send opinion', 'ask question', 'message posthog', 'github issue'],
                     executor: () => ({
                         scope: 'Sharing Feedback',
-                        instruction: "What's on your mind?",
-                        icon: CommentOutlined,
-                        resolver: (argument) => [
+                        resolver: [
                             {
-                                icon: SendOutlined,
                                 display: 'Send Message Directly to PostHog',
-                                executor: !argument?.length
-                                    ? undefined
-                                    : () => {
-                                          window.posthog?.capture('palette feedback', { message: argument })
-                                          return {
-                                              scope: 'Sharing Feedback',
-                                              resolver: {
-                                                  icon: CheckOutlined,
-                                                  display: 'Message Sent!',
-                                                  executor: true,
+                                icon: CommentOutlined,
+                                executor: () => ({
+                                    instruction: "What's on your mind?",
+                                    icon: CommentOutlined,
+                                    resolver: (argument) => ({
+                                        icon: SendOutlined,
+                                        display: 'Send',
+                                        executor: !argument?.length
+                                            ? undefined
+                                            : () => {
+                                                  window.posthog?.capture('palette feedback', { message: argument })
+                                                  return {
+                                                      resolver: {
+                                                          icon: CheckOutlined,
+                                                          display: 'Message Sent!',
+                                                          executor: true,
+                                                      },
+                                                  }
                                               },
-                                          }
-                                      },
+                                    }),
+                                }),
                             },
                             {
                                 icon: VideoCameraOutlined,
@@ -658,10 +663,10 @@ export const commandPaletteLogic = kea<
                                 },
                             },
                             {
-                                icon: MailOutlined,
-                                display: 'Email Core Team',
+                                icon: ExclamationCircleOutlined,
+                                display: 'Create GitHub Issue',
                                 executor: () => {
-                                    open('mailto:hey@posthog.com')
+                                    open('https://github.com/PostHog/posthog/issues/new/choose')
                                 },
                             },
                         ],

--- a/frontend/src/lib/components/CommandPalette/index.tsx
+++ b/frontend/src/lib/components/CommandPalette/index.tsx
@@ -12,7 +12,7 @@ import './index.scss'
 export function CommandPalette(): JSX.Element | null {
     useMountedLogic(commandPaletteLogic)
 
-    const { setInput, hidePalette, togglePalette, executeResult, activateFlow } = useActions(commandPaletteLogic)
+    const { setInput, hidePalette, togglePalette, executeResult, backFlow } = useActions(commandPaletteLogic)
     const { input, isPaletteShown, isSqueak, activeFlow, commandSearchResults } = useValues(commandPaletteLogic)
     const { user } = useValues(userLogic)
 
@@ -28,9 +28,9 @@ export function CommandPalette(): JSX.Element | null {
             squeakAudio?.play()
         } else if (event.key === 'Escape') {
             event.preventDefault()
-            // First of all, exit flow
-            if (activeFlow) activateFlow(null)
-            // Else just erase input
+            // Return to previous flow
+            if (activeFlow) backFlow()
+            // If no flw, erase input
             else if (input) setInput('')
             // Lastly hide palette
             else hidePalette()


### PR DESCRIPTION
## Changes

So as to resolve #1884, this makes direct messaging with feedback a distinct subcommand of Share Feedback. Also added backwards navigation using Esc.

<img width="598" alt="Screen Shot 2020-10-16 at 15 15 11" src="https://user-images.githubusercontent.com/4550621/96262812-97377c00-0fc2-11eb-8e87-d64ba8909025.png">

## Checklist

- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
