### PR TITLE
Fix click outside spam & public paths

### DIFF
--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -32,7 +32,7 @@ import { triggerResizeAfterADelay } from 'lib/utils'
 import { HogIcon } from 'lib/icons/HogIcon'
 import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import { ToolbarModal } from '~/layout/ToolbarModal/ToolbarModal'
-import whiteLogo from './../../public/posthog-logo-white.svg'
+import whiteLogo from 'public/posthog-logo-white.svg'
 import { hot } from 'react-hot-loader/root'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 

--- a/frontend/src/lib/components/CommandPalette/CommandInput.tsx
+++ b/frontend/src/lib/components/CommandPalette/CommandInput.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { SearchOutlined, EditOutlined } from '@ant-design/icons'
 import { useValues, useActions } from 'kea'
 import { commandPaletteLogic } from './commandPaletteLogic'
-import PostHogIcon from './../../../../public/icon-white.svg'
+import PostHogIcon from 'public/icon-white.svg'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 export function CommandInput(): JSX.Element {

--- a/frontend/src/lib/components/CommandPalette/index.tsx
+++ b/frontend/src/lib/components/CommandPalette/index.tsx
@@ -40,7 +40,15 @@ export function CommandPalette(): JSX.Element | null {
         }
     })
 
-    useOutsideClickHandler(boxRef, hidePalette)
+    useOutsideClickHandler(
+        boxRef,
+        () => {
+            if (isPaletteShown) {
+                hidePalette()
+            }
+        },
+        [boxRef, isPaletteShown]
+    )
 
     return !user || !isPaletteShown ? null : (
         <div className="palette__overlay">

--- a/frontend/src/lib/components/CommandPalette/index.tsx
+++ b/frontend/src/lib/components/CommandPalette/index.tsx
@@ -6,7 +6,7 @@ import { CommandInput } from './CommandInput'
 import { CommandResults } from './CommandResults'
 import { userLogic } from 'scenes/userLogic'
 import { useEventListener } from 'lib/hooks/useEventListener'
-import squeakFile from './../../../../public/squeak.mp3'
+import squeakFile from 'public/squeak.mp3'
 import './index.scss'
 
 export function CommandPalette(): JSX.Element | null {

--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -1,19 +1,25 @@
 import { useEffect, MutableRefObject } from 'react'
 
 export function useOutsideClickHandler(
-    refOrRefs: MutableRefObject<Element> | MutableRefObject<Element>[],
-    handleClickOutside: () => void
+    refOrRefs: MutableRefObject<Element | null> | MutableRefObject<Element | null>[],
+    handleClickOutside: () => void,
+    deps: any[] = [refOrRefs]
 ): void {
     useEffect(() => {
         function handleClick(event: Event): void {
-            const handleCondition = Array.isArray(refOrRefs)
-                ? !refOrRefs.some((ref) => ref.current?.contains(event.target as Node))
-                : !refOrRefs.current?.contains(event.target as Node)
-            if (handleCondition) handleClickOutside()
+            if (refOrRefs) {
+                const handleCondition = Array.isArray(refOrRefs)
+                    ? !refOrRefs.some((ref) => ref.current?.contains(event.target as Node))
+                    : !refOrRefs.current?.contains(event.target as Node)
+                if (handleCondition) {
+                    handleClickOutside()
+                }
+            }
         }
+
         document.addEventListener('mousedown', handleClick)
         return () => {
             document.removeEventListener('mousedown', handleClick)
         }
-    }, [refOrRefs, handleClickOutside])
+    }, deps)
 }

--- a/frontend/src/scenes/PreflightCheck/index.js
+++ b/frontend/src/scenes/PreflightCheck/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useValues, useActions } from 'kea'
 import { preflightLogic } from './logic'
 import { Row, Col, Space, Card, Button } from 'antd'
-import hedgehogBlue from './../../../public/hedgehog-blue.png'
+import hedgehogBlue from 'public/hedgehog-blue.png'
 import {
     CheckSquareFilled,
     CloseSquareFilled,

--- a/frontend/src/scenes/Signup/index.js
+++ b/frontend/src/scenes/Signup/index.js
@@ -1,8 +1,8 @@
 import React, { useState, useRef, lazy, Suspense } from 'react'
 import { useActions, useValues } from 'kea'
 import { signupLogic } from './logic'
-import hedgehogBlue from '../../../public/hedgehog-blue.png'
-import posthogLogo from '../../../public/posthog-icon.svg'
+import hedgehogBlue from 'public/hedgehog-blue.png'
+import posthogLogo from 'public/posthog-icon.svg'
 import { Row, Space, Button, Input, Checkbox } from 'antd'
 import queryString from 'query-string'
 const PasswordStrength = lazy(() => import('../../lib/components/PasswordStrength'))

--- a/frontend/src/scenes/actions/ActionsTable.js
+++ b/frontend/src/scenes/actions/ActionsTable.js
@@ -5,13 +5,13 @@ import { Table } from 'antd'
 import { QuestionCircleOutlined } from '@ant-design/icons'
 import { DeleteWithUndo } from 'lib/utils'
 import { useActions, useValues } from 'kea'
-import { actionsModel } from '../../models/actionsModel'
+import { actionsModel } from '~/models/actionsModel'
 import { NewActionButton } from './NewActionButton'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import moment from 'moment'
-import imgGrouping from '../../../public/actions-tutorial-grouping.svg'
-import imgStandardized from '../../../public/actions-tutorial-standardized.svg'
-import imgRetroactive from '../../../public/actions-tutorial-retroactive.svg'
+import imgGrouping from 'public/actions-tutorial-grouping.svg'
+import imgStandardized from 'public/actions-tutorial-standardized.svg'
+import imgRetroactive from 'public/actions-tutorial-retroactive.svg'
 
 export function ActionsTable() {
     const { actions, actionsLoading } = useValues(actionsModel({ params: 'include_count=1' }))

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -3,7 +3,7 @@ import { useValues, useActions } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { billingLogic } from './billingLogic'
 import { Card, Progress, Row, Col, Button, Popconfirm, Spin } from 'antd'
-import defaultImg from './../../../public/plan-default.svg'
+import defaultImg from 'public/plan-default.svg'
 import { PlanInterface } from '~/types'
 
 function Plan({ plan, onUpgrade }: { plan: PlanInterface; onUpgrade: (plan: PlanInterface) => void }): JSX.Element {

--- a/frontend/src/scenes/dashboard/SharedDashboard.js
+++ b/frontend/src/scenes/dashboard/SharedDashboard.js
@@ -8,7 +8,7 @@ import { getContext } from 'kea'
 import { initKea } from '~/initKea'
 import { Dashboard } from './Dashboard'
 
-import PostHogLogo from './../../../public/posthog-logo.svg'
+import PostHogLogo from 'public/posthog-logo.svg'
 import { Col, Row } from 'antd'
 
 initKea()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
             "lib/*": ["./src/lib/*"],
             "scenes/*": ["./src/scenes/*"],
             "~/*": ["./src/*"],
-            "types/*": ["./types/*"]
+            "types/*": ["./types/*"],
+            "public/*": ["./public/*"]
         },
         // https://www.sitepoint.com/react-with-typescript-best-practices/
         "allowJs": true, // Allow JavaScript files to be compiled

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ function createEntry(entry) {
                 lib: path.resolve(__dirname, 'frontend', 'src', 'lib'),
                 scenes: path.resolve(__dirname, 'frontend', 'src', 'scenes'),
                 types: path.resolve(__dirname, 'frontend', 'types'),
+                public: path.resolve(__dirname, 'frontend', 'public'),
                 ...(process.env.NODE_ENV !== 'production'
                     ? {
                           'react-dom': '@hot-loader/react-dom',


### PR DESCRIPTION
## Changes

Fixes two things:

- The "../../../../../../../../../../public/something.jpg" urls are now "public/something.jpg".
- I got tired of having redux spam with the click outside hook, so I added an if statement there:

![image](https://user-images.githubusercontent.com/53387/97161179-bcc04480-177d-11eb-8232-fcf5fda1fe0c.png)


## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
