### PR TITLE
Fix fetch single event clickhouse

### DIFF
--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -212,7 +212,7 @@ SELECT
     ewap.distinct_id,
     ewap.elements_chain,
     ewap.created_at
-FROM events_with_array_props_view WHERE uuid = %(event_id)s AND team_id = %(team_id)s
+FROM events_with_array_props_view ewap WHERE uuid = %(event_id)s AND team_id = %(team_id)s
 """
 
 GET_EARLIEST_TIMESTAMP_SQL = """

--- a/ee/clickhouse/views/test/test_clickhouse_event.py
+++ b/ee/clickhouse/views/test/test_clickhouse_event.py
@@ -21,3 +21,10 @@ def _create_action(**kwargs):
 
 def _create_person(**kwargs):
     return Person.objects.create(**kwargs)
+
+
+class ClickhouseTestEventApi(
+    ClickhouseTestMixin, test_event_api_factory(_create_event, _create_person, _create_action)  # type: ignore
+):
+    def test_live_action_events(self):
+        pass

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -233,6 +233,13 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.json()["results"]), 0)
 
+        def test_get_single_action(self):
+            event1 = event_factory(team=self.team, event="sign up", distinct_id="2", properties={"key": "test_val"})
+            response = self.client.get("/api/event/%s/" % event1.id)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["event"], "sign up")
+            self.assertEqual(response.json()["properties"], {"key": "test_val"})
+
     return TestEvents
 
 


### PR DESCRIPTION
## Changes

This cause [a sentry error](https://sentry.io/organizations/posthog/issues/1981771354/?project=1899813&query=is%3Aunresolved) when creating a new zapier integration. We'd also [accidentally removed all the events api tests](https://github.com/PostHog/posthog/commit/b5809139b3e7cc55c3411a0a086bf46f747e719f)

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
