### PR TITLE
Fix prop filtering when action has props

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -9,7 +9,7 @@ from posthog.models.action_step import ActionStep
 from posthog.models.event import Selector
 
 
-def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: bool = False) -> Tuple[str, Dict]:
+def format_action_filter(action: Action, prepend: str = "action", index=0, use_loop: bool = False) -> Tuple[str, Dict]:
     # get action steps
     params = {"team_id": action.team.pk}
     steps = action.steps.all()
@@ -51,8 +51,8 @@ def format_action_filter(action: Action, prepend: str = "", index=0, use_loop: b
     return formatted_query, params
 
 
-def filter_event(step: ActionStep, prepend: str = "", index: int = 0) -> Tuple[List[str], Dict]:
-    params = {}
+def filter_event(step: ActionStep, prepend: str = "event", index: int = 0) -> Tuple[List[str], Dict]:
+    params = {"{}_{}".format(prepend, index): step.event}
     conditions = []
 
     if step.url:
@@ -72,7 +72,7 @@ def filter_event(step: ActionStep, prepend: str = "", index: int = 0) -> Tuple[L
             )
             params.update({"{}_prop_val_{}".format(prepend, index): "%" + step.url + "%"})
 
-    conditions.append("event = '{}'".format(step.event))
+    conditions.append("event = %({}_{})s".format(prepend, index))
 
     return conditions, params
 

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -35,7 +35,9 @@ def format_action_filter(action: Action, prepend: str = "action", index=0, use_l
             from ee.clickhouse.models.property import parse_prop_clauses
 
             prop_query, prop_params = parse_prop_clauses(
-                Filter(data={"properties": step.properties}).properties, action.team.pk
+                Filter(data={"properties": step.properties}).properties,
+                action.team.pk,
+                prepend="action_props_{}".format(index),
             )
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -13,7 +13,7 @@ def format_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
     for group_idx, group in enumerate(cohort.groups):
         if group.get("action_id"):
             action = Action.objects.get(pk=group["action_id"], team_id=cohort.team.pk)
-            action_filter_query, action_params = format_action_filter(action)
+            action_filter_query, action_params = format_action_filter(action, index=group_idx)
             extract_person = "SELECT distinct_id FROM events WHERE team_id = %(team_id)s AND {query}".format(
                 query=action_filter_query
             )

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -11,7 +11,7 @@ from posthog.models.team import Team
 
 
 def parse_prop_clauses(
-    filters: List[Property], team_id: int, prepend: str = "", table_name: str = ""
+    filters: List[Property], team_id: int, prepend: str = "global", table_name: str = ""
 ) -> Tuple[str, Dict]:
     final = []
     params: Dict[str, Any] = {"team_id": team_id}

--- a/ee/clickhouse/queries/trends/normal.py
+++ b/ee/clickhouse/queries/trends/normal.py
@@ -26,7 +26,7 @@ class ClickhouseTrendsNormal:
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, prepend="_props")
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
 
         aggregate_operation, join_condition, math_params = process_math(entity)
 

--- a/ee/clickhouse/queries/trends/normal.py
+++ b/ee/clickhouse/queries/trends/normal.py
@@ -26,7 +26,7 @@ class ClickhouseTrendsNormal:
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, prepend="_props")
 
         aggregate_operation, join_condition, math_params = process_math(entity)
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes #2301 
- we weren't utilizing the enumeration of props when constructing clickhouse queries. So when an action that's define with a property was used with another property, they were conflicting. I added prepends globally

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
