### PR TITLE
Remove event properties from session filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
@@ -133,7 +133,8 @@ export const propertyFilterLogic = kea({
         afterMount: () => {
             actions.newFilter()
             actions.loadPersonProperties()
-            if (props.endpoint !== 'person') {
+            // TODO: Supporting event properties in sessions is temporarily unsupported (context https://github.com/PostHog/posthog/issues/2735)
+            if (props.endpoint !== 'person' && props.endpoint !== 'sessions') {
                 actions.setProperties(userLogic.values.eventProperties)
             }
         },

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -192,7 +192,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                     onChange={(newDuration) => setFilters(properties, selectedDate, newDuration)}
                 />
             )}
-            <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} />
+            <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} endpoint="sessions" />
 
             <div className="text-right mb">
                 <Tooltip title={playAllCTA}>


### PR DESCRIPTION
## Changes

Full context on #2735. Removes event properties on the sessions filter as they're not correctly supported.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
