### PR TITLE
Hogflix demo dashboard rename & delete

### DIFF
--- a/frontend/src/scenes/setup/DeleteDemoData.js
+++ b/frontend/src/scenes/setup/DeleteDemoData.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { kea, useActions, useValues } from 'kea'
 import api from '../../lib/api'
 import { Button } from 'antd'
+import { dashboardsModel } from '~/models'
 
 const deleteDemoDataLogic = kea({
     actions: () => ({
@@ -20,6 +21,7 @@ const deleteDemoDataLogic = kea({
         [actions.deleteDemoData]: async () => {
             await api.get('delete_demo_data')
             actions.demoDataDeleted()
+            dashboardsModel.actions.loadDashboards()
         },
     }),
 })

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -174,7 +174,7 @@ def _create_funnel(team: Team, base_url: str) -> None:
     )
 
     dashboard = Dashboard.objects.create(
-        name="Hogflix Demo", pinned=True, team=team, share_token=secrets.token_urlsafe(22)
+        name="HogFlix Demo", pinned=True, team=team, share_token=secrets.token_urlsafe(22)
     )
     DashboardItem.objects.create(
         team=team,
@@ -228,6 +228,6 @@ def delete_demo_data(request):
     Funnel.objects.filter(team=team, name__contains="HogFlix").delete()
     Action.objects.filter(team=team, name__contains="HogFlix").delete()
     DashboardItem.objects.filter(team=team, name__contains="HogFlix").delete()
-    Dashboard.objects.filter(team=team, name__contains="Hogflix Demo").delete()
+    Dashboard.objects.filter(team=team, name__contains="HogFlix Demo").delete()
 
     return JsonResponse({"status": "ok"})

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -173,7 +173,9 @@ def _create_funnel(team: Team, base_url: str) -> None:
         action=user_paid, event="$autocapture", url="%s/2" % base_url, url_matching="contains", selector="button",
     )
 
-    dashboard = Dashboard.objects.create(name="Default", pinned=True, team=team, share_token=secrets.token_urlsafe(22))
+    dashboard = Dashboard.objects.create(
+        name="Hogflix Demo", pinned=True, team=team, share_token=secrets.token_urlsafe(22)
+    )
     DashboardItem.objects.create(
         team=team,
         dashboard=dashboard,
@@ -226,5 +228,6 @@ def delete_demo_data(request):
     Funnel.objects.filter(team=team, name__contains="HogFlix").delete()
     Action.objects.filter(team=team, name__contains="HogFlix").delete()
     DashboardItem.objects.filter(team=team, name__contains="HogFlix").delete()
+    Dashboard.objects.filter(team=team, name__contains="Hogflix Demo").delete()
 
     return JsonResponse({"status": "ok"})


### PR DESCRIPTION
## Changes

* Avoids creating a second dashboard called "Default" when you load hogflix
* Delete the dashboard when clicking the "delete demo data" button

<img width="1073" alt="Screenshot 2020-10-17 at 21 02 02" src="https://user-images.githubusercontent.com/53387/96351778-f8904580-10bd-11eb-9c4d-0a6d5200d4c0.png">

<img width="262" alt="Screenshot 2020-10-17 at 22 33 06" src="https://user-images.githubusercontent.com/53387/96353072-1020fb80-10c9-11eb-9946-62fcbc084872.png">


## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
