### PR TITLE
Put organization switcher under user

### DIFF
--- a/frontend/src/layout/TopContent/TopSelectors.tsx
+++ b/frontend/src/layout/TopContent/TopSelectors.tsx
@@ -28,10 +28,13 @@ export function User(): JSX.Element {
             overlay={
                 <Menu>
                     <Menu.Item key="user-email">
-                        <Link to="/me/settings">
+                        <Link to="/me/settings" title="My Settings">
                             <SettingOutlined size={1} style={{ marginRight: '0.5rem' }} />
                             {user ? user.email : <i>loading</i>}
                         </Link>
+                    </Menu.Item>
+                    <Menu.Item key="user-organizations">
+                        <Organization />
                     </Menu.Item>
                     <Menu.Item key="user-logout">
                         <a href="#" onClick={logout} data-attr="user-options-logout" style={{ color: red.primary }}>
@@ -151,12 +154,7 @@ export function Organization(): JSX.Element {
                     </Menu>
                 }
             >
-                <div
-                    data-attr="user-organization-dropdown"
-                    className="btn btn-sm btn-light btn-top"
-                    style={{ marginRight: '0.75rem' }}
-                    title="Organizations"
-                >
+                <div data-attr="user-organization-dropdown" title="Current Organization">
                     <DeploymentUnitOutlined size={1} style={{ marginRight: '0.5rem' }} />
                     {user ? user.organization.name : <i>loading</i>}
                 </div>
@@ -275,7 +273,7 @@ export function Projects(): JSX.Element {
                     data-attr="user-project-dropdown"
                     className="btn btn-sm btn-light btn-top"
                     style={{ marginRight: '0.75rem' }}
-                    title="Organization Projects"
+                    title="Current Projects"
                 >
                     <ProjectOutlined size={1} style={{ marginRight: '0.5rem' }} />
                     {!user ? <i>loading</i> : user.team ? user.team.name : <i>none yet</i>}

--- a/frontend/src/layout/TopContent/index.tsx
+++ b/frontend/src/layout/TopContent/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { LatestVersion } from './LatestVersion'
-import { Organization, Projects, User } from './TopSelectors'
+import { Projects, User } from './TopSelectors'
 import { CommandPaletteButton } from './CommandPaletteButton'
 import { isMobile } from 'lib/utils'
 import './index.scss'
@@ -44,7 +44,6 @@ export function TopContent(): JSX.Element {
             >
                 <LatestVersion />
                 <Projects />
-                <Organization />
                 <User />
             </div>
         </div>


### PR DESCRIPTION
## Changes

Since we want to incentivize using multiple projects over multiple organizations, here's a proposal to put the organization switcher under user actions.

<img width="294" alt="Screen Shot 2020-10-23 at 12 55 49" src="https://user-images.githubusercontent.com/4550621/96996524-4bd81d00-1530-11eb-96b9-3cb2a393b6f0.png">

