### PR TITLE
Handle ChunkLoadError better

### DIFF
--- a/frontend/src/scenes/sceneLogic.js
+++ b/frontend/src/scenes/sceneLogic.js
@@ -190,7 +190,7 @@ export const sceneLogic = kea({
                             actions.setScene('4xx', {})
                             message = 'Showing error page.'
                         }
-                        console.error("App assets regenerated.", message)
+                        console.error('App assets regenerated.', message)
                     } else {
                         throw error
                     }

--- a/frontend/src/scenes/sceneLogic.js
+++ b/frontend/src/scenes/sceneLogic.js
@@ -180,17 +180,15 @@ export const sceneLogic = kea({
                     importedScene = await scenes[scene]()
                 } catch (error) {
                     if (error.name === 'ChunkLoadError') {
-                        let message
                         if (scene !== null) {
                             // We were on another page (not the first loaded scene)
+                            console.error('App assets regenerated. Reloading this page.')
                             window.location.reload()
-                            message = 'Reloading this page.'
                         } else {
                             // First scene, show an error page
+                            console.error('App assets regenerated. Showing error page.')
                             actions.setScene('4xx', {})
-                            message = 'Showing error page.'
                         }
-                        console.error('App assets regenerated.', message)
                     } else {
                         throw error
                     }

--- a/frontend/src/scenes/sceneLogic.js
+++ b/frontend/src/scenes/sceneLogic.js
@@ -180,20 +180,20 @@ export const sceneLogic = kea({
                     importedScene = await scenes[scene]()
                 } catch (error) {
                     if (error.name === 'ChunkLoadError') {
-                        console.error('Error loading webpack chunk!')
-
+                        let message
                         if (scene !== null) {
-                            // we were on another page (not the first loaded scene)
-                            console.error('Reloading!')
+                            // We were on another page (not the first loaded scene)
                             window.location.reload()
+                            message = 'Reloading this page.'
                         } else {
-                            // first scene, show an error page
-                            console.error("Redirecting to the 'Network Error' page!")
+                            // First scene, show an error page
                             actions.setScene('4xx', {})
-                            return
+                            message = 'Showing error page.'
                         }
+                        console.error("App assets regenerated.", message)
+                    } else {
+                        throw error
                     }
-                    throw error
                 }
                 breakpoint()
                 const { default: defaultExport, logic, ...others } = importedScene


### PR DESCRIPTION
## Changes

This should stop ChunkLoadError (which seems to happen when a user doesn't do a full page reload including assets after we redeploy the app) from spamming our Sentry issues list.
