### PR TITLE
Update to posthog-js@1.8.0.beta-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "kea-router": "^0.5.1",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "1.7.3-beta.11",
+        "posthog-js": "1.8.0-beta.1",
         "posthog-js-lite": "^0.0.3",
         "posthog-plugins": "0.1.3",
         "posthog-react-rrweb-player": "^1.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8220,10 +8220,10 @@ posthog-js-lite@^0.0.3:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.3.tgz#87e373706227a849c4e7c6b0cb2066a64ad5b6ed"
   integrity sha512-wEOs8DEjlFBwgd7l19grosaF7mTlliZ9G9pL0Qji189FDg2ukY5IegUxTyTs7gsTGt6WK9W47BF5yXA5+bwvZg==
 
-posthog-js@1.7.3-beta.11:
-  version "1.7.3-beta.11"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.7.3-beta.11.tgz#3521b532f1a2cfc30d67b6073fb9d56d0ae38f8f"
-  integrity sha512-HUpXg6BZRgKDvbJuAso2q7q2CpwCeEb73OOV21qc4jJC1yaJpZ8SN3Xo5eSdGyZJ+c2QEyRY8RV2AH2YpYU1gQ==
+posthog-js@1.8.0-beta.1:
+  version "1.8.0-beta.1"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.8.0-beta.1.tgz#848deeb0e1c7d5f3988fbb59d7ad0da8440a8568"
+  integrity sha512-MCuDLNNrELM17vvszx9aPD7y2ibH5pju80wUEbfqZVd/4739fuk6d6n4rZHFcey5SmFGBHvqteFgP33T0UdGPQ==
   dependencies:
     fflate "^0.4.1"
 


### PR DESCRIPTION
## Changes

This rolls out gzip support for everyone.  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
