### PR TITLE
Access config to unlock after 15 mins and template

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 import shutil
 import sys
+from datetime import timedelta
 from distutils.util import strtobool
 from typing import Dict, List, Sequence
 from urllib.parse import urlparse
@@ -183,9 +184,15 @@ STATSD_HOST = os.environ.get("STATSD_HOST")
 STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
 STATSD_PREFIX = os.environ.get("STATSD_PREFIX", "")
 
-# django-axes settings
+# django-axes settings to lockout after too many attempts
 AXES_ENABLED = get_bool_from_env("AXES_ENABLED", True)
-AXES_FAILURE_LIMIT = int(os.environ.get("AXES_FAILURE_LIMIT", 3))
+AXES_FAILURE_LIMIT = int(os.environ.get("AXES_FAILURE_LIMIT", 5))
+AXES_COOLOFF_TIME = timedelta(minutes=15)
+AXES_LOCKOUT_TEMPLATE = "too_many_failed_logins.html"
+AXES_META_PRECEDENCE_ORDER = [
+    "HTTP_X_FORWARDED_FOR",
+    "REMOTE_ADDR",
+]
 
 # Application definition
 

--- a/posthog/templates/too_many_failed_logins.html
+++ b/posthog/templates/too_many_failed_logins.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+ 
+<form class="form-signin" method="post" action="/login">
+    <h2>Too many failed login attempts</h2>
+
+    Please try again in 15 minutes or contact support.
+</form>
+{% endblock %}


### PR DESCRIPTION
## Changes

Follow up to #2582, make sure we don't _permanently_ lock people out, increase attempts to 5 and add a template.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
