### PR TITLE
[Clickhouse] fix events for action with no steps

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -46,6 +46,8 @@ class ClickhouseEvents(EventViewSet):
         prop_filters, prop_filter_params = parse_prop_clauses("uuid", filter.properties, team)
         if request.GET.get("action_id"):
             action = Action.objects.get(pk=request.GET["action_id"])
+            if action.steps.count() == 0:
+                return Response({"next": False, "results": []})
             action_query, params = format_action_filter(action)
             prop_filters += " AND uuid IN {}".format(action_query)
             prop_filter_params = {**prop_filter_params, **params}

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -292,6 +292,14 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
 
             self.assertEqual(len(page2["results"]), 50)
 
+        def test_action_no_steps(self):
+            action = Action.objects.create(team=self.team)
+            action.calculate_events()
+
+            response = self.client.get("/api/event/?action_id=%s" % action.pk)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json()["results"]), 0)
+
     return TestEvents
 
 


### PR DESCRIPTION
## Changes

Would error when you'd save an action without steps. https://sentry.io/organizations/posthog/issues/1926969130/?project=1899813&query=is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
