### PR TITLE
Fix 'Found 99 users' when there are more

### DIFF
--- a/frontend/src/scenes/insights/PeopleModal.js
+++ b/frontend/src/scenes/insights/PeopleModal.js
@@ -25,7 +25,7 @@ export function PeopleModal({ visible, view }) {
         >
             {people ? (
                 <p>
-                    Found {people.count} {people.count === 1 ? 'user' : 'users'}
+                    Found {people.count === 99 ? '99+' : people.count} {people.count === 1 ? 'user' : 'users'}
                 </p>
             ) : (
                 <p>Loading users...</p>


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

If a data point has more than 99 users, we currently say "found 99 users", which is weird for the user. This happens because of the endpoint pagination, which won't return all users at once. Adding a simple '+' here should improve the UX.

Closes #2246

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
