### PR TITLE
Session recording: persistent URLs, session_id, UI changes

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,7 +6,7 @@
   <body>
     {% include "overlays.html" %}
     <script>
-        if (typeof Object.entries === 'undefined') {
+        if (typeof Object.entries === 'undefined' || typeof Array.prototype.flatMap === 'undefined') {
             var div = document.createElement("div");
             div.style.color='#fef6f6'; div.style.background='#920c0c'; div.style.padding='5px 10px';
             div.innerHTML = "You are using a really old browser. Please upgrade to fully enjoy PostHog!"

--- a/frontend/src/lib/components/PropertyKeyInfo.js
+++ b/frontend/src/lib/components/PropertyKeyInfo.js
@@ -130,6 +130,11 @@ export const keyMapping = {
             description: 'JSON object used for session recordings.',
             hide: true,
         },
+        $session_id: {
+            label: 'Session ID',
+            description: 'Session ID used for session recordings',
+            hide: true,
+        },
         $had_persisted_distinct_id: {
             label: '$had_persisted_distinct_id',
             description: '',

--- a/frontend/src/lib/logic/featureFlagLogic.js
+++ b/frontend/src/lib/logic/featureFlagLogic.js
@@ -1,5 +1,7 @@
 /*
     This module allows us to **use** feature flags in PostHog.
+
+    Use this instead of `window.posthog.isFeatureEnabled('feature')`
 */
 import { kea } from 'kea'
 

--- a/frontend/src/scenes/project/Settings/index.js
+++ b/frontend/src/scenes/project/Settings/index.js
@@ -12,12 +12,13 @@ import { router } from 'kea-router'
 import { hot } from 'react-hot-loader/root'
 import { ToolbarSettings } from './ToolbarSettings'
 import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export const Setup = hot(_Setup)
 function _Setup() {
     const { user } = useValues(userLogic)
     const { location } = useValues(router)
-    const showSessionRecord = window.posthog?.isFeatureEnabled('session-recording-player')
+    const { featureFlags } = useValues(featureFlagLogic)
 
     useAnchor(location.hash)
 
@@ -57,7 +58,7 @@ function _Setup() {
             <h2 id="webhook">Slack / Microsoft Teams Integration</h2>
             <WebhookIntegration />
             <Divider />
-            {showSessionRecord && (
+            {featureFlags['session-recording-player'] && (
                 <>
                     <h2 id="sessionrecording">Collect session recordings</h2>
                     <OptInSessionRecording />

--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -7,7 +7,7 @@ export default function SessionsPlayer({ events }: { events: eventWithTime[] }):
     const target = useRef<HTMLDivElement | null>(null)
 
     useEffect(() => {
-        if (target.current) {
+        if (target.current && events) {
             const player = new rrwebPlayer({
                 target: target.current,
                 // eslint-disable-next-line

--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -1,25 +1,29 @@
+import { useValues } from 'kea'
 import React, { useEffect, useRef } from 'react'
 import rrwebPlayer from 'rrweb-player'
 import 'rrweb-player/dist/style.css'
-import { eventWithTime } from 'rrweb/typings/types'
+import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 
-export default function SessionsPlayer({ events }: { events: eventWithTime[] }): JSX.Element {
+export default function SessionsPlayer(): JSX.Element {
     const target = useRef<HTMLDivElement | null>(null)
+    const { sessionPlayerData, sessionPlayerDataLoading } = useValues(sessionsTableLogic)
 
     useEffect(() => {
-        if (target.current) {
-            new rrwebPlayer({
+        if (target.current && !sessionPlayerDataLoading) {
+            const player = new rrwebPlayer({
                 target: target.current,
                 // eslint-disable-next-line
                 // @ts-ignore
                 props: {
                     width: 900,
-                    events,
+                    events: sessionPlayerData,
                     autoPlay: true,
                 },
             })
+
+            return () => player.pause()
         }
-    }, [])
+    }, [sessionPlayerDataLoading])
 
     return <div ref={target} id="sessions-player"></div>
 }

--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -1,30 +1,27 @@
-import { useValues } from 'kea'
-import { Loading } from 'lib/utils'
 import React, { useEffect, useRef } from 'react'
 import rrwebPlayer from 'rrweb-player'
 import 'rrweb-player/dist/style.css'
-import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
+import { eventWithTime } from 'rrweb/typings/types'
 
-export default function SessionsPlayer(): JSX.Element {
+export default function SessionsPlayer({ events }: { events: eventWithTime[] }): JSX.Element {
     const target = useRef<HTMLDivElement | null>(null)
-    const { sessionPlayerData, sessionPlayerDataLoading } = useValues(sessionsTableLogic)
 
     useEffect(() => {
-        if (target.current && !sessionPlayerDataLoading) {
+        if (target.current) {
             const player = new rrwebPlayer({
                 target: target.current,
                 // eslint-disable-next-line
                 // @ts-ignore
                 props: {
                     width: 952,
-                    events: sessionPlayerData,
+                    events,
                     autoPlay: true,
                 },
             })
 
             return () => player.pause()
         }
-    }, [sessionPlayerDataLoading])
+    }, [])
 
-    return sessionPlayerDataLoading ? <Loading /> : <div ref={target} id="sessions-player"></div>
+    return <div ref={target} id="sessions-player"></div>
 }

--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -1,4 +1,5 @@
 import { useValues } from 'kea'
+import { Loading } from 'lib/utils'
 import React, { useEffect, useRef } from 'react'
 import rrwebPlayer from 'rrweb-player'
 import 'rrweb-player/dist/style.css'
@@ -25,5 +26,5 @@ export default function SessionsPlayer(): JSX.Element {
         }
     }, [sessionPlayerDataLoading])
 
-    return <div ref={target} id="sessions-player"></div>
+    return sessionPlayerDataLoading ? <Loading /> : <div ref={target} id="sessions-player"></div>
 }

--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -16,7 +16,7 @@ export default function SessionsPlayer(): JSX.Element {
                 // eslint-disable-next-line
                 // @ts-ignore
                 props: {
-                    width: 900,
+                    width: 952,
                     events: sessionPlayerData,
                     autoPlay: true,
                 },

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -20,7 +20,7 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
                     style={{ color: green.primary }}
                     onClick={(event: React.MouseEvent) => {
                         event.stopPropagation()
-                        loadSessionPlayer({ distinctId: session.distinct_id, sessionRecordingId })
+                        loadSessionPlayer(sessionRecordingId)
                     }}
                 ></PlayCircleOutlined>
             ))}

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -20,7 +20,6 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
                     style={{ color: green.primary }}
                     onClick={(event: React.MouseEvent) => {
                         event.stopPropagation()
-                        // showSessionPlayer(snapshotEventsData)
                         loadSessionPlayer({ distinctId: session.distinct_id, sessionRecordingId })
                     }}
                 ></PlayCircleOutlined>

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -1,39 +1,30 @@
 import React from 'react'
-import { eventWithTime } from 'rrweb/typings/types'
-import { SessionType } from '~/types'
-import { PlayCircleOutlined } from '@ant-design/icons'
-import { Modal } from 'antd'
+import { useActions } from 'kea'
 import { green } from '@ant-design/colors'
-import SessionsPlayer from './SessionsPlayer'
+import { PlayCircleOutlined } from '@ant-design/icons'
+import { SessionType } from '~/types'
+import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 
 interface SessionsPlayerButtonProps {
     session: SessionType
 }
 
-export default function SessionsPlayerButton({ session }: SessionsPlayerButtonProps): JSX.Element | null {
-    function showSessionPlayer(events: eventWithTime[]): void {
-        Modal.info({
-            centered: true,
-            content: <SessionsPlayer events={events}></SessionsPlayer>,
-            icon: null,
-            okType: 'primary',
-            okText: 'Done',
-            width: 1000,
-        })
-    }
-
-    const snapshotEventsData: eventWithTime[] = session.events
-        .filter((event) => event.event === '$snapshot')
-        .map((event) => event.properties?.$snapshot_data)
-    if (snapshotEventsData.length < 2) return null
+export default function SessionsPlayerButton({ session }: SessionsPlayerButtonProps): JSX.Element {
+    const { loadSessionPlayer } = useActions(sessionsTableLogic)
 
     return (
-        <PlayCircleOutlined
-            style={{ color: green.primary }}
-            onClick={(event: React.MouseEvent) => {
-                event.stopPropagation()
-                showSessionPlayer(snapshotEventsData)
-            }}
-        ></PlayCircleOutlined>
+        <>
+            {session.session_recording_ids.map((sessionRecordingId: string) => (
+                <PlayCircleOutlined
+                    key={sessionRecordingId}
+                    style={{ color: green.primary }}
+                    onClick={(event: React.MouseEvent) => {
+                        event.stopPropagation()
+                        // showSessionPlayer(snapshotEventsData)
+                        loadSessionPlayer({ distinctId: session.distinct_id, sessionRecordingId })
+                    }}
+                ></PlayCircleOutlined>
+            ))}
+        </>
     )
 }

--- a/frontend/src/scenes/sessions/SessionsPlayerDrawer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerDrawer.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Button, Drawer } from 'antd'
+import { useActions, useValues } from 'kea'
+import { Loading } from 'lib/utils'
+import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
+import SessionsPlayer from 'scenes/sessions/SessionsPlayer'
+
+export default function SessionsPlayerDrawer(): JSX.Element {
+    const { sessionPlayerData, sessionPlayerDataLoading, sessionRecordingNavigation: nav } = useValues(
+        sessionsTableLogic
+    )
+    const { loadSessionPlayer, closeSessionPlayer } = useActions(sessionsTableLogic)
+
+    return (
+        <Drawer
+            title="Session recording"
+            width={1000}
+            onClose={closeSessionPlayer}
+            destroyOnClose={true}
+            visible={true}
+            footer={
+                <>
+                    {nav.prev && (
+                        <Button style={{ marginRight: 12 }} onClick={() => loadSessionPlayer(nav.prev)}>
+                            Previous
+                        </Button>
+                    )}
+                    {nav.next && <Button onClick={() => loadSessionPlayer(nav.next)}>Next</Button>}
+                </>
+            }
+        >
+            {sessionPlayerDataLoading ? <Loading /> : <SessionsPlayer events={sessionPlayerData} />}
+        </Drawer>
+    )
+}

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -12,6 +12,7 @@ import { CaretLeftOutlined, CaretRightOutlined } from '@ant-design/icons'
 import SessionsPlayerButton from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -22,6 +23,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
     const logic = sessionsTableLogic({ personIds })
     const { sessions, sessionsLoading, nextOffset, isLoadingNext, selectedDate, filters } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const columns = [
         {
@@ -86,7 +88,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         },
     ]
 
-    if ((window as any).posthog && (window as any).posthog.isFeatureEnabled('session-recording-player')) {
+    if (featureFlags['session-recording-player']) {
         columns.push({
             title: 'Play Session',
             render: function RenderEndPoint(session: SessionType) {

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -28,7 +28,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         nextOffset,
         isLoadingNext,
         selectedDate,
-        filters,
+        properties,
         sessionRecordingId,
     } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
@@ -112,7 +112,11 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
             {!isPersonPage && <h1 className="page-header">Sessions By Day</h1>}
             <Space className="mb-2">
                 <Button onClick={previousDay} icon={<CaretLeftOutlined />} />
-                <DatePicker value={selectedDate} onChange={(date) => setFilters(filters, date)} allowClear={false} />
+                <DatePicker
+                    value={selectedDate}
+                    onChange={(date) => setFilters(properties, date, sessionRecordingId)}
+                    allowClear={false}
+                />
                 <Button onClick={nextDay} icon={<CaretRightOutlined />} />
             </Space>
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Button, Spin, Space, Drawer } from 'antd'
+import { Table, Button, Spin, Space } from 'antd'
 import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP } from '~/lib/utils'
@@ -13,7 +13,7 @@ import SessionsPlayerButton from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import SessionsPlayer from 'scenes/sessions/SessionsPlayer'
+import SessionsPlayerDrawer from 'scenes/sessions/SessionsPlayerDrawer'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -29,9 +29,9 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         isLoadingNext,
         selectedDate,
         filters,
-        sessionPlayerParams,
+        sessionRecordingId,
     } = useValues(logic)
-    const { fetchNextSessions, previousDay, nextDay, setFilters, closeSessionPlayer } = useActions(logic)
+    const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const columns = [
@@ -101,7 +101,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         columns.push({
             title: 'Play Session',
             render: function RenderEndPoint(session: SessionType) {
-                return <SessionsPlayerButton session={session}></SessionsPlayerButton>
+                return <SessionsPlayerButton session={session} />
             },
             ellipsis: true,
         })
@@ -134,17 +134,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                     expandRowByClick: true,
                 }}
             />
-            {!!sessionPlayerParams && (
-                <Drawer
-                    title="Session recording"
-                    width={1000}
-                    onClose={closeSessionPlayer}
-                    destroyOnClose={true}
-                    visible={true}
-                >
-                    <SessionsPlayer />
-                </Drawer>
-            )}
+            {!!sessionRecordingId && <SessionsPlayerDrawer />}
             <div style={{ marginTop: '5rem' }} />
             <div
                 style={{

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Button, Spin, Space } from 'antd'
+import { Table, Button, Spin, Space, Drawer } from 'antd'
 import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP } from '~/lib/utils'
@@ -13,6 +13,7 @@ import SessionsPlayerButton from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import SessionsPlayer from 'scenes/sessions/SessionsPlayer'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -21,8 +22,16 @@ interface SessionsTableProps {
 
 export function SessionsTable({ personIds, isPersonPage = false }: SessionsTableProps): JSX.Element {
     const logic = sessionsTableLogic({ personIds })
-    const { sessions, sessionsLoading, nextOffset, isLoadingNext, selectedDate, filters } = useValues(logic)
-    const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
+    const {
+        sessions,
+        sessionsLoading,
+        nextOffset,
+        isLoadingNext,
+        selectedDate,
+        filters,
+        sessionPlayerOpen,
+    } = useValues(logic)
+    const { fetchNextSessions, previousDay, nextDay, setFilters, closeSessionPlayer } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const columns = [
@@ -125,6 +134,17 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                     expandRowByClick: true,
                 }}
             />
+            {sessionPlayerOpen && (
+                <Drawer
+                    title="Session recording"
+                    width={1000}
+                    onClose={closeSessionPlayer}
+                    destroyOnClose={true}
+                    visible={true}
+                >
+                    <SessionsPlayer />
+                </Drawer>
+            )}
             <div style={{ marginTop: '5rem' }} />
             <div
                 style={{

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -29,7 +29,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         isLoadingNext,
         selectedDate,
         filters,
-        sessionPlayerOpen,
+        sessionPlayerParams,
     } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters, closeSessionPlayer } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -134,7 +134,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                     expandRowByClick: true,
                 }}
             />
-            {sessionPlayerOpen && (
+            {!!sessionPlayerParams && (
                 <Drawer
                     title="Session recording"
                     width={1000}

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -133,7 +133,7 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
                     result.next = recordings[index + 1]
                 }
                 if (index > 0) {
-                    result.next = recordings[index - 1]
+                    result.prev = recordings[index - 1]
                 }
                 return result
             },

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -129,7 +129,7 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
                 }
                 const index = recordings.indexOf(recordingId)
                 const result: { next?: SessionRecordingId; prev?: SessionRecordingId } = {}
-                if (index < recordings.length - 1) {
+                if (index !== -1 && index < recordings.length - 1) {
                     result.next = recordings[index + 1]
                 }
                 if (index > 0) {

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -113,6 +113,21 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
     },
     selectors: {
         selectedDateURLparam: [(s) => [s.selectedDate], (selectedDate) => selectedDate?.format('YYYY-MM-DD')],
+        sessionRecordingIds: [
+            (selectors) => [selectors.sessions],
+            (sessions: Array<SessionType>): string[] =>
+                sessions.flatMap((session) => session.session_recording_ids)
+        ],
+        playerSessionIndex: [
+            (selectors) => [selectors.sessions, selectors.sessionPlayerParams],
+            (sessions: SessionType[], params: RecordingParams | null) => {
+                if (!params) {
+                    return null
+                }
+                const index
+                params && sessions.findIndex((session) => session.session_recording_ids.includes(params.sessionRecordingId))
+            }
+        ],
     },
     listeners: ({ values, actions }) => ({
         fetchNextSessions: async (_, breakpoint) => {

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -178,6 +178,8 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
 
             if (params.sessionRecordingId) {
                 actions.loadSessionPlayer(params.sessionRecordingId)
+            } else {
+                actions.closeSessionPlayer()
             }
         },
         '/person/*': (_: any, params: Params) => {
@@ -188,6 +190,8 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
 
             if (params.sessionRecordingId) {
                 actions.loadSessionPlayer(params.sessionRecordingId)
+            } else {
+                actions.closeSessionPlayer()
             }
         },
     }),

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -5,6 +5,7 @@ import { toParams } from 'lib/utils'
 import { sessionsTableLogicType } from 'types/scenes/sessions/sessionsTableLogicType'
 import { PropertyFilter, SessionType } from '~/types'
 import { router } from 'kea-router'
+import { eventWithTime } from 'rrweb/typings/types'
 
 type Moment = moment.Moment
 
@@ -48,6 +49,13 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
                 return response.result
             },
         },
+        sessionPlayerData: {
+            loadSessionPlayer: async ({ distinctId, sessionRecordingId }): Promise<eventWithTime[]> => {
+                const params = toParams({ distinct_id: distinctId, session_recording_id: sessionRecordingId })
+                const response = await api.get(`api/event/session_recording?${params}`)
+                return response.result
+            },
+        },
     }),
     actions: () => ({
         setNextOffset: (nextOffset: number | null) => ({ nextOffset }),
@@ -56,6 +64,7 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
         previousDay: true,
         nextDay: true,
         setFilters: (properties: Array<PropertyFilter>, selectedDate: Moment | null) => ({ properties, selectedDate }),
+        closeSessionPlayer: true,
     }),
     reducers: {
         sessions: {
@@ -75,6 +84,19 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
             [],
             {
                 setFilters: (_, { properties }) => properties,
+            },
+        ],
+        sessionPlayerOpen: [
+            false,
+            {
+                loadSessionPlayer: () => true,
+                closeSessionPlayer: () => false,
+            },
+        ],
+        sessionPlayerData: [
+            null as null | eventWithTime[],
+            {
+                closeSessionPlayer: () => null,
             },
         ],
     },

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -14,7 +14,7 @@ type SessionRecordingId = string
 type Params = {
     date?: string
     properties?: any
-    sessionRecordingId?: SessionRecordingId,
+    sessionRecordingId?: SessionRecordingId
 }
 
 const buildURL = (selectedDateURLparam: string, sessionRecordingId: SessionRecordingId | null): [string, Params] => {
@@ -113,20 +113,30 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<Moment, SessionType
     },
     selectors: {
         selectedDateURLparam: [(s) => [s.selectedDate], (selectedDate) => selectedDate?.format('YYYY-MM-DD')],
-        sessionRecordingIds: [
+        orderedSessionRecordingIds: [
             (selectors) => [selectors.sessions],
-            (sessions: Array<SessionType>): string[] =>
-                sessions.flatMap((session) => session.session_recording_ids)
+            (sessions: SessionType[]): SessionRecordingId[] =>
+                sessions.flatMap((session) => session.session_recording_ids),
         ],
-        playerSessionIndex: [
-            (selectors) => [selectors.sessions, selectors.sessionPlayerParams],
-            (sessions: SessionType[], params: RecordingParams | null) => {
-                if (!params) {
-                    return null
+        sessionRecordingNavigation: [
+            (selectors) => [selectors.orderedSessionRecordingIds, selectors.sessionRecordingId],
+            (
+                recordings: SessionRecordingId[],
+                recordingId: SessionRecordingId | null
+            ): { next?: SessionRecordingId; prev?: SessionRecordingId } => {
+                if (recordingId === null) {
+                    return {}
                 }
-                const index
-                params && sessions.findIndex((session) => session.session_recording_ids.includes(params.sessionRecordingId))
-            }
+                const index = recordings.indexOf(recordingId)
+                const result: { next?: SessionRecordingId; prev?: SessionRecordingId } = {}
+                if (index < recordings.length - 1) {
+                    result.next = recordings[index + 1]
+                }
+                if (index > 0) {
+                    result.next = recordings[index - 1]
+                }
+                return result
+            },
         ],
     },
     listeners: ({ values, actions }) => ({

--- a/frontend/src/scenes/users/Person.js
+++ b/frontend/src/scenes/users/Person.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Events } from '../events/Events'
 import api from 'lib/api'
+import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { PersonTable } from './PersonTable'
 import { deletePersonData, savePersonData } from 'lib/utils'
@@ -9,6 +10,7 @@ import { Button, Modal, Tabs } from 'antd'
 import { CheckCircleTwoTone, DeleteOutlined } from '@ant-design/icons'
 import { hot } from 'react-hot-loader/root'
 import { SessionsTable } from '../sessions/SessionsTable'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 const { TabPane } = Tabs
 
@@ -22,6 +24,7 @@ function _Person({ _: distinctId, id }) {
     const [person, setPerson] = useState(null)
     const [personChanged, setPersonChanged] = useState(false)
     const [activeTab, setActiveTab] = useState('events')
+    const { featureFlags } = useValues(featureFlagLogic)
 
     useEffect(() => {
         if (distinctId) {
@@ -138,7 +141,7 @@ function _Person({ _: distinctId, id }) {
                     key="events"
                     data-attr="people-types-tab"
                 />
-                {window.posthog?.isFeatureEnabled('session-recording-player') && (
+                {featureFlags['session-recording-player'] && (
                     <TabPane
                         tab={<span data-attr="people-types-tab">Sessions By Day</span>}
                         key="sessions"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -165,6 +165,8 @@ export interface SessionType {
     length: number
     properties: Record<string, any>
     start_time: string
+    end_time: string
+    session_recording_ids: string[]
 }
 
 export interface OrganizationBilling {

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -25,6 +25,7 @@ from posthog.models import (
     PersonDistinctId,
     Team,
 )
+from posthog.queries.session_recording import SessionRecording
 from posthog.queries.sessions import Sessions
 from posthog.utils import (
     append_data,
@@ -319,9 +320,9 @@ class EventViewSet(viewsets.ModelViewSet):
     # ******************************************
     @action(methods=["GET"], detail=False)
     def session_recording(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
-        events = Event.objects.filter(team=request.user.team, event="$snapshot").filter(
-            **{"properties__$session_id": request.GET.get("session_recording_id"),}
+        team = self.request.user.team
+        snapshots = SessionRecording().run(
+            team=team, filter=None, session_recording_id=request.GET.get("session_recording_id")
         )
-        snapshots = sorted((e.properties["$snapshot_data"] for e in events), key=lambda s: s["timestamp"])
 
-        return response.Response({"result": list(snapshots)})
+        return response.Response({"result": snapshots})

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -326,5 +326,6 @@ class EventViewSet(viewsets.ModelViewSet):
                 "properties__$session_id": request.GET.get("session_recording_id"),
             }
         )
+        snapshots = sorted((e.properties["$snapshot_data"] for e in events), key=lambda s: s["timestamp"])
 
-        return response.Response({"result": [e.properties["$snapshot_data"] for e in events]})
+        return response.Response({"result": list(snapshots)})

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -322,7 +322,7 @@ class EventViewSet(viewsets.ModelViewSet):
     def session_recording(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         team = self.request.user.team
         snapshots = SessionRecording().run(
-            team=team, filter=None, session_recording_id=request.GET.get("session_recording_id")
+            team=team, filter=Filter(request=request), session_recording_id=request.GET.get("session_recording_id")
         )
 
         return response.Response({"result": snapshots})

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -107,7 +107,7 @@ class EventSerializer(serializers.HyperlinkedModelSerializer):
 
 class EventViewSet(viewsets.ModelViewSet):
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (csvrenderers.PaginatedCSVRenderer,)
-    queryset = Event.objects.all()
+    queryset = Event.objects.all().exclude(event="$snapshot")
     serializer_class = EventSerializer
 
     def get_queryset(self) -> QuerySet:

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -311,3 +311,20 @@ class EventViewSet(viewsets.ModelViewSet):
                 result.update({OFFSET: offset})
                 result.update({DATE_FROM: date_from})
         return response.Response(result)
+
+    # ******************************************
+    # /event/session_recording
+    # params:
+    # - distinct_id: (string) specifies whose recording to fetch
+    # - session_recording_id: (string) id of the session recording
+    # ******************************************
+    @action(methods=["GET"], detail=False)
+    def session_recording(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        events = Event.objects.filter(team=request.user.team, event="$snapshot").filter(
+            **{
+                "distinct_id": request.GET.get("distinct_id"),
+                "properties__$session_id": request.GET.get("session_recording_id"),
+            }
+        )
+
+        return response.Response({"result": [e.properties["$snapshot_data"] for e in events]})

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -275,7 +275,7 @@ class EventViewSet(viewsets.ModelViewSet):
             """
             SELECT
                 value, COUNT(1) as id
-            FROM ( 
+            FROM (
                 SELECT
                     ("posthog_event"."properties" -> %s) as "value"
                 FROM
@@ -320,9 +320,7 @@ class EventViewSet(viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False)
     def session_recording(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         events = Event.objects.filter(team=request.user.team, event="$snapshot").filter(
-            **{
-                "properties__$session_id": request.GET.get("session_recording_id"),
-            }
+            **{"properties__$session_id": request.GET.get("session_recording_id"),}
         )
         snapshots = sorted((e.properties["$snapshot_data"] for e in events), key=lambda s: s["timestamp"])
 

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -315,14 +315,12 @@ class EventViewSet(viewsets.ModelViewSet):
     # ******************************************
     # /event/session_recording
     # params:
-    # - distinct_id: (string) specifies whose recording to fetch
     # - session_recording_id: (string) id of the session recording
     # ******************************************
     @action(methods=["GET"], detail=False)
     def session_recording(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         events = Event.objects.filter(team=request.user.team, event="$snapshot").filter(
             **{
-                "distinct_id": request.GET.get("distinct_id"),
                 "properties__$session_id": request.GET.get("session_recording_id"),
             }
         )

--- a/posthog/queries/session_recording.py
+++ b/posthog/queries/session_recording.py
@@ -1,8 +1,17 @@
-from typing import Any, List
+from typing import Any, Dict, List
 
 from django.db.models import F, Max, Min
 
-from posthog.models import Event, Team
+from posthog.models import Event, Filter, Team
+from posthog.queries.base import BaseQuery
+
+
+class SessionRecording(BaseQuery):
+    def run(self, filter: Filter, team: Team, session_recording_id: str, *args, **kwargs) -> List[Dict[str, Any]]:
+        events = Event.objects.filter(team=team, event="$snapshot").filter(
+            **{"properties__$session_id": session_recording_id}
+        )
+        return list(sorted((e.properties["$snapshot_data"] for e in events), key=lambda s: s["timestamp"]))
 
 
 # :TRICKY: This mutates sessions list

--- a/posthog/queries/session_recording.py
+++ b/posthog/queries/session_recording.py
@@ -1,0 +1,32 @@
+from typing import Any, List
+
+from django.db.models import F, Max, Min
+
+from posthog.models import Event, Team
+
+
+# :TRICKY: This mutates sessions list
+def add_session_recording_ids(team: Team, sessions_results: List[Any]) -> List[Any]:
+    min_ts = min(it["start_time"] for it in sessions_results)
+    max_ts = max(it["end_time"] for it in sessions_results)
+
+    session_recordings = (
+        Event.objects.filter(team=team, event="$snapshot")
+        .values("distinct_id", "properties__$session_id")
+        .annotate(start_time=Min("timestamp"), end_time=Max("timestamp"))
+        .filter(start_time__lte=F("end_time"), end_time__gte=F("start_time"))
+    )
+
+    for session in sessions_results:
+        session["session_recording_ids"] = [
+            recording["properties__$session_id"] for recording in session_recordings if matches(session, recording)
+        ]
+    return sessions_results
+
+
+def matches(session: Any, session_recording: Any) -> bool:
+    return (
+        session["distinct_id"] == session_recording["distinct_id"]
+        and session["start_time"] <= session_recording["end_time"]
+        and session["end_time"] >= session_recording["start_time"]
+    )

--- a/posthog/queries/session_recording.py
+++ b/posthog/queries/session_recording.py
@@ -7,9 +7,9 @@ from posthog.queries.base import BaseQuery
 
 
 class SessionRecording(BaseQuery):
-    def run(self, filter: Filter, team: Team, session_recording_id: str, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
         events = Event.objects.filter(team=team, event="$snapshot").filter(
-            **{"properties__$session_id": session_recording_id}
+            **{"properties__$session_id": kwargs["session_recording_id"]}
         )
         return list(sorted((e.properties["$snapshot_data"] for e in events), key=lambda s: s["timestamp"]))
 

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -51,7 +51,7 @@ class Sessions(BaseQuery):
                 events = events.filter(filter.date_filter_Q)
             calculated = self.calculate_sessions(events, filter, team, limit, offset)
 
-        return add_session_recording_ids(team, calculated)
+        return calculated
 
     def calculate_sessions(
         self, events: QuerySet, filter: Filter, team: Team, limit: int, offset: int
@@ -188,7 +188,7 @@ class Sessions(BaseQuery):
                         )
                     except IndexError:
                         event.update({"elements": []})
-        return sessions
+        return add_session_recording_ids(team, sessions)
 
     def _session_avg(self, base_query: str, params: Tuple[Any, ...], filter: Filter) -> List[Dict[str, Any]]:
         def _determineInterval(interval):

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -12,6 +12,7 @@ from posthog.api.element import ElementSerializer
 from posthog.constants import SESSION_AVG, SESSION_DIST
 from posthog.models import ElementGroup, Event, Filter, Team
 from posthog.queries.base import BaseQuery, determine_compared_filter
+from posthog.queries.session_recording import add_session_recording_ids
 from posthog.utils import append_data, dict_from_cursor_fetchall, friendly_time
 
 SESSIONS_LIST_DEFAULT_LIMIT = 50
@@ -50,7 +51,7 @@ class Sessions(BaseQuery):
                 events = events.filter(filter.date_filter_Q)
             calculated = self.calculate_sessions(events, filter, team, limit, offset)
 
-        return calculated
+        return add_session_recording_ids(team, calculated)
 
     def calculate_sessions(
         self, events: QuerySet, filter: Filter, team: Team, limit: int, offset: int

--- a/posthog/queries/test/test_session_recording.py
+++ b/posthog/queries/test/test_session_recording.py
@@ -1,0 +1,70 @@
+import datetime
+
+from dateutil.relativedelta import relativedelta
+from django.utils.timezone import now
+from freezegun import freeze_time
+
+from posthog.api.test.base import BaseTest
+from posthog.models import Event
+from posthog.queries.session_recording import SessionRecording, add_session_recording_ids
+
+
+def session_recording_test_factory(session_recording, event_factory):
+    class TestSessionRecording(BaseTest):
+        def test_query_run(self):
+            with freeze_time("2020-09-13T12:26:40.000Z"):
+                self.create_snapshot("user", "1", now())
+                self.create_snapshot("user", "1", now() + relativedelta(seconds=10))
+                self.create_snapshot("user2", "2", now() + relativedelta(seconds=20))
+                self.create_snapshot("user", "1", now() + relativedelta(seconds=30))
+
+                snapshots = session_recording().run(team=self.team, filter=None, session_recording_id="1")
+                self.assertEqual(
+                    snapshots,
+                    [{"timestamp": 1_600_000_000}, {"timestamp": 1_600_000_010}, {"timestamp": 1_600_000_030},],
+                )
+
+        def test_query_run_with_no_such_session(self):
+            snapshots = session_recording().run(team=self.team, filter=None, session_recording_id="xxx")
+            self.assertEqual(snapshots, [])
+
+        def test_add_session_recording_ids(self):
+            with freeze_time("2020-09-13T12:26:40.000Z"):
+                self.create_snapshot("user", "1", now() + relativedelta(seconds=5))
+                self.create_snapshot("user", "1", now() + relativedelta(seconds=10))
+                self.create_snapshot("user", "1", now() + relativedelta(seconds=30))
+                self.create_snapshot("user2", "2", now() + relativedelta(seconds=20))
+                self.create_snapshot("user2", "2", now() + relativedelta(seconds=33))
+                # :TRICKY: same user, different session at the same time
+                self.create_snapshot("user", "3", now() + relativedelta(seconds=15))
+                self.create_snapshot("user", "3", now() + relativedelta(seconds=20))
+                self.create_snapshot("user", "3", now() + relativedelta(seconds=40))
+                self.create_snapshot("user", "4", now() + relativedelta(seconds=999))
+                self.create_snapshot("user", "4", now() + relativedelta(seconds=1020))
+
+                sessions = [
+                    {"distinct_id": "user", "start_time": now(), "end_time": now() + relativedelta(seconds=100)},
+                    {
+                        "distinct_id": "user",
+                        "start_time": now() + relativedelta(hours=99),
+                        "end_time": now() + relativedelta(hours=100),
+                    },
+                    {"distinct_id": "user2", "start_time": now(), "end_time": now() + relativedelta(seconds=30)},
+                ]
+                results = add_session_recording_ids(self.team, sessions)
+                self.assertEqual([r["session_recording_ids"] for r in results], [["1", "3"], [], ["2"]])
+
+        def create_snapshot(self, distinct_id, session_id, timestamp):
+            event_factory(
+                team=self.team,
+                distinct_id=distinct_id,
+                timestamp=timestamp,
+                event="$snapshot",
+                properties={"$snapshot_data": {"timestamp": timestamp.timestamp()}, "$session_id": session_id,},
+            )
+
+    return TestSessionRecording
+
+
+class DjangoSessionRecordingTest(session_recording_test_factory(SessionRecording, Event.objects.create)):  # type: ignore
+    pass

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
         "experimentalDecorators": true, // Enables experimental support for ES decorators
         "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
         "noFallthroughCasesInSwitch": true, // Report errors for fallthrough cases in switch statement
-        "lib": ["dom"]
+        "lib": ["dom", "es2019.array"]
     },
     "include": ["frontend/**/*"],
     "exclude": ["node_modules/**/*", "staticfiles/**/*", "frontend/dist/**/*"]


### PR DESCRIPTION
### Changes

- We now don't show $snapshot events in various views
- We hide system info on snapshot events
- New querying system for loading data from API
- Add sharable/persistent URLs for session recording
- Use Drawer over Modal to be able to fit more things into it
- Add Next/Previous buttons to session recording player

Cypress tests are upcoming in follow-ups.

![Screenshot from 2020-10-21 15-39-14](https://user-images.githubusercontent.com/148820/96720573-9aac7800-13b3-11eb-992c-07fa5b80af64.png)

Some of the BE and Kea-related code feels sort of disgusting - any and all pointers appreciated!

### Commits

﻿- Hide $session_id properties
- Exclude $snapshot events from event views
- Add end_time to sessions queries
- Add WIP way to return session recording
- Query for feature flags in a consistent way in frontend
- Improve documentation on featureFlagLogic
- Update frontend types
- Set up endpoint for querying event data for rrweb
- Sort snapshot data in BE before sending to FE
- Show sessions player in a drawer, load data from API
- Show loader while replay is loading
- Make player full-width
- Remove debug code
- Implement persistent URLs for sessions
- Use only $session_id for filtering sessions
- WIP
- Add `array.flatMap` to tsconfig
- Add selectors for prev/next session recording
- Clean up whitespace
- Make next and previous buttons work
- Patch prev/next behavior when not visible in page
- Session recording query testing


## Checklist

- [x] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [x] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
