### PR TITLE
Fix heroku worker

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "environments": {
         "review": {
             "scripts": {
-                "postdeploy": "python manage.py setup_dev"
+                "postdeploy": "OPT_OUT_CAPTURE=1 python manage.py setup_dev"
             },
             "env": {
                 "SELF_CAPTURE": true,


### PR DESCRIPTION
## Changes

The posthog python library keeps polling for changed feature flags every 30 sec (and always gets nothing since no personal api key is set), thus stalling the `setup_dev` script. Running it with `OPT_OUT_CAPTURE=1` prevents the broken poller from starting.

I'm not sure if there's anything we are legitimately `capture`ing in this setup script, which will now stop working. Doesn't seem like that for me.

More details [in this commit](https://github.com/PostHog/posthog/issues/2150#issuecomment-732174233).


## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
