### PR TITLE
Make PostHog compatibile with Python 3.9

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.7', '3.8', 'pypy3']
+                python-version: ['3.7', '3.8']
 
         services:
             postgres:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -62,11 +62,11 @@ jobs:
                   mypy posthog ee
 
     django:
-        name: Django tests (${{ matrix.python-version }})
+        name: Django tests – Py ${{ matrix.python-version }}
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.7', '3.8']
+                python-version: ['3.7.8', '3.8.5', '3.9.0']
 
         services:
             postgres:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -24,7 +24,7 @@ jobs:
                   fetch-depth: 1
 
             - name: Set up Python 3.8
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v2
               with:
                   python-version: 3.8
 
@@ -62,8 +62,11 @@ jobs:
                   mypy posthog ee
 
     django:
-        name: Django tests
+        name: Django tests (${{ matrix.python-version }})
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ['3.7', '3.8', 'pypy3']
 
         services:
             postgres:
@@ -86,10 +89,10 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.8
-              uses: actions/setup-python@v1
+            - name: Set up Python
+              uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: ${{ matrix.python-version }}
 
             - uses: actions/cache@v1
               with:
@@ -231,7 +234,7 @@ jobs:
                   fetch-depth: 1
 
             - name: Set up Python 3.8
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v2
               with:
                   python-version: 3.8
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v1
             - name: Set up Python 3.8
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v2
               with:
                   python-version: 3.8
             - uses: actions/cache@v1

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -318,7 +318,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
 
             self.assertEqual(sum(response[0]["data"]), 2)
             self.assertEqual(response[0]["data"][4 + 7], 2)
-            self.assertEqual(response[0]["breakdown_value"], "None")
+            self.assertEqual(response[0]["breakdown_value"], "nan")
 
             self.assertEqual(sum(response[1]["data"]), 1)
             self.assertEqual(response[1]["data"][5 + 7], 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ MarkupSafe==1.1.1
 monotonic==1.5
 numpy==1.18.1
 oauthlib==3.1.0
-pandas==1.0.3
+pandas==1.1.3
 parso==0.6.1
 pexpect==4.7.0
 pickleshare==0.7.5


### PR DESCRIPTION
## Changes

Python 3.9.0 has been released and all of PostHog seems to be compatible with it – except for Pandas 1.0.3, which had installation issues on the updated CPython. This fixes that by updating Pandas to 1.1.3.