### PR TITLE
Fix ee webhook

### DIFF
--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -12,40 +12,36 @@ from posthog.tasks.webhooks import determine_webhook_type, get_formatted_message
 
 @app.task(ignore_result=True, bind=True, max_retries=3)
 def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, site_url: str) -> None:
-    try:
-        team = Team.objects.get(pk=team_id)
-        _event = Event.objects.create(
-            event=event["event"],
-            distinct_id=event["distinct_id"],
-            properties=event["properties"],
-            team=team,
-            site_url=site_url,
-            **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
-            **({"elements": event["elements_list"]} if event["elements_list"] else {})
-        )
+    team = Team.objects.get(pk=team_id)
+    _event = Event.objects.create(
+        event=event["event"],
+        distinct_id=event["distinct_id"],
+        properties=event["properties"],
+        team=team,
+        site_url=site_url,
+        **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
+        **({"elements": event["elements_list"]} if event["elements_list"] else {})
+    )
 
-        actions = Action.objects.filter(team_id=team_id, post_to_slack=True).all()
+    actions = Action.objects.filter(team_id=team_id, post_to_slack=True).all()
 
-        if not site_url:
-            site_url = settings.SITE_URL
+    if not site_url:
+        site_url = settings.SITE_URL
 
-        if team.slack_incoming_webhook:
-            for action in actions:
-                qs = Event.objects.filter(pk=_event.pk).query_db_by_action(action)
-                if qs:
-                    message_text, message_markdown = get_formatted_message(action, _event, site_url,)
-                    if determine_webhook_type(team) == "slack":
-                        message = {
-                            "text": message_text,
-                            "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message_markdown},},],
-                        }
-                    else:
-                        message = {
-                            "text": message_markdown,
-                        }
-                    requests.post(team.slack_incoming_webhook, verify=False, json=message)
+    if team.slack_incoming_webhook:
+        for action in actions:
+            qs = Event.objects.filter(pk=_event.pk).query_db_by_action(action)
+            if qs:
+                message_text, message_markdown = get_formatted_message(action, _event, site_url,)
+                if determine_webhook_type(team) == "slack":
+                    message = {
+                        "text": message_text,
+                        "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message_markdown},},],
+                    }
+                else:
+                    message = {
+                        "text": message_markdown,
+                    }
+                requests.post(team.slack_incoming_webhook, verify=False, json=message)
 
-        _event.delete()
-
-    except:
-        self.retry(countdown=2 ** self.request.retries)
+    _event.delete()

--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -32,6 +32,8 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
         for action in actions:
             qs = Event.objects.filter(pk=_event.pk).query_db_by_action(action)
             if qs:
+                # webhooks
+                action.on_perform(_event)
                 message_text, message_markdown = get_formatted_message(action, _event, site_url,)
                 if determine_webhook_type(team) == "slack":
                     message = {

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -5,7 +5,7 @@ import { useValues, useActions } from 'kea'
 import { actionEditLogic } from './actionEditLogic'
 import './Actions.scss'
 import { ActionStep } from './ActionStep'
-import { Alert, Button, Col, Input, Row } from 'antd'
+import { Button, Col, Input, Row } from 'antd'
 import { InfoCircleOutlined, PlusOutlined, SaveOutlined } from '@ant-design/icons'
 
 export function ActionEdit({ actionId, apiURL, onSave, user, simmer, temporaryToken }) {
@@ -115,13 +115,6 @@ export function ActionEdit({ actionId, apiURL, onSave, user, simmer, temporaryTo
                 </div>
                 <div>
                     <div style={{ margin: '1rem 0' }}>
-                        {user?.is_multi_tenancy && (
-                            <Alert
-                                style={{ marginBottom: '1rem' }}
-                                message="Webhooks are currently unavailable on PostHog Cloud. The feature will be back online soon."
-                                type="warning"
-                            />
-                        )}
                         <p>
                             <input
                                 id="webhook-checkbox"
@@ -131,7 +124,7 @@ export function ActionEdit({ actionId, apiURL, onSave, user, simmer, temporaryTo
                                     setEdited(true)
                                 }}
                                 checked={!!action.post_to_slack}
-                                disabled={!slackEnabled || user.is_multi_tenancy}
+                                disabled={!slackEnabled}
                             />
                             <label
                                 className={slackEnabled ? '' : 'disabled'}
@@ -154,7 +147,7 @@ export function ActionEdit({ actionId, apiURL, onSave, user, simmer, temporaryTo
                                         setAction({ ...action, slack_message_format: e.target.value })
                                         setEdited(true)
                                     }}
-                                    disabled={!slackEnabled || !action.post_to_slack || user.is_multi_tenancy}
+                                    disabled={!slackEnabled || !action.post_to_slack}
                                     data-attr="edit-slack-message-format"
                                 />
                                 <small>

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { kea, useActions, useValues } from 'kea'
 import api from 'lib/api'
-import { Input, Button, Alert } from 'antd'
+import { Input, Button } from 'antd'
 import { userLogic } from 'scenes/userLogic'
 import { logicType } from 'types/scenes/project/Settings/WebhookIntegrationType'
 import { UserType } from '~/types'
@@ -114,7 +114,7 @@ const logic = kea<logicType<UserType>>({
     }),
 })
 
-export function WebhookIntegration({ user }: { user: UserType | null }): JSX.Element {
+export function WebhookIntegration(): JSX.Element {
     const { isSaving, editedWebhook } = useValues(logic)
     const { testThenSaveWebhook, setEditedWebhook } = useActions(logic)
 
@@ -128,21 +128,13 @@ export function WebhookIntegration({ user }: { user: UserType | null }): JSX.Ele
                 <a href="https://posthog.com/docs/integrations/microsoft-teams">for Microsoft Teams</a>. Discord is also
                 supported.
             </p>
-            {user?.is_multi_tenancy && (
-                <Alert
-                    style={{ maxWidth: '40rem', marginBottom: '1rem' }}
-                    message="Webhooks are currently unavailable on PostHog Cloud. The feature will be back online soon."
-                    type="warning"
-                />
-            )}
             <Input
                 value={editedWebhook}
                 addonBefore="Webhook URL"
                 onChange={(e) => setEditedWebhook(e.target.value)}
                 style={{ maxWidth: '40rem', marginBottom: '1rem', display: 'block' }}
                 type="url"
-                placeholder={'integration disabled' + (user?.is_multi_tenancy ? '' : ' – type a URL to enable')}
-                disabled={user.is_multi_tenancy}
+                placeholder={'integration disabled – type a URL to enable'}
             />
             <Button
                 type="primary"
@@ -150,7 +142,6 @@ export function WebhookIntegration({ user }: { user: UserType | null }): JSX.Ele
                     e.preventDefault()
                     testThenSaveWebhook()
                 }}
-                disabled={user.is_multi_tenancy}
             >
                 {isSaving ? '...' : editedWebhook ? 'Test & Save' : 'Save'}
             </Button>

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -90,7 +90,7 @@ function _Setup(): JSX.Element {
                 <h2 className="subtitle" id="webhook">
                     Webhook Integration
                 </h2>
-                <WebhookIntegration user={user} />
+                <WebhookIntegration />
                 <Divider />
                 <h2 className="subtitle" id="datacapture">
                     Data Capture Configuration


### PR DESCRIPTION
## Changes

IIRC, we disabled this b/c we had a user with high volume but the actual issue turned out to be something different. I feel reasonably confident turning this back on as I've gotten rid of the retry that caused messages to appear twice, and I'm doing some pre-filtering before firing an event into celery.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
