### PR TITLE
Fix entity.py comment

### DIFF
--- a/posthog/models/entity.py
+++ b/posthog/models/entity.py
@@ -7,7 +7,7 @@ from .property import Property, PropertyMixin
 
 class Entity(PropertyMixin):
     """
-    Filters allow us to describe what events to show/use in various places in the system, for example Trends or Funnels.
+    Entities represent either Action or Event objects, nested in Filter objects.
     This object isn't a table in the database. It gets stored against the specific models itself as JSON.
     This class just allows for stronger typing of this object.
     """


### PR DESCRIPTION
It seems the current comment was copy pasted from the `Filter` model. Updated slightly with an educated guess for what the model represents.

## Changes

Updated copy pasted documentation to reflect `Entity` rather than `Filter`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
