### PR TITLE
Revert "Add alt_host for graceful failover to our secondary clickhouse node (#2407)"

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -27,8 +27,6 @@ from posthog.settings import (
 
 CACHE_TTL = 60  # seconds
 
-PRIMARY_CLICKHOUSE_HOST, *ALTERNATE_CLICKHOUSE_HOSTS = CLICKHOUSE_HOST
-
 
 if PRIMARY_DB != CLICKHOUSE:
     ch_client = None  # type: Client
@@ -47,8 +45,7 @@ if PRIMARY_DB != CLICKHOUSE:
 else:
     if not TEST and CLICKHOUSE_ASYNC:
         ch_client = Client(
-            host=PRIMARY_CLICKHOUSE_HOST,
-            alt_hosts=ALTERNATE_CLICKHOUSE_HOSTS,
+            host=CLICKHOUSE_HOST,
             database=CLICKHOUSE_DATABASE,
             secure=CLICKHOUSE_SECURE,
             password=CLICKHOUSE_PASSWORD,
@@ -65,8 +62,7 @@ else:
     else:
         # if this is a test use the sync client
         ch_client = SyncClient(
-            host=PRIMARY_CLICKHOUSE_HOST,
-            alt_hosts=ALTERNATE_CLICKHOUSE_HOSTS,
+            host=CLICKHOUSE_HOST,
             database=CLICKHOUSE_DATABASE,
             secure=CLICKHOUSE_SECURE,
             password=CLICKHOUSE_PASSWORD,
@@ -78,8 +74,7 @@ else:
             return sync_execute(query, args)
 
     ch_sync_pool = ChPool(
-        host=PRIMARY_CLICKHOUSE_HOST,
-        alt_hosts=ALTERNATE_CLICKHOUSE_HOSTS,
+        host=CLICKHOUSE_HOST,
         database=CLICKHOUSE_DATABASE,
         secure=CLICKHOUSE_SECURE,
         password=CLICKHOUSE_PASSWORD,

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -117,7 +117,7 @@ if get_bool_from_env("ASYNC_EVENT_ACTION_MAPPING", False):
 # Clickhouse Settings
 CLICKHOUSE_TEST_DB = "posthog_test"
 
-CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost").split(",")
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
 CLICKHOUSE_USERNAME = os.environ.get("CLICKHOUSE_USERNAME", "default")
 CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
 CLICKHOUSE_DATABASE = CLICKHOUSE_TEST_DB if TEST else os.environ.get("CLICKHOUSE_DATABASE", "default")
@@ -134,7 +134,7 @@ if CLICKHOUSE_SECURE:
     _clickhouse_http_protocol = "https://"
     _clickhouse_http_port = "8443"
 
-CLICKHOUSE_HTTP_URL = _clickhouse_http_protocol + CLICKHOUSE_HOST[0] + ":" + _clickhouse_http_port + "/"
+CLICKHOUSE_HTTP_URL = _clickhouse_http_protocol + CLICKHOUSE_HOST + ":" + _clickhouse_http_port + "/"
 
 IS_HEROKU = get_bool_from_env("IS_HEROKU", False)
 KAFKA_URL = os.environ.get("KAFKA_URL", "kafka://kafka")


### PR DESCRIPTION
Reverting this for now because of a bug that it introduces