### PR TITLE
Use last selected dashboard when clicking 'save to dashboard'

### DIFF
--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
@@ -22,9 +22,9 @@ const saveToDashboardModalLogic = kea({
         _dashboardId: [null, { setDashboardId: (_, { id }) => id }],
     },
 
-    selectors: ({ props, selectors }) => ({
+    selectors: ({ props }) => ({
         dashboardId: [
-            () => [selectors._dashboardId, selectors.lastDashboardId, selectors.dashboards],
+            (s) => [s._dashboardId, s.lastDashboardId, s.dashboards],
             (_dashboardId, lastDashboardId, dashboards) =>
                 _dashboardId ||
                 props.fromDashboard ||
@@ -68,9 +68,8 @@ export function SaveToDashboardModal({
     fromItemName,
     annotations,
 }) {
-    const { dashboards } = useValues(dashboardsModel)
     const logic = saveToDashboardModalLogic({ fromDashboard })
-    const { dashboardId } = useValues(logic)
+    const { dashboards, dashboardId } = useValues(logic)
     const { addNewDashboard, setDashboardId } = useActions(logic)
     const [name, setName] = useState(fromItemName || initialName || '')
     const [visible, setVisible] = useState(true)

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
@@ -9,11 +9,35 @@ import { prompt } from 'lib/logic/prompt'
 import moment from 'moment'
 
 const saveToDashboardModalLogic = kea({
+    connect: {
+        values: [dashboardsModel, ['dashboards', 'lastDashboardId']],
+    },
+
     actions: () => ({
         addNewDashboard: true,
+        setDashboardId: (id) => ({ id }),
     }),
 
-    listeners: ({ props }) => ({
+    reducers: {
+        _dashboardId: [null, { setDashboardId: (_, { id }) => id }],
+    },
+
+    selectors: ({ props, selectors }) => ({
+        dashboardId: [
+            () => [selectors._dashboardId, selectors.lastDashboardId, selectors.dashboards],
+            (_dashboardId, lastDashboardId, dashboards) =>
+                _dashboardId ||
+                props.fromDashboard ||
+                lastDashboardId ||
+                (dashboards.length > 0 ? dashboards[0].id : null),
+        ],
+    }),
+
+    listeners: ({ actions }) => ({
+        setDashboardId: ({ id }) => {
+            dashboardsModel.actions.setLastDashboardId(id)
+        },
+
         addNewDashboard: async () => {
             prompt({ key: `saveToDashboardModalLogic-new-dashboard` }).actions.prompt({
                 title: 'New dashboard',
@@ -25,7 +49,7 @@ const saveToDashboardModalLogic = kea({
         },
 
         [dashboardsModel.actions.addDashboardSuccess]: ({ dashboard }) => {
-            props.setDashboardId && props.setDashboardId(dashboard.id)
+            actions.setDashboardId(dashboard.id)
         },
     }),
 })
@@ -44,11 +68,10 @@ export function SaveToDashboardModal({
     fromItemName,
     annotations,
 }) {
-    const { dashboards, lastVisitedDashboardId } = useValues(dashboardsModel)
-    const [dashboardId, setDashboardId] = useState(
-        fromDashboard || lastVisitedDashboardId || (dashboards.length > 0 ? dashboards[0].id : null)
-    )
-    const { addNewDashboard } = useActions(saveToDashboardModalLogic({ setDashboardId }))
+    const { dashboards } = useValues(dashboardsModel)
+    const logic = saveToDashboardModalLogic({ fromDashboard })
+    const { dashboardId } = useValues(logic)
+    const { addNewDashboard, setDashboardId } = useActions(logic)
     const [name, setName] = useState(fromItemName || initialName || '')
     const [visible, setVisible] = useState(true)
     const [newItem, setNewItem] = useState(!fromItem)

--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify'
 export const dashboardsModel = kea({
     actions: () => ({
         delayedDeleteDashboard: (id) => ({ id }),
-        setLastVisitedDashboardId: (id) => ({ id }),
+        setLastDashboardId: (id) => ({ id }),
         // this is moved out of dashboardLogic, so that you can click "undo" on a item move when already
         // on another dashboard - both dashboards can listen to and share this event, even if one is not yet mounted
         updateDashboardItem: (item) => ({ item }),
@@ -72,10 +72,11 @@ export const dashboardsModel = kea({
             pinDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
             unpinDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
         },
-        lastVisitedDashboardId: [
+        lastDashboardId: [
             null,
+            { persist: true },
             {
-                setLastVisitedDashboardId: (_, { id }) => id,
+                setLastDashboardId: (_, { id }) => id,
             },
         ],
     }),
@@ -147,6 +148,6 @@ export const dashboardsModel = kea({
     }),
 
     urlToAction: ({ actions }) => ({
-        '/dashboard/:id': ({ id }) => actions.setLastVisitedDashboardId(parseInt(id)),
+        '/dashboard/:id': ({ id }) => actions.setLastDashboardId(parseInt(id)),
     }),
 })


### PR DESCRIPTION
This also keeps all of the previous logic + makes last visited dashboard
persistent.

Fixes https://github.com/PostHog/posthog/issues/2585

cc @mariusandra if you have feedback on the kea parts.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
