### PR TITLE
Refactor /api/signup to Organization

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -1,13 +1,30 @@
 from typing import Any, Dict, Optional
 
+import posthoganalytics
 from django.conf import settings
+from django.contrib.auth import login, password_validation
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
-from rest_framework import exceptions, permissions, request, response, serializers, status, viewsets
+from rest_framework import (
+    exceptions,
+    generics,
+    permissions,
+    request,
+    response,
+    serializers,
+    status,
+    viewsets,
+)
 
-from posthog.models import Organization
+from posthog.api.user import UserSerializer
+from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
-from posthog.permissions import CREATE_METHODS, OrganizationAdminWritePermissions, OrganizationMemberPermissions
+from posthog.permissions import (
+    CREATE_METHODS,
+    OrganizationAdminWritePermissions,
+    OrganizationMemberPermissions,
+    UninitiatedOrCloudOnly,
+)
 
 
 class PremiumMultiorganizationPermissions(permissions.BasePermission):
@@ -91,3 +108,47 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         organization = get_object_or_404(queryset, **filter_kwargs)
         self.check_object_permissions(self.request, organization)
         return organization
+
+
+class OrganizationSignupSerializer(serializers.Serializer):
+    first_name: serializers.Field = serializers.CharField(max_length=128)
+    email: serializers.Field = serializers.EmailField()
+    password: serializers.Field = serializers.CharField()
+    company_name: serializers.Field = serializers.CharField(max_length=128, required=False, allow_blank=True)
+    email_opt_in: serializers.Field = serializers.BooleanField(default=True)
+
+    def validate_password(self, value):
+        password_validation.validate_password(value)
+        return value
+
+    def create(self, validated_data, **kwargs):
+        is_first_user: bool = not User.objects.exists()
+        realm: str = "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted"
+
+        company_name = validated_data.pop("company_name", validated_data["first_name"])
+        self._organization, self._team, self._user = User.objects.bootstrap(company_name=company_name, **validated_data)
+        user = self._user
+        login(
+            self.context["request"], user, backend="django.contrib.auth.backends.ModelBackend",
+        )
+
+        posthoganalytics.capture(
+            user.distinct_id,
+            "user signed up",
+            properties={"is_first_user": is_first_user, "is_organization_first_user": True},
+        )
+
+        posthoganalytics.identify(
+            user.distinct_id, properties={"email": user.email, "realm": realm, "ee_available": settings.EE_AVAILABLE},
+        )
+
+        return user
+
+    def to_representation(self, instance):
+        serializer = UserSerializer(instance=instance)
+        return serializer.data
+
+
+class OrganizationSignupViewset(generics.CreateAPIView):
+    serializer_class = OrganizationSignupSerializer
+    permission_classes = [UninitiatedOrCloudOnly]

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,7 +14,7 @@ from posthog.permissions import (
     ProjectMembershipNecessaryPermissions,
 )
 
-from .organization import OrganizationSignupViewset
+from .organization import OrganizationSignupSerializer, OrganizationSignupViewset
 
 
 class PremiumMultiprojectPermissions(permissions.BasePermission):
@@ -125,6 +125,15 @@ class TeamViewSet(viewsets.ModelViewSet):
 
 
 class TeamSignupViewset(OrganizationSignupViewset):
+    """
+    DEPRECATED: Only for transition purposes to support posthog-production repo. May be removed after
+    https://github.com/PostHog/posthog-production/pull/54 is merged.
+    """
+
+    pass
+
+
+class TeamSignupSerializer(OrganizationSignupSerializer):
     """
     DEPRECATED: Only for transition purposes to support posthog-production repo. May be removed after
     https://github.com/PostHog/posthog-production/pull/54 is merged.

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -125,4 +125,9 @@ class TeamViewSet(viewsets.ModelViewSet):
 
 
 class TeamSignupViewset(OrganizationSignupViewset):
+    """
+    DEPRECATED: Only for transition purposes to support posthog-production repo. May be removed after
+    https://github.com/PostHog/posthog-production/pull/54 is merged.
+    """
+
     pass

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,6 +14,8 @@ from posthog.permissions import (
     ProjectMembershipNecessaryPermissions,
 )
 
+from .organization import OrganizationSignupViewset
+
 
 class PremiumMultiprojectPermissions(permissions.BasePermission):
     """Require user to have all necessary premium features on their plan for create access to the endpoint."""
@@ -120,3 +122,7 @@ class TeamViewSet(viewsets.ModelViewSet):
         team.api_token = generate_random_token()
         team.save()
         return response.Response(TeamSerializer(team).data)
+
+
+class TeamSignupViewset(OrganizationSignupViewset):
+    pass

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,23 +1,17 @@
 from typing import Any, Dict
 
-import posthoganalytics
-from django.conf import settings
-from django.contrib.auth import login, password_validation
 from django.db import transaction
 from django.shortcuts import get_object_or_404
-from rest_framework import exceptions, generics, permissions, request, response, serializers, viewsets
+from rest_framework import exceptions, permissions, request, response, serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework_extensions.routers import NestedRouterMixin
 
-from posthog.api.user import UserSerializer
-from posthog.models import Team, User
+from posthog.models import Team
 from posthog.models.utils import generate_random_token
 from posthog.permissions import (
     CREATE_METHODS,
     OrganizationAdminWritePermissions,
     OrganizationMemberPermissions,
     ProjectMembershipNecessaryPermissions,
-    UninitiatedOrCloudOnly,
 )
 
 
@@ -126,47 +120,3 @@ class TeamViewSet(viewsets.ModelViewSet):
         team.api_token = generate_random_token()
         team.save()
         return response.Response(TeamSerializer(team).data)
-
-
-class TeamSignupSerializer(serializers.Serializer):
-    first_name: serializers.Field = serializers.CharField(max_length=128)
-    email: serializers.Field = serializers.EmailField()
-    password: serializers.Field = serializers.CharField()
-    company_name: serializers.Field = serializers.CharField(max_length=128, required=False, allow_blank=True)
-    email_opt_in: serializers.Field = serializers.BooleanField(default=True)
-
-    def validate_password(self, value):
-        password_validation.validate_password(value)
-        return value
-
-    def create(self, validated_data, **kwargs):
-        is_first_user: bool = not User.objects.exists()
-        realm: str = "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted"
-
-        company_name = validated_data.pop("company_name", validated_data["first_name"])
-        self._organization, self._team, self._user = User.objects.bootstrap(company_name=company_name, **validated_data)
-        user = self._user
-        login(
-            self.context["request"], user, backend="django.contrib.auth.backends.ModelBackend",
-        )
-
-        posthoganalytics.capture(
-            user.distinct_id,
-            "user signed up",
-            properties={"is_first_user": is_first_user, "is_organization_first_user": True},
-        )
-
-        posthoganalytics.identify(
-            user.distinct_id, properties={"email": user.email, "realm": realm, "ee_available": settings.EE_AVAILABLE},
-        )
-
-        return user
-
-    def to_representation(self, instance):
-        serializer = UserSerializer(instance=instance)
-        return serializer.data
-
-
-class TeamSignupViewset(generics.CreateAPIView):
-    serializer_class = TeamSignupSerializer
-    permission_classes = [UninitiatedOrCloudOnly]

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,14 +1,12 @@
 from typing import Any, Dict
 
 import posthoganalytics
-from django.conf import settings
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import exceptions, permissions, request, response, serializers, viewsets
 from rest_framework.decorators import action
 
 from posthog.models import Team
-from posthog.models.user import User
 from posthog.models.utils import generate_random_token
 from posthog.permissions import (
     CREATE_METHODS,
@@ -142,21 +140,4 @@ class TeamSignupSerializer(OrganizationSignupSerializer):
     https://github.com/PostHog/posthog-production/pull/54 is merged.
     """
 
-    def create(self, validated_data, **kwargs):
-        user = super().create(validated_data, **kwargs)
-
-        if settings.TEST:
-            is_first_user: bool = not User.objects.exists()
-            realm: str = "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted"
-            posthoganalytics.capture(
-                user.distinct_id,
-                "user signed up",
-                properties={"is_first_user": is_first_user, "is_organization_first_user": True},
-            )
-
-            posthoganalytics.identify(
-                user.distinct_id,
-                properties={"email": user.email, "realm": realm, "ee_available": settings.EE_AVAILABLE},
-            )
-
-        return user
+    pass

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -5,7 +5,6 @@ from django.test import tag
 from rest_framework import status
 
 from posthog.models import Dashboard, Organization, OrganizationMembership, Team, User
-from posthog.settings import MULTI_TENANCY
 from posthog.test.base import APIBaseTest
 
 
@@ -42,9 +41,9 @@ class TestSignup(APIBaseTest):
     CONFIG_USER_EMAIL = None
 
     @tag("skip_on_multitenancy")
-    @patch("posthog.api.team.settings.EE_AVAILABLE", False)
-    @patch("posthog.api.team.posthoganalytics.identify")
-    @patch("posthog.api.team.posthoganalytics.capture")
+    @patch("posthog.api.organization.settings.EE_AVAILABLE", False)
+    @patch("posthog.api.organization.posthoganalytics.identify")
+    @patch("posthog.api.organization.posthoganalytics.capture")
     def test_api_sign_up(self, mock_capture, mock_identify):
         response = self.client.post(
             "/api/signup/",
@@ -116,7 +115,7 @@ class TestSignup(APIBaseTest):
             )
 
     @tag("skip_on_multitenancy")
-    @patch("posthog.api.team.posthoganalytics.capture")
+    @patch("posthog.api.organization.posthoganalytics.capture")
     def test_signup_minimum_attrs(self, mock_capture):
         response = self.client.post(
             "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -10,7 +10,6 @@ from posthog.helpers.dashboard_templates import create_dashboard_from_template
 
 from .dashboard import Dashboard
 from .dashboard_item import DashboardItem
-from .personal_api_key import PersonalAPIKey
 from .utils import UUIDT, generate_random_token, sane_repr
 
 TEAM_CACHE: Dict[str, "Team"] = {}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -19,20 +19,20 @@ from sentry_sdk import capture_exception
 from social_core.pipeline.partial import partial
 from social_django.strategy import DjangoStrategy
 
-from posthog.demo import demo
-from posthog.email import is_email_available
-from posthog.models.organization import Organization
-
-from .api import (
+from posthog.api import (
     api_not_found,
     capture,
     dashboard,
     decide,
+    organization,
     projects_router,
     router,
-    team,
     user,
 )
+from posthog.demo import demo
+from posthog.email import is_email_available
+from posthog.models.organization import Organization
+
 from .models import OrganizationInvite, Team, User
 from .utils import render_template
 from .views import health, preflight_check, stats, system_status
@@ -313,7 +313,7 @@ urlpatterns = [
     opt_slash_path("api/user/change_password", user.change_password),
     opt_slash_path("api/user/test_slack_webhook", user.test_slack_webhook),
     opt_slash_path("api/user", user.user),
-    opt_slash_path("api/signup", team.TeamSignupViewset.as_view()),
+    opt_slash_path("api/signup", organization.OrganizationSignupViewset.as_view()),
     re_path(r"^api.+", api_not_found),
     path("authorize_and_redirect/", decorators.login_required(authorize_and_redirect)),
     path("shared_dashboard/<str:share_token>", dashboard.shared_dashboard),


### PR DESCRIPTION
## Changes

Refactors the /api/signup endpoint to live under the `Organization` model/API instead of `Team`. PR is complemented by https://github.com/PostHog/posthog-production/pull/54, however the PRs can be merged asynchronously. **This PR must be merged FIRST.**

- `TeamSignupViewset` is kept to support the async transition in posthog-production. The legacy viewset can be removed after https://github.com/PostHog/posthog-production/pull/54 is merged.

## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [X] Jest frontend tests
- [X] Cypress end-to-end tests
