### PR TITLE
Fix Docker Build

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /code
 WORKDIR /code
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl git make \
+    && apt-get install -y --no-install-recommends curl git build-essential \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && npm install -g yarn@1 \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git build-
     && yarn --frozen-lockfile \
     && cd .. \
     && yarn cache clean \
-    && apt-get purge -y curl \
+    && apt-get purge -y curl build-essential \
     && rm -rf node_modules \
 	&& rm -rf /var/lib/apt/lists/* \
     && rm -rf frontend/dist/*.map

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /code/plugins
 COPY plugins/package.json /code/plugins/
 COPY plugins/yarn.lock /code/plugins/
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl git make \
+RUN apt-get update && apt-get install -y --no-install-recommends curl git build-essential \
     && curl -sL https://deb.nodesource.com/setup_14.x  | bash - \
     && apt-get install nodejs -y --no-install-recommends \
     && npm install -g yarn@1 \


### PR DESCRIPTION
## Changes

- `node-rdkafka` requires a C compiler to install. This adds the `build-essentials` package that should fix this.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
