### PR TITLE
Handle intervals don't rely on date_to for people

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
+from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.decorators import action
@@ -65,12 +66,17 @@ class ClickhouseActions(ActionViewSet):
             entity = Entity({"id": request.GET["entityId"], "type": request.GET["type"]})
 
         # adhoc date handling. parsed differently with django orm
+        date_from = filter.date_from or timezone.now()
         if filter.interval == "month":
-            filter._date_to = (
-                timezone.now()
-                if not filter.date_from
-                else (filter.date_from + timedelta(days=31)).strftime("%Y-%m-%d %H:%M:%S")
-            )
+            filter._date_to = (date_from + relativedelta(months=1) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+        elif filter.interval == "week":
+            filter._date_to = date_from + relativedelta(weeks=1)
+        elif filter.interval == "day":
+            filter._date_to = date_from + relativedelta(day=1)
+        elif filter.interval == "hour":
+            filter._date_to = date_from + relativedelta(hours=1)
+        elif filter.interval == "minute":
+            filter._date_to = date_from + relativedelta(minutes=1)
 
         current_url = request.get_full_path()
 

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -179,7 +179,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "interval": "hour",
                     "date_from": "2020-01-04 14:00:00",
-                    "date_to": "2020-01-04 15:00:00",
+                    "date_to": "2020-01-04 14:00:00",
                     "type": "actions",
                     "entityId": sign_up_action.id,
                 },
@@ -189,12 +189,11 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "interval": "hour",
                     "date_from": "2020-01-04 14:00:00",
-                    "date_to": "2020-01-04 15:00:00",
+                    "date_to": "2020-01-04 14:00:00",
                     "type": "events",
                     "entityId": "sign up",
                 },
             ).json()
-
             self.assertEqual(str(action_response["results"][0]["people"][0]["id"]), str(person1.pk))
             self.assertEqual(len(action_response["results"][0]["people"]), 1)
             self.assertTrue(
@@ -207,7 +206,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "interval": "hour",
                     "date_from": "2020-01-04 16:00:00",
-                    "date_to": "2020-01-04 17:00:00",
+                    "date_to": "2020-01-04 16:00:00",
                     "type": "actions",
                     "entityId": sign_up_action.id,
                 },
@@ -217,7 +216,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "interval": "hour",
                     "date_from": "2020-01-04 16:00:00",
-                    "date_to": "2020-01-04 17:00:00",
+                    "date_to": "2020-01-04 16:00:00",
                     "type": "events",
                     "entityId": "sign up",
                 },
@@ -235,7 +234,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
             min_grouped_action_response = self.client.get(
                 "/api/action/people/",
                 data={
-                    "interval": "hour",
+                    "interval": "minute",
                     "date_from": "2020-01-04 19:20:00",
                     "date_to": "2020-01-04 19:20:00",
                     "type": "actions",
@@ -245,7 +244,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
             min_grouped_grevent_response = self.client.get(
                 "/api/action/people/",
                 data={
-                    "interval": "hour",
+                    "interval": "minute",
                     "date_from": "2020-01-04 19:20:00",
                     "date_to": "2020-01-04 19:20:00",
                     "type": "events",
@@ -268,7 +267,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "interval": "week",
                     "date_from": "2019-11-01",
-                    "date_to": "2019-11-08",
+                    "date_to": "2019-11-01",
                     "type": "actions",
                     "entityId": sign_up_action.id,
                 },
@@ -278,7 +277,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "interval": "week",
                     "date_from": "2019-11-01",
-                    "date_to": "2019-11-08",
+                    "date_to": "2019-11-01",
                     "type": "events",
                     "entityId": "sign up",
                 },


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
