### PR TITLE
Use posthog.js correctly in userLogic

### DIFF
--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -106,9 +106,10 @@ export const userLogic = kea<userLogicType<UserType, EventProperty, UserUpdateTy
                             posthog.reset()
                         }
 
-                        posthog.identify(user.distinct_id, {
-                            email: user.anonymize_data ? null : user.email,
-                        })
+                        posthog.identify(user.distinct_id)
+                        if (!user.anonymize_data) {
+                            posthog.people.set({ email: user.email })
+                        }
                         posthog.register({
                             posthog_version: user.posthog_version,
                             has_slack_webhook: !!user.team.slack_incoming_webhook,

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -107,9 +107,8 @@ export const userLogic = kea<userLogicType<UserType, EventProperty, UserUpdateTy
                         }
 
                         posthog.identify(user.distinct_id)
-                        if (!user.anonymize_data) {
-                            posthog.people.set({ email: user.email })
-                        }
+                        posthog.people.set({ email: user.anonymize_data ? null : user.email })
+
                         posthog.register({
                             posthog_version: user.posthog_version,
                             has_slack_webhook: !!user.team.slack_incoming_webhook,


### PR DESCRIPTION
This caused some confusion (issue #1955) - we should be using our own tools correctly. :sweat_smile:

Types could have avoided this, but adding PH typing here is surprisingly hard - doing follow-up PRs.