### PR TITLE
Reduce Heroku worker thread count

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -2,6 +2,7 @@
 set -e
 
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
+# https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 if [[ -z "${WEB_CONCURRENCY}" ]]; then
   celery -A posthog worker
 else

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
 
-celery -A posthog worker
+# On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
+if [[ -z "${WEB_CONCURRENCY}" ]]; then
+  celery -A posthog worker
+else
+  celery -A posthog worker --concurrency $WEB_CONCURRENCY
+fi


### PR DESCRIPTION
## Changes

- Extracted from https://github.com/PostHog/posthog/pull/1946
- Reduce the number of Heroku workers to follow the [WEB_CONCURRENCY](https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh) setting set by resource type

This reduces the number of concurrent threads used in a worker on a "hobby" dyno from 8 to 2, greatly reducing the memory/swap usage:
![image](https://user-images.githubusercontent.com/53387/97543023-f4bac800-19c7-11eb-82b1-7d45b306d966.png)

It also reduces the number of redis connections needed from ~19 when idle to ~15. 


## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
