### PR TITLE
Add eslint rule for empty JSX elements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,13 @@ module.exports = {
         'react/prop-types': [0],
         'react/no-unescaped-entities': [0],
         'react/jsx-no-target-blank': [0],
+        'react/self-closing-comp': [
+            'error',
+            {
+                component: true,
+                html: true,
+            },
+        ],
         'no-unused-vars': ['error', { ignoreRestSiblings: true }],
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/frontend/src/lib/components/ActionSelectBox.js
+++ b/frontend/src/lib/components/ActionSelectBox.js
@@ -23,11 +23,7 @@ function ActionSelectTabs(props) {
     return (
         <div className="select-box" style={{ padding: 0 }}>
             {labels.length > 1 && (
-                <ActionSelectTab
-                    entityType={activeTab}
-                    allTypes={labels}
-                    chooseEntityType={setActiveTab}
-                ></ActionSelectTab>
+                <ActionSelectTab entityType={activeTab} allTypes={labels} chooseEntityType={setActiveTab} />
             )}
             {Array.isArray(props.children)
                 ? props.children.map((child) => {

--- a/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
@@ -175,7 +175,7 @@ export function AnnotationMarker({
                                                 onClick={() => {
                                                     onDelete(data)
                                                 }}
-                                            ></DeleteOutlined>
+                                            />
                                         )}
                                     </Row>
                                     <span>{data.content}</span>
@@ -287,7 +287,7 @@ export function AnnotationMarker({
                         {annotations.length}
                     </span>
                 ) : (
-                    <PlusOutlined style={{ color: _accessoryColor }}></PlusOutlined>
+                    <PlusOutlined style={{ color: _accessoryColor }} />
                 )}
             </div>
         </Popover>

--- a/frontend/src/lib/components/Annotations/Annotations.tsx
+++ b/frontend/src/lib/components/Annotations/Annotations.tsx
@@ -65,7 +65,7 @@ export const Annotations = function Annotations({
                     accessoryColor={accessoryColor}
                     currentDateMarker={currentDateMarker}
                     index={index}
-                ></AnnotationMarker>
+                />
             )
         }
     })

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.js
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.js
@@ -19,7 +19,7 @@ export function ChartFilter(props) {
                 placement="right"
                 title="Click on a point to see users related to the datapoint"
             >
-                <InfoCircleOutlined className="info" style={{ color: '#007bff' }}></InfoCircleOutlined>
+                <InfoCircleOutlined className="info" style={{ color: '#007bff' }} />
             </Tooltip>
         ),
 

--- a/frontend/src/scenes/Signup/index.js
+++ b/frontend/src/scenes/Signup/index.js
@@ -131,7 +131,7 @@ function Signup() {
                                 disabled={accountLoading}
                                 id="signupPassword"
                             />
-                            <Suspense fallback={<span></span>}>
+                            <Suspense fallback={<span />}>
                                 <PasswordStrength password={formState.password.value} />
                             </Suspense>
                             {!formState.password.valid && (

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -135,7 +135,7 @@ function _Annotations(): JSX.Element {
                 }}
             >
                 {loadingNext ? (
-                    <Spin></Spin>
+                    <Spin />
                 ) : (
                     <Button
                         type="primary"
@@ -168,7 +168,7 @@ function _Annotations(): JSX.Element {
                     closeModal()
                 }}
                 annotation={selectedAnnotation}
-            ></CreateAnnotationModal>
+            />
         </div>
     )
 }
@@ -282,7 +282,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                     )}
                 </Row>
             )}
-            <br></br>
+            <br />
             {modalMode === ModalMode.CREATE && (
                 <div>
                     Date:
@@ -292,7 +292,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                         value={selectedDate}
                         onChange={(date): void => setDate(date)}
                         allowClear={false}
-                    ></DatePicker>
+                    />
                 </div>
             )}
             <TextArea
@@ -302,7 +302,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                 rows={4}
                 value={textInput}
                 onChange={(e): void => setTextInput(e.target.value)}
-            ></TextArea>
+            />
         </Modal>
     )
 }

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -41,7 +41,7 @@ export function Billing(): JSX.Element {
             <h1 className="page-header">
                 Billing &amp; usage information <span style={{ fontSize: 12, color: '#F7A501' }}>BETA</span>
             </h1>
-            <div className="space-top"></div>
+            <div className="space-top" />
             <Card title="Current usage">
                 {user?.billing?.current_usage && (
                     <>
@@ -74,7 +74,7 @@ export function Billing(): JSX.Element {
                     </div>
                 )}
             </Card>
-            <div className="space-top"></div>
+            <div className="space-top" />
             <Card title="Billing plan">
                 {user?.billing.plan && !user?.billing.should_setup_billing && (
                     <>
@@ -119,7 +119,7 @@ export function Billing(): JSX.Element {
                     </>
                 )}
             </Card>
-            <div style={{ marginBottom: 128 }}></div>
+            <div style={{ marginBottom: 128 }} />
         </>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -13,7 +13,7 @@ export function FunnelViz({ steps: stepsParam, dashboardItemId, funnelId, cached
     const { loadResults: loadFunnel } = useActions(logic)
 
     function buildChart() {
-        if (!steps || steps.length == 0) return
+        if (!steps || steps.length === 0) return
         if (container.current) container.current.innerHTML = ''
         let graph = new FunnelGraph({
             container: '.funnel-graph',
@@ -67,7 +67,7 @@ export function FunnelViz({ steps: stepsParam, dashboardItemId, funnelId, cached
                 ref={container}
                 className="svg-funnel-js"
                 style={{ height: '100%', width: '100%' }}
-            ></div>
+            />
         ) : (
             <p style={{ margin: '1rem' }}>This funnel doesn't have any steps. </p>
         )

--- a/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
@@ -52,7 +52,7 @@ export function PathTab(): JSX.Element {
                 style={{ width: 200, paddingTop: 2 }}
                 value={filter.start_point}
                 placeholder={'Select start element'}
-            ></PropertyValue>
+            />
             <hr />
             <h4 className="secondary">Filters</h4>
             <PropertyFilters pageKey="insight-path" />

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -34,7 +34,7 @@ export function TrendTab(): JSX.Element {
                     placement="right"
                     title="Use breakdown to see the volume of events for each variation of that property. For example, breaking down by $current_url will give you the event volume for each url your users have visited."
                 >
-                    <InfoCircleOutlined className="info" style={{ color: '#007bff' }}></InfoCircleOutlined>
+                    <InfoCircleOutlined className="info" style={{ color: '#007bff' }} />
                 </Tooltip>
             </h4>
             <Row>
@@ -59,7 +59,7 @@ export function TrendTab(): JSX.Element {
                                             performed an action on Monday and again on Friday, it would be shown 
                                             as "2 days".'
                 >
-                    <InfoCircleOutlined className="info" style={{ color: '#007bff' }}></InfoCircleOutlined>
+                    <InfoCircleOutlined className="info" style={{ color: '#007bff' }} />
                 </Tooltip>
             </h4>
             <ShownAsFilter filters={filters} onChange={(shown_as): void => setFilters({ shown_as })} />

--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -135,26 +135,14 @@ function _Insights() {
                         onChange={(key) => setActiveView(key)}
                         animated={false}
                     >
-                        <TabPane
-                            tab={<span data-attr="insight-trends-tab">Trends</span>}
-                            key={ViewType.TRENDS}
-                        ></TabPane>
-                        <TabPane
-                            tab={<span data-attr="insight-sessions-tab">Sessions</span>}
-                            key={ViewType.SESSIONS}
-                        ></TabPane>
-                        <TabPane
-                            tab={<span data-attr="insight-funnels-tab">Funnels</span>}
-                            key={ViewType.FUNNELS}
-                        ></TabPane>
+                        <TabPane tab={<span data-attr="insight-trends-tab">Trends</span>} key={ViewType.TRENDS} />
+                        <TabPane tab={<span data-attr="insight-sessions-tab">Sessions</span>} key={ViewType.SESSIONS} />
+                        <TabPane tab={<span data-attr="insight-funnels-tab">Funnels</span>} key={ViewType.FUNNELS} />
                         <TabPane
                             tab={<span data-attr="insight-retention-tab">Retention</span>}
                             key={ViewType.RETENTION}
-                        ></TabPane>
-                        <TabPane
-                            tab={<span data-attr="insight-path-tab">User Paths</span>}
-                            key={ViewType.PATHS}
-                        ></TabPane>
+                        />
+                        <TabPane tab={<span data-attr="insight-path-tab">User Paths</span>} key={ViewType.PATHS} />
                     </Tabs>
                     <Tabs
                         size="large"
@@ -172,7 +160,7 @@ function _Insights() {
                             }
                             key={'HISTORY'}
                             data-attr="insight-trend-tab"
-                        ></TabPane>
+                        />
                     </Tabs>
                 </Row>
                 <Row gutter={16}>
@@ -185,11 +173,11 @@ function _Insights() {
                             */}
                                 {
                                     {
-                                        [`${ViewType.TRENDS}`]: <TrendTab></TrendTab>,
+                                        [`${ViewType.TRENDS}`]: <TrendTab />,
                                         [`${ViewType.SESSIONS}`]: <SessionTab />,
-                                        [`${ViewType.FUNNELS}`]: <FunnelTab></FunnelTab>,
-                                        [`${ViewType.RETENTION}`]: <RetentionTab></RetentionTab>,
-                                        [`${ViewType.PATHS}`]: <PathTab></PathTab>,
+                                        [`${ViewType.FUNNELS}`]: <FunnelTab />,
+                                        [`${ViewType.RETENTION}`]: <RetentionTab />,
+                                        [`${ViewType.PATHS}`]: <PathTab />,
                                     }[activeView]
                                 }
                             </div>
@@ -205,16 +193,13 @@ function _Insights() {
                                             placement="right"
                                             title="These consist of funnels by you and the rest of the team"
                                         >
-                                            <InfoCircleOutlined
-                                                className="info"
-                                                style={{ color: '#007bff' }}
-                                            ></InfoCircleOutlined>
+                                            <InfoCircleOutlined className="info" style={{ color: '#007bff' }} />
                                         </Tooltip>
                                     </Row>
                                 }
                             >
                                 <div className="card-body px-4 mb-0">
-                                    <SavedFunnels></SavedFunnels>
+                                    <SavedFunnels />
                                 </div>
                             </Card>
                         )}
@@ -267,11 +252,9 @@ function _Insights() {
                             <div className="card-body card-body-graph">
                                 {
                                     {
-                                        [`${ViewType.TRENDS}`]: <TrendInsight view={ViewType.TRENDS}></TrendInsight>,
-                                        [`${ViewType.SESSIONS}`]: (
-                                            <TrendInsight view={ViewType.SESSIONS}></TrendInsight>
-                                        ),
-                                        [`${ViewType.FUNNELS}`]: <FunnelInsight></FunnelInsight>,
+                                        [`${ViewType.TRENDS}`]: <TrendInsight view={ViewType.TRENDS} />,
+                                        [`${ViewType.SESSIONS}`]: <TrendInsight view={ViewType.SESSIONS} />,
+                                        [`${ViewType.FUNNELS}`]: <FunnelInsight />,
                                         [`${ViewType.RETENTION}`]: <RetentionTable />,
                                         [`${ViewType.PATHS}`]: <Paths />,
                                     }[activeView]
@@ -280,7 +263,7 @@ function _Insights() {
                         </Card>
                         {activeView === ViewType.FUNNELS && (
                             <Card>
-                                <FunnelPeople></FunnelPeople>
+                                <FunnelPeople />
                             </Card>
                         )}
                     </Col>

--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -154,7 +154,7 @@ export function RetentionTable() {
                             )}
                         </div>
                     ) : (
-                        <Spin></Spin>
+                        <Spin />
                     )}
                 </Modal>
             )}

--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -23,5 +23,5 @@ export default function SessionsPlayer({ events }: { events: eventWithTime[] }):
         }
     }, [])
 
-    return <div ref={target} id="sessions-player"></div>
+    return <div ref={target} id="sessions-player" />
 }

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -27,7 +27,7 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
                         event.stopPropagation()
                         loadSessionPlayer(sessionRecordingId)
                     }}
-                ></PlayCircleOutlined>
+                />
             ))}
         </>
     )

--- a/frontend/src/scenes/users/Person.js
+++ b/frontend/src/scenes/users/Person.js
@@ -95,7 +95,7 @@ function _Person({ _: distinctId, id }) {
                 danger
                 onClick={() => deletePersonData(person, () => history.push('/people/persons'))}
             >
-                {isScreenSmall ? <DeleteOutlined></DeleteOutlined> : 'Delete all data on this person'}
+                {isScreenSmall ? <DeleteOutlined /> : 'Delete all data on this person'}
             </Button>
             <Button
                 className="float-right"


### PR DESCRIPTION
## Changes

I got tired of seeing the yellow background behind elements like this:

<img width="924" alt="Screenshot 2020-10-26 at 11 31 30" src="https://user-images.githubusercontent.com/53387/97162351-6227e800-177f-11eb-93bb-fab2756aaa87.png">

... so I added an eslint rule to prevent these from showing up and fixed the existing ones.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
