### PR TITLE
Added Revenue Data Generator

### DIFF
--- a/posthog/management/commands/generate_revenue_data.py
+++ b/posthog/management/commands/generate_revenue_data.py
@@ -1,0 +1,111 @@
+import random
+from uuid import uuid4
+
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+
+from ee.clickhouse.models.clickhouse import generate_clickhouse_uuid
+from ee.clickhouse.models.event import create_event
+from posthog.models import Event, Organization, Person, PersonDistinctId, Team
+from posthog.models.utils import UUIDT
+
+PRICING_TIERS = [("basic", 10), ("growth", 20), ("premium", 30)]
+
+# Note: Python's built-in hash function is not deterministic across runtimes
+# It is enough for this implementation
+def _deterministic_random_value(payload, max_val=3):
+    return hash(payload) % max_val
+
+
+class Command(BaseCommand):
+    help = "Set up the instance for development/review with demo data"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--org", nargs="+", type=str, help="Name of the organization to create data for")
+        parser.add_argument("--team_name", nargs="+", type=str, help="Name of the team to create data for")
+        parser.add_argument("--team_id", nargs="+", type=int, help="ID of the team to create data for")
+        parser.add_argument(
+            "--use_ch", nargs="+", type=bool, help="Override default and create data in ClickHouse instead of Postgres"
+        )
+
+    def handle(self, *args, **options):
+        if not options["org"] or (not options["team_name"] and not options["team_id"]):
+            if not options["org"]:
+                print("The argument --org is required")
+            else:
+                print("You need to specify a --team_id or --team_name to run this command")
+            exit(1)
+
+        team = self._get_team(options["org"][0], options["team_name"], options["team_id"])
+        if options["use_ch"]:
+            self._generate_ch_data(team)
+        else:
+            self._generate_psql_data(team)
+
+    def _generate_psql_data(self, team):
+        distinct_ids = []
+        for i in range(0, 10000):
+            distinct_id = str(UUIDT())
+            distinct_ids.append(distinct_id)
+            Person.objects.create(team=team, distinct_ids=[distinct_id], properties={"is_demo": True})
+
+        Event.objects.bulk_create(
+            Event(
+                event="$purchase",
+                team=team,
+                distinct_id=distinct_ids[i],
+                properties={
+                    "plan": PRICING_TIERS[_deterministic_random_value(distinct_ids[i])][0],
+                    "purchase_value": PRICING_TIERS[_deterministic_random_value(distinct_ids[i])][1],
+                },
+                timestamp=now() - relativedelta(days=random.randint(0, 100)),
+            )
+            for i in range(0, 10000)
+        )
+        team.event_names.append("$purchase")
+        team.event_properties.append("plan")
+        team.event_properties_numerical.append("purchase_value")
+        team.save()
+
+    def _generate_ch_data(self, team):
+        distinct_ids = []
+        for i in range(0, 10000):
+            distinct_id = generate_clickhouse_uuid()
+            distinct_ids.append(distinct_id)
+            Person.objects.create(team=team, distinct_ids=[distinct_id], properties={"is_demo": True})
+
+        for i in range(0, 10000):
+            event_uuid = uuid4()
+            create_event(
+                event="$purchase",
+                team=team,
+                distinct_id=distinct_ids[i],
+                properties={
+                    "plan": PRICING_TIERS[_deterministic_random_value(distinct_ids[i])][0],
+                    "purchase_value": PRICING_TIERS[_deterministic_random_value(distinct_ids[i])][1],
+                },
+                timestamp=now() - relativedelta(days=random.randint(0, 100)),
+                event_uuid=event_uuid,
+            )
+        team.event_names.append("$purchase")
+        team.event_properties.append("plan")
+        team.event_properties_numerical.append("purchase_value")
+        team.save()
+
+    def _get_team(self, org, team_name, team_id):
+        organization = Organization.objects.filter(name=org)[0]
+        try:
+            if team_name:
+                team = organization.teams.filter(name=team_name[0])[0]
+            else:
+                team = organization.teams.filter(id=team_id[0])[0]
+        except Team.DoesNotExist:
+            team = Team.objects.create_with_data(
+                organization=organization,
+                name=team_name if team_name else "HogFlix Demo App",
+                ingested_event=True,
+                completed_snippet_onboarding=True,
+            )
+        return team

--- a/posthog/management/commands/generate_revenue_data.py
+++ b/posthog/management/commands/generate_revenue_data.py
@@ -14,7 +14,7 @@ from posthog.models.utils import UUIDT
 PRICING_TIERS = [("basic", 10), ("growth", 20), ("premium", 30)]
 
 # Note: Python's built-in hash function is not deterministic across runtimes
-# It is enough for this implementation
+# But it is enough for this implementation
 def _deterministic_random_value(payload, max_val=3):
     return hash(payload) % max_val
 
@@ -44,6 +44,11 @@ class Command(BaseCommand):
         else:
             self._generate_psql_data(team)
 
+        team.event_names.append("$purchase")
+        team.event_properties.append("plan")
+        team.event_properties_numerical.append("purchase_value")
+        team.save()
+
     def _generate_psql_data(self, team):
         distinct_ids = []
         for i in range(0, 10000):
@@ -64,10 +69,6 @@ class Command(BaseCommand):
             )
             for i in range(0, 10000)
         )
-        team.event_names.append("$purchase")
-        team.event_properties.append("plan")
-        team.event_properties_numerical.append("purchase_value")
-        team.save()
 
     def _generate_ch_data(self, team):
         distinct_ids = []
@@ -89,10 +90,6 @@ class Command(BaseCommand):
                 timestamp=now() - relativedelta(days=random.randint(0, 100)),
                 event_uuid=event_uuid,
             )
-        team.event_names.append("$purchase")
-        team.event_properties.append("plan")
-        team.event_properties_numerical.append("purchase_value")
-        team.save()
 
     def _get_team(self, org, team_name, team_id):
         organization = Organization.objects.filter(name=org)[0]

--- a/posthog/management/commands/generate_revenue_data.py
+++ b/posthog/management/commands/generate_revenue_data.py
@@ -20,7 +20,7 @@ def _deterministic_random_value(payload, max_val=3):
 
 
 class Command(BaseCommand):
-    help = "Set up the instance for development/review with demo data"
+    help = "Generate 10,000 revenue data points"
 
     def add_arguments(self, parser):
         parser.add_argument("--org", nargs="+", type=str, help="Name of the organization to create data for")

--- a/posthog/management/commands/generate_revenue_data.py
+++ b/posthog/management/commands/generate_revenue_data.py
@@ -79,14 +79,12 @@ class Command(BaseCommand):
 
         for i in range(0, 10000):
             event_uuid = uuid4()
+            plan = random.choice(PRICING_TIERS)
             create_event(
                 event="$purchase",
                 team=team,
                 distinct_id=distinct_ids[i],
-                properties={
-                    "plan": PRICING_TIERS[_deterministic_random_value(distinct_ids[i])][0],
-                    "purchase_value": PRICING_TIERS[_deterministic_random_value(distinct_ids[i])][1],
-                },
+                properties={"plan": plan[0], "purchase_value": plan[1],},
                 timestamp=now() - relativedelta(days=random.randint(0, 100)),
                 event_uuid=event_uuid,
             )

--- a/posthog/management/commands/generate_revenue_data.py
+++ b/posthog/management/commands/generate_revenue_data.py
@@ -20,7 +20,7 @@ def _deterministic_random_value(payload, max_val=3):
 
 
 class Command(BaseCommand):
-    help = "Generate 10,000 revenue data points"
+    help = "Bulk generate revenue data points for demos"
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

Built this quickly to generate some data for a tutorial. Can definitely be iterated on, but this was just a quick thing I built for myself and thought it might be useful to share.

Can be ran like:

**Postgres**
`DEBUG=1 python manage.py generate_revenue_data --org="Test" --team_name="HogFlix Demo App"`

**CH**
`DEBUG=1 PRIMARY_DB=clickhouse DATABASE_URL=postgres://posthog:posthog@localhost:5439/posthog  python manage.py generate_revenue_data --org="Test" --team_name="HogFlix Demo App" --use_ch=True`

It was the case for me at first that the DB had multiple orgs and multiple teams with the same name. Can be the cause of confusion when events don't appear after running the command.

I'll also probably improve our demo data generation soon as well.

Gets you some nice (yet very simple) data to work with:

<img width="600" alt="Screenshot 2020-11-12 at 17 25 30" src="https://user-images.githubusercontent.com/38760734/98974175-866c1e80-250c-11eb-939e-009d6a5b73ae.png">
<img width="600" alt="Screenshot 2020-11-12 at 17 25 56" src="https://user-images.githubusercontent.com/38760734/98974183-88ce7880-250c-11eb-81fa-dfd717dc633d.png">
<img width="600" alt="Screenshot 2020-11-12 at 17 26 18" src="https://user-images.githubusercontent.com/38760734/98974187-89ffa580-250c-11eb-93d5-496fa3f4e77c.png">

### Potential further improvements

- Also give each person some pageviews and things to track: 
    - Retention by plan
    - Conversion by plan (funnels)

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
