### PR TITLE
Remove feature flags on clickhouse endpoints

### DIFF
--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -1,8 +1,6 @@
 from contextlib import contextmanager
 
-import posthoganalytics
 from clickhouse_driver.errors import ServerException
-from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 
 from ee.clickhouse.client import sync_execute
@@ -75,17 +73,3 @@ class ClickhouseTestMixin:
     # Ignore assertNumQueries in clickhouse tests
     def assertNumQueries(self, num, func=None, *args, using=DEFAULT_DB_ALIAS, **kwargs):
         return self._assertNumQueries(func)
-
-
-CH_PERSON_ENDPOINT = "ch-person-endpoint"
-CH_EVENT_ENDPOINT = "ch-event-endpoint"
-CH_ACTION_ENDPOINT = "ch-action-endpoint"
-CH_TREND_ENDPOINT = "ch-trend-endpoint"
-CH_SESSION_ENDPOINT = "ch-session-endpoint"
-CH_PATH_ENDPOINT = "ch-path-endpoint"
-CH_FUNNEL_ENDPOINT = "ch-funnel-endpoint"
-CH_RETENTION_ENDPOINT = "ch-retention-endpoint"
-
-
-def endpoint_enabled(endpoint_flag: str, distinct_id: str):
-    return settings.DEBUG or settings.TEST or posthoganalytics.feature_enabled(endpoint_flag, distinct_id)

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -15,7 +15,6 @@ from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.person import GET_LATEST_PERSON_SQL, PEOPLE_SQL, PEOPLE_THROUGH_DISTINCT_SQL, PERSON_TREND_SQL
 from ee.clickhouse.sql.stickiness.stickiness_people import STICKINESS_PEOPLE_SQL
-from ee.clickhouse.util import CH_ACTION_ENDPOINT, endpoint_enabled
 from posthog.api.action import ActionSerializer, ActionViewSet
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.action import Action
@@ -40,10 +39,6 @@ class ClickhouseActions(ActionViewSet):
 
     @action(methods=["GET"], detail=False)
     def people(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-
-        if not endpoint_enabled(CH_ACTION_ENDPOINT, request.user.distinct_id):
-            result = super().get_people(request)
-            return Response(result)
 
         team = request.user.team
         filter = Filter(request=request)

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -13,7 +13,6 @@ from ee.clickhouse.models.property import get_property_values_for_key, parse_pro
 from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_EVENT_WITH_PROP_SQL, SELECT_ONE_EVENT_SQL
-from ee.clickhouse.util import CH_EVENT_ENDPOINT, endpoint_enabled
 from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
 from posthog.models.action import Action
@@ -32,9 +31,6 @@ class ClickhouseEvents(EventViewSet):
         return distinct_to_person
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-
-        if not endpoint_enabled(CH_EVENT_ENDPOINT, request.user.distinct_id):
-            return super().list(request)
 
         team = request.user.team
         filter = Filter(request=request)
@@ -86,9 +82,6 @@ class ClickhouseEvents(EventViewSet):
 
     def retrieve(self, request: Request, pk: Optional[int] = None, *args: Any, **kwargs: Any) -> Response:
 
-        if not endpoint_enabled(CH_EVENT_ENDPOINT, request.user.distinct_id):
-            return super().retrieve(request, pk)
-
         # TODO: implement getting elements
         team = request.user.team
         query_result = sync_execute(SELECT_ONE_EVENT_SQL, {"team_id": team.pk, "event_id": pk},)
@@ -98,9 +91,6 @@ class ClickhouseEvents(EventViewSet):
 
     @action(methods=["GET"], detail=False)
     def values(self, request: Request) -> Response:
-
-        if not endpoint_enabled(CH_EVENT_ENDPOINT, request.user.distinct_id):
-            return Response(super().get_values(request))
 
         key = request.GET.get("key")
         team = request.user.team

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -11,14 +11,6 @@ from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
 from ee.clickhouse.queries.clickhouse_sessions import SESSIONS_LIST_DEFAULT_LIMIT, ClickhouseSessions
 from ee.clickhouse.queries.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.clickhouse_trends import ClickhouseTrends
-from ee.clickhouse.util import (
-    CH_FUNNEL_ENDPOINT,
-    CH_PATH_ENDPOINT,
-    CH_RETENTION_ENDPOINT,
-    CH_SESSION_ENDPOINT,
-    CH_TREND_ENDPOINT,
-    endpoint_enabled,
-)
 from posthog.api.insight import InsightViewSet
 from posthog.constants import TRENDS_STICKINESS
 from posthog.models.filter import Filter
@@ -27,9 +19,6 @@ from posthog.models.filter import Filter
 class ClickhouseInsights(InsightViewSet):
     @action(methods=["GET"], detail=False)
     def trend(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        if not endpoint_enabled(CH_TREND_ENDPOINT, request.user.distinct_id):
-            result = super().calculate_trends(request)
-            return Response(result)
 
         team = request.user.team
         filter = Filter(request=request)
@@ -45,9 +34,6 @@ class ClickhouseInsights(InsightViewSet):
 
     @action(methods=["GET"], detail=False)
     def session(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        if not endpoint_enabled(CH_SESSION_ENDPOINT, request.user.distinct_id):
-            result = super().calculate_session(request)
-            return Response(result)
 
         team = request.user.team
         filter = Filter(request=request)
@@ -73,10 +59,6 @@ class ClickhouseInsights(InsightViewSet):
     @action(methods=["GET"], detail=False)
     def path(self, request: Request, *args: Any, **kwargs: Any) -> Response:
 
-        if not endpoint_enabled(CH_PATH_ENDPOINT, request.user.distinct_id):
-            result = super().calculate_path(request)
-            return Response(result)
-
         team = request.user.team
         filter = Filter(request=request)
         resp = ClickhousePaths().run(filter=filter, team=team)
@@ -85,10 +67,6 @@ class ClickhouseInsights(InsightViewSet):
     @action(methods=["GET"], detail=False)
     def funnel(self, request: Request, *args: Any, **kwargs: Any) -> Response:
 
-        if not endpoint_enabled(CH_FUNNEL_ENDPOINT, request.user.distinct_id):
-            result = super().calculate_funnel(request)
-            return Response(result)
-
         team = request.user.team
         filter = Filter(request=request)
         response = ClickhouseFunnel(team=team, filter=filter).run()
@@ -96,10 +74,6 @@ class ClickhouseInsights(InsightViewSet):
 
     @action(methods=["GET"], detail=False)
     def retention(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-
-        if not endpoint_enabled(CH_RETENTION_ENDPOINT, request.user.distinct_id):
-            result = super().calculate_retention(request)
-            return Response({"data": result})
 
         team = request.user.team
         filter = Filter(request=request)

--- a/ee/clickhouse/views/paths.py
+++ b/ee/clickhouse/views/paths.py
@@ -6,7 +6,6 @@ from rest_framework.response import Response
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
 from ee.clickhouse.sql.events import ELEMENT_TAG_COUNT
-from ee.clickhouse.util import CH_PATH_ENDPOINT, endpoint_enabled
 from posthog.api.paths import PathsViewSet
 from posthog.models import Event, Filter
 
@@ -14,10 +13,6 @@ from posthog.models import Event, Filter
 class ClickhousePathsViewSet(PathsViewSet):
     @action(methods=["GET"], detail=False)
     def elements(self, request: request.Request):
-
-        if not endpoint_enabled(CH_PATH_ENDPOINT, request.user.distinct_id):
-            result = super().get_elements(request)
-            return Response(result)
 
         team = request.user.team
         response = sync_execute(ELEMENT_TAG_COUNT, {"team_id": team.pk, "limit": 20})
@@ -31,10 +26,6 @@ class ClickhousePathsViewSet(PathsViewSet):
     # FIXME: Timestamp is timezone aware timestamp, date range uses naive date.
     # To avoid unexpected results should convert date range to timestamps with timezone.
     def list(self, request):
-
-        if not endpoint_enabled(CH_PATH_ENDPOINT, request.user.distinct_id):
-            result = super().get_list(request)
-            return Response(result)
 
         team = request.user.team
         filter = Filter(request=request)

--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -4,7 +4,6 @@ from typing import List
 from rest_framework import request, response
 
 from ee.clickhouse.models.person import delete_person
-from ee.clickhouse.util import CH_PERSON_ENDPOINT, endpoint_enabled
 from posthog.api.person import PersonViewSet
 from posthog.models import Event, Person
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- we fully moved to clickhouse and postgres is off so there's no reason to have these flags anymore
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
