### PR TITLE
Fix team leakge in count

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -31,7 +31,9 @@ class ClickhouseActionSerializer(ActionSerializer):
             query, params = format_action_filter(action)
             if query == "":
                 return None
-            return sync_execute("SELECT count(1) FROM events WHERE {}".format(query), params)[0][0]
+            return sync_execute("SELECT count(1) FROM events WHERE team_id = %(team_id)s AND {}".format(query), params)[
+                0
+            ][0]
         return None
 
     def get_is_calculating(self, action: Action) -> bool:

--- a/ee/clickhouse/views/test/test_clickhouse_action.py
+++ b/ee/clickhouse/views/test/test_clickhouse_action.py
@@ -7,6 +7,7 @@ from posthog.api.test.test_action_people import action_people_test_factory
 from posthog.models import Action, ActionStep
 from posthog.models.cohort import Cohort
 from posthog.models.person import Person
+from posthog.models.team import Team
 
 
 def _create_action(**kwargs):
@@ -59,10 +60,13 @@ class TestAction(
         self.assertFalse(patch_delay.called)
 
     def test_only_get_count_on_retrieve(self):
+        team2 = Team.objects.create(name="bla")
         action = Action.objects.create(team=self.team, name="bla")
         ActionStep.objects.create(action=action, event="custom event")
         _create_event(event="custom event", team=self.team, distinct_id="test")
         _create_event(event="another event", team=self.team, distinct_id="test")
+        # test team leakage
+        _create_event(event="custom event", team=team2, distinct_id="test")
         response = self.client.get("/api/action/").json()
         self.assertEqual(response["results"][0]["count"], None)
 


### PR DESCRIPTION
## Changes

Count was incorrect as we weren't always filtering on team for the count

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
