### PR TITLE
Create DATABASE_URL if none found

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -327,6 +327,14 @@ elif os.environ.get("POSTHOG_DB_NAME"):
             "CONN_MAX_AGE": 0,
         }
     }
+    DATABASE_URL = "postgres://{}{}{}{}:{}/{}".format(
+        DATABASES["default"]["USER"],
+        ":" + DATABASES["default"]["PASSWORD"] if DATABASES["default"]["PASSWORD"] else "",
+        "@" if DATABASES["default"]["USER"] or DATABASES["default"]["PASSWORD"] else "",
+        DATABASES["default"]["HOST"],
+        DATABASES["default"]["PORT"],
+        DATABASES["default"]["NAME"],
+    )
 else:
     raise ImproperlyConfigured(
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'


### PR DESCRIPTION
## Changes

- Under helm charts we don't pass DATABASE_URL, but a bunch of different envs
- This PR consolidates them into DATABASE_URL, which is then exported for the plugin server
- There's simliar logic to create REDIS_URL somewhere lower in the file

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
