### PR TITLE
Save session player speed in localstorage

### DIFF
--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -1,10 +1,15 @@
+import { useActions, useValues } from 'kea'
 import React, { useEffect, useRef } from 'react'
 import rrwebPlayer from 'rrweb-player'
 import 'rrweb-player/dist/style.css'
 import { eventWithTime } from 'rrweb/typings/types'
+import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 
 export default function SessionsPlayer({ events }: { events: eventWithTime[] }): JSX.Element {
     const target = useRef<HTMLDivElement | null>(null)
+
+    const { sessionsPlayerSpeed } = useValues(sessionsTableLogic)
+    const { setPlayerSpeed } = useActions(sessionsTableLogic)
 
     useEffect(() => {
         if (target.current && events) {
@@ -17,6 +22,11 @@ export default function SessionsPlayer({ events }: { events: eventWithTime[] }):
                     events,
                     autoPlay: true,
                 },
+            })
+            player.setSpeed(sessionsPlayerSpeed)
+
+            player.getReplayer().on('state-change', () => {
+                setPlayerSpeed(player.getReplayer().config.speed)
             })
 
             return () => player.pause()

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -82,6 +82,7 @@ export const sessionsTableLogic = kea<
             sessionRecordingId: SessionRecordingId | null
         ) => ({ properties, selectedDate, sessionRecordingId }),
         closeSessionPlayer: true,
+        setPlayerSpeed: (speed: number) => ({ speed }),
     }),
     reducers: {
         sessions: {
@@ -113,6 +114,13 @@ export const sessionsTableLogic = kea<
             null as null | eventWithTime[],
             {
                 closeSessionPlayer: () => null,
+            },
+        ],
+        sessionsPlayerSpeed: [
+            1,
+            { persist: true },
+            {
+                setPlayerSpeed: (_, { speed }) => speed,
             },
         ],
     },


### PR DESCRIPTION
This makes the player slightly better to use.

Closes #2107

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
