### PR TITLE
Fix cypress tests

### DIFF
--- a/cypress/integration/people.js
+++ b/cypress/integration/people.js
@@ -4,7 +4,7 @@ describe('People', () => {
     })
 
     it('People loaded', () => {
-        cy.get('h1').should('contain', 'Users')
+        cy.get('h1').should('contain', 'Persons')
     })
 
     it('Go to new cohort from people screen', () => {
@@ -26,6 +26,6 @@ describe('People', () => {
         cy.get('[data-attr=menu-item-people-cohorts]').click()
         cy.get('[data-attr=menu-item-people-persons]').click()
 
-        cy.get('h1').should('contain', 'Users')
+        cy.get('h1').should('contain', 'Persons')
     })
 })


### PR DESCRIPTION
people.js was done by the refactoring/renaming being done in
533c7df10531ce17634feb61bc2ae4cf33802f82

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
