### PR TITLE
Fix bin/tests too many files watching error

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -2,4 +2,4 @@
 set -x
 
 REDIS_URL='redis:///' OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python manage.py test $@ --noinput
-REDIS_URL='redis:///' npx nodemon --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python manage.py test --noinput --keepdb $@; mypy posthog ee"
+REDIS_URL='redis:///' npx nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python manage.py test --noinput --keepdb $@; mypy posthog ee"


### PR DESCRIPTION
## Changes

quick fix, got 'emwatch watching too many files' errors because it was watching files in env/ folders

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
