### PR TITLE
More key feature instrumentation

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1,0 +1,35 @@
+import { kea } from 'kea'
+import posthog from 'posthog-js'
+import { userLogic } from 'scenes/userLogic'
+import { eventUsageLogicType } from 'types/lib/utils/eventUsageLogicType'
+import { AnnotationType } from '~/types'
+
+export const eventUsageLogic = kea<eventUsageLogicType>({
+    actions: {
+        reportAnnotationViewed: (payload) => ({ payload }),
+    },
+    listeners: {
+        reportAnnotationViewed: async ({ payload }: { payload: AnnotationType[] | null }, breakpoint) => {
+            if (!payload) {
+                // If value is `null` the component has been unmounted, we cancel the report if the timeout hasn't elapsed
+                return
+            }
+            await breakpoint(1500)
+
+            for (const annotation of payload) {
+                /* Report one event per annotation */
+                const properties = {
+                    total_items_count: payload.length,
+                    content_length: annotation.content.length,
+                    scope: annotation.scope,
+                    deleted: annotation.deleted,
+                    created_by_me: annotation.created_by && annotation.created_by?.id === userLogic.values.user?.id,
+                    creation_type: annotation.creation_type,
+                    created_at: annotation.created_at,
+                    updated_at: annotation.updated_at,
+                }
+                posthog.capture('annotation viewed', properties)
+            }
+        },
+    },
+})

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -16,10 +16,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
     listeners: {
         reportAnnotationViewed: async ({ annotations }: { annotations: AnnotationType[] | null }, breakpoint) => {
             if (!annotations) {
-                // If value is `null` the component has been unmounted, we cancel the report if the timeout hasn't elapsed
+                // If value is `null` the component has been unmounted, don't report
                 return
             }
-            await breakpoint(500)
+
+            await breakpoint(500) // Debounce calls to make sure we don't report accidentally hovering over an annotation.
 
             for (const annotation of annotations) {
                 /* Report one event per annotation */
@@ -57,7 +58,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
                 custom_properties_count,
                 posthog_properties_count,
             }
-            console.log('person viewed', properties)
             posthog.capture('person viewed', properties)
         },
     },

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -19,7 +19,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
                 // If value is `null` the component has been unmounted, we cancel the report if the timeout hasn't elapsed
                 return
             }
-            await breakpoint(1500)
+            await breakpoint(500)
 
             for (const annotation of annotations) {
                 /* Report one event per annotation */
@@ -37,7 +37,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             }
         },
         reportPersonDetailViewed: async ({ person }, breakpoint) => {
-            await breakpoint(5000)
+            await breakpoint(500)
 
             let custom_properties_count = 0
             let posthog_properties_count = 0

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -26,6 +26,14 @@ export interface UserType {
     email_service_available: boolean
 }
 
+/* Type for User objects in nested serializers (e.g. created_by) */
+export interface UserNestedType {
+    id: number
+    distinct_id: string
+    first_name: string
+    email: string
+}
+
 export interface UserUpdateType {
     user?: Omit<Partial<UserType>, 'team'>
     team?: Partial<TeamType>
@@ -310,4 +318,17 @@ export interface PluginErrorType {
     stack?: string
     name?: string
     event?: Record<string, any>
+}
+
+export interface AnnotationType {
+    id: string
+    scope: 'organization' | 'dashboard_item'
+    content: string
+    date_marker: string
+    created_by?: UserNestedType | null
+    created_at: string
+    updated_at: string
+    dashboard_item?: number
+    deleted?: boolean
+    creation_type?: string
 }


### PR DESCRIPTION
## Changes

Introduces more custom front-end events as planned on #2809.

- "person viewed" when the user views the person detail page is opened.
- "annotation viewed" when the user views an annotation pop-up.

In addition:
- It introduces an initial typing for "Annotation" (in the same spirit as #2787) and fixes
- Creates an `eventUsageLogic` to centralize custom front-end events reporting.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
