### PR TITLE
Refactor scene configuration logic

### DIFF
--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -166,6 +166,10 @@ $top_nav_height: 50px;
     z-index: 1000;
     color: $text_default;
 
+    &.full-width {
+        width: 100%;
+    }
+
     @media (max-width: 991px) {
         width: 100%;
         > div {

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -134,7 +134,7 @@ export function _TopNavigation(): JSX.Element {
     return (
         <>
             <div className="navigation-spacer" />
-            <div className={`navigation-top${sceneConfig.hideMainNav ? ' full-width' : ''}`}>
+            <div className={`navigation-top${sceneConfig.plain ? ' full-width' : ''}`}>
                 <div style={{ justifyContent: 'flex-start' }}>
                     <div className="hide-gte-lg menu-toggle" onClick={() => setMenuCollapsed(!menuCollapsed)}>
                         <IconMenu />

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -24,6 +24,7 @@ export function _TopNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
     const { logout } = useActions(userLogic)
     const { showUpgradeModal } = useActions(sceneLogic)
+    const { sceneConfig } = useValues(sceneLogic)
     const { push } = router.actions
     const [projectModalShown, setProjectModalShown] = useState(false) // TODO: Move to Kea (using useState for backwards-compatibility with TopSelectors.tsx)
     const [organizationModalShown, setOrganizationModalShown] = useState(false) // TODO: Same as above
@@ -133,7 +134,7 @@ export function _TopNavigation(): JSX.Element {
     return (
         <>
             <div className="navigation-spacer" />
-            <div className="navigation-top">
+            <div className={`navigation-top${sceneConfig.hideMainNav ? ' full-width' : ''}`}>
                 <div style={{ justifyContent: 'flex-start' }}>
                     <div className="hide-gte-lg menu-toggle" onClick={() => setMenuCollapsed(!menuCollapsed)}>
                         <IconMenu />

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -12,7 +12,7 @@ import { SendEventsOverlay } from '~/layout/SendEventsOverlay'
 import { BillingToolbar } from 'lib/components/BillingToolbar'
 
 import { userLogic } from 'scenes/userLogic'
-import { Scene, sceneLogic, unauthenticatedScenes } from 'scenes/sceneLogic'
+import { Scene, sceneLogic } from 'scenes/sceneLogic'
 import { SceneLoading } from 'lib/utils'
 import { router } from 'kea-router'
 import { CommandPalette } from 'lib/components/CommandPalette'
@@ -39,7 +39,7 @@ function _App(): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
-    const { scene, params, loadedScenes } = useValues(sceneLogic)
+    const { scene, params, loadedScenes, sceneConfig } = useValues(sceneLogic)
     const { location } = useValues(router)
     const { replace } = useActions(router)
     // used for legacy navigation [Sidebar.js]
@@ -51,7 +51,7 @@ function _App(): JSX.Element | null {
     useEffect(() => {
         if (user) {
             // If user is already logged in, redirect away from unauthenticated routes like signup
-            if (unauthenticatedScenes.includes(scene)) {
+            if (sceneConfig.unauthenticated) {
                 replace('/')
                 return
             }
@@ -77,7 +77,7 @@ function _App(): JSX.Element | null {
     }, [scene, user, currentOrganization, currentOrganizationLoading, currentTeam, currentTeamLoading])
 
     if (!user) {
-        return unauthenticatedScenes.includes(scene) ? (
+        return sceneConfig.unauthenticated ? (
             <Layout style={{ minHeight: '100vh' }}>
                 <Scene {...params} /> <Toast />
             </Layout>
@@ -100,7 +100,9 @@ function _App(): JSX.Element | null {
             <UpgradeModal />
             <Layout>
                 {featureFlags['navigation-1775'] ? (
-                    <MainNavigation />
+                    sceneConfig.hideMainNav ? (
+                        <MainNavigation />
+                    ) : null
                 ) : (
                     <Sidebar
                         user={user}

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -12,7 +12,7 @@ import { SendEventsOverlay } from '~/layout/SendEventsOverlay'
 import { BillingToolbar } from 'lib/components/BillingToolbar'
 
 import { userLogic } from 'scenes/userLogic'
-import { Scene, sceneLogic } from 'scenes/sceneLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneLoading } from 'lib/utils'
 import { router } from 'kea-router'
 import { CommandPalette } from 'lib/components/CommandPalette'
@@ -20,15 +20,6 @@ import { UpgradeModal } from './UpgradeModal'
 import { teamLogic } from './teamLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { organizationLogic } from './organizationLogic'
-
-const darkerScenes: Record<string, boolean> = {
-    dashboard: true,
-    insights: true,
-    funnel: true,
-    editFunnel: true,
-    paths: true,
-}
-const plainScenes: Scene[] = [Scene.Ingestion, Scene.OrganizationCreateFirst, Scene.ProjectCreateFirst]
 
 function Toast(): JSX.Element {
     return <ToastContainer autoClose={8000} transition={Slide} position="top-right" />
@@ -84,9 +75,10 @@ function _App(): JSX.Element | null {
         ) : null
     }
 
-    if (!scene || plainScenes.includes(scene)) {
+    if (!scene || sceneConfig.plain) {
         return (
             <Layout style={{ minHeight: '100vh' }}>
+                {featureFlags['navigation-1775'] ? <TopNavigation /> : null}
                 <Scene user={user} {...params} />
                 <Toast />
             </Layout>
@@ -100,9 +92,7 @@ function _App(): JSX.Element | null {
             <UpgradeModal />
             <Layout>
                 {featureFlags['navigation-1775'] ? (
-                    sceneConfig.hideMainNav ? (
-                        <MainNavigation />
-                    ) : null
+                    <MainNavigation />
                 ) : (
                     <Sidebar
                         user={user}
@@ -111,7 +101,7 @@ function _App(): JSX.Element | null {
                     />
                 )}
                 <Layout
-                    className={`${darkerScenes[scene] && 'bg-mid'}${
+                    className={`${sceneConfig.dark ? 'bg-mid' : ''}${
                         !featureFlags['navigation-1775'] && !sidebarCollapsed ? ' with-open-sidebar' : ''
                     }`}
                     style={{ minHeight: '100vh' }}

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -14,7 +14,13 @@ export function IngestionContainer({ children }: { children: React.ReactNode }):
     return (
         <div
             className="background"
-            style={{ display: 'flex', height: '100vh', width: '100vw', alignItems: 'center', justifyContent: 'center' }}
+            style={{
+                display: 'flex',
+                height: 'calc(100vh - 50px)',
+                width: '100vw',
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}
         >
             {children}
         </div>

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -88,9 +88,6 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
     [Scene.Signup]: {
         unauthenticated: true,
     },
-    [Scene.SessionsPlayer]: {
-        plain: true,
-    },
     [Scene.Dashboard]: {
         dark: true,
     },

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -75,8 +75,22 @@ export const scenes: Record<Scene, () => any> = {
     [Scene.Plugins]: () => import(/* webpackChunkName: 'plugins' */ './plugins/Plugins'),
 }
 
-/* List of routes that do not require authentication (N.B. add to posthog/urls.py too) */
-export const unauthenticatedScenes: Scene[] = [Scene.PreflightCheck, Scene.Signup]
+interface sceneConfigType {
+    unauthenticated?: boolean // If route is to be accessed when logged out (N.B. add to posthog/urls.py too)
+    hideMainNav?: boolean
+}
+
+export const sceneConfigurations: Record<string, sceneConfigType> = {
+    [Scene.PreflightCheck]: {
+        unauthenticated: true,
+    },
+    [Scene.Signup]: {
+        unauthenticated: true,
+    },
+    [Scene.SessionsPlayer]: {
+        hideMainNav: true,
+    },
+}
 
 export const redirects: Record<string, string | ((params: Params) => any)> = {
     '/': '/insights',
@@ -165,6 +179,17 @@ export const sceneLogic = kea<sceneLogicType>({
                 [actions.showUpgradeModal]: (_, { featureName }) => featureName,
                 [actions.hideUpgradeModal]: () => null,
                 [actions.takeToPricing]: () => null,
+            },
+        ],
+    }),
+    selectors: () => ({
+        sceneConfig: [
+            (selectors) => [selectors.scene],
+            (scene: string) => {
+                if (scene in sceneConfigurations) {
+                    return sceneConfigurations[scene]
+                }
+                return {} as sceneConfigType
             },
         ],
     }),

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -77,7 +77,8 @@ export const scenes: Record<Scene, () => any> = {
 
 interface sceneConfigType {
     unauthenticated?: boolean // If route is to be accessed when logged out (N.B. add to posthog/urls.py too)
-    hideMainNav?: boolean
+    dark?: boolean // Background is $bg_mid
+    plain?: boolean // Only keeps the main content and the top navigation bar
 }
 
 export const sceneConfigurations: Record<string, sceneConfigType> = {
@@ -88,7 +89,22 @@ export const sceneConfigurations: Record<string, sceneConfigType> = {
         unauthenticated: true,
     },
     [Scene.SessionsPlayer]: {
-        hideMainNav: true,
+        plain: true,
+    },
+    [Scene.Dashboard]: {
+        dark: true,
+    },
+    [Scene.Insights]: {
+        dark: true,
+    },
+    [Scene.Ingestion]: {
+        plain: true,
+    },
+    [Scene.OrganizationCreateFirst]: {
+        plain: true,
+    },
+    [Scene.ProjectCreateFirst]: {
+        plain: true,
     },
 }
 

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -75,13 +75,13 @@ export const scenes: Record<Scene, () => any> = {
     [Scene.Plugins]: () => import(/* webpackChunkName: 'plugins' */ './plugins/Plugins'),
 }
 
-interface sceneConfigType {
+interface SceneConfig {
     unauthenticated?: boolean // If route is to be accessed when logged out (N.B. add to posthog/urls.py too)
     dark?: boolean // Background is $bg_mid
     plain?: boolean // Only keeps the main content and the top navigation bar
 }
 
-export const sceneConfigurations: Record<string, sceneConfigType> = {
+export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
     [Scene.PreflightCheck]: {
         unauthenticated: true,
     },
@@ -201,11 +201,8 @@ export const sceneLogic = kea<sceneLogicType>({
     selectors: () => ({
         sceneConfig: [
             (selectors) => [selectors.scene],
-            (scene: string) => {
-                if (scene in sceneConfigurations) {
-                    return sceneConfigurations[scene]
-                }
-                return {} as sceneConfigType
+            (scene: Scene): SceneConfig => {
+                return sceneConfigurations[scene] ?? {}
             },
         ],
     }),


### PR DESCRIPTION
## Changes

- Refactors scene logic to introduce a general configuration object that can handle the different setups we have for scenes.
- Precursor for custom session player page.

## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
