### PR TITLE
Allow filtering sessions by recording duration

### DIFF
--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -61,8 +61,6 @@ def filter_sessions_by_recordings(team: Team, sessions_results: List[Any], filte
     if len(sessions_results) == 0:
         return sessions_results
 
-    print([filter])
-
     min_ts = min(it["start_time"] for it in sessions_results)
     max_ts = max(it["end_time"] for it in sessions_results)
 
@@ -83,10 +81,11 @@ def query_sessions_in_range(
 ) -> List[dict]:
     filter_query, filter_params = "", {}
 
-    if filter.min_recording_duration:
-        filter_query = "AND duration >= %(min_recording_duration)s"
+    if filter.duration:
+        operator = {"lt": "<", "gt": "> "}[filter.duration[0]]
+        filter_query = f"AND duration {operator} %(min_recording_duration)s"
         filter_params = {
-            "min_recording_duration": filter.min_recording_duration,
+            "min_recording_duration": filter.duration[1],
         }
 
     results = sync_execute(

--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -11,6 +11,8 @@ from posthog.queries.session_recording import SessionRecording as BaseSessionRec
 from posthog.queries.session_recording import Snapshots
 from posthog.queries.session_recording import filter_sessions_by_recordings as _filter_sessions_by_recordings
 
+OPERATORS = {"gt": ">", "lt": "<"}
+
 SINGLE_RECORDING_QUERY = """
     SELECT distinct_id, snapshot_data
     FROM session_recording_events
@@ -63,8 +65,7 @@ def query_sessions_in_range(
     filter_query, filter_params = "", {}
 
     if filter.duration:
-        operator = {"lt": "<", "gt": "> "}[filter.duration[0]]
-        filter_query = f"AND duration {operator} %(min_recording_duration)s"
+        filter_query = f"AND duration {OPERATORS[filter.duration[0]]} %(min_recording_duration)s"
         filter_params = {
             "min_recording_duration": filter.duration[1],
         }

--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -10,6 +10,7 @@ from posthog.queries.session_recording import DistinctId
 from posthog.queries.session_recording import SessionRecording as BaseSessionRecording
 from posthog.queries.session_recording import Snapshots
 from posthog.queries.session_recording import add_session_recording_ids as _add_session_recording_ids
+from posthog.queries.session_recording import matches
 
 SINGLE_RECORDING_QUERY = """
     SELECT distinct_id, snapshot_data
@@ -99,11 +100,3 @@ def query_sessions_in_range(
     )
 
     return [dict(zip(SESSIONS_RECORING_LIST_QUERY_COLUMNS, row)) for row in results]
-
-
-def matches(session: Any, session_recording: Any) -> bool:
-    return (
-        session["distinct_id"] == session_recording["distinct_id"]
-        and session["start_time"] <= session_recording["end_time"]
-        and session["end_time"] >= session_recording["start_time"]
-    )

--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, List, Optional, Tuple
 
 from ee.clickhouse.client import sync_execute
 from posthog.models import Team
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import BaseQuery
 from posthog.queries.session_recording import DistinctId
 from posthog.queries.session_recording import SessionRecording as BaseSessionRecording
@@ -22,17 +23,26 @@ SESSIONS_RECORING_LIST_QUERY = """
     SELECT
         session_id,
         distinct_id,
-        MIN(timestamp) AS start_time,
-        MAX(timestamp) AS end_time
-    FROM session_recording_events
-    WHERE
-        team_id = %(team_id)s
-        AND timestamp >= %(start_time)s
-        AND timestamp <= %(end_time)s
-        AND JSONExtractInt(snapshot_data, 'type') = 2
-    GROUP BY distinct_id, session_id
+        start_time,
+        end_time,
+        dateDiff('second', toDateTime(start_time), toDateTime(end_time)) as duration
+    FROM (
+        SELECT
+            session_id,
+            distinct_id,
+            MIN(timestamp) AS start_time,
+            MAX(timestamp) AS end_time,
+            COUNT(JSONExtractInt(snapshot_data, 'type') = 2 ? 1 : NULL) as full_snapshots
+        FROM session_recording_events
+        WHERE
+            team_id = %(team_id)s
+            AND timestamp >= %(start_time)s
+            AND timestamp <= %(end_time)s
+        GROUP BY distinct_id, session_id
+    )
+    WHERE full_snapshots > 0 {filter_query}
 """
-SESSIONS_RECORING_LIST_QUERY_COLUMNS = ["session_id", "distinct_id", "start_time", "end_time"]
+SESSIONS_RECORING_LIST_QUERY_COLUMNS = ["session_id", "distinct_id", "start_time", "end_time", "duration"]
 
 
 class SessionRecording(BaseSessionRecording):
@@ -47,14 +57,54 @@ def add_session_recording_ids(team: Team, sessions_results: List[Any]) -> List[A
     return _add_session_recording_ids(team, sessions_results, query=query_sessions_in_range)
 
 
-def query_sessions_in_range(team: Team, start_time: datetime.datetime, end_time: datetime.datetime) -> List[dict]:
+def filter_sessions_by_recordings(team: Team, sessions_results: List[Any], filter: SessionsFilter) -> List[Any]:
+    if len(sessions_results) == 0:
+        return sessions_results
+
+    print([filter])
+
+    min_ts = min(it["start_time"] for it in sessions_results)
+    max_ts = max(it["end_time"] for it in sessions_results)
+
+    session_recordings = query_sessions_in_range(team, min_ts, max_ts, filter)
+
+    for session in sessions_results:
+        session["session_recording_ids"] = [
+            recording["session_id"] for recording in session_recordings if matches(session, recording)
+        ]
+
+    if filter.limit_by_recordings:
+        sessions_results = [session for session in sessions_results if len(session["session_recording_ids"]) > 0]
+    return sessions_results
+
+
+def query_sessions_in_range(
+    team: Team, start_time: datetime.datetime, end_time: datetime.datetime, filter: SessionsFilter
+) -> List[dict]:
+    filter_query, filter_params = "", {}
+
+    if filter.min_recording_duration:
+        filter_query = "AND duration >= %(min_recording_duration)s"
+        filter_params = {
+            "min_recording_duration": filter.min_recording_duration,
+        }
+
     results = sync_execute(
-        SESSIONS_RECORING_LIST_QUERY,
+        SESSIONS_RECORING_LIST_QUERY.format(filter_query=filter_query),
         {
             "team_id": team.id,
             "start_time": start_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
             "end_time": end_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
+            **filter_params,
         },
     )
 
     return [dict(zip(SESSIONS_RECORING_LIST_QUERY_COLUMNS, row)) for row in results]
+
+
+def matches(session: Any, session_recording: Any) -> bool:
+    return (
+        session["distinct_id"] == session_recording["distinct_id"]
+        and session["start_time"] <= session_recording["end_time"]
+        and session["end_time"] >= session_recording["start_time"]
+    )

--- a/ee/clickhouse/queries/sessions/clickhouse_sessions.py
+++ b/ee/clickhouse/queries/sessions/clickhouse_sessions.py
@@ -8,6 +8,7 @@ from ee.clickhouse.queries.sessions.distribution import ClickhouseSessionsDist
 from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT, ClickhouseSessionsList
 from posthog.constants import SESSION_AVG, SESSION_DIST
 from posthog.models import Filter, Team
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
 from posthog.utils import relative_date_parse
 
@@ -26,7 +27,7 @@ class ClickhouseSessions(BaseQuery, ClickhouseSessionsList, ClickhouseSessionsAv
             if not filter._date_to:
                 filter._date_to = timezone.now()
 
-    def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
         limit = kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT)
         offset = kwargs.get("offset", 0)
 

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -4,16 +4,17 @@ from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.event import ClickhouseEventSerializer
 from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.models.property import parse_prop_clauses
-from ee.clickhouse.queries.clickhouse_session_recording import add_session_recording_ids
+from ee.clickhouse.queries.clickhouse_session_recording import filter_sessions_by_recordings
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.sessions.list import SESSION_SQL
-from posthog.models import Filter, Person, Team
+from posthog.models import Person, Team
+from posthog.models.filters.sessions_filter import SessionsFilter
 
 SESSIONS_LIST_DEFAULT_LIMIT = 50
 
 
 class ClickhouseSessionsList:
-    def calculate_list(self, filter: Filter, team: Team, limit: int, offset: int):
+    def calculate_list(self, filter: SessionsFilter, team: Team, limit: int, offset: int):
         filters, params = parse_prop_clauses(filter.properties, team.pk)
 
         date_from, date_to, _ = parse_timestamps(filter, team.pk)
@@ -26,7 +27,7 @@ class ClickhouseSessionsList:
 
         self._add_person_properties(team, result)
 
-        return add_session_recording_ids(team, result)
+        return filter_sessions_by_recordings(team, result, filter)
 
     def _add_person_properties(self, team=Team, sessions=List[Tuple]):
         distinct_id_hash = {}

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -25,9 +25,8 @@ class ClickhouseSessionsList:
         result = self._parse_list_results(query_result)
 
         self._add_person_properties(team, result)
-        add_session_recording_ids(team, result)
 
-        return result
+        return add_session_recording_ids(team, result)
 
     def _add_person_properties(self, team=Team, sessions=List[Tuple]):
         distinct_id_hash = {}

--- a/ee/clickhouse/queries/test/test_session_recording.py
+++ b/ee/clickhouse/queries/test/test_session_recording.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from ee.clickhouse.models.session_recording_event import create_session_recording_event
-from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording, add_session_recording_ids
+from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording, filter_sessions_by_recordings
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.queries.test.test_session_recording import session_recording_test_factory
 
@@ -13,6 +13,6 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseSessionRecording(
-    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, add_session_recording_ids, _create_event)  # type: ignore
+    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, _create_event)  # type: ignore
 ):
     pass

--- a/ee/clickhouse/queries/test/test_session_recording.py
+++ b/ee/clickhouse/queries/test/test_session_recording.py
@@ -13,6 +13,6 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseSessionRecording(
-    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, _create_event)  # type: ignore
+    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, _create_event, True)  # type: ignore
 ):
     pass

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -105,7 +105,7 @@ class ClickhouseEventsViewSet(EventViewSet):
     @action(methods=["GET"], detail=False)
     def session_recording(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         session_recording = SessionRecording().run(
-            team=self.team, filter=Filter(request=request), session_recording_id=request.GET.get("session_recording_id")
+            team=self.team, filter=Filter(request=request), session_recording_id=request.GET["session_recording_id"]
         )
 
         return Response({"result": session_recording})

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -20,6 +20,7 @@ from posthog.constants import TRENDS_STICKINESS
 from posthog.models import Event
 from posthog.models.filters import Filter
 from posthog.models.filters.retention_filter import RetentionFilter
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 
 
@@ -44,16 +45,16 @@ class ClickhouseInsightsViewSet(InsightViewSet):
     def session(self, request: Request, *args: Any, **kwargs: Any) -> Response:
 
         team = self.team
-        filter = Filter(request=request)
+        filter = SessionsFilter(request=request)
 
         limit = int(request.GET.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
         offset = int(request.GET.get("offset", 0))
 
         response = ClickhouseSessions().run(team=team, filter=filter, limit=limit + 1, offset=offset)
 
-        if "distinct_id" in request.GET and request.GET["distinct_id"]:
+        if filter.distinct_id:
             try:
-                person_ids = get_persons_by_distinct_ids(team.pk, [request.GET["distinct_id"]])[0].distinct_ids
+                person_ids = get_persons_by_distinct_ids(team.pk, [filter.distinct_id])[0].distinct_ids
                 response = [session for i, session in enumerate(response) if response[i]["distinct_id"] in person_ids]
             except IndexError:
                 response = []

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -10,7 +10,7 @@ interface Props {
 export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Element {
     const onOperatorChange = (value: '' | 'lt' | 'gt'): void => {
         if (value) {
-            onChange([value, duration ? duration[1] : null])
+            onChange([value, duration?.[1] || 0])
         } else {
             onChange(null)
         }
@@ -25,7 +25,7 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
                 onChange={onOperatorChange}
                 placeholder="Filter by recording duration"
             >
-                <Select.Option value="">Filter by recording duration</Select.Option>
+                <Select.Option value="">No filter</Select.Option>
                 <Select.Option value="gt">Recording longer than</Select.Option>
                 <Select.Option value="lt">Recording shorter than</Select.Option>
             </Select>
@@ -34,6 +34,7 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
                     style={{ width: 150, marginLeft: 8 }}
                     type="number"
                     value={duration[1] || undefined}
+                    placeholder="0"
                     min={0}
                     addonAfter="sec"
                     step={1}

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Input, Select } from 'antd'
+import { RecordingDurationFilter } from 'scenes/sessions/sessionsTableLogic'
+
+interface Props {
+    duration: RecordingDurationFilter | null
+    onChange: (duration: RecordingDurationFilter | null) => void
+}
+
+export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Element {
+    const onOperatorChange = (value: '' | 'lt' | 'gt'): void => {
+        if (value) {
+            onChange([value, duration ? duration[1] : null])
+        } else {
+            onChange(null)
+        }
+    }
+
+    return (
+        <div>
+            <Select
+                style={{ width: 212 }}
+                defaultValue={duration ? duration[0] : undefined}
+                value={duration ? duration[0] : undefined}
+                onChange={onOperatorChange}
+                placeholder="Filter by recording duration"
+            >
+                <Select.Option value="">Filter by recording duration</Select.Option>
+                <Select.Option value="gt">Recording longer than</Select.Option>
+                <Select.Option value="lt">Recording shorter than</Select.Option>
+            </Select>
+            {duration && (
+                <Input
+                    style={{ width: 150, marginLeft: 8 }}
+                    type="number"
+                    value={duration[1] || undefined}
+                    min={0}
+                    addonAfter="sec"
+                    step={1}
+                    onChange={(event) => onChange([duration[0], parseFloat(event.target.value)])}
+                />
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -179,7 +179,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
             {featureFlags['filter_by_session_props'] && (
                 <SessionRecordingFilters
                     duration={duration}
-                    onChange={(duration) => setFilters(properties, selectedDate, duration)}
+                    onChange={(newDuration) => setFilters(properties, selectedDate, newDuration)}
                 />
             )}
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -22,6 +22,7 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { SessionsPlay } from './SessionsPlay'
 import { userLogic } from 'scenes/userLogic'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
+import { SessionRecordingFilters } from 'scenes/sessions/SessionRecordingFilters'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -52,6 +53,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         selectedDate,
         properties,
         sessionRecordingId,
+        duration,
     } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
     const { user } = useValues(userLogic)
@@ -164,10 +166,20 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
             {!isPersonPage && <PageHeader title="Sessions By Day" />}
             <Space className="mb-05">
                 <Button onClick={previousDay} icon={<CaretLeftOutlined />} />
-                <DatePicker value={selectedDate} onChange={(date) => setFilters(properties, date)} allowClear={false} />
+                <DatePicker
+                    value={selectedDate}
+                    onChange={(date) => setFilters(properties, date, duration)}
+                    allowClear={false}
+                />
                 <Button onClick={nextDay} icon={<CaretRightOutlined />} />
             </Space>
+
+            <SessionRecordingFilters
+                duration={duration}
+                onChange={(duration) => setFilters(properties, selectedDate, duration)}
+            />
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />
+
             <Table
                 locale={{ emptyText: 'No Sessions on ' + moment(selectedDate).format('YYYY-MM-DD') }}
                 data-attr="sessions-table"

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -23,6 +23,7 @@ import { SessionsPlay } from './SessionsPlay'
 import { userLogic } from 'scenes/userLogic'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { SessionRecordingFilters } from 'scenes/sessions/SessionRecordingFilters'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -58,6 +59,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
     const { user } = useValues(userLogic)
     const { shareFeedbackCommand } = useActions(commandPaletteLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const columns = [
         {
@@ -174,10 +176,12 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                 <Button onClick={nextDay} icon={<CaretRightOutlined />} />
             </Space>
 
-            <SessionRecordingFilters
-                duration={duration}
-                onChange={(duration) => setFilters(properties, selectedDate, duration)}
-            />
+            {featureFlags['filter_by_session_props'] && (
+                <SessionRecordingFilters
+                    duration={duration}
+                    onChange={(duration) => setFilters(properties, selectedDate, duration)}
+                />
+            )}
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />
 
             <Table

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -11,13 +11,20 @@ type Moment = moment.Moment
 
 type SessionRecordingId = string
 
-type Params = {
+interface Params {
     date?: string
     properties?: any
+    duration?: any
     sessionRecordingId?: SessionRecordingId
 }
 
-const buildURL = (selectedDateURLparam?: string, sessionRecordingId?: SessionRecordingId | null): [string, Params] => {
+export type RecordingDurationFilter = ['lt' | 'gt', number | null]
+
+const buildURL = (
+    selectedDateURLparam?: string,
+    sessionRecordingId?: SessionRecordingId | null,
+    duration?: RecordingDurationFilter | null
+): [string, Params] => {
     const today = moment().startOf('day').format('YYYY-MM-DD')
     const params: Params = {}
 
@@ -28,6 +35,9 @@ const buildURL = (selectedDateURLparam?: string, sessionRecordingId?: SessionRec
     if (properties) {
         params.properties = properties
     }
+    if (duration) {
+        params.duration = duration
+    }
     if (sessionRecordingId) {
         params.sessionRecordingId = sessionRecordingId
     }
@@ -36,7 +46,14 @@ const buildURL = (selectedDateURLparam?: string, sessionRecordingId?: SessionRec
 }
 
 export const sessionsTableLogic = kea<
-    sessionsTableLogicType<Moment, SessionType, SessionRecordingId, eventWithTime, PropertyFilter>
+    sessionsTableLogicType<
+        Moment,
+        SessionType,
+        SessionRecordingId,
+        eventWithTime,
+        PropertyFilter,
+        RecordingDurationFilter
+    >
 >({
     props: {} as {
         personIds?: string[]
@@ -52,6 +69,7 @@ export const sessionsTableLogic = kea<
                     offset: 0,
                     distinct_id: props.personIds ? props.personIds[0] : '',
                     properties: values.properties,
+                    duration: values.duration,
                 })
                 await breakpoint(10)
                 const response = await api.get(`api/insight/session/?${params}`)
@@ -69,7 +87,11 @@ export const sessionsTableLogic = kea<
         appendNewSessions: (sessions) => ({ sessions }),
         previousDay: true,
         nextDay: true,
-        setFilters: (properties: Array<PropertyFilter>, selectedDate: Moment | null) => ({ properties, selectedDate }),
+        setFilters: (
+            properties: Array<PropertyFilter>,
+            selectedDate: Moment | null,
+            duration: RecordingDurationFilter | null
+        ) => ({ properties, selectedDate, duration }),
         setSessionRecordingId: (sessionRecordingId: SessionRecordingId) => ({ sessionRecordingId }),
         closeSessionPlayer: true,
     }),
@@ -87,6 +109,12 @@ export const sessionsTableLogic = kea<
             },
         ],
         selectedDate: [null as null | Moment, { setFilters: (_, { selectedDate }) => selectedDate }],
+        duration: [
+            null as RecordingDurationFilter | null,
+            {
+                setFilters: (_, { duration }) => duration,
+            },
+        ],
         properties: [
             [] as PropertyFilter[],
             {
@@ -150,16 +178,16 @@ export const sessionsTableLogic = kea<
             actions.loadSessions(true)
         },
         previousDay: () => {
-            actions.setFilters(values.properties, moment(values.selectedDate).add(-1, 'day'))
+            actions.setFilters(values.properties, moment(values.selectedDate).add(-1, 'day'), values.duration)
         },
         nextDay: () => {
-            actions.setFilters(values.properties, moment(values.selectedDate).add(1, 'day'))
+            actions.setFilters(values.properties, moment(values.selectedDate).add(1, 'day'), values.duration)
         },
     }),
     actionToUrl: ({ values }) => ({
-        setFilters: () => buildURL(values.selectedDateURLparam, values.sessionRecordingId),
-        setSessionRecordingId: () => buildURL(values.selectedDateURLparam, values.sessionRecordingId),
-        closeSessionPlayer: () => buildURL(values.selectedDateURLparam, null),
+        setFilters: () => buildURL(values.selectedDateURLparam, values.sessionRecordingId, values.duration),
+        setSessionRecordingId: () => buildURL(values.selectedDateURLparam, values.sessionRecordingId, values.duration),
+        closeSessionPlayer: () => buildURL(values.selectedDateURLparam, null, values.duration),
     }),
     urlToAction: ({ actions, values }) => ({
         '*': (_: any, params: Params) => {
@@ -167,9 +195,10 @@ export const sessionsTableLogic = kea<
 
             if (
                 JSON.stringify(params.properties || []) !== JSON.stringify(values.properties) ||
+                JSON.stringify(params.duration || {}) !== JSON.stringify(values.duration) ||
                 (values.selectedDate && values.selectedDate.format('YYYY-MM-DD') !== newDate.format('YYYY-MM-DD'))
             ) {
-                actions.setFilters(params.properties || [], newDate)
+                actions.setFilters(params.properties || [], newDate, params.duration || null)
             } else if (values.sessions.length === 0) {
                 actions.loadSessions(true)
             }

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -245,7 +245,7 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False)
     def session_recording(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         session_recording = SessionRecording().run(
-            team=self.team, filter=Filter(request=request), session_recording_id=request.GET.get("session_recording_id")
+            team=self.team, filter=Filter(request=request), session_recording_id=request.GET["session_recording_id"]
         )
 
         return response.Response({"result": session_recording})

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -180,25 +180,6 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         return Response(result)
 
-    def calculate_session(self, request: request.Request) -> Dict[str, Any]:
-        team = self.team
-
-        filter = Filter(request=request)
-        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter, team)}
-
-        if "distinct_id" in request.GET and request.GET["distinct_id"]:
-            result = self._filter_sessions_by_distinct_id(request.GET["distinct_id"], result)
-
-        # add pagination
-        if filter.session_type is None:
-            offset = filter.offset + 50
-            if len(result["result"]) > 49:
-                date_from = result["result"][0]["start_time"].isoformat()
-                result.update({OFFSET: offset})
-                result.update({DATE_FROM: date_from})
-
-        return result
-
     def _filter_sessions_by_distinct_id(self, distinct_id: str, result: Dict[str, Any]) -> Dict[str, Any]:
         person_ids = Person.objects.get(persondistinctid__distinct_id=distinct_id).distinct_ids
         result["result"] = [

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -17,6 +17,7 @@ from posthog.decorators import CacheType, cached_function
 from posthog.models import DashboardItem, Event, Filter, Person, Team
 from posthog.models.action import Action
 from posthog.models.filters import RetentionFilter
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
 from posthog.queries import paths, retention, sessions, stickiness, trends
@@ -162,12 +163,12 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         team = self.team
 
-        filter = Filter(request=request)
+        filter = SessionsFilter(request=request)
         limit = SESSIONS_LIST_DEFAULT_LIMIT + 1
         result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=filter, team=team, limit=limit)}
 
-        if "distinct_id" in request.GET and request.GET["distinct_id"]:
-            result = self._filter_sessions_by_distinct_id(request.GET["distinct_id"], result)
+        if filter.distinct_id:
+            result = self._filter_sessions_by_distinct_id(filter.distinct_id, result)
 
         if filter.session_type is None:
             offset = filter.offset + limit - 1

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -50,6 +50,8 @@ STICKINESS_DAYS = "stickiness_days"
 RETENTION_RECURRING = "retention_recurring"
 RETENTION_FIRST_TIME = "retention_first_time"
 
+DISTINCT_ID_FILTER = "distinct_id"
+
 
 class RDBMS(str, Enum):
     POSTGRES = "postgres"

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -10,6 +10,7 @@ RETENTION_DEFAULT_INTERVALS = 11
 
 class SessionsFilter(Filter):
     distinct_id: Optional[str]
+    min_recording_duration: Optional[int]
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         super().__init__(data, request, **kwargs)
@@ -21,3 +22,8 @@ class SessionsFilter(Filter):
             raise ValueError("You need to define either a data dict or a request")
 
         self.distinct_id = data.get(DISTINCT_ID_FILTER)
+        self.min_recording_duration = data.get("min_recording_duration")
+
+    @property
+    def limit_by_recordings(self):
+        return self.min_recording_duration is not None

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -24,7 +24,7 @@ class SessionsFilter(Filter):
 
         self.distinct_id = data.get(DISTINCT_ID_FILTER)
         if "duration" in data:
-            self.duration = json.loads(data.get("duration"))
+            self.duration = json.loads(data["duration"])
         else:
             self.duration = None
 

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, Optional
+
+from django.http import HttpRequest
+
+from posthog.constants import DISTINCT_ID_FILTER
+from posthog.models.filters.filter import Filter
+
+RETENTION_DEFAULT_INTERVALS = 11
+
+
+class SessionsFilter(Filter):
+    distinct_id: Optional[str]
+
+    def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
+        super().__init__(data, request, **kwargs)
+        if request:
+            data = {
+                **request.GET.dict(),
+            }
+        elif not data:
+            raise ValueError("You need to define either a data dict or a request")
+
+        self.distinct_id = data.get(DISTINCT_ID_FILTER)

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -1,16 +1,17 @@
-from typing import Any, Dict, Optional
+import json
+from typing import Any, Dict, Optional, Tuple
 
 from django.http import HttpRequest
 
 from posthog.constants import DISTINCT_ID_FILTER
-from posthog.models.filters.filter import Filter
+from posthog.models import Filter
 
 RETENTION_DEFAULT_INTERVALS = 11
 
 
 class SessionsFilter(Filter):
     distinct_id: Optional[str]
-    min_recording_duration: Optional[int]
+    duration: Optional[Tuple[str, int]]
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         super().__init__(data, request, **kwargs)
@@ -22,8 +23,11 @@ class SessionsFilter(Filter):
             raise ValueError("You need to define either a data dict or a request")
 
         self.distinct_id = data.get(DISTINCT_ID_FILTER)
-        self.min_recording_duration = data.get("min_recording_duration")
+        if "duration" in data:
+            self.duration = json.loads(data.get("duration"))
+        else:
+            self.duration = None
 
     @property
     def limit_by_recordings(self):
-        return self.min_recording_duration is not None
+        return self.duration is not None

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -6,8 +6,6 @@ from django.http import HttpRequest
 from posthog.constants import DISTINCT_ID_FILTER
 from posthog.models import Filter
 
-RETENTION_DEFAULT_INTERVALS = 11
-
 
 class SessionsFilter(Filter):
     distinct_id: Optional[str]

--- a/posthog/queries/session_recording.py
+++ b/posthog/queries/session_recording.py
@@ -3,7 +3,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from django.db.models import F, Max, Min
 
-from posthog.models import Filter, Person, SessionRecordingEvent, Team
+from posthog.models import Person, SessionRecordingEvent, Team
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import BaseQuery
 
 DistinctId = str
@@ -19,10 +20,10 @@ class SessionRecording:
 
         return events[0].distinct_id, [e.snapshot_data for e in events]
 
-    def run(self, filter: Filter, team: Team, *args, **kwargs) -> Dict[str, Any]:
+    def run(self, team: Team, session_recording_id: str, *args, **kwargs) -> Dict[str, Any]:
         from posthog.api.person import PersonSerializer
 
-        distinct_id, snapshots = self.query_recording_snapshots(team, kwargs["session_recording_id"])
+        distinct_id, snapshots = self.query_recording_snapshots(team, session_recording_id)
         person = (
             PersonSerializer(Person.objects.get(team=team, persondistinctid__distinct_id=distinct_id)).data
             if distinct_id
@@ -32,7 +33,9 @@ class SessionRecording:
         return {"snapshots": list(sorted(snapshots, key=lambda s: s["timestamp"])), "person": person}
 
 
-def query_sessions_in_range(team: Team, start_time: datetime.datetime, end_time: datetime.datetime) -> List[dict]:
+def query_sessions_in_range(
+    team: Team, start_time: datetime.datetime, end_time: datetime.datetime, filter: SessionsFilter
+) -> List[dict]:
     return list(
         SessionRecordingEvent.objects.filter(team=team)
         .values("distinct_id", "session_id")
@@ -43,8 +46,8 @@ def query_sessions_in_range(team: Team, start_time: datetime.datetime, end_time:
 
 
 # :TRICKY: This mutates sessions list
-def add_session_recording_ids(
-    team: Team, sessions_results: List[Any], query: Callable = query_sessions_in_range
+def filter_sessions_by_recordings(
+    team: Team, sessions_results: List[Any], filter: SessionsFilter, query: Callable = query_sessions_in_range
 ) -> List[Any]:
     if len(sessions_results) == 0:
         return sessions_results
@@ -52,12 +55,15 @@ def add_session_recording_ids(
     min_ts = min(it["start_time"] for it in sessions_results)
     max_ts = max(it["end_time"] for it in sessions_results)
 
-    session_recordings = query(team, min_ts, max_ts)
+    session_recordings = query(team, min_ts, max_ts, filter)
 
     for session in sessions_results:
         session["session_recording_ids"] = [
             recording["session_id"] for recording in session_recordings if matches(session, recording)
         ]
+
+    if filter.limit_by_recordings:
+        sessions_results = [session for session in sessions_results if len(session["session_recording_ids"]) > 0]
     return sessions_results
 
 

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -12,7 +12,7 @@ from posthog.api.element import ElementSerializer
 from posthog.constants import SESSION_AVG, SESSION_DIST
 from posthog.models import ElementGroup, Event, Filter, Team
 from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
-from posthog.queries.session_recording import add_session_recording_ids
+from posthog.queries.session_recording import filter_sessions_by_recordings
 from posthog.utils import append_data, dict_from_cursor_fetchall, friendly_time
 
 SESSIONS_LIST_DEFAULT_LIMIT = 50
@@ -198,7 +198,7 @@ class Sessions(BaseQuery):
                         )
                     except IndexError:
                         event.update({"elements": []})
-        return add_session_recording_ids(team, sessions)
+        return filter_sessions_by_recordings(team, sessions, filter)
 
     def _session_avg(self, base_query: str, params: Tuple[Any, ...], filter: Filter) -> List[Dict[str, Any]]:
         def _determineInterval(interval):

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -10,7 +10,8 @@ from django.utils.timezone import now
 
 from posthog.api.element import ElementSerializer
 from posthog.constants import SESSION_AVG, SESSION_DIST
-from posthog.models import ElementGroup, Event, Filter, Team
+from posthog.models import ElementGroup, Event, Team
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
 from posthog.queries.session_recording import filter_sessions_by_recordings
 from posthog.utils import append_data, dict_from_cursor_fetchall, friendly_time
@@ -31,7 +32,7 @@ DIST_LABELS = [
 
 
 class Sessions(BaseQuery):
-    def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
         events = (
             Event.objects.filter(team=team)
             .add_person_id(team.pk)
@@ -52,7 +53,7 @@ class Sessions(BaseQuery):
 
             compare_filter = determine_compared_filter(filter)
             compared_calculated = self.calculate_sessions(
-                events.filter(compare_filter.date_filter_Q), compare_filter, team, limit, offset
+                events.filter(compare_filter.date_filter_Q), compare_filter, team, limit, offset  # type: ignore
             )
             converted_compared_calculated = convert_to_comparison(compared_calculated, filter, "previous")
             calculated.extend(converted_compared_calculated)
@@ -65,7 +66,7 @@ class Sessions(BaseQuery):
         return calculated
 
     def calculate_sessions(
-        self, events: QuerySet, filter: Filter, team: Team, limit: int, offset: int
+        self, events: QuerySet, filter: SessionsFilter, team: Team, limit: int, offset: int
     ) -> List[Dict[str, Any]]:
 
         # format date filter for session view
@@ -128,7 +129,7 @@ class Sessions(BaseQuery):
         return result
 
     def _session_list(
-        self, base_query: str, params: Tuple[Any, ...], team: Team, filter: Filter, limit: int, offset: int
+        self, base_query: str, params: Tuple[Any, ...], team: Team, filter: SessionsFilter, limit: int, offset: int
     ) -> List[Dict[str, Any]]:
 
         session_list = """
@@ -200,7 +201,7 @@ class Sessions(BaseQuery):
                         event.update({"elements": []})
         return filter_sessions_by_recordings(team, sessions, filter)
 
-    def _session_avg(self, base_query: str, params: Tuple[Any, ...], filter: Filter) -> List[Dict[str, Any]]:
+    def _session_avg(self, base_query: str, params: Tuple[Any, ...], filter: SessionsFilter) -> List[Dict[str, Any]]:
         def _determineInterval(interval):
             if interval == "minute":
                 return (

--- a/posthog/queries/test/test_session_recording.py
+++ b/posthog/queries/test/test_session_recording.py
@@ -10,7 +10,7 @@ from posthog.queries.session_recording import SessionRecording, filter_sessions_
 from posthog.test.base import BaseTest
 
 
-def session_recording_test_factory(session_recording, filter_sessions, event_factory):
+def session_recording_test_factory(session_recording, filter_sessions, event_factory, test_duration):
     class TestSessionRecording(BaseTest):
         def test_query_run(self):
             with freeze_time("2020-09-13T12:26:40.000Z"):
@@ -71,11 +71,13 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
         def test_filter_sessions_by_recordings(self):
             self._test_filter_sessions(SessionsFilter(data={"offset": 0}), [["1", "3"], [], ["2"], []])
 
-        def test_filter_sessions_by_recording_duration_gt(self):
-            self._test_filter_sessions(SessionsFilter(data={"duration": '["gt", 15]'}), [["1", "3"]])
+        if test_duration:
 
-        def test_filter_sessions_by_recording_duration_lt(self):
-            self._test_filter_sessions(SessionsFilter(data={"duration": '["lt", 30]'}), [["1"], ["2"]])
+            def test_filter_sessions_by_recording_duration_gt(self):
+                self._test_filter_sessions(SessionsFilter(data={"duration": '["gt", 15]'}), [["1", "3"]])
+
+            def test_filter_sessions_by_recording_duration_lt(self):
+                self._test_filter_sessions(SessionsFilter(data={"duration": '["lt", 30]'}), [["1"], ["2"]])
 
         def test_query_run_with_no_sessions(self):
             self.assertEqual(filter_sessions(self.team, [], SessionsFilter(data={"offset": 0})), [])
@@ -93,6 +95,6 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
 
 
 class DjangoSessionRecordingTest(
-    session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, SessionRecordingEvent.objects.create)  # type: ignore
+    session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, SessionRecordingEvent.objects.create, False)  # type: ignore
 ):
     pass

--- a/posthog/queries/test/test_session_recording.py
+++ b/posthog/queries/test/test_session_recording.py
@@ -5,11 +5,12 @@ from django.utils.timezone import now
 from freezegun import freeze_time
 
 from posthog.models import Person, SessionRecordingEvent
-from posthog.queries.session_recording import SessionRecording, add_session_recording_ids
+from posthog.models.filters.sessions_filter import SessionsFilter
+from posthog.queries.session_recording import SessionRecording, filter_sessions_by_recordings
 from posthog.test.base import BaseTest
 
 
-def session_recording_test_factory(session_recording, add_ids, event_factory):
+def session_recording_test_factory(session_recording, filter_sessions, event_factory):
     class TestSessionRecording(BaseTest):
         def test_query_run(self):
             with freeze_time("2020-09-13T12:26:40.000Z"):
@@ -20,7 +21,7 @@ def session_recording_test_factory(session_recording, add_ids, event_factory):
                 self.create_snapshot("user2", "2", now() + relativedelta(seconds=20))
                 self.create_snapshot("user", "1", now() + relativedelta(seconds=30))
 
-                session = session_recording().run(team=self.team, filter=None, session_recording_id="1")
+                session = session_recording().run(team=self.team, session_recording_id="1")
                 self.assertEqual(
                     session["snapshots"],
                     [
@@ -32,10 +33,10 @@ def session_recording_test_factory(session_recording, add_ids, event_factory):
                 self.assertEqual(session["person"]["properties"], {"$some_prop": "something"})
 
         def test_query_run_with_no_such_session(self):
-            session = session_recording().run(team=self.team, filter=None, session_recording_id="xxx")
+            session = session_recording().run(team=self.team, session_recording_id="xxx")
             self.assertEqual(session, {"snapshots": [], "person": None})
 
-        def test_add_session_recording_ids(self):
+        def _test_filter_sessions(self, filter, expected):
             with freeze_time("2020-09-13T12:26:40.000Z"):
                 self.create_snapshot("user", "1", now() + relativedelta(seconds=5))
                 self.create_snapshot("user", "1", now() + relativedelta(seconds=10))
@@ -45,7 +46,7 @@ def session_recording_test_factory(session_recording, add_ids, event_factory):
                 # :TRICKY: same user, different session at the same time
                 self.create_snapshot("user", "3", now() + relativedelta(seconds=15))
                 self.create_snapshot("user", "3", now() + relativedelta(seconds=20))
-                self.create_snapshot("user", "3", now() + relativedelta(seconds=40))
+                self.create_snapshot("user", "3", now() + relativedelta(seconds=60))
                 self.create_snapshot("user", "4", now() + relativedelta(seconds=999))
                 self.create_snapshot("user", "4", now() + relativedelta(seconds=1020))
 
@@ -62,15 +63,26 @@ def session_recording_test_factory(session_recording, add_ids, event_factory):
                     {"distinct_id": "user2", "start_time": now(), "end_time": now() + relativedelta(seconds=30)},
                     {"distinct_id": "broken-user", "start_time": now(), "end_time": now() + relativedelta(seconds=100)},
                 ]
-                results = add_ids(self.team, sessions)
-                self.assertEqual([r["session_recording_ids"] for r in results], [["1", "3"], [], ["2"], []])
+
+                results = filter_sessions(self.team, sessions, filter)
+
+                self.assertEqual([r["session_recording_ids"] for r in results], expected)
+
+        def test_filter_sessions_by_recordings(self):
+            self._test_filter_sessions(SessionsFilter(data={"offset": 0}), [["1", "3"], [], ["2"], []])
+
+        def test_filter_sessions_by_recording_duration_gt(self):
+            self._test_filter_sessions(SessionsFilter(data={"duration": '["gt", 15]'}), [["1", "3"]])
+
+        def test_filter_sessions_by_recording_duration_lt(self):
+            self._test_filter_sessions(SessionsFilter(data={"duration": '["lt", 30]'}), [["1"], ["2"]])
 
         def test_query_run_with_no_sessions(self):
-            self.assertEqual(add_ids(self.team, []), [])
+            self.assertEqual(filter_sessions(self.team, [], SessionsFilter(data={"offset": 0})), [])
 
         def create_snapshot(self, distinct_id, session_id, timestamp, type=2):
             event_factory(
-                team_id=self.team.id,
+                team_id=self.team.pk,
                 distinct_id=distinct_id,
                 timestamp=timestamp,
                 session_id=session_id,
@@ -81,6 +93,6 @@ def session_recording_test_factory(session_recording, add_ids, event_factory):
 
 
 class DjangoSessionRecordingTest(
-    session_recording_test_factory(SessionRecording, add_session_recording_ids, SessionRecordingEvent.objects.create)  # type: ignore
+    session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, SessionRecordingEvent.objects.create)  # type: ignore
 ):
     pass

--- a/posthog/queries/test/test_sessions.py
+++ b/posthog/queries/test/test_sessions.py
@@ -1,7 +1,8 @@
 from freezegun import freeze_time
 
-from posthog.models import Event, Filter, Person, Team
+from posthog.models import Event, Person, Team
 from posthog.models.cohort import Cohort
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.sessions import Sessions
 from posthog.test.base import BaseTest
 
@@ -27,14 +28,16 @@ def sessions_test_factory(sessions, event_factory):
             # Test team leakage
             Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
             with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(Filter(data={"events": [], "session": None}), self.team)
+                response = sessions().run(SessionsFilter(data={"events": [], "session": None}), self.team)
 
             self.assertEqual(len(response), 2)
             self.assertEqual(response[0]["global_session_id"], 1)
 
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = sessions().run(
-                    Filter(data={"events": [], "properties": [{"key": "$os", "value": "Mac OS X"}], "session": None}),
+                    SessionsFilter(
+                        data={"events": [], "properties": [{"key": "$os", "value": "Mac OS X"}], "session": None}
+                    ),
                     self.team,
                 )
             self.assertEqual(len(response), 1)
@@ -61,7 +64,7 @@ def sessions_test_factory(sessions, event_factory):
                 event_factory(team=self.team, event="4th action", distinct_id="2")
 
             with freeze_time("2012-01-21T04:01:34.000Z"):
-                response = sessions().run(Filter(data={"session": "avg"}), self.team)
+                response = sessions().run(SessionsFilter(data={"session": "avg"}), self.team)
 
             self.assertEqual(response[0]["count"], 3)  # average length of all sessions
             # time series
@@ -97,7 +100,7 @@ def sessions_test_factory(sessions, event_factory):
 
             # month
             month_response = sessions().run(
-                Filter(
+                SessionsFilter(
                     data={"date_from": "2012-01-01", "date_to": "2012-04-01", "interval": "month", "session": "avg"}
                 ),
                 self.team,
@@ -112,7 +115,9 @@ def sessions_test_factory(sessions, event_factory):
 
             # # week
             week_response = sessions().run(
-                Filter(data={"date_from": "2012-01-01", "date_to": "2012-02-01", "interval": "week", "session": "avg"}),
+                SessionsFilter(
+                    data={"date_from": "2012-01-01", "date_to": "2012-02-01", "interval": "week", "session": "avg"}
+                ),
                 self.team,
             )
             self.assertEqual(week_response[0]["data"][1], 240.0)
@@ -124,7 +129,9 @@ def sessions_test_factory(sessions, event_factory):
 
             # # # hour
             hour_response = sessions().run(
-                Filter(data={"date_from": "2012-03-14", "date_to": "2012-03-16", "interval": "hour", "session": "avg"}),
+                SessionsFilter(
+                    data={"date_from": "2012-03-14", "date_to": "2012-03-16", "interval": "hour", "session": "avg"}
+                ),
                 self.team,
             )
             self.assertEqual(hour_response[0]["data"][3], 240.0)
@@ -136,7 +143,9 @@ def sessions_test_factory(sessions, event_factory):
 
         def test_no_events(self):
             response = sessions().run(
-                Filter(data={"date_from": "2012-01-20", "date_to": "2012-01-30", "interval": "day", "session": "avg"}),
+                SessionsFilter(
+                    data={"date_from": "2012-01-20", "date_to": "2012-01-30", "interval": "day", "session": "avg"}
+                ),
                 self.team,
             )
             self.assertEqual(response, [])
@@ -154,7 +163,7 @@ def sessions_test_factory(sessions, event_factory):
             with freeze_time("2012-01-25T04:01:34.000Z"):
                 event_factory(team=self.team, event="4th action", distinct_id="1")
                 event_factory(team=self.team, event="4th action", distinct_id="2")
-            filter = Filter(
+            filter = SessionsFilter(
                 data={
                     "date_from": "2012-01-20",
                     "date_to": "2012-01-30",
@@ -174,7 +183,7 @@ def sessions_test_factory(sessions, event_factory):
                 event_factory(team=self.team, event="1st action", distinct_id="2")
 
             with freeze_time("2012-01-21T01:25:30.000Z"):
-                response = sessions().run(Filter(data={"session": "dist"}), self.team)
+                response = sessions().run(SessionsFilter(data={"session": "dist"}), self.team)
                 for _, item in enumerate(response):
                     self.assertEqual(item["count"], 0)
 
@@ -235,9 +244,9 @@ def sessions_test_factory(sessions, event_factory):
             with freeze_time("2012-01-21T06:00:30.000Z"):
                 event_factory(team=self.team, event="3rd action", distinct_id="2")
 
-            response = sessions().run(Filter(data={"date_from": "all", "session": "dist"}), self.team)
+            response = sessions().run(SessionsFilter(data={"date_from": "all", "session": "dist"}), self.team)
             compared_response = sessions().run(
-                Filter(data={"date_from": "all", "compare": True, "session": "dist"}), self.team
+                SessionsFilter(data={"date_from": "all", "compare": True, "session": "dist"}), self.team
             )
             for index, item in enumerate(response):
                 if item["label"] == "30-60 minutes" or item["label"] == "3-10 seconds":
@@ -269,7 +278,7 @@ def sessions_test_factory(sessions, event_factory):
             cohort.calculate_people()
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = sessions().run(
-                    Filter(
+                    SessionsFilter(
                         data={
                             "events": [],
                             "session": None,


### PR DESCRIPTION
## Changes

Part 1 of 2 for adding filtering support for session recordings. The new code is all behind a feature flag.

Decided to split this into a separate PR to avoid making too large of a PR. Because of this, please don't do any edits to this PR - it will cause merge conflicts with WIP code. Instead will handle any comments in follow-up PRs if that's ok.

In next PR:
- Postgres support for this query
- Separating out session list query to a separate endpoint
- Handling offsets properly (this could start causing 

![Screenshot from 2020-12-10 00-14-44](https://user-images.githubusercontent.com/148820/101695074-bdd2da00-3a7c-11eb-9442-f1fd64764b68.png)

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
