### PR TITLE
Make active feature flags more obvious

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional
 
 from rest_framework import viewsets
@@ -94,10 +95,16 @@ class ClickhouseEventsViewSet(EventViewSet):
         key = request.GET.get("key")
         team = self.team
         result = []
+        flattened = []
         if key:
             result = get_property_values_for_key(key, team, value=request.GET.get("value"))
-            flattened = flatten(result)
-        return Response([{"name": convert_property_value(value[0])} for value in flattened])
+            for value in result:
+                try:
+                    # Try loading as json for dicts or arrays
+                    flattened.append(json.loads(value[0]))
+                except json.decoder.JSONDecodeError:
+                    flattened.append(value[0])
+        return Response([{"name": convert_property_value(value)} for value in flatten(flattened)])
 
     @action(methods=["GET"], detail=False)
     def sessions(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -96,8 +96,8 @@ class ClickhouseEventsViewSet(EventViewSet):
         result = []
         if key:
             result = get_property_values_for_key(key, team, value=request.GET.get("value"))
-            result = flatten(result)
-        return Response([{"name": convert_property_value(value[0])} for value in result])
+            flattened = flatten(result)
+        return Response([{"name": convert_property_value(value[0])} for value in flattened])
 
     @action(methods=["GET"], detail=False)
     def sessions(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -17,7 +17,7 @@ from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
 from posthog.models.action import Action
 from posthog.models.filters.sessions_filter import SessionsFilter
-from posthog.utils import convert_property_value
+from posthog.utils import convert_property_value, flatten
 
 
 class ClickhouseEventsViewSet(EventViewSet):
@@ -91,12 +91,12 @@ class ClickhouseEventsViewSet(EventViewSet):
 
     @action(methods=["GET"], detail=False)
     def values(self, request: Request, **kwargs) -> Response:
-
         key = request.GET.get("key")
         team = self.team
         result = []
         if key:
             result = get_property_values_for_key(key, team, value=request.GET.get("value"))
+            result = flatten(result)
         return Response([{"name": convert_property_value(value[0])} for value in result])
 
     @action(methods=["GET"], detail=False)

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -49,7 +49,7 @@ function PropertyPaneContents({
                             setThisFilter(
                                 newKey.value.replace(/^(event_|person_|element_)/gi, ''),
                                 undefined,
-                                operator,
+                                newKey.value === 'event_$active_feature_flags' ? 'icontains' : operator,
                                 newKey.type
                             )
                         }

--- a/frontend/src/lib/components/PropertyKeyInfo.js
+++ b/frontend/src/lib/components/PropertyKeyInfo.js
@@ -121,7 +121,15 @@ export const keyMapping = {
         },
         $feature_flag: {
             label: 'Feature Flag',
-            description: 'The feature flag that was called.',
+            description: (
+                <>
+                    The feature flag that was called.
+                    <br />
+                    <br />
+                    Warning! This only works in combination with the $feature_flag_called event. If you want to filter
+                    other events, try "Active Feature Flags".
+                </>
+            ),
             examples: ['beta-feature'],
         },
         $device: {

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -87,9 +87,9 @@ function _FeatureFlags() {
                 return (
                     <Link
                         to={
-                            '/insights?events=[{"id":"$feature_flag_called","name":"$feature_flag_called","type":"events","math":"dau"}]&properties=[{"key":"$feature_flag","value":"' +
+                            '/insights?events=[{"id":"$pageview","name":"$pageview","type":"events","math":"dau"}]&properties=[{"key":"$active_feature_flags","operator":"icontains","value":"' +
                             featureFlag.key +
-                            '"}]&breakdown=$feature_flag_response&breakdown_type=event#backTo=Feature Flags&backToURL=' +
+                            '"}]&breakdown_type=event#backTo=Feature Flags&backToURL=' +
                             window.location.pathname
                         }
                         data-attr="usage"

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -22,6 +22,14 @@ from posthog.queries.session_recording import SessionRecording
 from posthog.utils import convert_property_value
 
 
+def flatten(l: List[Any]):
+    for el in l:
+        if isinstance(el, list):
+            yield from flatten(el)
+        else:
+            yield el
+
+
 class ElementSerializer(serializers.ModelSerializer):
     event = serializers.CharField()
 
@@ -237,7 +245,8 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             params,
         )
 
-        return [{"name": convert_property_value(value.value)} for value in values]
+        values = flatten([value.value for value in values])
+        return [{"name": convert_property_value(value)} for value in values]
 
     # ******************************************
     # /event/sessions

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -237,8 +237,8 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             params,
         )
 
-        values = flatten([value.value for value in values])
-        return [{"name": convert_property_value(value)} for value in values]
+        flattened = flatten([value.value for value in values])
+        return [{"name": convert_property_value(value)} for value in flattened]
 
     # ******************************************
     # /event/sessions

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -19,15 +19,7 @@ from posthog.models.event import EventManager
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
 from posthog.queries.session_recording import SessionRecording
-from posthog.utils import convert_property_value
-
-
-def flatten(l: List[Any]):
-    for el in l:
-        if isinstance(el, list):
-            yield from flatten(el)
-        else:
-            yield el
+from posthog.utils import convert_property_value, flatten
 
 
 class ElementSerializer(serializers.ModelSerializer):

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -149,15 +149,33 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
                 distinct_id="bla", event="random event", team=self.team, properties={"something_else": "qwerty"}
             )
             event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": 565})
+            event_factory(
+                distinct_id="bla", event="random event", team=self.team, properties={"random_prop": ["item1", "item2"]}
+            )
+            event_factory(
+                distinct_id="bla", event="random event", team=self.team, properties={"random_prop": ["item3"]}
+            )
+
             team2 = Team.objects.create()
             event_factory(distinct_id="bla", event="random event", team=team2, properties={"random_prop": "abcd"})
             response = self.client.get("/api/event/values/?key=random_prop").json()
 
             keys = [resp["name"].replace(" ", "") for resp in response]
             self.assertCountEqual(
-                keys, ["asdf", "qwerty", "565", "false", "true", '{"first_name":"Mary","last_name":"Smith"}']
+                keys,
+                [
+                    "asdf",
+                    "qwerty",
+                    "565",
+                    "false",
+                    "true",
+                    '{"first_name":"Mary","last_name":"Smith"}',
+                    "item1",
+                    "item2",
+                    "item3",
+                ],
             )
-            self.assertEqual(len(response), 6)
+            self.assertEqual(len(response), 9)
 
             response = self.client.get("/api/event/values/?key=random_prop&value=qw").json()
             self.assertEqual(response[0]["name"], "qwerty")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -9,7 +9,16 @@ import subprocess
 import time
 import uuid
 from itertools import count
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 from urllib.parse import urljoin, urlparse
 
 import lzstring
@@ -464,7 +473,7 @@ def queryset_to_named_query(qs: QuerySet, prepend: str = "") -> Tuple[str, dict]
     return new_string, named_params
 
 
-def flatten(l: List[Any]) -> List:
+def flatten(l: List[Any]) -> Generator:
     for el in l:
         if isinstance(el, list):
             yield from flatten(el)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -462,3 +462,11 @@ def queryset_to_named_query(qs: QuerySet, prepend: str = "") -> Tuple[str, dict]
     for idx, param in enumerate(params):
         named_params.update({f"{prepend}_arg_{idx}": param})
     return new_string, named_params
+
+
+def flatten(l: List[Any]) -> List:
+    for el in l:
+        if isinstance(el, list):
+            yield from flatten(el)
+        else:
+            yield el


### PR DESCRIPTION
## Changes

- When selecting 'Active Feature Flags', automatically set the operator to 'contains' as that's the only thing that works
- Add a warning to 'feature flag', as you can only use that in combination with $feature_flag_called
![image](https://user-images.githubusercontent.com/1727427/101893374-f4a40f80-3ba4-11eb-9c16-d2a2dd504235.png)
- On postgres, if the values are returned as arrays, flatten that list instead so you can actually use them to filter


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
