### PR TITLE
Possibly fix org signup by fixing analytics

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -133,7 +133,7 @@ def signup_to_organization_view(request, invite_id):
             {
                 "email": request.user.email if not request.user.anonymize_data else None,
                 "company_name": organization.name,
-                "organization_id": organization.id,
+                "organization_id": str(organization.id),
                 "is_organization_first_user": False,
             },
         )


### PR DESCRIPTION
## Changes

User on Slack got error
```Dictionary values must be serializeable to JSON "organization_id" value 01750416-7a83-0000-13c7-6962e03b0d28 of type <class 'uuid.UUID'> is unsupported.```
that caused redirecting back to the app after signup from invite to fail. Not sure why it hasn't happened before, but this simple change should prevent it.