### PR TITLE
Verbose Yarn build on plugin server build

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -18,7 +18,7 @@ fi
 
 cd plugins
 
-yarn --frozen-lockfile -v
+yarn --frozen-lockfile --verbose
 
 if [ $? -ne 0 ]; then
     echo "Yarn failed!"


### PR DESCRIPTION
This fixes the last attempt at verbose building using yarn, turns out -v is version not verbose 🤦 