### PR TITLE
Bump posthog-react-rrweb-player 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "posthog-js": "^1.7.0",
         "posthog-js-lite": "^0.0.3",
         "posthog-plugins": "0.1.3",
-        "posthog-react-rrweb-player": "^1.0.7",
+        "posthog-react-rrweb-player": "^1.0.8",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.12.0",

--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -47,7 +47,7 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
 
         # Add first user more 3 distinct id's
         if index == 0:
-            for i in range(0, 3):
+            for _ in range(0, 3):
                 distinct_ids.append(PersonDistinctId(team=team, person=person, distinct_id=str(UUIDT())))
 
         date = now() - relativedelta(days=days_ago)
@@ -57,7 +57,7 @@ def _create_anonymous_users(team: Team, base_url: str) -> None:
                 team=team,
                 event="$pageview",
                 distinct_id=distinct_id,
-                properties={"$current_url": base_url, "$browser": browser, "$lib": "web",},
+                properties={"$current_url": base_url, "$browser": browser, "$lib": "web"},
                 timestamp=date,
             )
         )

--- a/posthog/test/test_demo.py
+++ b/posthog/test/test_demo.py
@@ -13,5 +13,8 @@ class TestDemo(BaseTest):
         self.assertEqual(Event.objects.count(), 192)
         self.assertEqual(Person.objects.count(), 100)
         self.assertEqual(Action.objects.count(), 4)
-        self.assertEqual(Action.objects.all()[1].events.count(), 9)
+
+        action_event_counts = [action.events.count() for action in Action.objects.all()]
+        self.assertCountEqual(action_event_counts, [2, 9, 100, 145])
+
         self.assertIn("$pageview", demo_team.event_names)

--- a/posthog/test/test_demo.py
+++ b/posthog/test/test_demo.py
@@ -1,6 +1,4 @@
-from django.test import Client, TestCase
-
-from posthog.models import Action, DashboardItem, Event, Funnel, Person, Team, User
+from posthog.models import Action, Event, Person, Team
 from posthog.test.base import BaseTest
 
 
@@ -12,7 +10,9 @@ class TestDemo(BaseTest):
         demo_team = Team.objects.get(name__icontains="demo")
         self.assertEqual(Event.objects.count(), 192)
         self.assertEqual(Person.objects.count(), 100)
-        self.assertEqual(Action.objects.count(), 4)
+        self.assertEqual(
+            Action.objects.count(), 4,
+        )  # TODO: Releasing 1694-dashboards should change this to 3 (Pageviews action is removed)
 
         action_event_counts = [action.events.count() for action in Action.objects.all()]
         self.assertCountEqual(action_event_counts, [2, 9, 100, 145])


### PR DESCRIPTION
## Changes

Bumps posthog-react-rrweb-player 1.0.8. Requires https://github.com/PostHog/posthog-react-rrweb-player/pull/2 to be merged and deployed first.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
