### PR TITLE
Simplify action queries

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -40,8 +40,11 @@ def format_action_filter(action: Action, prepend: str = "", index=0, avoid_loop:
             params = {**params, **prop_params}
 
         or_queries.append(" AND ".join(conditions))
-    or_separator = "OR"
-    formatted_query = or_separator.join(or_queries)
+    or_separator = "OR" if avoid_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
+    if avoid_loop:
+        formatted_query = or_separator.join(or_queries)
+    else:
+        formatted_query = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s".format(or_separator.join(or_queries))
 
     return formatted_query, params
 

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -24,11 +24,11 @@ def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: b
             el_conditions, element_params = filter_element(step, "{}{}".format(index, prepend))
             params = {**params, **element_params}
             conditions += el_conditions
-        # filter event
-        else:
-            event_conditions, event_params = filter_event(step, "{}{}".format(index, prepend), index)
-            params = {**params, **event_params}
-            conditions += event_conditions
+
+        # filter event conditions (ie URL)
+        event_conditions, event_params = filter_event(step, "{}{}".format(index, prepend), index)
+        params = {**params, **event_params}
+        conditions += event_conditions
 
         if step.properties:
             from ee.clickhouse.models.property import parse_prop_clauses
@@ -39,7 +39,8 @@ def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: b
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}
 
-        or_queries.append(" AND ".join(conditions))
+        if len(conditions) > 0:
+            or_queries.append(" AND ".join(conditions))
     or_separator = (
         ") OR (" if not use_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
     )

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -40,9 +40,9 @@ def format_action_filter(action: Action, prepend: str = "", index=0, avoid_loop:
             params = {**params, **prop_params}
 
         or_queries.append(" AND ".join(conditions))
-    or_separator = "OR" if avoid_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
+    or_separator = ") OR (" if avoid_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
     if avoid_loop:
-        formatted_query = or_separator.join(or_queries)
+        formatted_query = '({})'.format(or_separator.join(or_queries))
     else:
         formatted_query = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s".format(
             or_separator.join(or_queries)

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 from django.forms.models import model_to_dict
 
@@ -18,7 +18,7 @@ def format_action_filter(action: Action, prepend: str = "", index=0, avoid_loop:
 
     or_queries = []
     for index, step in enumerate(steps):
-        conditions = []
+        conditions: List[str] = []
         # filter element
         if step.event == AUTOCAPTURE_EVENT:
             el_conditions, element_params = filter_element(step, "{}{}".format(index, prepend))
@@ -26,7 +26,7 @@ def format_action_filter(action: Action, prepend: str = "", index=0, avoid_loop:
             conditions += el_conditions
         # filter event
         else:
-            event_conditions, event_params, index = filter_event(step, "{}{}".format(index, prepend), index)
+            event_conditions, event_params = filter_event(step, "{}{}".format(index, prepend), index)
             params = {**params, **event_params}
             conditions += event_conditions
 
@@ -46,7 +46,7 @@ def format_action_filter(action: Action, prepend: str = "", index=0, avoid_loop:
     return formatted_query, params
 
 
-def filter_event(step: ActionStep, prepend: str = "", index: int = 0) -> Tuple[str, Dict, int]:
+def filter_event(step: ActionStep, prepend: str = "", index: int = 0) -> Tuple[List[str], Dict]:
     params = {}
     conditions = []
 
@@ -63,7 +63,7 @@ def filter_event(step: ActionStep, prepend: str = "", index: int = 0) -> Tuple[s
 
     conditions.append("event = '{}'".format(step.event))
 
-    return conditions, params, index + 1
+    return conditions, params
 
 
 def _create_regex(selector: Selector) -> str:
@@ -83,7 +83,7 @@ def _create_regex(selector: Selector) -> str:
     return regex
 
 
-def filter_element(step: ActionStep, prepend: str = "") -> Tuple[str, Dict, int]:
+def filter_element(step: ActionStep, prepend: str = "") -> Tuple[List[str], Dict]:
     filters = model_to_dict(step)
     params = {}
     conditions = []

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -41,15 +41,12 @@ def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: b
 
         if len(conditions) > 0:
             or_queries.append(" AND ".join(conditions))
-    or_separator = (
-        ") OR (" if not use_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
-    )
     if use_loop:
         formatted_query = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s".format(
-            or_separator.join(or_queries)
+            ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND ".join(or_queries)
         )
     else:
-        formatted_query = "({})".format(or_separator.join(or_queries))
+        formatted_query = "({})".format(") OR (".join(or_queries))
     return formatted_query, params
 
 

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -40,13 +40,15 @@ def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: b
             params = {**params, **prop_params}
 
         or_queries.append(" AND ".join(conditions))
-    or_separator = ") OR (" if not use_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
+    or_separator = (
+        ") OR (" if not use_loop else ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND "
+    )
     if use_loop:
         formatted_query = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s".format(
             or_separator.join(or_queries)
         )
     else:
-        formatted_query = '({})'.format(or_separator.join(or_queries))
+        formatted_query = "({})".format(or_separator.join(or_queries))
     return formatted_query, params
 
 
@@ -56,13 +58,19 @@ def filter_event(step: ActionStep, prepend: str = "", index: int = 0) -> Tuple[L
 
     if step.url:
         if step.url_matching == ActionStep.EXACT:
-            conditions.append("JSONExtractString(properties, '$current_url') = %({}_prop_val_{})s".format(prepend, index))
+            conditions.append(
+                "JSONExtractString(properties, '$current_url') = %({}_prop_val_{})s".format(prepend, index)
+            )
             params.update({"{}_prop_val_{}".format(prepend, index): step.url})
         elif step.url_matching == ActionStep.REGEX:
-            conditions.append("match(JSONExtractString(properties, '$current_url'), %({}_prop_val_{})s)".format(prepend, index))
+            conditions.append(
+                "match(JSONExtractString(properties, '$current_url'), %({}_prop_val_{})s)".format(prepend, index)
+            )
             params.update({"{}_prop_val_{}".format(prepend, index): step.url})
         else:
-            conditions.append("JSONExtractString(properties, '$current_url') LIKE %({}_prop_val_{})s".format(prepend, index))
+            conditions.append(
+                "JSONExtractString(properties, '$current_url') LIKE %({}_prop_val_{})s".format(prepend, index)
+            )
             params.update({"{}_prop_val_{}".format(prepend, index): "%" + step.url + "%"})
 
     conditions.append("event = '{}'".format(step.event))

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -44,7 +44,9 @@ def format_action_filter(action: Action, prepend: str = "", index=0, avoid_loop:
     if avoid_loop:
         formatted_query = or_separator.join(or_queries)
     else:
-        formatted_query = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s".format(or_separator.join(or_queries))
+        formatted_query = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s".format(
+            or_separator.join(or_queries)
+        )
 
     return formatted_query, params
 

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -12,7 +12,7 @@ def format_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
     for group_idx, group in enumerate(cohort.groups):
         if group.get("action_id"):
             action = Action.objects.get(pk=group["action_id"], team_id=cohort.team.pk)
-            action_filter_query, action_params = format_action_filter(action, avoid_loop=True)
+            action_filter_query, action_params = format_action_filter(action)
             extract_person = "SELECT distinct_id FROM events WHERE {query}".format(query=action_filter_query)
             params = {**params, **action_params}
             filters.append("(" + extract_person + ")")

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -12,8 +12,8 @@ def format_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
     for group_idx, group in enumerate(cohort.groups):
         if group.get("action_id"):
             action = Action.objects.get(pk=group["action_id"], team_id=cohort.team.pk)
-            action_filter_query, action_params = format_action_filter(action)
-            extract_person = "SELECT distinct_id FROM events WHERE uuid IN ({query})".format(query=action_filter_query)
+            action_filter_query, action_params = format_action_filter(action, avoid_loop=True)
+            extract_person = "SELECT distinct_id FROM events WHERE {query}".format(query=action_filter_query)
             params = {**params, **action_params}
             filters.append("(" + extract_person + ")")
 

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -23,7 +23,7 @@ def _create_event(**kwargs) -> Event:
 
 
 def query_action(action: Action) -> Optional[List]:
-    formatted_query, params = format_action_filter(action, "", 0, avoid_loop=True)
+    formatted_query, params = format_action_filter(action, "", 0)
 
     query = ACTION_QUERY.format(action_filter=formatted_query)
 
@@ -86,7 +86,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         )
         query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE {}".format(query)
+        full_query = "SELECT uuid FROM events WHERE {}".format(' AND '.join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(str(result[0][0]), event_target.pk)
 
@@ -117,7 +117,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         step1 = ActionStep.objects.create(event="$autocapture", action=action1, url="https://posthog.com/feedback/123",)
         query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE {}".format(query)
+        full_query = "SELECT uuid FROM events WHERE {}".format(' AND '.join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)
 
@@ -150,6 +150,6 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         )
         query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE {}".format(query)
+        full_query = "SELECT uuid FROM events WHERE {}".format(' AND '.join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -84,9 +84,9 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         step1 = ActionStep.objects.create(
             event="$autocapture", action=action1, url="https://posthog.com/feedback/123", url_matching=ActionStep.EXACT,
         )
-        query, params, _ = filter_event(step1)
+        query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE uuid IN {}".format(query)
+        full_query = "SELECT uuid FROM events WHERE {}".format(query)
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(str(result[0][0]), event_target.pk)
 
@@ -115,9 +115,9 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         action1 = Action.objects.create(team=self.team, name="action1")
         step1 = ActionStep.objects.create(event="$autocapture", action=action1, url="https://posthog.com/feedback/123",)
-        query, params, _ = filter_event(step1)
+        query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE uuid IN {}".format(query)
+        full_query = "SELECT uuid FROM events WHERE {}".format(query)
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)
 
@@ -148,8 +148,8 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         step1 = ActionStep.objects.create(
             event="$autocapture", action=action1, url="/123", url_matching=ActionStep.REGEX,
         )
-        query, params, _ = filter_event(step1)
+        query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE uuid IN {}".format(query)
+        full_query = "SELECT uuid FROM events WHERE {}".format(query)
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -86,7 +86,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         )
         query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE {}".format(' AND '.join(query))
+        full_query = "SELECT uuid FROM events WHERE {}".format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(str(result[0][0]), event_target.pk)
 
@@ -117,7 +117,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         step1 = ActionStep.objects.create(event="$autocapture", action=action1, url="https://posthog.com/feedback/123",)
         query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE {}".format(' AND '.join(query))
+        full_query = "SELECT uuid FROM events WHERE {}".format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)
 
@@ -150,6 +150,6 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         )
         query, params = filter_event(step1)
 
-        full_query = "SELECT uuid FROM events WHERE {}".format(' AND '.join(query))
+        full_query = "SELECT uuid FROM events WHERE {}".format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -23,7 +23,7 @@ def _create_event(**kwargs) -> Event:
 
 
 def query_action(action: Action) -> Optional[List]:
-    formatted_query, params = format_action_filter(action, "", 0)
+    formatted_query, params = format_action_filter(action, "", 0, avoid_loop=True)
 
     query = ACTION_QUERY.format(action_filter=formatted_query)
 

--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -47,7 +47,7 @@ class ClickhouseFunnel(Funnel):
                 return ""
 
             self.params.update(action_params)
-            content_sql = "uuid IN {actions_query} {filters}".format(actions_query=action_query, filters=filters,)
+            content_sql = "{actions_query} {filters}".format(actions_query=action_query, filters=filters,)
         else:
             self.params["events"].append(entity.id)
             content_sql = "event = '{event}' {filters}".format(event=entity.id, filters=filters)
@@ -70,7 +70,6 @@ class ClickhouseFunnel(Funnel):
             "events": [],  # purely a speed optimization, don't need this for filtering
             **prop_filter_params,
         }
-        self.events: List[str] = []
         steps = [self._build_steps_query(entity, index) for index, entity in enumerate(self._filter.entities)]
         query = FUNNEL_SQL.format(
             team_id=self._team.id,

--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -42,7 +42,7 @@ class ClickhouseFunnel(Funnel):
             action = Action.objects.get(pk=entity.id)
             for action_step in action.steps.all():
                 self.params["events"].append(action_step.event)
-            action_query, action_params = format_action_filter(action, "step_{}".format(index), avoid_loop=True)
+            action_query, action_params = format_action_filter(action, "step_{}".format(index))
             if action_query == "":
                 return ""
 

--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -42,7 +42,7 @@ class ClickhouseFunnel(Funnel):
             action = Action.objects.get(pk=entity.id)
             for action_step in action.steps.all():
                 self.params["events"].append(action_step.event)
-            action_query, action_params = format_action_filter(action, "step_{}".format(index))
+            action_query, action_params = format_action_filter(action, "step_{}".format(index), avoid_loop=True)
             if action_query == "":
                 return ""
 

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -47,7 +47,7 @@ class ClickhouseRetention(BaseQuery):
         )
         if target_entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = Action.objects.get(pk=target_entity.id)
-            action_query, target_params = format_action_filter(action)
+            action_query, target_params = format_action_filter(action, use_loop=True)
             target_query = "AND e.uuid IN ({})".format(action_query)
         elif target_entity.type == TREND_FILTER_TYPE_EVENTS:
             target_query = "AND e.event = %(target_event)s"

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -50,7 +50,7 @@ class ClickhouseStickiness(BaseQuery):
         params = {**params, **prop_filter_params}
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = Action.objects.get(pk=entity.id)
-            action_query, action_params = format_action_filter(action, avoid_loop=True)
+            action_query, action_params = format_action_filter(action)
             if action_query == "":
                 return None
 

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -50,7 +50,7 @@ class ClickhouseStickiness(BaseQuery):
         params = {**params, **prop_filter_params}
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = Action.objects.get(pk=entity.id)
-            action_query, action_params = format_action_filter(action)
+            action_query, action_params = format_action_filter(action, avoid_loop=True)
             if action_query == "":
                 return None
 

--- a/ee/clickhouse/queries/clickhouse_trends.py
+++ b/ee/clickhouse/queries/clickhouse_trends.py
@@ -139,7 +139,7 @@ class ClickhouseTrends(BaseQuery):
         action_params: Dict = {}
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = Action.objects.get(pk=entity.id)
-            action_query, action_params = format_action_filter(action, avoid_loop=True)
+            action_query, action_params = format_action_filter(action)
 
         null_sql = NULL_BREAKDOWN_SQL.format(
             interval=interval_annotation,
@@ -392,7 +392,7 @@ class ClickhouseTrends(BaseQuery):
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             try:
                 action = Action.objects.get(pk=entity.id)
-                action_query, action_params = format_action_filter(action, avoid_loop=True)
+                action_query, action_params = format_action_filter(action)
                 params = {**params, **action_params}
                 content_sql = VOLUME_ACTIONS_SQL.format(
                     interval=interval_annotation,

--- a/ee/clickhouse/queries/clickhouse_trends.py
+++ b/ee/clickhouse/queries/clickhouse_trends.py
@@ -392,7 +392,7 @@ class ClickhouseTrends(BaseQuery):
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             try:
                 action = Action.objects.get(pk=entity.id)
-                action_query, action_params = format_action_filter(action)
+                action_query, action_params = format_action_filter(action, avoid_loop=True)
                 params = {**params, **action_params}
                 content_sql = VOLUME_ACTIONS_SQL.format(
                     interval=interval_annotation,

--- a/ee/clickhouse/queries/clickhouse_trends.py
+++ b/ee/clickhouse/queries/clickhouse_trends.py
@@ -139,7 +139,7 @@ class ClickhouseTrends(BaseQuery):
         action_params: Dict = {}
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = Action.objects.get(pk=entity.id)
-            action_query, action_params = format_action_filter(action)
+            action_query, action_params = format_action_filter(action, avoid_loop=True)
 
         null_sql = NULL_BREAKDOWN_SQL.format(
             interval=interval_annotation,
@@ -164,7 +164,7 @@ class ClickhouseTrends(BaseQuery):
                 conditions = BREAKDOWN_CONDITIONS_SQL.format(
                     parsed_date_from=parsed_date_from,
                     parsed_date_to=parsed_date_to,
-                    actions_query="AND uuid IN ({})".format(action_query) if action_query else "",
+                    actions_query="AND {}".format(action_query) if action_query else "",
                     event_filter="AND event = %(event)s" if not action_query else "",
                     filters="{filters}".format(filters=prop_filters) if props_to_filter else "",
                 )
@@ -182,7 +182,7 @@ class ClickhouseTrends(BaseQuery):
                     cohort_queries=cohort_queries,
                     parsed_date_from=parsed_date_from,
                     parsed_date_to=parsed_date_to,
-                    actions_query="AND uuid IN ({})".format(action_query) if action_query else "",
+                    actions_query="AND {}".format(action_query) if action_query else "",
                     event_filter="AND event = %(event)s" if not action_query else "",
                     filters="{filters}".format(filters=prop_filters) if props_to_filter else "",
                 )
@@ -207,7 +207,7 @@ class ClickhouseTrends(BaseQuery):
             breakdown_filter = BREAKDOWN_PERSON_PROP_JOIN_SQL.format(
                 parsed_date_from=parsed_date_from,
                 parsed_date_to=parsed_date_to,
-                actions_query="AND uuid IN ({})".format(action_query) if action_query else "",
+                actions_query="AND {}".format(action_query) if action_query else "",
                 event_filter="AND event = %(event)s" if not action_query else "",
             )
             breakdown_query = BREAKDOWN_QUERY_SQL.format(
@@ -233,7 +233,7 @@ class ClickhouseTrends(BaseQuery):
             breakdown_filter = BREAKDOWN_PROP_JOIN_SQL.format(
                 parsed_date_from=parsed_date_from,
                 parsed_date_to=parsed_date_to,
-                actions_query="AND uuid IN ({})".format(action_query) if action_query else "",
+                actions_query="AND {}".format(action_query) if action_query else "",
                 event_filter="AND event = %(event)s" if not action_query else "",
                 filters="{filters}".format(filters=prop_filters) if props_to_filter else "",
             )

--- a/ee/clickhouse/sql/actions.py
+++ b/ee/clickhouse/sql/actions.py
@@ -9,7 +9,7 @@ SELECT
     events.elements_chain,
     events.created_at
 FROM events
-WHERE uuid IN {action_filter}
+WHERE {action_filter}
 AND events.team_id = %(team_id)s
 ORDER BY events.timestamp DESC
 """

--- a/ee/clickhouse/sql/actions.py
+++ b/ee/clickhouse/sql/actions.py
@@ -13,32 +13,3 @@ WHERE uuid IN {action_filter}
 AND events.team_id = %(team_id)s
 ORDER BY events.timestamp DESC
 """
-
-# action_filter — concatenation of element_action_filters and event_action_filters
-
-ELEMENT_ACTION_FILTER = """
-(
-    SELECT uuid FROM events WHERE 
-        team_id = %(team_id)s
-        {selector_regex}
-        {attributes_regex}
-        {tag_name_regex}
-        {event_filter}
-)
-"""
-
-EVENT_ACTION_FILTER = """
-(
-    SELECT uuid from events_with_array_props_view WHERE uuid IN (
-        SELECT event_id
-        FROM events_properties_view AS ep
-        WHERE team_id = %(team_id)s {property_filter}
-    ) {event_filter}
-)
-"""
-
-EVENT_NO_PROP_FILTER = """
-(
-    SELECT uuid FROM events_with_array_props_view where team_id = %(team_id)s {event_filter}
-)
-"""

--- a/ee/clickhouse/sql/stickiness/stickiness_actions.py
+++ b/ee/clickhouse/sql/stickiness/stickiness_actions.py
@@ -3,7 +3,7 @@ STICKINESS_ACTIONS_SQL = """
          SELECT person_distinct_id.person_id, countDistinct(toDate(timestamp)) as day_count
          FROM events
          LEFT JOIN (SELECT person_id, distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s) as person_distinct_id ON person_distinct_id.distinct_id = events.distinct_id
-         WHERE team_id = %(team_id)s AND uuid IN ({actions_query}) {filters} {parsed_date_from} {parsed_date_to}
+         WHERE team_id = %(team_id)s AND {actions_query} {filters} {parsed_date_from} {parsed_date_to}
          GROUP BY person_distinct_id.person_id
     ) GROUP BY day_count ORDER BY day_count
 """

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -3,5 +3,5 @@ SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC'
 """
 
 VOLUME_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and uuid IN ({actions_query}) {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
 """

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -97,8 +97,8 @@ class ClickhouseActions(ActionViewSet):
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             try:
                 action = Action.objects.get(pk=entity.id)
-                action_query, params = format_action_filter(action)
-                entity_filter = "AND uuid IN ({})".format(action_query)
+                action_query, params = format_action_filter(action, avoid_loop=True)
+                entity_filter = "AND {}".format(action_query)
 
             except Action.DoesNotExist:
                 raise ValueError("This action does not exist")

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -97,7 +97,7 @@ class ClickhouseActions(ActionViewSet):
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             try:
                 action = Action.objects.get(pk=entity.id)
-                action_query, params = format_action_filter(action, avoid_loop=True)
+                action_query, params = format_action_filter(action)
                 entity_filter = "AND {}".format(action_query)
 
             except Action.DoesNotExist:

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -49,7 +49,7 @@ class ClickhouseEvents(EventViewSet):
             action = Action.objects.get(pk=request.GET["action_id"])
             if action.steps.count() == 0:
                 return Response({"next": False, "results": []})
-            action_query, params = format_action_filter(action, avoid_loop=True)
+            action_query, params = format_action_filter(action)
             prop_filters += " AND {}".format(action_query)
             prop_filter_params = {**prop_filter_params, **params}
 

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -49,8 +49,8 @@ class ClickhouseEvents(EventViewSet):
             action = Action.objects.get(pk=request.GET["action_id"])
             if action.steps.count() == 0:
                 return Response({"next": False, "results": []})
-            action_query, params = format_action_filter(action)
-            prop_filters += " AND uuid IN {}".format(action_query)
+            action_query, params = format_action_filter(action, avoid_loop=True)
+            prop_filters += " AND {}".format(action_query)
             prop_filter_params = {**prop_filter_params, **params}
 
         if prop_filters != "":

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -191,7 +191,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             # should not add a count
             without_property = person_factory(distinct_ids=["without_property"], team_id=self.team.pk)
             self._signup_event(distinct_id="without_property")
-            self._pay_event(distinct_id="without_property", properties={"$browser": "Safari"})
+            self._pay_event(distinct_id="without_property")
 
             # will add to first step
             half_property = person_factory(distinct_ids=["half_property"], team_id=self.team.pk)


### PR DESCRIPTION
## Changes

We were using a ton of `uuid IN (SELECT uuid FROM events {bla})`. This gets rid of those. Should also make all those queries faster.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
