### PR TITLE
Fix feature flag not getting created with same team and key after deleting it

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -53,6 +53,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
 
     def update(self, instance: FeatureFlag, validated_data: Dict, *args: Any, **kwargs: Any) -> FeatureFlag:  # type: ignore
         try:
+            FeatureFlag.objects.filter(key=validated_data["key"], team=request.user.team, deleted=True).delete()
             return super().update(instance, validated_data)
         except IntegrityError:
             raise serializers.ValidationError("This key already exists.", code="key-exists")

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -53,7 +53,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
 
     def update(self, instance: FeatureFlag, validated_data: Dict, *args: Any, **kwargs: Any) -> FeatureFlag:  # type: ignore
         try:
-            FeatureFlag.objects.filter(key=validated_data["key"], team=request.user.team, deleted=True).delete()
+            FeatureFlag.objects.filter(key=validated_data["key"], team=instance.team, deleted=True).delete()
             return super().update(instance, validated_data)
         except IntegrityError:
             raise serializers.ValidationError("This key already exists.", code="key-exists")

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -53,7 +53,9 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
 
     def update(self, instance: FeatureFlag, validated_data: Dict, *args: Any, **kwargs: Any) -> FeatureFlag:  # type: ignore
         try:
-            FeatureFlag.objects.filter(key=validated_data["key"], team=instance.team, deleted=True).delete()
+            validated_key = validated_data.get("key", None)
+            if validated_key:
+                FeatureFlag.objects.filter(key=validated_key, team=instance.team, deleted=True).delete()
             return super().update(instance, validated_data)
         except IntegrityError:
             raise serializers.ValidationError("This key already exists.", code="key-exists")

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -44,7 +44,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         validated_data["created_by"] = request.user
         validated_data["team"] = request.user.team
         try:
-            FeatureFlag.objects.get(key=validated_data['key'], team=request.user.team, deleted=True).delete()
+            FeatureFlag.objects.filter(key=validated_data["key"], team=request.user.team, deleted=True).delete()
             feature_flag = super().create(validated_data)
         except IntegrityError:
             raise serializers.ValidationError("This key already exists.", code="key-exists")

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -44,6 +44,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         validated_data["created_by"] = request.user
         validated_data["team"] = request.user.team
         try:
+            FeatureFlag.objects.get(key=validated_data['key'], team=request.user.team, deleted=True).delete()
             feature_flag = super().create(validated_data)
         except IntegrityError:
             raise serializers.ValidationError("This key already exists.", code="key-exists")

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -13,11 +13,7 @@ class TestFeatureFlag(TransactionBaseTest):
     def test_key_exists(self):
         feature_flag = self.client.post(
             "/api/feature_flag/",
-            data={
-                "name": "Beta feature",
-                "key": "beta-feature",
-                "rollout_percentage": 50,
-            },
+            data={"name": "Beta feature", "key": "beta-feature", "rollout_percentage": 50,},
             content_type="application/json",
         ).json()
         self.assertEqual(FeatureFlag.objects.get(pk=feature_flag["id"]).name, "Beta feature")
@@ -25,9 +21,7 @@ class TestFeatureFlag(TransactionBaseTest):
 
         # Make sure the endpoint works with and without the trailing slash
         response = self.client.post(
-            "/api/feature_flag",
-            data={"name": "Beta feature", "key": "beta-feature"},
-            content_type="application/json",
+            "/api/feature_flag", data={"name": "Beta feature", "key": "beta-feature"}, content_type="application/json",
         ).json()
 
         self.assertEqual(
@@ -36,11 +30,7 @@ class TestFeatureFlag(TransactionBaseTest):
         )
 
         another_feature_flag = FeatureFlag.objects.create(
-            team=self.team,
-            rollout_percentage=50,
-            name="some feature",
-            key="some-feature",
-            created_by=self.user,
+            team=self.team, rollout_percentage=50, name="some feature", key="some-feature", created_by=self.user,
         )
         # try updating into an existing feature flag
         response = self.client.patch(
@@ -80,23 +70,14 @@ class TestAPIFeatureFlag(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.organization, self.team, self.user = User.objects.bootstrap("Feature Flags", "ff@posthog.com", None)
-        self.feature_flag = FeatureFlag.objects.create(
-            team=self.team,
-            created_by=self.user,
-            key="red_button",
-        )
+        self.feature_flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="red_button",)
 
     @patch("posthoganalytics.capture")
     def test_creating_feature_flag(self, mock_capture):
         self.client.force_login(self.user)
 
         response = self.client.post(
-            "/api/feature_flag/",
-            {
-                "name": "Alpha feature",
-                "key": "alpha-feature",
-                "rollout_percentage": 50,
-            },
+            "/api/feature_flag/", {"name": "Alpha feature", "key": "alpha-feature", "rollout_percentage": 50,},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         instance = FeatureFlag.objects.get(id=response.data["id"])  # type: ignore
@@ -106,12 +87,7 @@ class TestAPIFeatureFlag(APIBaseTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "feature flag created",
-            {
-                "rollout_percentage": 50,
-                "has_filters": False,
-                "filter_count": 0,
-                "created_at": instance.created_at,
-            },
+            {"rollout_percentage": 50, "has_filters": False, "filter_count": 0, "created_at": instance.created_at,},
         )
 
     @patch("posthoganalytics.capture")
@@ -126,12 +102,7 @@ class TestAPIFeatureFlag(APIBaseTest):
                 "rollout_percentage": 65,
                 "filters": {
                     "properties": [
-                        {
-                            "key": "email",
-                            "type": "person",
-                            "value": "@posthog.com",
-                            "operator": "icontains",
-                        },
+                        {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains",},
                     ],
                 },
             },
@@ -146,12 +117,7 @@ class TestAPIFeatureFlag(APIBaseTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "feature flag updated",
-            {
-                "rollout_percentage": 65,
-                "has_filters": True,
-                "filter_count": 1,
-                "created_at": instance.created_at,
-            },
+            {"rollout_percentage": 65, "has_filters": True, "filter_count": 1, "created_at": instance.created_at,},
         )
 
     def test_deleting_feature_flag(self):
@@ -170,12 +136,7 @@ class TestAPIFeatureFlag(APIBaseTest):
         mock_capture.assert_called_once_with(
             new_user.distinct_id,
             "feature flag deleted",
-            {
-                "rollout_percentage": None,
-                "has_filters": False,
-                "filter_count": 0,
-                "created_at": instance.created_at,
-            },
+            {"rollout_percentage": None, "has_filters": False, "filter_count": 0, "created_at": instance.created_at,},
         )
 
     @patch("posthoganalytics.capture")
@@ -197,12 +158,7 @@ class TestAPIFeatureFlag(APIBaseTest):
         self.client.force_login(self.user)
 
         response = self.client.post(
-            "/api/feature_flag/",
-            {
-                "name": "Alpha feature",
-                "key": "alpha-feature",
-                "rollout_percentage": 50,
-            },
+            "/api/feature_flag/", {"name": "Alpha feature", "key": "alpha-feature", "rollout_percentage": 50,},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         instance = FeatureFlag.objects.get(id=response.data["id"])  # type: ignore

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -13,7 +13,11 @@ class TestFeatureFlag(TransactionBaseTest):
     def test_key_exists(self):
         feature_flag = self.client.post(
             "/api/feature_flag/",
-            data={"name": "Beta feature", "key": "beta-feature", "rollout_percentage": 50,},
+            data={
+                "name": "Beta feature",
+                "key": "beta-feature",
+                "rollout_percentage": 50,
+            },
             content_type="application/json",
         ).json()
         self.assertEqual(FeatureFlag.objects.get(pk=feature_flag["id"]).name, "Beta feature")
@@ -21,7 +25,9 @@ class TestFeatureFlag(TransactionBaseTest):
 
         # Make sure the endpoint works with and without the trailing slash
         response = self.client.post(
-            "/api/feature_flag", data={"name": "Beta feature", "key": "beta-feature"}, content_type="application/json",
+            "/api/feature_flag",
+            data={"name": "Beta feature", "key": "beta-feature"},
+            content_type="application/json",
         ).json()
 
         self.assertEqual(
@@ -30,7 +36,11 @@ class TestFeatureFlag(TransactionBaseTest):
         )
 
         another_feature_flag = FeatureFlag.objects.create(
-            team=self.team, rollout_percentage=50, name="some feature", key="some-feature", created_by=self.user,
+            team=self.team,
+            rollout_percentage=50,
+            name="some feature",
+            key="some-feature",
+            created_by=self.user,
         )
         # try updating into an existing feature flag
         response = self.client.patch(
@@ -70,14 +80,23 @@ class TestAPIFeatureFlag(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.organization, self.team, self.user = User.objects.bootstrap("Feature Flags", "ff@posthog.com", None)
-        self.feature_flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="red_button",)
+        self.feature_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="red_button",
+        )
 
     @patch("posthoganalytics.capture")
     def test_creating_feature_flag(self, mock_capture):
         self.client.force_login(self.user)
 
         response = self.client.post(
-            "/api/feature_flag/", {"name": "Alpha feature", "key": "alpha-feature", "rollout_percentage": 50,},
+            "/api/feature_flag/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "rollout_percentage": 50,
+            },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         instance = FeatureFlag.objects.get(id=response.data["id"])  # type: ignore
@@ -87,7 +106,12 @@ class TestAPIFeatureFlag(APIBaseTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "feature flag created",
-            {"rollout_percentage": 50, "has_filters": False, "filter_count": 0, "created_at": instance.created_at,},
+            {
+                "rollout_percentage": 50,
+                "has_filters": False,
+                "filter_count": 0,
+                "created_at": instance.created_at,
+            },
         )
 
     @patch("posthoganalytics.capture")
@@ -102,7 +126,12 @@ class TestAPIFeatureFlag(APIBaseTest):
                 "rollout_percentage": 65,
                 "filters": {
                     "properties": [
-                        {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains",},
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@posthog.com",
+                            "operator": "icontains",
+                        },
                     ],
                 },
             },
@@ -117,7 +146,12 @@ class TestAPIFeatureFlag(APIBaseTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "feature flag updated",
-            {"rollout_percentage": 65, "has_filters": True, "filter_count": 1, "created_at": instance.created_at,},
+            {
+                "rollout_percentage": 65,
+                "has_filters": True,
+                "filter_count": 1,
+                "created_at": instance.created_at,
+            },
         )
 
     def test_deleting_feature_flag(self):
@@ -136,7 +170,12 @@ class TestAPIFeatureFlag(APIBaseTest):
         mock_capture.assert_called_once_with(
             new_user.distinct_id,
             "feature flag deleted",
-            {"rollout_percentage": None, "has_filters": False, "filter_count": 0, "created_at": instance.created_at,},
+            {
+                "rollout_percentage": None,
+                "has_filters": False,
+                "filter_count": 0,
+                "created_at": instance.created_at,
+            },
         )
 
     @patch("posthoganalytics.capture")
@@ -151,7 +190,6 @@ class TestAPIFeatureFlag(APIBaseTest):
 
         mock_capture.assert_not_called()
 
-
     def test_creating_a_feature_flag_with_same_team_and_key_after_deleting(self):
         instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="alpha-feature")
         instance.delete()
@@ -159,18 +197,13 @@ class TestAPIFeatureFlag(APIBaseTest):
         self.client.force_login(self.user)
 
         response = self.client.post(
-            "/api/feature_flag/", {"name": "Alpha feature", "key": "alpha-feature", "rollout_percentage": 50,},
+            "/api/feature_flag/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "rollout_percentage": 50,
+            },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         instance = FeatureFlag.objects.get(id=response.data["id"])  # type: ignore
         self.assertEqual(instance.key, "alpha-feature")
-
-        # Assert analytics are sent
-        mock_capture.assert_called_once_with(
-            self.user.distinct_id,
-            "feature flag created",
-            {"rollout_percentage": 50, "has_filters": False, "filter_count": 0, "created_at": instance.created_at,},
-        )
-
-
-


### PR DESCRIPTION
## Changes

Before creating a new feature flag, checking if there are any objects with the same team and key which is marked as deleted, if so then deleting them permanently

closes #2421 

## Checklist

- [  ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [  ] Django backend tests (if this PR affects the backend).
- [  ] Cypress end-to-end tests (if this PR affects the frontend).
