### PR TITLE
Bring Papercups back

### DIFF
--- a/posthog/templates/overlays.html
+++ b/posthog/templates/overlays.html
@@ -22,3 +22,29 @@
     </script>
     
 {% endif %}
+
+{% if debug or request.get_host == 'app.posthog.com' %}	
+      <script>	
+        window.Papercups = {	
+          config: {	
+            accountId: '873f5102-d267-4b09-9de0-d6e741e0e076',	
+            title: 'Welcome to PostHog',	
+            subtitle: 'Ask us anything in the chat window below 😊',	
+            primaryColor: '#1890ff',	
+            greeting: "Hi! Send us a message and we'll respond as soon as we can.",	
+            customer: {	
+                email: '{{ request.user.email }}',	
+                name: '{{ request.user.first_name }}'	
+            },	
+            newMessagePlaceholder: 'Start typing…',	
+            baseUrl: 'https://app.papercups.io'	
+          },	
+        };	
+      </script>	
+      <script	
+        type="text/javascript"	
+        async	
+        defer	
+        src="https://app.papercups.io/widget.js"	
+      ></script>	
+{% endif %}


### PR DESCRIPTION
## Changes

Since Papercups have fixed the autofocus issue that crippled the PostHog command palette, this brings the chat widget back, just the way it was before.