### PR TITLE
Fix cohort query missing filters

### DIFF
--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -8,6 +8,8 @@ from ee.clickhouse.models.person import create_person, create_person_distinct_id
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.api.test.base import BaseTest
+from posthog.models.action import Action
+from posthog.models.action_step import ActionStep
 from posthog.models.cohort import Cohort
 from posthog.models.event import Event
 from posthog.models.feature_flag import FeatureFlag
@@ -22,6 +24,14 @@ def _create_event(**kwargs) -> Event:
     kwargs.update({"event_uuid": pk})
     create_event(**kwargs)
     return Event(pk=str(pk))
+
+
+def _create_action(**kwargs):
+    team = kwargs.pop("team")
+    name = kwargs.pop("name")
+    action = Action.objects.create(team=team, name=name)
+    ActionStep.objects.create(action=action, event=name)
+    return action
 
 
 # Some custom stuff for this test as going via Person postgres model won't allow 2 people with same ID
@@ -73,6 +83,34 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
         self.assertTrue(feature_flag.distinct_id_matches("some_id"))
         self.assertFalse(feature_flag.distinct_id_matches("no_match"))
+
+    def test_prop_cohort_basic_action(self):
+
+        _create_person(distinct_ids=["some_other_id"], team_id=self.team.pk, properties={"$some_prop": "something"})
+
+        _create_person(
+            distinct_ids=["some_id"],
+            team_id=self.team.pk,
+            properties={"$some_prop": "something", "$another_prop": "something"},
+        )
+        _create_person(distinct_ids=["no_match"], team_id=self.team.pk)
+
+        action = _create_action(team=self.team, name="$pageview")
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="some_id", properties={"attr": "some_val"},
+        )
+
+        _create_event(
+            event="$not_pageview", team=self.team, distinct_id="some_other_id", properties={"attr": "some_val"},
+        )
+
+        cohort1 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk}], name="cohort1",)
+
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+        query, params = parse_prop_clauses(filter.properties, self.team)
+        final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
+        result = sync_execute(final_query, {**params, "team_id": self.team.pk})
+        self.assertEqual(len(result), 1)
 
     def test_prop_cohort_multiple_groups(self):
 

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -1,3 +1,3 @@
 CALCULATE_COHORT_PEOPLE_SQL = """
-SELECT distinct_id FROM person_distinct_id where person_id IN {query} AND team_id = %(team_id)s
+SELECT distinct_id FROM person_distinct_id where {query} AND team_id = %(team_id)s
 """


### PR DESCRIPTION
## Changes

*Please describe.*  
- action based cohort query was missing the right comparison because it needs 'distinct_id IN ' rather than 'person_id IN'
- inner query needs to have team_id filter otherwise events table filters all events
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
