### PR TITLE
Install Local Plugins from the interface

### DIFF
--- a/frontend/src/scenes/plugins/LocalPlugin.tsx
+++ b/frontend/src/scenes/plugins/LocalPlugin.tsx
@@ -3,27 +3,23 @@ import { Button, Card, Col, Input, Row } from 'antd'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 
-export function CustomPlugin(): JSX.Element {
-    const { customPluginUrl, pluginError, loading } = useValues(pluginsLogic)
-    const { setCustomPluginUrl, installPlugin } = useActions(pluginsLogic)
+export function LocalPlugin(): JSX.Element {
+    const { localPluginUrl, pluginError, loading } = useValues(pluginsLogic)
+    const { setLocalPluginUrl, installPlugin } = useActions(pluginsLogic)
 
     return (
         <div style={{ marginTop: 32 }}>
             <Card>
-                <h3 className="l3">Install Custom Plugin</h3>
-                <p>
-                    To install a third-party or custom plugin, please paste the plugin's repository below.
-                    <br />
-                    <b className="text-warning">Warning: Only install plugins from trusted sources.</b>
-                </p>
+                <h3 className="l3">Install Local Plugin</h3>
+                <p>To install a local plugin from this computer/server, give its full path below.</p>
 
                 <Row style={{ width: '100%' }} gutter={16}>
                     <Col style={{ flex: 1 }}>
                         <Input
-                            value={customPluginUrl}
+                            value={localPluginUrl}
                             disabled={loading}
-                            onChange={(e) => setCustomPluginUrl(e.target.value)}
-                            placeholder="https://github.com/user/repo"
+                            onChange={(e) => setLocalPluginUrl(e.target.value)}
+                            placeholder="/var/posthog/plugins/helloworldplugin"
                         />
                     </Col>
                     <Col>
@@ -31,9 +27,9 @@ export function CustomPlugin(): JSX.Element {
                             disabled={loading}
                             loading={loading}
                             type="default"
-                            onClick={() => installPlugin(customPluginUrl, 'custom')}
+                            onClick={() => installPlugin(localPluginUrl, 'local')}
                         >
-                            Fetch and install
+                            Install
                         </Button>
                     </Col>
                 </Row>

--- a/frontend/src/scenes/plugins/LocalPluginTag.tsx
+++ b/frontend/src/scenes/plugins/LocalPluginTag.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Tag, Tooltip } from 'antd'
+import { copyToClipboard } from 'lib/utils'
+
+export function LocalPluginTag({
+    url,
+    title,
+    style,
+}: {
+    url: string
+    title?: string
+    style?: React.CSSProperties
+}): JSX.Element {
+    return (
+        <Tooltip title={url.substring(5)}>
+            <Tag color="geekblue" onClick={() => copyToClipboard(url.substring(5))} style={style}>
+                {title || 'Local Plugin'}
+            </Tag>
+        </Tooltip>
+    )
+}

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -8,6 +8,7 @@ import { PlusOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
 import { PluginImage } from './PluginImage'
 import { PluginError } from 'scenes/plugins/PluginError'
+import { LocalPluginTag } from 'scenes/plugins/LocalPluginTag'
 
 interface PluginCardProps {
     name: string
@@ -48,6 +49,13 @@ export function PluginCard({ name, description, url, pluginConfig, pluginId, err
                 style={{ height: '100%', display: 'flex', marginBottom: 20 }}
                 bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}
             >
+                {url?.startsWith('file:') ? (
+                    <LocalPluginTag
+                        url={url}
+                        title="Local"
+                        style={{ position: 'absolute', top: 10, left: 10, cursor: 'pointer' }}
+                    />
+                ) : null}
                 {pluginConfig?.error ? (
                     <PluginError
                         error={pluginConfig.error}
@@ -103,7 +111,7 @@ export function PluginCard({ name, description, url, pluginConfig, pluginId, err
                             <Button
                                 type="primary"
                                 loading={loading}
-                                onClick={() => installPlugin(url)}
+                                onClick={() => installPlugin(url, 'repository')}
                                 icon={<PlusOutlined />}
                             >
                                 Install

--- a/frontend/src/scenes/plugins/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/PluginDrawer.tsx
@@ -7,6 +7,7 @@ import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from './PluginImage'
 import { Link } from 'lib/components/Link'
 import { Drawer } from 'lib/components/Drawer'
+import { LocalPluginTag } from 'scenes/plugins/LocalPluginTag'
 
 export function PluginDrawer(): JSX.Element {
     const { user } = useValues(userLogic)
@@ -73,10 +74,14 @@ export function PluginDrawer(): JSX.Element {
                             </div>
                             <div style={{ flexGrow: 1, paddingLeft: 16 }}>
                                 {editingPlugin.description}
-                                <div>
-                                    <Link to={editingPlugin.url} target="_blank" rel="noopener noreferrer">
-                                        View plugin <ArrowRightOutlined />
-                                    </Link>
+                                <div style={{ marginTop: 5 }}>
+                                    {editingPlugin.url?.startsWith('file:') ? (
+                                        <LocalPluginTag url={editingPlugin.url} title="Installed Locally" />
+                                    ) : (
+                                        <Link to={editingPlugin.url} target="_blank" rel="noopener noreferrer">
+                                            View plugin <ArrowRightOutlined />
+                                        </Link>
+                                    )}
                                 </div>
                             </div>
                         </div>

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -10,6 +10,7 @@ import { pluginsLogic } from './pluginsLogic'
 import { Tabs, Tag } from 'antd'
 import { OptInPlugins } from 'scenes/plugins/OptInPlugins'
 import { OptOutPlugins } from 'scenes/plugins/OptOutPlugins'
+import { LocalPlugin } from 'scenes/plugins/LocalPlugin'
 
 export const Plugins = hot(_Plugins)
 function _Plugins(): JSX.Element {
@@ -49,6 +50,7 @@ function _Plugins(): JSX.Element {
                             <TabPane tab="Available" key="available">
                                 <Repository />
                                 <CustomPlugin />
+                                <LocalPlugin />
                             </TabPane>
                         )}
                     </Tabs>

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -12,9 +12,10 @@ export const pluginsLogic = kea<
     actions: {
         editPlugin: (id: number | null) => ({ id }),
         savePluginConfig: (pluginConfigChanges: Record<string, any>) => ({ pluginConfigChanges }),
-        installPlugin: (pluginUrl: string, isCustom: boolean = false) => ({ pluginUrl, isCustom }),
+        installPlugin: (pluginUrl: string, type: 'local' | 'custom' | 'repository') => ({ pluginUrl, type }),
         uninstallPlugin: (name: string) => ({ name }),
         setCustomPluginUrl: (customPluginUrl: string) => ({ customPluginUrl }),
+        setLocalPluginUrl: (localPluginUrl: string) => ({ localPluginUrl }),
         setPluginTab: (tab: string) => ({ tab }),
         resetPluginConfigError: (id: number) => ({ id }),
     },
@@ -31,8 +32,15 @@ export const pluginsLogic = kea<
                     }
                     return plugins
                 },
-                installPlugin: async ({ pluginUrl }) => {
+                installPlugin: async ({ pluginUrl, type }) => {
                     const { plugins } = values
+
+                    if (type === 'local') {
+                        const response = await api.create('api/plugin', {
+                            url: `file:${pluginUrl}`,
+                        })
+                        return { ...plugins, [response.id]: response }
+                    }
 
                     const { user, repo } = parseGithubRepoURL(pluginUrl)
 
@@ -174,6 +182,13 @@ export const pluginsLogic = kea<
             '',
             {
                 setCustomPluginUrl: (_, { customPluginUrl }) => customPluginUrl,
+                installPluginSuccess: () => '',
+            },
+        ],
+        localPluginUrl: [
+            '',
+            {
+                setLocalPluginUrl: (_, { localPluginUrl }) => localPluginUrl,
                 installPluginSuccess: () => '',
             },
         ],

--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -2,7 +2,7 @@ admin: 0003_logentry_add_action_flag_choices
 auth: 0011_update_proxy_permissions
 contenttypes: 0002_remove_content_type_name
 ee: 0002_hook
-posthog: 0096_auto_20201102_1021
+posthog: 0096_plugins
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0008_partial_timestamp

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any, Dict, Optional
 
 import requests
@@ -11,13 +12,14 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from posthog.models import Plugin, PluginConfig
+from posthog.models.plugin import Plugin, PluginConfig
 from posthog.plugins import (
     can_configure_plugins_via_api,
     can_install_plugins_via_api,
     download_plugin_github_zip,
     reload_plugins_on_workers,
 )
+from posthog.plugins.utils import load_json_file
 from posthog.redis import get_client
 
 
@@ -35,9 +37,25 @@ class PluginSerializer(serializers.ModelSerializer):
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> Plugin:
         if not can_install_plugins_via_api():
             raise ValidationError("Plugin installation via the web is disabled!")
+
+        local_plugin = validated_data.get("url", "").startswith("file:")
+
+        if local_plugin:
+            plugin_path = validated_data["url"][5:]
+            json_path = os.path.join(plugin_path, "plugin.json")
+            json = load_json_file(json_path)
+            if not json:
+                raise ValidationError("Could not load plugin.json from: {}".format(json_path))
+            validated_data["name"] = json.get("name", json_path.split("/")[-2])
+            validated_data["description"] = json.get("description", "")
+            validated_data["config_schema"] = json.get("config", {})
+
         if len(Plugin.objects.filter(name=validated_data["name"])) > 0:
             raise ValidationError('Plugin with name "{}" already installed!'.format(validated_data["name"]))
-        validated_data["archive"] = download_plugin_github_zip(validated_data["url"], validated_data["tag"])
+
+        if not local_plugin:
+            validated_data["archive"] = download_plugin_github_zip(validated_data["url"], validated_data["tag"])
+
         validated_data["from_web"] = True
         plugin = super().create(validated_data)
         reload_plugins_on_workers()

--- a/posthog/migrations/0096_plugins.py
+++ b/posthog/migrations/0096_plugins.py
@@ -1,7 +1,8 @@
 import django.contrib.postgres.fields.jsonb
 import django.db.models.deletion
-import posthog.models.plugin
 from django.db import migrations, models
+
+import posthog.models.plugin
 
 
 class Migration(migrations.Migration):
@@ -17,7 +18,7 @@ class Migration(migrations.Migration):
                 ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID",),),
                 ("name", models.CharField(blank=True, max_length=200, null=True)),
                 ("description", models.TextField(blank=True, null=True)),
-                ("url", posthog.models.plugin.FileURLField(blank=True, max_length=800, null=True),),
+                ("url", models.CharField(blank=True, max_length=800, null=True),),
                 ("config_schema", django.contrib.postgres.fields.jsonb.JSONField(default=dict),),
                 ("tag", models.CharField(blank=True, max_length=200, null=True)),
                 ("archive", models.BinaryField(blank=True, null=True)),

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -1,18 +1,11 @@
 from django.contrib.postgres.fields import JSONField
-from django.core import validators
 from django.db import models
-
-
-class FileURLField(models.URLField):
-    """URL field that accepts URLs that start with http://, https:// and file: only"""
-
-    default_validators = [validators.URLValidator(schemes=["http", "https", "file"])]
 
 
 class Plugin(models.Model):
     name: models.CharField = models.CharField(max_length=200, null=True, blank=True)
     description: models.TextField = models.TextField(null=True, blank=True)
-    url: models.CharField = FileURLField(max_length=800, null=True, blank=True)
+    url: models.CharField = models.CharField(max_length=800, null=True, blank=True)
     # Describe the fields to ask in the interface; store answers in PluginConfig->config
     # - config_schema = { [fieldKey]: { name: 'api key', type: 'string', default: '', required: true }  }
     config_schema: JSONField = JSONField(default=dict)


### PR DESCRIPTION
## Changes

- Adds this option when installing plugins:
![image](https://user-images.githubusercontent.com/53387/97887598-6c6f5680-1d2a-11eb-9a1a-295697bda97b.png)

- Plus a tag for local plugins (click to copy):
![image](https://user-images.githubusercontent.com/53387/97887667-7ee99000-1d2a-11eb-815c-1fbd37935e4c.png)

- Also in the drawer instead of the github link (click to copy):
![image](https://user-images.githubusercontent.com/53387/97887727-94f75080-1d2a-11eb-8227-66531e26e213.png)

This is really helpful when making plugins locally. Messing with the CLI is a bit cumbersome still.

I downgraded the validation of the `url` field in the django model to a regular `CharField`. I couldn't get the URL validation to accept `file:`. Wasted too much time on that :).

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
