### PR TITLE
Make possible CI optimizations

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -65,10 +65,9 @@ jobs:
         name: Django tests – Py ${{ matrix.python-version }}
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix:
-                fail-fast: false
                 python-version: ['3.7.8', '3.8.5', '3.9.0']
-
         services:
             postgres:
                 image: postgres:12

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -66,6 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
+                fail-fast: false
                 python-version: ['3.7.8', '3.8.5', '3.9.0']
 
         services:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
             fail-fast: false
             matrix:
                 # run 3 copies of the current job in parallel
-                containers: [1, 2, 3, 4]
+                containers: [1, 2, 3, 4, 5, 6]
         services:
             postgres:
                 image: postgres:12

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,8 +14,8 @@ jobs:
             # https://github.com/cypress-io/github-action/issues/48
             fail-fast: false
             matrix:
-                # run 3 copies of the current job in parallel
-                containers: [1, 2, 3, 4, 5, 6]
+                # run 7 copies of the current job in parallel
+                containers: [1, 2, 3, 4, 5, 6, 7]
         services:
             postgres:
                 image: postgres:12


### PR DESCRIPTION
## Changes

This disables `fail-fast` on multi-Python tests (which is particularly annoying when a flaky Clickhouse test fails one version and in turn cancels all…) and parallelizes Cypress tests more.