### PR TITLE
Create a bookmarklet for demoing posthog

### DIFF
--- a/frontend/src/lib/components/JSBookmarklet.tsx
+++ b/frontend/src/lib/components/JSBookmarklet.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { useValues } from 'kea'
+import { teamLogic } from 'scenes/teamLogic'
+import { BookOutlined } from '@ant-design/icons'
+
+export function JSBookmarklet(): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+
+    const initCall = `posthog.init('${currentTeam?.api_token}',{api_host:'${window.location.origin}', loaded: () => alert('Posthog is now tracking events!')})`
+    const href = `javascript:(function()%7Bif%20(window.posthog)%20%7Balert(%22Error%3A%20Posthog%20is%20already%20installed%20on%20this%20site%22)%7D%20else%20%7B!function(t%2Ce)%7Bvar%20o%2Cn%2Cp%2Cr%3Be.__SV%7C%7C(window.posthog%3De%2Ce._i%3D%5B%5D%2Ce.init%3Dfunction(i%2Cs%2Ca)%7Bfunction%20g(t%2Ce)%7Bvar%20o%3De.split(%22.%22)%3B2%3D%3Do.length%26%26(t%3Dt%5Bo%5B0%5D%5D%2Ce%3Do%5B1%5D)%2Ct%5Be%5D%3Dfunction()%7Bt.push(%5Be%5D.concat(Array.prototype.slice.call(arguments%2C0)))%7D%7D(p%3Dt.createElement(%22script%22)).type%3D%22text%2Fjavascript%22%2Cp.async%3D!0%2Cp.src%3Ds.api_host%2B%22%2Fstatic%2Farray.js%22%2C(r%3Dt.getElementsByTagName(%22script%22)%5B0%5D).parentNode.insertBefore(p%2Cr)%3Bvar%20u%3De%3Bfor(void%200!%3D%3Da%3Fu%3De%5Ba%5D%3D%5B%5D%3Aa%3D%22posthog%22%2Cu.people%3Du.people%7C%7C%5B%5D%2Cu.toString%3Dfunction(t)%7Bvar%20e%3D%22posthog%22%3Breturn%22posthog%22!%3D%3Da%26%26(e%2B%3D%22.%22%2Ba)%2Ct%7C%7C(e%2B%3D%22%20(stub)%22)%2Ce%7D%2Cu.people.toString%3Dfunction()%7Breturn%20u.toString(1)%2B%22.people%20(stub)%22%7D%2Co%3D%22capture%20identify%20alias%20people.set%20people.set_once%20set_config%20register%20register_once%20unregister%20opt_out_capturing%20has_opted_out_capturing%20opt_in_capturing%20reset%20isFeatureEnabled%20onFeatureFlags%22.split(%22%20%22)%2Cn%3D0%3Bn%3Co.length%3Bn%2B%2B)g(u%2Co%5Bn%5D)%3Be._i.push(%5Bi%2Cs%2Ca%5D)%7D%2Ce.__SV%3D1)%7D(document%2Cwindow.posthog%7C%7C%5B%5D)%3B${encodeURIComponent(
+        initCall
+    )}%7D%7D)()`
+
+    console.log(href)
+    return (
+        <a href={href}>
+            <BookOutlined /> Posthog bookmarklet
+        </a>
+    )
+}

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -47,8 +47,9 @@ function _Setup(): JSX.Element {
                 <a href="https://posthog.com/docs/integrations/js-integration">see PostHog Docs</a>.
                 <JSSnippet />
                 <br />
-                It's possible to test out Posthog on a live site without changing any code. Just drag this bookmarklet
-                to your bookmarks bar, open your site and click the bookmarklet: <JSBookmarklet />
+                It's possible to test out Posthog on a live site without changing any code. <br />
+                Just drag this bookmarklet to your bookmarks bar, open the website you want to track and click it:{' '}
+                <JSBookmarklet />
                 <Divider />
                 <h2 id="custom-events" className="subtitle">
                     Send Custom Events

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -19,6 +19,7 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { Link } from 'lib/components/Link'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { userLogic } from 'scenes/userLogic'
+import { JSBookmarklet } from 'lib/components/JSBookmarklet'
 
 export const Setup = hot(_Setup)
 function _Setup(): JSX.Element {
@@ -45,6 +46,9 @@ function _Setup(): JSX.Element {
                 For more guidance, including on identying users,{' '}
                 <a href="https://posthog.com/docs/integrations/js-integration">see PostHog Docs</a>.
                 <JSSnippet />
+                <br />
+                It's possible to test out Posthog on a live site without changing any code. Just drag this bookmarklet
+                to your bookmarks bar, open your site and click the bookmarklet: <JSBookmarklet />
                 <Divider />
                 <h2 id="custom-events" className="subtitle">
                     Send Custom Events


### PR DESCRIPTION
## Changes

This introduces a bookmarklet generated via https://mrcoles.com/bookmarklet/ into settings js setup code. Users can drag this to their bookmark bar and use it on a live site to generate events on real data.

I did not introduce this to setup flows - there wasn't a good place to put it without making things confusing.

### Images

Installing bookmarklet

![ezgif-6-af5146e62627](https://user-images.githubusercontent.com/148820/102246894-ec7f0380-3f07-11eb-8963-e817b5bcd990.gif)

Using it in bing

![Screenshot from 2020-12-15 19-04-10](https://user-images.githubusercontent.com/148820/102247225-58616c00-3f08-11eb-8331-4af217e27936.png)


Result

![Screenshot from 2020-12-15 18-00-48](https://user-images.githubusercontent.com/148820/102245816-abd2ba80-3f06-11eb-82bb-a61d39be28b5.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
