### PR TITLE
Invite team member on sidebar

### DIFF
--- a/frontend/src/layout/Sidebar.js
+++ b/frontend/src/layout/Sidebar.js
@@ -25,6 +25,7 @@ import {
     WalletOutlined,
     ApiOutlined,
     DatabaseOutlined,
+    PlusOutlined,
 } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
@@ -37,6 +38,7 @@ import { ToolbarModal } from '~/layout/ToolbarModal/ToolbarModal'
 import whiteLogo from 'public/posthog-logo-white.svg'
 import { hot } from 'react-hot-loader/root'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { CreateOrgInviteModalWithButton } from 'scenes/organization/Invites/CreateOrgInviteModal'
 
 const itemStyle = { display: 'flex', alignItems: 'center' }
 
@@ -345,6 +347,10 @@ function _Sidebar({ user, sidebarCollapsed, setSidebarCollapsed }) {
                         <SmileOutlined />
                         <span className="sidebar-label">Me</span>
                         <Link to={'/me/settings'} onClick={collapseSidebar} />
+                    </Menu.Item>
+                    <Menu.Item key="inviteTeamMember" style={itemStyle} data-attr="menu-item-inviteTeam">
+                        <PlusOutlined />
+                        <CreateOrgInviteModalWithButton type="text" />
                     </Menu.Item>
                 </Menu>
 

--- a/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
+++ b/frontend/src/scenes/organization/Invites/CreateOrgInviteModal.tsx
@@ -5,8 +5,9 @@ import { invitesLogic } from './logic'
 import { Input, Alert, Button } from 'antd'
 import Modal from 'antd/lib/modal/Modal'
 import { isEmail } from 'lib/utils'
+import { PlusOutlined } from '@ant-design/icons'
 
-export function CreateOrgInviteModalWithButton(): JSX.Element {
+export function CreateOrgInviteModalWithButton({ type = 'button' }: { type?: 'button' | 'text' }): JSX.Element {
     const { createInvite } = useActions(invitesLogic)
     const { push } = useActions(router)
     const { location } = useValues(router)
@@ -23,19 +24,31 @@ export function CreateOrgInviteModalWithButton(): JSX.Element {
 
     return (
         <>
-            <div className="mb text-right">
-                <Button
-                    type="primary"
-                    data-attr="invite-teammate-button"
+            {type === 'text' ? (
+                <span
                     onClick={() => {
                         setIsVisible(true)
                     }}
                 >
-                    + Invite Teammate
-                </Button>
-            </div>
+                    Invite Team Member
+                </span>
+            ) : (
+                <div className="mb text-right">
+                    <Button
+                        type="primary"
+                        data-attr="invite-teammate-button"
+                        onClick={() => {
+                            setIsVisible(true)
+                        }}
+                        icon={<PlusOutlined />}
+                    >
+                        Invite Team Member
+                    </Button>
+                </div>
+            )}
+
             <Modal
-                title="Inviting Teammate"
+                title="Inviting Team member"
                 okText="Create Invite Link"
                 cancelText="Cancel"
                 onOk={() => {
@@ -55,11 +68,10 @@ export function CreateOrgInviteModalWithButton(): JSX.Element {
                 visible={isVisible}
             >
                 <p>
-                    Create an invite link for a teammate with a specific email address.
+                    Create an invite link for a team member with a specific email address.
                     <br />
-                    Remember to send the link to the teammate.
-                    <br />
-                    <i>Invites emailed by PostHog coming soon.</i>
+                    Remember to <b>share the link</b> with the person you want to invite.
+                    <i> Invites emailed by PostHog coming soon.</i>
                 </p>
                 <Input
                     data-attr="invite-email-input"


### PR DESCRIPTION
## Changes

Per [discussion](https://posthog.slack.com/archives/C0113360FFV/p1604655397090100) this temporarily (because #2238 will override this) brings back the invite team member link to the sidebar while we rethink the internal referral process.

<img width="1200" alt="" src="https://user-images.githubusercontent.com/5864173/98355985-d2095e80-201a-11eb-85bd-3502faac1403.png">
