### PR TITLE
Make testing using docker a bit easier with docker-compose for ee

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -38,6 +38,8 @@ services:
         depends_on:
             - db
             - redis
+            - clickhouse
+            - kafka
         links:
             - db:db
             - redis:redis


### PR DESCRIPTION
This just makes sure that Kafka and Clickhouse are booted up if you want to run tests on docker (sometimes faster depending on the computer). This has been really helpful for me using remove dev environment.