### PR TITLE
Bump posthog-js 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "kea-router": "^0.5.1",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "^1.7.0",
+        "posthog-js": "1.7.2",
         "posthog-js-lite": "^0.0.3",
         "posthog-plugins": "0.1.3",
         "posthog-react-rrweb-player": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8210,10 +8210,10 @@ posthog-js-lite@^0.0.3:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.3.tgz#87e373706227a849c4e7c6b0cb2066a64ad5b6ed"
   integrity sha512-wEOs8DEjlFBwgd7l19grosaF7mTlliZ9G9pL0Qji189FDg2ukY5IegUxTyTs7gsTGt6WK9W47BF5yXA5+bwvZg==
 
-posthog-js@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.7.0.tgz#6542b0806e8ac7cb35f792fd6d98cb6dce599e47"
-  integrity sha512-zKM+IpW8B1rlav/LcNrOJLJKbeegxvCkcSk6GMJ62ReXCl3CilKn7NwHPk8/tG75BIOWeZGFs7wNeeEPdVBVWg==
+posthog-js@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.7.2.tgz#edacb90413630f85db0ec317a7d687704b3101fb"
+  integrity sha512-iv/2LTHFRFOrf4xih40Soa1tUNNIcg21LMP7rtUjAeg+TFJEToBPkUgp93b7tT1VXblN2irJHS7ELEo9EriJAQ==
 
 posthog-plugins@0.1.3:
   version "0.1.3"


### PR DESCRIPTION
## Changes

Fixes `posthogcompression` errors:
![image](https://user-images.githubusercontent.com/1727427/100515623-bad31200-317d-11eb-99c0-879fe9eed557.png)

@macobo fyi

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
