### PR TITLE
Fix flaky person test

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -162,7 +162,10 @@ class PersonViewSet(viewsets.ModelViewSet):
 
         people = self.get_queryset()
         people = (
-            people.annotate(keys=JsonKeys("properties")).values("keys").annotate(count=Count("id")).order_by("-count", 'keys')
+            people.annotate(keys=JsonKeys("properties"))
+            .values("keys")
+            .annotate(count=Count("id"))
+            .order_by("-count", "keys")
         )
         return [{"name": event["keys"], "count": event["count"]} for event in people]
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -162,7 +162,7 @@ class PersonViewSet(viewsets.ModelViewSet):
 
         people = self.get_queryset()
         people = (
-            people.annotate(keys=JsonKeys("properties")).values("keys").annotate(count=Count("id")).order_by("-count")
+            people.annotate(keys=JsonKeys("properties")).values("keys").annotate(count=Count("id")).order_by("-count", 'keys')
         )
         return [{"name": event["keys"], "count": event["count"]} for event in people]
 


### PR DESCRIPTION
## Changes

I think occasionaly the ordering is random for the `test_person_property_names` test, causing it to fail. Specify an order instead

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
