### PR TITLE
Deploy Plugins to AWS

### DIFF
--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -62,6 +62,14 @@ jobs:
                   container-name: posthog-production-worker
                   image: ${{ steps.build-image.outputs.image }}
 
+            - name: Fill in the new plugins image ID in the Amazon ECS task definition
+              id: task-def-plugins
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/task-definition.plugins.json
+                  container-name: posthog-production-plugins
+                  image: ${{ steps.build-image.outputs.image }}
+
             - name: Fill in the new migration image ID in the Amazon ECS task definition
               id: task-def-migrate
               uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -104,4 +112,11 @@ jobs:
               with:
                   task-definition: ${{ steps.task-def-worker.outputs.task-definition }}
                   service: posthog-production-worker
+                  cluster: posthog-production-cluster
+
+            - name: Deploy Amazon ECS plugins task definition
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.task-def-plugins.outputs.task-definition }}
+                  service: posthog-production-plugins
                   cluster: posthog-production-cluster

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -161,6 +161,6 @@
         }
     ],
     "requiresCompatibilities": ["FARGATE"],
-    "cpu": 1024,
-    "memory": 2048
+    "cpu": 4096,
+    "memory": 8192
 }

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -1,6 +1,7 @@
 {
     "family": "posthog-production-plugins",
     "networkMode": "awsvpc",
+    "name": "postiong-plugins",
     "executionRoleArn": "posthog-production-ecs-task",
     "taskRoleArn": "posthog-production-ecs-task",
     "containerDefinitions": [
@@ -151,52 +152,8 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SENTRY_DSN::"
                 },
                 {
-                    "name": "SOCIAL_AUTH_GITHUB_KEY",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITHUB_KEY::"
-                },
-                {
-                    "name": "SOCIAL_AUTH_GITHUB_SECRET",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITHUB_SECRET::"
-                },
-                {
-                    "name": "SOCIAL_AUTH_GITLAB_KEY",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITLAB_KEY::"
-                },
-                {
-                    "name": "SOCIAL_AUTH_GITLAB_SECRET",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITLAB_SECRET::"
-                },
-                {
-                    "name": "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GOOGLE_OAUTH2_KEY::"
-                },
-                {
-                    "name": "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET::"
-                },
-                {
                     "name": "STATSD_HOST",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
-                },
-                {
-                    "name": "STRIPE_API_KEY",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_API_KEY::"
-                },
-                {
-                    "name": "STRIPE_DEFAULT_PRICE_ID",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_DEFAULT_PRICE_ID::"
-                },
-                {
-                    "name": "STRIPE_GROWTH_PRICE_ID",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_GROWTH_PRICE_ID::"
-                },
-                {
-                    "name": "STRIPE_PUBLISHABLE_KEY",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_PUBLISHABLE_KEY::"
-                },
-                {
-                    "name": "STRIPE_WEBHOOK_SECRET",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
                 }
             ],
             "entryPoint": ["sh", "-c"],
@@ -204,6 +161,6 @@
         }
     ],
     "requiresCompatibilities": ["FARGATE"],
-    "cpu": "1024",
-    "memory": "2048"
+    "cpu": 1024,
+    "memory": 2048
 }

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -1,0 +1,209 @@
+{
+    "family": "posthog-production-plugins",
+    "networkMode": "awsvpc",
+    "executionRoleArn": "posthog-production-ecs-task",
+    "taskRoleArn": "posthog-production-ecs-task",
+    "containerDefinitions": [
+        {
+            "name": "posthog-production-plugins",
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "awslogs-posthog-production",
+                    "awslogs-region": "us-east-1",
+                    "awslogs-stream-prefix": "posthog-production-plugins"
+                }
+            },
+            "essential": true,
+            "environment": [
+                {
+                    "name": "USING_PGBOUNCER",
+                    "value": "True"
+                },
+                {
+                    "name": "DISABLE_SERVER_SIDE_CURSORS",
+                    "value": "True"
+                },
+                {
+                    "name": "CLICKHOUSE_ASYNC",
+                    "value": "False"
+                },
+                {
+                    "name": "CLICKHOUSE_DATABASE",
+                    "value": "posthog"
+                },
+                {
+                    "name": "CLICKHOUSE_ENABLE_STORAGE_POLICY",
+                    "value": "True"
+                },
+                {
+                    "name": "CLICKHOUSE_REPLICATION",
+                    "value": "True"
+                },
+                {
+                    "name": "CLICKHOUSE_SECURE",
+                    "value": "True"
+                },
+                {
+                    "name": "CLICKHOUSE_VERIFY",
+                    "value": "True"
+                },
+                {
+                    "name": "EVENT_USAGE_CACHING_TTL",
+                    "value": "3600"
+                },
+                {
+                    "name": "INCLUDE_DOCS",
+                    "value": "1"
+                },
+                {
+                    "name": "IS_BEHIND_PROXY",
+                    "value": "True"
+                },
+                {
+                    "name": "DISABLE_SECURE_SSL_REDIRECT",
+                    "value": "True"
+                },
+                {
+                    "name": "IS_DOCKER",
+                    "value": "True"
+                },
+                {
+                    "name": "KAFKA_BASE64_KEYS",
+                    "value": "True"
+                },
+                {
+                    "name": "PRIMARY_DB",
+                    "value": "clickhouse"
+                },
+                {
+                    "name": "SITE_URL",
+                    "value": "https://app.posthog.com"
+                }
+            ],
+            "secrets": [
+                {
+                    "name": "CLICKHOUSE_CA",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_CA::"
+                },
+                {
+                    "name": "CLICKHOUSE_HOST",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_HOST::"
+                },
+                {
+                    "name": "CLICKHOUSE_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_PASSWORD::"
+                },
+                {
+                    "name": "DATABASE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:DATABASE_URL::"
+                },
+                {
+                    "name": "EMAIL_HOST",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:EMAIL_HOST::"
+                },
+                {
+                    "name": "EMAIL_HOST_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:EMAIL_HOST_PASSWORD::"
+                },
+                {
+                    "name": "EMAIL_HOST_USER",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:EMAIL_HOST_USER::"
+                },
+                {
+                    "name": "EMAIL_PORT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:EMAIL_PORT::"
+                },
+                {
+                    "name": "EMAIL_USE_TLS",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:EMAIL_USE_TLS::"
+                },
+                {
+                    "name": "KAFKA_CLIENT_CERT_B64",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_CLIENT_CERT_B64::"
+                },
+                {
+                    "name": "KAFKA_CLIENT_CERT_KEY_B64",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_CLIENT_CERT_KEY_B64::"
+                },
+                {
+                    "name": "KAFKA_TRUSTED_CERT_B64",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_TRUSTED_CERT_B64::"
+                },
+                {
+                    "name": "KAFKA_URL",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_URL::"
+                },
+                {
+                    "name": "POSTHOG_PERSONAL_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:POSTHOG_PERSONAL_API_KEY::"
+                },
+                {
+                    "name": "REDIS_URL",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:REDIS_URL::"
+                },
+                {
+                    "name": "SECRET_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SECRET_KEY::"
+                },
+                {
+                    "name": "SENTRY_DSN",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SENTRY_DSN::"
+                },
+                {
+                    "name": "SOCIAL_AUTH_GITHUB_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITHUB_KEY::"
+                },
+                {
+                    "name": "SOCIAL_AUTH_GITHUB_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITHUB_SECRET::"
+                },
+                {
+                    "name": "SOCIAL_AUTH_GITLAB_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITLAB_KEY::"
+                },
+                {
+                    "name": "SOCIAL_AUTH_GITLAB_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GITLAB_SECRET::"
+                },
+                {
+                    "name": "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GOOGLE_OAUTH2_KEY::"
+                },
+                {
+                    "name": "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET::"
+                },
+                {
+                    "name": "STATSD_HOST",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
+                },
+                {
+                    "name": "STRIPE_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_API_KEY::"
+                },
+                {
+                    "name": "STRIPE_DEFAULT_PRICE_ID",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_DEFAULT_PRICE_ID::"
+                },
+                {
+                    "name": "STRIPE_GROWTH_PRICE_ID",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_GROWTH_PRICE_ID::"
+                },
+                {
+                    "name": "STRIPE_PUBLISHABLE_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_PUBLISHABLE_KEY::"
+                },
+                {
+                    "name": "STRIPE_WEBHOOK_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
+                }
+            ],
+            "entryPoint": ["sh", "-c"],
+            "command": ["./bin/plugin-server"]
+        }
+    ],
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "1024",
+    "memory": "2048"
+}

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -200,7 +200,7 @@
                 }
             ],
             "entryPoint": ["sh", "-c"],
-            "command": ["./bin/docker-worker"]
+            "command": ["./bin/docker-worker-celery --with-scheduler"]
         }
     ],
     "requiresCompatibilities": ["FARGATE"],


### PR DESCRIPTION
## Changes

Hi @fuziontech , I have no idea what I'm doing, but PRs over issues! :)

Starting as soon as feasible, we should run the `bin/plugin-server` script in production. It's not yet connected to Kafka, but we can still run scheduled plugins on it... and I'd like to just make sure it even starts and stays up. 

I modified some files to create a `plugins` task definition, but have no idea if I missed anything or even did the right thing.

Can you help get this running?

Also, I'm not sure if the worker should be called `plugins` or `plugin-server`. I went with the shorter one for now.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
