### PR TITLE
Force frontend to build on ./bin/start-frontend

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -5,4 +5,5 @@ set -e
 [ $# -ge 1 ] && export WEBPACK_HOT_RELOAD_HOST=$1
 
 yarn install
+yarn build
 yarn start


### PR DESCRIPTION
## Changes

Many users have been having isues with PostHog not building the frontend and ending up with a blank page forever.

This PR tries to fix that. It's a bit of a WIP currently.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
