### PR TITLE
Show which heroku processes are optional

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker
-celeryworker: ./bin/docker-worker-celery --with-beat
-pluginworker: ./bin/plugin-server
+celeryworker: ./bin/docker-worker-celery --with-beat # optional
+pluginworker: ./bin/plugin-server # optional


### PR DESCRIPTION
## Changes

Just make it obvious if you're looking at your heroku processes that these don't need to be turned on

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
