### PR TITLE
Make log output locally less noisy

### DIFF
--- a/bin/start-worker
+++ b/bin/start-worker
@@ -2,4 +2,4 @@
 set -e
 
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler  --loglevel=debug
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler


### PR DESCRIPTION
## Changes

Workers had a lot of output, very little of it being useful. This remove thats

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
