### PR TITLE
Add CH Person Sessions By Day

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -4,13 +4,13 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.queries.clickhouse_funnel import ClickhouseFunnel
 from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
 from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
 from ee.clickhouse.queries.clickhouse_sessions import SESSIONS_LIST_DEFAULT_LIMIT, ClickhouseSessions
 from ee.clickhouse.queries.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.clickhouse_trends import ClickhouseTrends
-from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.util import (
     CH_FUNNEL_ENDPOINT,
     CH_PATH_ENDPOINT,
@@ -61,7 +61,7 @@ class ClickhouseInsights(InsightViewSet):
             try:
                 person_ids = get_persons_by_distinct_ids(team.pk, [request.GET["distinct_id"]])[0].distinct_ids
                 response = [session for i, session in enumerate(response) if response[i]["distinct_id"] in person_ids]
-            except IndexError: 
+            except IndexError:
                 response = []
 
         if len(response) > limit:


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

**Quick and dirty** solution to CH person sessions by day. More like setting context for you @macobo here instead of an issue. 

Also `get_person_by_distinct_id` didn't work for me so I had to use `get_persons_by_distinct_ids` because I wasn't about to debug the query right now. 

There's most definitely better ways to do this, but yeah this was a quick fix from someone who hasn't been involved with CH.

## Before 

<img width="600" alt="Screenshot 2020-10-28 at 18 46 30" src="https://user-images.githubusercontent.com/38760734/97482704-65bd9980-194e-11eb-9733-56f21671b012.png">

## After 

<img width="600" alt="Screenshot 2020-10-28 at 18 45 58" src="https://user-images.githubusercontent.com/38760734/97482719-6b1ae400-194e-11eb-9767-55a912fb169c.png">



## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
