### PR TITLE
UI improvements to sessions page

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -309,7 +309,7 @@ style files without adding already imported styles. */
 
 // Overlays styles
 #bottom-notice {
-    z-index: 999;
+    z-index: 10500;
     display: flex;
     flex-direction: row;
     position: fixed;

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -1,7 +1,7 @@
 @import '~/vars';
 
 .sessions-player-button {
-    color: #52c41a;
+    color: $success;
     font-size: 16px;
     margin-right: 5px;
 
@@ -27,6 +27,14 @@
         > .ant-col {
             height: calc(100% - #{$default_spacing});
         }
+    }
+
+    .url-info {
+        max-width: 50%;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        display: inline-block;
+        white-space: nowrap;
     }
 
     .sidebar {

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -19,6 +19,7 @@ import { IconExternalLink } from 'lib/components/icons'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import './Sessions.scss'
 import './SessionsPlayer.scss'
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 
 export const SessionsPlay = hot(_SessionsPlay)
 function _SessionsPlay(): JSX.Element {
@@ -50,15 +51,18 @@ function _SessionsPlay(): JSX.Element {
         <div className="session-player">
             <Row gutter={16} style={{ height: '100%' }}>
                 <Col span={18} style={{ paddingRight: 0 }}>
-                    <div className="mb-05">
+                    <div className="mb-05" style={{ display: 'flex' }}>
                         {sessionPlayerDataLoading && <Skeleton paragraph={{ rows: 0 }} active />}
 
                         {!sessionPlayerDataLoading && (
                             <>
                                 {pageEvent ? (
                                     <>
-                                        <b>Current URL: </b>
-                                        {pageEvent.href}
+                                        <b>Current URL:</b>
+                                        <span className="url-info ml-05">{pageEvent.href}</span>
+                                        <CopyToClipboardInline explicitValue={pageEvent.href} isValueSensitive>
+                                            &nbsp;
+                                        </CopyToClipboardInline>
                                     </>
                                 ) : null}
                                 {/* TODO: Not implemented */}

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Player, PlayerRef } from 'posthog-react-rrweb-player'
-import { Card, Col, Input, Row, Tag } from 'antd'
+import { Card, Col, Input, Row, Skeleton, Tag } from 'antd'
 import {
     AppleOutlined,
     ChromeOutlined,
@@ -51,16 +51,22 @@ function _SessionsPlay(): JSX.Element {
             <Row gutter={16} style={{ height: '100%' }}>
                 <Col span={18} style={{ paddingRight: 0 }}>
                     <div className="mb-05">
-                        {pageEvent ? (
+                        {sessionPlayerDataLoading && <Skeleton paragraph={{ rows: 0 }} active />}
+
+                        {!sessionPlayerDataLoading && (
                             <>
-                                <b>Current URL: </b>
-                                {pageEvent.href}
+                                {pageEvent ? (
+                                    <>
+                                        <b>Current URL: </b>
+                                        {pageEvent.href}
+                                    </>
+                                ) : null}
+                                {/* TODO: Not implemented */}
+                                <span className="float-right" style={{ display: 'none' }}>
+                                    <ChromeOutlined /> Chrome on <AppleOutlined /> macOS (1400 x 600)
+                                </span>
                             </>
-                        ) : null}
-                        {/* TODO: Not implemented */}
-                        <span className="float-right" style={{ display: 'none' }}>
-                            <ChromeOutlined /> Chrome on <AppleOutlined /> macOS (1400 x 600)
-                        </span>
+                        )}
                     </div>
                     <div className="ph-no-capture player-container">
                         {sessionPlayerDataLoading ? (
@@ -77,62 +83,78 @@ function _SessionsPlay(): JSX.Element {
                 <Col span={6} className="sidebar" style={{ paddingLeft: 16 }}>
                     <Card className="card-elevated">
                         <h3 className="l3">Session Information</h3>
-                        <div className="mb-05" style={{ display: 'none' }}>
-                            {/* TODO: Add session duration information */}
-                            <FieldTimeOutlined /> {sessionTimestamp}
-                        </div>
-                        {sessionPlayerData?.person && (
+                        {sessionPlayerDataLoading && (
                             <div>
-                                <UserOutlined style={{ marginRight: 4 }} />
-                                <Link
-                                    to={`/person/${encodeURIComponent(sessionPlayerData.person.distinct_ids[0])}`}
-                                    className={rrwebBlockClass + ' ph-no-capture'}
-                                    target="_blank"
-                                    style={{ display: 'inline-flex', alignItems: 'center' }}
-                                >
-                                    <span style={{ marginRight: 4 }}>{sessionPlayerData.person.name}</span>
-                                    <IconExternalLink />
-                                </Link>
+                                <Skeleton paragraph={{ rows: 3 }} active />
                             </div>
                         )}
-                        <div className="mt" style={{ display: 'none' }}>
-                            <div>
-                                <b>Tags</b>
-                            </div>
-                            {tags.map((tag, index) => {
-                                return (
-                                    <Tag key={index} color={colorForString(tag)} closable className="tag-wrapper">
-                                        {tag}
-                                    </Tag>
-                                )
-                            })}
-                            <span className="tag-wrapper" style={{ display: 'inline-flex' }}>
-                                <Tag
-                                    onClick={toggleAddingTagShown}
-                                    data-attr="button-add-tag"
-                                    style={{
-                                        cursor: 'pointer',
-                                        borderStyle: 'dashed',
-                                        backgroundColor: '#ffffff',
-                                        display: addingTagShown ? 'none' : 'initial',
-                                    }}
-                                >
-                                    <PlusOutlined /> New Tag
-                                </Tag>
-                                <Input
-                                    type="text"
-                                    size="small"
-                                    onBlur={toggleAddingTagShown}
-                                    ref={addTagInput}
-                                    style={{ width: 78, display: !addingTagShown ? 'none' : 'flex' }}
-                                    value={addingTag}
-                                    onChange={(e) => setAddingTag(e.target.value)}
-                                    onPressEnter={createTag}
-                                    disabled={tagsLoading}
-                                    prefix={tagsLoading ? <SyncOutlined spin /> : null}
-                                />
-                            </span>
-                        </div>
+                        {!sessionPlayerDataLoading && (
+                            <>
+                                <div className="mb-05" style={{ display: 'none' }}>
+                                    {/* TODO: Add session duration information */}
+                                    <FieldTimeOutlined /> {sessionTimestamp}
+                                </div>
+                                {sessionPlayerData?.person && (
+                                    <div>
+                                        <UserOutlined style={{ marginRight: 4 }} />
+                                        <Link
+                                            to={`/person/${encodeURIComponent(
+                                                sessionPlayerData.person.distinct_ids[0]
+                                            )}`}
+                                            className={rrwebBlockClass + ' ph-no-capture'}
+                                            target="_blank"
+                                            style={{ display: 'inline-flex', alignItems: 'center' }}
+                                        >
+                                            <span style={{ marginRight: 4 }}>{sessionPlayerData.person.name}</span>
+                                            <IconExternalLink />
+                                        </Link>
+                                    </div>
+                                )}
+                                <div className="mt" style={{ display: 'none' }}>
+                                    <div>
+                                        <b>Tags</b>
+                                    </div>
+                                    {tags.map((tag, index) => {
+                                        return (
+                                            <Tag
+                                                key={index}
+                                                color={colorForString(tag)}
+                                                closable
+                                                className="tag-wrapper"
+                                            >
+                                                {tag}
+                                            </Tag>
+                                        )
+                                    })}
+                                    <span className="tag-wrapper" style={{ display: 'inline-flex' }}>
+                                        <Tag
+                                            onClick={toggleAddingTagShown}
+                                            data-attr="button-add-tag"
+                                            style={{
+                                                cursor: 'pointer',
+                                                borderStyle: 'dashed',
+                                                backgroundColor: '#ffffff',
+                                                display: addingTagShown ? 'none' : 'initial',
+                                            }}
+                                        >
+                                            <PlusOutlined /> New Tag
+                                        </Tag>
+                                        <Input
+                                            type="text"
+                                            size="small"
+                                            onBlur={toggleAddingTagShown}
+                                            ref={addTagInput}
+                                            style={{ width: 78, display: !addingTagShown ? 'none' : 'flex' }}
+                                            value={addingTag}
+                                            onChange={(e) => setAddingTag(e.target.value)}
+                                            onPressEnter={createTag}
+                                            disabled={tagsLoading}
+                                            prefix={tagsLoading ? <SyncOutlined spin /> : null}
+                                        />
+                                    </span>
+                                </div>
+                            </>
+                        )}
                     </Card>
                     <div className="mt" />
                     <Card className="card-elevated">
@@ -140,16 +162,23 @@ function _SessionsPlay(): JSX.Element {
                         <p className="text-muted text-small">
                             Click on an item to jump to that point in the recording.
                         </p>
-                        <div className="timeline">
-                            <div className="line" />
-                            <div className="timeline-items">
-                                {pageVisitEvents.map(({ href, playerTime }, index) => (
-                                    <div className={index === atPageIndex ? 'current' : undefined} key={index}>
-                                        <Tag onClick={() => playerRef.current?.seek(playerTime)}>{href}</Tag>
-                                    </div>
-                                ))}
+                        {sessionPlayerDataLoading && (
+                            <div>
+                                <Skeleton paragraph={{ rows: 6 }} active />
                             </div>
-                        </div>
+                        )}
+                        {!sessionPlayerDataLoading && (
+                            <div className="timeline">
+                                <div className="line" />
+                                <div className="timeline-items">
+                                    {pageVisitEvents.map(({ href, playerTime }, index) => (
+                                        <div className={index === atPageIndex ? 'current' : undefined} key={index}>
+                                            <Tag onClick={() => playerRef.current?.seek(playerTime)}>{href}</Tag>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </Card>
                 </Col>
             </Row>

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { EventIndex, Player, PlayerRef } from 'posthog-react-rrweb-player'
+import { Player, PlayerRef } from 'posthog-react-rrweb-player'
 import { Card, Col, Input, Row, Tag } from 'antd'
 import {
     AppleOutlined,
@@ -30,17 +30,15 @@ function _SessionsPlay(): JSX.Element {
         tags,
         tagsLoading,
         sessionTimestamp,
+        eventIndex,
+        pageVisitEvents,
     } = useValues(sessionsPlayLogic)
     const { toggleAddingTagShown, setAddingTag, createTag } = useActions(sessionsPlayLogic)
     const addTagInput = useRef<Input>(null)
 
     const [playerTime, setCurrentPlayerTime] = useState(0)
     const playerRef = useRef<PlayerRef>(null)
-    const eventIndex: EventIndex = useMemo(() => new EventIndex(sessionPlayerData?.snapshots || []), [
-        sessionPlayerData,
-    ])
     const [pageEvent, atPageIndex] = useMemo(() => eventIndex.getPageMetadata(playerTime), [eventIndex, playerTime])
-    const pageVisitEvents = useMemo(() => eventIndex.pageChangeEvents(), [eventIndex])
 
     useEffect(() => {
         if (addingTagShown && addTagInput.current) {

--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -5,6 +5,7 @@ import { toParams } from 'lib/utils'
 import { sessionsPlayLogicType } from 'types/scenes/sessions/sessionsPlayLogicType'
 import { PersonType } from '~/types'
 import moment from 'moment'
+import { EventIndex } from 'posthog-react-rrweb-player'
 interface SessionPlayerData {
     snapshots: eventWithTime[]
     person: PersonType | null
@@ -88,6 +89,18 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData>>({
                 }
                 // TODO: Client-side timestamp, needs review
                 return moment(sessionPlayerData.snapshots[0].timestamp).format('lll')
+            },
+        ],
+        eventIndex: [
+            (selectors) => [selectors.sessionPlayerData],
+            (sessionPlayerData: SessionPlayerData): EventIndex => {
+                return new EventIndex(sessionPlayerData?.snapshots || [])
+            },
+        ],
+        pageVisitEvents: [
+            (selectors) => [selectors.eventIndex],
+            (eventIndex) => {
+                return eventIndex.pageChangeEvents()
             },
         ],
     },


### PR DESCRIPTION
## Changes

Introduces a few extra improvements to the session player page.

- Shows a nice loading state when session data is not yet ready.
    <img width="1437" alt="" src="https://user-images.githubusercontent.com/5864173/100399984-e4c3f180-3022-11eb-96c5-8fb9fb383cae.png">
- Makes sure long URLs don't overflow everywhere and adds a helper to copy URL to clipboard.

**Before**
<img width="1090" alt="" src="https://user-images.githubusercontent.com/5864173/100400032-0cb35500-3023-11eb-8293-06e5e7616653.png">

**After**
<img width="1073" alt="" src="https://user-images.githubusercontent.com/5864173/100400038-10df7280-3023-11eb-9f1f-57f7e92ba5fc.png">

- Refactors some logic to Kea.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
