### PR TITLE
Fix lifecycle date rounding

### DIFF
--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -71,7 +71,7 @@ SELECT groupArray(day_start), groupArray(counts), status FROM (
                         ) as b WHERE has(day, subsequent_day) = 0
                         ORDER BY person_id, subsequent_day ASC
                         ) WHERE
-                        ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != toDateTime(%(date_from)s))
+                        ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != {trunc_func}(toDateTime(%(date_from)s) + INTERVAL {interval} - INTERVAL {sub_interval}))
                         OR
                         ( (neighbor(person_id, -1) = person_id) AND neighbor(subsequent_day, -1) < subsequent_day - INTERVAL {interval})
                     ) e
@@ -136,7 +136,7 @@ SELECT person_id FROM (
         GROUP BY person_id
         UNION ALL
         SELECT person_id, base_day, subsequent_day FROM (
-            SELECT person_id, total as base_day, day_start as subsequent_day FROM (
+            SELECT person_id, dummy as base_day, day_start as subsequent_day FROM (
                 SELECT DISTINCT person_id, groupArray({trunc_func}(events.timestamp)) day FROM events 
                 JOIN
                 (SELECT person_id,
@@ -148,11 +148,11 @@ SELECT person_id FROM (
                 GROUP BY person_id
             ) as e
             CROSS JOIN (
-                SELECT toDateTime('0000-00-00 00:00:00') AS total, {trunc_func}(toDateTime(%(date_to)s) - number * %(seconds_in_interval)s) as day_start from numbers(%(num_intervals)s)
+                SELECT toDateTime('0000-00-00 00:00:00') AS dummy, {trunc_func}(toDateTime(%(date_to)s) - number * %(seconds_in_interval)s) as day_start from numbers(%(num_intervals)s)
             ) as b WHERE has(day, subsequent_day) = 0
             ORDER BY person_id, subsequent_day ASC
             ) WHERE
-            ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != toDateTime(%(date_from)s))
+            ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != {trunc_func}(toDateTime(%(date_from)s) + INTERVAL {interval} - INTERVAL {sub_interval}))
             OR
             ( (neighbor(person_id, -1) = person_id) AND neighbor(subsequent_day, -1) < subsequent_day - INTERVAL {interval})
         ) e


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes #2650 
- accounts for the rounding that happens in the filtering
- when calculating dormant actions, the query wasn't considering the rounding of the dates when they're trunc'd

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
