### PR TITLE
Fix funnels with multiple property filters

### DIFF
--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -31,7 +31,7 @@ class ClickhouseFunnel(Funnel):
         prop_filters, prop_filter_params = parse_prop_clauses("uuid", entity.properties, self._team, prepend=str(index))
         self.params.update(prop_filter_params)
         if entity.properties:
-            return prop_filters.replace("uuid IN", "random_event_id IN", 1)
+            return prop_filters
         return ""
 
     def _build_steps_query(self, entity: Entity, index: int) -> str:

--- a/ee/clickhouse/sql/funnels/step_action.py
+++ b/ee/clickhouse/sql/funnels/step_action.py
@@ -1,9 +1,9 @@
 STEP_ACTION_SQL = """
     arrayFilter(
-        (timestamp, event, random_event_id) ->
+        (timestamp, event, uuid) ->
             {is_first_step} AND
             (team_id = {team_id}) AND
-            random_event_id IN ({actions_query}) {filters}
+            uuid IN ({actions_query}) {filters}
         , timestamps, eventsArr, event_ids
     )[1] AS step_{step}
 """

--- a/ee/clickhouse/sql/funnels/step_event.py
+++ b/ee/clickhouse/sql/funnels/step_event.py
@@ -1,6 +1,6 @@
 STEP_EVENT_SQL = """
     arrayFilter(
-        (timestamp, event, random_event_id) ->
+        (timestamp, event, uuid) ->
             {is_first_step} AND
             (team_id = {team_id}) AND
             event = '{event}' {filters} 

--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -14,10 +14,13 @@ class Command(BaseCommand):
     help = "Migrate clickhouse"
 
     def handle(self, *args, **options):
-        Database(
-            CLICKHOUSE_DATABASE,
-            db_url=CLICKHOUSE_HTTP_URL,
-            username=CLICKHOUSE_USERNAME,
-            password=CLICKHOUSE_PASSWORD,
-            verify_ssl_cert=False,
-        ).migrate("ee.clickhouse.migrations")
+        try:
+            Database(
+                CLICKHOUSE_DATABASE,
+                db_url=CLICKHOUSE_HTTP_URL,
+                username=CLICKHOUSE_USERNAME,
+                password=CLICKHOUSE_PASSWORD,
+                verify_ssl_cert=False,
+            ).migrate("ee.clickhouse.migrations")
+        except Exception as e:
+            print(e)

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -215,7 +215,10 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                         "id": "user signed up",
                         "type": "events",
                         "order": 0,
-                        "properties": [{"key": "$browser", "value": "Safari"}],
+                        "properties": [
+                            {"key": "$browser", "value": "Safari"},
+                            {"key": "$browser", "operator": "is_not", "value": "Chrome"},
+                        ],
                     },
                 ],
                 "actions": [


### PR DESCRIPTION
## Changes

Previously any funnels with multiple filters per step OR negative (ie isnot) filters would fail. Fixed and added tests.
Fixes https://sentry.io/organizations/posthog/issues/1926590454/?project=1899813&query=is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
