### PR TITLE
Update session recording settings

### DIFF
--- a/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/CodeSnippet.tsx
@@ -70,7 +70,7 @@ SyntaxHighlighter.registerLanguage(Language.Markup, markup)
 SyntaxHighlighter.registerLanguage(Language.HTTP, http)
 
 export interface CodeSnippetProps {
-    children: string
+    children: string | undefined
     language?: Language
     wrap?: boolean
     actions?: Action[]

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -114,7 +114,7 @@ const logic = kea<logicType<UserType>>({
     }),
 })
 
-export function WebhookIntegration({ user }: { user: UserType }): JSX.Element {
+export function WebhookIntegration({ user }: { user: UserType | null }): JSX.Element {
     const { isSaving, editedWebhook } = useValues(logic)
     const { testThenSaveWebhook, setEditedWebhook } = useActions(logic)
 

--- a/frontend/src/scenes/project/Settings/index.js
+++ b/frontend/src/scenes/project/Settings/index.js
@@ -16,6 +16,7 @@ import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { teamLogic } from 'scenes/teamLogic'
 import { DangerZone } from './DangerZone'
 import { PageHeader } from 'lib/components/PageHeader'
+import { Link } from 'lib/components/Link'
 
 export const Setup = hot(_Setup)
 function _Setup({ user }) {
@@ -100,7 +101,19 @@ function _Setup({ user }) {
                         BETA
                     </Tag>
                 </h2>
-                <p>Watch sessions replays to see how users interact with your app and find out what can be improved.</p>
+                <p>
+                    Watch sessions replays to see how users interact with your app and find out what can be improved.
+                    You can watch recorded sessions in the <Link to="/sessions">sessions page</Link>. Please note{' '}
+                    <b>your website needs to have</b> the <a href="#snippet">PostHog snippet</a> or the latest version
+                    of{' '}
+                    <a
+                        href="https://posthog.com/docs/integrations/js-integration?utm_campaign=session-recording&utm_medium=in-product"
+                        target="_blank"
+                    >
+                        posthog-js
+                    </a>{' '}
+                    installed.
+                </p>
                 <OptInSessionRecording />
                 <p>
                     This is a new feature of PostHog. Please{' '}


### PR DESCRIPTION
## Changes

From user feedback and some session recordings ([#1](https://app.posthog.com/sessions/play?id=1760bd675e53be-0e1242623a085a-16144b58-13c680-1760bd675e6bdc)),
- Adds a few clarifications around requirements for session recordings.
- Simplifies the process for giving feedback on the session recording feature (seems like opening a GH is too much friction), using the command palette.
- Migrates project settings page to TS.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
