### PR TITLE
Break down feature_flag_response and add to propertykeyinfo

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.js
+++ b/frontend/src/lib/components/PropertyKeyInfo.js
@@ -114,6 +114,16 @@ export const keyMapping = {
             description: 'Keys of the feature flags that were active while this event was sent.',
             examples: ['beta-feature'],
         },
+        $feature_flag_response: {
+            label: 'Feature Flag Response',
+            description: 'What the call to feature flag responded with.',
+            examples: ['true', 'false'],
+        },
+        $feature_flag: {
+            label: 'Feature Flag',
+            description: 'The feature flag that was called.',
+            examples: ['beta-feature'],
+        },
         $device: {
             label: 'Device',
             description: 'The mobile device that was used.',

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -57,7 +57,7 @@ function _FeatureFlags() {
                         to={
                             '/insights?events=[{"id":"$feature_flag_called","name":"$feature_flag_called","type":"events"}]&properties=[{"key":"$feature_flag","value":"' +
                             featureFlag.key +
-                            '"}]#backTo=Feature Flags&backToURL=' +
+                            '"}]&breakdown=$feature_flag_response&breakdown_type=event#backTo=Feature Flags&backToURL=' +
                             window.location.pathname
                         }
                         type="primary"


### PR DESCRIPTION
## Changes

We weren't breaking down by the response, so you couldn't actually tell what gate the feature flag went through. Now we automatically show that breakdown: (this is clickhouse sessions)

![image](https://user-images.githubusercontent.com/1727427/96899932-ce5dcf80-1491-11eb-9f13-1180ba7f9196.png)


## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
