### PR TITLE
Fix posthog identify

### DIFF
--- a/frontend/src/layout.ejs
+++ b/frontend/src/layout.ejs
@@ -5,9 +5,15 @@
     <meta name="robots" content="noindex">
     <title>PostHog</title>
     {% include "head.html" %}
+
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init({{js_posthog_api_key | safe}}, {api_host: {{js_posthog_host | safe}}})
+    </script>
     <%= htmlWebpackPlugin.tags.headTags %><%/* This adds the main.css file! */%>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet"
         crossorigin="anonymous" />
+
 <style>
     html,
 body {

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -101,7 +101,11 @@ export const userLogic = kea<userLogicType<UserType, EventProperty, UserUpdateTy
                     })
 
                     if (posthog) {
-                        if (posthog.get_distinct_id() !== user.distinct_id) {
+                        // If user is not anonymous and the distinct id is different from the current one, reset
+                        if (
+                            posthog.get_property('$device_id') !== posthog.get_distinct_id() &&
+                            posthog.get_distinct_id() !== user.distinct_id
+                        ) {
                             posthog.reset()
                         }
 

--- a/posthog/models/dashboard_item.py
+++ b/posthog/models/dashboard_item.py
@@ -2,7 +2,6 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
-from sentry_sdk import capture_exception
 
 from posthog.models.filter import Filter
 from posthog.utils import generate_cache_key

--- a/posthog/models/dashboard_item.py
+++ b/posthog/models/dashboard_item.py
@@ -2,6 +2,7 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
+from sentry_sdk import capture_exception
 
 from posthog.models.filter import Filter
 from posthog.utils import generate_cache_key


### PR DESCRIPTION
## Changes

- We were resetting the user every time the distinct id was different, even if that ID was anonymous.
- Also add tracking to login etc pages.

Would be nice to have a is_anonymous function on posthog-js or something but this is good enough for now.

cc @macobo b/c he made this change so checking if there was another reason I'm missing.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
