### PR TITLE
Add device type icons to session player page

### DIFF
--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Player, PlayerRef } from 'posthog-react-rrweb-player'
 import { Card, Col, Input, Row, Skeleton, Tag } from 'antd'
-import { UserOutlined, FieldTimeOutlined, PlusOutlined, SyncOutlined } from '@ant-design/icons'
+import {
+    UserOutlined,
+    FieldTimeOutlined,
+    PlusOutlined,
+    SyncOutlined,
+    LaptopOutlined,
+    MobileOutlined,
+    TabletOutlined,
+} from '@ant-design/icons'
 import { hot } from 'react-hot-loader/root'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
@@ -27,6 +35,15 @@ function formatDuration(milliseconds: number): string {
         }
     }
     return `${Math.round(milliseconds / 1000)} second`
+}
+
+function DeviceIcon({ width }: { width: number }): JSX.Element {
+    if (width <= 475) {
+        return <MobileOutlined />
+    } else if (width > 475 && width < 860) {
+        return <TabletOutlined />
+    }
+    return <LaptopOutlined />
 }
 
 export const SessionsPlay = hot(_SessionsPlay)
@@ -79,10 +96,12 @@ function _SessionsPlay(): JSX.Element {
                                         </CopyToClipboardInline>
                                     </>
                                 ) : null}
-                                <span style={{ marginLeft: 'auto' }}>
-                                    <b>Resolution: </b>
-                                    {recordingMetadata && recordingMetadata.resolution}
-                                </span>
+                                {recordingMetadata && (
+                                    <span style={{ marginLeft: 'auto' }}>
+                                        <b>Resolution: </b>
+                                        <DeviceIcon width={recordingMetadata.width} /> {recordingMetadata.resolution}
+                                    </span>
+                                )}
                             </>
                         )}
                     </div>

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -48,7 +48,7 @@ function _SessionsPlay(): JSX.Element {
     const [playerTime, setCurrentPlayerTime] = useState(0)
     const playerRef = useRef<PlayerRef>(null)
     const [pageEvent, atPageIndex] = useMemo(() => eventIndex.getPageMetadata(playerTime), [eventIndex, playerTime])
-    const [sizeEvent] = useMemo(() => eventIndex.getSizeMetadata(playerTime), [eventIndex, playerTime])
+    const [recordingMetadata] = useMemo(() => eventIndex.getRecordingMetadata(playerTime), [eventIndex, playerTime])
 
     useEffect(() => {
         if (addingTagShown && addTagInput.current) {
@@ -81,7 +81,7 @@ function _SessionsPlay(): JSX.Element {
                                 ) : null}
                                 <span style={{ marginLeft: 'auto' }}>
                                     <b>Resolution: </b>
-                                    {sizeEvent && sizeEvent.size}
+                                    {recordingMetadata && recordingMetadata.resolution}
                                 </span>
                             </>
                         )}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "posthog-js": "1.7.3-beta.1",
         "posthog-js-lite": "^0.0.3",
         "posthog-plugins": "0.1.3",
-        "posthog-react-rrweb-player": "^1.0.9",
+        "posthog-react-rrweb-player": "^1.0.10",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "posthog-js": "1.7.3-beta.1",
         "posthog-js-lite": "^0.0.3",
         "posthog-plugins": "0.1.3",
-        "posthog-react-rrweb-player": "^1.0.10",
+        "posthog-react-rrweb-player": "^1.0.11",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8220,10 +8220,10 @@ posthog-plugins@0.1.3:
   resolved "https://registry.yarnpkg.com/posthog-plugins/-/posthog-plugins-0.1.3.tgz#3a47f1303733720c308f33f67162ca2823845bbf"
   integrity sha512-6VElUUux/AA+uetGWk9p0+cep8+ByE0P0Zv8cypT9z/3hLUhueTjrvQZDL835656BOPtVRdBOxjBqQ7fYog57g==
 
-posthog-react-rrweb-player@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/posthog-react-rrweb-player/-/posthog-react-rrweb-player-1.0.10.tgz#292848998f06d216ee653ed75a62554f2db7d22a"
-  integrity sha512-Uu++fp1V0ioBoqmZxeBjHX8yu3yX1xSz2S1RNlzBbC63aSzdnGG3MZD3f5zr7BJqLszEJ9iqf3tW6fay5qDqVQ==
+posthog-react-rrweb-player@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/posthog-react-rrweb-player/-/posthog-react-rrweb-player-1.0.11.tgz#960c6198af179242e5c94aebdb8301d2439eb51a"
+  integrity sha512-aCBcTQfbKWj/k1OAxIIe8m0FBLmJpvAyCYe9dcgmGLuac8G92CaMaV9RKUvPaZPpLexyxGRaB117w1MX9g7RKg==
   dependencies:
     rc-slider "^9.6.2"
     rc-tooltip "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8220,10 +8220,10 @@ posthog-plugins@0.1.3:
   resolved "https://registry.yarnpkg.com/posthog-plugins/-/posthog-plugins-0.1.3.tgz#3a47f1303733720c308f33f67162ca2823845bbf"
   integrity sha512-6VElUUux/AA+uetGWk9p0+cep8+ByE0P0Zv8cypT9z/3hLUhueTjrvQZDL835656BOPtVRdBOxjBqQ7fYog57g==
 
-posthog-react-rrweb-player@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/posthog-react-rrweb-player/-/posthog-react-rrweb-player-1.0.9.tgz#8bf92bae8c90b5080ca591226a014d65be200ad7"
-  integrity sha512-1iWJgJRUhC2uUrJelXnqynLhbnJ/gZ0SBT2jTHoKKOVT4NsQ7in6yH4GW5NFDEnTAMjtavZ6+P8G4mkb4tXkeA==
+posthog-react-rrweb-player@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/posthog-react-rrweb-player/-/posthog-react-rrweb-player-1.0.10.tgz#292848998f06d216ee653ed75a62554f2db7d22a"
+  integrity sha512-Uu++fp1V0ioBoqmZxeBjHX8yu3yX1xSz2S1RNlzBbC63aSzdnGG3MZD3f5zr7BJqLszEJ9iqf3tW6fay5qDqVQ==
   dependencies:
     rc-slider "^9.6.2"
     rc-tooltip "^5.0.1"


### PR DESCRIPTION
## Changes

- Adds device type icons to session player page (mobile, tablet, desktop) based on the device's width.
- Updates posthog-react-rrweb-player

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
