### PR TITLE
Closes #2508 Fix cohort days

### DIFF
--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -109,7 +109,7 @@ class Cohort(models.Model):
                     .filter(
                         team_id=self.team_id,
                         **(
-                            {"timestamp__gt": timezone.now() - relativedelta(days=group["days"])}
+                            {"timestamp__gt": timezone.now() - relativedelta(days=int(group["days"]))}
                             if group.get("days")
                             else {}
                         ),

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -19,7 +19,7 @@ class TestCohort(BaseTest):
         person3 = Person.objects.create(distinct_ids=["person_3"], team=self.team)
         person4 = Person.objects.create(distinct_ids=["person_4"], team=self.team)
 
-        cohort = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk, "days": 7}])
+        cohort = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk, "days": "7"}])
         cohort.calculate_people(use_clickhouse=False)
         with self.assertNumQueries(1):
             self.assertEqual([p for p in cohort.people.all()], [person1])


### PR DESCRIPTION
## Changes

When trying to save groups we sometimes save it as string. Just parse it instead of not allowing cohort to save.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
