### PR TITLE
Fixes to Persons page 201210

### DIFF
--- a/frontend/src/lib/components/CopyToClipboard.tsx
+++ b/frontend/src/lib/components/CopyToClipboard.tsx
@@ -11,6 +11,7 @@ interface InlineProps {
     isValueSensitive?: boolean
     tooltipMessage?: string
     iconStyle?: Record<string, string | number>
+    iconPosition?: 'end' | 'start'
 }
 
 interface InputProps {
@@ -27,20 +28,28 @@ export function CopyToClipboardInline({
     isValueSensitive = false,
     tooltipMessage = 'Click to copy',
     iconStyle = {},
+    iconPosition = 'end',
     ...props
 }: InlineProps): JSX.Element {
     return (
         <Tooltip title={tooltipMessage}>
             <span
                 className={isValueSensitive ? 'ph-no-capture ' + rrwebBlockClass : ''}
-                style={{ cursor: 'pointer' }}
+                style={{
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexDirection: iconPosition === 'end' ? 'row' : 'row-reverse',
+                }}
                 onClick={() => {
                     copyToClipboard(explicitValue ?? children.toString(), description)
                 }}
                 {...props}
             >
-                {children}
-                <CopyOutlined style={{ marginLeft: 4, ...iconStyle }} />
+                <span style={iconPosition === 'start' ? { flexGrow: 1 } : {}}>{children}</span>
+                <CopyOutlined
+                    style={iconPosition === 'end' ? { marginLeft: 4, ...iconStyle } : { marginRight: 4, ...iconStyle }}
+                />
             </span>
         </Tooltip>
     )

--- a/frontend/src/scenes/persons/MergePerson.tsx
+++ b/frontend/src/scenes/persons/MergePerson.tsx
@@ -35,7 +35,7 @@ export function MergePersonButton({
                             ids: selectedPeople,
                         })
                         if (newPerson.id) {
-                            toast('People succesfully merged into one.')
+                            toast('Persons succesfully merged.')
                             posthog.capture('merge person completed')
                             setIsModalOpen(false)
                             onPersonChange(newPerson)

--- a/frontend/src/scenes/persons/PersonsTableV2.tsx
+++ b/frontend/src/scenes/persons/PersonsTableV2.tsx
@@ -75,6 +75,7 @@ export function PersonsTable({
                                 explicitValue={person.distinct_ids[0]}
                                 tooltipMessage=""
                                 iconStyle={{ color: 'var(--primary)' }}
+                                iconPosition="start"
                             >
                                 {midEllipsis(person.distinct_ids[0], 32)}
                             </CopyToClipboardInline>

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -60,11 +60,8 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
             }
         },
     }),
-    urlToAction: ({ actions, values, props }) => ({
+    urlToAction: ({ actions, values }) => ({
         '/persons': (_, searchParams: Record<string, string>) => {
-            if (!props.updateURL) {
-                return
-            }
             actions.setListFilters(searchParams)
             if (!values.persons.results.length && !values.personsLoading) {
                 // Initial load


### PR DESCRIPTION
## Changes

- Fixes the way the table is shown where the copy to clipboard icon was shown in the end and therefore was not aligned.

**Before**
<img width="900" alt="" src="https://user-images.githubusercontent.com/5864173/101843271-76495e00-3b0f-11eb-8861-9784b94c1109.png">


**After**
<img width="900" alt="" src="https://user-images.githubusercontent.com/5864173/101843274-79444e80-3b0f-11eb-9c0e-22e81fcbddf8.png">


- Fixes a bug from #2644 that caused the persons page not to load the list of users initially (i.e. you would have to change the persons filters for the list to be loaded).


## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [X] Jest frontend tests
- [X] Cypress end-to-end tests
