### PR TITLE
Make debug bar tricolor again and fix its text color outside of SPA

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -282,21 +282,25 @@ style files without adding already imported styles. */
     color: #fff;
     font-size: 0.75rem;
     line-height: 1.5rem;
+    code {
+        color: inherit;
+        font-size: inherit;
+    }
     &.warning div {
         height: auto;
         background: $danger;
     }
-
-    div:nth-child(1) {
-        background: $purple_700;
+    &.tricolor {
+        div:nth-child(1) {
+            background: $brand_blue;
+        }
+        div:nth-child(2) {
+            background: $brand_red;
+        }
+        div:nth-child(3) {
+            background: $brand_yellow;
+        }
     }
-    div:nth-child(2) {
-        background: $purple_500;
-    }
-    div:nth-child(3) {
-        background: $purple_300;
-    }
-
     div {
         flex-basis: 0;
         flex-grow: 1;
@@ -309,6 +313,7 @@ style files without adding already imported styles. */
     button {
         border: none;
         background: transparent;
+        color: inherit;
         width: 1.5rem;
         height: 1.5rem;
         padding: 0;

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -8,6 +8,12 @@ $success: #77b96c;
 $warning: #f7a501;
 $danger: #f96132;
 
+
+// Brand colors, as in logo
+$brand_blue: #1d4aff;
+$brand_red: #f54e00;
+$brand_yellow: #f9bd2b;
+
 // Text colors
 $text_default: #2d2d2d;
 $text_light: rgba(255, 255, 255, 0.88);

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -8,7 +8,6 @@ $success: #77b96c;
 $warning: #f7a501;
 $danger: #f96132;
 
-
 // Brand colors, as in logo
 $brand_blue: #1d4aff;
 $brand_red: #f54e00;

--- a/posthog/templates/overlays.html
+++ b/posthog/templates/overlays.html
@@ -1,5 +1,5 @@
 {% if debug %}
-<div id="bottom-notice">
+<div id="bottom-notice" class="tricolor">
     <div>
         <span>Current branch: </span><b><code>{{ git_branch|default:"unknown" }}</code></b
         ><span>.</span>
@@ -27,8 +27,8 @@
         document.body.prepend(element)
     }
 </script>
+{% endif %}
 
-{% endif %} {% if not debug %}
 <script>
     window.Papercups = {
         config: {
@@ -47,4 +47,3 @@
     }
 </script>
 <script type="text/javascript" async defer src="https://app.papercups.io/widget.js"></script>
-{% endif %}


### PR DESCRIPTION
## Changes

#2114 made the debug bar a purple gradient, which IMO is too tame and detracts from the original purpose of the bar: bringing attention to the fact that PostHog is running in development mode. Also, the bar's text color got broken outside of the React SPA (so for example on the login screen) by a Bootstrap dependency, which this also fixes (though I'm unsure why the issue has arisen in the first place).

Login screen before: 
<img width="1680" alt="Login screen before" src="https://user-images.githubusercontent.com/4550621/98496959-1bd48d80-2243-11eb-8718-0aa3065a2be4.png">

Login screen after:
<img width="1680" alt="Login screen after" src="https://user-images.githubusercontent.com/4550621/98496965-2131d800-2243-11eb-9afe-1a98468a5bc7.png">



