### PR TITLE
Make DELETE synchronous in clickhouse tests / make tests less flaky

### DIFF
--- a/ee/clickhouse/clickhouse_test_runner.py
+++ b/ee/clickhouse/clickhouse_test_runner.py
@@ -1,6 +1,7 @@
 from django.test.runner import DiscoverRunner
 from infi.clickhouse_orm import Database  # type: ignore
 
+from ee.clickhouse.client import sync_execute
 from posthog.settings import (
     CLICKHOUSE_DATABASE,
     CLICKHOUSE_HTTP_URL,
@@ -28,6 +29,8 @@ class ClickhouseTestRunner(DiscoverRunner):
             pass
         database.create_database()
         database.migrate("ee.clickhouse.migrations")
+        # Make DELETE / UPDATE synchronous to avoid flaky tests
+        sync_execute("SET mutations_sync = 1")
         return super().setup_databases(**kwargs)
 
     def teardown_databases(self, old_config, **kwargs):

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -148,8 +148,11 @@ def delete_person(person_id: UUID, delete_events: bool = False, team_id: int = F
         sync_execute(DELETE_PERSON_EVENTS_BY_ID, {"id": person_id, "team_id": team_id})
 
     sync_execute(DELETE_PERSON_BY_ID, {"id": person_id,})
-    sync_execute(DELETE_PERSON_MATERIALIZED_BY_ID, {"id": person_id})
     sync_execute(DELETE_PERSON_DISTINCT_ID_BY_PERSON_ID, {"id": person_id,})
+
+    # :KLUDGE: https://github.com/ClickHouse/ClickHouse/issues/16548
+    if not settings.TEST:
+        sync_execute(DELETE_PERSON_MATERIALIZED_BY_ID, {"id": person_id})
 
 
 class ClickhousePersonSerializer(serializers.Serializer):


### PR DESCRIPTION
This avoids some flaky behavior, example:
- https://github.com/PostHog/posthog/pull/2110/checks?check_run_id=1327279229

Documentation:
- https://clickhouse.tech/docs/en/operations/settings/settings/#mutations_sync

Tested it out by running the following test 1000 times - before change
it fails every ~50 runs locally.

```
         def test_delete_person(self):
-            person = person_factory(
-                team=self.team, distinct_ids=["person_1", "anonymous_id"], properties={"$os": "Chrom
e"},
-            )
-            event_factory(event="test", team=self.team, distinct_id="person_1")
-            event_factory(event="test", team=self.team, distinct_id="anonymous_id")
-            event_factory(event="test", team=self.team, distinct_id="someone_else")
-
-            response = self.client.delete(f"/api/person/{person.pk}/")
-            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-            self.assertEqual(response.data, None)
-            self.assertEqual(len(get_people()), 0)
-            self.assertEqual(len(get_events()), 1)
-
-        def test_filters_by_endpoints_are_deprecated(self):
+            for index in range(1000):
+                print([index])
+                person = person_factory(
+                    team=self.team, distinct_ids=["person_1", "anonymous_id"], properties={"$os": "Chrome"},
+                )
+                event_factory(event="test", team=self.team, distinct_id="person_1")
+                event_factory(event="test", team=self.team, distinct_id="anonymous_id")
+                event_factory(event="test", team=self.team, distinct_id="someone_else")
+
+                response = self.client.delete(f"/api/person/{person.pk}/")
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+                self.assertEqual(response.data, None)
+                self.assertEqual(len(get_people()), 0)
+                self.assertEqual(len(get_events()), 1)
```

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
