### PR TITLE
Add missing copy over in dev.dockerfile for new config

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     && yarn --frozen-lockfile
 
 COPY requirements.txt /code/
+COPY requirements-dev.txt /code/
 # install dependencies but ignore any we don't need for dev environment
 RUN pip install $(grep -ivE "psycopg2" requirements.txt | cut -d'#' -f1) --compile\
     && pip install psycopg2-binary


### PR DESCRIPTION
## Changes

*Please describe.*  
- after switching to new format for requirements.txt we're missing a copy in the dev.dockerfile
- this will stop all the failed dockerfile tests on master
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
