### PR TITLE
[Clickhouse] Fix action filtering on events

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.event import ClickhouseEventSerializer, determine_event_conditions
 from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.models.property import get_property_values_for_key, parse_prop_clauses
@@ -14,6 +15,7 @@ from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_E
 from ee.clickhouse.util import CH_EVENT_ENDPOINT, endpoint_enabled
 from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
+from posthog.models.action import Action
 from posthog.utils import convert_property_value
 
 
@@ -42,6 +44,11 @@ class ClickhouseEvents(EventViewSet):
         limit = "LIMIT 101"
         conditions, condition_params = determine_event_conditions(request.GET.dict())
         prop_filters, prop_filter_params = parse_prop_clauses("uuid", filter.properties, team)
+        if request.GET.get("action_id"):
+            action = Action.objects.get(pk=request.GET["action_id"])
+            action_query, params = format_action_filter(action)
+            prop_filters += " AND uuid IN {}".format(action_query)
+            prop_filter_params = {**prop_filter_params, **params}
 
         if prop_filters != "":
             query_result = sync_execute(

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -243,6 +243,7 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
                 event1 = event_factory(team=self.team, event="sign up", distinct_id="2")
             with freeze_time("2020-01-8"):
                 event2 = event_factory(team=self.team, event="sign up", distinct_id="2")
+            with freeze_time("2020-01-7"):
                 event3 = event_factory(team=self.team, event="random other event", distinct_id="2")
 
             action = Action.objects.create(team=self.team)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -265,8 +265,8 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
 
             response = self.client.get("/api/event/?before=2020-01-09T00:00:00.000Z").json()
             self.assertEqual(len(response["results"]), 2)
-            self.assertEqual(response["results"][0]["id"], event3.pk)
-            self.assertEqual(response["results"][1]["id"], event2.pk)
+            self.assertEqual(response["results"][0]["id"], event2.pk)
+            self.assertEqual(response["results"][1]["id"], event3.pk)
 
         def test_pagination(self):
             person_factory(team=self.team, distinct_ids=["1"])

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -243,6 +243,7 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
                 event1 = event_factory(team=self.team, event="sign up", distinct_id="2")
             with freeze_time("2020-01-8"):
                 event2 = event_factory(team=self.team, event="sign up", distinct_id="2")
+                event3 = event_factory(team=self.team, event="random other event", distinct_id="2")
 
             action = Action.objects.create(team=self.team)
             ActionStep.objects.create(action=action, event="sign up")
@@ -262,8 +263,9 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             self.assertEqual(response["results"][0]["id"], event1.pk)
 
             response = self.client.get("/api/event/?before=2020-01-09T00:00:00.000Z").json()
-            self.assertEqual(len(response["results"]), 1)
-            self.assertEqual(response["results"][0]["id"], event2.pk)
+            self.assertEqual(len(response["results"]), 2)
+            self.assertEqual(response["results"][0]["id"], event3.pk)
+            self.assertEqual(response["results"][1]["id"], event2.pk)
 
         def test_pagination(self):
             person_factory(team=self.team, distinct_ids=["1"])


### PR DESCRIPTION
## Changes

Previously we weren't filtering events at all on the action edit pages.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
