### PR TITLE
Closes #1534 Adds events column config field in user model.

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -1,5 +1,16 @@
 describe('Events', () => {
     beforeEach(() => {
+        // Before each should reset the column config to DEFAULT config
+        cy.getCookie('csrftoken').then((csrftoken) => {
+            cy.request({
+                url: '/api/user/',
+                body: { user: { events_column_config: { active: 'DEFAULT' } } },
+                method: 'PATCH',
+                headers: {
+                    'X-CSRFToken': csrftoken.value,
+                },
+            })
+        })
         cy.visit('/events')
     })
 
@@ -10,6 +21,125 @@ describe('Events', () => {
     it('Click on an event', () => {
         cy.get('[data-attr=events-table] .event-row:nth-child(2) td:first-child').click()
         cy.get('[data-attr=event-details]').should('exist')
+    })
+
+    it('Only selected columns from column selector exists in table', () => {
+        cy.get('[data-attr=events-table-column-selector]').click()
+        cy.get('.items-selector-modal')
+            .should('be.visible')
+            .then(() => {
+                cy.get('.items-selector-modal input:checked')
+                    .parents('label')
+                    .each(($elem) => {
+                        cy.get('[data-attr=events-table] thead').within(() =>
+                            cy.get('th').contains($elem.text()).should('exist')
+                        )
+                    })
+                cy.get('.items-selector-checkbox input:not(:checked)')
+                    .parents('label')
+                    .each(($elem) => {
+                        cy.get('[data-attr=events-table] thead').within(() =>
+                            cy.get('th').contains($elem.text()).should('not.exist')
+                        )
+                    })
+            })
+    })
+
+    it('Add columns to event table', () => {
+        const newColumns = []
+        let oldColumnsCount
+        cy.get('[data-attr=events-table-column-selector]').click()
+        cy.get('[data-attr=events-table] thead th').then(($headings) => {
+            oldColumnsCount = $headings.length
+        })
+        cy.get('.items-selector-modal')
+            .should('be.visible')
+            .within(() => {
+                cy.get('.items-selector-checkbox input:not(:checked)')
+                    .parents('label')
+                    .should('be.visible')
+                    .each(($elem) => {
+                        newColumns.push($elem.text())
+                    })
+                    .then(() => {
+                        expect(newColumns).to.be.not.empty
+                    })
+                    .click({ multiple: true })
+            })
+        cy.get('.items-selector-modal .items-selector-confirm').click()
+        cy.get('.items-selector-modal').should('not.be.visible')
+        cy.get('[data-attr=events-table] thead').within(() => {
+            cy.get('th').should('have.length.greaterThan', oldColumnsCount)
+            expect(newColumns).to.be.not.empty
+            newColumns.forEach((title) => {
+                cy.get('th').contains(title).should('exist')
+            })
+        })
+        cy.get('[data-attr=events-table-column-selector]').click()
+
+        // All old and new titles should be selected in column selector modal after it opens again
+        // And should be present in table
+        cy.get('.items-selector-modal')
+            .should('be.visible')
+            .then(() => {
+                cy.get('.items-selector-modal input:checked')
+                    .parents('label')
+                    .each(($elem) => {
+                        cy.get('[data-attr=events-table] thead').within(() =>
+                            cy.get('th').contains($elem.text()).should('exist')
+                        )
+                    })
+            })
+    })
+
+    it('Remove columns from event table', () => {
+        const removedColumns = []
+        let oldColumnsCount
+        cy.get('[data-attr=events-table-column-selector]').click()
+        cy.get('[data-attr=events-table] thead th').then(($headings) => {
+            oldColumnsCount = $headings.length
+        })
+        cy.get('.items-selector-modal')
+            .should('be.visible')
+            .within(() => {
+                cy.get('.items-selector-checkbox input:checked')
+                    .parents('label')
+                    .should('be.visible')
+                    .then(($checkedElems) => {
+                        let numCheckboxesToUncheck = 2
+                        $checkedElems.each((index, elem) => {
+                            if (numCheckboxesToUncheck < index) {
+                                removedColumns.push(Cypress.$(elem).text())
+                                cy.wrap(Cypress.$(elem)).click()
+                            }
+                        })
+                        expect(removedColumns).to.be.not.empty
+                    })
+            })
+        cy.get('.items-selector-modal .items-selector-confirm').click()
+        cy.get('.items-selector-modal').should('not.be.visible')
+        cy.get('[data-attr=events-table] thead').within(() => {
+            cy.get('th').should('have.length.lessThan', oldColumnsCount)
+            expect(removedColumns).to.be.not.empty
+            removedColumns.forEach((title) => {
+                cy.get('th').contains(title).should('not.exist')
+            })
+        })
+        cy.get('[data-attr=events-table-column-selector]').click()
+
+        // All old and new titles should be selected in column selector modal after it opens again
+        // And should be present in table
+        cy.get('.items-selector-modal')
+            .should('be.visible')
+            .then(() => {
+                cy.get('.items-selector-checkbox input:not(:checked)')
+                    .parents('label')
+                    .each(($elem) => {
+                        cy.get('[data-attr=events-table] thead').within(() =>
+                            cy.get('th').contains($elem.text()).should('not.exist')
+                        )
+                    })
+            })
     })
 
     it('Apply 1 overall filter', () => {

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -8,7 +8,7 @@ describe('Events', () => {
     })
 
     it('Click on an event', () => {
-        cy.get('[data-attr=events-table] .event-row:first-child td:first-child').click()
+        cy.get('[data-attr=events-table] .event-row:nth-child(2) td:first-child').click()
         cy.get('[data-attr=event-details]').should('exist')
     })
 

--- a/frontend/src/lib/components/ItemsSelectorModal/ItemsSelectorModal.scss
+++ b/frontend/src/lib/components/ItemsSelectorModal/ItemsSelectorModal.scss
@@ -1,0 +1,8 @@
+.items-selector-modal {
+    .items-selector-checkbox {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        width: 100%;
+    }
+}

--- a/frontend/src/lib/components/ItemsSelectorModal/ItemsSelectorModal.tsx
+++ b/frontend/src/lib/components/ItemsSelectorModal/ItemsSelectorModal.tsx
@@ -1,0 +1,71 @@
+import React, { ReactElement, useState } from 'react'
+import { Modal, Checkbox, Row, Col } from 'antd'
+import { CheckboxValueType, CheckboxOptionType } from 'antd/lib/checkbox/Group'
+import './ItemsSelectorModal.scss'
+
+type onConfirmCallback = (options: CheckboxValueType[]) => any
+type onCancelCallback = (options: CheckboxValueType[]) => any
+
+interface ItemsSelectorModalProps {
+    options: CheckboxOptionType[]
+    onConfirm?: onConfirmCallback
+    onCancel?: onCancelCallback
+    title: string
+    visible: boolean
+    loading: boolean
+    selectedItems: CheckboxValueType[]
+}
+
+export function ItemsSelectorModal(props: ItemsSelectorModalProps): ReactElement | null {
+    const { title, onConfirm, onCancel, selectedItems = [], options = [], visible = false, loading = false } = props
+    const [checkedValues, setCheckedValues] = useState(selectedItems)
+    const _onConfirm = (): void => {
+        if (onConfirm) {
+            onConfirm(checkedValues)
+        }
+    }
+    const _onCancel = (): void => {
+        if (onCancel) {
+            onCancel(checkedValues)
+        }
+        setCheckedValues(selectedItems)
+    }
+
+    const onChange = (checkedValues: Array<CheckboxValueType>): void => {
+        setCheckedValues(checkedValues)
+    }
+
+    return (
+        <>
+            <Modal
+                centered
+                title={title}
+                visible={visible}
+                onOk={_onConfirm}
+                confirmLoading={loading}
+                onCancel={_onCancel}
+                width={700}
+                bodyStyle={{
+                    maxHeight: '520px',
+                    overflow: 'auto',
+                }}
+                className="items-selector-modal"
+                okButtonProps={{
+                    className: 'items-selector-confirm',
+                }}
+            >
+                <Checkbox.Group style={{ width: '100%' }} value={checkedValues} onChange={onChange}>
+                    <Row>
+                        {options.map((option, index) => (
+                            <Col key={index} span={8}>
+                                <Checkbox className={'items-selector-checkbox'} value={option['value']}>
+                                    {option['label']}
+                                </Checkbox>
+                            </Col>
+                        ))}
+                    </Row>
+                </Checkbox.Group>
+            </Modal>
+        </>
+    )
+}

--- a/frontend/src/lib/components/ItemsSelectorModal/index.ts
+++ b/frontend/src/lib/components/ItemsSelectorModal/index.ts
@@ -1,0 +1,1 @@
+export * from './ItemsSelectorModal'

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -279,7 +279,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                     columns={columns}
                     size="small"
                     className="ph-no-capture"
-                    scroll={{ x: columns.length * 180 }}
+                    scroll={{ x: true }}
                     locale={{
                         emptyText: (
                             <span>

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -246,7 +246,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                     </Button>
                 </Col>
                 <Col span={pageKey === 'events' ? 2 : 4}>
-                    <Button onClick={openColumnChooser} type="secondary">
+                    <Button data-attr="events-table-column-selector" onClick={openColumnChooser} type="secondary">
                         Change columns
                     </Button>
                     <Tooltip title="Up to 100,000 latest events.">

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -210,7 +210,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                             ? `There is 1 new event. Click here to load it.`
                             : `There are ${newEvents.length} new events. Click here to load them.`,
                         props: {
-                            colSpan: 6,
+                            colSpan: columnsToRenderFromConfig.length + 1,
                             style: {
                                 cursor: 'pointer',
                             },

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -200,6 +200,9 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
             title: `Event${eventFilter ? ` (${eventFilter})` : ''}`,
             key: 'event',
             rowKey: 'id',
+            fixed: 'left',
+            width: 200,
+            ellipsis: true,
             render: function renderEvent(item) {
                 if (!item.event) {
                     return {
@@ -278,6 +281,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                     columns={columns}
                     size="small"
                     className="ph-no-capture"
+                    scroll={{ x: columns.length * 180 }}
                     locale={{
                         emptyText: (
                             <span>

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -200,8 +200,6 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
             title: `Event${eventFilter ? ` (${eventFilter})` : ''}`,
             key: 'event',
             rowKey: 'id',
-            fixed: 'left',
-            width: 200,
             ellipsis: true,
             render: function renderEvent(item) {
                 if (!item.event) {

--- a/frontend/src/scenes/events/EventsTable.scss
+++ b/frontend/src/scenes/events/EventsTable.scss
@@ -1,12 +1,24 @@
 @import '~/vars';
 
 .events {
+    .ant-table-row-expand-icon-cell {
+        min-width: 0 !important;
+    }
+
     .event-day-separator {
         background-color: darken($bg_mid, 10%);
         font-weight: bold;
         text-align: center;
     }
+    thead th {
+        max-width: 360px;
+        min-width: 160px;
+    }
     .event-row {
+        td {
+            max-width: 360px;
+            min-width: 160px;
+        }
         transition: background-color 2s;
         background-color: #fff;
         cursor: pointer;

--- a/frontend/src/scenes/events/eventsTableLogic.js
+++ b/frontend/src/scenes/events/eventsTableLogic.js
@@ -3,6 +3,7 @@ import { objectsEqual, toParams } from 'lib/utils'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import dayjs from 'dayjs'
+import { userLogic } from 'scenes/userLogic'
 
 const POLL_TIMEOUT = 5000
 
@@ -47,6 +48,7 @@ export const eventsTableLogic = kea({
 
     actions: () => ({
         setProperties: (properties) => ({ properties }),
+        setColumnConfig: (columnConfig) => ({ columnConfig }),
         fetchEvents: (nextParams = null) => ({ nextParams }),
         fetchEventsSuccess: (events, hasNext = false, isNext = false) => ({ events, hasNext, isNext }),
         fetchNextEvents: true,
@@ -157,6 +159,8 @@ export const eventsTableLogic = kea({
             () => [selectors.events, selectors.newEvents],
             (events, newEvents) => formatEvents(events, newEvents, props.apiUrl),
         ],
+        columnConfig: [() => [userLogic.selectors.user], (user) => user.events_column_config.active],
+        eventProperties: [() => [userLogic.selectors.eventProperties], (eventProperties) => eventProperties],
     }),
 
     events: ({ values }) => ({
@@ -192,6 +196,8 @@ export const eventsTableLogic = kea({
     }),
 
     listeners: ({ actions, values, props }) => ({
+        setColumnConfig: ({ columnConfig }) =>
+            userLogic.actions.userUpdateRequest({ user: { events_column_config: { active: columnConfig } } }),
         setProperties: () => actions.fetchEvents(),
         flipSort: () => actions.fetchEvents(),
         setEventFilter: () => actions.fetchEvents(),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,6 +20,7 @@ export interface UserType {
     email_opt_in: boolean
     id: number
     name: string
+    events_column_config: Record<string, string[] | 'DEFAULT'>
     posthog_version: string
     organization: OrganizationType | null
     team: TeamType | null

--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -3,7 +3,7 @@ auth: 0011_update_proxy_permissions
 axes: 0006_remove_accesslog_trusted
 contenttypes: 0002_remove_content_type_name
 ee: 0002_hook
-posthog: 0139_auto_20210325_1757
+posthog: 0140_user_events_column_config
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0008_partial_timestamp

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -51,6 +51,39 @@ class TestUser(BaseTest):
             ],
         )
 
+    def test_user_events_column_config_change_to_default(self):
+        user = User.objects.get(id=self.user.id)
+        user.events_column_config = {"active": ["column_1", "column_2"]}
+        user.save()
+        self.assertDictEqual(user.events_column_config, {"active": ["column_1", "column_2"]})
+
+        response = self.client.patch(
+            "/api/user/",
+            data={"user": {"events_column_config": {"active": "DEFAULT"}}},
+            content_type="application/json",
+        ).json()
+        self.assertDictEqual(response["events_column_config"], {"active": "DEFAULT"})
+
+        user = User.objects.get(id=self.user.id)
+        self.assertDictEqual(user.events_column_config, {"active": "DEFAULT"})
+
+    def test_user_events_column_config_patch(self):
+        user = User.objects.get(id=self.user.id)
+        user.events_column_config = {"active": "DEFAULT"}
+        user.save()
+        self.assertDictEqual(user.events_column_config, {"active": "DEFAULT"})
+
+        response = self.client.patch(
+            "/api/user/",
+            data={"user": {"events_column_config": {"active": ["column_1", "column_2"]}}},
+            content_type="application/json",
+        ).json()
+
+        self.assertDictEqual(response["events_column_config"], {"active": ["column_1", "column_2"]})
+
+        user = User.objects.get(id=self.user.id)
+        self.assertDictEqual(user.events_column_config, {"active": ["column_1", "column_2"]})
+
 
 class TestUserChangePassword(BaseTest):
     TESTS_API = True

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -106,6 +106,7 @@ def user(request):
             user.email_opt_in = data["user"].get("email_opt_in", user.email_opt_in)
             user.anonymize_data = data["user"].get("anonymize_data", user.anonymize_data)
             user.toolbar_mode = data["user"].get("toolbar_mode", user.toolbar_mode)
+            user.events_column_config = data["user"].get("events_column_config", user.events_column_config)
             user.save()
 
     user_identify.identify_task.delay(user_id=user.id)
@@ -119,6 +120,7 @@ def user(request):
             "email_opt_in": user.email_opt_in,
             "anonymize_data": user.anonymize_data,
             "toolbar_mode": user.toolbar_mode,
+            "events_column_config": user.events_column_config,
             "organization": None
             if organization is None
             else {

--- a/posthog/migrations/0140_user_events_column_config.py
+++ b/posthog/migrations/0140_user_events_column_config.py
@@ -1,0 +1,21 @@
+import django.contrib.postgres.fields.jsonb
+from django.db import migrations
+
+import posthog.models.user
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("posthog", "0139_dashboard_tagging"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="events_column_config",
+            field=django.contrib.postgres.fields.jsonb.JSONField(
+                default=posthog.models.user.events_column_config_default
+            ),
+        ),
+    ]

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser, BaseUserManager
+from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.utils import timezone
@@ -85,6 +86,10 @@ class UserManager(BaseUserManager):
             return personal_api_key.user
 
 
+def events_column_config_default() -> Dict[str, Any]:
+    return {"active": "DEFAULT"}
+
+
 class User(AbstractUser):
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS: List[str] = []
@@ -110,6 +115,7 @@ class User(AbstractUser):
         max_length=200, null=True, blank=True, choices=TOOLBAR_CHOICES, default=TOOLBAR
     )
 
+    events_column_config: JSONField = JSONField(default=events_column_config_default)
     objects: UserManager = UserManager()  # type: ignore
 
     @property


### PR DESCRIPTION
## Changes
* Used a JSONField to store current active config.

* Backend code will contain only column names in config. The frontend
  code will decide which and how event property will be processed for
  each column name.

* {"active": "DEFAULT"} means the default columns defined in frontend

* {"active": ["column_name_1", "column_name_2"]} column names array
  pointing to columns defined in frontend code.

* Frontend code for a generic reusable multi item selector modal

* Allow user defined event properties to be selected as columns in events table.

* The default prev. columns behave as they did before this PR. New user defined event property columns are filter links.

* By default user defined properties are set `ph-no-capture` to protect posthog user's privacy.

Closes #1534.

## Checklist

- [x] Django backend tests (if this PR affects the backend).
- [x] Cypress end-to-end tests (if this PR affects the frontend).
