### PR TITLE
Remove Omni-Person logic for ee

### DIFF
--- a/ee/clickhouse/migrations/0004_kafka.py
+++ b/ee/clickhouse/migrations/0004_kafka.py
@@ -2,7 +2,6 @@ from infi.clickhouse_orm import migrations  # type: ignore
 
 from ee.clickhouse.sql.events import EVENTS_TABLE_MV_SQL, KAFKA_EVENTS_TABLE_SQL
 from ee.clickhouse.sql.person import (
-    KAFKA_OMNI_PERSONS_TABLE_SQL,
     KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL,
     KAFKA_PERSONS_TABLE_SQL,
     PERSONS_DISTINCT_ID_TABLE_MV_SQL,
@@ -12,7 +11,6 @@ from ee.clickhouse.sql.person import (
 operations = [
     migrations.RunSQL(KAFKA_EVENTS_TABLE_SQL),
     migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
-    migrations.RunSQL(KAFKA_OMNI_PERSONS_TABLE_SQL),
     migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
     migrations.RunSQL(EVENTS_TABLE_MV_SQL),
     migrations.RunSQL(PERSONS_TABLE_MV_SQL),

--- a/ee/clickhouse/migrations/0004_kafka.py
+++ b/ee/clickhouse/migrations/0004_kafka.py
@@ -5,7 +5,6 @@ from ee.clickhouse.sql.person import (
     KAFKA_OMNI_PERSONS_TABLE_SQL,
     KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL,
     KAFKA_PERSONS_TABLE_SQL,
-    OMNI_PERSONS_TABLE_MV_SQL,
     PERSONS_DISTINCT_ID_TABLE_MV_SQL,
     PERSONS_TABLE_MV_SQL,
 )
@@ -17,6 +16,5 @@ operations = [
     migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
     migrations.RunSQL(EVENTS_TABLE_MV_SQL),
     migrations.RunSQL(PERSONS_TABLE_MV_SQL),
-    migrations.RunSQL(OMNI_PERSONS_TABLE_MV_SQL),
     migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),
 ]

--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from celery import shared_task
 
 from ee.clickhouse.models.event import create_event
-from ee.clickhouse.models.person import emit_omni_person
 from ee.kafka_client.client import KafkaProducer
 from ee.kafka_client.topics import KAFKA_EVENTS_WAL
 from posthog.ee import check_ee_enabled
@@ -64,14 +63,6 @@ def _capture_ee(
         distinct_id=distinct_id,
         elements=elements_list,
     )
-    emit_omni_person(
-        event_uuid=event_uuid,
-        uuid=person_uuid,
-        team_id=team_id,
-        distinct_id=distinct_id,
-        timestamp=timestamp,
-        properties=properties,
-    )
 
 
 if check_ee_enabled():
@@ -80,58 +71,11 @@ if check_ee_enabled():
     def process_event_ee(
         distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str],
     ) -> None:
-        properties = data.get("properties", None)
+        properties = data.get("properties", data.get("$set", {}))
         person_uuid = UUIDT()
         event_uuid = UUIDT()
         ts = handle_timestamp(data, now, sent_at)
 
-        if data["event"] == "$create_alias":
-            emit_omni_person(
-                event_uuid=event_uuid,
-                uuid=person_uuid,
-                team_id=team_id,
-                distinct_id=distinct_id,
-                timestamp=ts,
-                properties=properties,
-            )
-            emit_omni_person(
-                event_uuid=event_uuid,
-                uuid=person_uuid,
-                team_id=team_id,
-                distinct_id=properties["alias"],
-                timestamp=ts,
-                properties=properties,
-            )
-        elif data["event"] == "$identify":
-            if properties and properties.get("$anon_distinct_id"):
-                emit_omni_person(
-                    event_uuid=event_uuid,
-                    uuid=person_uuid,
-                    team_id=team_id,
-                    distinct_id=distinct_id,
-                    timestamp=ts,
-                    properties=properties,
-                )
-                emit_omni_person(
-                    event_uuid=event_uuid,
-                    uuid=person_uuid,
-                    team_id=team_id,
-                    distinct_id=properties["$anon_distinct_id"],
-                    timestamp=ts,
-                    properties=properties,
-                )
-            if data.get("$set"):
-                emit_omni_person(
-                    event_uuid=event_uuid,
-                    uuid=person_uuid,
-                    team_id=team_id,
-                    distinct_id=distinct_id,
-                    timestamp=ts,
-                    properties=data["$set"],
-                    is_identified=True,
-                )
-
-        properties = data.get("properties", data.get("$set", {}))
         _capture_ee(
             event_uuid=event_uuid,
             person_uuid=person_uuid,

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -1,4 +1,4 @@
-from ee.kafka_client.topics import KAFKA_OMNI_PERSON, KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
+from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
 
 from .clickhouse import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine, table_engine
 
@@ -54,57 +54,6 @@ _offset
 FROM kafka_{table_name} 
 """.format(
     table_name=PERSONS_TABLE
-)
-
-
-OMNI_PERSONS_TABLE = "omni_person"
-
-OMNI_PERSONS_TABLE_BASE_SQL = """
-CREATE TABLE {table_name} 
-(
-    uuid UUID,
-    event_uuid UUID,
-    team_id Int64,
-    distinct_id VARCHAR,
-    properties VARCHAR,
-    is_identified Boolean,
-    ts DateTime64
-    {extra_fields}
-) ENGINE = {engine} 
-"""
-
-OMNI_PERSONS_TABLE_SQL = (
-    OMNI_PERSONS_TABLE_BASE_SQL
-    + """Order By (team_id, uuid, distinct_id)
-{storage_policy}
-"""
-).format(
-    table_name=OMNI_PERSONS_TABLE,
-    engine=table_engine(OMNI_PERSONS_TABLE, "_timestamp"),
-    extra_fields=KAFKA_COLUMNS,
-    storage_policy=STORAGE_POLICY,
-)
-
-KAFKA_OMNI_PERSONS_TABLE_SQL = OMNI_PERSONS_TABLE_BASE_SQL.format(
-    table_name="kafka_" + OMNI_PERSONS_TABLE, engine=kafka_engine(KAFKA_OMNI_PERSON), extra_fields=""
-)
-
-OMNI_PERSONS_TABLE_MV_SQL = """
-CREATE MATERIALIZED VIEW {table_name}_mv 
-TO {table_name} 
-AS SELECT
-uuid,
-event_uuid,
-team_id,
-distinct_id,
-properties,
-is_identified,
-ts,
-_timestamp,
-_offset
-FROM kafka_{table_name} 
-""".format(
-    table_name=OMNI_PERSONS_TABLE
 )
 
 

--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -2,6 +2,5 @@ KAFKA_EVENTS = "clickhouse_events"
 KAFKA_ELEMENTS = "clickhouse_elements"
 KAFKA_PERSON = "clickhouse_person"
 KAFKA_PERSON_UNIQUE_ID = "clickhouse_person_unique_id"
-KAFKA_OMNI_PERSON = "clickhouse_omni_person"
 
 KAFKA_EVENTS_WAL = "events_write_ahead_log"


### PR DESCRIPTION
## Changes

Clean up an unused path on ee that is consuming considerable kafka disk space.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
