### PR TITLE
Add flags to `bin/docker-worker-celery`

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: REDIS_URL='redis://' python manage.py migrate
 web: gunicorn posthog.wsgi --log-file -
 worker: ./bin/docker-worker
-celeryworker: ./bin/docker-worker-celery --with-beat # optional
+celeryworker: ./bin/docker-worker-celery --with-scheduler # optional
 pluginworker: ./bin/plugin-server # optional

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -15,5 +15,5 @@ then
   echo "⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️"
 else
   ./bin/plugin-server &
-  ./bin/docker-worker-celery --with-beat
+  ./bin/docker-worker-celery --with-scheduler
 fi

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -1,17 +1,78 @@
 #!/bin/bash
 set -e
 
-if [ "$1" == "--with-beat" ]; then
+help () {
+  echo "$0 - Start PostHog's celery worker"
+  echo " "
+  echo "$0 [options]"
+  echo " "
+  echo "Options:"
+  echo "  --help, -h            show brief help"
+  echo "  --with-scheduler      start RedBeat, the celery scheduler (deprecates: --with-beat)"
+  echo "  --concurrency=<N>     start N workers. Can be set via WEB_CONCURRENCY env"
+  echo ""
+  echo "Advanced celery options (disabled by default):"
+  echo "  --with-gossip         start celery gossip (useful for prometheus)"
+  echo "  --with-heartbeat      start celery internal heartbeat (normally not useful)"
+  echo "  --with-mingle         start celery mingle (normally not useful)"
+  exit 0
+}
+
+with_scheduler=false
+with_gossip=false
+with_heartbeat=false
+with_mingle=false
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      help
+      ;;
+    --with-scheduler)
+      with_scheduler=true
+      shift
+      ;;
+    --with-beat) # deprecated since the name is similar to "heartbeat", use "--with-scheduler" instead
+      echo "!! Using docker-worker-celery with --with-beat. This argument is deprecated. Use --with-scheduler instead!"
+      with_scheduler=true
+      shift
+      ;;
+    --with-gossip)
+      with_gossip=true
+      shift
+      ;;
+    --with-heartbeat)
+      with_heartbeat=true
+      shift
+      ;;
+    --with-mingle)
+      with_mingle=true
+      shift
+      ;;
+    --concurrency*)
+      export WEB_CONCURRENCY=`echo $1 | sed -e 's/^[^=]*=//g'`
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &
 fi
 
+FLAGS=""
+[ "$with_gossip" == "false" ]    && FLAGS="$FLAGS --without-gossip"
+[ "$with_mingle" == "false" ]    && FLAGS="$FLAGS --without-mingle"
+[ "$with_heartbeat" == "false" ] && FLAGS="$FLAGS --without-heartbeat"
+
 # On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
-if [[ -z "${WEB_CONCURRENCY}" ]]; then
-  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle
-else
-  celery -A posthog worker --without-heartbeat --without-gossip --without-mingle --concurrency $WEB_CONCURRENCY
-fi
+[[ -n "${WEB_CONCURRENCY}" ]]    && FLAGS="$FLAGS --concurrency $WEB_CONCURRENCY"
+
+celery -A posthog worker $FLAGS
 
 # Stop the beat!
 trap 'kill $(jobs -p)' EXIT

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -2,19 +2,19 @@
 set -e
 
 help () {
-  echo "$0 - Start PostHog's celery worker"
-  echo " "
+  echo "$0 - start PostHog's Celery worker"
+  echo
   echo "$0 [options]"
-  echo " "
+  echo
   echo "Options:"
-  echo "  --help, -h            show brief help"
-  echo "  --with-scheduler      start RedBeat, the celery scheduler (deprecates: --with-beat)"
-  echo "  --concurrency=<N>     start N workers. Can be set via WEB_CONCURRENCY env"
-  echo ""
-  echo "Advanced celery options (disabled by default):"
-  echo "  --with-gossip         start celery gossip (useful for prometheus)"
-  echo "  --with-heartbeat      start celery internal heartbeat (normally not useful)"
-  echo "  --with-mingle         start celery mingle (normally not useful)"
+  echo "  --help, -h            show this brief help"
+  echo "  --with-scheduler      start RedBeat, the Celery scheduler (deprecates --with-beat)"
+  echo "  --concurrency=<N>     start N workers (overrides env var WEB_CONCURRENCY)"
+  echo
+  echo "Advanced Celery options (disabled by default):"
+  echo "  --with-gossip         start Celery gossip (useful for Prometheus)"
+  echo "  --with-heartbeat      start Celery internal heartbeat (normally not useful)"
+  echo "  --with-mingle         start Celery mingle (normally not useful)"
   exit 0
 }
 
@@ -32,8 +32,8 @@ while test $# -gt 0; do
       with_scheduler=true
       shift
       ;;
-    --with-beat) # deprecated since the name is similar to "heartbeat", use "--with-scheduler" instead
-      echo "!! Using docker-worker-celery with --with-beat. This argument is deprecated. Use --with-scheduler instead!"
+    --with-beat) # Deprecated since the name is too similar to "heartbeat"
+      echo "⚠️ Using docker-worker-celery with --with-beat. This argument is deprecated. Use --with-scheduler instead!"
       with_scheduler=true
       shift
       ;;
@@ -63,16 +63,19 @@ if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &
 fi
 
-FLAGS=""
-[ "$with_gossip" == "false" ]    && FLAGS="$FLAGS --without-gossip"
-[ "$with_mingle" == "false" ]    && FLAGS="$FLAGS --without-mingle"
-[ "$with_heartbeat" == "false" ] && FLAGS="$FLAGS --without-heartbeat"
+FLAGS=()
+[ "$with_gossip" == "false" ]    && FLAGS+=("--without-gossip")
+[ "$with_mingle" == "false" ]    && FLAGS+=("--without-mingle")
+[ "$with_heartbeat" == "false" ] && FLAGS+=("--without-heartbeat")
 
-# On heroku $WEB_CONCURRENCY contains suggested nr of forks per dyno type
+# On Heroku $WEB_CONCURRENCY contains suggested number of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
-[[ -n "${WEB_CONCURRENCY}" ]]    && FLAGS="$FLAGS --concurrency $WEB_CONCURRENCY"
+[[ -n "${WEB_CONCURRENCY}" ]]    && FLAGS+=" --concurrency $WEB_CONCURRENCY"
 
-celery -A posthog worker $FLAGS
+echo
+echo "celery -A posthog worker ${FLAGS[*]}"
+echo
+celery -A posthog worker ${FLAGS[*]}
 
 # Stop the beat!
 trap 'kill $(jobs -p)' EXIT


### PR DESCRIPTION
## Changes

- Add more flags to `bin/docker-worker-celery`
- Rename `--with-beat` to `--with-scheduler` to make it more obvious
- Closes #2607

```
help () {
  echo "$0 - Start PostHog's celery worker"
  echo " "
  echo "$0 [options]"
  echo " "
  echo "Options:"
  echo "  --help, -h            show brief help"
  echo "  --with-scheduler      start RedBeat, the celery scheduler (deprecates: --with-beat)"
  echo "  --concurrency=<N>     start N workers. Can be set via WEB_CONCURRENCY env"
  echo ""
  echo "Advanced celery options (disabled by default):"
  echo "  --with-gossip         start celery gossip (useful for prometheus)"
  echo "  --with-heartbeat      start celery internal heartbeat (normally not useful)"
  echo "  --with-mingle         start celery mingle (normally not useful)"
  exit 0
}
```


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
