### PR TITLE
DAU breakdown and filter bug

### DIFF
--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -56,7 +56,7 @@ class ClickhouseTrendsBreakdown:
         parsed_date_from, parsed_date_to = parse_timestamps(filter=filter)
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, table_name="e")
         aggregate_operation, join_condition, math_params = process_math(entity)
 
         action_query = ""


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes bug related to #2569. When applying the dau condition with breakdown and filters, the prop filter statements need a specific table name which was missing

*If this affects the frontend, include screenshots.*  

## Checklist

- [x] Django backend tests
