### PR TITLE
Fix cohorts stuck on empty querysets

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -64,12 +64,12 @@ def setup_periodic_tasks(sender, **kwargs):
 
     if not is_ee_enabled():
         sender.add_periodic_task(600, check_cached_items.s(), name="check dashboard items")
-        sender.add_periodic_task(15 * 60, calculate_cohort.s(), name="recalculate cohorts")
     else:
         # ee enabled scheduled tasks
         sender.add_periodic_task(120, clickhouse_lag.s(), name="clickhouse table lag")
         sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
-        sender.add_periodic_task(60 * 60, calculate_cohort.s(), name="recalculate cohorts")
+
+    sender.add_periodic_task(60, calculate_cohort.s(), name="recalculate cohorts")
 
     if settings.ASYNC_EVENT_ACTION_MAPPING:
         sender.add_periodic_task(

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.postgres.fields import JSONField
+from django.core.exceptions import EmptyResultSet
 from django.db import connection, models, transaction
 from django.db.models import Q
 from django.utils import timezone
@@ -15,8 +16,11 @@ from .event import Event
 from .filter import Filter
 from .person import Person
 
-UPDATE_QUERY = """
+DELETE_QUERY = """
 DELETE FROM "posthog_cohortpeople" WHERE "cohort_id" = {cohort_id};
+"""
+
+UPDATE_QUERY = """
 INSERT INTO "posthog_cohortpeople" ("person_id", "cohort_id")
 {values_query}
 ON CONFLICT DO NOTHING
@@ -62,12 +66,16 @@ class Cohort(models.Model):
                 self.save()
 
             persons_query = self._clickhouse_persons_query() if use_clickhouse else self._postgres_persons_query()
-            sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
-
-            query = UPDATE_QUERY.format(
-                cohort_id=self.pk,
-                values_query=sql.replace('FROM "posthog_person"', ', {} FROM "posthog_person"'.format(self.pk), 1,),
-            )
+            try:
+                sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
+            except EmptyResultSet:
+                query = DELETE_QUERY.format(cohort_id=self.pk)
+                params = {}
+            else:
+                query = "{}{}".format(DELETE_QUERY, UPDATE_QUERY).format(
+                    cohort_id=self.pk,
+                    values_query=sql.replace('FROM "posthog_person"', ', {} FROM "posthog_person"'.format(self.pk), 1,),
+                )
 
             cursor = connection.cursor()
             with transaction.atomic():

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -13,12 +13,15 @@ from posthog.models import Cohort
 
 logger = logging.getLogger(__name__)
 
+MAX_AGE_MINUTES = 15
 
-def calculate_cohorts(max_age_minutes: int = 15) -> None:
-    start_time = time.time()
+
+def calculate_cohorts() -> None:
+    # This task will be run every minute
+    # Every minute, grab a few cohorts off the list and execute them
     for cohort in Cohort.objects.filter(
-        Q(is_calculating=False) | Q(last_calculation__lte=timezone.now() - relativedelta(minutes=max_age_minutes))
-    ).order_by("id"):
+        Q(is_calculating=False) | Q(last_calculation__lte=timezone.now() - relativedelta(minutes=MAX_AGE_MINUTES))
+    ).order_by("last_calculation")[0:15]:
         calculate_cohort.delay(cohort.id)
 
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -3,17 +3,15 @@ import time
 
 from celery import shared_task
 from dateutil.relativedelta import relativedelta
-from django.db.models import Q
-from django.db.models.query import QuerySet
+from django.db.models import F, Q
 from django.utils import timezone
 
-from posthog.celery import app
-from posthog.ee import is_ee_enabled
 from posthog.models import Cohort
 
 logger = logging.getLogger(__name__)
 
 MAX_AGE_MINUTES = 15
+PARALLEL_COHORTS = 15
 
 
 def calculate_cohorts() -> None:
@@ -21,7 +19,7 @@ def calculate_cohorts() -> None:
     # Every minute, grab a few cohorts off the list and execute them
     for cohort in Cohort.objects.filter(
         Q(is_calculating=False) | Q(last_calculation__lte=timezone.now() - relativedelta(minutes=MAX_AGE_MINUTES))
-    ).order_by("last_calculation")[0:15]:
+    ).order_by(F("last_contacted").asc(nulls_first=True))[0:PARALLEL_COHORTS]:
         calculate_cohort.delay(cohort.id)
 
 

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -59,3 +59,20 @@ class TestCohort(BaseTest):
         cohort.calculate_people(use_clickhouse=True)
 
         self.assertCountEqual(list(cohort.people.all()), [person1, person2])
+
+    @tag("ee")
+    def test_clickhouse_empty_query(self):
+        cohort2 = Cohort.objects.create(
+            team=self.team, groups=[{"properties": {"$some_prop": "nomatchihope"}}], name="cohort1",
+        )
+
+        cohort2.calculate_people(use_clickhouse=True)
+        self.assertFalse(Cohort.objects.get().is_calculating)
+
+    def test_empty_query(self):
+        cohort2 = Cohort.objects.create(
+            team=self.team, groups=[{"properties": {"$some_prop": "nomatchihope"}}], name="cohort1",
+        )
+
+        cohort2.calculate_people()
+        self.assertFalse(Cohort.objects.get().is_calculating)


### PR DESCRIPTION
## Changes

- Catch the EmptyResultsSet error ([see sentry](https://sentry.io/organizations/posthog/issues/2033356114/?project=1899813&query=is%3Aunresolved))
- Continuously run cohort update 15 at a time to avoid overwhelming clickhouse every hour.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
