### PR TITLE
Feature flag table improvements

### DIFF
--- a/cypress/integration/featureFlags.js
+++ b/cypress/integration/featureFlags.js
@@ -10,7 +10,7 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-key').should('have.value', 'beta-feature')
 
         // select "add filter" and "property"
-        cy.get('[data-attr=new-prop-filter-feature-flag').click()
+        cy.get('[data-attr=new-prop-filter-feature-flag-undefined').click()
 
         // select the first property
         cy.get('[data-attr=property-filter-dropdown]').click()

--- a/frontend/src/scenes/experimentation/EditFeatureFlag.js
+++ b/frontend/src/scenes/experimentation/EditFeatureFlag.js
@@ -115,7 +115,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
 
             <Form.Item className={rrwebBlockClass} label="Filter by user properties">
                 <PropertyFilters
-                    pageKey="feature-flag"
+                    pageKey={'feature-flag-' + featureFlag.id}
                     propertyFilters={filters?.properties}
                     onChange={(properties) => setFilters({ properties })}
                     endpoint="person"

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -40,13 +40,17 @@ function _FeatureFlags() {
                     </Tooltip>
                 )
             },
-            sorter: (a, b) => moment(a.created_at).isBefore(b.created_at),
+            sorter: (a, b) => a.created_at > b.created_at,
         },
         {
             title: 'Created by',
             render: function RenderCreatedBy(_, featureFlag) {
                 return featureFlag.created_by.first_name || featureFlag.created_by.email
             },
+            sorter: (a, b) =>
+                (a.created_by.first_name || a.created_by.email).localeCompare(
+                    b.created_by.first_name || b.created_by.email
+                ),
         },
         {
             title: 'Rollout Precentage',

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -23,10 +23,12 @@ function _FeatureFlags() {
         {
             title: 'Name',
             dataIndex: 'name',
+            sorter: (a, b) => ('' + a.name).localeCompare(b.name),
         },
         {
             title: 'Key',
             dataIndex: 'key',
+            sorter: (a, b) => ('' + a.key).localeCompare(b.key),
         },
 
         {
@@ -38,6 +40,7 @@ function _FeatureFlags() {
                     </Tooltip>
                 )
             },
+            sorter: (a, b) => moment(a.created_at).isBefore(b.created_at),
         },
         {
             title: 'Created by',
@@ -54,6 +57,7 @@ function _FeatureFlags() {
                     </div>
                 )
             },
+            sorter: (a, b) => a.rollout_percentage - b.rollout_percentage,
         },
         {
             title: 'Filters',


### PR DESCRIPTION
## Changes

- Adds sorting
- Fixes issue where if you had just clicked on a feature flag with filters and you created a new feature flag, the old filters would automatically be set.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
