### PR TITLE
Sessions filtering postgres support

### DIFF
--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -21,7 +21,7 @@ SINGLE_RECORDING_QUERY = """
         AND session_id = %(session_id)s
 """
 
-SESSIONS_RECORING_LIST_QUERY = """
+SESSIONS_IN_RANGE_QUERY = """
     SELECT
         session_id,
         distinct_id,
@@ -44,7 +44,7 @@ SESSIONS_RECORING_LIST_QUERY = """
     )
     WHERE full_snapshots > 0 {filter_query}
 """
-SESSIONS_RECORING_LIST_QUERY_COLUMNS = ["session_id", "distinct_id", "start_time", "end_time", "duration"]
+SESSIONS_IN_RANGE_QUERY_COLUMNS = ["session_id", "distinct_id", "start_time", "end_time", "duration"]
 
 
 class SessionRecording(BaseSessionRecording):
@@ -71,7 +71,7 @@ def query_sessions_in_range(
         }
 
     results = sync_execute(
-        SESSIONS_RECORING_LIST_QUERY.format(filter_query=filter_query),
+        SESSIONS_IN_RANGE_QUERY.format(filter_query=filter_query),
         {
             "team_id": team.id,
             "start_time": start_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
@@ -80,4 +80,4 @@ def query_sessions_in_range(
         },
     )
 
-    return [dict(zip(SESSIONS_RECORING_LIST_QUERY_COLUMNS, row)) for row in results]
+    return [dict(zip(SESSIONS_IN_RANGE_QUERY_COLUMNS, row)) for row in results]

--- a/ee/clickhouse/queries/sessions/clickhouse_sessions.py
+++ b/ee/clickhouse/queries/sessions/clickhouse_sessions.py
@@ -5,10 +5,8 @@ from django.utils import timezone
 
 from ee.clickhouse.queries.sessions.average import ClickhouseSessionsAvg
 from ee.clickhouse.queries.sessions.distribution import ClickhouseSessionsDist
-from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT, ClickhouseSessionsList
 from posthog.constants import SESSION_AVG, SESSION_DIST
 from posthog.models import Filter, Team
-from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
 from posthog.utils import relative_date_parse
 
@@ -26,8 +24,8 @@ def set_default_dates(filter: Filter) -> None:
             filter._date_to = timezone.now()
 
 
-class ClickhouseSessions(BaseQuery, ClickhouseSessionsList, ClickhouseSessionsAvg, ClickhouseSessionsDist):
-    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+class ClickhouseSessions(BaseQuery, ClickhouseSessionsAvg, ClickhouseSessionsDist):
+    def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
         result: List = []
 
         set_default_dates(filter)
@@ -46,9 +44,5 @@ class ClickhouseSessions(BaseQuery, ClickhouseSessionsList, ClickhouseSessionsAv
 
         elif filter.session_type == SESSION_DIST:
             result = self.calculate_dist(filter, team)
-        else:
-            limit = kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT)
-            offset = kwargs.get("offset", 0)
-            result = self.calculate_list(filter, team, limit, offset)
 
         return result

--- a/ee/clickhouse/queries/sessions/clickhouse_sessions.py
+++ b/ee/clickhouse/queries/sessions/clickhouse_sessions.py
@@ -28,9 +28,6 @@ def set_default_dates(filter: Filter) -> None:
 
 class ClickhouseSessions(BaseQuery, ClickhouseSessionsList, ClickhouseSessionsAvg, ClickhouseSessionsDist):
     def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
-        limit = kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT)
-        offset = kwargs.get("offset", 0)
-
         result: List = []
 
         set_default_dates(filter)
@@ -50,6 +47,8 @@ class ClickhouseSessions(BaseQuery, ClickhouseSessionsList, ClickhouseSessionsAv
         elif filter.session_type == SESSION_DIST:
             result = self.calculate_dist(filter, team)
         else:
+            limit = kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT)
+            offset = kwargs.get("offset", 0)
             result = self.calculate_list(filter, team, limit, offset)
 
         return result

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -1,20 +1,26 @@
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.event import ClickhouseEventSerializer
 from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.clickhouse_session_recording import filter_sessions_by_recordings
+from ee.clickhouse.queries.sessions.clickhouse_sessions import set_default_dates
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.sessions.list import SESSION_SQL
 from posthog.models import Person, Team
 from posthog.models.filters.sessions_filter import SessionsFilter
+from posthog.queries.base import BaseQuery
 
 SESSIONS_LIST_DEFAULT_LIMIT = 50
 
 
-class ClickhouseSessionsList:
-    def calculate_list(self, filter: SessionsFilter, team: Team, limit: int, offset: int):
+class ClickhouseSessionsList(BaseQuery):
+    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        limit = kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT)
+        offset = kwargs.get("offset", 0)
+        set_default_dates(filter)
+
         filters, params = parse_prop_clauses(filter.properties, team.pk)
 
         date_from, date_to, _ = parse_timestamps(filter, team.pk)

--- a/ee/clickhouse/queries/test/test_session_recording.py
+++ b/ee/clickhouse/queries/test/test_session_recording.py
@@ -13,6 +13,6 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseSessionRecording(
-    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, _create_event, True)  # type: ignore
+    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, _create_event)  # type: ignore
 ):
     pass

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -2,8 +2,10 @@ from uuid import uuid4
 
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
+from ee.clickhouse.queries.sessions.list import ClickhouseSessionsList
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.queries.test.test_sessions import sessions_test_factory
+from posthog.queries.test.test_sessions_list import sessions_list_test_factory
 
 
 def _create_event(**kwargs):
@@ -12,4 +14,8 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(ClickhouseSessions, _create_event)):  # type: ignore
+    pass
+
+
+class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event)):  # type: ignore
     pass

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -11,10 +11,13 @@ from ee.clickhouse.models.event import ClickhouseEventSerializer, determine_even
 from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.models.property import get_property_values_for_key, parse_prop_clauses
 from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording
+from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
+from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT
 from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_EVENT_WITH_PROP_SQL, SELECT_ONE_EVENT_SQL
 from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
 from posthog.models.action import Action
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.utils import convert_property_value
 
 
@@ -96,6 +99,29 @@ class ClickhouseEventsViewSet(EventViewSet):
         if key:
             result = get_property_values_for_key(key, team, value=request.GET.get("value"))
         return Response([{"name": convert_property_value(value[0])} for value in result])
+
+    @action(methods=["GET"], detail=False)
+    def sessions(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        team = self.team
+        filter = SessionsFilter(request=request)
+
+        limit = int(request.GET.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
+        offset = int(request.GET.get("offset", 0))
+
+        response = ClickhouseSessions().run(team=team, filter=filter, limit=limit + 1, offset=offset)
+
+        if filter.distinct_id:
+            try:
+                person_ids = get_persons_by_distinct_ids(team.pk, [filter.distinct_id])[0].distinct_ids
+                response = [session for i, session in enumerate(response) if response[i]["distinct_id"] in person_ids]
+            except IndexError:
+                response = []
+
+        if len(response) > limit:
+            response.pop()
+            return Response({"result": response, "offset": offset + limit})
+        else:
+            return Response({"result": response,})
 
     # ******************************************
     # /event/session_recording

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -11,8 +11,7 @@ from ee.clickhouse.models.event import ClickhouseEventSerializer, determine_even
 from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.models.property import get_property_values_for_key, parse_prop_clauses
 from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording
-from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
-from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT
+from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT, ClickhouseSessionsList
 from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_EVENT_WITH_PROP_SQL, SELECT_ONE_EVENT_SQL
 from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
@@ -108,7 +107,7 @@ class ClickhouseEventsViewSet(EventViewSet):
         limit = int(request.GET.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
         offset = int(request.GET.get("offset", 0))
 
-        response = ClickhouseSessions().run(team=team, filter=filter, limit=limit + 1, offset=offset)
+        response = ClickhouseSessionsList().run(team=team, filter=filter, limit=limit + 1, offset=offset)
 
         if filter.distinct_id:
             try:

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -4,20 +4,15 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from ee.clickhouse.client import sync_execute
-from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.queries.clickhouse_funnel import ClickhouseFunnel
 from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
 from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
 from ee.clickhouse.queries.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
-from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
 from ee.clickhouse.queries.util import get_earliest_timestamp
-from ee.clickhouse.sql.events import GET_EARLIEST_TIMESTAMP_SQL
 from posthog.api.insight import InsightViewSet
 from posthog.constants import TRENDS_STICKINESS
-from posthog.models import Event
 from posthog.models.filters import Filter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.sessions_filter import SessionsFilter
@@ -43,12 +38,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
 
     @action(methods=["GET"], detail=False)
     def session(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        filter = SessionsFilter(request=request)
-
-        limit = int(request.GET.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
-        offset = int(request.GET.get("offset", 0))
-
-        response = ClickhouseSessions().run(team=self.team, filter=filter, limit=limit + 1, offset=offset)
+        response = ClickhouseSessions().run(team=self.team, filter=Filter(request=request))
 
         return Response({"result": response,})
 

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -43,27 +43,14 @@ class ClickhouseInsightsViewSet(InsightViewSet):
 
     @action(methods=["GET"], detail=False)
     def session(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-
-        team = self.team
         filter = SessionsFilter(request=request)
 
         limit = int(request.GET.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
         offset = int(request.GET.get("offset", 0))
 
-        response = ClickhouseSessions().run(team=team, filter=filter, limit=limit + 1, offset=offset)
+        response = ClickhouseSessions().run(team=self.team, filter=filter, limit=limit + 1, offset=offset)
 
-        if filter.distinct_id:
-            try:
-                person_ids = get_persons_by_distinct_ids(team.pk, [filter.distinct_id])[0].distinct_ids
-                response = [session for i, session in enumerate(response) if response[i]["distinct_id"] in person_ids]
-            except IndexError:
-                response = []
-
-        if len(response) > limit:
-            response.pop()
-            return Response({"result": response, "offset": offset + limit})
-        else:
-            return Response({"result": response,})
+        return Response({"result": response,})
 
     @action(methods=["GET"], detail=False)
     def path(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -72,7 +72,7 @@ export const sessionsTableLogic = kea<
                     ...values.durationFilter,
                 })
                 await breakpoint(10)
-                const response = await api.get(`api/insight/session/?${params}`)
+                const response = await api.get(`api/event/sessions/?${params}`)
                 breakpoint()
                 if (response.offset) {
                     actions.setNextOffset(response.offset)
@@ -176,7 +176,7 @@ export const sessionsTableLogic = kea<
                 date_to: values.selectedDateURLparam,
                 offset: values.nextOffset,
             })
-            const response = await api.get(`api/insight/session/?${params}`)
+            const response = await api.get(`api/event/sessions/?${params}`)
             breakpoint()
             if (response.offset) {
                 actions.setNextOffset(response.offset)

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -245,6 +245,9 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     #
     # params:
     # - offset: (number) offset query param for paginated list of user sessions
+    # - distinct_id: (string) filter sessions by distinct id
+    # - duration: (float) filter sessions by recording duration
+    # - duration_operator: (string: lt, gt)
     # - **shared filter types
     # ******************************************
     @action(methods=["GET"], detail=False)

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 
@@ -15,7 +16,9 @@ from posthog.constants import DATE_FROM, OFFSET
 from posthog.models import Element, ElementGroup, Event, Filter, Person, PersonDistinctId
 from posthog.models.action import Action
 from posthog.models.event import EventManager
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
+from posthog.queries import sessions
 from posthog.queries.session_recording import SessionRecording
 from posthog.utils import convert_property_value
 
@@ -236,6 +239,43 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
 
         return [{"name": convert_property_value(value.value)} for value in values]
+
+    # ******************************************
+    # /event/sessions
+    #
+    # params:
+    # - offset: (number) offset query param for paginated list of user sessions
+    # - **shared filter types
+    # ******************************************
+    @action(methods=["GET"], detail=False)
+    def sessions(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        from posthog.queries.sessions import SESSIONS_LIST_DEFAULT_LIMIT
+
+        team = self.team
+
+        filter = SessionsFilter(request=request)
+        limit = SESSIONS_LIST_DEFAULT_LIMIT + 1
+        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=filter, team=team, limit=limit)}
+
+        if filter.distinct_id:
+            result = self._filter_sessions_by_distinct_id(filter.distinct_id, result)
+
+        if filter.session_type is None:
+            offset = filter.offset + limit - 1
+            if len(result["result"]) > SESSIONS_LIST_DEFAULT_LIMIT:
+                result["result"].pop()
+                date_from = result["result"][0]["start_time"].isoformat()
+                result.update({OFFSET: offset})
+                result.update({DATE_FROM: date_from})
+
+        return Response(result)
+
+    def _filter_sessions_by_distinct_id(self, distinct_id: str, result: Dict[str, Any]) -> Dict[str, Any]:
+        person_ids = Person.objects.get(persondistinctid__distinct_id=distinct_id).distinct_ids
+        result["result"] = [
+            session for i, session in enumerate(result["result"]) if result["result"][i]["distinct_id"] in person_ids
+        ]
+        return result
 
     # ******************************************
     # /event/session_recording

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -18,7 +18,6 @@ from posthog.models.action import Action
 from posthog.models.event import EventManager
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
-from posthog.queries import sessions
 from posthog.queries.session_recording import SessionRecording
 from posthog.utils import convert_property_value
 
@@ -252,13 +251,11 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     # ******************************************
     @action(methods=["GET"], detail=False)
     def sessions(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        from posthog.queries.sessions import SESSIONS_LIST_DEFAULT_LIMIT
-
-        team = self.team
+        from posthog.queries.sessions_list import SESSIONS_LIST_DEFAULT_LIMIT, SessionsList
 
         filter = SessionsFilter(request=request)
         limit = SESSIONS_LIST_DEFAULT_LIMIT + 1
-        result: Dict[str, Any] = {"result": sessions.SessionsList().run(filter=filter, team=team, limit=limit)}
+        result: Dict[str, Any] = {"result": SessionsList().run(filter=filter, team=self.team, limit=limit)}
 
         if filter.distinct_id:
             result = self._filter_sessions_by_distinct_id(filter.distinct_id, result)

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -258,7 +258,7 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         filter = SessionsFilter(request=request)
         limit = SESSIONS_LIST_DEFAULT_LIMIT + 1
-        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=filter, team=team, limit=limit)}
+        result: Dict[str, Any] = {"result": sessions.SessionsList().run(filter=filter, team=team, limit=limit)}
 
         if filter.distinct_id:
             result = self._filter_sessions_by_distinct_id(filter.distinct_id, result)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -154,38 +154,17 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     #
     # params:
     # - session: (string: avg, dist) specifies session type
-    # - offset: (number) offset query param for paginated list of user sessions
     # - **shared filter types
     # ******************************************
     @action(methods=["GET"], detail=False)
     def session(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         from posthog.queries.sessions import SESSIONS_LIST_DEFAULT_LIMIT
 
-        team = self.team
-
         filter = SessionsFilter(request=request)
         limit = SESSIONS_LIST_DEFAULT_LIMIT + 1
-        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=filter, team=team, limit=limit)}
-
-        if filter.distinct_id:
-            result = self._filter_sessions_by_distinct_id(filter.distinct_id, result)
-
-        if filter.session_type is None:
-            offset = filter.offset + limit - 1
-            if len(result["result"]) > SESSIONS_LIST_DEFAULT_LIMIT:
-                result["result"].pop()
-                date_from = result["result"][0]["start_time"].isoformat()
-                result.update({OFFSET: offset})
-                result.update({DATE_FROM: date_from})
+        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=filter, team=self.team, limit=limit)}
 
         return Response(result)
-
-    def _filter_sessions_by_distinct_id(self, distinct_id: str, result: Dict[str, Any]) -> Dict[str, Any]:
-        person_ids = Person.objects.get(persondistinctid__distinct_id=distinct_id).distinct_ids
-        result["result"] = [
-            session for i, session in enumerate(result["result"]) if result["result"][i]["distinct_id"] in person_ids
-        ]
-        return result
 
     # ******************************************
     # /insight/funnel

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -158,11 +158,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     # ******************************************
     @action(methods=["GET"], detail=False)
     def session(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        from posthog.queries.sessions import SESSIONS_LIST_DEFAULT_LIMIT
-
-        filter = SessionsFilter(request=request)
-        limit = SESSIONS_LIST_DEFAULT_LIMIT + 1
-        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=filter, team=self.team, limit=limit)}
+        result: Dict[str, Any] = {"result": sessions.Sessions().run(filter=Filter(request=request), team=self.team)}
 
         return Response(result)
 

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 
 from posthog.models import Action, ActionStep, Element, Event, Person, Team
 from posthog.test.base import BaseTest, TransactionBaseTest
+from posthog.utils import relative_date_parse
 
 
 def test_event_api_factory(event_factory, person_factory, action_factory):
@@ -238,6 +239,68 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json()["event"], "sign up")
             self.assertEqual(response.json()["properties"], {"key": "test_val"})
+
+        def test_events_sessions_basic(self):
+            with freeze_time("2012-01-14T03:21:34.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="1")
+                event_factory(team=self.team, event="1st action", distinct_id="2")
+            with freeze_time("2012-01-14T03:25:34.000Z"):
+                event_factory(team=self.team, event="2nd action", distinct_id="1")
+                event_factory(team=self.team, event="2nd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:34.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:35.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="1")
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
+                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
+
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                response = self.client.get("/api/event/sessions/",).json()
+
+            self.assertEqual(len(response["result"]), 2)
+
+            response = self.client.get("/api/event/sessions/?date_from=2012-01-14&date_to=2012-01-15",).json()
+            self.assertEqual(len(response["result"]), 4)
+
+            for i in range(46):
+                with freeze_time(relative_date_parse("2012-01-15T04:01:34.000Z") + relativedelta(hours=i)):
+                    event_factory(team=self.team, event="action {}".format(i), distinct_id=str(i + 3))
+
+            response = self.client.get("/api/event/sessions/?date_from=2012-01-14&date_to=2012-01-17",).json()
+            self.assertEqual(len(response["result"]), 50)
+            self.assertEqual(response.get("offset", None), None)
+
+            for i in range(2):
+                with freeze_time(relative_date_parse("2012-01-15T04:01:34.000Z") + relativedelta(hours=i + 46)):
+                    event_factory(team=self.team, event="action {}".format(i), distinct_id=str(i + 49))
+
+            response = self.client.get("/api/event/sessions/?date_from=2012-01-14&date_to=2012-01-17",).json()
+            self.assertEqual(len(response["result"]), 50)
+            self.assertEqual(response["offset"], 50)
+
+            response = self.client.get("/api/event/sessions/?date_from=2012-01-14&date_to=2012-01-17&offset=50",).json()
+            self.assertEqual(len(response["result"]), 2)
+            self.assertEqual(response.get("offset", None), None)
+
+        def test_event_sessions_by_id(self):
+            Person.objects.create(team=self.team, distinct_ids=["1"])
+            with freeze_time("2012-01-14T03:21:34.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="1")
+                event_factory(team=self.team, event="1st action", distinct_id="2")
+            with freeze_time("2012-01-14T03:25:34.000Z"):
+                event_factory(team=self.team, event="2nd action", distinct_id="1")
+                event_factory(team=self.team, event="2nd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:35.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="1")
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
+                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
+
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                response_person_1 = self.client.get("/api/event/sessions/?distinct_id=1",).json()
+
+            self.assertEqual(len(response_person_1["result"]), 1)
 
     return TestEvents
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -12,7 +12,6 @@ from posthog.models.event import Event
 from posthog.models.filters import Filter
 from posthog.models.person import Person
 from posthog.test.base import TransactionBaseTest
-from posthog.utils import relative_date_parse
 
 # TODO: two tests below fail in EE
 
@@ -92,51 +91,6 @@ def insight_test_factory(event_factory, person_factory):
             self.assertEqual(response[0]["count"], 2)
             self.assertEqual(response[0]["action"]["name"], "$pageview")
 
-        def test_insight_session_basic(self):
-            with freeze_time("2012-01-14T03:21:34.000Z"):
-                event_factory(team=self.team, event="1st action", distinct_id="1")
-                event_factory(team=self.team, event="1st action", distinct_id="2")
-            with freeze_time("2012-01-14T03:25:34.000Z"):
-                event_factory(team=self.team, event="2nd action", distinct_id="1")
-                event_factory(team=self.team, event="2nd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:34.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:35.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="1")
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
-                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = self.client.get("/api/insight/session/",).json()
-
-            self.assertEqual(len(response["result"]), 2)
-
-            response = self.client.get("/api/insight/session/?date_from=2012-01-14&date_to=2012-01-15",).json()
-            self.assertEqual(len(response["result"]), 4)
-
-            for i in range(46):
-                with freeze_time(relative_date_parse("2012-01-15T04:01:34.000Z") + relativedelta(hours=i)):
-                    event_factory(team=self.team, event="action {}".format(i), distinct_id=str(i + 3))
-
-            response = self.client.get("/api/insight/session/?date_from=2012-01-14&date_to=2012-01-17",).json()
-            self.assertEqual(len(response["result"]), 50)
-            self.assertEqual(response.get("offset", None), None)
-
-            for i in range(2):
-                with freeze_time(relative_date_parse("2012-01-15T04:01:34.000Z") + relativedelta(hours=i + 46)):
-                    event_factory(team=self.team, event="action {}".format(i), distinct_id=str(i + 49))
-
-            response = self.client.get("/api/insight/session/?date_from=2012-01-14&date_to=2012-01-17",).json()
-            self.assertEqual(len(response["result"]), 50)
-            self.assertEqual(response["offset"], 50)
-
-            response = self.client.get(
-                "/api/insight/session/?date_from=2012-01-14&date_to=2012-01-17&offset=50",
-            ).json()
-            self.assertEqual(len(response["result"]), 2)
-            self.assertEqual(response.get("offset", None), None)
-
         def test_insight_paths_basic(self):
             person1 = person_factory(team=self.team, distinct_ids=["person_1"])
             event_factory(
@@ -183,25 +137,6 @@ def insight_test_factory(event_factory, person_factory):
                 response = self.client.get("/api/insight/retention/",).json()
 
                 self.assertEqual(len(response["data"]), 11)
-
-            def test_insight_session_by_id(self):
-                Person.objects.create(team=self.team, distinct_ids=["1"])
-                with freeze_time("2012-01-14T03:21:34.000Z"):
-                    event_factory(team=self.team, event="1st action", distinct_id="1")
-                    event_factory(team=self.team, event="1st action", distinct_id="2")
-                with freeze_time("2012-01-14T03:25:34.000Z"):
-                    event_factory(team=self.team, event="2nd action", distinct_id="1")
-                    event_factory(team=self.team, event="2nd action", distinct_id="2")
-                with freeze_time("2012-01-15T03:59:35.000Z"):
-                    event_factory(team=self.team, event="3rd action", distinct_id="1")
-                with freeze_time("2012-01-15T04:01:34.000Z"):
-                    event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
-                    event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-
-                with freeze_time("2012-01-15T04:01:34.000Z"):
-                    response_person_1 = self.client.get("/api/insight/session/?distinct_id=1",).json()
-
-                self.assertEqual(len(response_person_1["result"]), 1)
 
     return TestInsightApi
 

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -8,15 +8,11 @@ from django.db.models.expressions import Window
 from django.db.models.functions import Lag
 from django.utils.timezone import now
 
-from posthog.api.element import ElementSerializer
-from posthog.constants import SESSION_AVG, SESSION_DIST
-from posthog.models import ElementGroup, Event, Filter, Team
-from posthog.models.filters.sessions_filter import SessionsFilter
+from posthog.constants import SESSION_AVG
+from posthog.models import Event, Filter, Team
 from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
-from posthog.queries.session_recording import filter_sessions_by_recordings
-from posthog.utils import append_data, dict_from_cursor_fetchall, friendly_time
+from posthog.utils import append_data, friendly_time
 
-SESSIONS_LIST_DEFAULT_LIMIT = 50
 DIST_LABELS = [
     "0 seconds (1 event)",
     "0-3 seconds",
@@ -34,7 +30,7 @@ Query = str
 QueryParams = Tuple[Any, ...]
 
 
-class BaseSessions:
+class BaseSessions(BaseQuery):
     def events_query(self, filter: Filter, team: Team) -> QuerySet:
         return (
             Event.objects.filter(team=team)
@@ -76,123 +72,7 @@ class BaseSessions:
         return all_sessions, sessions_sql_params
 
 
-class SessionsList(BaseQuery, BaseSessions):
-    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
-        events = self.events_query(filter, team)
-
-        limit = int(kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
-        offset = filter.offset
-
-        return self.calculate_sessions(events, filter, team, limit, offset)
-
-    def calculate_sessions(
-        self, events: QuerySet, filter: SessionsFilter, team: Team, limit: int, offset: int
-    ) -> List[Dict[str, Any]]:
-
-        # format date filter for session view
-        _date_gte = Q()
-        if filter.session_type is None:
-            # if _date_from is not explicitely set we only want to get the last day worth of data
-            # otherwise the query is very slow
-            if filter._date_from and filter.date_to:
-                _date_gte = Q(timestamp__gte=filter.date_from, timestamp__lte=filter.date_to + relativedelta(days=1),)
-            else:
-                dt = now()
-                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
-                _date_gte = Q(timestamp__gte=dt, timestamp__lte=dt + relativedelta(days=1))
-        else:
-            if not filter.date_from:
-                filter._date_from = (
-                    Event.objects.filter(team_id=team)
-                    .order_by("timestamp")[0]
-                    .timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
-                    .isoformat()
-                )
-
-        all_sessions, sessions_sql_params = self.build_all_sessions_query(events, _date_gte)
-        return self._session_list(all_sessions, sessions_sql_params, team, filter, limit, offset)
-
-    def _session_list(
-        self, base_query: Query, params: QueryParams, team: Team, filter: SessionsFilter, limit: int, offset: int
-    ) -> List[Dict[str, Any]]:
-
-        session_list = """
-            SELECT
-                *
-            FROM (
-                SELECT
-                    global_session_id,
-                    properties,
-                    start_time,
-                    end_time,
-                    length,
-                    sessions.distinct_id,
-                    event_count,
-                    events
-                FROM (
-                    SELECT
-                        global_session_id,
-                        count(1) as event_count,
-                        MAX(distinct_id) as distinct_id,
-                        EXTRACT('EPOCH' FROM (MAX(timestamp) - MIN(timestamp))) AS length,
-                        MIN(timestamp) as start_time,
-                        MAX(timestamp) as end_time,
-                        array_agg(json_build_object( 'id', id, 'event', event, 'timestamp', timestamp, 'properties', properties, 'elements_hash', elements_hash) ORDER BY timestamp) as events
-                    FROM
-                        ({base_query}) as count
-                    GROUP BY 1
-                ) as sessions
-                LEFT OUTER JOIN
-                    posthog_persondistinctid ON posthog_persondistinctid.distinct_id = sessions.distinct_id AND posthog_persondistinctid.team_id = %s
-                LEFT OUTER JOIN
-                    posthog_person ON posthog_person.id = posthog_persondistinctid.person_id
-                ORDER BY
-                    start_time DESC
-            ) as ordered_sessions
-            OFFSET %s
-            LIMIT %s
-        """.format(
-            base_query=base_query
-        )
-
-        with connection.cursor() as cursor:
-            params = params + (team.pk, offset, limit,)
-            cursor.execute(session_list, params)
-            sessions = dict_from_cursor_fetchall(cursor)
-
-            hash_ids = []
-            for session in sessions:
-                for event in session["events"]:
-                    if event.get("elements_hash"):
-                        hash_ids.append(event["elements_hash"])
-
-            groups = self._prefetch_elements(hash_ids, team)
-
-            for session in sessions:
-                for event in session["events"]:
-                    try:
-                        event.update(
-                            {
-                                "elements": ElementSerializer(
-                                    [group for group in groups if group.hash == event["elements_hash"]][0]
-                                    .element_set.all()
-                                    .order_by("order"),
-                                    many=True,
-                                ).data
-                            }
-                        )
-                    except IndexError:
-                        event.update({"elements": []})
-        return filter_sessions_by_recordings(team, sessions, filter)
-
-    def _prefetch_elements(self, hash_ids: List[str], team: Team) -> QuerySet:
-        groups = ElementGroup.objects.none()
-        if len(hash_ids) > 0:
-            groups = ElementGroup.objects.filter(team=team, hash__in=hash_ids).prefetch_related("element_set")
-        return groups
-
-
-class Sessions(BaseQuery, BaseSessions):
+class Sessions(BaseSessions):
     def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
         events = self.events_query(filter, team)
         calculated = []

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -10,7 +10,7 @@ from django.utils.timezone import now
 
 from posthog.api.element import ElementSerializer
 from posthog.constants import SESSION_AVG, SESSION_DIST
-from posthog.models import ElementGroup, Event, Team
+from posthog.models import ElementGroup, Event, Filter, Team
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
 from posthog.queries.session_recording import filter_sessions_by_recordings
@@ -30,65 +30,20 @@ DIST_LABELS = [
     "1+ hours",
 ]
 
+Query = str
+QueryParams = Tuple[Any, ...]
 
-class Sessions(BaseQuery):
-    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
-        events = (
+
+class BaseSessions:
+    def events_query(self, filter: Filter, team: Team) -> QuerySet:
+        return (
             Event.objects.filter(team=team)
             .add_person_id(team.pk)
             .filter(filter.properties_to_Q(team_id=team.pk))
             .order_by("-timestamp")
         )
 
-        limit = int(kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
-        offset = filter.offset
-
-        calculated = []
-
-        # get compared period
-        if filter.compare and filter._date_from != "all" and filter.session_type == SESSION_AVG:
-
-            calculated = self.calculate_sessions(events.filter(filter.date_filter_Q), filter, team, limit, offset)
-            calculated = convert_to_comparison(calculated, filter, "current")
-
-            compare_filter = determine_compared_filter(filter)
-            compared_calculated = self.calculate_sessions(
-                events.filter(compare_filter.date_filter_Q), compare_filter, team, limit, offset  # type: ignore
-            )
-            converted_compared_calculated = convert_to_comparison(compared_calculated, filter, "previous")
-            calculated.extend(converted_compared_calculated)
-        else:
-            # if session_type is None, it's a list of sessions which shouldn't have any date filtering
-            if filter.session_type is not None:
-                events = events.filter(filter.date_filter_Q)
-            calculated = self.calculate_sessions(events, filter, team, limit, offset)
-
-        return calculated
-
-    def calculate_sessions(
-        self, events: QuerySet, filter: SessionsFilter, team: Team, limit: int, offset: int
-    ) -> List[Dict[str, Any]]:
-
-        # format date filter for session view
-        _date_gte = Q()
-        if filter.session_type is None:
-            # if _date_from is not explicitely set we only want to get the last day worth of data
-            # otherwise the query is very slow
-            if filter._date_from and filter.date_to:
-                _date_gte = Q(timestamp__gte=filter.date_from, timestamp__lte=filter.date_to + relativedelta(days=1),)
-            else:
-                dt = now()
-                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
-                _date_gte = Q(timestamp__gte=dt, timestamp__lte=dt + relativedelta(days=1))
-        else:
-            if not filter.date_from:
-                filter._date_from = (
-                    Event.objects.filter(team_id=team)
-                    .order_by("timestamp")[0]
-                    .timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
-                    .isoformat()
-                )
-
+    def build_all_sessions_query(self, events: QuerySet, _date_gte=Q()) -> Tuple[Query, QueryParams]:
         sessions = (
             events.filter(_date_gte)
             .annotate(
@@ -118,18 +73,47 @@ class Sessions(BaseQuery):
             sessions_sql
         )
 
-        result: List = []
-        if filter.session_type == SESSION_AVG:
-            result = self._session_avg(all_sessions, sessions_sql_params, filter)
-        elif filter.session_type == SESSION_DIST:
-            result = self._session_dist(all_sessions, sessions_sql_params)
-        else:
-            result = self._session_list(all_sessions, sessions_sql_params, team, filter, limit, offset)
+        return all_sessions, sessions_sql_params
 
-        return result
+
+class SessionsList(BaseQuery, BaseSessions):
+    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        events = self.events_query(filter, team)
+
+        limit = int(kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
+        offset = filter.offset
+
+        return self.calculate_sessions(events, filter, team, limit, offset)
+
+    def calculate_sessions(
+        self, events: QuerySet, filter: SessionsFilter, team: Team, limit: int, offset: int
+    ) -> List[Dict[str, Any]]:
+
+        # format date filter for session view
+        _date_gte = Q()
+        if filter.session_type is None:
+            # if _date_from is not explicitely set we only want to get the last day worth of data
+            # otherwise the query is very slow
+            if filter._date_from and filter.date_to:
+                _date_gte = Q(timestamp__gte=filter.date_from, timestamp__lte=filter.date_to + relativedelta(days=1),)
+            else:
+                dt = now()
+                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+                _date_gte = Q(timestamp__gte=dt, timestamp__lte=dt + relativedelta(days=1))
+        else:
+            if not filter.date_from:
+                filter._date_from = (
+                    Event.objects.filter(team_id=team)
+                    .order_by("timestamp")[0]
+                    .timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+                    .isoformat()
+                )
+
+        all_sessions, sessions_sql_params = self.build_all_sessions_query(events, _date_gte)
+        return self._session_list(all_sessions, sessions_sql_params, team, filter, limit, offset)
 
     def _session_list(
-        self, base_query: str, params: Tuple[Any, ...], team: Team, filter: SessionsFilter, limit: int, offset: int
+        self, base_query: Query, params: QueryParams, team: Team, filter: SessionsFilter, limit: int, offset: int
     ) -> List[Dict[str, Any]]:
 
         session_list = """
@@ -201,7 +185,52 @@ class Sessions(BaseQuery):
                         event.update({"elements": []})
         return filter_sessions_by_recordings(team, sessions, filter)
 
-    def _session_avg(self, base_query: str, params: Tuple[Any, ...], filter: SessionsFilter) -> List[Dict[str, Any]]:
+    def _prefetch_elements(self, hash_ids: List[str], team: Team) -> QuerySet:
+        groups = ElementGroup.objects.none()
+        if len(hash_ids) > 0:
+            groups = ElementGroup.objects.filter(team=team, hash__in=hash_ids).prefetch_related("element_set")
+        return groups
+
+
+class Sessions(BaseQuery, BaseSessions):
+    def run(self, filter: Filter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        events = self.events_query(filter, team)
+        calculated = []
+
+        # get compared period
+        if filter.compare and filter._date_from != "all" and filter.session_type == SESSION_AVG:
+
+            calculated = self.calculate_sessions(events.filter(filter.date_filter_Q), filter, team)
+            calculated = convert_to_comparison(calculated, filter, "current")
+
+            compare_filter = determine_compared_filter(filter)
+            compared_calculated = self.calculate_sessions(
+                events.filter(compare_filter.date_filter_Q), compare_filter, team
+            )
+            converted_compared_calculated = convert_to_comparison(compared_calculated, filter, "previous")
+            calculated.extend(converted_compared_calculated)
+        else:
+            events = events.filter(filter.date_filter_Q)
+            calculated = self.calculate_sessions(events, filter, team)
+
+        return calculated
+
+    def calculate_sessions(self, events: QuerySet, filter: Filter, team: Team) -> List[Dict[str, Any]]:
+        all_sessions, sessions_sql_params = self.build_all_sessions_query(events)
+
+        if filter.session_type == SESSION_AVG:
+            if not filter.date_from:
+                filter._date_from = (
+                    Event.objects.filter(team_id=team)
+                    .order_by("timestamp")[0]
+                    .timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+                    .isoformat()
+                )
+            return self._session_avg(all_sessions, sessions_sql_params, filter)
+        else:  # SESSION_DIST
+            return self._session_dist(all_sessions, sessions_sql_params)
+
+    def _session_avg(self, base_query: Query, params: QueryParams, filter: Filter) -> List[Dict[str, Any]]:
         def _determineInterval(interval):
             if interval == "minute":
                 return (
@@ -260,7 +289,7 @@ class Sessions(BaseQuery):
         result = [time_series_data]
         return result
 
-    def _session_dist(self, base_query: str, params: Tuple[Any, ...]) -> List[Dict[str, Any]]:
+    def _session_dist(self, base_query: Query, params: QueryParams) -> List[Dict[str, Any]]:
         distribution = "SELECT COUNT(CASE WHEN length = 0 THEN 1 ELSE NULL END) as first,\
                         COUNT(CASE WHEN length > 0 AND length <= 3 THEN 1 ELSE NULL END) as second,\
                         COUNT(CASE WHEN length > 3 AND length <= 10 THEN 1 ELSE NULL END) as third,\
@@ -281,9 +310,3 @@ class Sessions(BaseQuery):
         calculated = cursor.fetchall()
         result = [{"label": DIST_LABELS[index], "count": calculated[0][index]} for index in range(len(DIST_LABELS))]
         return result
-
-    def _prefetch_elements(self, hash_ids: List[str], team: Team) -> QuerySet:
-        groups = ElementGroup.objects.none()
-        if len(hash_ids) > 0:
-            groups = ElementGroup.objects.filter(team=team, hash__in=hash_ids).prefetch_related("element_set")
-        return groups

--- a/posthog/queries/sessions_list.py
+++ b/posthog/queries/sessions_list.py
@@ -1,0 +1,131 @@
+from typing import Any, Dict, List
+
+from dateutil.relativedelta import relativedelta
+from django.db import connection
+from django.db.models import Q, QuerySet
+from django.utils.timezone import now
+
+from posthog.api.element import ElementSerializer
+from posthog.models import ElementGroup, Event, Team
+from posthog.models.filters.sessions_filter import SessionsFilter
+from posthog.queries.session_recording import filter_sessions_by_recordings
+from posthog.queries.sessions import BaseSessions, Query, QueryParams
+from posthog.utils import dict_from_cursor_fetchall
+
+SESSIONS_LIST_DEFAULT_LIMIT = 50
+
+
+class SessionsList(BaseSessions):
+    def run(self, filter: SessionsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        events = self.events_query(filter, team)
+
+        limit = int(kwargs.get("limit", SESSIONS_LIST_DEFAULT_LIMIT))
+        offset = filter.offset
+
+        return self.calculate_sessions(events, filter, team, limit, offset)
+
+    def calculate_sessions(
+        self, events: QuerySet, filter: SessionsFilter, team: Team, limit: int, offset: int
+    ) -> List[Dict[str, Any]]:
+
+        # format date filter for session view
+        _date_gte = Q()
+        if filter.session_type is None:
+            # if _date_from is not explicitely set we only want to get the last day worth of data
+            # otherwise the query is very slow
+            if filter._date_from and filter.date_to:
+                _date_gte = Q(timestamp__gte=filter.date_from, timestamp__lte=filter.date_to + relativedelta(days=1),)
+            else:
+                dt = now()
+                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+                _date_gte = Q(timestamp__gte=dt, timestamp__lte=dt + relativedelta(days=1))
+        else:
+            if not filter.date_from:
+                filter._date_from = (
+                    Event.objects.filter(team_id=team)
+                    .order_by("timestamp")[0]
+                    .timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+                    .isoformat()
+                )
+
+        all_sessions, sessions_sql_params = self.build_all_sessions_query(events, _date_gte)
+        return self._session_list(all_sessions, sessions_sql_params, team, filter, limit, offset)
+
+    def _session_list(
+        self, base_query: Query, params: QueryParams, team: Team, filter: SessionsFilter, limit: int, offset: int
+    ) -> List[Dict[str, Any]]:
+
+        session_list = """
+            SELECT
+                *
+            FROM (
+                SELECT
+                    global_session_id,
+                    properties,
+                    start_time,
+                    end_time,
+                    length,
+                    sessions.distinct_id,
+                    event_count,
+                    events
+                FROM (
+                    SELECT
+                        global_session_id,
+                        count(1) as event_count,
+                        MAX(distinct_id) as distinct_id,
+                        EXTRACT('EPOCH' FROM (MAX(timestamp) - MIN(timestamp))) AS length,
+                        MIN(timestamp) as start_time,
+                        MAX(timestamp) as end_time,
+                        array_agg(json_build_object( 'id', id, 'event', event, 'timestamp', timestamp, 'properties', properties, 'elements_hash', elements_hash) ORDER BY timestamp) as events
+                    FROM
+                        ({base_query}) as count
+                    GROUP BY 1
+                ) as sessions
+                LEFT OUTER JOIN
+                    posthog_persondistinctid ON posthog_persondistinctid.distinct_id = sessions.distinct_id AND posthog_persondistinctid.team_id = %s
+                LEFT OUTER JOIN
+                    posthog_person ON posthog_person.id = posthog_persondistinctid.person_id
+                ORDER BY
+                    start_time DESC
+            ) as ordered_sessions
+            OFFSET %s
+            LIMIT %s
+        """.format(
+            base_query=base_query
+        )
+
+        with connection.cursor() as cursor:
+            params = params + (team.pk, offset, limit,)
+            cursor.execute(session_list, params)
+            sessions = dict_from_cursor_fetchall(cursor)
+
+            hash_ids = []
+            for session in sessions:
+                for event in session["events"]:
+                    if event.get("elements_hash"):
+                        hash_ids.append(event["elements_hash"])
+
+            groups = self._prefetch_elements(hash_ids, team)
+
+            for session in sessions:
+                for event in session["events"]:
+                    try:
+                        event.update(
+                            {
+                                "elements": ElementSerializer(
+                                    [group for group in groups if group.hash == event["elements_hash"]][0]
+                                    .element_set.all()
+                                    .order_by("order"),
+                                    many=True,
+                                ).data
+                            }
+                        )
+                    except IndexError:
+                        event.update({"elements": []})
+        return filter_sessions_by_recordings(team, sessions, filter)
+
+    def _prefetch_elements(self, hash_ids: List[str], team: Team) -> QuerySet:
+        groups = ElementGroup.objects.none()
+        if len(hash_ids) > 0:
+            groups = ElementGroup.objects.filter(team=team, hash__in=hash_ids).prefetch_related("element_set")
+        return groups

--- a/posthog/queries/test/test_session_recording.py
+++ b/posthog/queries/test/test_session_recording.py
@@ -1,5 +1,3 @@
-import datetime
-
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
 from freezegun import freeze_time
@@ -10,7 +8,7 @@ from posthog.queries.session_recording import SessionRecording, filter_sessions_
 from posthog.test.base import BaseTest
 
 
-def session_recording_test_factory(session_recording, filter_sessions, event_factory, test_duration):
+def session_recording_test_factory(session_recording, filter_sessions, event_factory):
     class TestSessionRecording(BaseTest):
         def test_query_run(self):
             with freeze_time("2020-09-13T12:26:40.000Z"):
@@ -71,17 +69,11 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
         def test_filter_sessions_by_recordings(self):
             self._test_filter_sessions(SessionsFilter(data={"offset": 0}), [["1", "3"], [], ["2"], []])
 
-        if test_duration:
+        def test_filter_sessions_by_recording_duration_gt(self):
+            self._test_filter_sessions(SessionsFilter(data={"duration_operator": "gt", "duration": 15}), [["1", "3"]])
 
-            def test_filter_sessions_by_recording_duration_gt(self):
-                self._test_filter_sessions(
-                    SessionsFilter(data={"duration_operator": "gt", "duration": 15}), [["1", "3"]]
-                )
-
-            def test_filter_sessions_by_recording_duration_lt(self):
-                self._test_filter_sessions(
-                    SessionsFilter(data={"duration_operator": "lt", "duration": 30}), [["1"], ["2"]]
-                )
+        def test_filter_sessions_by_recording_duration_lt(self):
+            self._test_filter_sessions(SessionsFilter(data={"duration_operator": "lt", "duration": 30}), [["1"], ["2"]])
 
         def test_query_run_with_no_sessions(self):
             self.assertEqual(filter_sessions(self.team, [], SessionsFilter(data={"offset": 0})), [])
@@ -99,6 +91,6 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
 
 
 class DjangoSessionRecordingTest(
-    session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, SessionRecordingEvent.objects.create, False)  # type: ignore
+    session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, SessionRecordingEvent.objects.create)  # type: ignore
 ):
     pass

--- a/posthog/queries/test/test_sessions.py
+++ b/posthog/queries/test/test_sessions.py
@@ -9,39 +9,6 @@ from posthog.test.base import BaseTest
 
 def sessions_test_factory(sessions, event_factory):
     class TestSessions(BaseTest):
-        def test_sessions_list(self):
-            with freeze_time("2012-01-14T03:21:34.000Z"):
-                event_factory(team=self.team, event="1st action", distinct_id="1")
-                event_factory(team=self.team, event="1st action", distinct_id="2")
-            with freeze_time("2012-01-14T03:25:34.000Z"):
-                event_factory(team=self.team, event="2nd action", distinct_id="1")
-                event_factory(team=self.team, event="2nd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:34.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:35.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="1")
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
-                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-            team_2 = Team.objects.create()
-            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            # Test team leakage
-            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(SessionsFilter(data={"events": [], "session": None}), self.team)
-
-            self.assertEqual(len(response), 2)
-            self.assertEqual(response[0]["global_session_id"], 1)
-
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(
-                    SessionsFilter(
-                        data={"events": [], "properties": [{"key": "$os", "value": "Mac OS X"}], "session": None}
-                    ),
-                    self.team,
-                )
-            self.assertEqual(len(response), 1)
-
         def test_sessions_avg_length(self):
             # make sure out of range event doesn't get included
             with freeze_time("2012-01-01T03:21:34.000Z"):
@@ -255,39 +222,6 @@ def sessions_test_factory(sessions, event_factory):
                 else:
                     self.assertEqual(item["count"], 1)
                     self.assertEqual(compared_response[index]["count"], 1)
-
-        def test_sessions_and_cohort(self):
-            with freeze_time("2012-01-14T03:21:34.000Z"):
-                event_factory(team=self.team, event="1st action", distinct_id="1")
-                event_factory(team=self.team, event="1st action", distinct_id="2")
-            with freeze_time("2012-01-14T03:25:34.000Z"):
-                event_factory(team=self.team, event="2nd action", distinct_id="1")
-                event_factory(team=self.team, event="2nd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:34.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:35.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="1")
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
-                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-            team_2 = Team.objects.create()
-            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            # Test team leakage
-            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            cohort = Cohort.objects.create(team=self.team, groups=[{"properties": {"email": "bla"}}])
-            cohort.calculate_people()
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(
-                    SessionsFilter(
-                        data={
-                            "events": [],
-                            "session": None,
-                            "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
-                        }
-                    ),
-                    self.team,
-                )
-            self.assertEqual(len(response), 1)
 
     return TestSessions
 

--- a/posthog/queries/test/test_sessions_list.py
+++ b/posthog/queries/test/test_sessions_list.py
@@ -1,0 +1,82 @@
+from freezegun import freeze_time
+
+from posthog.models import Event, Person, Team
+from posthog.models.cohort import Cohort
+from posthog.models.filters.sessions_filter import SessionsFilter
+from posthog.queries.sessions_list import SessionsList
+from posthog.test.base import BaseTest
+
+
+def sessions_list_test_factory(sessions, event_factory):
+    class TestSessionsList(BaseTest):
+        def test_sessions_list(self):
+            with freeze_time("2012-01-14T03:21:34.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="1")
+                event_factory(team=self.team, event="1st action", distinct_id="2")
+            with freeze_time("2012-01-14T03:25:34.000Z"):
+                event_factory(team=self.team, event="2nd action", distinct_id="1")
+                event_factory(team=self.team, event="2nd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:34.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:35.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="1")
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
+                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
+            team_2 = Team.objects.create()
+            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            # Test team leakage
+            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                response = sessions().run(SessionsFilter(data={"events": [], "session": None}), self.team)
+
+            self.assertEqual(len(response), 2)
+            self.assertEqual(response[0]["global_session_id"], 1)
+
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                response = sessions().run(
+                    SessionsFilter(
+                        data={"events": [], "properties": [{"key": "$os", "value": "Mac OS X"}], "session": None}
+                    ),
+                    self.team,
+                )
+            self.assertEqual(len(response), 1)
+
+        def test_sessions_and_cohort(self):
+            with freeze_time("2012-01-14T03:21:34.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="1")
+                event_factory(team=self.team, event="1st action", distinct_id="2")
+            with freeze_time("2012-01-14T03:25:34.000Z"):
+                event_factory(team=self.team, event="2nd action", distinct_id="1")
+                event_factory(team=self.team, event="2nd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:34.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:35.000Z"):
+                event_factory(team=self.team, event="3rd action", distinct_id="1")
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
+                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
+            team_2 = Team.objects.create()
+            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            # Test team leakage
+            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            cohort = Cohort.objects.create(team=self.team, groups=[{"properties": {"email": "bla"}}])
+            cohort.calculate_people()
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                response = sessions().run(
+                    SessionsFilter(
+                        data={
+                            "events": [],
+                            "session": None,
+                            "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
+                        }
+                    ),
+                    self.team,
+                )
+            self.assertEqual(len(response), 1)
+
+    return TestSessionsList
+
+
+class DjangoSessionsListTest(sessions_list_test_factory(SessionsList, Event.objects.create)):  # type: ignore
+    pass


### PR DESCRIPTION
## Changes

After this:
- Sessions list logic will be under a separate endpoint - /api/event/sessions
- Filtering by session recording duration works under postgres

I did not put the offset handling code into this query as it would have become quite expensive. Will handle that in a separate PR.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
