### PR TITLE
Fix cypress projectSettings

### DIFF
--- a/cypress/integration/projectSettings.js
+++ b/cypress/integration/projectSettings.js
@@ -18,15 +18,7 @@ describe('Setup', () => {
         cy.reload(true)
         cy.get('[data-attr=menu-item-project]').click()
         cy.get('[data-attr=app-url-suggestion]').click()
-
-        const possibleSuggestions = ['/insights', '/demo']
-        let suggestionUrlMatched = false
-        for (const url of possibleSuggestions) {
-            if (cy.get('[data-attr=app-url-item]').contains(url)) {
-                suggestionUrlMatched = true
-            }
-        }
-        expect(suggestionUrlMatched).to.be.true
+        cy.get('[data-attr=app-url-item]').contains(/\/insights|\/demo/g)
 
         cy.title().should('equal', 'Project Settings • PostHog')
     })

--- a/cypress/integration/projectSettings.js
+++ b/cypress/integration/projectSettings.js
@@ -18,7 +18,7 @@ describe('Setup', () => {
         cy.reload(true)
         cy.get('[data-attr=menu-item-project]').click()
         cy.get('[data-attr=app-url-suggestion]').click()
-        cy.get('[data-attr=app-url-item]').should('contain', '/demo')
+        cy.get('[data-attr=app-url-item]').should('contain', '/insights')
         cy.title().should('equal', 'Project Settings • PostHog')
     })
 })

--- a/cypress/integration/projectSettings.js
+++ b/cypress/integration/projectSettings.js
@@ -18,7 +18,16 @@ describe('Setup', () => {
         cy.reload(true)
         cy.get('[data-attr=menu-item-project]').click()
         cy.get('[data-attr=app-url-suggestion]').click()
-        cy.get('[data-attr=app-url-item]').should('contain', '/insights')
+
+        const possibleSuggestions = ['/insights', '/demo']
+        let suggestionUrlMatched = false
+        for (const url of possibleSuggestions) {
+            if (cy.get('[data-attr=app-url-item]').contains(url)) {
+                suggestionUrlMatched = true
+            }
+        }
+        expect(suggestionUrlMatched).toBe(true)
+
         cy.title().should('equal', 'Project Settings • PostHog')
     })
 })

--- a/cypress/integration/projectSettings.js
+++ b/cypress/integration/projectSettings.js
@@ -26,7 +26,7 @@ describe('Setup', () => {
                 suggestionUrlMatched = true
             }
         }
-        expect(suggestionUrlMatched).toBe(true)
+        expect(suggestionUrlMatched).to.be.true
 
         cy.title().should('equal', 'Project Settings • PostHog')
     })


### PR DESCRIPTION
## Changes

Fixes broken Cypress projectSettings test.

## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [X] Jest frontend tests
- [X] Cypress end-to-end tests
