### PR TITLE
Simplify clickhouse events query

### DIFF
--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -178,7 +178,7 @@ SELECT
 FROM
     events_with_array_props_view ewap
 where ewap.team_id = %(team_id)s
-AND ewap.uuid IN (select uuid from events WHERE team_id = %(team_id)s {conditions})
+{conditions}
 ORDER BY toDate(ewap.timestamp) DESC, ewap.timestamp DESC {limit}
 """
 
@@ -194,7 +194,8 @@ SELECT
     ewap.created_at
 FROM events_with_array_props_view AS ewap
 WHERE 
-ewap.uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s {conditions})
+team_id = %(team_id)s
+{conditions}
 {filters}
 ORDER BY toDate(ewap.timestamp) DESC, ewap.timestamp DESC {limit}
 """

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict, List, Optional
 
 from rest_framework import viewsets


### PR DESCRIPTION
## Changes

In testing this shaved a couple of seconds off loading /events

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
