### PR TITLE
Honor next URL when logged out

### DIFF
--- a/posthog/templates/login.html
+++ b/posthog/templates/login.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block content %}
-    <form class="form-signin" method="post" action="/login">
+    <form class="form-signin" method="post" action="{{ action }}">
         {% csrf_token %}
         <h1 class="h3 mb-3 font-weight-normal">Log in to <a href='https://posthog.com'>PostHog</a></h1>
 

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -1,4 +1,5 @@
 from django.test import Client, TestCase
+from rest_framework import status
 
 from posthog.models import OrganizationInvite, OrganizationMembership, User
 from posthog.test.base import BaseTest
@@ -53,7 +54,7 @@ class TestUrls(TestCase):
         with self.settings(TEST=False):
             response = self.client.post(
                 f"/signup/{signup_token}",
-                {"name": "Jane", "email": invited_email, "password": "hunter2", "emailOptIn": "",},
+                {"name": "Jane", "email": invited_email, "password": "hunter2", "emailOptIn": ""},
                 follow=True,
             )
         self.assertRedirects(response, "/")
@@ -62,16 +63,40 @@ class TestUrls(TestCase):
             OrganizationMembership.objects.filter(organization=organization, user__email=invited_email).exists()
         )
 
+    def test_logged_out_user_is_redirected_to_login(self):
+        self.client.logout()
+
+        response = self.client.get(
+            '/insights?interval=day&display=ActionsLineGraph&events=[{"id":"$pageview","name":"$pageview","type":"events","order":0}]&properties=[]',
+        )
+
+        # Test that the URL is properly encoded to redirect the user to the final destination
+        self.assertRedirects(
+            response,
+            "/login?next=/insights%3Finterval%3Dday%26display%3DActionsLineGraph%26events%3D%5B%257B%2522id%2522%3A%2522%24pageview%2522%2C%2522name%2522%3A%2522%24pageview%2522%2C%2522type%2522%3A%2522events%2522%2C%2522order%2522%3A0%257D%5D%26properties%3D%5B%5D",
+            fetch_redirect_response=False,
+        )
+
     def test_login_with_next_url(self):
         organization, team, user = User.objects.bootstrap(
             "test", "adminuser@posthog.com", None, team_fields={"signup_token": "abcd1234"}
         )
         User.objects.create_and_join(organization=organization, email="jane@acme.com", password="password")
-        with self.settings(TEST=False):
-            response = self.client.post(
-                f"/login?next=/demo", {"email": "jane@acme.com", "password": "password"}, follow=True,
-            )
+
+        # Standard redirect
+        response = self.client.post("/login?next=/demo", {"email": "jane@acme.com", "password": "password"})
         self.assertRedirects(response, "/demo")
+
+        # Complex redirect (url-encoded)
+        self.client.logout()
+        response = self.client.post(
+            "/login?next=/insights%3Finterval%3Dday%26display%3DActionsLineGraph%26events%3D%5B%257B%2522id%2522%3A%2522%24pageview%2522%2C%2522name%2522%3A%2522%24pageview%2522%2C%2522type%2522%3A%2522events%2522%2C%2522order%2522%3A0%257D%5D%26properties%3D%5B%5D",
+            {"email": "jane@acme.com", "password": "password"},
+        )
+        self.assertRedirects(
+            response,
+            '/insights?interval=day&display=ActionsLineGraph&events=[{"id":"$pageview","name":"$pageview","type":"events","order":0}]&properties=[]',
+        )
 
 
 class TestUrlsLoggedIn(BaseTest):

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -62,6 +62,17 @@ class TestUrls(TestCase):
             OrganizationMembership.objects.filter(organization=organization, user__email=invited_email).exists()
         )
 
+    def test_login_with_next_url(self):
+        organization, team, user = User.objects.bootstrap(
+            "test", "adminuser@posthog.com", None, team_fields={"signup_token": "abcd1234"}
+        )
+        User.objects.create_and_join(organization=organization, email="jane@acme.com", password="password")
+        with self.settings(TEST=False):
+            response = self.client.post(
+                f"/login?next=/demo", {"email": "jane@acme.com", "password": "password"}, follow=True,
+            )
+        self.assertRedirects(response, "/demo")
+
 
 class TestUrlsLoggedIn(BaseTest):
     TESTS_API = True

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -54,7 +54,7 @@ def login_view(request):
         email = request.POST["email"]
         password = request.POST["password"]
         user = cast(Optional[User], authenticate(request, email=email, password=password))
-        next_url = request.GET.get("next", "")
+        next_url = request.GET.get("next")
         if user is not None:
             login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             if user.distinct_id:

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -54,13 +54,24 @@ def login_view(request):
         email = request.POST["email"]
         password = request.POST["password"]
         user = cast(Optional[User], authenticate(request, email=email, password=password))
+        next_url = request.GET.get("next", "")
         if user is not None:
             login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             if user.distinct_id:
                 posthoganalytics.capture(user.distinct_id, "user logged in")
+            if next_url:
+                return redirect(next_url)
             return redirect("/")
         else:
-            return render_template("login.html", request=request, context={"email": email, "error": True})
+            return render_template(
+                "login.html",
+                request=request,
+                context={
+                    "email": email,
+                    "error": True,
+                    "action": "/login" if not next_url else f"/login?next={next_url}",
+                },
+            )
     return render_template("login.html", request)
 
 


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Make sure we redirect appropriately based on the /next url if you try to access a page and are not logged in.

Closes #2636

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
