### PR TITLE
Restart plugins on error

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -1,8 +1,8 @@
 #!/bin/bash
 KEYS="DATABASE_URL REDIS_URL PLUGINS_CELERY_QUEUE CELERY_DEFAULT_QUEUE BASE_DIR PLUGINS_RELOAD_PUBSUB_CHANNEL"
 
-# Export $CONFIG_JSON to posthog-plugin-server
-export CONFIG_JSON=`python manage.py print_settings --format json --indent 0 $KEYS 2> /dev/null | tr -d '\n' | sed 's/\n$//'`
+# Export $CONFIG to posthog-plugin-server
+export CONFIG=`python manage.py print_settings --format json --indent 0 $KEYS 2> /dev/null | tr -d '\n' | sed 's/\n$//'`
 
 # On _Heroku_, the $WEB_CONCURRENCY env contains suggested number of workers per dyno.
 # Unfortunately we are running a NodeJS app, yet get the value for the "python" buildpack.

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -1,4 +1,7 @@
 #!/bin/bash
+# this makes the script exit if `yarn --frozen-lockfile` fails
+set -e
+
 KEYS="DATABASE_URL REDIS_URL PLUGINS_CELERY_QUEUE CELERY_DEFAULT_QUEUE BASE_DIR PLUGINS_RELOAD_PUBSUB_CHANNEL"
 
 # Export $CONFIG to posthog-plugin-server
@@ -14,4 +17,10 @@ if [[ -n "${DYNO_RAM}" ]]; then
   export WORKER_CONCURRENCY=$(( ($DYNO_RAM - 1) / 512 + 1 ))
 fi
 
-cd plugins && yarn --frozen-lockfile --silent && yarn --silent start
+cd plugins
+yarn --frozen-lockfile --silent
+
+while true; do
+  # break loop if exiting normally (incl CTRL+C)
+  yarn --silent start && break
+done

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -1,8 +1,8 @@
 #!/bin/bash
 KEYS="DATABASE_URL REDIS_URL PLUGINS_CELERY_QUEUE CELERY_DEFAULT_QUEUE BASE_DIR PLUGINS_RELOAD_PUBSUB_CHANNEL"
-CONF=`python manage.py print_settings --format json --indent 0 $KEYS 2> /dev/null | tr -d '\n' | sed 's/\n$//'`
 
-FLAGS=()
+# Export $CONFIG_JSON to posthog-plugin-server
+export CONFIG_JSON=`python manage.py print_settings --format json --indent 0 $KEYS 2> /dev/null | tr -d '\n' | sed 's/\n$//'`
 
 # On _Heroku_, the $WEB_CONCURRENCY env contains suggested number of workers per dyno.
 # Unfortunately we are running a NodeJS app, yet get the value for the "python" buildpack.
@@ -14,4 +14,4 @@ if [[ -n "${DYNO_RAM}" ]]; then
   export WORKER_CONCURRENCY=$(( ($DYNO_RAM - 1) / 512 + 1 ))
 fi
 
-cd plugins && yarn --frozen-lockfile --silent && yarn --silent start --config "$CONF"
+cd plugins && yarn --frozen-lockfile --silent && yarn --silent start

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -1,7 +1,5 @@
 #!/bin/bash
-# this makes the script exit if `yarn --frozen-lockfile` fails
-set -e
-
+# Keys to export from django settings.py
 KEYS="DATABASE_URL REDIS_URL PLUGINS_CELERY_QUEUE CELERY_DEFAULT_QUEUE BASE_DIR PLUGINS_RELOAD_PUBSUB_CHANNEL"
 
 # Export $CONFIG to posthog-plugin-server
@@ -18,9 +16,19 @@ if [[ -n "${DYNO_RAM}" ]]; then
 fi
 
 cd plugins
+
 yarn --frozen-lockfile --silent
+if [ $? -ne 0 ]; then
+    echo "Yarn failed!"
+    exit 1
+fi
 
 while true; do
-  # break loop if exiting normally (incl CTRL+C)
-  yarn --silent start && break
+  # Run: posthog-plugin-server
+  yarn --silent start
+  echo ""
+  echo "🔴 Plugin server crashed!"
+  echo "⌛️ Waiting 2 seconds before restarting!"
+  echo ""
+  sleep 2
 done

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,9 +4,9 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "posthog-plugin-server": "0.4.1"
+        "posthog-plugin-server": "0.4.3"
     },
     "scripts": {
-        "start": "posthog-plugin-server start"
+        "start": "posthog-plugin-server"
     }
 }

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -650,10 +650,10 @@ posthog-js-lite@^0.0.5:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.5.tgz#984a619190d1c4ef003cb81194d0a6276491d2e8"
   integrity sha512-xHVZ9qbBdoqK7G1JVA4k6nheWu50aiEwjJIPQw7Zhi705aX5wr2W8zxdmvtadeEE5qbJNg+/uZ7renOQoqcbJw==
 
-posthog-plugin-server@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/posthog-plugin-server/-/posthog-plugin-server-0.4.1.tgz#21c3de2303ea61699f53c9f69df3ae8bd1b3754e"
-  integrity sha512-+EZiyn7t6TtjJSId64j+3bEh+8cvnr8manTA8aSgr67H72SK8ySza0Yi4SIe3RK2nlT8qAihdJ978JEMjbp17Q==
+posthog-plugin-server@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/posthog-plugin-server/-/posthog-plugin-server-0.4.3.tgz#32352162162d169b99f3348a338be838eb164aed"
+  integrity sha512-mmDufu3TYP0nLLgzj3KPhdf3ftyf4JfoIQliR1wgu4qR88Ob4XE9EXHM055y2gfQb8jM6LcUPjpSSPsgLEO9RQ==
   dependencies:
     "@sentry/node" "^5.29.0"
     "@sentry/tracing" "^5.29.0"


### PR DESCRIPTION
## Changes

- Restart posthig-plugin-server in case it crashes. For example: the process runs out of memory on a tiny node. This way event ingestion might resume automatically. Running the `bin/posthog-plugin-server` script and pressing CTRL+C still stops the script like before. Just now if the node script gets killed, it'll restart. I tried this via pm2, but couldn't its "no-daemon" mode is actually just "print logs" and was too tricky to work around.
- Also updated posthog-plugin-server to 0.4.3, which supports getting all the config from `$CONFIG` directly. This still seems like the safest way to export settings from django other than making a custom script. This `print_settings` [has some formats](https://django-extensions.readthedocs.io/en/latest/print_settings.html) other than JSON, but none I would feel comfortable piping to bash to export as envs. Too many serialisation and string escaping issues this can run into that I'd just avoid.

WIP since I want to still test this in the heroku review app manually.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
