### PR TITLE
Add caching support for recorder.js

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -203,7 +203,7 @@ AXES_META_PRECEDENCE_ORDER = [
 # Application definition
 
 INSTALLED_APPS = [
-    "whitenoise.runserver_nostatic",
+    "whitenoise.runserver_nostatic",  # makes sure that whitenoise handles static files in development
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -203,6 +203,7 @@ AXES_META_PRECEDENCE_ORDER = [
 # Application definition
 
 INSTALLED_APPS = [
+    "whitenoise.runserver_nostatic",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -492,6 +493,14 @@ if TEST:
 
     celery.current_app.conf.CELERY_ALWAYS_EAGER = True
     celery.current_app.conf.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+
+
+def add_recorder_js_headers(headers, path, url):
+    if url.endswith("/recorder.js"):
+        headers["Cache-Control"] = "max-age=31536000, public"
+
+
+WHITENOISE_ADD_HEADERS_FUNCTION = add_recorder_js_headers
 
 if DEBUG and not TEST:
     print_warning(


### PR DESCRIPTION
## Changes

After this, recorder.js is only reloaded by users when it changes, not every page load.

Companion PR: https://github.com/PostHog/posthog-js/pull/153

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
