### PR TITLE
Don't record session player

### DIFF
--- a/frontend/src/scenes/sessions/SessionsPlayer.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayer.tsx
@@ -33,5 +33,5 @@ export default function SessionsPlayer({ events }: { events: eventWithTime[] }):
         }
     }, [])
 
-    return <div ref={target} id="sessions-player" />
+    return <div ref={target} id="sessions-player" className="ph-no-capture" />
 }


### PR DESCRIPTION
## Changes

We were recording the session player which cause a crazy amount of events happening

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
