### PR TITLE
Prevent overscroll y on body

### DIFF
--- a/frontend/src/layout.ejs
+++ b/frontend/src/layout.ejs
@@ -21,6 +21,7 @@ body {
   align-items: center;
   padding-top: 40px;
   padding-bottom: 40px;
+  overscroll-behavior-y: none;
 }
 
 .form-signin {


### PR DESCRIPTION
Add overscroll-behavior-y: none to body

## Changes

overscroll is the behavior where if you scroll to the top of the page, your momentum can take you past the body, and show a big ol empty stripe across the top:

<img width="898" alt="Screen Shot 2020-11-05 at 5 05 21 PM" src="https://user-images.githubusercontent.com/923033/98301802-5d3a1400-1f89-11eb-9ce8-c5affb85618b.png">

Obviously a super tiny nit, and i missed hacktoberfest, but am enjoying using the product and wanted to contribute, however small! 😄 

## Checklist

I didn't do any of this but its hard to imagine this tiny change would fail cypress!

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
