### PR TITLE
Fix Heroku worker, part 2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,7 @@ pandas==1.1.3
 parso==0.6.1
 pexpect==4.7.0
 pickleshare==0.7.5
-posthoganalytics==1.1.2
+posthoganalytics==1.1.3
 protobuf==3.13.0
 psycopg2-binary==2.8.4
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ pandas==1.1.3             # via -r requirements.in
 parso==0.6.1              # via -r requirements.in
 pexpect==4.7.0            # via -r requirements.in
 pickleshare==0.7.5        # via -r requirements.in
-posthoganalytics==1.1.2   # via -r requirements.in
+posthoganalytics==1.1.3   # via -r requirements.in
 protobuf==3.13.0          # via -r requirements.in
 psycopg2-binary==2.8.4    # via -r requirements.in
 ptyprocess==0.6.0         # via pexpect


### PR DESCRIPTION
## Changes

See https://github.com/PostHog/posthog/pull/2473 for context

This upgraded `posthoganalytics` to a version that doesn't start the background polling when no personal API key set.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
