### PR TITLE
Fix cohort page link

### DIFF
--- a/frontend/src/scenes/users/Cohorts.js
+++ b/frontend/src/scenes/users/Cohorts.js
@@ -21,7 +21,7 @@ function _Cohorts() {
             key: 'name',
             render: function RenderName(_, cohort) {
                 return (
-                    <Link className={rrwebBlockClass} to={'/people?cohort=' + cohort.id}>
+                    <Link className={rrwebBlockClass} to={'/people/persons?cohort=' + cohort.id}>
                         {cohort.name}
                     </Link>
                 )


### PR DESCRIPTION
## Changes

Fixes this:

![2020-10-23 10 52 40](https://user-images.githubusercontent.com/53387/96978770-065f2400-151f-11eb-81c7-30079e0bdb94.gif)

Should get a test to make sure this doesn't break...

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
