### PR TITLE
Fix invalid date format for labels on Windows

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -216,7 +216,7 @@ def append_data(dates_filled: List, interval=None, math="sum") -> Dict[str, Any]
     append["labels"] = []
     append["days"] = []
 
-    labels_format = "%a. %-d %B"
+    labels_format = "%a. {day} %B"
     days_format = "%Y-%m-%d"
 
     if interval == "hour" or interval == "minute":
@@ -227,7 +227,7 @@ def append_data(dates_filled: List, interval=None, math="sum") -> Dict[str, Any]
         date = item[0]
         value = item[1]
         append["days"].append(date.strftime(days_format))
-        append["labels"].append(date.strftime(labels_format))
+        append["labels"].append(date.strftime(labels_format.format(day=date.day)))
         append["data"].append(value)
     if math == "sum":
         append["count"] = sum(append["data"])


### PR DESCRIPTION
## Changes

In Python `datetime.strftime()` calls the platform library implementation of strftime. On Linux `%-d` returns the day number without a leading zero, but this raises a ValueError On Windows. The Windows version is `%#d` but that doesn't remove the leading zero on Linux.

This PR uses `datetime.day` to work on both platforms.

There is another instance of `%-d` in the ClickHouse files, but I don't think there's any point making that Windows compatible...
https://github.com/PostHog/posthog/blob/4e610a0136247f0e1f0981359719783f3430af01/ee/clickhouse/queries/trends/util.py#L41-L46

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [x] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
