### PR TITLE
Add ability to reset project API token

### DIFF
--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { useValues } from 'kea'
-import { userLogic } from 'scenes/userLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 export function JSSnippet(): JSX.Element {
-    const { user } = useValues(userLogic)
+    const { currentTeam } = useValues(teamLogic)
 
     return (
         <CodeSnippet language={Language.HTML}>{`<script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('${user?.team?.api_token}',{api_host:'${window.location.origin}'})
+    posthog.init('${currentTeam?.api_token}',{api_host:'${window.location.origin}'})
 </script>`}</CodeSnippet>
     )
 }

--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -110,7 +110,7 @@ function PersonalAPIKeysTable(): JSX.Element {
             title: 'Last Used',
             dataIndex: 'last_used_at',
             key: 'lastUsedAt',
-            render: (lastUsedAt: string) => (lastUsedAt ? humanFriendlyDetailedTime(lastUsedAt) : 'never'),
+            render: (lastUsedAt: string | null) => humanFriendlyDetailedTime(lastUsedAt),
         },
         {
             title: 'Created',

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -354,7 +354,8 @@ export function humanFriendlyDiff(from: moment.MomentInput, to: moment.MomentInp
     return humanFriendlyDuration(diff)
 }
 
-export function humanFriendlyDetailedTime(date: moment.MomentInput, withSeconds: boolean = false): string {
+export function humanFriendlyDetailedTime(date: moment.MomentInput | null, withSeconds: boolean = false): string {
+    if (!date) return 'Never'
     let formatString = 'MMMM Do YYYY h:mm'
     const today = moment().startOf('day')
     const yesterday = today.clone().subtract(1, 'days').startOf('day')

--- a/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
@@ -25,6 +25,7 @@ import { PopconfirmProps } from 'antd/lib/popconfirm'
 export interface Action {
     Icon: any
     callback: () => void
+    popconfirmProps?: Omit<PopconfirmProps, 'onConfirm'>
 }
 
 export enum Language {
@@ -73,7 +74,6 @@ export interface CodeSnippetProps {
     language?: Language
     wrap?: boolean
     actions?: Action[]
-    popconfirmProps?: PopconfirmProps
 }
 
 export function CodeSnippet({
@@ -81,16 +81,20 @@ export function CodeSnippet({
     language = Language.Text,
     wrap = false,
     actions,
-    popconfirmProps,
 }: CodeSnippetProps): JSX.Element {
     return (
         <div className="code-container">
             <div className="action-icon-container">
                 {actions &&
-                    actions.map(({ Icon, callback }, index) => {
-                        const icon = <Icon key={`snippet-action-${index}`} className="action-icon" onClick={callback} />
-                        return !popconfirmProps ? icon : <Popconfirm {...popconfirmProps}>{icon}</Popconfirm>
-                    })}
+                    actions.map(({ Icon, callback, popconfirmProps }, index) =>
+                        !popconfirmProps ? (
+                            <Icon key={`snippet-action-${index}`} className="action-icon" onClick={callback} />
+                        ) : (
+                            <Popconfirm {...popconfirmProps} onConfirm={callback}>
+                                <Icon key={`snippet-action-${index}`} className="action-icon" />
+                            </Popconfirm>
+                        )
+                    )}
                 <CopyOutlined
                     className="action-icon"
                     onClick={() => {

--- a/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
@@ -90,8 +90,8 @@ export function CodeSnippet({
                         !popconfirmProps ? (
                             <Icon key={`snippet-action-${index}`} className="action-icon" onClick={callback} />
                         ) : (
-                            <Popconfirm {...popconfirmProps} onConfirm={callback}>
-                                <Icon key={`snippet-action-${index}`} className="action-icon" />
+                            <Popconfirm key={`snippet-action-${index}`} {...popconfirmProps} onConfirm={callback}>
+                                <Icon className="action-icon" />
                             </Popconfirm>
                         )
                     )}

--- a/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
@@ -19,6 +19,13 @@ import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml'
 import markup from 'react-syntax-highlighter/dist/esm/languages/prism/markup'
 import http from 'react-syntax-highlighter/dist/esm/languages/prism/http'
 import { copyToClipboard } from 'lib/utils'
+import { Popconfirm } from 'antd'
+import { PopconfirmProps } from 'antd/lib/popconfirm'
+
+export interface Action {
+    Icon: any
+    callback: () => void
+}
 
 export enum Language {
     Text = 'text',
@@ -61,23 +68,36 @@ SyntaxHighlighter.registerLanguage(Language.XML, markup)
 SyntaxHighlighter.registerLanguage(Language.Markup, markup)
 SyntaxHighlighter.registerLanguage(Language.HTTP, http)
 
+export interface CodeSnippetProps {
+    children: string
+    language?: Language
+    wrap?: boolean
+    actions?: Action[]
+    popconfirmProps?: PopconfirmProps
+}
+
 export function CodeSnippet({
     children,
     language = Language.Text,
     wrap = false,
-}: {
-    children: string
-    language?: Language
-    wrap?: boolean
-}): JSX.Element {
+    actions,
+    popconfirmProps,
+}: CodeSnippetProps): JSX.Element {
     return (
         <div className="code-container">
-            <CopyOutlined
-                className="copy-icon"
-                onClick={() => {
-                    copyToClipboard(children, 'code snippet')
-                }}
-            />
+            <div className="action-icon-container">
+                {actions &&
+                    actions.map(({ Icon, callback }, index) => {
+                        const icon = <Icon key={`snippet-action-${index}`} className="action-icon" onClick={callback} />
+                        return !popconfirmProps ? icon : <Popconfirm {...popconfirmProps}>{icon}</Popconfirm>
+                    })}
+                <CopyOutlined
+                    className="action-icon"
+                    onClick={() => {
+                        copyToClipboard(children, 'code snippet')
+                    }}
+                />
+            </div>
             <SyntaxHighlighter
                 style={okaidia}
                 language={language}

--- a/frontend/src/scenes/project/Settings/index.js
+++ b/frontend/src/scenes/project/Settings/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Divider } from 'antd'
 import { IPCapture } from './IPCapture'
 import { JSSnippet } from 'lib/components/JSSnippet'
@@ -9,13 +9,18 @@ import { userLogic } from 'scenes/userLogic'
 import { WebhookIntegration } from './WebhookIntegration'
 import { useAnchor } from 'lib/hooks/useAnchor'
 import { router } from 'kea-router'
+import { ReloadOutlined } from '@ant-design/icons'
+import { red } from '@ant-design/colors'
 import { hot } from 'react-hot-loader/root'
 import { ToolbarSettings } from './ToolbarSettings'
 import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
+import { teamLogic } from 'scenes/teamLogic'
 
 export const Setup = hot(_Setup)
 function _Setup() {
     const { user } = useValues(userLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { resetToken } = useActions(teamLogic)
     const { location } = useValues(router)
     const showSessionRecord = window.posthog?.isFeatureEnabled('session-recording-player')
 
@@ -42,7 +47,24 @@ function _Setup() {
             <h2 id="project-api-key">Project API Key</h2>
             You can use this write-only key in any one of{' '}
             <a href="https://posthog.com/docs/integrations">our libraries</a>.
-            <CodeSnippet>{user.team.api_token}</CodeSnippet>
+            <CodeSnippet
+                actions={[
+                    {
+                        Icon: ReloadOutlined,
+                        popconfirmProps: {
+                            title: 'Reset project API key, invalidating the current one?',
+                            okText: 'Reset Project API Key',
+                            okType: 'danger',
+                            icon: <ReloadOutlined style={{ color: red.primary }} />,
+                            placement: 'left',
+                            onConfirm: resetToken,
+                        },
+                        callback: resetToken,
+                    },
+                ]}
+            >
+                {currentTeam?.api_token}
+            </CodeSnippet>
             Write-only means it can only create new events. It can't read events or any of your other data stored with
             PostHog, so it's safe to use in public apps. Still, if possible, include it in the build as an environment
             variable instead of hard-coding.

--- a/frontend/src/scenes/project/Settings/index.js
+++ b/frontend/src/scenes/project/Settings/index.js
@@ -53,7 +53,7 @@ function _Setup() {
                         Icon: ReloadOutlined,
                         popconfirmProps: {
                             title: 'Reset project API key, invalidating the current one?',
-                            okText: 'Reset Project API Key',
+                            okText: 'Reset Key',
                             okType: 'danger',
                             icon: <ReloadOutlined style={{ color: red.primary }} />,
                             placement: 'left',
@@ -65,8 +65,7 @@ function _Setup() {
                 {currentTeam?.api_token}
             </CodeSnippet>
             Write-only means it can only create new events. It can't read events or any of your other data stored with
-            PostHog, so it's safe to use in public apps. Still, if possible, include it in the build as an environment
-            variable instead of hard-coding.
+            PostHog, so it's safe to use in public apps.
             <Divider />
             <h2 id="urls">Permitted Domains/URLs</h2>
             <p>

--- a/frontend/src/scenes/project/Settings/index.js
+++ b/frontend/src/scenes/project/Settings/index.js
@@ -57,7 +57,6 @@ function _Setup() {
                             okType: 'danger',
                             icon: <ReloadOutlined style={{ color: red.primary }} />,
                             placement: 'left',
-                            onConfirm: resetToken,
                         },
                         callback: resetToken,
                     },

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -15,8 +15,10 @@ export const teamLogic = kea<teamLogicType>({
                         return null
                     }
                 },
+                // no API request in patch as that's handled in userLogic for now
                 patchCurrentTeam: (patch: Partial<TeamType>) => ({ ...values.currentTeam, ...patch }),
                 createTeam: async (name: string) => await api.create('api/projects/', { name }),
+                resetToken: async () => await api.update('api/projects/@current/reset_token'),
             },
         ],
     }),

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -146,7 +146,7 @@ $body-color: #37352f;
         right: 1em;
     }
     .action-icon {
-        margin-left: 4px;
+        margin-left: 0.5em;
         padding: 2px;
         color: white;
         background-color: inherit;

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -140,10 +140,13 @@ $body-color: #37352f;
 
 .code-container {
     position: relative;
-    .copy-icon {
+    .action-icon-container {
         position: absolute;
         top: 1em;
         right: 1em;
+    }
+    .action-icon {
+        margin-left: 4px;
         padding: 2px;
         color: white;
         background-color: inherit;

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -107,7 +107,10 @@ class TeamViewSet(viewsets.ModelViewSet):
             return self.request.user.team
         queryset = self.filter_queryset(self.get_queryset())
         filter_kwargs = {self.lookup_field: lookup_value}
-        obj = get_object_or_404(queryset, **filter_kwargs)
+        try:
+            obj = get_object_or_404(queryset, **filter_kwargs)
+        except ValueError as error:
+            raise exceptions.ValidationError(error)
         self.check_object_permissions(self.request, obj)
         return obj
 
@@ -121,8 +124,8 @@ class TeamViewSet(viewsets.ModelViewSet):
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=["PATCH"], detail=True)
-    def reset_token(self, request: request.Request, id: str = None) -> response.Response:
-        team = request.user.team if id == "@current" else Team.objects.get(id=id)
+    def reset_token(self, request: request.Request, id: str) -> response.Response:
+        team = self.get_object()
         team.api_token = generate_random_token()
         team.save()
         return response.Response(TeamSerializer(team).data)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -110,7 +110,7 @@ class TeamViewSet(viewsets.ModelViewSet):
         try:
             obj = get_object_or_404(queryset, **filter_kwargs)
         except ValueError as error:
-            raise exceptions.ValidationError(error)
+            raise exceptions.ValidationError(str(error))
         self.check_object_permissions(self.request, obj)
         return obj
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -38,7 +38,6 @@ def user(request):
         data = json.loads(request.body)
 
         if "team" in data:
-            team.api_token = data["team"].get("api_token", team.api_token)
             team.app_urls = data["team"].get("app_urls", team.app_urls)
             team.opt_out_capture = data["team"].get("opt_out_capture", team.opt_out_capture)
             team.slack_incoming_webhook = data["team"].get("slack_incoming_webhook", team.slack_incoming_webhook)


### PR DESCRIPTION
## Changes

This adds a "reset API token" icon to the Project Settings page, along with an appropriate endpoint.

<img width="908" alt="Screenshot" src="https://user-images.githubusercontent.com/4550621/97023792-4f7e9a80-1556-11eb-9b91-99c6e2d87468.png">
