### PR TITLE
Increase max request body size

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -248,6 +248,9 @@ else:
 INTERNAL_IPS = ["127.0.0.1", "172.18.0.1"]  # Docker IP
 CORS_ORIGIN_ALLOW_ALL = True
 
+# Max size of a POST body (for event ingestion)
+DATA_UPLOAD_MAX_MEMORY_SIZE = 20971520  # 20 MB
+
 ROOT_URLCONF = "posthog.urls"
 
 TEMPLATES = [


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/1726055541/?project=1899813&query=is%3Aunresolved

This started occurring because of session recording. While we can (and
will) add compression to session recording, we should also avoid
dropping events.

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
