### PR TITLE
Add trailing slash to record endpoint

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -107,5 +107,5 @@ def get_decide(request: HttpRequest):
         if team:
             response["featureFlags"] = feature_flags(request, team, data_from_request["data"])
             if team.session_recording_opt_in and (on_permitted_domain(team, request) or len(team.app_urls) == 0):
-                response["sessionRecording"] = {"endpoint": "/s"}
+                response["sessionRecording"] = {"endpoint": "/s/"}
     return cors_response(request, JsonResponse(response))

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -76,7 +76,7 @@ class TestDecide(BaseTest):
         self.team.save()
 
         response = self._post_decide()
-        self.assertEqual(response["sessionRecording"], {"endpoint": "/s"})
+        self.assertEqual(response["sessionRecording"], {"endpoint": "/s/"})
 
     def test_user_session_recording_evil_site(self):
         self.team.app_urls = ["https://example.com"]
@@ -87,7 +87,7 @@ class TestDecide(BaseTest):
         self.assertEqual(response["sessionRecording"], False)
 
         response = self._post_decide(origin="https://example.com")
-        self.assertEqual(response["sessionRecording"], {"endpoint": "/s"})
+        self.assertEqual(response["sessionRecording"], {"endpoint": "/s/"})
 
     def test_feature_flags(self):
         self.team.app_urls = ["https://example.com"]


### PR DESCRIPTION
## Changes

Add trailing slash so the AWS load balancer can correctly route these to the event handler workers

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
