### PR TITLE
Fix Identified persons pagination

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -55,7 +55,9 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
             {
                 loadPersons: async (url: string | null = '') => {
                     const qs = Object.keys(values.listFilters)
-                        .filter((key) => FILTER_WHITELIST.includes(key))
+                        .filter((key) =>
+                            key !== 'is_identified' ? FILTER_WHITELIST.includes(key) : !url?.includes('is_identified')
+                        )
                         .reduce(function (result, key) {
                             const value = values.listFilters[key]
                             if (value !== undefined && value !== null) {


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Close #2752

Problem was that we kept adding is_identified to the URL

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
