### PR TITLE
Automatically run CH migrations locally

### DIFF
--- a/bin/docker-ch-dev-web
+++ b/bin/docker-ch-dev-web
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+python manage.py migrate
+python manage.py migrate_clickhouse
+
+python manage.py runserver 0.0.0.0:8000 & ./bin/start-frontend 0.0.0.0

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     db:
-        image: postgres:alpine
+        image: postgres:11-alpine
         environment:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
@@ -17,7 +17,7 @@ services:
         build:
             context: ../
             dockerfile: dev.Dockerfile
-        command: ./bin/docker-dev-web
+        command: ./bin/docker-ch-dev-web
         volumes:
             - ..:/code
         ports:


### PR DESCRIPTION
## Changes

We weren't running CH migrations locally automatically which confused me for a little bit. It also pins the postgres version to 11, had some problems with that too at one point.

## Checklist

- [ ] All querysets/queries filter by Team (if this PR affects any querysets/queries)
- [ ] Backend tests (if this PR affects the backend)
- [ ] Cypress E2E tests (if this PR affects the front and/or backend)
