### PR TITLE
Add data-attr to session recording toggle

### DIFF
--- a/frontend/src/scenes/project/Settings/OptInSessionRecording.tsx
+++ b/frontend/src/scenes/project/Settings/OptInSessionRecording.tsx
@@ -10,6 +10,7 @@ export function OptInSessionRecording(): JSX.Element {
     return (
         <div>
             <Switch
+                data-attr="opt-in-session-recording-switch"
                 onChange={(checked) => {
                     userUpdateRequest({ team: { session_recording_opt_in: checked } })
                 }}


### PR DESCRIPTION
Without this we can't really measure it being toggled

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
