### PR TITLE
Improve instance status report

### DIFF
--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -64,7 +64,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
     return report
 
 
-def capture_event(name, report, dry_run):
+def capture_event(name: str, report: Dict[str, Any], dry_run: bool) -> None:
     if not dry_run:
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
         disabled = posthoganalytics.disabled
@@ -87,7 +87,7 @@ def fetch_persons_count_active_in_period(params: Tuple[Any, ...]) -> int:
 def fetch_event_counts_by_lib(params: Tuple[Any, ...]) -> dict:
     results = fetch_sql(
         """
-        SELECT properties->>'$lib' as lib, COUNT(*) as count
+        SELECT properties->>'$lib' as lib, COUNT(1) as count
         FROM posthog_event WHERE team_id = %s AND timestamp >= %s AND timestamp <= %s
         GROUP BY lib
         """,
@@ -99,7 +99,7 @@ def fetch_event_counts_by_lib(params: Tuple[Any, ...]) -> dict:
 def fetch_events_count_by_name(params: Tuple[Any, ...]) -> dict:
     results = fetch_sql(
         """
-        SELECT event as name, COUNT(*) as count
+        SELECT event as name, COUNT(1) as count
         FROM posthog_event WHERE team_id = %s AND timestamp >= %s AND timestamp <= %s
         GROUP BY name
         """,

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -29,6 +29,11 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         for user in User.objects.filter(last_login__gte=period_start)
     ]
     report["teams"] = {}
+    report["table_sizes"] = {
+        "posthog_event": fetch_table_size("posthog_event"),
+        "posthog_sessionrecordingevent": fetch_table_size("posthog_sessionrecordingevent"),
+    }
+
     for team in Team.objects.all():
         team_report: Dict[str, Any] = {}
         events_considered_total = Event.objects.filter(team_id=team.id)
@@ -94,6 +99,10 @@ def fetch_events_count_by_name(params: Tuple[Any, ...]) -> dict:
         params,
     )
     return {result.name: result.count for result in results}
+
+
+def fetch_table_size(table_name: str) -> int:
+    return fetch_sql("SELECT pg_total_relation_size(%s) as size", (table_name,))[0].size
 
 
 def fetch_sql(sql_: str, params: Tuple[Any, ...]) -> List[Any]:

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, Dict, List, Tuple
 
 import posthoganalytics
@@ -17,8 +18,10 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
     period_start, period_end = get_previous_week()
     report: Dict[str, Any] = {
         "posthog_version": VERSION,
+        "deployment": os.environ.get("DEPLOYMENT", "unknown"),
         "period": {"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
     }
+
     report["users_who_logged_in"] = [
         {"id": user.id, "distinct_id": user.distinct_id}
         if user.anonymize_data

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -6,7 +6,7 @@ import posthoganalytics
 from django.db import connection
 from psycopg2 import sql
 
-from posthog.models import Event, Team, User
+from posthog.models import Event, Person, Team, User
 from posthog.models.utils import namedtuplefetchall
 from posthog.utils import get_machine_id, get_previous_week
 from posthog.version import VERSION
@@ -40,9 +40,9 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         events_considered_new_in_period = events_considered_total.filter(
             timestamp__gte=period_start, timestamp__lte=period_end,
         )
-        persons_considered_total = Event.objects.filter(team_id=team.id)
+        persons_considered_total = Person.objects.filter(team_id=team.id)
         persons_considered_total_new_in_period = persons_considered_total.filter(
-            timestamp__gte=period_start, timestamp__lte=period_end,
+            created_at__gte=period_start, created_at__lte=period_end,
         )
         team_report["events_count_total"] = events_considered_total.count()
         team_report["events_count_new_in_period"] = events_considered_new_in_period.count()

--- a/posthog/tasks/test/test_status_report.py
+++ b/posthog/tasks/test/test_status_report.py
@@ -19,6 +19,8 @@ class TestStatusReport(BaseTest):
 
         self.assertEqual(report["posthog_version"], VERSION)
         self.assertEqual(report["deployment"], "tests")
+        self.assertLess(report["table_sizes"]["posthog_event"], 10 ** 7)  # <10MB
+        self.assertLess(report["table_sizes"]["posthog_sessionrecordingevent"], 10 ** 7)  # <10MB
 
     def test_team_status_report_event_counts(self) -> None:
         with freeze_time("2020-01-04T13:01:01Z"):

--- a/posthog/tasks/test/test_status_report.py
+++ b/posthog/tasks/test/test_status_report.py
@@ -5,7 +5,7 @@ from django.utils.timezone import datetime, now
 from freezegun import freeze_time
 
 from posthog.api.test.base import BaseTest
-from posthog.models import Dashboard, Event
+from posthog.models import Dashboard, Event, Person
 from posthog.tasks.status_report import status_report
 from posthog.version import VERSION
 
@@ -23,11 +23,17 @@ class TestStatusReport(BaseTest):
         self.assertLess(report["table_sizes"]["posthog_sessionrecordingevent"], 10 ** 7)  # <10MB
 
     def test_team_status_report_event_counts(self) -> None:
-        with freeze_time("2020-01-04T13:01:01Z"):
-            self.create_event("$event1", "$web", now() - relativedelta(weeks=1, hours=2))
-            self.create_event("$event2", "$web", now() - relativedelta(weeks=1, hours=1))
-            self.create_event("$event2", "$mobile", now() - relativedelta(weeks=1, hours=1))
-            self.create_event("$event3", "$mobile", now() - relativedelta(weeks=5))
+        with freeze_time("2020-11-02"):
+            self.create_person("old_user1")
+            self.create_person("old_user2")
+
+        with freeze_time("2020-11-10"):
+            self.create_person("new_user1")
+            self.create_person("new_user2")
+            self.create_event("new_user1", "$event1", "$web", now() - relativedelta(weeks=1, hours=2))
+            self.create_event("new_user1", "$event2", "$web", now() - relativedelta(weeks=1, hours=1))
+            self.create_event("new_user1", "$event2", "$mobile", now() - relativedelta(weeks=1, hours=1))
+            self.create_event("new_user1", "$event3", "$mobile", now() - relativedelta(weeks=5))
 
             team_report = status_report(dry_run=True).get("teams")[self.team.id]  # type: ignore
 
@@ -36,7 +42,19 @@ class TestStatusReport(BaseTest):
             self.assertEqual(team_report["events_count_by_lib"], {"$mobile": 1, "$web": 2})
             self.assertEqual(team_report["events_count_by_name"], {"$event1": 1, "$event2": 2})
 
-    def create_event(self, event: str, lib: str, created_at: datetime) -> None:
+            self.assertEqual(team_report["persons_count_total"], 4)
+            self.assertEqual(team_report["persons_count_new_in_period"], 2)
+            self.assertEqual(team_report["persons_count_active_in_period"], 1)
+
+    def create_person(self, distinct_id: str) -> None:
+        Person.objects.create(team=self.team, distinct_ids=[distinct_id])
+
+    def create_event(self, distinct_id: str, event: str, lib: str, created_at: datetime) -> None:
         Event.objects.create(
-            team=self.team, event=event, timestamp=created_at, created_at=created_at, properties={"$lib": lib}
+            team=self.team,
+            distinct_id=distinct_id,
+            event=event,
+            timestamp=created_at,
+            created_at=created_at,
+            properties={"$lib": lib},
         )

--- a/posthog/tasks/test/test_status_report.py
+++ b/posthog/tasks/test/test_status_report.py
@@ -1,13 +1,34 @@
+from dateutil.relativedelta import relativedelta
+from django.utils.timezone import datetime, now
 from freezegun import freeze_time
 
 from posthog.api.test.base import BaseTest
-from posthog.models import Dashboard
+from posthog.models import Dashboard, Event
 from posthog.tasks.status_report import status_report
 
 
 class TestStatusReport(BaseTest):
     TESTS_API = True
 
-    def test_sttus_report(self) -> None:
+    def test_status_report(self) -> None:
         with freeze_time("2020-01-04T13:01:01Z"):
             status_report(dry_run=True)
+
+    def test_team_status_report_event_counts(self) -> None:
+        with freeze_time("2020-01-04T13:01:01Z"):
+            self.create_event("$event1", "$web", now() - relativedelta(weeks=1, hours=2))
+            self.create_event("$event2", "$web", now() - relativedelta(weeks=1, hours=1))
+            self.create_event("$event2", "$mobile", now() - relativedelta(weeks=1, hours=1))
+            self.create_event("$event3", "$mobile", now() - relativedelta(weeks=5))
+
+            team_report = status_report(dry_run=True).get("teams")[self.team.id]  # type: ignore
+
+            self.assertEquals(team_report["events_count_total"], 4)
+            self.assertEquals(team_report["events_count_new_in_period"], 3)
+            self.assertEquals(team_report["events_count_by_lib"], {"$mobile": 1, "$web": 2})
+            self.assertEquals(team_report["events_count_by_name"], {"$event1": 1, "$event2": 2})
+
+    def create_event(self, event: str, lib: str, created_at: datetime) -> None:
+        Event.objects.create(
+            team=self.team, event=event, timestamp=created_at, created_at=created_at, properties={"$lib": lib}
+        )


### PR DESCRIPTION
- Refactor status report task, add tests
  Also discovered issue #2255
- Refactor status report further
- Add DEPLOYMENT env variable to instance status report
  Related issue #2138
- Report posthog_event and posthog_session_recordingevent table sizes
- Fix instance status report person numbers
  Fixes #2255

## Checklist

- [x] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [x] Django backend tests (if this PR affects the backend).
- [x] Cypress end-to-end tests (if this PR affects the frontend).
