### PR TITLE
Closes #2286 remove restrict signups

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -14,14 +14,6 @@ class TestUser(BaseTest):
         response = self.client.get("/api/user/redirect_to_site/?actionId=1")
         self.assertIn("http://somewebsite.com", response.url)
 
-    def test_create_user_when_restricted(self):
-        with self.settings(RESTRICT_SIGNUPS="posthog.com,uk.posthog.com"):
-            with self.assertRaisesMessage(ValueError, "Can't sign up with this email"):
-                User.objects.create_user(first_name="Tim Gmail", email="tim@gmail.com", password=None)
-
-            user = User.objects.create_user(first_name="Tim PostHog", email="tim@uk.posthog.com", password=None)
-            self.assertEqual(user.email, "tim@uk.posthog.com")
-
     def test_create_user_with_distinct_id(self):
         with self.settings(TEST=False):
             user = User.objects.create_user(first_name="Tim", email="tim@gmail.com", password=None)

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -11,22 +11,6 @@ from .team import Team
 from .utils import generate_random_token, sane_repr
 
 
-def is_email_restricted_from_signup(email: str) -> bool:
-    if not getattr(settings, "RESTRICT_SIGNUPS", False):
-        return False
-
-    restricted_signups: Union[str, bool] = settings.RESTRICT_SIGNUPS
-    if restricted_signups is False:
-        return False
-
-    domain = email.rsplit("@", 1)[1]
-    whitelisted_domains = str(settings.RESTRICT_SIGNUPS).split(",")
-    if domain in whitelisted_domains:
-        return False
-
-    return True
-
-
 class UserManager(BaseUserManager):
     """Define a model manager for User model with no username field."""
 
@@ -37,8 +21,6 @@ class UserManager(BaseUserManager):
         if email is None:
             raise ValueError("Email must be provided!")
         email = self.normalize_email(email)
-        if is_email_restricted_from_signup(email):
-            raise ValueError("Can't sign up with this email!")
         extra_fields.setdefault("distinct_id", generate_random_token())
         user = self.model(email=email, first_name=first_name, **extra_fields)
         if password is not None:

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -452,9 +452,6 @@ EMAIL_USE_SSL = get_bool_from_env("EMAIL_USE_SSL", False)
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "hey@posthog.com")
 
 
-# You can pass a comma deliminated list of domains with which users can sign up to this service
-RESTRICT_SIGNUPS = get_bool_from_env("RESTRICT_SIGNUPS", False)
-
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",


### PR DESCRIPTION
## Changes

We're now doing individual invites per email so don't need this anymore

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
