### PR TITLE
Heroku Review App upgrades

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker
+plugins: ./bin/plugin-server

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker
-plugins: ./bin/plugin-server
+worker:celery: ./bin/docker-worker-celery --with-beat
+worker:plugins: ./bin/plugin-server

--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker
 celeryworker: ./bin/docker-worker-celery --with-beat
-pluginsworker: ./bin/plugin-server
+pluginworker: ./bin/plugin-server

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker
-worker:celery: ./bin/docker-worker-celery --with-beat
-worker:plugins: ./bin/plugin-server
+celeryworker: ./bin/docker-worker-celery --with-beat
+pluginsworker: ./bin/plugin-server

--- a/app.json
+++ b/app.json
@@ -21,6 +21,9 @@
                 },
                 "worker": {
                     "quantity": 1
+                },
+                "plugins": {
+                    "quantity": 1
                 }
             }
         },
@@ -47,6 +50,9 @@
             "quantity": 1
         },
         "worker": {
+            "quantity": 1
+        },
+        "plugins": {
             "quantity": 1
         }
     },

--- a/app.json
+++ b/app.json
@@ -34,7 +34,7 @@
                 "celeryworker": {
                     "quantity": 0
                 },
-                "pluginsworker": {
+                "pluginworker": {
                     "quantity": 0
                 }
             }
@@ -51,7 +51,7 @@
     "addons": [
         "heroku-postgresql",
         {
-            "plan": "heroku-redis",
+            "plan": "heroku-redis:premium-0",
             "options": {
                 "maxmemory_policy": "allkeys-lru"
             }
@@ -67,7 +67,7 @@
         "celeryworker": {
             "quantity": 0
         },
-        "pluginsworker": {
+        "pluginworker": {
             "quantity": 0
         }
     },

--- a/app.json
+++ b/app.json
@@ -15,15 +15,6 @@
                 }
             },
             "buildpacks": [{ "url": "heroku/nodejs" }, { "url": "heroku/python" }],
-            "addons": [
-                "heroku-postgresql",
-                {
-                    "plan": "heroku-redis:premium-0",
-                    "options": {
-                        "maxmemory_policy": "allkeys-lru"
-                    }
-                }
-            ],
             "formation": {
                 "web": {
                     "quantity": 1

--- a/app.json
+++ b/app.json
@@ -31,10 +31,10 @@
                 "worker": {
                     "quantity": 1
                 },
-                "worker:celery": {
+                "celeryworker": {
                     "quantity": 0
                 },
-                "worker:plugins": {
+                "pluginsworker": {
                     "quantity": 0
                 }
             }
@@ -64,10 +64,10 @@
         "worker": {
             "quantity": 1
         },
-        "worker:celery": {
+        "celeryworker": {
             "quantity": 0
         },
-        "worker:plugins": {
+        "pluginsworker": {
             "quantity": 0
         }
     },

--- a/app.json
+++ b/app.json
@@ -15,6 +15,15 @@
                 }
             },
             "buildpacks": [{ "url": "heroku/nodejs" }, { "url": "heroku/python" }],
+            "addons": [
+                "heroku-postgresql",
+                {
+                    "plan": "heroku-redis:premium-0",
+                    "options": {
+                        "maxmemory_policy": "allkeys-lru"
+                    }
+                }
+            ],
             "formation": {
                 "web": {
                     "quantity": 1

--- a/app.json
+++ b/app.json
@@ -22,8 +22,11 @@
                 "worker": {
                     "quantity": 1
                 },
-                "plugins": {
-                    "quantity": 1
+                "worker:celery": {
+                    "quantity": 0
+                },
+                "worker:plugins": {
+                    "quantity": 0
                 }
             }
         },
@@ -52,8 +55,11 @@
         "worker": {
             "quantity": 1
         },
-        "plugins": {
-            "quantity": 1
+        "worker:celery": {
+            "quantity": 0
+        },
+        "worker:plugins": {
+            "quantity": 0
         }
     },
     "env": {

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -15,6 +15,7 @@ then
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
   rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
+  ./bin/docker-worker-plugins &
   ./bin/docker-worker-beat &
   ./bin/docker-worker-celery
 fi

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -15,7 +15,6 @@ then
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
   rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-  ./bin/docker-worker-plugins &
   ./bin/docker-worker-beat &
   ./bin/docker-worker-celery
 fi

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -14,7 +14,6 @@ then
   echo "⚠️ --> https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011"
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
-  rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
   ./bin/docker-worker-plugins &
   ./bin/docker-worker-beat &
   ./bin/docker-worker-celery

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -14,6 +14,6 @@ then
   echo "⚠️ --> https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011"
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
-  ./bin/docker-worker-plugins &
+  ./bin/plugin-server &
   ./bin/docker-worker-celery --with-beat
 fi

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -15,6 +15,5 @@ then
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
   ./bin/docker-worker-plugins &
-  ./bin/docker-worker-beat &
-  ./bin/docker-worker-celery
+  ./bin/docker-worker-celery --with-beat
 fi

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 
+rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
 celery -A posthog beat -S redbeat.RedBeatScheduler

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [ "$1" == "--with-beat" ]; then
+  ./bin/docker-worker-beat
+fi
+
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 if [[ -z "${WEB_CONCURRENCY}" ]]; then

--- a/bin/docker-worker-plugins
+++ b/bin/docker-worker-plugins
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-./bin/plugin-server

--- a/bin/plugin-server-dev
+++ b/bin/plugin-server-dev
@@ -1,0 +1,3 @@
+#!/bin/bash
+export WEB_CONCURRENCY=1
+./bin/plugin-server


### PR DESCRIPTION
## Changes

**Still draft**

Two changes for heroku apps:
- Optional `celeryworker` and `pluginworker` dynos that can be individually enabled as needed (default quantity = 0). The default `worker` dyno (quantity = 1) still launches both processes inside itself.
- Upgrade the default redis addon to "premium-0", at $15/month.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
