### PR TITLE
Improve weekly report testing

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -20,8 +20,8 @@ def send_weekly_email_reports() -> None:
         logger.info("Skipping send_weekly_email_report because email is not properly configured")
         return
 
-    for team in Team.objects.all():
-        _send_weekly_email_report_for_team.delay(team_id=team.pk,)
+    for team in Team.objects.order_by("pk"):
+        _send_weekly_email_report_for_team.delay(team_id=team.pk)
 
 
 @app.task(max_retries=1)


### PR DESCRIPTION
## Changes

- Sends weekly report email starting from the oldest team (so that we can test with PostHog Team before it hits other teams) just as an extra precaution.
