### PR TITLE
Decrease parallel cohorts

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -11,7 +11,7 @@ from posthog.models import Cohort
 logger = logging.getLogger(__name__)
 
 MAX_AGE_MINUTES = 15
-PARALLEL_COHORTS = 15
+PARALLEL_COHORTS = 5
 
 
 def calculate_cohorts() -> None:

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -23,7 +23,7 @@ def calculate_cohorts() -> None:
         calculate_cohort.delay(cohort.id)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, max_retries=1)
 def calculate_cohort(cohort_id: int) -> None:
     start_time = time.time()
     cohort = Cohort.objects.get(pk=cohort_id)


### PR DESCRIPTION
## Changes

I think this is what's actually causing the too many [simultanious connections issue](https://sentry.io/organizations/posthog/issues/2034432877/?project=1899813&query=is%3Aunresolved)

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
