### PR TITLE
Clarify invite creation

### DIFF
--- a/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
+++ b/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
@@ -52,7 +52,12 @@ export function CreateOrgInviteModalWithButton(): JSX.Element {
                 onCancel={closeModal}
                 visible={isVisible}
             >
-                <p>Create an invite for a teammate with a specific email address.</p>
+                <p>
+                    Create an invite for a teammate with a specific email address.
+                    <br />
+                    Automatic invite emails are coming soon! For now remember to send the invite link over to the
+                    teammate yourself.
+                </p>
                 <Input
                     data-attr="invite-email-input"
                     addonBefore="Email address"

--- a/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
+++ b/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
@@ -34,7 +34,7 @@ export function CreateOrgInviteModalWithButton(): JSX.Element {
             </Button>
             <Modal
                 title="Inviting Teammate"
-                okText="Create Invite"
+                okText="Create Invite Link"
                 cancelText="Cancel"
                 onOk={() => {
                     setErrorMessage(null)

--- a/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
+++ b/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
@@ -53,10 +53,11 @@ export function CreateOrgInviteModalWithButton(): JSX.Element {
                 visible={isVisible}
             >
                 <p>
-                    Create an invite for a teammate with a specific email address.
+                    Create an invite link for a teammate with a specific email address.
                     <br />
-                    Automatic invite emails are coming soon! For now remember to send the invite link over to the
-                    teammate yourself.
+                    Remember to send the link to the teammate.
+                    <br />
+                    <i>Invites emailed by PostHog coming soon.</i>
                 </p>
                 <Input
                     data-attr="invite-email-input"


### PR DESCRIPTION
## Changes

This adds wording to clarify that invites are not autoemailed just yet and the user needs to send the link over themselves.

<img width="537" alt="Create Invite" src="https://user-images.githubusercontent.com/4550621/97599677-8a764780-1a08-11eb-9286-1835643d3be3.png">
