### PR TITLE
Fix doubled up slack hook

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -48,7 +48,7 @@ def get_person_ids_by_cohort_id(team: Team, cohort_id: int):
     from ee.clickhouse.models.property import parse_prop_clauses
 
     filters = Filter(data={"properties": [{"key": "id", "value": cohort_id, "type": "cohort"}],})
-    filter_query, filter_params = parse_prop_clauses(filters.properties, team, table_name="pid")
+    filter_query, filter_params = parse_prop_clauses(filters.properties, team.pk, table_name="pid")
 
     results = sync_execute(GET_PERSON_IDS_BY_FILTER.format(distinct_query=filter_query, query=""), filter_params)
 

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -29,13 +29,13 @@ from ee.clickhouse.sql.person import (
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
 from posthog import settings
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models.filter import Filter
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
 
-if settings.EE_AVAILABLE and check_ee_enabled():
+if settings.EE_AVAILABLE and is_ee_enabled():
 
     @receiver(post_save, sender=Person)
     def person_created(sender, instance: Person, created, **kwargs):

--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -14,7 +14,7 @@ from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.session_recording_event import create_session_recording_event
 from ee.kafka_client.client import KafkaProducer
 from ee.kafka_client.topics import KAFKA_EVENTS_WAL
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models.element import Element
 from posthog.models.person import Person
 from posthog.models.team import Team
@@ -101,7 +101,7 @@ def handle_timestamp(data: dict, now: datetime.datetime, sent_at: Optional[datet
     return now_datetime
 
 
-if check_ee_enabled():
+if is_ee_enabled():
 
     def process_event_ee(
         distinct_id: str,

--- a/ee/tasks/test/test_webhooks_ee.py
+++ b/ee/tasks/test/test_webhooks_ee.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytz
 from django.utils.timezone import now
@@ -21,8 +21,7 @@ def _create_action(**kwargs):
 
 class TestWebhooksEE(BaseTest):
     @patch("requests.post")
-    @patch("celery.current_app.send_task")
-    def test_post_event_to_webhook_ee(self, requests_post, _):
+    def test_post_event_to_webhook_ee(self, requests_post):
 
         self.team.slack_incoming_webhook = "http://slack.com/hook"
         self.team.save()
@@ -40,7 +39,6 @@ class TestWebhooksEE(BaseTest):
         }
         site_url = "http://testserver"
         post_event_to_webhook_ee(event, self.team.pk, site_url)
-
         self.assertEqual(requests_post.call_count, 1)
 
         events = Event.objects.filter(event="User paid")

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -1,7 +1,7 @@
 from rest_framework import decorators, exceptions, response
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 
 from . import (
     action,
@@ -64,7 +64,7 @@ organizations_router.register(
     parents_query_lookups=["organization_id"],
 )
 
-if check_ee_enabled():
+if is_ee_enabled():
     try:
         from ee.clickhouse.views.actions import ClickhouseActions
         from ee.clickhouse.views.element import ClickhouseElement

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.celery import app as celery_app
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models import Team
 from posthog.utils import cors_response, get_ip_address, load_data_from_request
 
@@ -165,7 +165,7 @@ def get_event(request):
                 ),
             )
 
-        if check_ee_enabled():
+        if is_ee_enabled():
             process_event_ee(
                 distinct_id=distinct_id,
                 ip=get_ip_address(request),
@@ -196,7 +196,7 @@ def get_event(request):
                 ],
             )
 
-        if check_ee_enabled() and settings.LOG_TO_WAL:
+        if is_ee_enabled() and settings.LOG_TO_WAL:
             # log the event to kafka write ahead log for processing
             log_event(
                 distinct_id=distinct_id,

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -216,9 +216,9 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             self.assertIn("http://testserver/api/event/?distinct_id=1&before=", response["next"])
 
             page2 = self.client.get(response["next"]).json()
-            from posthog.ee import check_ee_enabled
+            from posthog.ee import is_ee_enabled
 
-            if check_ee_enabled():
+            if is_ee_enabled():
                 from ee.clickhouse.client import sync_execute
 
                 self.assertEqual(sync_execute("select count(*) from events")[0][0], 150)

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models.dashboard_item import DashboardItem
 from posthog.models.event import Event
 from posthog.models.filter import Filter
@@ -151,7 +151,7 @@ def insight_test_factory(event_factory, person_factory):
             self.assertEqual(len(response), 1)
 
         # TODO: remove this check
-        if not check_ee_enabled():
+        if not is_ee_enabled():
 
             @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
             def test_insight_funnels_basic(self):

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db import connection
 from django.utils import timezone
 
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.redis import get_client
 
 # set the default Django settings module for the 'celery' program.
@@ -61,7 +61,7 @@ def setup_periodic_tasks(sender, **kwargs):
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 
-    if not check_ee_enabled():
+    if not is_ee_enabled():
         sender.add_periodic_task(15 * 60, calculate_cohort.s(), name="debug")
         sender.add_periodic_task(600, check_cached_items.s(), name="check dashboard items")
     else:
@@ -84,7 +84,7 @@ def redis_heartbeat():
 
 @app.task(ignore_result=True)
 def clickhouse_lag():
-    if check_ee_enabled() and settings.EE_AVAILABLE:
+    if is_ee_enabled() and settings.EE_AVAILABLE:
         from ee.clickhouse.client import sync_execute
 
         QUERY = """select max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag from events;"""

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseNotFound, JsonResponse
 from django.utils.timezone import now
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models import (
     Action,
     ActionStep,
@@ -217,7 +217,7 @@ def demo(request):
         team.event_names.append("$pageview")
         team.save()
 
-    if check_ee_enabled():
+    if is_ee_enabled():
         from ee.clickhouse.demo import create_anonymous_users_ch
         from ee.clickhouse.models.event import get_events_by_team
 

--- a/posthog/ee.py
+++ b/posthog/ee.py
@@ -2,6 +2,6 @@ from django.conf import settings
 
 
 # add all conditions to check here
-def check_ee_enabled() -> bool:
+def is_ee_enabled() -> bool:
     flag_enabled = settings.PRIMARY_DB == settings.CLICKHOUSE
     return flag_enabled

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -12,6 +12,8 @@ from django.db.models import Exists, F, OuterRef, Prefetch, Q, QuerySet, Subquer
 from django.forms.models import model_to_dict
 from django.utils import timezone
 
+from posthog.ee import is_ee_enabled
+
 from .action import Action
 from .action_step import ActionStep
 from .element import Element
@@ -244,7 +246,9 @@ class EventManager(models.QuerySet):
                         should_post_webhook = True
                 Action.events.through.objects.bulk_create(relations, ignore_conflicts=True)
                 team = kwargs.get("team", event.team)
-                if should_post_webhook and team and team.slack_incoming_webhook:
+                if (
+                    should_post_webhook and team and team.slack_incoming_webhook and not is_ee_enabled()
+                ):  # ee will handle separately
                     celery.current_app.send_task("posthog.tasks.webhooks.post_event_to_webhook", (event.pk, site_url))
 
             return event

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.dispatch import receiver
 from django.utils import timezone
 
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 
 from .filter import Filter
 from .person import Person
@@ -44,7 +44,7 @@ class FeatureFlag(models.Model):
         return len(get_person_by_distinct_id(self.team, distinct_id, Filter(data=self.filters))) > 0
 
     def _match_distinct_id(self, distinct_id: str) -> bool:
-        if check_ee_enabled():
+        if is_ee_enabled():
             return self._query_clickhouse(distinct_id)
         return self._query_postgres(distinct_id)
 

--- a/posthog/tasks/calculate_action.py
+++ b/posthog/tasks/calculate_action.py
@@ -4,7 +4,7 @@ import time
 from celery import shared_task
 
 from posthog.celery import app
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models import Action
 
 logger = logging.getLogger(__name__)

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from posthog.celery import app
-from posthog.ee import check_ee_enabled
+from posthog.ee import is_ee_enabled
 from posthog.models import Cohort
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Changes

*Please describe.*  
- the slack hook was being called twice because event.objects.create in webhooks_ee was triggering another task
- changed the name of `check_ee_enabled` to something more friendly
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
