### PR TITLE
Fix local static file host on Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin')
 
 const webpackDevServerHost = process.env.WEBPACK_HOT_RELOAD_HOST || '127.0.0.1'
+const webpackDevServerFrontendAddr = webpackDevServerHost === '0.0.0.0' ? '127.0.0.1' : webpackDevServerHost
 
 // main = app
 // toolbar = toolbar
@@ -41,7 +42,7 @@ function createEntry(entry) {
                     ? `${process.env.JS_URL}${process.env.JS_URL.endsWith('/') ? '' : '/'}static/`
                     : process.env.IS_PORTER
                     ? `https://${process.env.PORTER_WEBPACK_HOST}/static/`
-                    : `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerHost}:8234/static/`,
+                    : `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerFrontendAddr}:8234/static/`,
         },
         resolve: {
             extensions: ['.js', '.ts', '.tsx'],
@@ -196,7 +197,7 @@ function createEntry(entry) {
                 ? new URL(process.env.JS_URL).host
                 : process.env.IS_PORTER
                 ? `${process.env.PORTER_WEBPACK_HOST}`
-                : `${webpackDevServerHost}:8234`,
+                : `${webpackDevServerFrontendAddr}:8234`,
             allowedHosts: process.env.IS_PORTER
                 ? [`${process.env.PORTER_WEBPACK_HOST}`, `${process.env.PORTER_SERVER_HOST}`]
                 : [],


### PR DESCRIPTION
## Changes

Addresses a Windows specific issue following on from #1912.

`0.0.0.0` is non-routable address that a browser won't connect to. Linux helps out by converting that to `127.0.0.1` automatically but Windows does not.

On local deployment the frontend server is set to listen on `0.0.0.0` which is correct, but the client also uses this as the host address to connect to the server which results in an error on Windows.

![image](https://user-images.githubusercontent.com/11885987/98691354-dceb2880-2365-11eb-935a-1615eaf35cee.png)

This PR keeps the server listening on `0.0.0.0` (or whatever `WEBPACK_HOT_RELOAD_HOST` is set to), but changes the address on the client end to point to localhost (or `WEBPACK_HOT_RELOAD_HOST` if set).

## Checklist

- [ ] ~All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).~
- [ ] ~Django backend tests (if this PR affects the backend).~
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
