### PR TITLE
Fix Asterisk in action selector

### DIFF
--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -95,10 +95,12 @@ class Selector(object):
 
     def __init__(self, selector: str, escape_slashes=True):
         self.parts = []
+        # Sometimes people manually add *, just remove them as they don't do anything
+        selector = selector.replace("> * > ", "").replace("> *", "")
         tags = re.split(" ", selector.strip())
         tags.reverse()
         for index, tag in enumerate(tags):
-            if tag == ">":
+            if tag == ">" or tag == "":
                 continue
             direct_descendant = False
             if index > 0 and tags[index - 1] == ">":

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -610,3 +610,21 @@ class TestSelectors(BaseTest):
         self.assertEqual(selector1.parts[1].data, {"tag_name": "div"})
         self.assertEqual(selector1.parts[1].direct_descendant, True)
         self.assertEqual(selector1.parts[1].unique_order, 1)
+
+    def test_asterisk_in_query(self):
+        # Sometimes people randomly add * but they don't do very much, so just remove them
+        selector1 = Selector("div > *")
+        self.assertEqual(selector1.parts[0].data, {"tag_name": "div"})
+        self.assertEqual(selector1.parts[0].direct_descendant, False)
+        self.assertEqual(selector1.parts[0].unique_order, 0)
+        self.assertEqual(len(selector1.parts), 1)
+
+    def test_asterisk_in_middle_of_query(self):
+        selector1 = Selector("div > * > div")
+        self.assertEqual(selector1.parts[0].data, {"tag_name": "div"})
+        self.assertEqual(selector1.parts[0].direct_descendant, False)
+        self.assertEqual(selector1.parts[0].unique_order, 0)
+
+        self.assertEqual(selector1.parts[1].data, {"tag_name": "div"})
+        self.assertEqual(selector1.parts[1].direct_descendant, False)
+        self.assertEqual(selector1.parts[1].unique_order, 1)


### PR DESCRIPTION
## Changes

Fixes [this Sentry error](https://sentry.io/organizations/posthog/issues/2011624721/events/19337ab10aa94b9ba6c54258f6f71b43/?project=1899813&query=is%3Aunresolved+api%2Faction&statsPeriod=14d) where someone had randomly added an * in the selectorl

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
