### PR TITLE
Add ee to docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@
 !frontend/src
 !frontend/types
 !frontend/public
+!ee


### PR DESCRIPTION
## Changes

We didn't have the ee folder in docker ignore, so wasn't loaded in docker images.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
