### PR TITLE
Capture plugin installation events

### DIFF
--- a/frontend/src/scenes/plugins/OptInPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptInPlugins.tsx
@@ -4,6 +4,7 @@ import { Button, Checkbox, Spin } from 'antd'
 import { CheckOutlined, WarningOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import api from 'lib/api'
+import posthog from 'posthog-js'
 
 export function OptInPlugins(): JSX.Element {
     const { userUpdateRequest } = useActions(userLogic)
@@ -76,7 +77,10 @@ export function OptInPlugins(): JSX.Element {
                     type="primary"
                     disabled={!optIn || serverStatus !== 'online'}
                     data-attr="enable-plugins"
-                    onClick={() => userUpdateRequest({ team: { plugins_opt_in: true } })}
+                    onClick={() => {
+                        userUpdateRequest({ team: { plugins_opt_in: true } })
+                        posthog.capture('plugins enabled for project')
+                    }}
                 >
                     Enable plugins for this project
                 </Button>

--- a/frontend/src/scenes/plugins/OptOutPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptOutPlugins.tsx
@@ -3,6 +3,7 @@ import { useActions } from 'kea'
 import { Button, Popconfirm } from 'antd'
 import { ApiOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
+import posthog from 'posthog-js'
 
 export function OptOutPlugins(): JSX.Element {
     const { userUpdateRequest } = useActions(userLogic)
@@ -11,7 +12,10 @@ export function OptOutPlugins(): JSX.Element {
         <div style={{ float: 'right' }}>
             <Popconfirm
                 title="Are you sure you want to disable plugins?"
-                onConfirm={() => userUpdateRequest({ team: { plugins_opt_in: false } })}
+                onConfirm={() => {
+                    userUpdateRequest({ team: { plugins_opt_in: false } })
+                    posthog.capture('plugins disabled for project')
+                }}
                 onCancel={() => null}
                 okText="Yes"
                 cancelText="No"

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -2,12 +2,10 @@ import { kea } from 'kea'
 import { pluginsLogicType } from 'types/scenes/plugins/pluginsLogicType'
 import api from 'lib/api'
 import { PluginConfigType, PluginType } from '~/types'
-import { PluginRepositoryEntry, PluginTypeWithConfig } from './types'
+import { PluginInstallationType, PluginRepositoryEntry, PluginTypeWithConfig } from './types'
 import { userLogic } from 'scenes/userLogic'
 import { getConfigSchemaObject, getPluginConfigFormData } from 'scenes/plugins/utils'
 import posthog from 'posthog-js'
-
-type PluginInstallationType = 'local' | 'custom' | 'repository'
 
 function capturePluginEvent(event: string, plugin: PluginType, type?: PluginInstallationType): void {
     posthog.capture(event, {

--- a/frontend/src/scenes/plugins/types.ts
+++ b/frontend/src/scenes/plugins/types.ts
@@ -11,3 +11,5 @@ export interface PluginRepositoryEntry {
 export interface PluginTypeWithConfig extends PluginType {
     pluginConfig: PluginConfigType
 }
+
+export type PluginInstallationType = 'local' | 'custom' | 'repository'


### PR DESCRIPTION
## Changes

- Add some instrumentation to plugins
- Events implemented:
  - `plugin installed`
  - `plugin uninstalled`
  - `plugin config updated`
  - `plugin enabled`
  - `plugin disabled`
- All of them contain the following properties:
  - `plugin_name`
  - `plugin_url` (masked as `"file:/masked_local_path/"` if local plugin)
  - `plugin_tag` (npm version or git tag/commit)
- In addition when opting in to the plugins beta (and opting out), the following events are sent (with no properties)
  - `plugins enabled for project`
  - `plugins disabled for project`
- Closes https://github.com/PostHog/posthog-plugin-server/issues/52

Here's a sample event:

![image](https://user-images.githubusercontent.com/53387/101773081-90be1000-3aec-11eb-9384-e5fd14cecaeb.png)

Questions:
- Are these event names fine? (Tagging @paolodamico who has done most instrumentation I think?)
- Anything else/more/different to track?


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
