### PR TITLE
Fix Heroku deploy collectstatic

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -23,7 +23,7 @@ class PostHogConfig(AppConfig):
             not settings.TEST
             and not "makemigrations" in sys.argv
             and not "migrate" in sys.argv
-            and not "manage.py" in sys.argv
+            and not "manage.py" in " ".join(sys.argv)
             and not "/mypy" in sys.argv[0]
         ):
             from posthog.plugins import sync_plugin_config


### PR DESCRIPTION
## Changes

- `manage.py` in the block in apps.py can be part of a path (e.g. 'deploy/manage.py')

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
