### PR TITLE
Optionally join args for funnel query

### DIFF
--- a/ee/clickhouse/sql/funnels/funnel.py
+++ b/ee/clickhouse/sql/funnels/funnel.py
@@ -5,8 +5,8 @@ SELECT id, {select_steps} FROM (
         groupArray(events.timestamp) as timestamps,
         groupArray(events.event) as eventsArr,
         groupArray(events.uuid) as event_ids,
-        groupArray(events.properties) as event_props,
-        groupArray(events.distinct_id) as distinct_ids,
+        {event_prop_alias}
+        {distinct_id_alias}
         {person_prop_alias}
         {steps}
     FROM events 

--- a/ee/clickhouse/sql/funnels/step_action.py
+++ b/ee/clickhouse/sql/funnels/step_action.py
@@ -1,9 +1,9 @@
 STEP_ACTION_SQL = """
     arrayFilter(
-        (timestamp, event, uuid, properties, distinct_id {person_prop_param}) ->
+        (timestamp, event, uuid {event_prop_param} {distinct_id_param} {person_prop_param}) ->
             {is_first_step} AND
             (team_id = {team_id}) AND
             uuid IN {actions_query} {filters}
-        , timestamps, eventsArr, event_ids, event_props, distinct_ids {person_prop_arg}
+        , timestamps, eventsArr, event_ids {event_prop_arg} {distinct_id_arg} {person_prop_arg}
     )[1] AS step_{step}
 """

--- a/ee/clickhouse/sql/funnels/step_event.py
+++ b/ee/clickhouse/sql/funnels/step_event.py
@@ -1,9 +1,9 @@
 STEP_EVENT_SQL = """
     arrayFilter(
-        (timestamp, event, uuid, properties, distinct_id  {person_prop_param}) ->
+        (timestamp, event, uuid {event_prop_param} {distinct_id_param} {person_prop_param}) ->
             {is_first_step} AND
             (team_id = {team_id}) AND
             event = '{event}' {filters} 
-        , timestamps, eventsArr, event_ids, event_props, distinct_ids {person_prop_arg}
+        , timestamps, eventsArr, event_ids {event_prop_arg} {distinct_id_arg} {person_prop_arg}
     )[1] AS step_{step}
 """


### PR DESCRIPTION
## Changes

*Please describe.*  
- funnels work but are slow on app because adding in event properties and distinct_ids into the goruparray is very slow
- this helps ease queries that are simple

Still need a solution when there's a bunch of requirements in the query (person props, event props, and distinct_id)
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
