### PR TITLE
Remove deprecated celery tasks

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -123,11 +123,6 @@ else:
         return
 
 
-@shared_task(name="process_event_ee", ignore_result=True)
-def process_event_ee_deprecated(*args, **kwargs) -> None:
-    process_event_ee(*args, **kwargs)
-
-
 def log_event(
     distinct_id: str,
     ip: str,

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -243,11 +243,6 @@ def handle_identify_or_alias(event: str, properties: dict, distinct_id: str, tea
         _set_is_identified(team_id=team_id, distinct_id=distinct_id)
 
 
-@shared_task(name="process_event", ignore_result=True)
-def process_event_deprecated(*args, **kwargs) -> None:  # type: ignore
-    process_event(*args, **kwargs)
-
-
 @shared_task(name="posthog.tasks.process_event.process_event", ignore_result=True)
 def process_event(
     distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str],


### PR DESCRIPTION
## Changes

We're back to using the original task names on production

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
