### PR TITLE
Make sure properties filter on breakdown

### DIFF
--- a/ee/clickhouse/queries/clickhouse_trends.py
+++ b/ee/clickhouse/queries/clickhouse_trends.py
@@ -214,6 +214,7 @@ class ClickhouseTrends(BaseQuery):
                 actions_query="AND {}".format(action_query) if action_query else "",
                 event_filter="AND event = %(event)s" if not action_query else "",
                 latest_person_sql=GET_LATEST_PERSON_SQL.format(query=""),
+                filters="{filters}".format(filters=prop_filters) if props_to_filter else "",
             )
             breakdown_query = BREAKDOWN_QUERY_SQL.format(
                 null_sql=null_sql,
@@ -251,6 +252,7 @@ class ClickhouseTrends(BaseQuery):
                 aggregate_operation=aggregate_operation,
                 interval_annotation=interval_annotation,
             )
+
         try:
             result = sync_execute(breakdown_query, params)
         except:

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -64,7 +64,7 @@ INNER JOIN (
     ) ep
     WHERE key = %(key)s
 ) ep 
-ON person_id = ep.id WHERE e.team_id = %(team_id)s {event_filter} {parsed_date_from} {parsed_date_to}
+ON person_id = ep.id WHERE e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from} {parsed_date_to}
 AND breakdown_value in (%(values)s) {actions_query}
 """
 
@@ -75,7 +75,7 @@ INNER JOIN (
     FROM events_properties_view AS ep
     WHERE key = %(key)s and team_id = %(team_id)s
 ) ep 
-ON uuid = ep.event_id where e.team_id = %(team_id)s {event_filter} {parsed_date_from} {parsed_date_to}
+ON uuid = ep.event_id where e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from} {parsed_date_to}
 AND breakdown_value in (%(values)s) {actions_query}
 """
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses #2313 
- breakdown query was missing filtering param

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
