### PR TITLE
Proposal: When clicking 'add action/event', populate the generated event with last event data

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import { useActions, useValues } from 'kea'
 import { Button, Tooltip, Dropdown, Menu, Col, Row, Select } from 'antd'
 import { EntityTypes } from '../trendsLogic'
@@ -138,10 +138,17 @@ const determineFilterLabel = (visible, filter) => {
 
 export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
     const node = useRef()
-    const { selectedFilter, entities } = useValues(logic)
-    const { selectFilter, updateFilterMath, removeLocalFilter, updateFilterProperty } = useActions(logic)
+    const { selectedFilter, entities, entityFilterVisible } = useValues(logic)
+    const {
+        selectFilter,
+        updateFilterMath,
+        removeLocalFilter,
+        updateFilterProperty,
+        setEntityFilterVisibility,
+    } = useActions(logic)
     const { eventProperties, eventPropertiesNumerical } = useValues(userLogic)
-    const [entityFilterVisible, setEntityFilterVisible] = useState(false)
+
+    const visible = entityFilterVisible[filter.order]
 
     let entity, name, value
     let math = filter.math
@@ -241,10 +248,10 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 <span style={{ color: '#C4C4C4', fontSize: 18, paddingLeft: 6, paddingRight: 2 }}>&#8627;</span>
                 <Button
                     className="ant-btn-md"
-                    onClick={() => setEntityFilterVisible(!entityFilterVisible)}
+                    onClick={() => setEntityFilterVisibility(filter.order, !visible)}
                     data-attr={'show-prop-filter-' + index}
                 >
-                    {determineFilterLabel(entityFilterVisible, filter)}
+                    {determineFilterLabel(visible, filter)}
                 </Button>
                 <CloseButton
                     onClick={onClose}
@@ -257,7 +264,7 @@ export function ActionFilterRow({ logic, filter, index, hideMathSelector }) {
                 />
             </div>
 
-            {entityFilterVisible && (
+            {visible && (
                 <div className="ml">
                     <PropertyFilters
                         pageKey={`${index}-${value}-filter`}

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.js
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.js
@@ -101,10 +101,12 @@ export const entityFilterLogic = kea({
             actions.setFilters(values.localFilters.filter((_, i) => i !== index))
         },
         addFilter: () => {
-            actions.setFilters([
-                ...values.localFilters,
-                { id: null, type: EntityTypes.NEW_ENTITY, order: values.localFilters.length },
-            ])
+            if (values.localFilters.length > 0) {
+                const lastFilter = values.localFilters[values.localFilters.length - 1]
+                actions.setFilters([...values.localFilters, { ...lastFilter, order: values.localFilters.length }])
+            } else {
+                actions.setFilters([{ id: null, type: EntityTypes.NEW_ENTITY, order: values.localFilters.length }])
+            }
         },
         setFilters: ({ filters }) => {
             props.setFilters(toFilters(filters))

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.js
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.js
@@ -50,6 +50,7 @@ export const entityFilterLogic = kea({
         updateFilterProperty: (filter) => ({ properties: filter.properties, index: filter.index }),
         setFilters: (filters) => ({ filters }),
         setLocalFilters: (filters) => ({ filters }),
+        setEntityFilterVisibility: (index, value) => ({ index, value }),
     }),
 
     reducers: ({ props }) => ({
@@ -63,6 +64,12 @@ export const entityFilterLogic = kea({
             toLocalFilters(props.filters),
             {
                 setLocalFilters: (_, { filters }) => toLocalFilters(filters),
+            },
+        ],
+        entityFilterVisible: [
+            {},
+            {
+                setEntityFilterVisibility: (state, { index, value }) => ({ ...state, [index]: value }),
             },
         ],
     }),
@@ -103,9 +110,11 @@ export const entityFilterLogic = kea({
         addFilter: () => {
             if (values.localFilters.length > 0) {
                 const lastFilter = values.localFilters[values.localFilters.length - 1]
-                actions.setFilters([...values.localFilters, { ...lastFilter, order: values.localFilters.length }])
+                const order = lastFilter.order + 1
+                actions.setFilters([...values.localFilters, { ...lastFilter, order }])
+                actions.setEntityFilterVisibility(order, values.entityFilterVisible[lastFilter.order])
             } else {
-                actions.setFilters([{ id: null, type: EntityTypes.NEW_ENTITY, order: values.localFilters.length }])
+                actions.setFilters([{ id: null, type: EntityTypes.NEW_ENTITY, order: 0 }])
             }
         },
         setFilters: ({ filters }) => {


### PR DESCRIPTION
In my usecase I was analyzing $capture_failed_request with different
percentiles/math operators on the same properties. Doing this was
slightly painful, since I needed to enter the same data over and over
again.

After this change we'll populate the action/event with last row.
My hypothesis is this will speed things up generally.

![Peek 2020-12-02 20-46](https://user-images.githubusercontent.com/148820/100917188-7e861580-34df-11eb-87dc-f35be46f1472.gif)

Note that I'm not confident in this change - feel free to raise any counter-arguments.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
