### PR TITLE
Fix shared dashboards

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -122,6 +122,11 @@ class DashboardsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         return queryset
 
+    def get_parents_query_dict(self) -> Dict[str, Any]:
+        if not self.request.user.is_authenticated or "share_token" in self.request.GET:
+            return {}
+        return {"team_id": self.request.user.team.id}
+
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> response.Response:
         pk = kwargs["pk"]
         queryset = self.get_queryset()


### PR DESCRIPTION
## Changes

Fix for data not loading in shared dashboards when logged out, caused by method not being copied over from #2445 to #2485. This needs a Django test.

## Checklist

- [ ] Django backend tests