### PR TITLE
Fix aggregates clickhouse

### DIFF
--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple
 
-from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL, EVENT_JOIN_PROPERTY_WITH_KEY_SQL
+from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL
 from posthog.models.entity import Entity
 from posthog.models.filter import Filter
 

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -1,33 +1,30 @@
 from datetime import timedelta
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL, EVENT_JOIN_PROPERTY_WITH_KEY_SQL
+from posthog.models.entity import Entity
 from posthog.models.filter import Filter
 
 
-def process_math(entity):
-    join_condition = ""
+def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
     aggregate_operation = "count(*)"
     params = {}
+    join_condition = ""
+    value = "toFloat64OrNull(JSONExtractRaw(properties, '{}'))".format(entity.math_property)
     if entity.math == "dau":
         join_condition = EVENT_JOIN_PERSON_SQL
         aggregate_operation = "count(DISTINCT person_id)"
     elif entity.math == "sum":
-        aggregate_operation = "sum(value)"
-        join_condition = EVENT_JOIN_PROPERTY_WITH_KEY_SQL
+        aggregate_operation = "sum({})".format(value)
         params = {"join_property_key": entity.math_property}
-
     elif entity.math == "avg":
-        aggregate_operation = "avg(value)"
-        join_condition = EVENT_JOIN_PROPERTY_WITH_KEY_SQL
+        aggregate_operation = "avg({})".format(value)
         params = {"join_property_key": entity.math_property}
     elif entity.math == "min":
-        aggregate_operation = "min(value)"
-        join_condition = EVENT_JOIN_PROPERTY_WITH_KEY_SQL
+        aggregate_operation = "min({})".format(value)
         params = {"join_property_key": entity.math_property}
     elif entity.math == "max":
-        aggregate_operation = "max(value)"
-        join_condition = EVENT_JOIN_PROPERTY_WITH_KEY_SQL
+        aggregate_operation = "max({})".format(value)
         params = {"join_property_key": entity.math_property}
 
     return aggregate_operation, join_condition, params

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -231,10 +231,6 @@ EVENT_JOIN_PERSON_SQL = """
 INNER JOIN (SELECT person_id, distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s) as pid ON events.distinct_id = pid.distinct_id
 """
 
-EVENT_JOIN_PROPERTY_WITH_KEY_SQL = """
-INNER JOIN (SELECT event_id, toInt64OrNull(value) as value FROM events_properties_view WHERE team_id = %(team_id)s AND key = %(join_property_key)s AND value IS NOT NULL) as pid ON events.uuid = pid.event_id
-"""
-
 GET_EVENTS_WITH_PROPERTIES = """
 SELECT * FROM events WHERE 
 team_id = %(team_id)s

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -427,8 +427,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             person_factory(team_id=self.team.pk, distinct_ids=["someone_else"])
             event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": 2})
             event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": 3})
-            event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": 5})
-            event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": 8})
+            event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": 5.5})
+            event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": 7.5})
+            event_factory(team=self.team, event="sign up", distinct_id="someone_else", properties={"some_number": None})
             return sign_up_action
 
         def test_sum_filtering(self):
@@ -478,7 +479,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             event_response = trends().run(
                 Filter(data={"events": [{"id": "sign up", "math": "max", "math_property": "some_number"}]}), self.team
             )
-            self.assertEqual(action_response[0]["data"][-1], 8)
+            self.assertEqual(action_response[0]["data"][-1], 7.5)
             self.assertTrue(self._compare_entity_response(action_response, event_response))
 
         def test_avg_filtering_non_number_resiliency(self):


### PR DESCRIPTION
## Changes

- We had a customer who noticed his queries would time out, this was because we were using an inefficient join to get the keys
- Also added a test for floats and null values, as I don't think we handled them correctly before.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
