### PR TITLE
Split the concurrency on Heroku Workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
-worker: ./bin/docker-worker
+worker: ./bin/docker-worker --split-concurrency
 celeryworker: ./bin/docker-worker-celery --with-beat
 pluginworker: ./bin/plugin-server

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -1,19 +1,9 @@
 #!/bin/bash
 set -e
 
-if [ -z "$REDIS_URL$POSTHOG_REDIS_HOST" ]
-then
-  echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
-  echo "️⚠️ 🚨🚨🚨 PostHog warning! 🚨🚨🚨"
-  echo "⚠️"
-  echo "️⚠️ The environment variable REDIS_URL or POSTHOG_REDIS_HOST is not configured!"
-  echo "⚠️ Redis will be mandatory in the next versions of PostHog (1.1.0+)."
-  echo "⚠️ Please configure it now to avoid future surprises!"
-  echo "⚠️"
-  echo "⚠️ See here for more information!"
-  echo "⚠️ --> https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011"
-  echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
-else
-  ./bin/plugin-server &
-  ./bin/docker-worker-celery --with-beat
+if [[ "$1" == "--split-concurrency" && -n "${WEB_CONCURRENCY}" ]]; then
+  export WEB_CONCURRENCY=`expr $WEB_CONCURRENCY / 2 + $WEB_CONCURRENCY % 2`
 fi
+
+./bin/plugin-server &
+./bin/docker-worker-celery --with-beat

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -2,4 +2,4 @@
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler
+celery -A posthog beat -S redbeat.RedBeatScheduler --without-gossip

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -8,9 +8,9 @@ fi
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 if [[ -z "${WEB_CONCURRENCY}" ]]; then
-  celery -A posthog worker
+  celery -A posthog worker --without-gossip
 else
-  celery -A posthog worker --concurrency $WEB_CONCURRENCY
+  celery -A posthog worker --without-gossip --concurrency $WEB_CONCURRENCY
 fi
 
 # Stop the beat!


### PR DESCRIPTION
## Changes

Followup of issue #2493

This won't affect `posthog-production` that has a custom start script and is not running plugins anyway.


## Checklist

- [ ] All querysets/queries filter by Organization, Team, and User (if this PR affects ANY querysets/queries).
- [ ] Django backend tests (if this PR affects the backend).
- [ ] Cypress end-to-end tests (if this PR affects the frontend).
