### PR TITLE
Attempt at making sessions list query size dynamic

### DIFF
--- a/ee/clickhouse/queries/clickhouse_sessions.py
+++ b/ee/clickhouse/queries/clickhouse_sessions.py
@@ -61,11 +61,6 @@ class ClickhouseSessions(BaseQuery):
             filter._date_from = filter.date_to - diff_check
             date_from, date_to = parse_timestamps(filter)
 
-            print(
-                "SELECT count(DISTINCT distinct_id) FROM events WHERE team_id = %(team_id)s {date_from} {date_to}".format(
-                    date_from=date_from, date_to=date_to
-                )
-            )
             result = sync_execute(
                 "SELECT count(DISTINCT distinct_id) FROM events WHERE team_id = %(team_id)s {date_from} {date_to}".format(
                     date_from=date_from, date_to=date_to
@@ -75,7 +70,7 @@ class ClickhouseSessions(BaseQuery):
 
             if result:
                 count = result[0][0]
-            print(count)
+
             # if this option cross 100 threshold, then return so filter retains the current date range
             if count > 100:
                 return

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -1,8 +1,13 @@
 from uuid import uuid4
 
+from freezegun import freeze_time
+
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.queries.clickhouse_sessions import ClickhouseSessions
 from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.models.filter import Filter
+from posthog.models.person import Person
+from posthog.models.team import Team
 from posthog.queries.test.test_sessions import sessions_test_factory
 
 
@@ -12,4 +17,34 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(ClickhouseSessions, _create_event)):  # type: ignore
-    pass
+    def test_sessions_list_time_clamp(self):
+        with freeze_time("2012-01-14T03:21:34.000Z"):
+            _create_event(team=self.team, event="1st action", distinct_id="1")
+            _create_event(team=self.team, event="1st action", distinct_id="2")
+        with freeze_time("2012-01-14T03:25:34.000Z"):
+            _create_event(team=self.team, event="2nd action", distinct_id="1")
+            _create_event(team=self.team, event="2nd action", distinct_id="2")
+        with freeze_time("2012-01-15T03:59:34.000Z"):
+            _create_event(team=self.team, event="3rd action", distinct_id="2")
+        with freeze_time("2012-01-15T03:59:35.000Z"):
+            _create_event(team=self.team, event="3rd action", distinct_id="1")
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            _create_event(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
+            _create_event(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
+
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            _create_event(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
+            _create_event(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
+
+        with freeze_time("2012-01-15T20:01:34.000Z"):
+            for i in range(100, 201):
+                _create_event(team=self.team, event="4th action", distinct_id=str(i), properties={"$os": "Mac OS X"})
+
+        team_2 = Team.objects.create()
+        Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+        # Test team leakage
+        Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            response = ClickhouseSessions().run(Filter(data={"events": [], "session": None}), self.team)
+
+        self.assertEqual(len(response), 50)


### PR DESCRIPTION
## Changes

*Please describe.*  
- run multiple counts beforehand to find the optimal time to run the query list on
- search for a timerange that provides 100 unique distinct_ids. there's a rough equivalence of sessions to distinct_ids so as long as we get enough events that cover 100 unique distinct_ids, we can provide a result

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] test pagination
