### PR TITLE
UX Improvements for first-time retention

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -4,7 +4,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { ActionFilterDropdown } from '../ActionFilter/ActionFilterDropdown'
 import { entityFilterLogic } from '../ActionFilter/entityFilterLogic'
 
-import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
+import { DownOutlined, InfoCircleOutlined, ExportOutlined } from '@ant-design/icons'
 import {
     retentionTableLogic,
     dateOptions,
@@ -12,6 +12,7 @@ import {
     retentionOptionDescriptions,
 } from 'scenes/retention/retentionTableLogic'
 import { Button, DatePicker, Select, Tooltip } from 'antd'
+import { Link } from 'lib/components/Link'
 
 export function RetentionTab(): JSX.Element {
     const node = useRef()
@@ -91,7 +92,6 @@ export function RetentionTab(): JSX.Element {
                     }}
                 />
             )}
-            <hr />
             <h4 style={{ marginTop: '0.5rem' }} className="secondary">
                 Retaining event
                 <Tooltip
@@ -122,6 +122,15 @@ export function RetentionTab(): JSX.Element {
                     }}
                 />
             )}
+            <div className="mt-05">
+                <Link
+                    to="https://posthog.com/docs/features/retention?utm_campaign=learn-more&utm_medium=in-product"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    More info on retention <ExportOutlined />
+                </Link>
+            </div>
 
             <hr />
             <h4 className="secondary">Filters</h4>

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -44,41 +44,42 @@ export function RetentionTab(): JSX.Element {
 
     return (
         <div data-attr="retention-tab">
-            <h4 className="secondary">Retention Type</h4>
-            <div>
-                <Select
-                    value={retentionOptions[retentionType]}
-                    onChange={(value): void => setFilters({ retentionType: value })}
-                    dropdownMatchSelectWidth={false}
-                >
-                    {Object.entries(retentionOptions).map(([key, value]) => (
-                        <Select.Option key={key} value={key}>
-                            {value}
-                            <Tooltip placement="right" title={retentionOptionDescriptions[key]}>
-                                <InfoCircleOutlined className="info-indicator" />
-                            </Tooltip>
-                        </Select.Option>
-                    ))}
-                </Select>
-            </div>
-            <hr />
             <h4 className="secondary">
-                {retentionType === 'retention_first_time' ? 'Cohortizing Event' : 'Target Event'}
-                {retentionType === 'retention_first_time' && (
-                    <Tooltip
-                        key="2"
-                        placement="right"
-                        title="Choose the event that will determine which users are considered in the cohort at the start period"
-                    >
-                        <InfoCircleOutlined className="info-indicator" />
-                    </Tooltip>
-                )}
+                Cohortizing Event
+                <Tooltip
+                    key="2"
+                    placement="right"
+                    title={`Event that determines which users are considered to form each cohort (i.e. performed event in ${
+                        dateOptions[filters.period]
+                    } 0)`}
+                >
+                    <InfoCircleOutlined className="info-indicator" />
+                </Tooltip>
             </h4>
-
-            <Button ref={node} data-attr="retention-action" onClick={(): void => setOpen(!open)}>
+            <Button
+                ref={node}
+                data-attr="retention-action"
+                onClick={(): void => setOpen(!open)}
+                style={{ marginRight: 8 }}
+            >
                 {startEntity?.name || 'Select action'}
                 <DownOutlined className="text-muted" style={{ marginRight: '-6px' }} />
             </Button>
+            <Select
+                value={retentionOptions[retentionType]}
+                onChange={(value): void => setFilters({ retentionType: value })}
+                dropdownMatchSelectWidth={false}
+                style={{ marginTop: 8 }}
+            >
+                {Object.entries(retentionOptions).map(([key, value]) => (
+                    <Select.Option key={key} value={key}>
+                        {value}
+                        <Tooltip placement="right" title={retentionOptionDescriptions[key]}>
+                            <InfoCircleOutlined className="info-indicator" />
+                        </Tooltip>
+                    </Select.Option>
+                ))}
+            </Select>
             {open && (
                 <ActionFilterDropdown
                     logic={entityLogic}
@@ -90,42 +91,38 @@ export function RetentionTab(): JSX.Element {
                     }}
                 />
             )}
-            {retentionType === 'retention_first_time' && (
-                <>
-                    <h4 style={{ marginTop: '0.5rem' }} className="secondary">
-                        {'Retained event'}
-                        {retentionType === 'retention_first_time' && (
-                            <Tooltip
-                                key="3"
-                                placement="right"
-                                title="Choose the event that will determine if users in a cohort come back"
-                            >
-                                <InfoCircleOutlined className="info-indicator" />
-                            </Tooltip>
-                        )}
-                    </h4>
+            <hr />
+            <h4 style={{ marginTop: '0.5rem' }} className="secondary">
+                Retaining event
+                <Tooltip
+                    key="3"
+                    placement="right"
+                    title="Event that determines if each user came back on each period (i.e. if they were retained)"
+                >
+                    <InfoCircleOutlined className="info-indicator" />
+                </Tooltip>
+            </h4>
 
-                    <Button
-                        ref={returningNode}
-                        data-attr="retention-returning-action"
-                        onClick={(): void => setReturningOpen(!returningOpen)}
-                    >
-                        {returningEntity?.name || 'Select action'}
-                        <DownOutlined className="text-muted" style={{ marginRight: '-6px' }} />
-                    </Button>
-                    {returningOpen && (
-                        <ActionFilterDropdown
-                            logic={entityLogicReturning}
-                            onClickOutside={(e): void => {
-                                if (node.current.contains(e.target)) {
-                                    return
-                                }
-                                setReturningOpen(false)
-                            }}
-                        />
-                    )}
-                </>
+            <Button
+                ref={returningNode}
+                data-attr="retention-returning-action"
+                onClick={(): void => setReturningOpen(!returningOpen)}
+            >
+                {returningEntity?.name || 'Select action'}
+                <DownOutlined className="text-muted" style={{ marginRight: '-6px' }} />
+            </Button>
+            {returningOpen && (
+                <ActionFilterDropdown
+                    logic={entityLogicReturning}
+                    onClickOutside={(e): void => {
+                        if (node.current.contains(e.target)) {
+                            return
+                        }
+                        setReturningOpen(false)
+                    }}
+                />
             )}
+
             <hr />
             <h4 className="secondary">Filters</h4>
             <PropertyFilters pageKey="insight-retention" />

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -18,13 +18,13 @@ const RETENTION_RECURRING = 'retention_recurring'
 const RETENTION_FIRST_TIME = 'retention_first_time'
 
 export const retentionOptions = {
-    [`${RETENTION_RECURRING}`]: 'Recurring',
     [`${RETENTION_FIRST_TIME}`]: 'First Time',
+    [`${RETENTION_RECURRING}`]: 'Recurring',
 }
 
 export const retentionOptionDescriptions = {
-    [`${RETENTION_RECURRING}`]: 'Track an event and show the specific days that users who performed the event in the initial period come back',
-    [`${RETENTION_FIRST_TIME}`]: 'Determine a cohort of users by an initial event and track a second event that will determine if a user returns',
+    [`${RETENTION_RECURRING}`]: 'A user will belong to any cohort where they have performed the event in its Period 0.',
+    [`${RETENTION_FIRST_TIME}`]: 'A user will only belong to the cohort for which they performed the event for the first time.',
 }
 
 function cleanRetentionParams(filters, properties): any {
@@ -44,7 +44,7 @@ function cleanFilters(filters): any {
         returningEntity: filters.returningEntity || {
             events: [{ id: '$pageview', name: '$pageview', type: 'events' }],
         },
-        retentionType: filters.retentionType || RETENTION_RECURRING,
+        retentionType: filters.retentionType || RETENTION_FIRST_TIME,
         selectedDate: filters.selectedDate ? moment(filters.selectedDate) : moment().startOf('hour'),
         period: filters.period || 'd',
     }
@@ -129,7 +129,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
                           actions: [],
                       },
                       period: props.filters.period || 'd',
-                      retentionType: props.filters.retentionType || RETENTION_RECURRING,
+                      retentionType: props.filters.retentionType || RETENTION_FIRST_TIME,
                   }
                 : (state) => cleanFilters(router.selectors.searchParams(state)),
             {


### PR DESCRIPTION
## Changes

Small PR to introduce proposed changes to the UX of the new first time retention from #2325. I think it's a bit easier to digest this way, and we can also keep the extra "Retention Type" for when we do unbounded retention.

As an alternative, we could consider doing a switch instead of a select for the type of cohortizing event as it ends up being a binary state. Example:
<img width="340" alt="image" src="https://user-images.githubusercontent.com/5864173/98935279-30cb4e00-24db-11eb-819b-e0850c7aaf59.png">


**Warning.** This introduces an edge case that does not work yet (as the extra functionality would need to be incorporated) which is having different cohortizing & retaining events in recurring retention.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
