### PR TITLE
Add alt_host for graceful failover to our secondary clickhouse node

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -27,6 +27,8 @@ from posthog.settings import (
 
 CACHE_TTL = 60  # seconds
 
+PRIMARY_CLICKHOUSE_HOST, *ALTERNATE_CLICKHOUSE_HOSTS = CLICKHOUSE_HOST
+
 
 if PRIMARY_DB != CLICKHOUSE:
     ch_client = None  # type: Client
@@ -45,7 +47,8 @@ if PRIMARY_DB != CLICKHOUSE:
 else:
     if not TEST and CLICKHOUSE_ASYNC:
         ch_client = Client(
-            host=CLICKHOUSE_HOST,
+            host=PRIMARY_CLICKHOUSE_HOST,
+            alt_hosts=ALTERNATE_CLICKHOUSE_HOSTS,
             database=CLICKHOUSE_DATABASE,
             secure=CLICKHOUSE_SECURE,
             password=CLICKHOUSE_PASSWORD,
@@ -62,7 +65,8 @@ else:
     else:
         # if this is a test use the sync client
         ch_client = SyncClient(
-            host=CLICKHOUSE_HOST,
+            host=PRIMARY_CLICKHOUSE_HOST,
+            alt_hosts=ALTERNATE_CLICKHOUSE_HOSTS,
             database=CLICKHOUSE_DATABASE,
             secure=CLICKHOUSE_SECURE,
             password=CLICKHOUSE_PASSWORD,
@@ -74,7 +78,8 @@ else:
             return sync_execute(query, args)
 
     ch_sync_pool = ChPool(
-        host=CLICKHOUSE_HOST,
+        host=PRIMARY_CLICKHOUSE_HOST,
+        alt_hosts=ALTERNATE_CLICKHOUSE_HOSTS,
         database=CLICKHOUSE_DATABASE,
         secure=CLICKHOUSE_SECURE,
         password=CLICKHOUSE_PASSWORD,

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -117,7 +117,7 @@ if get_bool_from_env("ASYNC_EVENT_ACTION_MAPPING", False):
 # Clickhouse Settings
 CLICKHOUSE_TEST_DB = "posthog_test"
 
-CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost").split(",")
 CLICKHOUSE_USERNAME = os.environ.get("CLICKHOUSE_USERNAME", "default")
 CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
 CLICKHOUSE_DATABASE = CLICKHOUSE_TEST_DB if TEST else os.environ.get("CLICKHOUSE_DATABASE", "default")
@@ -134,7 +134,7 @@ if CLICKHOUSE_SECURE:
     _clickhouse_http_protocol = "https://"
     _clickhouse_http_port = "8443"
 
-CLICKHOUSE_HTTP_URL = _clickhouse_http_protocol + CLICKHOUSE_HOST + ":" + _clickhouse_http_port + "/"
+CLICKHOUSE_HTTP_URL = _clickhouse_http_protocol + CLICKHOUSE_HOST[0] + ":" + _clickhouse_http_port + "/"
 
 IS_HEROKU = get_bool_from_env("IS_HEROKU", False)
 KAFKA_URL = os.environ.get("KAFKA_URL", "kafka://kafka")


### PR DESCRIPTION
## Changes

This is a simple backwards compatible update that will allow us to either have a `CLICKHOUSE_URL` be a single node or multiple comma delimited nodes.

If it is a `,` delimited list then if the clickhouse driver is unable to connect to the first node it will sequentially try all of the hosts listed in the alternate list which is composed of the nodes listed after the first hostname in the `CLICKHOUSE_URL` list.

This enables us to do live failover drills of our clickhouse nodes as well as taking the primary node down for maintenace.

