### PR TITLE
Feature flags larger pages and rename sidebar item

### DIFF
--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -14,7 +14,7 @@ import {
     ContainerOutlined,
     LineChartOutlined,
     FundOutlined,
-    ExperimentOutlined,
+    FlagOutlined,
     ClockCircleOutlined,
     MessageOutlined,
     TeamOutlined,
@@ -227,7 +227,7 @@ export function Sidebar({ user, sidebarCollapsed, setSidebarCollapsed }) {
                         </Menu.Item>
                     </Menu.SubMenu>
                     <Menu.Item key="experiments" style={itemStyle} data-attr="menu-item-feature-f">
-                        <ExperimentOutlined />
+                        <FlagOutlined />
                         <span className="sidebar-label">{'Feature Flags'}</span>
                         <Link to={'/experiments/feature_flags'} onClick={collapseSidebar} />
                     </Menu.Item>

--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -228,7 +228,7 @@ export function Sidebar({ user, sidebarCollapsed, setSidebarCollapsed }) {
                     </Menu.SubMenu>
                     <Menu.Item key="experiments" style={itemStyle} data-attr="menu-item-feature-f">
                         <ExperimentOutlined />
-                        <span className="sidebar-label">{'Experiments'}</span>
+                        <span className="sidebar-label">{'Feature Flags'}</span>
                         <Link to={'/experiments/feature_flags'} onClick={collapseSidebar} />
                     </Menu.Item>
 

--- a/frontend/src/scenes/experiments/FeatureFlags.js
+++ b/frontend/src/scenes/experiments/FeatureFlags.js
@@ -65,6 +65,7 @@ function _FeatureFlags() {
                 dataSource={featureFlags}
                 columns={columns}
                 loading={!featureFlags && featureFlagsLoading}
+                pagination={{ pageSize: 99999, hideOnSinglePage: true }}
                 onRow={(featureFlag) => ({
                     onClick: () => setOpenFeatureFlag(featureFlag),
                 })}


### PR DESCRIPTION
## Changes

- Rename "Experiments" to "Feature Flags" as I think this might be confusing people. We will have experiments at some point but for now it's just feature flags 
![image](https://user-images.githubusercontent.com/1727427/96425899-d0f3c700-11fc-11eb-900a-342ed0fc9d46.png)
- Show way more feature flags per page

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
