### PR TITLE
Fix plugin server url

### DIFF
--- a/frontend/src/scenes/plugins/OptInPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptInPlugins.tsx
@@ -39,7 +39,11 @@ export function OptInPlugins(): JSX.Element {
                 <>
                     <div style={{ marginBottom: 20 }}>
                         Plugin support requires the cooperation of the main PostHog application and the new NodeJS-based{' '}
-                        <a href="https://github.com/PostHog/posthog-plugins" target="_blank" rel="noreferrer noopener">
+                        <a
+                            href="https://github.com/PostHog/posthog-plugin-server"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                        >
                             <code>posthog-plugin-server</code>
                         </a>
                         . In case the plugin server is not properly configured, you <em>might</em> experience data loss.


### PR DESCRIPTION
## Changes

Fixes the URL here:

![image](https://user-images.githubusercontent.com/53387/99813071-8640d400-2b47-11eb-8ece-f0f3ed5b22a9.png)

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
