### PR TITLE
Session recording: only check permitted domains if defined

### DIFF
--- a/frontend/src/scenes/project/Settings/OptInSessionRecording.tsx
+++ b/frontend/src/scenes/project/Settings/OptInSessionRecording.tsx
@@ -21,7 +21,7 @@ export function OptInSessionRecording(): JSX.Element {
                     marginLeft: '10px',
                 }}
             >
-                Record user sessions
+                Record user sessions on Permitted Domains
             </label>
         </div>
     )

--- a/frontend/src/scenes/project/Settings/index.js
+++ b/frontend/src/scenes/project/Settings/index.js
@@ -78,7 +78,7 @@ function _Setup() {
                 </h2>
                 <p>
                     These are the domains and URLs where the Toolbar will automatically open if you're logged in. It's
-                    also where you'll be able to create Actions.
+                    also where you'll be able to create Actions and record sessions.
                 </p>
                 <EditAppUrls />
                 <Divider />

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -128,6 +128,6 @@ def get_decide(request: HttpRequest):
         team = get_team_from_token(request, data_from_request)
         if team:
             response["featureFlags"] = feature_flags(request, team, data_from_request["data"])
-            if team.session_recording_opt_in and on_permitted_domain(team, request):
+            if team.session_recording_opt_in and (on_permitted_domain(team, request) or len(team.app_urls) == 0):
                 response["sessionRecording"] = {"endpoint": "/s"}
     return cors_response(request, JsonResponse(response))

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -79,11 +79,15 @@ class TestDecide(BaseTest):
         self.assertEqual(response["sessionRecording"], {"endpoint": "/s"})
 
     def test_user_session_recording_evil_site(self):
+        self.team.app_urls = ["https://example.com"]
         self.team.session_recording_opt_in = True
         self.team.save()
 
         response = self._post_decide(origin="evil.site.com")
         self.assertEqual(response["sessionRecording"], False)
+
+        response = self._post_decide(origin="https://example.com")
+        self.assertEqual(response["sessionRecording"], {"endpoint": "/s"})
 
     def test_feature_flags(self):
         self.team.app_urls = ["https://example.com"]


### PR DESCRIPTION
This caused some confusion yesterday on users slack.

## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
