### PR TITLE
Separate endpoint for session recordings

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -129,5 +129,5 @@ def get_decide(request: HttpRequest):
         if team:
             response["featureFlags"] = feature_flags(request, team, data_from_request["data"])
             if team.session_recording_opt_in and on_permitted_domain(team, request):
-                response["sessionRecording"] = {"endpoint": "/ses"}
+                response["sessionRecording"] = {"endpoint": "/s"}
     return cors_response(request, JsonResponse(response))

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -128,5 +128,6 @@ def get_decide(request: HttpRequest):
         team = get_team_from_token(request, data_from_request)
         if team:
             response["featureFlags"] = feature_flags(request, team, data_from_request["data"])
-            response["sessionRecording"] = team.session_recording_opt_in and on_permitted_domain(team, request)
+            if team.session_recording_opt_in and on_permitted_domain(team, request):
+                response["sessionRecording"] = {"endpoint": "/ses"}
     return cors_response(request, JsonResponse(response))

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -76,7 +76,7 @@ class TestDecide(BaseTest):
         self.team.save()
 
         response = self._post_decide()
-        self.assertEqual(response["sessionRecording"], {"endpoint": "/ses"})
+        self.assertEqual(response["sessionRecording"], {"endpoint": "/s"})
 
     def test_user_session_recording_evil_site(self):
         self.team.session_recording_opt_in = True

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -76,7 +76,7 @@ class TestDecide(BaseTest):
         self.team.save()
 
         response = self._post_decide()
-        self.assertEqual(response["sessionRecording"], True)
+        self.assertEqual(response["sessionRecording"], {"endpoint": "/ses"})
 
     def test_user_session_recording_evil_site(self):
         self.team.session_recording_opt_in = True

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -293,7 +293,7 @@ urlpatterns = [
     opt_slash_path("track", capture.get_event),
     opt_slash_path("capture", capture.get_event),
     opt_slash_path("batch", capture.get_event),
-    opt_slash_path("ses", capture.get_event),
+    opt_slash_path("s", capture.get_event),  # session recordings
     # auth
     path("logout", logout, name="login"),
     path("login", login_view, name="login"),

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -293,6 +293,7 @@ urlpatterns = [
     opt_slash_path("track", capture.get_event),
     opt_slash_path("capture", capture.get_event),
     opt_slash_path("batch", capture.get_event),
+    opt_slash_path("ses", capture.get_event),
     # auth
     path("logout", logout, name="login"),
     path("login", login_view, name="login"),


### PR DESCRIPTION
This will make it easier to debug capture failures - if they're because
of session recordings it will be clearly indicated in the logs.

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
