### PR TITLE
Give staff users superuser permissions

### DIFF
--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -94,7 +94,6 @@ class User(AbstractUser):
     ]
 
     username = None  # type: ignore
-    is_superuser = None  # type: ignore
     current_organization = models.ForeignKey(
         "posthog.Organization", models.SET_NULL, null=True, related_name="users_currently+",
     )
@@ -115,7 +114,7 @@ class User(AbstractUser):
         return settings.EE_AVAILABLE
 
     @property
-    def is_superuser(self) -> bool:
+    def is_superuser(self) -> bool:  # type: ignore
         return self.is_staff
 
     @property

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser, BaseUserManager
@@ -113,6 +113,10 @@ class User(AbstractUser):
     @property
     def ee_available(self) -> bool:
         return settings.EE_AVAILABLE
+
+    @property
+    def is_superuser(self) -> bool:
+        return self.is_staff
 
     @property
     def teams(self):


### PR DESCRIPTION
## Changes

This allows for compatibility with pieces of code that still use `is_superuser` somewhere (i.e. Django admin) even though we consolidated it into `is_staff`.