### PR TITLE
Add flag for heartbeat check on debug

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -293,6 +293,10 @@ def get_redis_heartbeat() -> Union[str, int]:
 
     if worker_heartbeat and (worker_heartbeat == 0 or worker_heartbeat < 300):
         return worker_heartbeat
+
+    if settings.DEBUG:
+        return 1
+
     return "offline"
 
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- if redis doesn't emit hearbeat on DEBUG, initialization will never pass
*If this affects the front-end, include screenshots.*  
<img width="618" alt="Screen Shot 2020-10-16 at 3 44 37 PM" src="https://user-images.githubusercontent.com/13127476/96266287-7ce6a980-0f94-11eb-82a1-0af6cb463d75.png">

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
