### PR TITLE
Fix flaky test

### DIFF
--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -265,7 +265,7 @@ where person_distinct_id.team_id = %(team_id)s
 """
 
 INSERT_PERSON_SQL = """
-INSERT INTO person SELECT %(id)s, now(), %(team_id)s, %(properties)s, %(is_identified)s, now(), 0
+INSERT INTO person SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, now(), 0
 """
 
 INSERT_PERSON_DISTINCT_ID = """


### PR DESCRIPTION
## Changes

*Please describe.*  
It's really hard/near impossible to reproduce the flaky test locally. I think the issue had to do with timestamps because somehow all the rows that were inserted had the same timestamp (even though there should be some millisecond of difference between them which is probably due to batch processing). I made all the timestamps explicit and explicitly called optimize which just simulates clickhouse performing a merge to drop duplicates.

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
