### PR TITLE
Ignore sentry error about mis-matched timezones for now

### DIFF
--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -7,9 +7,8 @@ from celery import shared_task
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.db import IntegrityError
-from sentry_sdk import capture_exception
 
-from posthog.models import Element, Event, Person, SessionRecordingEvent, Team, User
+from posthog.models import Element, Event, Person, SessionRecordingEvent, Team
 
 
 def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_failed: bool = True,) -> None:
@@ -220,7 +219,7 @@ def handle_timestamp(data: dict, now: str, sent_at: Optional[str]) -> datetime.d
                 # otherwise we can't get a diff to add to now
                 return parser.isoparse(now) + (parser.isoparse(data["timestamp"]) - parser.isoparse(sent_at))
             except TypeError as e:
-                capture_exception(e)
+                pass
         return parser.isoparse(data["timestamp"])
     now_datetime = parser.parse(now)
     if data.get("offset"):


### PR DESCRIPTION
## Changes

We're starting to hit Sentry limits. I've created #2173 to solve the actual issue but we don't need these sentry errors for now

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
