### PR TITLE
Disable server side cursors for PGBouncer

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -341,6 +341,9 @@ else:
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
 
+# See https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS
+DISABLE_SERVER_SIDE_CURSORS = get_bool_from_env("USING_PGBOUNCER", False)
+
 # Broker
 
 # The last case happens when someone upgrades Heroku but doesn't have Redis installed yet. Collectstatic gets called before we can provision Redis.


### PR DESCRIPTION
## Changes

Add a `USING_PGBOUNCER` venv, otherwise you get [these errors](https://sentry.io/organizations/posthog/issues/2008799268/?project=1899813&query=is%3Aunresolved)

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
