### PR TITLE
Do not use SessionsFilter for insights sessions

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -14,18 +14,7 @@ from rest_framework.response import Response
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.user import UserSerializer
 from posthog.celery import update_cache_item_task
-from posthog.constants import (
-    DATE_FROM,
-    FROM_DASHBOARD,
-    INSIGHT,
-    INSIGHT_FUNNELS,
-    INSIGHT_PATHS,
-    INSIGHT_RETENTION,
-    INSIGHT_SESSIONS,
-    INSIGHT_TRENDS,
-    OFFSET,
-    TRENDS_STICKINESS,
-)
+from posthog.constants import FROM_DASHBOARD, INSIGHT, INSIGHT_FUNNELS, INSIGHT_PATHS, TRENDS_STICKINESS
 from posthog.decorators import CacheType, cached_function
 from posthog.models import DashboardItem, Event, Person, Team
 from posthog.models.filters import Filter, RetentionFilter

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -21,7 +21,6 @@ from posthog.constants import (
     EVENTS,
     INSIGHT,
     INSIGHT_RETENTION,
-    INSIGHT_SESSIONS,
     INSIGHT_TO_DISPLAY,
     INSIGHT_TRENDS,
     INTERVAL,
@@ -240,8 +239,6 @@ def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None) -> 
         insight = request.GET.get("insight")
     if insight == INSIGHT_RETENTION:
         return RetentionFilter(data={**data, "insight": INSIGHT_RETENTION}, request=request)
-    elif insight == INSIGHT_SESSIONS:
-        return SessionsFilter(data={**data, "insight": INSIGHT_SESSIONS}, request=request)
     elif insight == INSIGHT_TRENDS and data.get("shown_as") == "Stickiness":
         return StickinessFilter(data=data, request=request, team=team)
     return Filter(data=data, request=request)

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional
 
 from django.http import HttpRequest
 
-from posthog.constants import DISTINCT_ID_FILTER, INSIGHT_SESSIONS
+from posthog.constants import DISTINCT_ID_FILTER
 from posthog.models import Filter
 
 
@@ -12,7 +12,6 @@ class SessionsFilter(Filter):
     _duration: Optional[str]
 
     def __init__(self, data: Dict[str, Any] = {}, request: Optional[HttpRequest] = None, **kwargs) -> None:
-        data["insight"] = INSIGHT_SESSIONS
         super().__init__(data, request, **kwargs)
         if request:
             data = {


### PR DESCRIPTION
This is a bit confusing (my bad) - both insights and sessions list page
used to run under the same code path, but no more. SessionsFilter is for
sessions list.

Will fix and rename it once I get my open PR in :)

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
