### PR TITLE
Fix people filtering with entity filters

### DIFF
--- a/frontend/src/scenes/insights/trendsLogic.js
+++ b/frontend/src/scenes/insights/trendsLogic.js
@@ -100,6 +100,9 @@ function parsePeopleParams(peopleParams, filters) {
     if (breakdown_value && filters.breakdown_type != 'cohort' && filters.breakdown_type != 'person') {
         params.properties = [...params.properties, { key: params.breakdown, value: breakdown_value, type: 'event' }]
     }
+    if (action.properties) {
+        params.properties = [...params.properties, ...action.properties]
+    }
 
     return toAPIParams(params)
 }


### PR DESCRIPTION
## Changes

Previously, if you had set properties on an entity in trends (rather than on the entire trends filter) clicking on a point on the graph to load the people wouldn't actually be filtered by those properties.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
