### PR TITLE
Closes #2283 fix heatmap

### DIFF
--- a/ee/clickhouse/sql/element.py
+++ b/ee/clickhouse/sql/element.py
@@ -1,0 +1,32 @@
+GET_ELEMENTS = """
+SELECT
+    elements_chain, count(1) as count
+FROM events
+WHERE
+    team_id = %(team_id)s AND
+    event = '$autocapture' AND
+    elements_chain != ''
+    {date_from}
+    {date_to}
+    {query}
+GROUP BY elements_chain
+ORDER BY count DESC
+LIMIT 100;
+"""
+
+GET_VALUES = """
+SELECT
+    extract(elements_chain, %(regex)s) as value, count(1) as count
+FROM (
+      SELECT elements_chain
+      FROM events
+      WHERE team_id = %(team_id)s
+        AND event = '$autocapture'
+        AND elements_chain != ''
+        AND match(elements_chain, %(filter_regex)s)
+        LIMIT 100000
+)
+GROUP BY value
+ORDER BY count desc
+LIMIT 100;
+"""

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -1,0 +1,60 @@
+from rest_framework import authentication, request, response, serializers, viewsets
+from rest_framework.decorators import action
+
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.element import chain_to_elements
+from ee.clickhouse.models.property import parse_prop_clauses
+from ee.clickhouse.queries.util import parse_timestamps
+from ee.clickhouse.sql.element import GET_ELEMENTS, GET_VALUES
+from posthog.api.element import ElementSerializer, ElementViewSet
+from posthog.models.filter import Filter
+
+
+class ClickhouseElement(ElementViewSet):
+    @action(methods=["GET"], detail=False)
+    def stats(self, request: request.Request) -> response.Response:
+        filter = Filter(request=request)
+
+        date_from, date_to = parse_timestamps(filter)
+
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, request.user.team)
+        result = sync_execute(
+            GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters),
+            {"team_id": request.user.team.id, **prop_filter_params},
+        )
+        return response.Response(
+            [
+                {
+                    "count": elements[1],
+                    "hash": None,
+                    "elements": [ElementSerializer(element).data for element in chain_to_elements(elements[0])],
+                }
+                for elements in result
+            ]
+        )
+
+    @action(methods=["GET"], detail=False)
+    def values(self, request: request.Request) -> response.Response:
+        key = request.GET.get("key")
+        value = request.GET.get("value")
+        select_regex = '[:|"]{}="(.*?)"'.format(key)
+
+        # Make sure key exists, otherwise could lead to sql injection lower down
+        if key not in self.serializer_class.Meta.fields:
+            return response.Response([])
+
+        if key == "tag_name":
+            select_regex = "^([-_a-zA-Z0-9]*?)[\.|:]"
+            filter_regex = select_regex
+            if value:
+                filter_regex = "^([-_a-zA-Z0-9]*?{}[-_a-zA-Z0-9]*?)[\.|:]".format(value)
+        else:
+            if value:
+                filter_regex = '[:|"]{}=".*?{}.*?"'.format(key, value)
+            else:
+                filter_regex = select_regex
+
+        result = sync_execute(
+            GET_VALUES.format(), {"team_id": request.user.team.id, "regex": select_regex, "filter_regex": filter_regex}
+        )
+        return response.Response([{"name": value[0]} for value in result])

--- a/ee/clickhouse/views/test/test_clickhouse_element.py
+++ b/ee/clickhouse/views/test/test_clickhouse_element.py
@@ -1,0 +1,17 @@
+from uuid import uuid4
+
+from ee.clickhouse.models.event import create_event
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.api.test.test_element import test_element_factory
+from posthog.models import Event
+
+
+def _create_event(**kwargs):
+    kwargs.update({"event_uuid": uuid4()})
+    return Event(pk=create_event(**kwargs))
+
+
+class TestElement(
+    ClickhouseTestMixin, test_element_factory(_create_event)  # type: ignore
+):
+    pass

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -41,7 +41,6 @@ def api_not_found(request):
 
 router = DefaultRouterPlusPlus()
 router.register(r"annotation", annotation.AnnotationsViewSet)
-router.register(r"element", element.ElementViewSet)
 router.register(r"feature_flag", feature_flag.FeatureFlagViewSet)
 router.register(r"funnel", funnel.FunnelViewSet)
 router.register(r"dashboard", dashboard.DashboardsViewSet)
@@ -68,6 +67,7 @@ organizations_router.register(
 if check_ee_enabled():
     try:
         from ee.clickhouse.views.actions import ClickhouseActions
+        from ee.clickhouse.views.element import ClickhouseElement
         from ee.clickhouse.views.events import ClickhouseEvents
         from ee.clickhouse.views.insights import ClickhouseInsights
         from ee.clickhouse.views.paths import ClickhousePathsViewSet
@@ -81,6 +81,7 @@ if check_ee_enabled():
     router.register(r"insight", ClickhouseInsights, basename="insight")
     router.register(r"person", ClickhousePerson, basename="person")
     router.register(r"paths", ClickhousePathsViewSet, basename="paths")
+    router.register(r"element", ClickhouseElement, basename="element")
 
 else:
     router.register(r"insight", insight.InsightViewSet)
@@ -88,3 +89,4 @@ else:
     router.register(r"person", person.PersonViewSet)
     router.register(r"event", event.EventViewSet)
     router.register(r"paths", paths.PathsViewSet, basename="paths")
+    router.register(r"element", element.ElementViewSet)

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -1,5 +1,3 @@
-import json
-
 from django.db.models import Count, Prefetch, QuerySet
 from rest_framework import authentication, request, response, serializers, viewsets
 from rest_framework.decorators import action

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -1,4 +1,5 @@
 import json
+from typing import Callable
 
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
@@ -8,76 +9,91 @@ from posthog.models import Element, ElementGroup, Event, Team
 from .base import BaseTest
 
 
-class TestElement(BaseTest):
-    TESTS_API = True
+def test_element_factory(create_event: Callable) -> Callable:
+    class TestElement(BaseTest):
+        TESTS_API = True
 
-    def test_element_automatic_order(self):
-        elements = [
-            Element(tag_name="a", href="https://posthog.com/about", text="click here"),
-            Element(tag_name="span"),
-            Element(tag_name="div"),
-        ]
-        ElementGroup.objects.create(team=self.team, elements=elements)
+        def test_element_automatic_order(self):
+            elements = [
+                Element(tag_name="a", href="https://posthog.com/about", text="click here"),
+                Element(tag_name="span"),
+                Element(tag_name="div"),
+            ]
+            ElementGroup.objects.create(team=self.team, elements=elements)
 
-        self.assertEqual(elements[0].order, 0)
-        self.assertEqual(elements[1].order, 1)
-        self.assertEqual(elements[2].order, 2)
+            self.assertEqual(elements[0].order, 0)
+            self.assertEqual(elements[1].order, 1)
+            self.assertEqual(elements[2].order, 2)
 
-    def test_event_property_values(self):
-        group = ElementGroup.objects.create(
-            team=self.team, elements=[Element(tag_name="a", href="https://posthog.com/about", text="click here")],
-        )
-        team2 = Team.objects.create()
-        ElementGroup.objects.create(team=team2, elements=[Element(tag_name="bla")])
-        response = self.client.get("/api/element/values/?key=tag_name").json()
-        self.assertEqual(response[0]["name"], "a")
-        self.assertEqual(len(response), 1)
+        def test_event_property_values(self):
+            create_event(
+                team=self.team,
+                distinct_id="test",
+                event="$autocapture",
+                elements=[Element(tag_name="a", href="https://posthog.com/about", text="click here")],
+            )
+            team2 = Team.objects.create()
+            create_event(team=team2, distinct_id="test", event="$autocapture", elements=[Element(tag_name="bla")])
+            response = self.client.get("/api/element/values/?key=tag_name").json()
+            self.assertEqual(response[0]["name"], "a")
+            self.assertEqual(len(response), 1)
 
-        response = self.client.get("/api/element/values/?key=text&value=click").json()
-        self.assertEqual(response[0]["name"], "click here")
-        self.assertEqual(len(response), 1)
+            response = self.client.get("/api/element/values/?key=text&value=click").json()
+            self.assertEqual(response[0]["name"], "click here")
+            self.assertEqual(len(response), 1)
 
-    def test_element_stats(self):
-        elements = [
-            Element(tag_name="a", href="https://posthog.com/about", text="click here", order=0,),
-            Element(tag_name="div", href="https://posthog.com/about", text="click here", order=1,),
-        ]
-        event1 = Event.objects.create(
-            team=self.team,
-            elements=elements,
-            event="$autocapture",
-            properties={"$current_url": "http://example.com/demo"},
-        )
-        Event.objects.create(
-            team=self.team,
-            elements=elements,
-            event="$autocapture",
-            properties={"$current_url": "http://example.com/demo"},
-        )
-        # make sure we only load last 7 days by default
-        Event.objects.create(
-            timestamp=now() - relativedelta(days=8),
-            team=self.team,
-            elements=elements,
-            event="$autocapture",
-            properties={"$current_url": "http://example.com/demo"},
-        )
+        def test_element_stats(self):
+            elements = [
+                Element(tag_name="a", href="https://posthog.com/about", text="click here", order=0,),
+                Element(tag_name="div", href="https://posthog.com/about", text="click here", order=1,),
+            ]
+            event1 = create_event(
+                team=self.team,
+                elements=elements,
+                event="$autocapture",
+                distinct_id="test",
+                properties={"$current_url": "http://example.com/demo"},
+            )
+            create_event(
+                team=self.team,
+                elements=elements,
+                event="$autocapture",
+                distinct_id="test",
+                properties={"$current_url": "http://example.com/demo"},
+            )
+            # make sure we only load last 7 days by default
+            create_event(
+                timestamp=now() - relativedelta(days=8),
+                team=self.team,
+                elements=elements,
+                event="$autocapture",
+                distinct_id="test",
+                properties={"$current_url": "http://example.com/demo"},
+            )
 
-        Event.objects.create(
-            team=self.team,
-            event="$autocapture",
-            properties={"$current_url": "http://example.com/something_else"},
-            elements=[Element(tag_name="img")],
-        )
+            create_event(
+                team=self.team,
+                event="$autocapture",
+                distinct_id="test",
+                properties={"$current_url": "http://example.com/something_else"},
+                elements=[Element(tag_name="img")],
+            )
 
-        with self.assertNumQueries(6):
-            response = self.client.get("/api/element/stats/").json()
-        self.assertEqual(response[0]["count"], 2)
-        self.assertEqual(response[0]["hash"], event1.elements_hash)
-        self.assertEqual(response[0]["elements"][0]["tag_name"], "a")
-        self.assertEqual(response[1]["count"], 1)
+            with self.assertNumQueries(6):
+                response = self.client.get("/api/element/stats/").json()
+            self.assertEqual(response[0]["count"], 2)
+            self.assertEqual(response[0]["hash"], event1.elements_hash)
+            self.assertEqual(response[0]["elements"][0]["tag_name"], "a")
+            self.assertEqual(response[1]["count"], 1)
 
-        response = self.client.get(
-            "/api/element/stats/?properties=%s"
-            % json.dumps([{"key": "$current_url", "value": "http://example.com/demo"}])
-        ).json()
+            response = self.client.get(
+                "/api/element/stats/?properties=%s"
+                % json.dumps([{"key": "$current_url", "value": "http://example.com/demo"}])
+            ).json()
+            self.assertEqual(len(response), 1)
+
+    return TestElement
+
+
+class TestElement(test_element_factory(Event.objects.create)):  # type: ignore
+    pass


### PR DESCRIPTION
## Changes

We hadn't implemented the /stats and /values endpoint for elements in clickhouse yet.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
