### PR TITLE
Fix cohorts not being calculated

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -167,10 +167,10 @@ def calculate_event_action_mappings():
 
 
 @app.task(ignore_result=True)
-def calculate_cohort(max_age_minutes):
+def calculate_cohort():
     from posthog.tasks.calculate_cohort import calculate_cohorts
 
-    calculate_cohorts(max_age_minutes)
+    calculate_cohorts()
 
 
 @app.task(ignore_result=True)


### PR DESCRIPTION
## Changes

See [this Sentry error](https://sentry.io/organizations/posthog/issues/2025429285/?project=1899813&query=is%3Aunresolved&statsPeriod=14d). I'm not sure why this argument was added but it wasn't called when scheduling. I think this also means cohorts are broken for self-hosted users, so this is a release blocking fix?

@macobo thoughts?

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
