### PR TITLE
Rename existing projects to "Default Project"

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -2,7 +2,7 @@ admin: 0003_logentry_add_action_flag_choices
 auth: 0011_update_proxy_permissions
 contenttypes: 0002_remove_content_type_name
 ee: 0002_hook
-posthog: 0091_messagingrecord
+posthog: 0092_rename_projects_to_default
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0008_partial_timestamp

--- a/posthog/migrations/0092_rename_projects_to_default.py
+++ b/posthog/migrations/0092_rename_projects_to_default.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("posthog", "0091_messagingrecord"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            UPDATE "posthog_team"
+            SET "name" = 'Default Project';
+            """,
+            "",
+        )
+    ]


### PR DESCRIPTION
## Changes

As per discussion on Slack, Teams being migrated into Organizations and Projects - with both these entities named the same - is somewhat confusing. Since the feature hasn't actually been released yet, this renames all projects to the default value "Default Project". 