### PR TITLE
MV -> View for events_with_array_props_view and remove EVENT_PROP_TABLE_SQL

### DIFF
--- a/ee/clickhouse/migrations/0002_events_materialized.py
+++ b/ee/clickhouse/migrations/0002_events_materialized.py
@@ -3,11 +3,9 @@ from infi.clickhouse_orm import migrations
 from ee.clickhouse.sql.events import (
     EVENTS_WITH_PROPS_TABLE_SQL,
     MAT_EVENT_PROP_TABLE_SQL,
-    MAT_EVENTS_WITH_PROPS_TABLE_SQL,
 )
 
 operations = [
     migrations.RunSQL(EVENTS_WITH_PROPS_TABLE_SQL),
-    migrations.RunSQL(MAT_EVENTS_WITH_PROPS_TABLE_SQL),
     migrations.RunSQL(MAT_EVENT_PROP_TABLE_SQL),
 ]

--- a/ee/clickhouse/migrations/0002_events_materialized.py
+++ b/ee/clickhouse/migrations/0002_events_materialized.py
@@ -1,9 +1,6 @@
 from infi.clickhouse_orm import migrations
 
-from ee.clickhouse.sql.events import (
-    EVENTS_WITH_PROPS_TABLE_SQL,
-    MAT_EVENT_PROP_TABLE_SQL,
-)
+from ee.clickhouse.sql.events import EVENTS_WITH_PROPS_TABLE_SQL, MAT_EVENT_PROP_TABLE_SQL
 
 operations = [
     migrations.RunSQL(EVENTS_WITH_PROPS_TABLE_SQL),

--- a/ee/clickhouse/migrations/0002_events_materialized.py
+++ b/ee/clickhouse/migrations/0002_events_materialized.py
@@ -1,8 +1,7 @@
 from infi.clickhouse_orm import migrations
 
-from ee.clickhouse.sql.events import EVENT_PROP_TABLE_SQL, EVENTS_WITH_PROPS_TABLE_SQL
+from ee.clickhouse.sql.events import EVENTS_WITH_PROPS_TABLE_SQL
 
 operations = [
     migrations.RunSQL(EVENTS_WITH_PROPS_TABLE_SQL),
-    migrations.RunSQL(EVENT_PROP_TABLE_SQL),
 ]

--- a/ee/clickhouse/migrations/0002_events_materialized.py
+++ b/ee/clickhouse/migrations/0002_events_materialized.py
@@ -1,8 +1,8 @@
 from infi.clickhouse_orm import migrations
 
-from ee.clickhouse.sql.events import EVENTS_WITH_PROPS_TABLE_SQL, MAT_EVENT_PROP_TABLE_SQL
+from ee.clickhouse.sql.events import EVENT_PROP_TABLE_SQL, EVENTS_WITH_PROPS_TABLE_SQL
 
 operations = [
     migrations.RunSQL(EVENTS_WITH_PROPS_TABLE_SQL),
-    migrations.RunSQL(MAT_EVENT_PROP_TABLE_SQL),
+    migrations.RunSQL(EVENT_PROP_TABLE_SQL),
 ]

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -118,10 +118,8 @@ _offset
 FROM events
 """
 
-MAT_EVENT_PROP_TABLE_SQL = """
-CREATE MATERIALIZED VIEW events_properties_view
-ENGINE = MergeTree()
-ORDER BY (team_id, key, value, event_id)
+EVENT_PROP_TABLE_SQL = """
+CREATE VIEW events_properties_view
 AS SELECT uuid as event_id,
 team_id,
 array_property_keys as key,

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -10,10 +10,6 @@ DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL = """
 DROP TABLE events_with_array_props_view
 """
 
-DROP_MAT_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL = """
-DROP TABLE events_with_array_props_mv
-"""
-
 DROP_MAT_EVENTS_PROP_TABLE_SQL = """
 DROP TABLE events_properties_view
 """
@@ -105,32 +101,7 @@ FROM events WHERE team_id = %(team_id)s
 """
 
 EVENTS_WITH_PROPS_TABLE_SQL = """
-CREATE TABLE events_with_array_props_view
-(
-    uuid UUID,
-    event VARCHAR,
-    properties VARCHAR,
-    timestamp DateTime64(6, 'UTC'),
-    team_id Int64,
-    distinct_id VARCHAR,
-    elements_chain VARCHAR,
-    created_at DateTime64,
-    array_property_keys Array(VARCHAR),
-    array_property_values Array(VARCHAR),
-    _timestamp UInt64,
-    _offset UInt64
-) ENGINE = {engine} 
-PARTITION BY toYYYYMM(timestamp)
-ORDER BY (team_id, toDate(timestamp), distinct_id, uuid)
-SAMPLE BY uuid 
-{storage_policy}
-""".format(
-    engine=table_engine("events_with_array_props_view", "_timestamp"), storage_policy=STORAGE_POLICY
-)
-
-MAT_EVENTS_WITH_PROPS_TABLE_SQL = """
-CREATE MATERIALIZED VIEW events_with_array_props_mv
-TO events_with_array_props_view
+CREATE VIEW events_with_array_props_view
 AS SELECT
 uuid,
 event,

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -10,10 +10,6 @@ DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL = """
 DROP TABLE events_with_array_props_view
 """
 
-DROP_EVENTS_PROP_TABLE_SQL = """
-DROP TABLE events_properties_view
-"""
-
 EVENTS_TABLE = "events"
 
 EVENTS_TABLE_BASE_SQL = """
@@ -116,16 +112,6 @@ arrayMap(k -> toString(k.2), JSONExtractKeysAndValuesRaw(properties)) array_prop
 _timestamp,
 _offset
 FROM events
-"""
-
-EVENT_PROP_TABLE_SQL = """
-CREATE VIEW events_properties_view
-AS SELECT uuid as event_id,
-team_id,
-array_property_keys as key,
-array_property_values as value
-from events_with_array_props_view
-ARRAY JOIN array_property_keys, array_property_values
 """
 
 SELECT_PROP_VALUES_SQL = """

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -10,7 +10,7 @@ DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL = """
 DROP TABLE events_with_array_props_view
 """
 
-DROP_MAT_EVENTS_PROP_TABLE_SQL = """
+DROP_EVENTS_PROP_TABLE_SQL = """
 DROP TABLE events_properties_view
 """
 

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -9,8 +9,8 @@ from ee.clickhouse.sql.events import (
     DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
     DROP_MAT_EVENTS_PROP_TABLE_SQL,
     EVENTS_TABLE_SQL,
-    MAT_EVENT_PROP_TABLE_SQL,
     EVENTS_WITH_PROPS_TABLE_SQL,
+    MAT_EVENT_PROP_TABLE_SQL,
 )
 from ee.clickhouse.sql.person import (
     DROP_PERSON_DISTINCT_ID_TABLE_SQL,

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -5,9 +5,9 @@ from django.db import DEFAULT_DB_ALIAS
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import (
+    DROP_EVENTS_PROP_TABLE_SQL,
     DROP_EVENTS_TABLE_SQL,
     DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
-    DROP_MAT_EVENTS_PROP_TABLE_SQL,
     EVENT_PROP_TABLE_SQL,
     EVENTS_TABLE_SQL,
     EVENTS_WITH_PROPS_TABLE_SQL,
@@ -55,7 +55,7 @@ class ClickhouseTestMixin:
     def _destroy_event_tables(self):
         sync_execute(DROP_EVENTS_TABLE_SQL)
         sync_execute(DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL)
-        sync_execute(DROP_MAT_EVENTS_PROP_TABLE_SQL)
+        sync_execute(DROP_EVENTS_PROP_TABLE_SQL)
 
     def _create_event_tables(self):
         sync_execute(EVENTS_TABLE_SQL)

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -8,9 +8,9 @@ from ee.clickhouse.sql.events import (
     DROP_EVENTS_TABLE_SQL,
     DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
     DROP_MAT_EVENTS_PROP_TABLE_SQL,
+    EVENT_PROP_TABLE_SQL,
     EVENTS_TABLE_SQL,
     EVENTS_WITH_PROPS_TABLE_SQL,
-    MAT_EVENT_PROP_TABLE_SQL,
 )
 from ee.clickhouse.sql.person import (
     DROP_PERSON_DISTINCT_ID_TABLE_SQL,
@@ -60,7 +60,7 @@ class ClickhouseTestMixin:
     def _create_event_tables(self):
         sync_execute(EVENTS_TABLE_SQL)
         sync_execute(EVENTS_WITH_PROPS_TABLE_SQL)
-        sync_execute(MAT_EVENT_PROP_TABLE_SQL)
+        sync_execute(EVENT_PROP_TABLE_SQL)
 
     @contextmanager
     def _assertNumQueries(self, func):

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -8,11 +8,9 @@ from ee.clickhouse.sql.events import (
     DROP_EVENTS_TABLE_SQL,
     DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
     DROP_MAT_EVENTS_PROP_TABLE_SQL,
-    DROP_MAT_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
     EVENTS_TABLE_SQL,
-    EVENTS_WITH_PROPS_TABLE_SQL,
     MAT_EVENT_PROP_TABLE_SQL,
-    MAT_EVENTS_WITH_PROPS_TABLE_SQL,
+    EVENTS_WITH_PROPS_TABLE_SQL,
 )
 from ee.clickhouse.sql.person import (
     DROP_PERSON_DISTINCT_ID_TABLE_SQL,
@@ -57,13 +55,11 @@ class ClickhouseTestMixin:
     def _destroy_event_tables(self):
         sync_execute(DROP_EVENTS_TABLE_SQL)
         sync_execute(DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL)
-        sync_execute(DROP_MAT_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL)
         sync_execute(DROP_MAT_EVENTS_PROP_TABLE_SQL)
 
     def _create_event_tables(self):
         sync_execute(EVENTS_TABLE_SQL)
         sync_execute(EVENTS_WITH_PROPS_TABLE_SQL)
-        sync_execute(MAT_EVENTS_WITH_PROPS_TABLE_SQL)
         sync_execute(MAT_EVENT_PROP_TABLE_SQL)
 
     @contextmanager

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -5,10 +5,8 @@ from django.db import DEFAULT_DB_ALIAS
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import (
-    DROP_EVENTS_PROP_TABLE_SQL,
     DROP_EVENTS_TABLE_SQL,
     DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL,
-    EVENT_PROP_TABLE_SQL,
     EVENTS_TABLE_SQL,
     EVENTS_WITH_PROPS_TABLE_SQL,
 )
@@ -55,12 +53,10 @@ class ClickhouseTestMixin:
     def _destroy_event_tables(self):
         sync_execute(DROP_EVENTS_TABLE_SQL)
         sync_execute(DROP_EVENTS_WITH_ARRAY_PROPS_TABLE_SQL)
-        sync_execute(DROP_EVENTS_PROP_TABLE_SQL)
 
     def _create_event_tables(self):
         sync_execute(EVENTS_TABLE_SQL)
         sync_execute(EVENTS_WITH_PROPS_TABLE_SQL)
-        sync_execute(EVENT_PROP_TABLE_SQL)
 
     @contextmanager
     def _assertNumQueries(self, func):


### PR DESCRIPTION
## Changes

Making the schema used for testing match the schema that is currently in production.

We just nuked two materialized views turning them into simple views because of an issue with parts growing out of control on clickhouse which would have eventually taken us down.
