### PR TITLE
Use uuids in funnels for consistency

### DIFF
--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -102,7 +102,7 @@ class ClickhouseFunnel(Funnel):
         res = []
         for result_tuple in results:
             result = list(result_tuple)
-            person = Person(pk=result[0])
+            person = Person(pk=result[0], uuid=result[0])
             for step in range(0, width - 1):
                 setattr(person, "step_{}".format(step), result[step + 1] if result[step + 1].year != 1970 else None)
             res.append(person)

--- a/ee/clickhouse/queries/test/test_funnel.py
+++ b/ee/clickhouse/queries/test/test_funnel.py
@@ -9,7 +9,7 @@ from posthog.queries.test.test_funnel import funnel_test_factory
 
 def _create_person(**kwargs):
     person = Person.objects.create(**kwargs)
-    return Person(id=person.uuid)
+    return Person(id=person.uuid, uuid=person.uuid)
 
 
 def _create_event(**kwargs):

--- a/frontend/src/scenes/funnels/People.js
+++ b/frontend/src/scenes/funnels/People.js
@@ -52,7 +52,7 @@ export function People() {
                                         <td
                                             key={index}
                                             className={
-                                                step.people.indexOf(person.id) > -1
+                                                step.people.indexOf(person.uuid) > -1
                                                     ? 'funnel-success'
                                                     : 'funnel-dropped'
                                             }

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -57,7 +57,7 @@ export const funnelLogic = kea({
     loaders: () => ({
         people: {
             loadPeople: async (steps) => {
-                return (await api.get('api/person/?id=' + steps[0].people.join(','))).results
+                return (await api.get('api/person/?uuid=' + steps[0].people.join(','))).results
             },
         },
     }),
@@ -95,7 +95,7 @@ export const funnelLogic = kea({
             (steps, people) => {
                 if (!people) return null
                 const score = (person) => {
-                    return steps.reduce((val, step) => (step.people.indexOf(person.id) > -1 ? val + 1 : val), 0)
+                    return steps.reduce((val, step) => (step.people.indexOf(person.uuid) > -1 ? val + 1 : val), 0)
                 }
                 return people.sort((a, b) => score(b) - score(a))
             },

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,9 +1,11 @@
 import json
+import uuid
 import warnings
 from typing import Any, Dict, List
 
 from django.core.cache import cache
 from django.db.models import Count, Func, Prefetch, Q, QuerySet
+from django.db.models.expressions import Value
 from django_filters import rest_framework as filters
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
@@ -27,6 +29,7 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
             "distinct_ids",
             "properties",
             "created_at",
+            "uuid",
         ]
 
     def get_name(self, person: Person) -> str:
@@ -69,8 +72,11 @@ class PersonViewSet(viewsets.ModelViewSet):
 
     def _filter_request(self, request: request.Request, queryset: QuerySet, team: Team) -> QuerySet:
         if request.GET.get("id"):
-            people = request.GET["id"].split(",")
-            queryset = queryset.filter(id__in=people)
+            ids = request.GET["id"].split(",")
+            queryset = queryset.filter(id__in=ids)
+        if request.GET.get("uuid"):
+            uuids = request.GET["uuid"].split(",")
+            queryset = queryset.filter(uuid__in=uuids)
         if request.GET.get("search"):
             parts = request.GET["search"].split(" ")
             contains = []

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -256,6 +256,17 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
                 str(warnings.warning), "/api/person/by_email/ endpoint is deprecated; use /api/person/ instead.",
             )
 
+        def test_filter_id_or_uuid(self) -> None:
+            person1 = person_factory(team=self.team, properties={"$browser": "whatever", "$os": "Mac OS X"})
+            person2 = person_factory(team=self.team, properties={"random_prop": "asdf"})
+            person_factory(team=self.team, properties={"random_prop": "asdf"})
+
+            response = self.client.get("/api/person/?id={},{}".format(person1.id, person2.id))
+            response_uuid = self.client.get("/api/person/?uuid={},{}".format(person1.uuid, person2.uuid))
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), response_uuid.json())
+            self.assertEqual(len(response.json()["results"]), 2)
+
     return TestPerson
 
 

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from collections import defaultdict
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
@@ -74,7 +75,7 @@ class Funnel(BaseQuery):
             annotations["step_{}".format(index)] = query
         return annotations
 
-    def _serialize_step(self, step: Entity, people: Optional[List[int]] = None) -> Dict[str, Any]:
+    def _serialize_step(self, step: Entity, people: Optional[List[uuid.UUID]] = None) -> Dict[str, Any]:
         if step.type == TREND_FILTER_TYPE_ACTIONS:
             name = Action.objects.get(team=self._team.pk, pk=step.id).name
         else:

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -100,7 +100,7 @@ class Funnel(BaseQuery):
             """({query}) {step} {on_true} {join}""" if len(query_bodies) > 1 else """({query}) {step} {on_true} """
         )
         PERSON_FIELDS = [
-            [sql.Identifier("posthog_person"), sql.Identifier("id")],
+            [sql.Identifier("posthog_person"), sql.Identifier("uuid")],
             [sql.Identifier("posthog_person"), sql.Identifier("created_at")],
             [sql.Identifier("posthog_person"), sql.Identifier("team_id")],
             [sql.Identifier("posthog_person"), sql.Identifier("properties")],
@@ -181,8 +181,8 @@ class Funnel(BaseQuery):
                     average_time[index]["total_people"] += 1
 
                 if getattr(person, "step_{}".format(index)):
-                    person_score[person.id] += 1
-                    relevant_people.append(person.id)
+                    person_score[person.uuid] += 1
+                    relevant_people.append(person.uuid)
             steps.append(self._serialize_step(funnel_step, relevant_people))
 
         if len(steps) > 0:

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -103,7 +103,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[0]["count"], 2)
             # check ordering of people in first step
             self.assertEqual(
-                result[0]["people"], [person1_stopped_after_signup.pk, person2_stopped_after_signup.pk],
+                result[0]["people"], [person1_stopped_after_signup.uuid, person2_stopped_after_signup.uuid],
             )
 
         def test_funnel_events(self):
@@ -141,17 +141,17 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(
                 result[0]["people"],
                 [
-                    person_stopped_after_movie.pk,
-                    person_stopped_after_pay.pk,
-                    person_stopped_after_signup.pk,
-                    person_wrong_order.pk,
+                    person_stopped_after_movie.uuid,
+                    person_stopped_after_pay.uuid,
+                    person_stopped_after_signup.uuid,
+                    person_wrong_order.uuid,
                 ],
             )
             self.assertEqual(result[1]["name"], "paid")
             self.assertEqual(result[1]["count"], 2)
             self.assertEqual(result[2]["name"], "watched movie")
             self.assertEqual(result[2]["count"], 1)
-            self.assertEqual(result[2]["people"], [person_stopped_after_movie.pk])
+            self.assertEqual(result[2]["people"], [person_stopped_after_movie.uuid])
 
             # make sure it's O(n)
             person_wrong_order = person_factory(distinct_ids=["badalgo"], team_id=self.team.pk)


### PR DESCRIPTION
## Changes

This fixes funnels not loading in clickhouse and also this sentry error: https://sentry.io/organizations/posthog/issues/1926590421/?project=1899813&query=is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
