### PR TITLE
Fixes for differences between terraform and GA task-definition

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -1,7 +1,6 @@
 {
     "family": "posthog-production-plugins",
     "networkMode": "awsvpc",
-    "name": "postiong-plugins",
     "executionRoleArn": "posthog-production-ecs-task",
     "taskRoleArn": "posthog-production-ecs-task",
     "containerDefinitions": [
@@ -161,6 +160,6 @@
         }
     ],
     "requiresCompatibilities": ["FARGATE"],
-    "cpu": 4096,
-    "memory": 8192
+    "cpu": "4096",
+    "memory": "8192"
 }


### PR DESCRIPTION
## Changes

I introduced a few bugs when I was testing this using terraform over on https://github.com/PostHog/deployment/pull/42 . The AWS ECS deploy steps require no `name` value and the cpu and memory fields to be string.

