### PR TITLE
Persist database after docker-compose down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
             POSTGRES_PASSWORD: posthog
             POSTGRES_USER: posthog
         image: postgres:alpine
+        volumes:
+            - postgres-data:/var/lib/postgresql/data
     redis:
         container_name: posthog_redis
         image: redis:alpine
@@ -26,4 +28,6 @@ services:
         ports:
             - 8000:8000
             - 80:8000
+volumes:
+    postgres-data:
 version: '3'


### PR DESCRIPTION
Fixes #2079.

Adds a Docker volume to the production compose file and binds it to the postgres container, this allows the data to persist after a `docker-compose down` / `docker-compose up` cycle.

#### A note for anyone already running in production who needs to use `docker-compose down`:
It should be possible to migrate your data to this mounted storage volume from the old anonymous one. The new mounted storage volume will be located on your host machine at `/var/lib/docker/volumes/posthog_postgres-data/`. The old volume will be in the same `docker/volumes` directory, but with a random hash name. If your database container is still running, you can use `docker inspect <your-container> --format='{{json .Mounts}}'` to find that hash, otherwise you'll have to look through the volumes for postgres files to find the right one. You should then be able to copy the contents of the old volume to the new one with `rsync` to move your data with something like this:

    rsync -a --delete /var/lib/docker/volumes/03fc4b1b047a473c587e8961a78a403bd7d6bcf44eb8492e2202f44acb3235c5/_data/ /var/lib/docker/volumes/posthog_postgres-data/_data