### PR TITLE
Fixed webpack on docker-compose.dev (Close #1912)

### DIFF
--- a/bin/docker-dev-web
+++ b/bin/docker-dev-web
@@ -3,4 +3,4 @@
 set -e
 python manage.py migrate
 
-python manage.py runserver 0.0.0.0:8000 & ./bin/start-frontend 127.0.0.1
+python manage.py runserver 0.0.0.0:8000 & ./bin/start-frontend 0.0.0.0


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

RE discussion on #1912: The reason setting the default value for the host wasn't working is because the host was always being set by the `docker-dev-web` script. 

Since that script is only referenced by `docker-compose.dev.yml` and `docker-compose.ch.yml` this should be a safe minimal change.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
