### PR TITLE
Show session player icons as greyed out if visited

### DIFF
--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -1,0 +1,11 @@
+@import '~/vars';
+
+.sessions-player-button {
+    color: #52c41a;
+    font-size: 16px;
+    margin-right: 5px;
+
+    &:visited * {
+        color: $text_muted;
+    }
+}

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import { useActions } from 'kea'
 import { PlayCircleOutlined } from '@ant-design/icons'
 import { SessionType } from '~/types'
-import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 
 import './Sessions.scss'
 import { fromParams, toParams } from 'lib/utils'
+import { Link } from 'lib/components/Link'
 
 function sessionPlayerUrl(sessionRecordingId: string): string {
     const params = { ...fromParams(), sessionRecordingId }
@@ -21,23 +20,16 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
         return null
     }
 
-    const { loadSessionPlayer } = useActions(sessionsTableLogic)
-
     return (
         <>
             {session.session_recording_ids.map((sessionRecordingId: string) => (
-                <a
-                    href={sessionPlayerUrl(sessionRecordingId)}
+                <Link
+                    to={sessionPlayerUrl(sessionRecordingId)}
                     className="sessions-player-button"
                     key={sessionRecordingId}
-                    onClick={(event: React.MouseEvent) => {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        loadSessionPlayer(sessionRecordingId)
-                    }}
                 >
                     <PlayCircleOutlined />
-                </a>
+                </Link>
             ))}
         </>
     )

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { useActions } from 'kea'
-import { green } from '@ant-design/colors'
 import { PlayCircleOutlined } from '@ant-design/icons'
 import { SessionType } from '~/types'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
+
+import './Sessions.scss'
+import { fromParams, toParams } from 'lib/utils'
+
+function sessionPlayerUrl(sessionRecordingId: string): string {
+    const params = { ...fromParams(), sessionRecordingId }
+    return location.pathname + '?' + toParams(params)
+}
 
 interface SessionsPlayerButtonProps {
     session: SessionType
@@ -19,14 +26,18 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
     return (
         <>
             {session.session_recording_ids.map((sessionRecordingId: string) => (
-                <PlayCircleOutlined
+                <a
+                    href={sessionPlayerUrl(sessionRecordingId)}
+                    className="sessions-player-button"
                     key={sessionRecordingId}
-                    style={{ color: green.primary, marginRight: 5, fontSize: 16 }}
                     onClick={(event: React.MouseEvent) => {
+                        event.preventDefault()
                         event.stopPropagation()
                         loadSessionPlayer(sessionRecordingId)
                     }}
-                />
+                >
+                    <PlayCircleOutlined />
+                </a>
             ))}
         </>
     )


### PR DESCRIPTION
## Changes

What it looks like:

![Screenshot from 2020-11-25 23-09-00](https://user-images.githubusercontent.com/148820/100281916-6eb48180-2f73-11eb-82ca-e40b4b0636f9.png)
![Screenshot from 2020-11-25 23-08-52](https://user-images.githubusercontent.com/148820/100281922-7116db80-2f73-11eb-847d-7a49f794341a.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
