### PR TITLE
Showcase Feature Flag in HogFlix

### DIFF
--- a/posthog/demo.py
+++ b/posthog/demo.py
@@ -17,6 +17,7 @@ from posthog.models import (
     DashboardItem,
     Element,
     Event,
+    FeatureFlag,
     Person,
     PersonDistinctId,
     Team,
@@ -214,6 +215,9 @@ def demo(request):
         )
         _create_anonymous_users(team=team, base_url=request.build_absolute_uri("/demo"))
         _create_funnel(team=team, base_url=request.build_absolute_uri("/demo"))
+        FeatureFlag.objects.create(
+            team=team, rollout_percentage=100, name="Sign Up CTA", key="sign-up-cta", created_by=user,
+        )
         _recalculate(team=team)
     user.current_team = team
     user.save()

--- a/posthog/templates/demo.html
+++ b/posthog/templates/demo.html
@@ -74,7 +74,7 @@
             <p>The one-stop shop for all your hedgehog movies.</p>
             <br>
 
-            <a href='/demo/1' id='sign-up'><button>Sign up</button></a>
+            <a href='/demo/1' id='sign-up'><button id='sign-up-cta'>Sign up</button></a>
         </header>
         {% endif %}
 
@@ -202,6 +202,10 @@
     </div>
 
     <script>
+        if (posthog.isFeatureEnabled('sign-up-cta')) {
+            document.getElementById('sign-up-cta').innerText = 'Get started now'
+        }
+
         document.getElementById('submit-review').addEventListener('click', () => {
             document.getElementById('new-review').innerText = document.getElementById('review-text').value
         })


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Keeping master in line with the changes I make in the demo env. 

This PR creates a feature flag referenced from HogFlix along with the demo data. Allows us to quickly show users how feature flags work by flipping the toggle on and off during a demo.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
