### PR TITLE
Drop parallel cohorts to 0

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -83,6 +83,10 @@
                 {
                     "name": "SITE_URL",
                     "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "PARALLEL_COHORTS",
+                    "value": "0"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -83,6 +83,10 @@
                 {
                     "name": "SITE_URL",
                     "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "PARALLEL_COHORTS",
+                    "value": "0"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

I think we're getting completely hammered by this, so dropping to 0 for now. 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
