### PR TITLE
Hide Billing Toolbar from PostHog team

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -98,7 +98,7 @@ function _App(): JSX.Element {
                 >
                     {featureFlags['navigation-1775'] ? <TopNavigation /> : <TopContent />}
                     <Layout.Content className="main-app-content" data-attr="layout-content">
-                        <BillingToolbar />
+                        {!featureFlags['hide-billing-toolbar'] && <BillingToolbar />}
                         {currentTeam &&
                         !currentTeam.ingested_event &&
                         !['project', 'organization', 'instance', 'my'].some((prefix) => scene.startsWith(prefix)) ? (


### PR DESCRIPTION
## Changes

I set up a flag that filters by the `posthog team` cohort to hide the billing toolbar from us. Of course this could have been done by team, but having it behind a feature flag let's us easily test it in production ourselves if need to. 

<img width="1435" alt="Screenshot 2020-11-19 at 09 00 51" src="https://user-images.githubusercontent.com/38760734/99644368-c0c24800-2a45-11eb-8f1a-5e8799d09c84.png">
