### PR TITLE
[Clickhouse] More speed optimizations for funnels

### DIFF
--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -91,7 +91,7 @@ class ClickhouseFunnel(Funnel):
 
         for step in reversed(self._filter.entities):
             # Clickhouse step order starts at one, hence the +1
-            result_step = [x for x in results if step.order + 1 == x[0]]
+            result_step = [x for x in results if step.order and step.order + 1 == x[0]]
             if len(result_step) > 0:
                 total_people += result_step[0][1]
                 relevant_people += result_step[0][2]

--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -91,7 +91,7 @@ class ClickhouseFunnel(Funnel):
 
         for step in reversed(self._filter.entities):
             # Clickhouse step order starts at one, hence the +1
-            result_step = [x for x in results if step.order and step.order + 1 == x[0]]
+            result_step = [x for x in results if step.order + 1 == x[0]]  # type: ignore
             if len(result_step) > 0:
                 total_people += result_step[0][1]
                 relevant_people += result_step[0][2]

--- a/ee/clickhouse/sql/funnels/funnel.py
+++ b/ee/clickhouse/sql/funnels/funnel.py
@@ -1,6 +1,6 @@
 FUNNEL_SQL = """
-SELECT id, max_step FROM (
-    SELECT 
+SELECT max_step, count(1), groupArray(100)(id) FROM (
+    SELECT
         pid.person_id as id,
         windowFunnel(6048000000000000)(toUInt64(toUnixTimestamp64Micro(timestamp)),
             {steps}
@@ -15,5 +15,9 @@ SELECT id, max_step FROM (
         team_id = %(team_id)s {filters} {parsed_date_from} {parsed_date_to}
         AND event IN %(events)s
     GROUP BY pid.person_id
-) WHERE max_step > 0;
+)
+WHERE max_step > 0
+GROUP BY max_step
+ORDER BY max_step ASC
+;
 """

--- a/ee/clickhouse/sql/funnels/funnel.py
+++ b/ee/clickhouse/sql/funnels/funnel.py
@@ -1,16 +1,19 @@
 FUNNEL_SQL = """
+SELECT id, max_step FROM (
     SELECT 
         pid.person_id as id,
         windowFunnel(6048000000000000)(toUInt64(toUnixTimestamp64Micro(timestamp)),
             {steps}
-        )
+        ) as max_step
     FROM 
-            events
+        events
     JOIN (
         SELECT person_id, distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s
     ) as pid
     ON pid.distinct_id = events.distinct_id
     WHERE
         team_id = %(team_id)s {filters} {parsed_date_from} {parsed_date_to}
+        AND event IN %(events)s
     GROUP BY pid.person_id
+) WHERE max_step > 0;
 """

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -75,7 +75,7 @@ class Funnel(BaseQuery):
             annotations["step_{}".format(index)] = query
         return annotations
 
-    def _serialize_step(self, step: Entity, people: Optional[List[uuid.UUID]] = None) -> Dict[str, Any]:
+    def _serialize_step(self, step: Entity, count: int, people: Optional[List[uuid.UUID]] = None) -> Dict[str, Any]:
         if step.type == TREND_FILTER_TYPE_ACTIONS:
             name = Action.objects.get(team=self._team.pk, pk=step.id).name
         else:
@@ -85,7 +85,7 @@ class Funnel(BaseQuery):
             "name": name,
             "order": step.order,
             "people": people if people else [],
-            "count": len(people) if people else 0,
+            "count": count,
             "type": step.type,
         }
 
@@ -184,7 +184,9 @@ class Funnel(BaseQuery):
                 if getattr(person, "step_{}".format(index)):
                     person_score[person.uuid] += 1
                     relevant_people.append(person.uuid)
-            steps.append(self._serialize_step(funnel_step, relevant_people))
+            steps.append(
+                self._serialize_step(funnel_step, relevant_people, len(relevant_people) if relevant_people else 0)
+            )
 
         if len(steps) > 0:
             for index, _ in enumerate(steps):

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -185,7 +185,7 @@ class Funnel(BaseQuery):
                     person_score[person.uuid] += 1
                     relevant_people.append(person.uuid)
             steps.append(
-                self._serialize_step(funnel_step, relevant_people, len(relevant_people) if relevant_people else 0)
+                self._serialize_step(funnel_step, len(relevant_people) if relevant_people else 0, relevant_people)
             )
 
         if len(steps) > 0:

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -83,8 +83,8 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 )
                 self._signup_event(distinct_id="stopped_after_signup2")
 
-            # with self.assertNumQueries(1):
-            result = funnel.run()
+            with self.assertNumQueries(1):
+                result = funnel.run()
             self.assertEqual(result[0]["count"], 0)
 
         def test_funnel_with_single_step(self):
@@ -156,12 +156,12 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             # make sure it's O(n)
             person_wrong_order = person_factory(distinct_ids=["badalgo"], team_id=self.team.pk)
             self._signup_event(distinct_id="badalgo")
-            # with self.assertNumQueries(3):
-            funnel.run()
+            with self.assertNumQueries(3):
+                funnel.run()
 
             self._pay_event(distinct_id="badalgo")
-            # with self.assertNumQueries(3):
-            funnel.run()
+            with self.assertNumQueries(3):
+                funnel.run()
 
         def test_funnel_no_events(self):
             funnel = self._basic_funnel()


### PR DESCRIPTION
## Changes

- pre-filter events to just those in the query
- only return people that have at least one step

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
