### PR TITLE
Tag Heroku Redis version on app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,7 +44,8 @@
         {
             "plan": "heroku-redis",
             "options": {
-                "maxmemory_policy": "allkeys-lru"
+                "maxmemory_policy": "allkeys-lru",
+                "version": "5"
             }
         }
     ],


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Heroku Redis now defaults to version 6, whereas we ourselves use version 5. One problem with this is that with version 6, for any plan above hobby-dev, heroku will attach Redis with a `rediss://` URL (SSL), and Celery on our end isn't configured to accept this, meaning PostHog won't work.

This means that when using the PostHog one-click deploy nowadays, if I decide to scale Redis, the app will fail.

Tagging the version for now because there may be other considerations for supporting Redis 6.0 beyond SSL that we might need to look at.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
