### PR TITLE
First time retention bug fixes

### DIFF
--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -63,9 +63,7 @@ class ClickhouseRetention(Retention):
         )
 
         reference_event_sql = (REFERENCE_EVENT_UNIQUE_SQL if is_first_time_retention else REFERENCE_EVENT_SQL).format(
-            target_query=target_query_formatted,
-            filters=prop_filters if filter.properties else "",
-            trunc_func=trunc_func,
+            target_query=target_query_formatted, filters=prop_filters, trunc_func=trunc_func,
         )
         result = sync_execute(
             RETENTION_SQL.format(

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -45,15 +45,21 @@ class ClickhouseRetention(Retention):
             target_params = {"target_event": target_entity.id}
 
         target_query, target_params = self._get_condition(target_entity)
-        returning_query, returning_params = self._get_condition(
-            returning_entity, "returning" if is_first_time_retention else ""
-        )
+        returning_query, returning_params = self._get_condition(returning_entity, "returning")
 
-        target_query_formatted = "AND {target_query}".format(target_query=target_query)
+        target_query_formatted = (
+            "AND {target_query}".format(target_query=target_query)
+            if is_first_time_retention
+            else "AND ({target_query} OR {returning_query})".format(
+                target_query=target_query, returning_query=returning_query
+            )
+        )
         returning_query_formatted = (
             "AND {returning_query}".format(returning_query=returning_query)
             if is_first_time_retention
-            else "AND {target_query}".format(target_query=target_query)
+            else "AND ({target_query} OR {returning_query})".format(
+                target_query=target_query, returning_query=returning_query
+            )
         )
 
         reference_event_sql = (REFERENCE_EVENT_UNIQUE_SQL if is_first_time_retention else REFERENCE_EVENT_SQL).format(
@@ -61,12 +67,11 @@ class ClickhouseRetention(Retention):
             filters=prop_filters if filter.properties else "",
             trunc_func=trunc_func,
         )
-
         result = sync_execute(
             RETENTION_SQL.format(
                 target_query=target_query_formatted,
                 returning_query=returning_query_formatted,
-                filters=prop_filters if filter.properties else "",
+                filters=prop_filters,
                 trunc_func=trunc_func,
                 extra_union="UNION ALL {}".format(reference_event_sql) if is_first_time_retention else "",
                 reference_event_sql=reference_event_sql,

--- a/ee/clickhouse/sql/retention/retention.py
+++ b/ee/clickhouse/sql/retention/retention.py
@@ -37,6 +37,7 @@ SELECT DISTINCT
 min({trunc_func}(e.timestamp)) as event_date,
 pdi.person_id as person_id
 from events e JOIN (SELECT person_id, distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s) pdi on e.distinct_id = pdi.distinct_id
-where toDateTime(e.timestamp) >= toDateTime(%(start_date)s) AND toDateTime(e.timestamp) <= toDateTime(%(end_date)s)
-AND e.team_id = %(team_id)s {target_query} {filters} GROUP BY person_id
+WHERE e.team_id = %(team_id)s {target_query} {filters} 
+GROUP BY person_id HAVING
+event_date >= toDateTime(%(start_date)s) AND event_date <= toDateTime(%(end_date)s)
 """

--- a/posthog/models/filter.py
+++ b/posthog/models/filter.py
@@ -202,5 +202,16 @@ class Filter(PropertyMixin):
             filter &= Q(timestamp__lte=self.date_to)
         return filter
 
+    def custom_date_filter_Q(self, field: str = "timestamp") -> Q:
+        date_from = self.date_from
+        if self._date_from == "all":
+            return Q()
+        if not date_from:
+            date_from = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(days=7)
+        filter = Q(**{"{}__gte".format(field): date_from})
+        if self.date_to:
+            filter &= Q(**{"{}__lte".format(field): self.date_to})
+        return filter
+
     def toJSON(self):
         return json.dumps(self.to_dict(), default=lambda o: o.__dict__, sort_keys=True, indent=4)

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -50,13 +50,9 @@ class Retention(BaseQuery):
         )
 
         returning_entity = (
-            (
-                Entity({"id": "$pageview", "type": TREND_FILTER_TYPE_EVENTS})
-                if not len(filter.entities) > 0
-                else filter.entities[0]
-            )
-            if first_time_retention
-            else entity
+            Entity({"id": "$pageview", "type": TREND_FILTER_TYPE_EVENTS})
+            if not len(filter.entities) > 0
+            else filter.entities[0]
         )
         # need explicit handling of date_from so it's not optional but also need filter object for date_filter_Q
         return filter, entity, returning_entity, first_time_retention, date_from, date_to
@@ -127,13 +123,8 @@ class Retention(BaseQuery):
                 .union(first_date.values_list("first_date", "person_id"))
             )
         else:
-            first_date = (
-                filtered_events.filter(entity_condition)
-                .annotate(first_date=trunc)
-                .values("first_date", "person_id")
-                .distinct()
-            )
-            final_query = filtered_events.filter(returning_condition)
+            first_date = filtered_events.annotate(first_date=trunc).values("first_date", "person_id").distinct()
+            final_query = filtered_events
         event_query, events_query_params = final_query.query.sql_with_params()
         reference_event_query, first_date_params = first_date.query.sql_with_params()
 

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -110,10 +110,10 @@ class Retention(BaseQuery):
             .annotate(event_date=F("timestamp"))
         )
 
-        filtered_events = events.filter(filter.date_filter_Q).filter(filter.properties_to_Q(team_id=team.pk))
         trunc, fields = self._get_trunc_func("timestamp", period)
 
         if is_first_time_retention:
+            filtered_events = events.filter(filter.properties_to_Q(team_id=team.pk))
             first_date = (
                 filtered_events.filter(entity_condition).values("person_id").annotate(first_date=Min(trunc)).distinct()
             )
@@ -123,6 +123,7 @@ class Retention(BaseQuery):
                 .union(first_date.values_list("first_date", "person_id"))
             )
         else:
+            filtered_events = events.filter(filter.date_filter_Q).filter(filter.properties_to_Q(team_id=team.pk))
             first_date = filtered_events.annotate(first_date=trunc).values("first_date", "person_id").distinct()
             final_query = filtered_events
         event_query, events_query_params = final_query.query.sql_with_params()

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -146,9 +146,12 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
             person_factory(team_id=self.team.pk, distinct_ids=["person2"])
             person_factory(team_id=self.team.pk, distinct_ids=["person3"])
             person_factory(team_id=self.team.pk, distinct_ids=["person4"])
+            person_factory(team_id=self.team.pk, distinct_ids=["shouldnt_include"])
 
             self._create_events(
                 [
+                    ("shouldnt_include", self._date(-5)),
+                    ("shouldnt_include", self._date(-1)),
                     ("person1", self._date(-1)),
                     ("person1", self._date(1)),
                     ("person1", self._date(2)),

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -94,6 +94,53 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
                 ],
             )
 
+        def test_retention_multiple_events(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person2"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person3"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person4"])
+
+            first_event = "$some_event"
+            self._create_events(
+                [
+                    ("person1", self._date(0)),
+                    ("person1", self._date(1)),
+                    ("person1", self._date(2)),
+                    ("person1", self._date(3)),
+                    ("person2", self._date(0)),
+                    ("person2", self._date(1)),
+                    ("person2", self._date(2)),
+                    ("person2", self._date(3)),
+                ],
+                first_event,
+            )
+
+            self._create_events(
+                [("person1", self._date(5)), ("person1", self._date(6)), ("person2", self._date(5)),], "$pageview",
+            )
+
+            target_entity = json.dumps({"id": first_event, "type": TREND_FILTER_TYPE_EVENTS})
+            result = retention().run(
+                Filter(
+                    data={
+                        "date_to": self._date(6, hour=6),
+                        "target_entity": target_entity,
+                        "events": [{"id": "$pageview", "type": "events"},],
+                    }
+                ),
+                self.team,
+                total_intervals=7,
+            )
+            self.assertEqual(len(result), 7)
+            self.assertEqual(
+                self.pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"],
+            )
+
+            self.assertEqual(
+                self.pluck(result, "values", "count"),
+                [[2, 2, 2, 2, 0, 2, 1], [2, 2, 2, 0, 2, 1], [2, 2, 0, 2, 1], [2, 0, 2, 1], [0, 0, 0], [2, 1], [1]],
+            )
+
         def test_first_user_retention(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
             person_factory(team_id=self.team.pk, distinct_ids=["person2"])


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses #2368. we had different definitions of first time event. This changes it so that the first time event will be considered across the entire user lifespan not just in the period
- also fixes recurring retention bug with 2 events

*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
