### PR TITLE
Event usage split clickhouse queries

### DIFF
--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -258,8 +258,25 @@ LIMIT %(limit)s
     tag_regex=EXTRACT_TAG_REGEX, text_regex=EXTRACT_TEXT_REGEX
 )
 
-GET_PROPERTIES_VOLUME = """
-    SELECT arrayJoin(array_property_keys) as key, count(1) as count FROM events_with_array_props_view WHERE team_id = %(team_id)s AND timestamp > %(timestamp)s GROUP BY key ORDER BY count DESC
+GET_PROPERTIES_FOR_TEAM = """
+    SELECT team_id, arrayJoin(array_property_keys) as key, count(1) as count FROM events_with_array_props_view WHERE timestamp > %(timestamp)s AND team_id = %(team_id)s GROUP BY team_id, key ORDER BY count DESC
 """
 
-GET_EVENTS_VOLUME = "SELECT event, count(1) as count FROM events WHERE team_id = %(team_id)s AND timestamp > %(timestamp)s GROUP BY event ORDER BY count DESC"
+GET_PROPERTIES_LOW_VOLUME = """
+SELECT
+    team_id,
+    arrayJoin(array_property_keys) as key,
+    count(1) as count
+FROM events_with_array_props_view
+WHERE
+    timestamp > %(timestamp)s AND
+    team_id IN (
+        SELECT team_id
+        FROM events
+        GROUP BY team_id
+        HAVING count(1) < %(cutoff)s
+    )
+GROUP BY team_id, key ORDER BY count DESC
+"""
+
+GET_EVENTS_VOLUME = "SELECT team_id, event, count(1) as count FROM events WHERE timestamp > %(timestamp)s GROUP BY team_id, event ORDER BY count DESC"

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -21,13 +21,11 @@ class CalculateEventPropertyUsage:
     _teams: QuerySet
     _event_names_dict: Dict[int, Dict[str, Dict[str, Union[int, str]]]] = {}
     _event_properties_dict: Dict[int, Dict[str, Dict[str, Union[int, str]]]] = {}
-    # number of events at which we query events individually
-    _clickhouse_volume_cutoff = 1000000
 
-    def __init__(self, clickhouse_volume_cutoff: Optional[int] = None) -> None:
-        # Purely set in tests
-        if clickhouse_volume_cutoff:
-            self._clickhouse_volume_cutoff = clickhouse_volume_cutoff
+    def __init__(self, clickhouse_volume_cutoff: int = 1_000_000) -> None:
+        # Number of events at which we query events individually
+        # Only set in tests
+        self._clickhouse_volume_cutoff = clickhouse_volume_cutoff
 
     def run(self) -> None:
         self._teams = Team.objects.all()

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -12,9 +13,15 @@ from posthog.models import Team
 from posthog.models.dashboard_item import DashboardItem
 from posthog.models.event import Event
 
+ValueByTeamEvent = Dict[Tuple[int, str], int]
+
 
 def calculate_event_property_usage() -> None:
     CalculateEventPropertyUsage().run()
+
+
+def key_by_team_and_event(query_results: List[Tuple[int, str, int]]) -> ValueByTeamEvent:
+    return {(team_id, event): value for team_id, event, value in query_results}
 
 
 class CalculateEventPropertyUsage:
@@ -26,84 +33,34 @@ class CalculateEventPropertyUsage:
         # Number of events at which we query events individually
         # Only set in tests
         self._clickhouse_volume_cutoff = clickhouse_volume_cutoff
+        self.team_calculators = [CalculateTeamEventPropertyUsage(team) for team in Team.objects.all()]
 
     def run(self) -> None:
-        self._teams = Team.objects.all()
-        for team in self._teams:
-            self.calculate_usage_count_for_team(team=team)
+        for team_calculator in self.team_calculators:
+            team_calculator.populate_event_usage_count()
+            team_calculator.save()
 
-        self.calculate_event_volume()
+        event_volumes = self._get_events_volume()
+        for team_calculator in self.team_calculators:
+            team_calculator.populate_event_volume(event_volumes)
+            team_calculator.save()
 
         if is_ee_enabled():
             self._clickhouse_calculate_properties_volume()
         else:
-            volume = self._psql_get_properties_volume()
-            self.save_properties_volume(volume)
+            volumes = self._psql_get_properties_volume()
+            for team_calculator in self.team_calculators:
+                team_calculator.populate_property_volume(volumes)
+                team_calculator.save()
 
-    def _save_team(self, team: Team) -> None:
-        def _sort(to_sort: List) -> List:
-            return sorted(to_sort, key=lambda item: (item.get("usage_count", 0), item.get("volume", 0)), reverse=True)
-
-        team.event_names_with_usage = _sort([val for _, val in self._event_names_dict[team.pk].items()])
-        team.event_properties_with_usage = _sort([val for _, val in self._event_properties_dict[team.pk].items()])
-        team.save()
-
-    def calculate_usage_count_for_team(self, team: Team) -> None:
-        self._event_names_dict[team.pk] = {event: {"event": event, "usage_count": 0} for event in team.event_names}
-
-        self._event_properties_dict[team.pk] = {key: {"key": key, "usage_count": 0} for key in team.event_properties}
-
-        for item in DashboardItem.objects.filter(team=team, created_at__gt=now() - timedelta(days=30)):
-            for event in item.filters.get("events", []):
-                if event["id"] in self._event_names_dict[team.pk]:
-                    self._event_names_dict[team.pk][event["id"]]["usage_count"] += 1  # type: ignore
-
-            for prop in item.filters.get("properties", []):
-                if prop.get("key") in self._event_properties_dict[team.pk]:
-                    self._event_properties_dict[team.pk][prop["key"]]["usage_count"] += 1  # type: ignore
-
-        # intermittent save in case the heavier queries don't finish
-        self._save_team(team)
-
-    def calculate_event_volume(self) -> None:
-        #  Returns a list of tuples, [(team_id, event, volume)]
-        events_volume = self._get_events_volume()
-        for team in self._teams:
-            for key in team.event_names:
-                try:
-                    volume = [e for e in events_volume if e[0] == team.pk and e[1] == key][0][2]
-                except IndexError:
-                    volume = 0
-                try:
-                    self._event_names_dict[team.pk][key]["volume"] = volume
-                except KeyError:
-                    pass
-
-            self._save_team(team)
-
-    def save_properties_volume(self, volume: List[Tuple[int, str, int]]) -> None:
-        for team in self._teams:
-            for key in team.event_properties:
-                try:
-                    set_volume = [e for e in volume if e[0] == team.pk and e[1] == key][0][2]
-                except IndexError:
-                    set_volume = 0
-                try:
-                    self._event_properties_dict[team.pk][key]["volume"] = set_volume
-                except KeyError:
-                    pass
-
-            self._save_team(team)
-
-    #  Returns a list of tuples, [(team_id, key, volume)]
-    def _psql_get_properties_volume(self) -> List[Tuple[int, str, int]]:
+    def _psql_get_properties_volume(self) -> ValueByTeamEvent:
         timestamp = now() - timedelta(days=30)
         cursor = connection.cursor()
         cursor.execute(
             "SELECT team_id, json_build_array(jsonb_object_keys(properties)) ->> 0 as key1, count(1) FROM posthog_event WHERE timestamp > %s group by team_id, key1 order by count desc",
             [timestamp],
         )
-        return cursor.fetchall()
+        return key_by_team_and_event(cursor.fetchall())
 
     def _clickhouse_calculate_properties_volume(self) -> None:
         from ee.clickhouse.client import sync_execute
@@ -112,40 +69,84 @@ class CalculateEventPropertyUsage:
         timestamp = now() - timedelta(days=30)
 
         # Combine all low volume clients in one query
-        volume = sync_execute(
-            GET_PROPERTIES_LOW_VOLUME, {"timestamp": timestamp, "cutoff": self._clickhouse_volume_cutoff},
+        low_usage_volumes = key_by_team_and_event(
+            sync_execute(GET_PROPERTIES_LOW_VOLUME, {"timestamp": timestamp, "cutoff": self._clickhouse_volume_cutoff},)
         )
-        self.save_properties_volume(volume)
+        for team_calculator in self.team_calculators:
+            team_calculator.populate_property_volume(low_usage_volumes)
+            team_calculator.save()
 
-        high_volume_clients = [
-            team[0]
-            for team in sync_execute(
+        high_volume_clients = set(
+            team_id[0]
+            for team_id in sync_execute(
                 "SELECT team_id FROM (SELECT team_id, count(1) as count FROM events GROUP BY team_id) WHERE count >= {}".format(
                     self._clickhouse_volume_cutoff
                 ),
                 {"timestamp": timestamp},
             )
-        ]
-        for team in [team for team in self._teams if team.pk in high_volume_clients]:
-            volume = sync_execute(GET_PROPERTIES_FOR_TEAM, {"timestamp": timestamp, "team_id": team.pk},)
-            for key in team.event_properties:
-                try:
-                    self._event_properties_dict[team.pk][key]["volume"] = [v[2] for v in volume if v[1] == key][0]
-                except (KeyError, IndexError):
-                    pass
+        )
+        for team_calculator in self.team_calculators:
+            if team_calculator.team.pk in high_volume_clients:
+                volume = key_by_team_and_event(
+                    sync_execute(GET_PROPERTIES_FOR_TEAM, {"timestamp": timestamp, "team_id": team_calculator.team.pk},)
+                )
+                team_calculator.populate_property_volume(volume)
+                team_calculator.save()
 
-            self._save_team(team)
-
-    def _get_events_volume(self) -> List[Tuple[int, str, int]]:
+    def _get_events_volume(self) -> ValueByTeamEvent:
         timestamp = now() - timedelta(days=30)
         if is_ee_enabled():
             from ee.clickhouse.client import sync_execute
             from ee.clickhouse.sql.events import GET_EVENTS_VOLUME
 
-            return sync_execute(GET_EVENTS_VOLUME, {"timestamp": timestamp},)
-        return (
+            return key_by_team_and_event(sync_execute(GET_EVENTS_VOLUME, {"timestamp": timestamp},))
+        return key_by_team_and_event(
             Event.objects.filter(timestamp__gt=timestamp)
             .values("team_id", "event")
             .annotate(count=Count("id"))
             .values_list("team_id", "event", "count")
         )
+
+
+class CalculateTeamEventPropertyUsage:
+    def __init__(self, team: Team) -> None:
+        self.team = team
+        self.event_usage_count: Dict[str, int] = defaultdict(int)
+        self.event_properties_count: Dict[str, int] = defaultdict(int)
+        self.event_usage_volume: Dict[str, int] = defaultdict(int)
+        self.event_properties_volume: Dict[str, int] = defaultdict(int)
+
+    def populate_event_usage_count(self) -> None:
+        for item in DashboardItem.objects.filter(team=self.team, created_at__gt=now() - timedelta(days=30)):
+            for event in item.filters.get("events", []):
+                self.event_usage_count[event["id"]] += 1
+
+            for prop in item.filters.get("properties", []):
+                if "key" in prop:  # Note: Only needed if we need none protection
+                    self.event_properties_count[prop["key"]] += 1
+
+    def populate_event_volume(self, event_usage_volume: ValueByTeamEvent) -> None:
+        self._populate(self.team.event_names, event_usage_volume, self.event_usage_volume)
+
+    def populate_property_volume(self, property_usage_volume: ValueByTeamEvent) -> None:
+        self._populate(self.team.event_properties, property_usage_volume, self.event_properties_volume)
+
+    def _populate(self, keys: List[str], usage_dict: ValueByTeamEvent, counts_object: Dict[str, int]) -> None:
+        for key in keys:
+            counts_object[key] = usage_dict.get((self.team.pk, key), 0)
+
+    def save(self) -> None:
+        self.team.event_names_with_usage = self._construct_usage_volume_list(
+            "event", self.team.event_names, self.event_usage_count, self.event_usage_volume
+        )
+        self.team.event_properties_with_usage = self._construct_usage_volume_list(
+            "key", self.team.event_properties, self.event_properties_count, self.event_properties_volume
+        )
+        self.team.save()
+
+    def _construct_usage_volume_list(
+        self, key_name: str, keys: Dict[str, int], usage_counts: Dict[str, int], volumes: Dict[str, int]
+    ) -> List:
+        to_sort = [{key_name: key, "usage_count": usage_counts[key], "volume": volumes[key]} for key in keys]
+
+        return sorted(to_sort, key=lambda item: (item.get("usage_count", 0), item.get("volume", 0)), reverse=True)

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -58,7 +58,7 @@ class CalculateEventPropertyUsage:
         for item in DashboardItem.objects.filter(team=team, created_at__gt=now() - timedelta(days=30)):
             for event in item.filters.get("events", []):
                 if event["id"] in self._event_names_dict[team.pk]:
-                    self._event_names_dict[team.pk][event["id"]]["usage_count"] += 1  #  type: ignore
+                    self._event_names_dict[team.pk][event["id"]]["usage_count"] += 1  # type: ignore
 
             for prop in item.filters.get("properties", []):
                 if prop.get("key") in self._event_properties_dict[team.pk]:

--- a/posthog/tasks/test/test_calculate_event_property_usage.py
+++ b/posthog/tasks/test/test_calculate_event_property_usage.py
@@ -81,7 +81,7 @@ def test_calculate_event_property_usage(create_event: Callable) -> Callable:
                     },
                 )
 
-                # Team 2 will fall in the cutoff so the low volume/high volume path for clickhouse will be tested
+                # First team will fall in the cutoff so the low volume/high volume path for clickhouse will be tested
                 cls = CalculateEventPropertyUsage(clickhouse_volume_cutoff=2)
                 cls.run()
             team = Team.objects.get(pk=self.team.pk)

--- a/posthog/tasks/test/test_calculate_event_property_usage.py
+++ b/posthog/tasks/test/test_calculate_event_property_usage.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from posthog.api.test.base import BaseTest
 from posthog.models import DashboardItem, Event
 from posthog.models.team import Team
-from posthog.tasks.calculate_event_property_usage import calculate_event_property_usage_for_team
+from posthog.tasks.calculate_event_property_usage import CalculateEventPropertyUsage, calculate_event_property_usage
 
 
 def test_calculate_event_property_usage(create_event: Callable) -> Callable:
@@ -14,7 +14,7 @@ def test_calculate_event_property_usage(create_event: Callable) -> Callable:
             self.team.event_names = ["$pageview", "custom event"]
             self.team.event_properties = ["$current_url", "team_id", "value"]
             self.team.save()
-            team2 = Team.objects.create()
+            team2 = Team.objects.create(name="team 2", event_names=["$pageview"], event_properties=["$current_url"])
             with freeze_time("2020-08-01"):
                 # ignore stuff older than 30 days
                 DashboardItem.objects.create(
@@ -81,8 +81,11 @@ def test_calculate_event_property_usage(create_event: Callable) -> Callable:
                     },
                 )
 
-                calculate_event_property_usage_for_team(self.team.pk)
+                # Team 2 will fall in the cutoff so the low volume/high volume path for clickhouse will be tested
+                cls = CalculateEventPropertyUsage(clickhouse_volume_cutoff=2)
+                cls.run()
             team = Team.objects.get(pk=self.team.pk)
+            team2 = Team.objects.get(pk=team2.pk)
             self.assertEqual(
                 team.event_names_with_usage,
                 [
@@ -97,6 +100,9 @@ def test_calculate_event_property_usage(create_event: Callable) -> Callable:
                     {"key": "team_id", "usage_count": 1, "volume": 1},
                     {"key": "value", "usage_count": 0, "volume": 0},
                 ],
+            )
+            self.assertEqual(
+                team2.event_properties_with_usage, [{"key": "$current_url", "usage_count": 1, "volume": 1},],
             )
 
     return Test


### PR DESCRIPTION
## Changes

- This makes sure all queries are executed in sequence rather than in parallel to avoid overwhelming clikhouse
- It executes all the event volume queries in one go
- It'll grab all property key usage of low volume teams in one go
- For large team usage we do a query for each, again sequentially

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
