### PR TITLE
Fix suggestion loading error

### DIFF
--- a/frontend/src/lib/components/AppEditorLink/appUrlsLogic.js
+++ b/frontend/src/lib/components/AppEditorLink/appUrlsLogic.js
@@ -4,6 +4,7 @@ import { toParams } from 'lib/utils'
 import { appEditorUrl } from 'lib/components/AppEditorLink/utils'
 import { toast } from 'react-toastify'
 import { userLogic } from 'scenes/userLogic'
+import moment from 'moment'
 
 const defaultValue = 'https://'
 
@@ -22,6 +23,7 @@ export const appUrlsLogic = kea({
                 let params = {
                     events: [{ id: '$pageview', name: '$pageview', type: 'events' }],
                     breakdown: '$current_url',
+                    date_from: moment().subtract(3, 'days').toISOString(),
                 }
                 let data = await api.get('api/insight/trend/?' + toParams(params))
                 if (data[0]?.count === 0) return []


### PR DESCRIPTION
## Changes

In the appUrlsLogic, we were calling insights with no from_date. This caused that to error.

However, we shouldn't be calling this at all on most pages. it looks like the command bar calls this every time any page loads. @Twixes any thoughts on how to avoid that?

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
