### PR TITLE
Ignore plugins optional deps

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -18,7 +18,7 @@ fi
 
 cd plugins
 
-yarn --frozen-lockfile --silent
+yarn --frozen-lockfile --ignore-optional --silent
 if [ $? -ne 0 ]; then
     echo "Yarn failed!"
     exit 1

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && yarn --frozen-lockfile \
     && yarn build \
     && cd plugins \
-    && yarn --frozen-lockfile \
+    && yarn --frozen-lockfile --ignore-optional \
     && cd .. \
     && yarn cache clean \
     && apt-get purge -y curl \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git build-
     && yarn --frozen-lockfile \
     && yarn build \
     && cd plugins \
-    && yarn --frozen-lockfile \
+    && yarn --frozen-lockfile --ignore-optional \
     && cd .. \
     && yarn cache clean \
     && apt-get purge -y curl build-essential \


### PR DESCRIPTION
## Changes

- Alternative to https://github.com/PostHog/posthog-plugin-server/pull/78#pullrequestreview-554120750, this adds `--ignore-optional` to all `yarn install` commands running in `plugins/` 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
