### PR TITLE
Fix actions grouping by OR

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -46,7 +46,7 @@ def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: b
             ") OR uuid IN (SELECT uuid FROM events WHERE team_id = %(team_id)s AND ".join(or_queries)
         )
     else:
-        formatted_query = "({})".format(") OR (".join(or_queries))
+        formatted_query = "(({}))".format(") OR (".join(or_queries))
     return formatted_query, params
 
 

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -109,6 +109,7 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
             ActionStep.objects.create(event="$autocapture", action=action1, href="/a-url", selector="a")
             ActionStep.objects.create(event="$autocapture", action=action1, href="/a-url-2")
 
+            team2 = Team.objects.create()
             event1 = _create_event(
                 team=self.team,
                 event="$autocapture",
@@ -143,6 +144,20 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
                     # make sure elements don't get double counted if they're part of the same event
                     Element(tag_name="div", text="some_other_text", nth_child=0, nth_of_type=0,),
                 ],
+            )
+
+            # team leakage
+            _create_event(
+                team=team2,
+                event="$autocapture",
+                distinct_id="whatever2",
+                elements=[Element(tag_name="a", href="/a-url", text="some_other_text", nth_child=0, nth_of_type=0,),],
+            )
+            _create_event(
+                team=team2,
+                event="$autocapture",
+                distinct_id="whatever2",
+                elements=[Element(tag_name="a", href="/a-url-2", text="some_other_text", nth_child=0, nth_of_type=0,),],
             )
 
             events = _get_events_for_action(action1)


### PR DESCRIPTION
## Changes

Previously if actions had multiple steps (ie an or query), it would look like this: `(1=1) OR (1=2) AND team_id=2`, which would mean only the last OR query would be filtered by team, but the first one wouldn't. This fixes that.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
