### PR TITLE
Capture social_create_user exception with Sentry

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -14,6 +14,7 @@ from django.template.loader import render_to_string
 from django.urls import include, path, re_path, reverse
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.generic.base import TemplateView
+from sentry_sdk import capture_exception
 from social_core.pipeline.partial import partial
 from social_django.models import Partial
 from social_django.strategy import DjangoStrategy
@@ -199,6 +200,7 @@ def social_create_user(strategy: DjangoStrategy, details, backend, user=None, *a
         try:
             user = strategy.create_user(email=user_email, name=user_name)
         except Exception as e:
+            capture_exception(e)
             processed = render_to_string(
                 "auth_error.html",
                 {


### PR DESCRIPTION
## Changes

There seems to be a problem with creating accounts in Cloud. I can't reproduce it locally though and the relevant exception is suppressed in an `except` block, so this should record the problem with Sentry.