### PR TITLE
Introduce NGINX in front of our web workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: REDIS_URL='redis://' python manage.py migrate
-web: gunicorn posthog.wsgi --log-file -
+web: bin/start-nginx bundle exec gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,61 @@
+daemon off;
+# Heroku dynos have at least 4 cores.
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+
+events {
+	use epoll;
+	accept_mutex on;
+	worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
+}
+
+http {
+	gzip on;
+	gzip_comp_level 2;
+	gzip_min_length 512;
+
+	server_tokens off;
+
+	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+	access_log <%= ENV['NGINX_ACCESS_LOG_PATH'] || 'logs/nginx/access.log' %> l2met;
+	error_log <%= ENV['NGINX_ERROR_LOG_PATH'] || 'logs/nginx/error.log' %>;
+
+	include mime.types;
+	default_type application/octet-stream;
+	sendfile on;
+
+	# Must read the body in 5 seconds.
+	client_body_timeout 5;
+
+	upstream app_server {
+		server unix:/tmp/nginx.socket fail_timeout=0;
+	}
+
+	server {
+		listen <%= ENV["PORT"] %>;
+		server_name _;
+		keepalive_timeout 5;
+
+		location / {
+			# Uncomment this if statement to force SSL/redirect http -> https
+			# if ($http_x_forwarded_proto != "https") {
+			#   return 301 https://$host$request_uri;
+			# }
+
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header Host $http_host;
+			proxy_redirect off;
+			proxy_pass http://app_server;
+		}
+		# static
+		location /static {
+            autoindex on;
+            alias _site/staticfiles/;
+        }
+		location ~* \.(jpg|jpeg|png|gif|ico|svg|otf)$ {
+            expires 7d;
+        }
+        location ~* \.(css|js|map)$ {
+            expires 1d;
+        }
+	}
+}

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -3,6 +3,9 @@
 
 
 loglevel = "error"
+bind = "unix://tmp/nginx.socket"
+worker_class = "gevent"
+timeout = 90
 
 
 def on_starting(server):
@@ -26,3 +29,7 @@ def on_starting(server):
     print("Server running on \x1b[4mhttp://{}:{}\x1b[0m".format(*server.address[0]))
     print("Questions? Please shoot us an email at \x1b[4mhey@posthog.com\x1b[0m")
     print("\nTo stop, press CTRL + C")
+
+
+def when_ready(server):
+    open("/tmp/app-initialized", "w").close()


### PR DESCRIPTION
This will reduce some of the burden of serving static assets and decouple the app processes from the request being received. It will also let us split out the `/capture` endpoint if we need to, bypassing gunicorn and django entirely.

The main thing is it shortens the path from client -> gunicorn to nginx on localhost -> gunicorn. For large payloads and a slow connection this can tie up a gunicorn process for a long time reducing the number of requests gunicorn can handle. NGINX can handle a lot more of these simultaneously than gunicorn.

Some other improvements is caching of files before serving. NGINX will cache images, css, and js payloads in memory speeding up delivery.

>the Heroku router engages the dyno during the entire body transfer –from the client to dyno. For applications servers with blocking I/O, the latency per request will be degraded by the content transfer. By using NGINX in front of the application server, we can eliminate a great deal of transfer time from the application server. In addition to making request body transfers more efficient, all other I/O should be improved since the application server need only communicate with a UNIX socket on localhost. Basically, for webservers that are not designed for efficient, non-blocking I/O, we will benefit from having NGINX to handle all I/O operations.