### PR TITLE
Disable celery heartbeat, gossip and mingle

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -34,4 +34,4 @@
   workers:
     worker:
       commands:
-          start: celery -A posthog worker --beat --scheduler redbeat.RedBeatScheduler  --loglevel=info --pidfile="/tmp/celerybeat.pid" --concurrency=2
+          start: celery -A posthog worker --beat --scheduler redbeat.RedBeatScheduler  --loglevel=info --pidfile="/tmp/celerybeat.pid" --concurrency=2 --without-heartbeat --without-gossip --without-mingle

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -34,4 +34,4 @@
   workers:
     worker:
       commands:
-          start: celery -A posthog worker --beat --scheduler redbeat.RedBeatScheduler  --loglevel=info --pidfile="/tmp/celerybeat.pid" --concurrency=2 --without-gossip --without-mingle
+          start: celery -A posthog worker --beat --scheduler redbeat.RedBeatScheduler  --loglevel=info --pidfile="/tmp/celerybeat.pid" --concurrency=2 --without-heartbeat --without-gossip --without-mingle

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -34,4 +34,4 @@
   workers:
     worker:
       commands:
-          start: celery -A posthog worker --beat --scheduler redbeat.RedBeatScheduler  --loglevel=info --pidfile="/tmp/celerybeat.pid" --concurrency=2 --without-heartbeat --without-gossip --without-mingle
+          start: celery -A posthog worker --beat --scheduler redbeat.RedBeatScheduler  --loglevel=info --pidfile="/tmp/celerybeat.pid" --concurrency=2 --without-gossip --without-mingle

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -2,4 +2,4 @@
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler --without-gossip --without-mingle
+celery -A posthog beat -S redbeat.RedBeatScheduler

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -2,4 +2,4 @@
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle
+celery -A posthog beat -S redbeat.RedBeatScheduler --without-gossip --without-mingle

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -2,4 +2,4 @@
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler
+celery -A posthog beat -S redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -8,9 +8,9 @@ fi
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 if [[ -z "${WEB_CONCURRENCY}" ]]; then
-  celery -A posthog worker
+  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle
 else
-  celery -A posthog worker --concurrency $WEB_CONCURRENCY
+  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle --concurrency $WEB_CONCURRENCY
 fi
 
 # Stop the beat!

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -8,9 +8,9 @@ fi
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 if [[ -z "${WEB_CONCURRENCY}" ]]; then
-  celery -A posthog worker --without-gossip --without-mingle
+  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle
 else
-  celery -A posthog worker --without-gossip --without-mingle --concurrency $WEB_CONCURRENCY
+  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle --concurrency $WEB_CONCURRENCY
 fi
 
 # Stop the beat!

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -8,9 +8,9 @@ fi
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 if [[ -z "${WEB_CONCURRENCY}" ]]; then
-  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle
+  celery -A posthog worker --without-gossip --without-mingle
 else
-  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle --concurrency $WEB_CONCURRENCY
+  celery -A posthog worker --without-gossip --without-mingle --concurrency $WEB_CONCURRENCY
 fi
 
 # Stop the beat!

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -5,7 +5,7 @@ set -e
 trap 'kill $(jobs -p)' EXIT
 
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle &
 
 # start celery plugin worker
 ./bin/plugin-server

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -5,7 +5,7 @@ set -e
 trap 'kill $(jobs -p)' EXIT
 
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-gossip --without-mingle &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle &
 
 # start celery plugin worker
 ./bin/plugin-server

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -5,7 +5,7 @@ set -e
 trap 'kill $(jobs -p)' EXIT
 
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-gossip --without-mingle &
 
 # start celery plugin worker
 ./bin/plugin-server


### PR DESCRIPTION
## Changes

More context in https://github.com/PostHog/posthog/issues/2493

This disables three celery services, that take up to 3 Redis connections per worker. This might be enough to push Heroku under the 20 connection limit. Halving the concurrency setting (#2494) might also be needed, but will be considered separately to keep the PRs small.

The services disabled ([as described by this SO answer](https://stackoverflow.com/questions/55249197/what-are-the-consequences-of-disabling-gossip-mingle-and-heartbeat-for-celery-w)):

1. **Heartbeat** (1 redis connection per celery)
Celery seems to use one connection to only send a "hi, I'm alive" ping every 2 seconds. This seems to be useful in the "AMPQ" era, where just one TCP connection is used and such a `keepalive` makes some sense. With Redis, this makes less sense since it's a separate connection, which says nothing about the main `psubscribe` connection being up or not. We also have our own "celery is up" heartbeat through a scheduled task.

2. **Gossip** (2 redis connections per worker)
This uses 2 connections. From the docs:
> Workers are now passively subscribing to worker related events like heartbeats.
>
> This means that a worker knows what other workers are doing and can detect if they go offline. **Currently this is only used for clock synchronization, but there are many possibilities for future additions and you can write extensions that take advantage of this already.**
>
> Some ideas include consensus protocols, reroute task to best worker (based on resource usage or data locality) or restarting workers when they crash.
>
> We believe that although this is a small addition, it opens amazing possibilities.
>
> You can disable this bootstep using the --without-gossip argument.

So we're not using it and it takes 2 connections? Cull.

3. **Mingle** (no extra connections)
Also something people seem to disable regularly:
> The worker will now attempt to synchronize with other workers in the same cluster.
> 
> Synchronized data currently includes revoked tasks and logical clock.
> 
> This only happens at startup and causes a one second startup delay to collect broadcast responses from other workers.
> 
> You can disable this bootstep using the --without-mingle argument.

I didn't find any way to disable these services with settings --> they have to be CLI arguments 🤷 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
