### PR TITLE
gitignore __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ venv
 env
 .venv
 *.pyc
+__pycache__/
 staticfiles
 .env
 settings.yml


### PR DESCRIPTION
## Changes

We already were ignoring `*.pyc`, but sometimes `__pycache__` dirs contain files like `*.pyc.123456789` (with some digits), so this ignores cache directories completely.