### PR TITLE
Fix filtering is not bool

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -48,7 +48,7 @@ def prop_filter_json_extract(
     if operator == "is_not":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND NOT (JSONExtractString({prop_var}, %(k{prepend}_{idx})s) = %(v{prepend}_{idx})s)".format(
+            "AND NOT (trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s)) = %(v{prepend}_{idx})s)".format(
                 idx=idx, prepend=prepend, prop_var=prop_var
             ),
             params,
@@ -57,7 +57,7 @@ def prop_filter_json_extract(
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND JSONExtractString({prop_var}, %(k{prepend}_{idx})s) LIKE %(v{prepend}_{idx})s".format(
+            "AND trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s)) LIKE %(v{prepend}_{idx})s".format(
                 idx=idx, prepend=prepend, prop_var=prop_var
             ),
             params,
@@ -66,7 +66,7 @@ def prop_filter_json_extract(
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND NOT (JSONExtractString({prop_var}, %(k{prepend}_{idx})s) LIKE %(v{prepend}_{idx})s)".format(
+            "AND NOT (trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s)) LIKE %(v{prepend}_{idx})s)".format(
                 idx=idx, prepend=prepend, prop_var=prop_var
             ),
             params,
@@ -74,7 +74,7 @@ def prop_filter_json_extract(
     elif operator == "regex":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND match(JSONExtractString({prop_var}, %(k{prepend}_{idx})s), %(v{prepend}_{idx})s)".format(
+            "AND match(trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s)), %(v{prepend}_{idx})s)".format(
                 idx=idx, prepend=prepend, prop_var=prop_var
             ),
             params,
@@ -82,7 +82,7 @@ def prop_filter_json_extract(
     elif operator == "not_regex":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND NOT match(JSONExtractString({prop_var}, %(k{prepend}_{idx})s), %(v{prepend}_{idx})s)".format(
+            "AND NOT match(trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s)), %(v{prepend}_{idx})s)".format(
                 idx=idx, prepend=prepend, prop_var=prop_var
             ),
             params,
@@ -96,7 +96,7 @@ def prop_filter_json_extract(
     elif operator == "is_not_set":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND (isNull(JSONExtractString({prop_var}, %(k{prepend}_{idx})s)) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
+            "AND (isNull(trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s))) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
                 idx=idx, prepend=prepend, prop_var=prop_var
             ),
             params,
@@ -123,7 +123,7 @@ def prop_filter_json_extract(
         elif is_json(prop.value):
             clause = "AND replaceRegexpAll(visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s),' ', '') = replaceRegexpAll(toString(%(v{prepend}_{idx})s),' ', '')"
         else:
-            clause = "AND JSONExtractString({prop_var}, %(k{prepend}_{idx})s) = %(v{prepend}_{idx})s"
+            clause = "AND trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s)) = %(v{prepend}_{idx})s"
 
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -516,5 +516,3 @@ LOGGING = {
         "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"), "propagate": False,},
     },
 }
-
-MULTI_TENANCY = True

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -516,3 +516,5 @@ LOGGING = {
         "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"), "propagate": False,},
     },
 }
+
+MULTI_TENANCY = True

--- a/posthog/test/test_filter_model.py
+++ b/posthog/test/test_filter_model.py
@@ -279,6 +279,15 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
             events = filter_events(filter, self.team)
             self.assertEqual(events[0]["id"], event2.pk)
 
+        def test_is_not_true_false(self):
+            event = event_factory(team=self.team, distinct_id="test", event="$pageview")
+            event2 = event_factory(
+                team=self.team, event="$pageview", distinct_id="test", properties={"is_first": True},
+            )
+            filter = Filter(data={"properties": [{"key": "is_first", "value": "true", "operator": "is_not"}]})
+            events = filter_events(filter, self.team)
+            self.assertEqual(events[0]["id"], event.pk)
+
         def test_json_object(self):
             person1 = person_factory(
                 team_id=self.team.pk,


### PR DESCRIPTION
## Changes

I'm not sure this is the right approach, but the problem with using `JSONExtractString` is it'll just be empty if the value isn't a string (ie a bool, int or float)

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
