### PR TITLE
Sessions table improvements 1202

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -136,6 +136,7 @@ export const commandPaletteLogic = kea<
         deregisterCommand: (commandKey: string) => ({ commandKey }),
         setCustomCommand: (commandKey: string) => ({ commandKey }),
         deregisterScope: (scope: string) => ({ scope }),
+        shareFeedbackCommand: (instruction: string) => ({ instruction }),
     },
     reducers: {
         isPaletteShown: [
@@ -257,6 +258,30 @@ export const commandPaletteLogic = kea<
                     })
                 }
             }
+        },
+        shareFeedbackCommand: ({ instruction }) => {
+            actions.showPalette()
+            actions.activateFlow({
+                scope: 'Sharing Feedback',
+                instruction,
+                icon: CommentOutlined,
+                resolver: (argument) => ({
+                    icon: SendOutlined,
+                    display: 'Send',
+                    executor: !argument?.length
+                        ? undefined
+                        : () => {
+                              posthog.capture('palette feedback', { message: argument })
+                              return {
+                                  resolver: {
+                                      icon: CheckOutlined,
+                                      display: 'Message Sent!',
+                                      executor: true,
+                                  },
+                              }
+                          },
+                }),
+            })
         },
     }),
     selectors: {

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -136,7 +136,7 @@ export const commandPaletteLogic = kea<
         deregisterCommand: (commandKey: string) => ({ commandKey }),
         setCustomCommand: (commandKey: string) => ({ commandKey }),
         deregisterScope: (scope: string) => ({ scope }),
-        shareFeedbackCommand: (instruction: string) => ({ instruction }),
+        shareFeedbackCommand: (instruction?: string) => ({ instruction }),
     },
     reducers: {
         isPaletteShown: [
@@ -259,7 +259,7 @@ export const commandPaletteLogic = kea<
                 }
             }
         },
-        shareFeedbackCommand: ({ instruction }) => {
+        shareFeedbackCommand: ({ instruction = "What's on your mind?" }) => {
             actions.showPalette()
             actions.activateFlow({
                 scope: 'Sharing Feedback',

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -18,9 +18,7 @@ import { DangerZone } from './DangerZone'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Link } from 'lib/components/Link'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
-import { CommentOutlined, SendOutlined, CheckOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
-import posthog from 'posthog-js'
 
 export const Setup = hot(_Setup)
 function _Setup(): JSX.Element {
@@ -29,32 +27,7 @@ function _Setup(): JSX.Element {
     const { location } = useValues(router)
     const { user } = useValues(userLogic)
 
-    const { activateFlow, showPalette } = useActions(commandPaletteLogic)
-
-    const shareFeedback = (instruction: string = "What's on your mind?"): void => {
-        showPalette()
-        activateFlow({
-            scope: 'Sharing Feedback',
-            instruction,
-            icon: CommentOutlined,
-            resolver: (argument) => ({
-                icon: SendOutlined,
-                display: 'Send',
-                executor: !argument?.length
-                    ? undefined
-                    : () => {
-                          posthog.capture('palette feedback', { message: argument })
-                          return {
-                              resolver: {
-                                  icon: CheckOutlined,
-                                  display: 'Message Sent!',
-                                  executor: true,
-                              },
-                          }
-                      },
-            }),
-        })
-    }
+    const { shareFeedbackCommand } = useActions(commandPaletteLogic)
 
     useAnchor(location.hash)
 
@@ -149,8 +122,8 @@ function _Setup(): JSX.Element {
                 <OptInSessionRecording />
                 <p>
                     This is a new feature of PostHog. Please{' '}
-                    <a onClick={() => shareFeedback('How can we improve session recording?')}>share feedback</a> with
-                    us!
+                    <a onClick={() => shareFeedbackCommand('How can we improve session recording?')}>share feedback</a>{' '}
+                    with us!
                 </p>
                 <Divider />
                 <h2 style={{ color: 'var(--danger)' }} className="subtitle">

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { PlayCircleOutlined } from '@ant-design/icons'
 import { SessionType } from '~/types'
-
-import './Sessions.scss'
 import { fromParams, toParams } from 'lib/utils'
 import { Link } from 'lib/components/Link'
 import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import './Sessions.scss'
 
 interface SessionsPlayerButtonProps {
     session: SessionType

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
 import { Table, Button, Spin, Space, Tooltip } from 'antd'
-import { InfoCircleOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP } from '~/lib/utils'
@@ -9,12 +8,14 @@ import { SessionDetails } from './SessionDetails'
 import { DatePicker } from 'antd'
 import moment from 'moment'
 import { SessionType } from '~/types'
-import { CaretLeftOutlined, CaretRightOutlined } from '@ant-design/icons'
+import { CaretLeftOutlined, CaretRightOutlined, PoweroffOutlined, QuestionCircleOutlined } from '@ant-design/icons'
 import SessionsPlayerButton from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import SessionsPlayerDrawer from 'scenes/sessions/SessionsPlayerDrawer'
 import { PageHeader } from 'lib/components/PageHeader'
+import { userLogic } from 'scenes/userLogic'
+import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -33,6 +34,8 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         sessionRecordingId,
     } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
+    const { user } = useValues(userLogic)
+    const { shareFeedbackCommand } = useActions(commandPaletteLogic)
 
     const columns = [
         {
@@ -98,12 +101,35 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         {
             title: (
                 <span>
-                    <Tooltip title="Enable session recording from Project > Settings">
-                        <span>
-                            Play session
-                            <InfoCircleOutlined style={{ marginLeft: 6 }} />
-                        </span>
-                    </Tooltip>
+                    {user?.team?.session_recording_opt_in ? (
+                        <Tooltip
+                            title={
+                                <>
+                                    Replay sessions as if you were in front of your users. Not seeing a recording you're
+                                    expecting? <a onClick={() => shareFeedbackCommand()}>Let us know</a>.
+                                </>
+                            }
+                        >
+                            <span>
+                                Play session
+                                <QuestionCircleOutlined style={{ marginLeft: 6 }} />
+                            </span>
+                        </Tooltip>
+                    ) : (
+                        <Tooltip
+                            title={
+                                <>
+                                    Session recording is turned off for this project. Go to{' '}
+                                    <Link to="/project/settings#session-recording"> project settings</Link> to enable.
+                                </>
+                            }
+                        >
+                            <span>
+                                <PoweroffOutlined style={{ marginRight: 6 }} className="text-warning" />
+                                Play session
+                            </span>
+                        </Tooltip>
+                    )}
                 </span>
             ),
             render: function RenderEndPoint(session: SessionType) {


### PR DESCRIPTION
## Changes

- Addresses post-merge feedback on #2609.

Inspired by watching a [session recording](https://app.posthog.com/sessions?sessionRecordingId=1761b13deabb1-0937e04b84293e-4b524b53-144000-1761b13deac1cd),
- Makes it more evident when session recording is turned off and makes it easier to enable it.
    <img width="1203" alt="" src="https://user-images.githubusercontent.com/5864173/100957559-4df2ab80-34e0-11eb-945a-6bcc0ebdb596.png">


- Adds an easy way for sharing feedback when session recording is enabled.
    <img width="1201" alt="" src="https://user-images.githubusercontent.com/5864173/100957567-51863280-34e0-11eb-853c-ec45688dda17.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
