### PR TITLE
Run E2E tests without celery

### DIFF
--- a/bin/frontend-test-runner
+++ b/bin/frontend-test-runner
@@ -4,7 +4,6 @@ set -e
 dropdb --if-exists posthog_e2e_test
 createdb posthog_e2e_test
 DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py migrate
-DATABASE_URL=postgres://localhost:5432/posthog_e2e_test celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler &
 ./bin/start-frontend &
 CYPRESS_BASE_URL=http://localhost:8080 npx cypress open &
-DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py runserver 8080
+DEBUG=1 TEST=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py runserver 8080

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -12,13 +12,3 @@ class TestPreflight(BaseTest):
         response = response.json()
         self.assertEqual(response["django"], True)
         self.assertEqual(response["db"], True)
-
-    def test_preflight_request_no_redis(self):
-
-        with self.settings(REDIS_URL=None):
-            response = self.client.get(
-                "/_preflight"
-            )  # Make sure the endpoint works with and without the trailing slash
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"django": True, "redis": False, "db": True})

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -58,7 +58,7 @@ def print_warning(warning_lines: Sequence[str]):
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 DEBUG = get_bool_from_env("DEBUG", False)
-TEST = "test" in sys.argv  # type: bool
+TEST = "test" in sys.argv or get_bool_from_env("TEST", False)  # type: bool
 SELF_CAPTURE = get_bool_from_env("SELF_CAPTURE", DEBUG)
 SHELL_PLUS_PRINT_SQL = get_bool_from_env("PRINT_SQL", False)
 
@@ -466,6 +466,11 @@ if TEST:
     CACHES["default"] = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     }
+
+    import celery
+
+    celery.current_app.conf.CELERY_ALWAYS_EAGER = True
+    celery.current_app.conf.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 if DEBUG and not TEST:
     print_warning(

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -7,6 +7,7 @@ from django.http import HttpResponse, JsonResponse
 from django.views.decorators.cache import never_cache
 from rest_framework.exceptions import AuthenticationFailed
 
+from posthog.settings import TEST
 from posthog.utils import (
     get_redis_info,
     get_redis_queue_depth,
@@ -97,4 +98,4 @@ def system_status(request):
 
 @never_cache
 def preflight_check(request):
-    return JsonResponse({"django": True, "redis": is_redis_alive(), "db": is_postgres_alive()})
+    return JsonResponse({"django": True, "redis": is_redis_alive() or TEST, "db": is_postgres_alive()})


### PR DESCRIPTION
I spent ~hour today figuring out why a task was not executing,
restarting frontend test runner each time.

By not running celery in test and forcing all things to evaluate eagerly
we can avoid that pain

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
