### PR TITLE
Fix History button layout in Insights

### DIFF
--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -144,24 +144,13 @@ function _Insights() {
                         />
                         <TabPane tab={<span data-attr="insight-path-tab">User Paths</span>} key={ViewType.PATHS} />
                     </Tabs>
-                    <Tabs
-                        size="large"
-                        activeKey={null}
-                        style={{
-                            overflow: 'visible',
-                        }}
-                        animated={false}
-                    >
-                        <TabPane
-                            tab={
-                                <Button onClick={() => setOpenHistory(true)} data-attr="insight-history-button">
-                                    {'History'}
-                                </Button>
-                            }
-                            key={'HISTORY'}
-                            data-attr="insight-trend-tab"
-                        />
-                    </Tabs>
+                    <div className="ant-tabs ant-tabs-top">
+                        <div className="ant-tabs-nav">
+                            <Button onClick={() => setOpenHistory(true)} data-attr="insight-history-button">
+                                History
+                            </Button>
+                        </div>
+                    </div>
                 </Row>
                 <Row gutter={16}>
                     <Col xs={24} xl={7}>


### PR DESCRIPTION
## Changes

The History button was laid out in a weird way, brought it in line.

| Before | After |
| --- | --- |
| <img width="788" alt="Screen Shot 2020-10-28 at 11 34 35" src="https://user-images.githubusercontent.com/4550621/97425046-ddb99e80-1911-11eb-978e-5e3f00d0a374.png"> | <img width="788" alt="Screen Shot 2020-10-28 at 11 33 58" src="https://user-images.githubusercontent.com/4550621/97425038-dbefdb00-1911-11eb-860e-c29152416609.png"> |