### PR TITLE
Command palette missing routes & fix

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -32,6 +32,8 @@ import {
     LogoutOutlined,
     PlusOutlined,
     LineChartOutlined,
+    ApiOutlined,
+    DatabaseOutlined,
 } from '@ant-design/icons'
 import { DashboardType } from '~/types'
 import api from 'lib/api'
@@ -531,6 +533,22 @@ export const commandPaletteLogic = kea<
                         },
                     },
                     {
+                        icon: ApiOutlined,
+                        display: 'Go to Plugins',
+                        synonyms: ['integrations'],
+                        executor: () => {
+                            push('/project/plugins')
+                        },
+                    },
+                    {
+                        icon: DatabaseOutlined,
+                        display: 'Go to System Status Page',
+                        synonyms: ['redis', 'celery', 'django', 'postgres', 'backend', 'service', 'online'],
+                        executor: () => {
+                            push('/instance/status')
+                        },
+                    },
+                    {
                         icon: PlusOutlined,
                         display: 'Create Action',
                         executor: () => {
@@ -627,7 +645,7 @@ export const commandPaletteLogic = kea<
                                     display: `Create Key "${argument}"`,
                                     executor: () => {
                                         personalAPIKeysLogic.actions.createKey(argument)
-                                        push('/my/settings', {}, 'personal-api-keys')
+                                        push('/me/settings', {}, 'personal-api-keys')
                                     },
                                 }
                             }


### PR DESCRIPTION
## Changes

- Fixes creating API keys with the command palette.
- Adds some missing routes to the command palette.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
