### PR TITLE
Fixes Link component default behavior

### DIFF
--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -2,17 +2,16 @@ import React, { HTMLProps } from 'react'
 import { router } from 'kea-router'
 
 interface LinkProps extends HTMLProps<HTMLAnchorElement> {
-    to: string | [string, string?, string?]
+    to: string
     preventClick?: boolean
     tag?: string | React.Component
 }
 
 export function Link({ to, preventClick = false, tag = 'a', ...props }: LinkProps): JSX.Element {
-    const onClick = (event): void => {
+    const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.metaKey || event.ctrlKey) {
-            event.preventDefault()
             event.stopPropagation()
-            return window.open(to, '_blank')
+            return
         }
 
         if (!props.target) {


### PR DESCRIPTION
## Changes

- Fixes Link behavior when cmd (or control on Windows) clicking a link that caused the new tab to be focused immediately after opening it (as opposed to the default browser behavior of opening the new tab but staying in the current tab).
    ![image](https://user-images.githubusercontent.com/5864173/100800077-aeec8780-33eb-11eb-99d4-82289eca0619.gif)
- Fixes some TS linting issues
