### PR TITLE
Move redis status closer to other fields

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -52,9 +52,7 @@ def system_status(request):
 
     metrics = list()
 
-    metrics.append({"key": "redis_alive", "metric": "Redis alive", "value": redis_alive})
     metrics.append({"key": "db_alive", "metric": "Postgres DB alive", "value": postgres_alive})
-
     if postgres_alive:
         postgres_version = connection.cursor().connection.server_version
         metrics.append(
@@ -77,6 +75,7 @@ def system_status(request):
         )
         metrics.append({"metric": "Postgres Event table", "value": f"ca {event_table_count} rows ({event_table_size})"})
 
+    metrics.append({"key": "redis_alive", "metric": "Redis alive", "value": redis_alive})
     if redis_alive:
         import redis
 


### PR DESCRIPTION
## Changes

Moves the "Redis alive [yes]" part down with the rest of the redis metrics. 

![image](https://user-images.githubusercontent.com/53387/100333675-2d53be80-2fd3-11eb-95d4-b298620eb211.png)

I find this cleaner than the previous version:

![image](https://user-images.githubusercontent.com/53387/100333626-1dd47580-2fd3-11eb-9167-0da836341c57.png)

There are still many things to improve on that page, but I'm not planning to tackle them with this.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
