### PR TITLE
Docker nodejs support for plugins

### DIFF
--- a/bin/docker-preview
+++ b/bin/docker-preview
@@ -9,6 +9,5 @@ export REDIS_URL=redis://localhost
 /etc/init.d/postgresql start > /dev/null
 /etc/init.d/redis-server start > /dev/null
 
-DEBUG=1 celery -A posthog worker --loglevel=info &
-DEBUG=1 ./bin/plugin-server &
+DEBUG=1 ./bin/docker-worker &
 DEBUG=1 gunicorn posthog.wsgi --config gunicorn.config.py --bind 0.0.0.0:8000 --log-file - -e DEBUG=1 -e DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -56,8 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && yarn --frozen-lockfile \
     && cd .. \
     && yarn cache clean \
-    && npm uninstall -g yarn \
-    && apt-get purge -y nodejs curl \
+    && apt-get purge -y curl \
     && rm -rf node_modules \
 	&& rm -rf /var/lib/apt/lists/* \
     && rm -rf frontend/dist/*.map

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git \
     && yarn --frozen-lockfile \
     && cd .. \
     && yarn cache clean \
-    && npm uninstall -g yarn \
-    && apt-get purge -y nodejs curl \
+    && apt-get purge -y curl \
     && rm -rf node_modules \
 	&& rm -rf /var/lib/apt/lists/* \
     && rm -rf frontend/dist/*.map


### PR DESCRIPTION
## Changes

`posthog-plugin-server` won't start in `production.Dockerfile` and `preview.Dockerfile`:

![image](https://user-images.githubusercontent.com/53387/99819208-762cf280-2b4f-11eb-8248-34c11bd2762e.png)

The reason is that we remove yarn & nodejs to save space. Unfortunately we can't do this anymore, as the plugin server is built with Node. This PR keeps them installed. 

These changes bring the size of the image built from `production.Dockerfile` from `673MB` to `775MB`.

Tagging @timgl as this is unfortunately a requirement for using plugins with helm charts... and to get that working, we should release a new version of PostHog... or at least a new docker image, with these changes.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
