### PR TITLE
Not-so-big play button

### DIFF
--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLProps } from 'react'
 import { router } from 'kea-router'
 
-interface LinkProps extends HTMLProps<HTMLAnchorElement> {
+export interface LinkProps extends HTMLProps<HTMLAnchorElement> {
     to: string
     preventClick?: boolean
     tag?: string | React.Component

--- a/frontend/src/lib/components/LinkButton.tsx
+++ b/frontend/src/lib/components/LinkButton.tsx
@@ -1,7 +1,7 @@
-import React, { HTMLProps } from 'react'
+import React from 'react'
 import { Button } from 'antd'
-import { Link } from 'lib/components/Link'
+import { Link, LinkProps } from 'lib/components/Link'
 
-export function LinkButton(props: HTMLProps<HTMLAnchorElement>): JSX.Element {
+export function LinkButton(props: LinkProps): JSX.Element {
     return <Link {...props} tag={Button} />
 }

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -88,9 +88,9 @@ function _SessionsPlay(): JSX.Element {
             <Row gutter={16} style={{ height: '100%' }}>
                 <Col span={18} style={{ paddingRight: 0 }}>
                     <div className="mb-05" style={{ display: 'flex' }}>
-                        {isLoading && <Skeleton paragraph={{ rows: 0 }} active />}
-
-                        {!isLoading && (
+                        {isLoading ? (
+                            <Skeleton paragraph={{ rows: 0 }} active />
+                        ) : (
                             <>
                                 {pageEvent ? (
                                     <>

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -58,8 +58,10 @@ function _SessionsPlay(): JSX.Element {
         tagsLoading,
         eventIndex,
         pageVisitEvents,
+        showNext,
+        showPrev,
     } = useValues(sessionsPlayLogic)
-    const { toggleAddingTagShown, setAddingTag, createTag } = useActions(sessionsPlayLogic)
+    const { toggleAddingTagShown, setAddingTag, createTag, goToNext, goToPrevious } = useActions(sessionsPlayLogic)
     const addTagInput = useRef<Input>(null)
 
     const [playerTime, setCurrentPlayerTime] = useState(0)
@@ -113,6 +115,8 @@ function _SessionsPlay(): JSX.Element {
                                 ref={playerRef}
                                 events={sessionPlayerData?.snapshots || []}
                                 onPlayerTimeChange={setCurrentPlayerTime}
+                                onNext={showNext ? goToNext : undefined}
+                                onPrevious={showPrev ? goToPrevious : undefined}
                             />
                         )}
                     </div>

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -51,6 +51,7 @@ function _SessionsPlay(): JSX.Element {
     const {
         sessionPlayerData,
         sessionPlayerDataLoading,
+        loadingNextRecording,
         sessionDate,
         addingTagShown,
         addingTag,
@@ -69,6 +70,8 @@ function _SessionsPlay(): JSX.Element {
     const [pageEvent, atPageIndex] = useMemo(() => eventIndex.getPageMetadata(playerTime), [eventIndex, playerTime])
     const [recordingMetadata] = useMemo(() => eventIndex.getRecordingMetadata(playerTime), [eventIndex, playerTime])
 
+    const isLoading = sessionPlayerDataLoading || loadingNextRecording
+
     useEffect(() => {
         if (addingTagShown && addTagInput.current) {
             addTagInput.current.focus()
@@ -85,9 +88,9 @@ function _SessionsPlay(): JSX.Element {
             <Row gutter={16} style={{ height: '100%' }}>
                 <Col span={18} style={{ paddingRight: 0 }}>
                     <div className="mb-05" style={{ display: 'flex' }}>
-                        {sessionPlayerDataLoading && <Skeleton paragraph={{ rows: 0 }} active />}
+                        {isLoading && <Skeleton paragraph={{ rows: 0 }} active />}
 
-                        {!sessionPlayerDataLoading && (
+                        {!isLoading && (
                             <>
                                 {pageEvent ? (
                                     <>
@@ -108,7 +111,7 @@ function _SessionsPlay(): JSX.Element {
                         )}
                     </div>
                     <div className="ph-no-capture player-container">
-                        {sessionPlayerDataLoading ? (
+                        {isLoading ? (
                             <Loading />
                         ) : (
                             <Player
@@ -124,7 +127,7 @@ function _SessionsPlay(): JSX.Element {
                 <Col span={6} className="sidebar" style={{ paddingLeft: 16 }}>
                     <Card className="card-elevated">
                         <h3 className="l3">Session Information</h3>
-                        {sessionPlayerDataLoading ? (
+                        {isLoading ? (
                             <div>
                                 <Skeleton paragraph={{ rows: 3 }} active />
                             </div>
@@ -200,7 +203,7 @@ function _SessionsPlay(): JSX.Element {
                         <p className="text-muted text-small">
                             Click on an item to jump to that point in the recording.
                         </p>
-                        {sessionPlayerDataLoading ? (
+                        {isLoading ? (
                             <div>
                                 <Skeleton paragraph={{ rows: 6 }} active />
                             </div>

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -13,7 +13,7 @@ export const sessionPlayerUrl = (sessionRecordingId: string): string => {
     return `${location.pathname}?${toParams({ ...fromParams(), sessionRecordingId })}`
 }
 
-export default function SessionsPlayerButton({ session }: SessionsPlayerButtonProps): JSX.Element | null {
+export function SessionsPlayerButton({ session }: SessionsPlayerButtonProps): JSX.Element | null {
     if (!session.session_recording_ids) {
         return null
     }

--- a/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlayerButton.tsx
@@ -9,11 +9,11 @@ interface SessionsPlayerButtonProps {
     session: SessionType
 }
 
-export default function SessionsPlayerButton({ session }: SessionsPlayerButtonProps): JSX.Element | null {
-    const sessionPlayerUrl = (sessionRecordingId: string): string => {
-        return `${location.pathname}?${toParams({ ...fromParams(), sessionRecordingId })}`
-    }
+export const sessionPlayerUrl = (sessionRecordingId: string): string => {
+    return `${location.pathname}?${toParams({ ...fromParams(), sessionRecordingId })}`
+}
 
+export default function SessionsPlayerButton({ session }: SessionsPlayerButtonProps): JSX.Element | null {
     if (!session.session_recording_ids) {
         return null
     }

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -14,6 +14,7 @@ import {
     PoweroffOutlined,
     QuestionCircleOutlined,
     ArrowLeftOutlined,
+    PlaySquareOutlined,
 } from '@ant-design/icons'
 import SessionsPlayerButton from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
@@ -60,6 +61,13 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
     const { user } = useValues(userLogic)
     const { shareFeedbackCommand } = useActions(commandPaletteLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+
+    const sessionRecordingCTA = (
+        <>
+            Session recording is turned off for this project. Go to{' '}
+            <Link to="/project/settings#session-recording"> project settings</Link> to enable.
+        </>
+    )
 
     const columns = [
         {
@@ -140,14 +148,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                             </span>
                         </Tooltip>
                     ) : (
-                        <Tooltip
-                            title={
-                                <>
-                                    Session recording is turned off for this project. Go to{' '}
-                                    <Link to="/project/settings#session-recording"> project settings</Link> to enable.
-                                </>
-                            }
-                        >
+                        <Tooltip title={sessionRecordingCTA}>
                             <span>
                                 <PoweroffOutlined style={{ marginRight: 6 }} className="text-warning" />
                                 Play session
@@ -165,7 +166,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
 
     return (
         <div className="events" data-attr="events-table">
-            {!isPersonPage && <PageHeader title="Sessions By Day" />}
+            {!isPersonPage && <PageHeader title="Sessions" />}
             <Space className="mb-05">
                 <Button onClick={previousDay} icon={<CaretLeftOutlined />} />
                 <DatePicker
@@ -183,6 +184,19 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                 />
             )}
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />
+
+            <div className="text-right mb">
+                <Tooltip title={!user?.team?.session_recording_opt_in ? sessionRecordingCTA : ''}>
+                    <Button
+                        icon={<PlaySquareOutlined />}
+                        type="primary"
+                        data-attr="play-all-recordings"
+                        disabled={!user?.team?.session_recording_opt_in}
+                    >
+                        Play all
+                    </Button>
+                </Tooltip>
+            </div>
 
             <Table
                 locale={{ emptyText: 'No Sessions on ' + moment(selectedDate).format('YYYY-MM-DD') }}

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -16,7 +16,7 @@ import {
     ArrowLeftOutlined,
     PlaySquareOutlined,
 } from '@ant-design/icons'
-import SessionsPlayerButton, { sessionPlayerUrl } from './SessionsPlayerButton'
+import { SessionsPlayerButton, sessionPlayerUrl } from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { PageHeader } from 'lib/components/PageHeader'

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -56,18 +56,26 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         properties,
         sessionRecordingId,
         duration,
+        firstRecordingId,
     } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
     const { user } = useValues(userLogic)
     const { shareFeedbackCommand } = useActions(commandPaletteLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const sessionRecordingCTA = (
+    const enableSessionRecordingCTA = (
         <>
             Session recording is turned off for this project. Go to{' '}
             <Link to="/project/settings#session-recording"> project settings</Link> to enable.
         </>
     )
+
+    const playAllCTA =
+        firstRecordingId === null
+            ? user?.team?.session_recording_opt_in
+                ? 'No recordings found for this date'
+                : enableSessionRecordingCTA
+            : undefined
 
     const columns = [
         {
@@ -148,7 +156,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                             </span>
                         </Tooltip>
                     ) : (
-                        <Tooltip title={sessionRecordingCTA}>
+                        <Tooltip title={enableSessionRecordingCTA}>
                             <span>
                                 <PoweroffOutlined style={{ marginRight: 6 }} className="text-warning" />
                                 Play session
@@ -186,12 +194,12 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />
 
             <div className="text-right mb">
-                <Tooltip title={!user?.team?.session_recording_opt_in ? sessionRecordingCTA : ''}>
+                <Tooltip title={playAllCTA}>
                     <Button
                         icon={<PlaySquareOutlined />}
                         type="primary"
                         data-attr="play-all-recordings"
-                        disabled={!user?.team?.session_recording_opt_in}
+                        disabled={!user?.team?.session_recording_opt_in || firstRecordingId === null}
                     >
                         Play all
                     </Button>

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -16,7 +16,7 @@ import {
     ArrowLeftOutlined,
     PlaySquareOutlined,
 } from '@ant-design/icons'
-import SessionsPlayerButton from './SessionsPlayerButton'
+import SessionsPlayerButton, { sessionPlayerUrl } from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -25,6 +25,7 @@ import { userLogic } from 'scenes/userLogic'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { SessionRecordingFilters } from 'scenes/sessions/SessionRecordingFilters'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { LinkButton } from 'lib/components/LinkButton'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -195,14 +196,15 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
 
             <div className="text-right mb">
                 <Tooltip title={playAllCTA}>
-                    <Button
+                    <LinkButton
+                        to={firstRecordingId !== null ? sessionPlayerUrl(firstRecordingId) : '#'}
                         icon={<PlaySquareOutlined />}
                         type="primary"
                         data-attr="play-all-recordings"
                         disabled={!user?.team?.session_recording_opt_in || firstRecordingId === null}
                     >
                         Play all
-                    </Button>
+                    </LinkButton>
                 </Tooltip>
             </div>
 

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -25,7 +25,7 @@ import { userLogic } from 'scenes/userLogic'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { SessionRecordingFilters } from 'scenes/sessions/SessionRecordingFilters'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { LinkButton } from 'lib/components/LinkButton'
+import { router } from 'kea-router'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -196,15 +196,15 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
 
             <div className="text-right mb">
                 <Tooltip title={playAllCTA}>
-                    <LinkButton
-                        to={firstRecordingId !== null ? sessionPlayerUrl(firstRecordingId) : '#'}
+                    <Button
+                        onClick={() => firstRecordingId && router.actions.push(sessionPlayerUrl(firstRecordingId))}
                         icon={<PlaySquareOutlined />}
                         type="primary"
                         data-attr="play-all-recordings"
-                        disabled={!user?.team?.session_recording_opt_in || firstRecordingId === null}
+                        disabled={firstRecordingId === null} // We allow playback of previously recorded sessions even if new recordings are disabled
                     >
                         Play all
-                    </LinkButton>
+                    </Button>
                 </Tooltip>
             </div>
 

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -25,7 +25,7 @@ import { userLogic } from 'scenes/userLogic'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { SessionRecordingFilters } from 'scenes/sessions/SessionRecordingFilters'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { router } from 'kea-router'
+import { LinkButton } from 'lib/components/LinkButton'
 
 interface SessionsTableProps {
     personIds?: string[]
@@ -196,15 +196,17 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
 
             <div className="text-right mb">
                 <Tooltip title={playAllCTA}>
-                    <Button
-                        onClick={() => firstRecordingId && router.actions.push(sessionPlayerUrl(firstRecordingId))}
-                        icon={<PlaySquareOutlined />}
-                        type="primary"
-                        data-attr="play-all-recordings"
-                        disabled={firstRecordingId === null} // We allow playback of previously recorded sessions even if new recordings are disabled
-                    >
-                        Play all
-                    </Button>
+                    <span>
+                        <LinkButton
+                            to={firstRecordingId ? sessionPlayerUrl(firstRecordingId) : '#'}
+                            icon={<PlaySquareOutlined />}
+                            type="primary"
+                            data-attr="play-all-recordings"
+                            disabled={firstRecordingId === null} // We allow playback of previously recorded sessions even if new recordings are disabled
+                        >
+                            Play all
+                        </LinkButton>
+                    </span>
                 </Tooltip>
             </div>
 

--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -70,16 +70,10 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
             }
         },
         goToNext: () => {
-            console.log(
-                values.recordingIndex,
-                values.orderedSessionRecordingIds.length,
-                values.orderedSessionRecordingIds
-            )
             if (values.recordingIndex < values.orderedSessionRecordingIds.length - 1) {
                 const id = values.orderedSessionRecordingIds[values.recordingIndex + 1]
                 actions.loadRecording(id)
             } else if (values.nextOffset) {
-                console.log('next page loading!')
                 // :TRICKY: Load next page of sessions, which will call appendNewSessions which will call goToNext again
                 actions.openNextRecordingOnLoad()
                 actions.fetchNextSessions()

--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -3,7 +3,7 @@ import { eventWithTime } from 'rrweb/typings/types'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { sessionsPlayLogicType } from 'types/scenes/sessions/sessionsPlayLogicType'
-import { PersonType, SessionType } from '~/types'
+import { PersonType } from '~/types'
 import moment from 'moment'
 import { EventIndex } from 'posthog-react-rrweb-player'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
@@ -18,7 +18,7 @@ interface SessionPlayerData {
 
 export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, EventIndex>>({
     connect: {
-        values: [sessionsTableLogic, ['sessions', 'nextOffset']],
+        values: [sessionsTableLogic, ['sessions', 'nextOffset', 'orderedSessionRecordingIds']],
         actions: [sessionsTableLogic, ['fetchNextSessions', 'appendNewSessions', 'closeSessionPlayer']],
     },
     actions: {
@@ -143,11 +143,6 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
             (sessionPlayerData: SessionPlayerData): EventIndex => new EventIndex(sessionPlayerData?.snapshots || []),
         ],
         pageVisitEvents: [(selectors) => [selectors.eventIndex], (eventIndex) => eventIndex.pageChangeEvents()],
-        orderedSessionRecordingIds: [
-            (selectors) => [selectors.sessions],
-            (sessions: SessionType[]): SessionRecordingId[] =>
-                Array.from(new Set(sessions.flatMap((session) => session.session_recording_ids))),
-        ],
         recordingIndex: [
             (selectors) => [selectors.orderedSessionRecordingIds, selectors.sessionRecordingId],
             (recordingIds: SessionRecordingId[], id: SessionRecordingId): number => recordingIds.indexOf(id),

--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -7,6 +7,7 @@ import { PersonType, SessionType } from '~/types'
 import moment from 'moment'
 import { EventIndex } from 'posthog-react-rrweb-player'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
+import { toast } from 'react-toastify'
 
 type SessionRecordingId = string
 
@@ -18,13 +19,14 @@ interface SessionPlayerData {
 export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, EventIndex>>({
     connect: {
         values: [sessionsTableLogic, ['sessions', 'nextOffset']],
-        actions: [sessionsTableLogic, ['fetchNextSessions', 'appendNewSessions']],
+        actions: [sessionsTableLogic, ['fetchNextSessions', 'appendNewSessions', 'closeSessionPlayer']],
     },
     actions: {
         toggleAddingTagShown: () => {},
         setAddingTag: (payload: string) => ({ payload }),
         goToNext: true,
         goToPrevious: true,
+        openNextRecordingOnLoad: true,
     },
     reducers: {
         sessionRecordingId: [
@@ -51,6 +53,14 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
                 setAddingTag: (_, { payload }) => payload,
             },
         ],
+        loadingNextRecording: [
+            false,
+            {
+                openNextRecordingOnLoad: () => true,
+                loadRecording: () => false,
+                closeSessionPlayer: () => false,
+            },
+        ],
     },
     listeners: ({ values, actions }) => ({
         toggleAddingTagShown: () => {
@@ -60,12 +70,31 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
             }
         },
         goToNext: () => {
-            const id = values.orderedSessionRecordingIds[values.recordingIndex + 1]
-            actions.loadRecording(id)
+            console.log(
+                values.recordingIndex,
+                values.orderedSessionRecordingIds.length,
+                values.orderedSessionRecordingIds
+            )
+            if (values.recordingIndex < values.orderedSessionRecordingIds.length - 1) {
+                const id = values.orderedSessionRecordingIds[values.recordingIndex + 1]
+                actions.loadRecording(id)
+            } else if (values.nextOffset) {
+                console.log('next page loading!')
+                // :TRICKY: Load next page of sessions, which will call appendNewSessions which will call goToNext again
+                actions.openNextRecordingOnLoad()
+                actions.fetchNextSessions()
+            } else {
+                toast('Found no more recordings.', { type: 'info' })
+            }
         },
         goToPrevious: () => {
             const id = values.orderedSessionRecordingIds[values.recordingIndex - 1]
             actions.loadRecording(id)
+        },
+        appendNewSessions: () => {
+            if (values.sessionRecordingId && values.loadingNextRecording) {
+                actions.goToNext()
+            }
         },
     }),
     urlToAction: ({ actions, values }) => ({
@@ -117,7 +146,7 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
         orderedSessionRecordingIds: [
             (selectors) => [selectors.sessions],
             (sessions: SessionType[]): SessionRecordingId[] =>
-                sessions.flatMap((session) => session.session_recording_ids),
+                Array.from(new Set(sessions.flatMap((session) => session.session_recording_ids))),
         ],
         recordingIndex: [
             (selectors) => [selectors.orderedSessionRecordingIds, selectors.sessionRecordingId],
@@ -127,7 +156,7 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
         showNext: [
             (selectors) => [selectors.recordingIndex, selectors.orderedSessionRecordingIds, selectors.nextOffset],
             (index: number, ids: SessionRecordingId[], offset: number | null) =>
-                index > -1 && (index < ids.length || offset !== null),
+                index > -1 && (index < ids.length - 1 || offset !== null),
         ],
     },
 })

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -183,7 +183,7 @@ export const sessionsTableLogic = kea<
 
             if (
                 JSON.stringify(params.properties || []) !== JSON.stringify(values.properties) ||
-                JSON.stringify(params.duration || {}) !== JSON.stringify(values.duration) ||
+                JSON.stringify(params.duration || {}) !== JSON.stringify(values.duration || {}) ||
                 (values.selectedDate && values.selectedDate.format('YYYY-MM-DD') !== newDate.format('YYYY-MM-DD'))
             ) {
                 actions.setFilters(params.properties || [], newDate, params.duration || null)

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -186,6 +186,7 @@ export const sessionsTableLogic = kea<
             if (
                 JSON.stringify(params.properties || []) !== JSON.stringify(values.properties) ||
                 JSON.stringify(params.duration || {}) !== JSON.stringify(values.duration || {}) ||
+                (!values.selectedDate && params.date) ||
                 (values.selectedDate && values.selectedDate.format('YYYY-MM-DD') !== newDate.format('YYYY-MM-DD'))
             ) {
                 actions.setFilters(params.properties || [], newDate, params.duration || null)

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -143,6 +143,15 @@ export const sessionsTableLogic = kea<
                 return { duration_operator: duration[0], duration: seconds }
             },
         ],
+        orderedSessionRecordingIds: [
+            (selectors) => [selectors.sessions],
+            (sessions: SessionType[]): SessionRecordingId[] =>
+                Array.from(new Set(sessions.flatMap((session) => session.session_recording_ids))),
+        ],
+        firstRecordingId: [
+            (selectors) => [selectors.orderedSessionRecordingIds],
+            (ids: SessionRecordingId[]): SessionRecordingId | null => ids[0] || null,
+        ],
     },
     listeners: ({ values, actions, props }) => ({
         fetchNextSessions: async (_, breakpoint) => {

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -9,8 +9,6 @@ import { eventWithTime } from 'rrweb/typings/types'
 
 type Moment = moment.Moment
 
-type SessionRecordingId = string
-
 interface Params {
     date?: string
     properties?: any
@@ -131,31 +129,6 @@ export const sessionsTableLogic = kea<
     },
     selectors: {
         selectedDateURLparam: [(s) => [s.selectedDate], (selectedDate) => selectedDate?.format('YYYY-MM-DD')],
-        orderedSessionRecordingIds: [
-            (selectors) => [selectors.sessions],
-            (sessions: SessionType[]): SessionRecordingId[] =>
-                sessions.flatMap((session) => session.session_recording_ids),
-        ],
-        sessionRecordingNavigation: [
-            (selectors) => [selectors.orderedSessionRecordingIds, selectors.sessionRecordingId],
-            (
-                recordings: SessionRecordingId[],
-                recordingId: SessionRecordingId | null
-            ): { next?: SessionRecordingId; prev?: SessionRecordingId } => {
-                if (recordingId === null) {
-                    return {}
-                }
-                const index = recordings.indexOf(recordingId)
-                const result: { next?: SessionRecordingId; prev?: SessionRecordingId } = {}
-                if (index !== -1 && index < recordings.length - 1) {
-                    result.next = recordings[index + 1]
-                }
-                if (index > 0) {
-                    result.prev = recordings[index - 1]
-                }
-                return result
-            },
-        ],
         durationFilter: [
             (selectors) => [selectors.duration],
             (duration: RecordingDurationFilter | null) => {

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -9,6 +9,8 @@ import { eventWithTime } from 'rrweb/typings/types'
 
 type Moment = moment.Moment
 
+type SessionRecordingId = string
+
 interface Params {
     date?: string
     properties?: any

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -169,12 +169,15 @@ export const sessionsTableLogic = kea<
             },
         ],
     },
-    listeners: ({ values, actions }) => ({
+    listeners: ({ values, actions, props }) => ({
         fetchNextSessions: async (_, breakpoint) => {
             const params = toParams({
                 date_from: values.selectedDateURLparam,
                 date_to: values.selectedDateURLparam,
                 offset: values.nextOffset,
+                distinct_id: props.personIds ? props.personIds[0] : '',
+                properties: values.properties,
+                ...values.durationFilter,
             })
             const response = await api.get(`api/event/sessions/?${params}`)
             breakpoint()

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -195,7 +195,7 @@ export const sessionsTableLogic = kea<
             if (
                 JSON.stringify(params.properties || []) !== JSON.stringify(values.properties) ||
                 JSON.stringify(params.duration || {}) !== JSON.stringify(values.duration || {}) ||
-                (!values.selectedDate && params.date) ||
+                !values.selectedDate ||
                 (values.selectedDate && values.selectedDate.format('YYYY-MM-DD') !== newDate.format('YYYY-MM-DD'))
             ) {
                 actions.setFilters(params.properties || [], newDate, params.duration || null)


### PR DESCRIPTION
## Changes

- Closes #2596
- Introduces a big play button to play all sessions in the current filter.
- Shows a call to action to enable session recording if it's disabled.

<img width="1200" alt="" src="https://user-images.githubusercontent.com/5864173/101927232-db499600-3b99-11eb-9e02-e13d21a25b68.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
