### PR TITLE
Sessions filtering: improve UX

### DIFF
--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -65,9 +65,9 @@ def query_sessions_in_range(
     filter_query, filter_params = "", {}
 
     if filter.duration:
-        filter_query = f"AND duration {OPERATORS[filter.duration[0]]} %(min_recording_duration)s"
+        filter_query = f"AND duration {OPERATORS[filter.duration_operator]} %(min_recording_duration)s"
         filter_params = {
-            "min_recording_duration": filter.duration[1],
+            "min_recording_duration": filter.duration,
         }
 
     results = sync_execute(

--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -64,7 +64,7 @@ def query_sessions_in_range(
 ) -> List[dict]:
     filter_query, filter_params = "", {}
 
-    if filter.duration:
+    if filter.duration_operator:
         filter_query = f"AND duration {OPERATORS[filter.duration_operator]} %(min_recording_duration)s"
         filter_params = {
             "min_recording_duration": filter.duration,

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -20,13 +20,12 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
     return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
             <Select
-                style={{ width: 212 }}
+                style={{ width: 233 }}
                 defaultValue={duration ? duration[0] : undefined}
                 value={duration ? duration[0] : undefined}
                 onChange={onOperatorChange}
                 placeholder="Filter by recording duration"
             >
-                <Select.Option value="">Filter by recording duration</Select.Option>
                 <Select.Option value="gt">Recording longer than</Select.Option>
                 <Select.Option value="lt">Recording shorter than</Select.Option>
             </Select>

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -25,7 +25,7 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
                 onChange={onOperatorChange}
                 placeholder="Filter by recording duration"
             >
-                <Select.Option value="">No filter</Select.Option>
+                <Select.Option value="">Filter by recording duration</Select.Option>
                 <Select.Option value="gt">Recording longer than</Select.Option>
                 <Select.Option value="lt">Recording shorter than</Select.Option>
             </Select>

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Element {
     const onOperatorChange = (value: '' | 'lt' | 'gt'): void => {
         if (value) {
-            onChange([value, duration?.[1] || 0])
+            onChange([value, duration?.[1] || 0, duration?.[2] || 'm'])
         } else {
             onChange(null)
         }
@@ -33,14 +33,25 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
             {duration && (
                 <>
                     <Input
-                        style={{ width: 150, marginLeft: 8 }}
+                        style={{ width: 200, marginLeft: 8 }}
                         type="number"
                         value={duration[1] || undefined}
                         placeholder="0"
                         min={0}
-                        addonAfter="sec"
+                        addonAfter={
+                            <Select
+                                showArrow={false}
+                                showSearch={false}
+                                value={duration[2]}
+                                onChange={(value) => onChange([duration[0], duration[1], value])}
+                            >
+                                <Select.Option value="s">seconds</Select.Option>
+                                <Select.Option value="m">minutes</Select.Option>
+                                <Select.Option value="h">hours</Select.Option>
+                            </Select>
+                        }
                         step={1}
-                        onChange={(event) => onChange([duration[0], parseFloat(event.target.value)])}
+                        onChange={(event) => onChange([duration[0], parseFloat(event.target.value), duration[2]])}
                     />
                     <CloseButton
                         onClick={() => onChange(null)}

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Input, Select } from 'antd'
 import { RecordingDurationFilter } from 'scenes/sessions/sessionsTableLogic'
+import { CloseButton } from 'lib/components/CloseButton'
 
 interface Props {
     duration: RecordingDurationFilter | null
@@ -17,7 +18,7 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
     }
 
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
             <Select
                 style={{ width: 212 }}
                 defaultValue={duration ? duration[0] : undefined}
@@ -30,16 +31,25 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
                 <Select.Option value="lt">Recording shorter than</Select.Option>
             </Select>
             {duration && (
-                <Input
-                    style={{ width: 150, marginLeft: 8 }}
-                    type="number"
-                    value={duration[1] || undefined}
-                    placeholder="0"
-                    min={0}
-                    addonAfter="sec"
-                    step={1}
-                    onChange={(event) => onChange([duration[0], parseFloat(event.target.value)])}
-                />
+                <>
+                    <Input
+                        style={{ width: 150, marginLeft: 8 }}
+                        type="number"
+                        value={duration[1] || undefined}
+                        placeholder="0"
+                        min={0}
+                        addonAfter="sec"
+                        step={1}
+                        onChange={(event) => onChange([duration[0], parseFloat(event.target.value)])}
+                    />
+                    <CloseButton
+                        onClick={() => onChange(null)}
+                        style={{
+                            float: 'none',
+                            marginLeft: 4,
+                        }}
+                    />
+                </>
             )}
         </div>
     )

--- a/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingFilters.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Input, Select } from 'antd'
 import { RecordingDurationFilter } from 'scenes/sessions/sessionsTableLogic'
 import { CloseButton } from 'lib/components/CloseButton'
-
 interface Props {
     duration: RecordingDurationFilter | null
     onChange: (duration: RecordingDurationFilter | null) => void
@@ -39,7 +38,6 @@ export function SessionRecordingFilters({ duration, onChange }: Props): JSX.Elem
                         min={0}
                         addonAfter={
                             <Select
-                                showArrow={false}
                                 showSearch={false}
                                 value={duration[2]}
                                 onChange={(value) => onChange([duration[0], duration[1], value])}

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -18,7 +18,7 @@ interface Params {
     sessionRecordingId?: SessionRecordingId
 }
 
-export type RecordingDurationFilter = ['lt' | 'gt', number | null]
+export type RecordingDurationFilter = ['lt' | 'gt', number | null, 's' | 'm' | 'h']
 
 const buildURL = (
     selectedDateURLparam?: string,
@@ -69,8 +69,7 @@ export const sessionsTableLogic = kea<
                     offset: 0,
                     distinct_id: props.personIds ? props.personIds[0] : '',
                     properties: values.properties,
-                    duration_operator: values.duration ? values.duration[0] : undefined,
-                    duration: values.duration ? values.duration[1] || 0 : undefined,
+                    ...values.durationFilter,
                 })
                 await breakpoint(10)
                 const response = await api.get(`api/insight/session/?${params}`)
@@ -155,6 +154,18 @@ export const sessionsTableLogic = kea<
                     result.prev = recordings[index - 1]
                 }
                 return result
+            },
+        ],
+        durationFilter: [
+            (selectors) => [selectors.duration],
+            (duration: RecordingDurationFilter | null) => {
+                if (!duration) {
+                    return undefined
+                }
+
+                const multipliers = { s: 1, m: 60, h: 3600 }
+                const seconds = (duration[1] || 0) * multipliers[duration[2]]
+                return { duration_operator: duration[0], duration: seconds }
             },
         ],
     },

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -69,7 +69,8 @@ export const sessionsTableLogic = kea<
                     offset: 0,
                     distinct_id: props.personIds ? props.personIds[0] : '',
                     properties: values.properties,
-                    duration: values.duration,
+                    duration_operator: values.duration ? values.duration[0] : undefined,
+                    duration: values.duration ? values.duration[1] || 0 : undefined,
                 })
                 await breakpoint(10)
                 const response = await api.get(`api/insight/session/?${params}`)

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from django.http import HttpRequest
 
@@ -23,7 +22,7 @@ class SessionsFilter(Filter):
 
         self.distinct_id = data.get(DISTINCT_ID_FILTER)
         self.duration_operator = data.get("duration_operator")
-        self.duration = data.get("duration", 0)
+        self.duration = float(data.get("duration", 0))
 
     @property
     def limit_by_recordings(self):

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -9,7 +9,7 @@ from posthog.models import Filter
 class SessionsFilter(Filter):
     distinct_id: Optional[str]
     duration_operator: Optional[str]  # lt, gt
-    duration: Optional[int]
+    _duration: Optional[str]
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         super().__init__(data, request, **kwargs)
@@ -22,8 +22,12 @@ class SessionsFilter(Filter):
 
         self.distinct_id = data.get(DISTINCT_ID_FILTER)
         self.duration_operator = data.get("duration_operator")
-        self.duration = float(data.get("duration", 0))
+        self._duration = data.get("duration")
 
     @property
-    def limit_by_recordings(self):
+    def duration(self) -> float:
+        return float(self._duration or 0)
+
+    @property
+    def limit_by_recordings(self) -> bool:
         return self.duration_operator is not None

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -9,7 +9,8 @@ from posthog.models import Filter
 
 class SessionsFilter(Filter):
     distinct_id: Optional[str]
-    duration: Optional[Tuple[str, int]]
+    duration_operator: Optional[str]  # lt, gt
+    duration: Optional[int]
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         super().__init__(data, request, **kwargs)
@@ -21,11 +22,9 @@ class SessionsFilter(Filter):
             raise ValueError("You need to define either a data dict or a request")
 
         self.distinct_id = data.get(DISTINCT_ID_FILTER)
-        if "duration" in data:
-            self.duration = json.loads(data["duration"])
-        else:
-            self.duration = None
+        self.duration_operator = data.get("duration_operator")
+        self.duration = data.get("duration", 0)
 
     @property
     def limit_by_recordings(self):
-        return self.duration is not None
+        return self.duration_operator is not None

--- a/posthog/queries/test/test_session_recording.py
+++ b/posthog/queries/test/test_session_recording.py
@@ -74,10 +74,14 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
         if test_duration:
 
             def test_filter_sessions_by_recording_duration_gt(self):
-                self._test_filter_sessions(SessionsFilter(data={"duration": '["gt", 15]'}), [["1", "3"]])
+                self._test_filter_sessions(
+                    SessionsFilter(data={"duration_operator": "gt", "duration": 15}), [["1", "3"]]
+                )
 
             def test_filter_sessions_by_recording_duration_lt(self):
-                self._test_filter_sessions(SessionsFilter(data={"duration": '["lt", 30]'}), [["1"], ["2"]])
+                self._test_filter_sessions(
+                    SessionsFilter(data={"duration_operator": "lt", "duration": 30}), [["1"], ["2"]]
+                )
 
         def test_query_run_with_no_sessions(self):
             self.assertEqual(filter_sessions(self.team, [], SessionsFilter(data={"offset": 0})), [])


### PR DESCRIPTION
## Changes

This solves feedback from https://github.com/PostHog/posthog/pull/2721:
- [ ] Duration filter confusing
- [ ] Width of the element
- [x] Renamed the no option
- [x] Add close button
- [x] Allow choosing time unit
- [x] Empty input should behave as 0

Let's discuss the two remaining to do tonight.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
