### PR TITLE
Fix webpack-dev-server inside Docker

### DIFF
--- a/bin/docker-dev
+++ b/bin/docker-dev
@@ -3,4 +3,4 @@
 set -e
 python manage.py migrate
 
-python manage.py runserver 0.0.0.0:8000 & ./bin/start-worker & ./bin/start-frontend 0.0.0.0
+python manage.py runserver 0.0.0.0:8000 & ./bin/start-worker & ./bin/docker-frontend

--- a/bin/docker-dev-web
+++ b/bin/docker-dev-web
@@ -3,4 +3,4 @@
 set -e
 python manage.py migrate
 
-python manage.py runserver 0.0.0.0:8000 & ./bin/start-frontend 0.0.0.0
+python manage.py runserver 0.0.0.0:8000 & ./bin/docker-frontend

--- a/bin/docker-frontend
+++ b/bin/docker-frontend
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+export WEBPACK_HOT_RELOAD_HOST="0.0.0.0"
+
+yarn install
+yarn start-docker

--- a/ee/bin/docker-ch-dev-web
+++ b/ee/bin/docker-ch-dev-web
@@ -4,4 +4,4 @@ set -e
 python manage.py migrate
 python manage.py migrate_clickhouse
 
-python manage.py runserver 0.0.0.0:8000 & ./bin/start-frontend 0.0.0.0
+python manage.py runserver 0.0.0.0:8000 & ./bin/docker-frontend

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -17,7 +17,7 @@ services:
         build:
             context: ../
             dockerfile: dev.Dockerfile
-        command: ./bin/docker-ch-dev-web
+        command: ./ee/bin/docker-ch-dev-web
         volumes:
             - ..:/code
         ports:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "start": "concurrently -n WEBPACK,TYPEGEN -c blue,green \"yarn run start-http\" \"yarn run typegen:watch\"",
         "start-http": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack-dev-server --hotOnly",
         "start-https": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack-dev-server --hotOnly --https",
+        "start-docker": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack-dev-server --hotOnly --host 0.0.0.0",
         "build": "echo \"Building Webpack\" && NODE_ENV=production webpack --config webpack.config.js && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts",
         "prettier": "prettier --write \"./frontend/src/**/*.{js,ts,tsx,json,yml,css,scss}\"",
         "prettier:check": "prettier --check \"./**/*.{js,ts,tsx,json,yml,css,scss}\"",


### PR DESCRIPTION
## Changes

`webpack-dev-server` needs `--host 0.0.0.0` to serve properly insider Docker. This adjusts `package.json` and `bin/*` scripts for that.