### PR TITLE
Don't toggle rows when viewing player

### DIFF
--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -17,8 +17,7 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
 
     const sessionPlayerUrl = (sessionRecordingId: string): string => {
         if (featureFlags['full-page-player']) {
-            const params = { ...fromParams(), id: sessionRecordingId }
-            return `/sessions/play?${toParams(params)}`
+            return `/sessions/play?${toParams({ id: sessionRecordingId })}`
         }
         return `${location.pathname}?${toParams({ ...fromParams(), sessionRecordingId })}`
     }
@@ -35,6 +34,7 @@ export default function SessionsPlayerButton({ session }: SessionsPlayerButtonPr
                     target={featureFlags['full-page-player'] ? '_blank' : undefined}
                     className="sessions-player-button"
                     key={sessionRecordingId}
+                    onClick={(event) => event.stopPropagation()}
                 >
                     <PlayCircleOutlined />
                 </Link>


### PR DESCRIPTION
## Changes

After recent changes, viewing a recording would toggle player rows. This fixes it.  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
