### PR TITLE
Allow for duplicate invites

### DIFF
--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -45,12 +45,6 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
             organization_id=self.context["organization_id"], user__email=validated_data["target_email"]
         ).exists():
             raise exceptions.ValidationError("A user with this email address already belongs to the organization.")
-        if OrganizationInvite.objects.filter(
-            organization_id=self.context["organization_id"], target_email=validated_data["target_email"]
-        ).exists():
-            raise exceptions.ValidationError(
-                "An invite intended for this email already is active in this organization."
-            )
         invite: OrganizationInvite = OrganizationInvite.objects.create(
             organization_id=self.context["organization_id"],
             created_by=self.context["request"].user,

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -179,7 +179,7 @@ class OrganizationInvite(UUIDModel):
         if not prevalidated:
             self.validate(user=user)
         user.join(organization=self.organization)
-        self.delete()
+        self.objects.filter(target_email=self.target_email).delete()
 
     def is_expired(self) -> bool:
         """Check if invite is older than 3 days."""

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -179,7 +179,7 @@ class OrganizationInvite(UUIDModel):
         if not prevalidated:
             self.validate(user=user)
         user.join(organization=self.organization)
-        OrganizationInvite.objects.filter(target_email=self.target_email).delete()
+        OrganizationInvite.objects.filter(target_email__iexact=self.target_email).delete()
 
     def is_expired(self) -> bool:
         """Check if invite is older than 3 days."""

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -179,7 +179,7 @@ class OrganizationInvite(UUIDModel):
         if not prevalidated:
             self.validate(user=user)
         user.join(organization=self.organization)
-        self.objects.filter(target_email=self.target_email).delete()
+        OrganizationInvite.objects.filter(target_email=self.target_email).delete()
 
     def is_expired(self) -> bool:
         """Check if invite is older than 3 days."""


### PR DESCRIPTION
## Changes

So as to resolve #2260, this allows for duplicate invites without erroring out. Less friction this way and there isn't really a downside, especially with #2482.
