### PR TITLE
Add option to print clickhouse SQL to terminal

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -1,9 +1,12 @@
 import asyncio
+from time import time
 
+import sqlparse
 from aioch import Client
 from asgiref.sync import async_to_sync
 from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
+from django.conf import settings
 
 from posthog.settings import (
     CLICKHOUSE,
@@ -72,6 +75,29 @@ else:
     )
 
     def sync_execute(query, args=None):
-        with ch_sync_pool.get_client() as client:
-            result = client.execute(query, args)
+        start_time = time()
+        try:
+            with ch_sync_pool.get_client() as client:
+                result = client.execute(query, args)
+        finally:
+            execution_time = time() - start_time
+            if settings.SHELL_PLUS_PRINT_SQL:
+                print(format_sql(query, args))
+                print("Execution time: %.6fs" % (execution_time,))
         return result
+
+
+def format_sql(parameterized_sql, params):
+    params = {key: repr(value) for key, value in (params or {}).items()}
+    sql = parameterized_sql.replace("%(", "{").replace(")s", "}").format(**params)
+
+    sql = sqlparse.format(sql, reindent_aligned=True)
+    try:
+        import pygments.formatters
+        import pygments.lexers
+
+        sql = pygments.highlight(sql, pygments.lexers.get_lexer_by_name("sql"), pygments.formatters.TerminalFormatter())
+    except:
+        pass
+
+    return sql

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -87,10 +87,8 @@ else:
         return result
 
 
-def format_sql(parameterized_sql, params):
-    params = {key: repr(value) for key, value in (params or {}).items()}
-    sql = parameterized_sql.replace("%(", "{").replace(")s", "}").format(**params)
-
+def format_sql(sql, params):
+    sql = ch_client.substitute_params(sql, params)
     sql = sqlparse.format(sql, reindent_aligned=True)
     try:
         import pygments.formatters

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -60,6 +60,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEBUG = get_bool_from_env("DEBUG", False)
 TEST = "test" in sys.argv  # type: bool
 SELF_CAPTURE = get_bool_from_env("SELF_CAPTURE", DEBUG)
+SHELL_PLUS_PRINT_SQL = get_bool_from_env("PRINT_SQL", False)
 
 SITE_URL = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
 


### PR DESCRIPTION
Without this, debugging why queries are slow requires a lot of work to
figure out what the actual query is. This came up yesterday when
debugging slow /decide endpoint responses.

Heavily inspired by https://github.com/django-extensions/django-extensions/blob/dba2da861b9412c1e0b67ae4b3f80df0c6bc23ea/django_extensions/management/debug_cursor.py

To use this, run e.g. `PRINT_SQL=1 ./bin/start-backend` or `PRINT_SQL=1
python manage.py shell_plus`

![Screenshot from 2020-11-10 10-18-44](https://user-images.githubusercontent.com/148820/98648232-acdc5f00-233e-11eb-9730-7e024a921067.png)
