### PR TITLE
Retention ux fixes

### DIFF
--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -87,7 +87,7 @@ class ClickhouseRetention(BaseQuery):
             date_from = date_from - timedelta(days=date_from.isoweekday() % 7)
 
         labels_format = "%b %-d"
-        hourly_format = ", %-H %p"
+        hourly_format = ", %-I %p"
         parsed = [
             {
                 "values": [

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
-from django.utils import timezone
 from django.utils.timezone import now
 
 from ee.clickhouse.client import sync_execute
@@ -32,13 +31,11 @@ class ClickhouseRetention(BaseQuery):
         filter._date_to = ((filter.date_to if filter.date_to else now()) + t1).isoformat()
 
         if period == "Hour":
-            date_to: datetime = filter.date_to if filter.date_to else now()
-            date_from: datetime.datetime = date_to - tdelta  # type: ignore
+            date_to = filter.date_to if filter.date_to else now()
+            date_from = date_to - tdelta
         else:
-            date_to: datetime = (filter.date_to if filter.date_to else now()).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-            date_from: datetime.datetime = date_to - tdelta  # type: ignore
+            date_to = (filter.date_to if filter.date_to else now()).replace(hour=0, minute=0, second=0, microsecond=0)
+            date_from = date_to - tdelta
 
         filter._date_from = date_from.isoformat()
         filter._date_to = date_to.isoformat()
@@ -117,7 +114,7 @@ class ClickhouseRetention(BaseQuery):
         elif period == "Day":
             return timedelta(days=total_intervals), PERIOD_TRUNC_DAY, timedelta(days=1)
         elif period == "Month":
-            return relativedelta(months=total_intervals), PERIOD_TRUNC_MONTH, timedelta(months=1)
+            return relativedelta(months=total_intervals), PERIOD_TRUNC_MONTH, relativedelta(months=1)
         else:
             raise ValueError(f"Period {period} is unsupported.")
 

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -86,8 +86,6 @@ class ClickhouseRetention(BaseQuery):
         if period == "Week":
             date_from = date_from - timedelta(days=date_from.isoweekday() % 7)
 
-        labels_format = "%b %-d"
-        hourly_format = ", %-I %p"
         parsed = [
             {
                 "values": [
@@ -95,9 +93,7 @@ class ClickhouseRetention(BaseQuery):
                     for day in range(total_intervals - first_day)
                 ],
                 "label": "{} {}".format(period, first_day),
-                "date": (date_from + self._determineTimedelta(first_day, period)[0]).strftime(
-                    labels_format + (hourly_format if period == "Hour" else "")
-                ),
+                "date": (date_from + self._determineTimedelta(first_day, period)[0]),
             }
             for first_day in range(total_intervals)
         ]

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -18,9 +18,8 @@ def _create_event(**kwargs):
 def _create_action(**kwargs):
     team = kwargs.pop("team")
     name = kwargs.pop("name")
-    event_name = kwargs.pop("event_name")
     action = Action.objects.create(team=team, name=name)
-    ActionStep.objects.create(action=action, event=event_name)
+    ActionStep.objects.create(action=action, event=name)
     return action
 
 
@@ -52,7 +51,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
             ]
         )
 
-        filter = Filter(data={"date_from": self._date(0, hour=0), "period": "Week"})
+        filter = Filter(data={"date_to": self._date(10, month=1, hour=0), "period": "Week"})
 
         result = ClickhouseRetention().run(filter, self.team, total_intervals=7)
 
@@ -66,14 +65,5 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
         )
 
         self.assertEqual(
-            self.pluck(result, "date"),
-            [
-                "Sun. 7 June",
-                "Sun. 14 June",
-                "Sun. 21 June",
-                "Sun. 28 June",
-                "Sun. 5 July",
-                "Sun. 12 July",
-                "Sun. 19 July",
-            ],
+            self.pluck(result, "date"), ["Jun 7", "Jun 14", "Jun 21", "Jun 28", "Jul 5", "Jul 12", "Jul 19"],
         )

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -1,4 +1,7 @@
+from datetime import datetime
 from uuid import uuid4
+
+import pytz
 
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
@@ -26,7 +29,7 @@ def _create_action(**kwargs):
 class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(ClickhouseRetention, _create_event, Person.objects.create, _create_action)):  # type: ignore
 
     # period filtering for clickhouse only because start of week is different
-    def test_retention_period(self):
+    def test_retention_period_weekly(self):
         Person.objects.create(
             team=self.team, distinct_ids=["person1", "alias1"], properties={"email": "person1@test.com"},
         )
@@ -65,5 +68,14 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
         )
 
         self.assertEqual(
-            self.pluck(result, "date"), ["Jun 7", "Jun 14", "Jun 21", "Jun 28", "Jul 5", "Jul 12", "Jul 19"],
+            self.pluck(result, "date"),
+            [
+                datetime(2020, 6, 7, 0, tzinfo=pytz.UTC),
+                datetime(2020, 6, 14, 0, tzinfo=pytz.UTC),
+                datetime(2020, 6, 21, 0, tzinfo=pytz.UTC),
+                datetime(2020, 6, 28, 0, tzinfo=pytz.UTC),
+                datetime(2020, 7, 5, 0, tzinfo=pytz.UTC),
+                datetime(2020, 7, 12, 0, tzinfo=pytz.UTC),
+                datetime(2020, 7, 19, 0, tzinfo=pytz.UTC),
+            ],
         )

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -53,35 +53,34 @@ export function RetentionTab(): JSX.Element {
             <hr />
             <h4 className="secondary">Filters</h4>
             <PropertyFilters pageKey="insight-retention" />
-            {window.posthog?.isFeatureEnabled('ch-retention-endpoint') && (
-                <>
-                    <hr />
-                    <h4 className="secondary">Start Day</h4>
-                    <div>
-                        <DatePicker
-                            className="mb-2"
-                            value={selectedDate}
-                            onChange={(date): void => setFilters({ selectedDate: date })}
-                            allowClear={false}
-                        />
-                    </div>
-                    <hr />
-                    <h4 className="secondary">Period</h4>
-                    <div>
-                        <Select
-                            value={dateOptions[period]}
-                            onChange={(value): void => setFilters({ period: value })}
-                            dropdownMatchSelectWidth={false}
-                        >
-                            {Object.entries(dateOptions).map(([key, value]) => (
-                                <Select.Option key={key} value={key}>
-                                    {value}
-                                </Select.Option>
-                            ))}
-                        </Select>
-                    </div>
-                </>
-            )}
+
+            <>
+                <hr />
+                <h4 className="secondary">Current Day</h4>
+                <div>
+                    <DatePicker
+                        className="mb-2"
+                        value={selectedDate}
+                        onChange={(date): void => setFilters({ selectedDate: date })}
+                        allowClear={false}
+                    />
+                </div>
+                <hr />
+                <h4 className="secondary">Period</h4>
+                <div>
+                    <Select
+                        value={dateOptions[period]}
+                        onChange={(value): void => setFilters({ period: value })}
+                        dropdownMatchSelectWidth={false}
+                    >
+                        {Object.entries(dateOptions).map(([key, value]) => (
+                            <Select.Option key={key} value={key}>
+                                {value}
+                            </Select.Option>
+                        ))}
+                    </Select>
+                </div>
+            </>
         </div>
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -59,9 +59,9 @@ export function RetentionTab(): JSX.Element {
                 <h4 className="secondary">Current Date</h4>
                 <div>
                     <DatePicker
-                        showTime
+                        showTime={filters.period === 'h'}
                         use12Hours
-                        format="YYYY-MM-DD, h a"
+                        format={filters.period === 'h' ? 'YYYY-MM-DD, h a' : 'YYYY-MM-DD'}
                         className="mb-2"
                         value={selectedDate}
                         onChange={(date): void => setFilters({ selectedDate: date })}

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -56,9 +56,12 @@ export function RetentionTab(): JSX.Element {
 
             <>
                 <hr />
-                <h4 className="secondary">Current Day</h4>
+                <h4 className="secondary">Current Date</h4>
                 <div>
                     <DatePicker
+                        showTime
+                        use12Hours
+                        format="YYYY-MM-DD, h a"
                         className="mb-2"
                         value={selectedDate}
                         onChange={(date): void => setFilters({ selectedDate: date })}

--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -4,9 +4,17 @@ import { Table, Modal, Button, Spin } from 'antd'
 import { percentage } from 'lib/utils'
 import { Link } from 'lib/components/Link'
 import { retentionTableLogic } from './retentionTableLogic'
+import moment from 'moment'
 
 export function RetentionTable() {
-    const { retention, retentionLoading, peopleLoading, people, loadingMore } = useValues(retentionTableLogic)
+    const {
+        retention,
+        retentionLoading,
+        peopleLoading,
+        people,
+        loadingMore,
+        filters: { period },
+    } = useValues(retentionTableLogic)
     const { loadPeople, loadMore } = useActions(retentionTableLogic)
     const [modalVisible, setModalVisible] = useState(false)
     const [selectedRow, selectRow] = useState(0)
@@ -15,7 +23,7 @@ export function RetentionTable() {
         {
             title: 'Date',
             key: 'date',
-            render: (row) => row.date,
+            render: (row) => moment(row.date).format(period === 'h' ? 'MMM D, h a' : 'MMM D'),
         },
         {
             title: 'Users',

--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -13,8 +13,8 @@ export function RetentionTable() {
 
     let columns = [
         {
-            title: 'Cohort',
-            key: 'cohort',
+            title: 'Date',
+            key: 'date',
             render: (row) => row.date,
         },
         {

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -17,6 +17,7 @@ export const dateOptions = {
 function cleanRetentionParams(filters, properties): any {
     return {
         ...filters,
+        selectedDate: filters.selectedDate?.format('YYYY-MM-DD HH') || moment().format('YYYY-MM-DD HH'),
         properties: properties,
         insight: ViewType.RETENTION,
     }
@@ -26,14 +27,16 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
     loaders: ({ values }) => ({
         retention: {
             __default: {},
-            loadRetention: async () => {
+            loadRetention: async (_: any, breakpoint) => {
                 const params: Record<string, any> = {}
                 params['properties'] = values.properties
                 if (values.selectedDate) params['date_to'] = values.selectedDate.toISOString()
                 if (values.period) params['period'] = dateOptions[values.period]
                 if (values.startEntity) params['target_entity'] = values.startEntity
                 const urlParams = toParams(params)
-                return await api.get(`api/insight/retention/?${urlParams}`)
+                const res = await api.get(`api/insight/retention/?${urlParams}`)
+                breakpoint()
+                return res
             },
         },
         people: {
@@ -138,7 +141,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
         setFilters: () => ['/insights', values.propertiesForUrl],
     }),
     urlToAction: ({ actions, values }) => ({
-        '*': (_, searchParams: Record<string, any>) => {
+        '/insights': (_, searchParams: Record<string, any>) => {
             try {
                 // if the url changed, but we are not anymore on the page we were at when the logic was mounted
                 if (router.values.location.pathname !== values.initialPathname) {
@@ -149,24 +152,40 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
                 // if we have an error accessing the filter value, the logic is gone and we should return
                 return
             }
+            if (searchParams.insight === ViewType.RETENTION) {
+                const paramsToCheck = {
+                    selectedDate: searchParams.selectedDate,
+                    startEntity: searchParams.startEntity,
+                    period: searchParams.period,
+                    properties: searchParams.properties,
+                }
+                const _filters = {
+                    selectedDate: values.filters.selectedDate.toISOString(),
+                    startEntity: values.filters.startEntity,
+                    period: values.filters.period,
+                    properties: values.properties,
+                }
 
-            if (!objectsEqual(searchParams.properties || [], values.properties)) {
-                actions.setProperties(searchParams.properties || [])
-            }
-            if (searchParams.target && values.startEntity.id !== searchParams.target?.id) {
-                actions.setFilters({
-                    [`${searchParams.target.type}`]: [searchParams.target],
-                })
+                if (!objectsEqual(paramsToCheck, _filters)) {
+                    actions.setProperties(searchParams.properties || [])
+                    actions.setFilters({
+                        selectedDate: searchParams.selectedDate
+                            ? moment(searchParams.selectedDate)
+                            : values.filters.selectedDate,
+                        startEntity: searchParams.startEntity || values.filters.startEntity,
+                        period: searchParams.period || values.filters.period,
+                    })
+                }
             }
         },
     }),
     listeners: ({ actions, values }) => ({
         setProperties: () => {
-            actions.loadRetention()
+            actions.loadRetention(true)
             actions.setAllFilters(cleanRetentionParams({ target: values.startEntity }, values.properties))
         },
         setFilters: () => {
-            actions.loadRetention()
+            actions.loadRetention(true)
             actions.setAllFilters(cleanRetentionParams({ target: values.startEntity }, values.properties))
         },
         loadRetentionSuccess: () => {

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -77,7 +77,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
                 startEntity: {
                     events: [{ id: '$pageview', type: 'events', name: '$pageview' }],
                 },
-                selectedDate: moment(),
+                selectedDate: moment().startOf('hour'),
                 period: 'd',
             },
             {

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -29,14 +29,11 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
             loadRetention: async () => {
                 const params: Record<string, any> = {}
                 params['properties'] = values.properties
-                console.log(values.selectedDate.toISOString())
                 if (values.selectedDate) params['date_to'] = values.selectedDate.toISOString()
                 if (values.period) params['period'] = dateOptions[values.period]
                 if (values.startEntity) params['target_entity'] = values.startEntity
                 const urlParams = toParams(params)
-                const res = await api.get(`api/insight/retention/?${urlParams}`)
-                console.log(res)
-                return res
+                return await api.get(`api/insight/retention/?${urlParams}`)
             },
         },
         people: {

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -29,7 +29,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
             loadRetention: async () => {
                 const params: Record<string, any> = {}
                 params['properties'] = values.properties
-                if (values.selectedDate) params['date_from'] = values.selectedDate.toISOString()
+                if (values.selectedDate) params['date_to'] = values.selectedDate.toISOString()
                 if (values.period) params['period'] = dateOptions[values.period]
                 if (values.startEntity) params['target_entity'] = values.startEntity
                 const urlParams = toParams(params)
@@ -77,7 +77,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
                 startEntity: {
                     events: [{ id: '$pageview', type: 'events', name: '$pageview' }],
                 },
-                selectedDate: moment().subtract(11, 'days'),
+                selectedDate: moment(),
                 period: 'd',
             },
             {

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -29,11 +29,14 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
             loadRetention: async () => {
                 const params: Record<string, any> = {}
                 params['properties'] = values.properties
+                console.log(values.selectedDate.toISOString())
                 if (values.selectedDate) params['date_to'] = values.selectedDate.toISOString()
                 if (values.period) params['period'] = dateOptions[values.period]
                 if (values.startEntity) params['target_entity'] = values.startEntity
                 const urlParams = toParams(params)
-                return await api.get(`api/insight/retention/?${urlParams}`)
+                const res = await api.get(`api/insight/retention/?${urlParams}`)
+                console.log(res)
+                return res
             },
         },
         people: {

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -103,13 +103,9 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
     }),
     selectors: ({ selectors }) => ({
         propertiesForUrl: [
-            () => [selectors.properties],
-            (properties) => {
-                if (Object.keys(properties).length > 0) {
-                    return { properties }
-                } else {
-                    return ''
-                }
+            () => [selectors.filters, selectors.properties],
+            (filters, properties) => {
+                return cleanRetentionParams(filters, properties)
             },
         ],
         startEntity: [
@@ -139,7 +135,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
         afterMount: actions.loadRetention,
     }),
     actionToUrl: ({ values }) => ({
-        setFilters: () => ['/insights', { target: values.startEntity, insight: ViewType.RETENTION }],
+        setFilters: () => ['/insights', values.propertiesForUrl],
     }),
     urlToAction: ({ actions, values }) => ({
         '*': (_, searchParams: Record<string, any>) => {

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -252,19 +252,35 @@ class EventManager(models.QuerySet):
 
         filtered_events = events.filter(filter.date_filter_Q).filter(filter.properties_to_Q(team_id=team.pk))
 
-        def _determineTrunc(subject: str, period: str) -> Union[TruncHour, TruncDay, TruncWeek, TruncMonth]:
+        def _determineTrunc(subject: str, period: str) -> Tuple[Union[TruncHour, TruncDay, TruncWeek, TruncMonth], str]:
             if period == "Hour":
-                return TruncHour(subject)
+                fields = """
+                FLOOR(DATE_PART('hour', first_date - %s)) AS first_date,
+                FLOOR(DATE_PART('hour', timestamp - first_date)) AS date,
+                """
+                return TruncHour(subject), fields
             elif period == "Day":
-                return TruncDay(subject)
+                fields = """
+                FLOOR(DATE_PART('day', first_date - %s)) AS first_date,
+                FLOOR(DATE_PART('day', timestamp - first_date)) AS date,
+                """
+                return TruncDay(subject), fields
             elif period == "Week":
-                return TruncWeek(subject)
+                fields = """
+                FLOOR(DATE_PART('day', first_date - %s) / 7) AS first_date,
+                FLOOR(DATE_PART('day', timestamp - first_date) / 7) AS date,
+                """
+                return TruncWeek(subject), fields
             elif period == "Month":
-                return TruncMonth(subject)
+                fields = """
+                FLOOR((DATE_PART('year', first_date) - DATE_PART('year', %s)) * 12 + DATE_PART('month', first_date) - DATE_PART('month', %s)) AS first_date,
+                FLOOR((DATE_PART('year', timestamp) - DATE_PART('year', first_date)) * 12 + DATE_PART('month', timestamp) - DATE_PART('month', first_date)) AS date,
+                """
+                return TruncMonth(subject), fields
             else:
                 raise ValueError(f"Period {period} is unsupported.")
 
-        trunc = _determineTrunc("timestamp", period)
+        trunc, fields = _determineTrunc("timestamp", period)
         first_date = filtered_events.annotate(first_date=trunc).values("first_date", "person_id").distinct()
 
         events_query, events_query_params = filtered_events.query.sql_with_params()
@@ -272,8 +288,7 @@ class EventManager(models.QuerySet):
 
         full_query = """
             SELECT
-                FLOOR(DATE_PART('{period}s', first_date - %s) {calculation}) AS first_date,
-                FLOOR(DATE_PART('{period}s', timestamp - first_date) {calculation}) AS date,
+                {fields}
                 COUNT(DISTINCT "events"."person_id"),
                 array_agg(DISTINCT "events"."person_id") as people
             FROM ({events_query}) events
@@ -283,17 +298,13 @@ class EventManager(models.QuerySet):
             GROUP BY date, first_date
         """
 
-        full_query = full_query.format(
-            events_query=events_query,
-            first_date_query=first_date_query,
-            event_date_query=trunc,
-            period="Day" if period == "Week" else period,
-            calculation="/ 7" if period == "Week" else "",
-        )
+        full_query = full_query.format(events_query=events_query, first_date_query=first_date_query, fields=fields)
+
+        start_params = (filter.date_from, filter.date_from) if period == "Month" else (filter.date_from,)
 
         with connection.cursor() as cursor:
             cursor.execute(
-                full_query, (filter.date_from,) + events_query_params + first_date_params,
+                full_query, start_params + events_query_params + first_date_params,
             )
             data = namedtuplefetchall(cursor)
 

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -32,14 +32,12 @@ class Retention(BaseQuery):
         filter._date_to = ((filter.date_to if filter.date_to else now()) + t1).isoformat()
 
         if period == "Hour":
-            date_to: datetime.datetime = filter.date_to if filter.date_to else now()
-            date_from: datetime.datetime = date_to - tdelta  # type: ignore
+            date_to = filter.date_to if filter.date_to else now()
+            date_from = date_to - tdelta
         else:
 
-            date_to: datetime.datetime = (filter.date_to if filter.date_to else now()).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-            date_from: datetime.datetime = date_to - tdelta  # type: ignore
+            date_to = (filter.date_to if filter.date_to else now()).replace(hour=0, minute=0, second=0, microsecond=0)
+            date_from = date_to - tdelta
 
         filter._date_from = date_from.isoformat()
         filter._date_to = date_to.isoformat()

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -1,8 +1,9 @@
 import datetime
 from datetime import timedelta
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
+from django.utils.timezone import now
 
 from posthog.models import Event, Filter, Team
 from posthog.queries.base import BaseQuery
@@ -10,33 +11,40 @@ from posthog.queries.base import BaseQuery
 
 class Retention(BaseQuery):
     def calculate_retention(self, filter: Filter, team: Team, total_intervals=11):
-        def _determineTimedelta(total_intervals: int, period: str) -> Union[timedelta, relativedelta]:
+        def _determineTimedelta(
+            total_intervals: int, period: str
+        ) -> Tuple[Union[timedelta, relativedelta], Union[timedelta, relativedelta]]:
             if period == "Hour":
-                return timedelta(hours=total_intervals)
+                return timedelta(hours=total_intervals), timedelta(hours=1)
             elif period == "Week":
-                return timedelta(weeks=total_intervals)
+                return timedelta(weeks=total_intervals), timedelta(weeks=1)
             elif period == "Month":
-                return relativedelta(months=total_intervals)
+                return relativedelta(months=total_intervals), relativedelta(months=1)
             elif period == "Day":
-                return timedelta(days=total_intervals)
+                return timedelta(days=total_intervals), timedelta(days=1)
             else:
                 raise ValueError(f"Period {period} is unsupported.")
 
         period = filter.period or "Day"
 
-        if period == "Hour":
-            date_from: datetime.datetime = filter.date_from  # type: ignore
-            filter._date_to = (date_from + _determineTimedelta(total_intervals, period)).isoformat()
-        else:
-            filter._date_from = (
-                (filter.date_from.replace(hour=0, minute=0, second=0, microsecond=0)).isoformat()
-                if filter.date_from
-                else filter._date_from
-            )
-            date_from: datetime.datetime = filter.date_from  # type: ignore
-            filter._date_to = (date_from + _determineTimedelta(total_intervals, period)).isoformat()
+        tdelta, t1 = _determineTimedelta(total_intervals, period)
 
-        labels_format = "%a. %-d %B"
+        filter._date_to = ((filter.date_to if filter.date_to else now()) + t1).isoformat()
+
+        if period == "Hour":
+            date_to: datetime.datetime = filter.date_to if filter.date_to else now()
+            date_from: datetime.datetime = date_to - tdelta  # type: ignore
+        else:
+
+            date_to: datetime.datetime = (filter.date_to if filter.date_to else now()).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            date_from: datetime.datetime = date_to - tdelta  # type: ignore
+
+        filter._date_from = date_from.isoformat()
+        filter._date_to = date_to.isoformat()
+
+        labels_format = "%-d %B"
         hourly_format = "%-H:%M %p"
         resultset = Event.objects.query_retention(filter, team)
 
@@ -47,7 +55,7 @@ class Retention(BaseQuery):
                     for day in range(total_intervals - first_day)
                 ],
                 "label": "{} {}".format(period, first_day),
-                "date": (date_from + _determineTimedelta(first_day, period)).strftime(
+                "date": (date_from + _determineTimedelta(first_day, period)[0]).strftime(
                     labels_format + (hourly_format if period == "Hour" else "")
                 ),
             }

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -43,7 +43,7 @@ class Retention(BaseQuery):
         filter._date_to = date_to.isoformat()
 
         labels_format = "%b %-d"
-        hourly_format = ", %-H %p"
+        hourly_format = ", %-I %p"
         resultset = Event.objects.query_retention(filter, team)
 
         result = [

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -42,8 +42,6 @@ class Retention(BaseQuery):
         filter._date_from = date_from.isoformat()
         filter._date_to = date_to.isoformat()
 
-        labels_format = "%b %-d"
-        hourly_format = ", %-I %p"
         resultset = Event.objects.query_retention(filter, team)
 
         result = [
@@ -53,9 +51,7 @@ class Retention(BaseQuery):
                     for day in range(total_intervals - first_day)
                 ],
                 "label": "{} {}".format(period, first_day),
-                "date": (date_from + _determineTimedelta(first_day, period)[0]).strftime(
-                    labels_format + (hourly_format if period == "Hour" else "")
-                ),
+                "date": (date_from + _determineTimedelta(first_day, period)[0]),
             }
             for first_day in range(total_intervals)
         ]

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -44,8 +44,8 @@ class Retention(BaseQuery):
         filter._date_from = date_from.isoformat()
         filter._date_to = date_to.isoformat()
 
-        labels_format = "%-d %B"
-        hourly_format = "%-H:%M %p"
+        labels_format = "%b %-d"
+        hourly_format = ", %-H %p"
         resultset = Event.objects.query_retention(filter, team)
 
         result = [

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -266,7 +266,6 @@ def _create_action(**kwargs):
     action = Action.objects.create(team=team, name=name)
     ActionStep.objects.create(action=action, event=name)
     action.calculate_events()
-    print(action)
     return action
 
 

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -70,13 +70,13 @@ def retention_test_factory(retention, event_factory, person_factory):
             )
 
             # even if set to hour 6 it should default to beginning of day and include all pageviews above
-            result = retention().run(Filter(data={"date_from": self._date(0, hour=6)}), self.team)
+            result = retention().run(Filter(data={"date_to": self._date(10, hour=6)}), self.team)
             self.assertEqual(len(result), 11)
             self.assertEqual(
                 self.pluck(result, "label"),
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10",],
             )
-            self.assertEqual(result[0]["date"], "Wed. 10 June")
+            self.assertEqual(result[0]["date"], "Jun 10")
 
             self.assertEqual(
                 self.pluck(result, "values", "count"),
@@ -119,7 +119,7 @@ def retention_test_factory(retention, event_factory, person_factory):
                 Filter(
                     data={
                         "properties": [{"key": "$some_property", "value": "value"}],
-                        "date_from": self._date(0, hour=0),
+                        "date_to": self._date(10, hour=0),
                     }
                 ),
                 self.team,
@@ -129,7 +129,7 @@ def retention_test_factory(retention, event_factory, person_factory):
                 self.pluck(result, "label"),
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10",],
             )
-            self.assertEqual(result[0]["date"], "Wed. 10 June")
+            self.assertEqual(result[0]["date"], "Jun 10")
 
             self.assertEqual(
                 self.pluck(result, "values", "count"),
@@ -175,7 +175,7 @@ def retention_test_factory(retention, event_factory, person_factory):
                 Filter(
                     data={
                         "properties": [{"key": "email", "value": "person1@test.com", "type": "person",}],
-                        "date_from": self._date(0, hour=0),
+                        "date_to": self._date(6, hour=0),
                     }
                 ),
                 self.team,
@@ -186,7 +186,7 @@ def retention_test_factory(retention, event_factory, person_factory):
             self.assertEqual(
                 self.pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"],
             )
-            self.assertEqual(result[0]["date"], "Wed. 10 June")
+            self.assertEqual(result[0]["date"], "Jun 10")
             self.assertEqual(
                 self.pluck(result, "values", "count"),
                 [[1, 1, 1, 0, 0, 1, 1], [1, 1, 0, 0, 1, 1], [1, 0, 0, 1, 1], [0, 0, 0, 0], [0, 0, 0], [1, 1], [1],],
@@ -213,7 +213,7 @@ def retention_test_factory(retention, event_factory, person_factory):
 
             start_entity = json.dumps({"id": action.pk, "type": TREND_FILTER_TYPE_ACTIONS})
             result = retention().run(
-                Filter(data={"date_from": self._date(0, hour=0), "target_entity": start_entity,}),
+                Filter(data={"date_to": self._date(6, hour=0), "target_entity": start_entity,}),
                 self.team,
                 total_intervals=7,
             )
@@ -222,7 +222,7 @@ def retention_test_factory(retention, event_factory, person_factory):
             self.assertEqual(
                 self.pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"],
             )
-            self.assertEqual(result[0]["date"], "Wed. 10 June")
+            self.assertEqual(result[0]["date"], "Jun 10")
 
             self.assertEqual(
                 self.pluck(result, "values", "count"),
@@ -288,7 +288,7 @@ class TestDjangoRetention(retention_test_factory(Retention, Event.objects.create
         )
 
         result = Retention().run(
-            Filter(data={"date_from": self._date(0, hour=0), "period": "Week"}), self.team, total_intervals=7,
+            Filter(data={"date_to": self._date(15, month=1, hour=0), "period": "Week"}), self.team, total_intervals=7,
         )
 
         self.assertEqual(
@@ -301,14 +301,5 @@ class TestDjangoRetention(retention_test_factory(Retention, Event.objects.create
         )
 
         self.assertEqual(
-            self.pluck(result, "date"),
-            [
-                "Wed. 10 June",
-                "Wed. 17 June",
-                "Wed. 24 June",
-                "Wed. 1 July",
-                "Wed. 8 July",
-                "Wed. 15 July",
-                "Wed. 22 July",
-            ],
+            self.pluck(result, "date"), ["Jun 13", "Jun 20", "Jun 27", "Jul 4", "Jul 11", "Jul 18", "Jul 25",],
         )


### PR DESCRIPTION
## Changes

*Please describe.*  
- addressing a labels and dates in #1995 
- retention dates now are parsed on the frontend
- added more tests for monthly and hourly period

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
