### PR TITLE
Allow going from insights -> sessions (on cloud)

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -14,10 +14,12 @@ from posthog.utils import relative_date_parse
 
 
 def parse_prop_clauses(
-    filters: List[Property], team_id: int, prepend: str = "global", table_name: str = ""
+    filters: List[Property], team_id: Optional[int], prepend: str = "global", table_name: str = ""
 ) -> Tuple[str, Dict]:
     final = []
-    params: Dict[str, Any] = {"team_id": team_id}
+    params: Dict[str, Any] = {}
+    if team_id is not None:
+        params["team_id"] = team_id
     if table_name != "":
         table_name += "."
 
@@ -41,11 +43,8 @@ def parse_prop_clauses(
             filter_query, filter_params = prop_filter_json_extract(
                 prop, idx, prepend, prop_var="{}properties".format(table_name)
             )
-            final.append(
-                "{filter_query} AND {table_name}team_id = %(team_id)s".format(
-                    table_name=table_name, filter_query=filter_query
-                )
-            )
+
+            final.append(f"{filter_query} AND {table_name}team_id = %(team_id)s" if team_id else filter_query)
             params.update(filter_params)
     return " ".join(final), params
 

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -23,7 +23,7 @@ class ClickhouseSessionsList(BaseQuery):
         filter = set_default_dates(filter)
 
         filters, params = parse_prop_clauses(filter.properties, team.pk)
-        action_filter_timestamp_sql, action_filter_params = format_action_filter_aggregate(filter)
+        action_filter_timestamp_sql, action_filter_params = format_action_filter_aggregate(filter, team.pk)
 
         date_from, date_to, _ = parse_timestamps(filter, team.pk)
         params = {
@@ -102,9 +102,14 @@ class ClickhouseSessionsList(BaseQuery):
         return final
 
 
-def format_action_filter_aggregate(filter: SessionsFilter):
+def format_action_filter_aggregate(filter: SessionsFilter, team_id: int):
     if filter.action_filter is None:
         return "timestamp", {}
 
     filter_sql, params = format_entity_filter(filter.action_filter)
+    if filter.action_filter.properties:
+        filters, filter_params = parse_prop_clauses(filter.action_filter.properties, team_id=None)
+        filter_sql += f" {filters}"
+        params = {**params, **filter_params}
+
     return f"({filter_sql}) ? timestamp : NULL", params

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -17,5 +17,5 @@ class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(Clickhou
     pass
 
 
-class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event)):  # type: ignore
+class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event, action_filter_enabled=True)):  # type: ignore
     pass

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -9,7 +9,8 @@ SESSION_SQL = """
         groupArray(properties) properties,
         groupArray(timestamp) timestamps,
         groupArray(elements_chain) elements_chain,
-        arrayReduce('max', groupArray(timestamp)) as end_time
+        arrayReduce('max', groupArray(timestamp)) as end_time,
+        groupArray(1)(action_filter_timestamp) as action_filter_timestamp
     FROM (
         SELECT
             distinct_id,
@@ -18,7 +19,8 @@ SESSION_SQL = """
             uuid,
             properties,
             elements_chain,
-            arraySum(arraySlice(gids, 1, idx)) AS gid
+            arraySum(arraySlice(gids, 1, idx)) AS gid,
+            ({action_filter_timestamp}) as action_filter_timestamp
         FROM (
             SELECT
                 groupArray(timestamp) as timestamps,
@@ -90,6 +92,8 @@ SESSION_SQL = """
     GROUP BY
         distinct_id,
         gid
+    HAVING
+        notEmpty(action_filter_timestamp)
     ORDER BY
         start_time DESC
     {sessions_limit}

--- a/frontend/src/scenes/insights/PersonModal.js
+++ b/frontend/src/scenes/insights/PersonModal.js
@@ -5,10 +5,12 @@ import { trendsLogic } from 'scenes/insights/trendsLogic'
 import { Modal, Button, Spin } from 'antd'
 import { PersonsTable } from 'scenes/persons/PersonsTable'
 import { LinkButton } from 'lib/components/LinkButton'
+import { userLogic } from 'scenes/userLogic'
 
 export function PersonModal({ visible, view }) {
     const { people, filters, peopleModalURL } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setShowingPeople, loadMorePeople } = useActions(trendsLogic({ dashboardItemId: null, view }))
+    const { user } = useValues(userLogic)
 
     const title =
         filters.shown_as === 'Stickiness'
@@ -29,14 +31,16 @@ export function PersonModal({ visible, view }) {
                     style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
                 >
                     Found {people.count === 99 ? '99+' : people.count} {people.count === 1 ? 'user' : 'users'}
-                    <div>
-                        <LinkButton to={peopleModalURL.recordings} type="primary" target="_blank">
-                            View recordings
-                        </LinkButton>
-                        <LinkButton to={peopleModalURL.sessions} style={{ marginLeft: 8 }} target="_blank">
-                            View sessions
-                        </LinkButton>
-                    </div>
+                    {user?.is_multi_tenancy ? (
+                        <div>
+                            <LinkButton to={peopleModalURL.recordings} type="primary" target="_blank">
+                                View recordings
+                            </LinkButton>
+                            <LinkButton to={peopleModalURL.sessions} style={{ marginLeft: 8 }} target="_blank">
+                                View sessions
+                            </LinkButton>
+                        </div>
+                    ) : null}
                 </div>
             ) : (
                 <p>Loading users...</p>

--- a/frontend/src/scenes/insights/PersonModal.js
+++ b/frontend/src/scenes/insights/PersonModal.js
@@ -4,9 +4,10 @@ import moment from 'moment'
 import { trendsLogic } from 'scenes/insights/trendsLogic'
 import { Modal, Button, Spin } from 'antd'
 import { PersonsTable } from 'scenes/persons/PersonsTable'
+import { LinkButton } from 'lib/components/LinkButton'
 
 export function PersonModal({ visible, view }) {
-    const { people, filters } = useValues(trendsLogic({ dashboardItemId: null, view }))
+    const { people, filters, peopleModalURL } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setShowingPeople, loadMorePeople } = useActions(trendsLogic({ dashboardItemId: null, view }))
 
     const title =
@@ -24,9 +25,19 @@ export function PersonModal({ visible, view }) {
             width={800}
         >
             {people ? (
-                <p>
+                <div
+                    style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+                >
                     Found {people.count === 99 ? '99+' : people.count} {people.count === 1 ? 'user' : 'users'}
-                </p>
+                    <div>
+                        <LinkButton to={peopleModalURL.recordings} type="primary" target="_blank">
+                            View recordings
+                        </LinkButton>
+                        <LinkButton to={peopleModalURL.sessions} style={{ marginLeft: 8 }} target="_blank">
+                            View sessions
+                        </LinkButton>
+                    </div>
+                </div>
             ) : (
                 <p>Loading users...</p>
             )}

--- a/frontend/src/scenes/insights/PersonModal.js
+++ b/frontend/src/scenes/insights/PersonModal.js
@@ -4,8 +4,9 @@ import moment from 'moment'
 import { trendsLogic } from 'scenes/insights/trendsLogic'
 import { Modal, Button, Spin } from 'antd'
 import { PersonsTable } from 'scenes/persons/PersonsTable'
-import { LinkButton } from 'lib/components/LinkButton'
+import { Link } from 'lib/components/Link'
 import { userLogic } from 'scenes/userLogic'
+import { ArrowRightOutlined, ClockCircleOutlined } from '@ant-design/icons'
 
 export function PersonModal({ visible, view }) {
     const { people, filters, peopleModalURL } = useValues(trendsLogic({ dashboardItemId: null, view }))
@@ -31,14 +32,18 @@ export function PersonModal({ visible, view }) {
                     style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
                 >
                     Found {people.count === 99 ? '99+' : people.count} {people.count === 1 ? 'user' : 'users'}
-                    {user?.is_multi_tenancy ? (
-                        <div>
-                            <LinkButton to={peopleModalURL.recordings} type="primary" target="_blank">
-                                View recordings
-                            </LinkButton>
-                            <LinkButton to={peopleModalURL.sessions} style={{ marginLeft: 8 }} target="_blank">
-                                View sessions
-                            </LinkButton>
+                    {user?.is_multi_tenancy || true ? (
+                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+                            <Link
+                                to={peopleModalURL.sessions}
+                                style={{ marginLeft: 8 }}
+                                data-attr="persons-modal-sessions"
+                            >
+                                <ClockCircleOutlined /> View related sessions <ArrowRightOutlined />
+                            </Link>
+                            <Link to={peopleModalURL.recordings} type="primary" data-attr="persons-modal-recordings">
+                                View related recordings <ArrowRightOutlined />
+                            </Link>
                         </div>
                     ) : null}
                 </div>

--- a/frontend/src/scenes/insights/trendsLogic.js
+++ b/frontend/src/scenes/insights/trendsLogic.js
@@ -221,6 +221,37 @@ export const trendsLogic = kea({
                 filters.people_action ? actions.find((a) => a.id === parseInt(filters.people_action)) : null,
         ],
         peopleDay: [() => [selectors.filters], (filters) => filters.people_day],
+
+        sessionsPageParams: [
+            () => [selectors.filters, selectors.people],
+            (filters, people) => {
+                if (!people) {
+                    return {}
+                }
+
+                const { action, day, breakdown_value } = people
+                const properties = [...filters.properties, ...action.properties]
+                if (filters.breakdown) {
+                    properties.push({ key: filters.breakdown, value: breakdown_value, type: filters.breakdown_type })
+                }
+
+                return {
+                    date: day,
+                    actionFilter: {
+                        ...action,
+                        properties,
+                    },
+                }
+            },
+        ],
+
+        peopleModalURL: [
+            () => [selectors.sessionsPageParams],
+            (params) => ({
+                sessions: `/sessions?${toAPIParams(params)}`,
+                recordings: `/sessions?${toAPIParams({ ...params, duration: ['gt', 0, 'm'] })}`,
+            }),
+        ],
     }),
 
     listeners: ({ actions, values, props }) => ({

--- a/frontend/src/scenes/persons/PersonsV2.tsx
+++ b/frontend/src/scenes/persons/PersonsV2.tsx
@@ -7,6 +7,9 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { personsLogic } from './personsLogic'
 import { Link } from 'lib/components/Link'
 import { CohortType } from '~/types'
+import { LinkButton } from 'lib/components/LinkButton'
+import { ClockCircleFilled } from '@ant-design/icons'
+import { toParams } from 'lib/utils'
 
 export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
     const { loadPersons, setListFilters } = useActions(personsLogic)
@@ -69,10 +72,19 @@ export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
                 </div>
             </Row>
             <div className="mb text-right">
+                {cohort ? (
+                    <LinkButton
+                        to={`/sessions?${toParams({ properties: [{ key: 'id', value: cohort.id, type: 'cohort' }] })}`}
+                        target="_blank"
+                    >
+                        <ClockCircleFilled /> View sessions
+                    </LinkButton>
+                ) : null}
                 <Button
                     type="default"
                     icon={<ExportOutlined />}
                     href={'/api/person.csv' + (listFilters.cohort ? '?cohort=' + listFilters.cohort : '')}
+                    style={{ marginLeft: 8 }}
                 >
                     Export
                 </Button>

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -58,6 +58,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
         sessionRecordingId,
         duration,
         firstRecordingId,
+        actionFilter,
     } = useValues(logic)
     const { fetchNextSessions, previousDay, nextDay, setFilters } = useActions(logic)
     const { user } = useValues(userLogic)
@@ -180,7 +181,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                 <Button onClick={previousDay} icon={<CaretLeftOutlined />} />
                 <DatePicker
                     value={selectedDate}
-                    onChange={(date) => setFilters(properties, date, duration)}
+                    onChange={(date) => setFilters(properties, date, duration, actionFilter)}
                     allowClear={false}
                 />
                 <Button onClick={nextDay} icon={<CaretRightOutlined />} />
@@ -189,7 +190,7 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
             {featureFlags['filter_by_session_props'] && (
                 <SessionRecordingFilters
                     duration={duration}
-                    onChange={(newDuration) => setFilters(properties, selectedDate, newDuration)}
+                    onChange={(newDuration) => setFilters(properties, selectedDate, newDuration, actionFilter)}
                 />
             )}
             <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} endpoint="sessions" />

--- a/frontend/src/scenes/sessions/SessionsTable.tsx
+++ b/frontend/src/scenes/sessions/SessionsTable.tsx
@@ -211,6 +211,11 @@ export function SessionsTable({ personIds, isPersonPage = false }: SessionsTable
                 </Tooltip>
             </div>
 
+            {actionFilter && (
+                <p className="text-muted">
+                    Showing only sessions where <b>{actionFilter.name}</b> occurred
+                </p>
+            )}
             <Table
                 locale={{ emptyText: 'No Sessions on ' + moment(selectedDate).format('YYYY-MM-DD') }}
                 data-attr="sessions-table"

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -181,26 +181,17 @@ export const sessionsTableLogic = kea<
     actionToUrl: ({ values }) => {
         const buildURL = (overrides: Partial<Params> = {}): [string, Params] => {
             const today = moment().startOf('day').format('YYYY-MM-DD')
-            let params: Params = {}
 
             const { properties } = router.values.searchParams // eslint-disable-line
-            if (values.selectedDateURLparam !== today) {
-                params.date = values.selectedDateURLparam
-            }
-            if (properties) {
-                params.properties = properties
-            }
-            if (values.duration) {
-                params.duration = values.duration
-            }
-            if (values.sessionRecordingId) {
-                params.sessionRecordingId = values.sessionRecordingId
-            }
-            if (values.actionFilter) {
-                params.actionFilter = values.actionFilter
-            }
 
-            params = { ...params, ...overrides }
+            const params: Params = {
+                date: values.selectedDateURLparam !== today ? values.selectedDateURLparam : undefined,
+                properties: properties || undefined,
+                duration: values.duration || undefined,
+                sessionRecordingId: values.sessionRecordingId || undefined,
+                actionFilter: values.actionFilter || undefined,
+                ...overrides,
+            }
 
             return [router.values.location.pathname, params]
         }

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -3,7 +3,7 @@ import api from 'lib/api'
 import moment from 'moment'
 import { toParams } from 'lib/utils'
 import { sessionsTableLogicType } from 'types/scenes/sessions/sessionsTableLogicType'
-import { PropertyFilter, SessionType } from '~/types'
+import { EntityWithProperties, PropertyFilter, SessionType } from '~/types'
 import { router } from 'kea-router'
 import { eventWithTime } from 'rrweb/typings/types'
 
@@ -16,34 +16,10 @@ interface Params {
     properties?: any
     duration?: any
     sessionRecordingId?: SessionRecordingId
+    actionFilter?: EntityWithProperties
 }
 
 export type RecordingDurationFilter = ['lt' | 'gt', number | null, 's' | 'm' | 'h']
-
-const buildURL = (
-    selectedDateURLparam?: string,
-    sessionRecordingId?: SessionRecordingId | null,
-    duration?: RecordingDurationFilter | null
-): [string, Params] => {
-    const today = moment().startOf('day').format('YYYY-MM-DD')
-    const params: Params = {}
-
-    const { properties } = router.values.searchParams // eslint-disable-line
-    if (selectedDateURLparam !== today) {
-        params.date = selectedDateURLparam
-    }
-    if (properties) {
-        params.properties = properties
-    }
-    if (duration) {
-        params.duration = duration
-    }
-    if (sessionRecordingId) {
-        params.sessionRecordingId = sessionRecordingId
-    }
-
-    return [router.values.location.pathname, params]
-}
 
 export const sessionsTableLogic = kea<
     sessionsTableLogicType<
@@ -52,7 +28,8 @@ export const sessionsTableLogic = kea<
         SessionRecordingId,
         eventWithTime,
         PropertyFilter,
-        RecordingDurationFilter
+        RecordingDurationFilter,
+        EntityWithProperties
     >
 >({
     props: {} as {
@@ -69,6 +46,7 @@ export const sessionsTableLogic = kea<
                     offset: 0,
                     distinct_id: props.personIds ? props.personIds[0] : '',
                     properties: values.properties,
+                    action_filter: values.actionFilter || undefined,
                     ...values.durationFilter,
                 })
                 await breakpoint(10)
@@ -90,8 +68,9 @@ export const sessionsTableLogic = kea<
         setFilters: (
             properties: Array<PropertyFilter>,
             selectedDate: Moment | null,
-            duration: RecordingDurationFilter | null
-        ) => ({ properties, selectedDate, duration }),
+            duration: RecordingDurationFilter | null,
+            actionFilter: EntityWithProperties | null
+        ) => ({ properties, selectedDate, duration, actionFilter }),
         setSessionRecordingId: (sessionRecordingId: SessionRecordingId) => ({ sessionRecordingId }),
         closeSessionPlayer: true,
     }),
@@ -126,6 +105,12 @@ export const sessionsTableLogic = kea<
             {
                 setSessionRecordingId: (_, { sessionRecordingId }) => sessionRecordingId,
                 closeSessionPlayer: () => null,
+            },
+        ],
+        actionFilter: [
+            null as EntityWithProperties | null,
+            {
+                setFilters: (_, { actionFilter }) => actionFilter,
             },
         ],
     },
@@ -177,17 +162,55 @@ export const sessionsTableLogic = kea<
             actions.loadSessions(true)
         },
         previousDay: () => {
-            actions.setFilters(values.properties, moment(values.selectedDate).add(-1, 'day'), values.duration)
+            actions.setFilters(
+                values.properties,
+                moment(values.selectedDate).add(-1, 'day'),
+                values.duration,
+                values.actionFilter
+            )
         },
         nextDay: () => {
-            actions.setFilters(values.properties, moment(values.selectedDate).add(1, 'day'), values.duration)
+            actions.setFilters(
+                values.properties,
+                moment(values.selectedDate).add(1, 'day'),
+                values.duration,
+                values.actionFilter
+            )
         },
     }),
-    actionToUrl: ({ values }) => ({
-        setFilters: () => buildURL(values.selectedDateURLparam, values.sessionRecordingId, values.duration),
-        setSessionRecordingId: () => buildURL(values.selectedDateURLparam, values.sessionRecordingId, values.duration),
-        closeSessionPlayer: () => buildURL(values.selectedDateURLparam, null, values.duration),
-    }),
+    actionToUrl: ({ values }) => {
+        const buildURL = (overrides: Partial<Params> = {}): [string, Params] => {
+            const today = moment().startOf('day').format('YYYY-MM-DD')
+            let params: Params = {}
+
+            const { properties } = router.values.searchParams // eslint-disable-line
+            if (values.selectedDateURLparam !== today) {
+                params.date = values.selectedDateURLparam
+            }
+            if (properties) {
+                params.properties = properties
+            }
+            if (values.duration) {
+                params.duration = values.duration
+            }
+            if (values.sessionRecordingId) {
+                params.sessionRecordingId = values.sessionRecordingId
+            }
+            if (values.actionFilter) {
+                params.actionFilter = values.actionFilter
+            }
+
+            params = { ...params, ...overrides }
+
+            return [router.values.location.pathname, params]
+        }
+
+        return {
+            setFilters: () => buildURL(),
+            setSessionRecordingId: () => buildURL(),
+            closeSessionPlayer: () => buildURL({ sessionRecordingId: undefined }),
+        }
+    },
     urlToAction: ({ actions, values }) => ({
         '*': (_: any, params: Params) => {
             const newDate = params.date ? moment(params.date).startOf('day') : moment().startOf('day')
@@ -195,10 +218,16 @@ export const sessionsTableLogic = kea<
             if (
                 JSON.stringify(params.properties || []) !== JSON.stringify(values.properties) ||
                 JSON.stringify(params.duration || {}) !== JSON.stringify(values.duration || {}) ||
+                JSON.stringify(params.actionFilter || {}) !== JSON.stringify(values.actionFilter || {}) ||
                 !values.selectedDate ||
-                (values.selectedDate && values.selectedDate.format('YYYY-MM-DD') !== newDate.format('YYYY-MM-DD'))
+                values.selectedDate.format('YYYY-MM-DD') !== newDate.format('YYYY-MM-DD')
             ) {
-                actions.setFilters(params.properties || [], newDate, params.duration || null)
+                actions.setFilters(
+                    params.properties || [],
+                    newDate,
+                    params.duration || null,
+                    params.actionFilter || null
+                )
             } else if (values.sessions.length === 0) {
                 actions.loadSessions(true)
             }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -161,7 +161,7 @@ export interface Entity {
     id: string | number
     name: string
     order: number
-    type: string
+    type: 'actions' | 'events'
 }
 
 export interface PersonType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -164,6 +164,10 @@ export interface Entity {
     type: 'actions' | 'events'
 }
 
+export interface EntityWithProperties extends Entity {
+    properties: Record<string, any>
+}
+
 export interface PersonType {
     id: number
     uuid: string

--- a/posthog/models/filters/mixins/sessions.py
+++ b/posthog/models/filters/mixins/sessions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Dict, Optional, Union, cast
 
 from posthog.constants import DISTINCT_ID_FILTER
 from posthog.models.entity import Entity
@@ -41,7 +41,7 @@ class ActionFilterMixin(BaseParamMixin):
     @cached_property
     def action_filter(self) -> Optional[Entity]:
         if self._data.get("action_filter") is not None:
-            action_filter = self._data.get("action_filter")
+            action_filter = cast(Union[str, Dict], self._data.get("action_filter"))
             action_filter = json.loads(action_filter) if isinstance(action_filter, str) else action_filter
             return Entity(action_filter)
         else:

--- a/posthog/models/filters/mixins/sessions.py
+++ b/posthog/models/filters/mixins/sessions.py
@@ -1,6 +1,8 @@
+import json
 from typing import Optional
 
 from posthog.constants import DISTINCT_ID_FILTER
+from posthog.models.entity import Entity
 from posthog.models.filters.mixins.common import BaseParamMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
 
@@ -33,3 +35,14 @@ class DistinctIdMixin(BaseParamMixin):
     @include_dict
     def distinct_id_to_dict(self):
         return {"distinct_id": self.distinct_id} if self.distinct_id else {}
+
+
+class ActionFilterMixin(BaseParamMixin):
+    @cached_property
+    def action_filter(self) -> Optional[Entity]:
+        if self._data.get("action_filter") is not None:
+            action_filter = self._data.get("action_filter")
+            action_filter = json.loads(action_filter) if isinstance(action_filter, str) else action_filter
+            return Entity(action_filter)
+        else:
+            return None

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -1,12 +1,13 @@
+import json
 from typing import Any, Dict, Optional
 
 from django.http import HttpRequest
 
 from posthog.models import Filter
-from posthog.models.filters.mixins.sessions import DistinctIdMixin, DurationMixin, DurationOperatorMixin
+from posthog.models.filters.mixins.sessions import ActionFilterMixin, DistinctIdMixin, DurationMixin, DurationOperatorMixin
 
 
-class SessionsFilter(DurationMixin, DurationOperatorMixin, DistinctIdMixin, Filter):
+class SessionsFilter(ActionFilterMixin, DurationMixin, DurationOperatorMixin, DistinctIdMixin, Filter):
     def __init__(self, data: Dict[str, Any] = {}, request: Optional[HttpRequest] = None, **kwargs) -> None:
         super().__init__(data, request, **kwargs)
 

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -1,10 +1,14 @@
-import json
 from typing import Any, Dict, Optional
 
 from django.http import HttpRequest
 
 from posthog.models import Filter
-from posthog.models.filters.mixins.sessions import ActionFilterMixin, DistinctIdMixin, DurationMixin, DurationOperatorMixin
+from posthog.models.filters.mixins.sessions import (
+    ActionFilterMixin,
+    DistinctIdMixin,
+    DurationMixin,
+    DurationOperatorMixin,
+)
 
 
 class SessionsFilter(ActionFilterMixin, DurationMixin, DurationOperatorMixin, DistinctIdMixin, Filter):

--- a/posthog/queries/test/test_sessions.py
+++ b/posthog/queries/test/test_sessions.py
@@ -1,7 +1,6 @@
 from freezegun import freeze_time
 
-from posthog.models import Event, Person, Team
-from posthog.models.cohort import Cohort
+from posthog.models import Event
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.sessions import Sessions
 from posthog.test.base import BaseTest

--- a/posthog/queries/test/test_sessions_list.py
+++ b/posthog/queries/test/test_sessions_list.py
@@ -1,73 +1,135 @@
 from freezegun import freeze_time
 
-from posthog.models import Event, Person, Team
+from posthog.models import Action, ActionStep, Event, Person, Team
 from posthog.models.cohort import Cohort
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.sessions_list import SessionsList
 from posthog.test.base import BaseTest
 
 
-def sessions_list_test_factory(sessions, event_factory):
+def _create_action(**kwargs):
+    team = kwargs.pop("team")
+    name = kwargs.pop("name")
+    action = Action.objects.create(team=team, name=name)
+    ActionStep.objects.create(action=action, event=name)
+    return action
+
+
+def sessions_list_test_factory(sessions, event_factory, action_filter_enabled):
     class TestSessionsList(BaseTest):
         def test_sessions_list(self):
-            with freeze_time("2012-01-14T03:21:34.000Z"):
-                event_factory(team=self.team, event="1st action", distinct_id="1")
-                event_factory(team=self.team, event="1st action", distinct_id="2")
-            with freeze_time("2012-01-14T03:25:34.000Z"):
-                event_factory(team=self.team, event="2nd action", distinct_id="1")
-                event_factory(team=self.team, event="2nd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:34.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:35.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="1")
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
-                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-            team_2 = Team.objects.create()
-            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            # Test team leakage
-            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(SessionsFilter(data={"properties": []}), self.team)
-
-            self.assertEqual(len(response), 2)
-            self.assertEqual(response[0]["global_session_id"], 1)
+            self.create_test_data()
 
             with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(
-                    SessionsFilter(data={"properties": [{"key": "$os", "value": "Mac OS X"}]}), self.team,
-                )
-            self.assertEqual(len(response), 1)
+                response = self.run_query(SessionsFilter(data={"properties": []}))
+
+                self.assertEqual(len(response), 2)
+                self.assertEqual(response[0]["global_session_id"], 1)
+
+                response = self.run_query(SessionsFilter(data={"properties": [{"key": "$os", "value": "Mac OS X"}]}))
+                self.assertEqual(len(response), 1)
 
         def test_sessions_and_cohort(self):
-            with freeze_time("2012-01-14T03:21:34.000Z"):
-                event_factory(team=self.team, event="1st action", distinct_id="1")
-                event_factory(team=self.team, event="1st action", distinct_id="2")
-            with freeze_time("2012-01-14T03:25:34.000Z"):
-                event_factory(team=self.team, event="2nd action", distinct_id="1")
-                event_factory(team=self.team, event="2nd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:34.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="2")
-            with freeze_time("2012-01-15T03:59:35.000Z"):
-                event_factory(team=self.team, event="3rd action", distinct_id="1")
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                event_factory(team=self.team, event="4th action", distinct_id="1", properties={"$os": "Mac OS X"})
-                event_factory(team=self.team, event="4th action", distinct_id="2", properties={"$os": "Windows 95"})
-            team_2 = Team.objects.create()
-            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
-            # Test team leakage
-            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            self.create_test_data()
             cohort = Cohort.objects.create(team=self.team, groups=[{"properties": {"email": "bla"}}])
             cohort.calculate_people()
             with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(
-                    SessionsFilter(data={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}),
-                    self.team,
+                response = self.run_query(
+                    SessionsFilter(data={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],})
                 )
-            self.assertEqual(len(response), 1)
+                self.assertEqual(len(response), 1)
+
+        if action_filter_enabled:
+
+            def test_filter_by_entity_event(self):
+                self.create_test_data()
+
+                with freeze_time("2012-01-15T04:01:34.000Z"):
+                    self.assertLength(
+                        self.run_query(
+                            SessionsFilter(data={"action_filter": {"type": "events", "id": "custom-event"}})
+                        ),
+                        2,
+                    )
+                    self.assertLength(
+                        self.run_query(
+                            SessionsFilter(data={"action_filter": {"type": "events", "id": "another-event"}})
+                        ),
+                        1,
+                    )
+
+                    self.assertLength(
+                        self.run_query(
+                            SessionsFilter(
+                                data={
+                                    "action_filter": {
+                                        "type": "events",
+                                        "id": "custom-event",
+                                        "properties": [{"key": "$os", "value": "Mac OS X"}],
+                                    }
+                                }
+                            )
+                        ),
+                        1,
+                    )
+
+            def test_filter_by_entity_action(self):
+                action1 = _create_action(name="custom-event", team=self.team)
+                action2 = _create_action(name="another-event", team=self.team)
+
+                self.create_test_data()
+
+                with freeze_time("2012-01-15T04:01:34.000Z"):
+                    self.assertLength(
+                        self.run_query(SessionsFilter(data={"action_filter": {"type": "actions", "id": action1.id}})), 2
+                    )
+                    self.assertLength(
+                        self.run_query(SessionsFilter(data={"action_filter": {"type": "actions", "id": action2.id}})), 1
+                    )
+
+                    self.assertLength(
+                        self.run_query(
+                            SessionsFilter(
+                                data={
+                                    "action_filter": {
+                                        "type": "actions",
+                                        "id": action1.id,
+                                        "properties": [{"key": "$os", "value": "Mac OS X"}],
+                                    }
+                                }
+                            )
+                        ),
+                        1,
+                    )
+
+        def run_query(self, sessions_filter):
+            return sessions().run(sessions_filter, self.team)
+
+        def assertLength(self, value, expected):
+            self.assertEqual(len(value), expected)
+
+        def create_test_data(self):
+            with freeze_time("2012-01-14T03:21:34.000Z"):
+                event_factory(team=self.team, event="$pageview", distinct_id="1")
+                event_factory(team=self.team, event="$pageview", distinct_id="2")
+            with freeze_time("2012-01-14T03:25:34.000Z"):
+                event_factory(team=self.team, event="$pageview", distinct_id="1")
+                event_factory(team=self.team, event="$pageview", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:34.000Z"):
+                event_factory(team=self.team, event="$pageview", distinct_id="2")
+            with freeze_time("2012-01-15T03:59:35.000Z"):
+                event_factory(team=self.team, event="$pageview", distinct_id="1")
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                event_factory(team=self.team, event="custom-event", distinct_id="1", properties={"$os": "Mac OS X"})
+                event_factory(team=self.team, event="custom-event", distinct_id="2", properties={"$os": "Windows 95"})
+                event_factory(team=self.team, event="another-event", distinct_id="2", properties={"$os": "Windows 95"})
+            team_2 = Team.objects.create()
+            Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
+            # Test team leakage
+            Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
 
     return TestSessionsList
 
 
-class DjangoSessionsListTest(sessions_list_test_factory(SessionsList, Event.objects.create)):  # type: ignore
+class DjangoSessionsListTest(sessions_list_test_factory(SessionsList, Event.objects.create, action_filter_enabled=False)):  # type: ignore
     pass

--- a/posthog/queries/test/test_sessions_list.py
+++ b/posthog/queries/test/test_sessions_list.py
@@ -28,17 +28,14 @@ def sessions_list_test_factory(sessions, event_factory):
             # Test team leakage
             Person.objects.create(team=team_2, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
             with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = sessions().run(SessionsFilter(data={"events": [], "session": None}), self.team)
+                response = sessions().run(SessionsFilter(data={"properties": []}), self.team)
 
             self.assertEqual(len(response), 2)
             self.assertEqual(response[0]["global_session_id"], 1)
 
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = sessions().run(
-                    SessionsFilter(
-                        data={"events": [], "properties": [{"key": "$os", "value": "Mac OS X"}], "session": None}
-                    ),
-                    self.team,
+                    SessionsFilter(data={"properties": [{"key": "$os", "value": "Mac OS X"}]}), self.team,
                 )
             self.assertEqual(len(response), 1)
 
@@ -64,13 +61,7 @@ def sessions_list_test_factory(sessions, event_factory):
             cohort.calculate_people()
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = sessions().run(
-                    SessionsFilter(
-                        data={
-                            "events": [],
-                            "session": None,
-                            "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
-                        }
-                    ),
+                    SessionsFilter(data={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}),
                     self.team,
                 )
             self.assertEqual(len(response), 1)


### PR DESCRIPTION
## Changes

Video: https://i.imgur.com/oVcNPu4.mp4

Also added a shortcut to the new cohorts page:

![Screenshot from 2020-12-16 14-15-04](https://user-images.githubusercontent.com/148820/102347467-1fc59f00-3fa9-11eb-9fdf-b8ddf11982da.png)

## Next steps
I did not get to implementing it on postgres - it's slightly trickier to do so and it would make https://github.com/PostHog/posthog/issues/2739 even worse. 

Planning on tacking that next - either this week or in the new year.

Also we could move the action filter from insights page to sessions page to allow better filtering in there - will experiment in a separate branch.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
