### PR TITLE
Fix Password Change

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -49,17 +49,19 @@ class TestUserChangePassword(BaseTest):
         self.assertEqual(response.status_code, 400)
 
     def test_change_password_invalid_old_password(self):
-        response = self.send_request({"oldPassword": "12345", "newPassword": "12345"})
+        response = self.send_request({"currentPassword": "12345", "newPassword": "12345"})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["error"], "Incorrect old password")
 
     def test_change_password_invalid_new_password(self):
-        response = self.send_request({"oldPassword": self.TESTS_PASSWORD, "newPassword": "123456"})
+        response = self.send_request({"currentPassword": self.TESTS_PASSWORD, "newPassword": "123456"})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["error"], "This password is too short. It must contain at least 8 characters.")
 
     def test_change_password_success(self):
-        response = self.send_request({"oldPassword": self.TESTS_PASSWORD, "newPassword": "prettyhardpassword123456",})
+        response = self.send_request(
+            {"currentPassword": self.TESTS_PASSWORD, "newPassword": "prettyhardpassword123456",}
+        )
         self.assertEqual(response.status_code, 200)
 
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -198,7 +198,7 @@ def change_password(request):
     except (TypeError, json.decoder.JSONDecodeError):
         return JsonResponse({"error": "Cannot parse request body"}, status=400)
 
-    old_password = body.get("oldPassword")
+    old_password = body.get("currentPassword")
     new_password = body.get("newPassword")
 
     user = cast(User, request.user)


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the front-end, include screenshots.*  

We were checking for `oldPassword` whereas the PATCH request was sending `currentPassword`.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
