### PR TITLE
Fix Hidden Properties Display State

### DIFF
--- a/frontend/src/scenes/events/EventDetails.js
+++ b/frontend/src/scenes/events/EventDetails.js
@@ -12,12 +12,14 @@ export function EventDetails({ event }) {
     const [showHiddenProps, setShowHiddenProps] = useState(false)
 
     let displayedEventProperties = {}
+    let visibleHiddenProperties = {}
     let hiddenPropsCount = 0
     for (let key of Object.keys(event.properties)) {
         if (keyMapping.event[key] && keyMapping.event[key].hide) {
             hiddenPropsCount += 1
+            if (showHiddenProps) visibleHiddenProperties[key] = event.properties[key]
         }
-        if (!keyMapping.event[key] || !keyMapping.event[key].hide || showHiddenProps) {
+        if (!keyMapping.event[key] || !keyMapping.event[key].hide) {
             displayedEventProperties[key] = event.properties[key]
         }
     }
@@ -42,6 +44,7 @@ export function EventDetails({ event }) {
                         properties={{
                             $timestamp: moment(event.timestamp).toISOString(),
                             ...displayedEventProperties,
+                            ...visibleHiddenProperties,
                         }}
                     />
                     {hiddenPropsCount > 0 && (


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Closes #1928 

Hidden properties will now be added to the bottom of the list when made visible.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
