### PR TITLE
Cohorts Test

### DIFF
--- a/cypress/integration/cohorts.js
+++ b/cypress/integration/cohorts.js
@@ -3,7 +3,41 @@ describe('Cohorts', () => {
         cy.get('[data-attr=menu-item-people]').click()
         cy.get('[data-attr=menu-item-people-cohorts]').click()
     })
-    it('Cohorts loaded', () => {
+    it('Cohorts new and list', () => {
+        // load an empty page
         cy.get('h1').should('contain', 'Cohorts')
+
+        // go to create a new cohort
+        cy.get('[data-attr="create-cohort"]').click()
+        cy.get('form.card-body > .form-control').type('Test Cohort')
+
+        // select "add filter" and "property"
+        cy.get('[data-attr="cohort-group-property"]').click()
+        cy.get('[data-attr="new-prop-filter-cohort_0"]').click()
+
+        // select the first property
+        cy.get('[data-attr=property-filter-dropdown]').click()
+        cy.get('[data-attr=prop-filter-person-0]').click({ force: true })
+
+        cy.get('[data-attr=prop-val]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
+
+        // save
+        cy.get('[data-attr="save-cohort"]').click()
+        cy.get('[data-attr=success-toast]').should('exist')
+
+        // back to cohorts
+        cy.get('h1').should('contain', 'Persons')
+        cy.get('[data-attr=menu-item-people-cohorts]').click()
+
+        cy.get('h1').should('contain', 'Cohorts')
+        cy.get('.ant-empty').should('not.exist')
+
+        // click the first row's first column's cohort title
+        cy.get('[data-row-key="1"] > :nth-child(1) > a').click()
+
+        // back on the persons page
+        cy.get('h1').should('contain', 'Persons')
+        cy.get('.ant-table-tbody > tr').should('exist')
     })
 })

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -21,16 +21,16 @@ describe('Events', () => {
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=new-prop-filter-EventsTable]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('[data-attr=prop-filter-event-0]').click()
+        cy.get('[data-attr=prop-filter-event-0]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-0]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
         cy.get('[data-attr=events-table]').should('exist')
     })
 
     it('Filter by event', () => {
         cy.get('[data-attr=event-filter-trigger]').click()
         cy.get('[data-attr=event-name-box]').click()
-        cy.get('[data-attr=prop-val-0]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
         cy.get('[data-attr=events-table]').should('exist')
     })
 })

--- a/cypress/integration/liveActions.js
+++ b/cypress/integration/liveActions.js
@@ -11,9 +11,9 @@ describe('Live Actions', () => {
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=new-prop-filter-LiveActionsTable]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('[data-attr=prop-filter-event-1]').click()
+        cy.get('[data-attr=prop-filter-event-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-1]').click()
+        cy.get('[data-attr=prop-val-1]').click({ force: true })
 
         cy.get('[data-attr=events-table]').should('exist')
     })

--- a/cypress/integration/retention.js
+++ b/cypress/integration/retention.js
@@ -7,9 +7,9 @@ describe('Retention', () => {
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=new-prop-filter-insight-retention]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('[data-attr=prop-filter-person-0]').click()
+        cy.get('[data-attr=prop-filter-person-0]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-0]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
         cy.get('[data-attr=retention-table').should('exist')
     })
 })

--- a/cypress/integration/trendsElements.js
+++ b/cypress/integration/trendsElements.js
@@ -36,18 +36,18 @@ describe('Trends actions & events', () => {
         cy.get('[data-attr=show-prop-filter-0]').click()
         cy.get('[data-attr=new-prop-filter-0-\\$pageview-filter]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('[data-attr=prop-filter-event-1]').click()
+        cy.get('[data-attr=prop-filter-event-1]').click({ force: true })
         cy.get('#rc_select_6').click()
-        cy.get('[data-attr=prop-val-0]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('[data-attr=prop-filter-event-1]').click()
+        cy.get('[data-attr=prop-filter-event-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-0]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
 
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })

--- a/cypress/integration/trendsSessions.js
+++ b/cypress/integration/trendsSessions.js
@@ -13,9 +13,9 @@ describe('Trends sessions', () => {
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=new-prop-filter-trends-sessions]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('[data-attr=prop-filter-event-1]').click()
+        cy.get('[data-attr=prop-filter-event-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-1]').click()
+        cy.get('[data-attr=prop-val-1]').click({ force: true })
 
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })

--- a/frontend/src/scenes/users/Cohort.js
+++ b/frontend/src/scenes/users/Cohort.js
@@ -87,6 +87,7 @@ export function Cohort({ onChange }) {
                         type="primary"
                         htmlType="submit"
                         disabled={isSubmitDisabled(cohort)}
+                        data-attr="save-cohort"
                         style={{ marginTop: '1rem' }}
                     >
                         Save cohort

--- a/frontend/src/scenes/users/CohortGroup.js
+++ b/frontend/src/scenes/users/CohortGroup.js
@@ -40,6 +40,7 @@ export function CohortGroup({ onChange, onRemove, group, index }) {
                                 onChange({})
                             }}
                             type="button"
+                            data-attr="cohort-group-action"
                             className={'btn btn-sm ' + (selected == 'action' ? 'btn-secondary' : 'btn-light')}
                         >
                             action
@@ -50,6 +51,7 @@ export function CohortGroup({ onChange, onRemove, group, index }) {
                                 onChange({})
                             }}
                             type="button"
+                            data-attr="cohort-group-property"
                             className={'btn btn-sm ' + (selected == 'property' ? 'btn-secondary' : 'btn-light')}
                         >
                             property

--- a/frontend/src/scenes/users/cohortLogic.js
+++ b/frontend/src/scenes/users/cohortLogic.js
@@ -80,7 +80,9 @@ export const cohortLogic = kea({
                 actions.setPollTimeout(setTimeout(() => actions.checkIsFinished(cohort), 1000))
             } else {
                 toast.update(values.toastId, {
-                    render: 'Cohort saved!',
+                    render: function RenderToast() {
+                        return <span data-attr="success-toast">Cohort saved!</span>
+                    },
                     autoClose: 5000,
                 })
                 props.onChange(cohort.id)


### PR DESCRIPTION
## Changes

- Adds test to create new cohorts and then open the cohort
- Will avoid the cohorts table links breaking like just happened

- Also added: fix the flaky tests by sending `{ force: true }` to clicks to property list dropdowns. This will make the code click the dropdown item, even if it's hidden from CSS due to timing issues if clicking the original dropdown field to open it... and then it closes because an autofocus already opened it.


## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
