### PR TITLE
Implement missing person datapoint on breakdown

### DIFF
--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -204,7 +204,7 @@ ALTER TABLE person UPDATE is_identified = %(is_identified)s where id = %(id)s
 """
 
 PERSON_TREND_SQL = """
-SELECT DISTINCT distinct_id FROM events WHERE team_id = %(team_id)s {entity_filter} {filters} {parsed_date_from} {parsed_date_to}
+SELECT DISTINCT distinct_id FROM events WHERE team_id = %(team_id)s {entity_filter} {filters} {parsed_date_from} {parsed_date_to} {person_filter}
 """
 
 PEOPLE_THROUGH_DISTINCT_SQL = """

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
+from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.person import ClickhousePersonSerializer
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.util import parse_timestamps
@@ -19,8 +20,10 @@ from ee.clickhouse.sql.stickiness.stickiness_people import STICKINESS_PEOPLE_SQL
 from posthog.api.action import ActionSerializer, ActionViewSet
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.action import Action
+from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filter import Filter
+from posthog.models.property import Property
 from posthog.models.team import Team
 
 
@@ -153,22 +156,34 @@ class ClickhouseActions(ActionViewSet):
 
     def _calculate_entity_people(self, team: Team, entity: Entity, filter: Filter):
         parsed_date_from, parsed_date_to = parse_timestamps(filter=filter)
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team)
         entity_sql, entity_params = self._format_entity_filter(entity=entity)
+        person_filter, person_filter_params = "", {}
+
+        if filter.breakdown_type == "cohort" and filter.breakdown_value != "all":
+            cohort = Cohort.objects.get(pk=filter.breakdown_value)
+            person_filter, person_filter_params = format_filter_query(cohort)
+            person_filter = "AND distinct_id IN ({})".format(person_filter)
+        elif filter.breakdown_type == "person":
+            person_prop = Property(**{"key": filter.breakdown, "value": filter.breakdown_value, "type": "person"})
+            filter.properties.append(person_prop)
+
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team)
         params: Dict = {"team_id": team.pk, **prop_filter_params, **entity_params, "offset": filter.offset}
 
         content_sql = PERSON_TREND_SQL.format(
             entity_filter=entity_sql,
             parsed_date_from=(parsed_date_from or ""),
             parsed_date_to=(parsed_date_to or ""),
-            filters="{filters}".format(filters=prop_filters) if filter.properties else "",
+            filters=prop_filters if filter.properties else "",
             breakdown_filter="",
+            person_filter=person_filter,
         )
+
         people = sync_execute(
             PEOPLE_THROUGH_DISTINCT_SQL.format(
                 content_sql=content_sql, latest_person_sql=GET_LATEST_PERSON_SQL.format(query="")
             ),
-            params,
+            {**params, **person_filter_params},
         )
         serialized_people = ClickhousePersonSerializer(people, many=True).data
 

--- a/ee/clickhouse/views/test/test_clickhouse_action.py
+++ b/ee/clickhouse/views/test/test_clickhouse_action.py
@@ -28,7 +28,7 @@ def _create_cohort(**kwargs):
 
 def _create_person(**kwargs):
     person = Person.objects.create(**kwargs)
-    return Person(id=person.uuid)
+    return Person(id=str(person.uuid))
 
 
 def _create_event(**kwargs):

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -440,70 +440,70 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 self._compare_entity_response(action_response["results"], event_response["results"], remove=[])
             )
 
-        # def test_breakdown_by_cohort_people_endpoint(self):
-        #     person1, person2, person3, person4 = self._create_multiple_people()
-        #     cohort = cohort_factory(name="cohort1", team=self.team, groups=[{"properties": {"name": "person1"}}])
-        #     cohort2 = cohort_factory(name="cohort2", team=self.team, groups=[{"properties": {"name": "person2"}}])
-        #     cohort3 = cohort_factory(
-        #         name="cohort3",
-        #         team=self.team,
-        #         groups=[{"properties": {"name": "person1"}}, {"properties": {"name": "person2"}},],
-        #     )
-        #     action = action_factory(name="watched movie", team=self.team)
+        def test_breakdown_by_cohort_people_endpoint(self):
+            person1, person2, person3, person4 = self._create_multiple_people()
+            cohort = cohort_factory(name="cohort1", team=self.team, groups=[{"properties": {"name": "person1"}}])
+            cohort2 = cohort_factory(name="cohort2", team=self.team, groups=[{"properties": {"name": "person2"}}])
+            cohort3 = cohort_factory(
+                name="cohort3",
+                team=self.team,
+                groups=[{"properties": {"name": "person1"}}, {"properties": {"name": "person2"}},],
+            )
+            action = action_factory(name="watched movie", team=self.team)
 
-        #     people = self.client.get(
-        #         "/api/action/people/",
-        #         data={
-        #             "date_from": "2020-01-01",
-        #             "date_to": "2020-01-07",
-        #             "type": "events",
-        #             "entityId": "watched movie",
-        #             "breakdown_type": "cohort",
-        #             "breakdown_value": cohort.pk,
-        #             "breakdown": [cohort.pk],  # this shouldn't do anything
-        #         },
-        #     ).json()
+            people = self.client.get(
+                "/api/action/people/",
+                data={
+                    "date_from": "2020-01-01",
+                    "date_to": "2020-01-07",
+                    "type": "events",
+                    "entityId": "watched movie",
+                    "breakdown_type": "cohort",
+                    "breakdown_value": cohort.pk,
+                    "breakdown": [cohort.pk],  # this shouldn't do anything
+                },
+            ).json()
 
-        #     self.assertEqual(len(people["results"][0]["people"]), 1)
-        #     ordered_people = sorted(people["results"][0]["people"], key= lambda i: i['id'])
-        #     self.assertEqual(ordered_people[0]["id"], person1)
+            self.assertEqual(len(people["results"][0]["people"]), 1)
+            ordered_people = sorted(people["results"][0]["people"], key=lambda i: i["id"])
+            self.assertEqual(ordered_people[0]["id"], person1.pk)
 
-        #     # all people
-        #     people = self.client.get(
-        #         "/api/action/people/",
-        #         data={
-        #             "date_from": "2020-01-01",
-        #             "date_to": "2020-01-07",
-        #             "type": "events",
-        #             "entityId": "watched movie",
-        #             "breakdown_type": "cohort",
-        #             "breakdown_value": "all",
-        #             "breakdown": [cohort.pk],
-        #         },
-        #     ).json()
+            # all people
+            people = self.client.get(
+                "/api/action/people/",
+                data={
+                    "date_from": "2020-01-01",
+                    "date_to": "2020-01-07",
+                    "type": "events",
+                    "entityId": "watched movie",
+                    "breakdown_type": "cohort",
+                    "breakdown_value": "all",
+                    "breakdown": [cohort.pk],
+                },
+            ).json()
 
-        #     self.assertEqual(len(people["results"][0]["people"]), 4)
-        #     ordered_people = sorted(people["results"][0]["people"], key= lambda i: i['id'])
-        #     self.assertEqual(ordered_people[0]["id"], person1)
+            self.assertEqual(len(people["results"][0]["people"]), 4)
+            ordered_people = sorted(people["results"][0]["people"], key=lambda i: i["id"])
+            self.assertEqual(ordered_people[0]["id"], person1.pk)
 
-        # def test_breakdown_by_person_property_people_endpoint(self):
-        #     person1, person2, person3, person4 = self._create_multiple_people()
-        #     action = action_factory(name="watched movie", team=self.team)
+        def test_breakdown_by_person_property_people_endpoint(self):
+            person1, person2, person3, person4 = self._create_multiple_people()
+            action = action_factory(name="watched movie", team=self.team)
 
-        #     people = self.client.get(
-        #         "/api/action/people/",
-        #         data={
-        #             "date_from": "2020-01-01",
-        #             "date_to": "2020-01-07",
-        #             "type": "events",
-        #             "entityId": "watched movie",
-        #             "breakdown_type": "person",
-        #             "breakdown_value": "person3",
-        #             "breakdown": "name",
-        #         },
-        #     ).json()
-        #     self.assertEqual(len(people["results"][0]["people"]), 1)
-        #     self.assertEqual(people["results"][0]["people"][0]["name"], "person3")
+            people = self.client.get(
+                "/api/action/people/",
+                data={
+                    "date_from": "2020-01-01",
+                    "date_to": "2020-01-07",
+                    "type": "events",
+                    "entityId": "watched movie",
+                    "breakdown_type": "person",
+                    "breakdown_value": "person3",
+                    "breakdown": "name",
+                },
+            ).json()
+            self.assertEqual(len(people["results"][0]["people"]), 1)
+            self.assertEqual(people["results"][0]["people"][0]["id"], person3.pk)
 
     return TestActionPeople
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- properly query users when datapoint si clicked with breakdown
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
