### PR TITLE
Spy on feature flags 🕵️

### DIFF
--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -28,12 +28,14 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
             {
                 get(_, flag) {
                     const flagString = flag.toString()
-                    notifyFlagIfNeeded(flagString, !!featureFlags[flagString])
-                    return featureFlags[flagString]
+                    const flagState = !!featureFlags[flagString]
+                    notifyFlagIfNeeded(flagString, flagState)
+                    return flagState
                 },
             }
         )
     } else {
+        // Fallback for IE11. Won't track "false" results. ¯\_(ツ)_/¯
         const flags: FeatureFlagsSet = {}
         for (const flag of Object.keys(featureFlags)) {
             Object.defineProperty(flags, flag, {

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -10,6 +10,43 @@ import posthog from 'posthog-js'
 
 type FeatureFlagsSet = { [flag: string]: boolean }
 
+const eventsNotified: Record<string, boolean> = {}
+function notifyFlagIfNeeded(flag: string, flagState: boolean): void {
+    if (!eventsNotified[flag]) {
+        posthog.capture('$feature_flag_called', {
+            $feature_flag: flag,
+            $feature_flag_response: flagState,
+        })
+        eventsNotified[flag] = true
+    }
+}
+
+function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
+    if (typeof window.Proxy !== 'undefined') {
+        return new Proxy(
+            {},
+            {
+                get(_, flag) {
+                    const flagString = flag.toString()
+                    notifyFlagIfNeeded(flagString, !!featureFlags[flagString])
+                    return featureFlags[flagString]
+                },
+            }
+        )
+    } else {
+        const flags: FeatureFlagsSet = {}
+        for (const flag of Object.keys(featureFlags)) {
+            Object.defineProperty(flags, flag, {
+                get: function () {
+                    notifyFlagIfNeeded(flag, true)
+                    return true
+                },
+            })
+        }
+        return flags
+    }
+}
+
 export const featureFlagLogic = kea<featureFlagLogicType<PostHog, FeatureFlagsSet>>({
     actions: {
         setFeatureFlags: (featureFlags: string[]) => ({ featureFlags }),
@@ -19,12 +56,12 @@ export const featureFlagLogic = kea<featureFlagLogicType<PostHog, FeatureFlagsSe
         featureFlags: [
             {} as FeatureFlagsSet,
             {
-                setFeatureFlags: (_: FeatureFlagsSet, { featureFlags }: { featureFlags: string[] }) => {
+                setFeatureFlags: (_, { featureFlags }) => {
                     const flags: FeatureFlagsSet = {}
                     for (const flag of featureFlags) {
                         flags[flag] = true
                     }
-                    return flags
+                    return spyOnFeatureFlags(flags)
                 },
             },
         ],


### PR DESCRIPTION
## Changes

- Use a `Proxy` to spy on the feature flags `object`.
- Send a `$feature_flag_called` event on first access.
- Fallback to getters/setters for IE11 or other rare cases [without Proxy](https://caniuse.com/?search=proxy)
- Helps with https://github.com/PostHog/posthog/issues/2614#issuecomment-737244349

WIP because I haven't run the code yet. My dev setup is under (thanks [big sur](https://github.com/Homebrew/homebrew-core/pull/66105)). Will fix and test.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
