### PR TITLE
Refactor useEventListener to TypeScript

### DIFF
--- a/frontend/src/lib/hooks/useEventListener.ts
+++ b/frontend/src/lib/hooks/useEventListener.ts
@@ -1,13 +1,13 @@
 import { useEffect, useRef } from 'react'
 
-export function useEventListener(eventName, handler, element = window) {
-    // Create a ref that stores handler
-    const savedHandler = useRef()
+export type EventHandler = (event: Event) => void
 
-    // Update ref.current value if handler changes.
-    // This allows our effect below to always get latest handler ...
-    // ... without us needing to pass it in effect deps array ...
-    // ... and potentially cause effect to re-run every render.
+export function useEventListener(eventName: string, handler: EventHandler, element: Element | Window = window): void {
+    // Create a ref that stores handler
+    const savedHandler = useRef<EventHandler>(() => {})
+
+    // This allows our effect below to always get latest handler without us needing to pass it in effect deps array,
+    // which would potentially cause effect to re-run every render
     useEffect(() => {
         savedHandler.current = handler
     }, [handler])
@@ -15,18 +15,16 @@ export function useEventListener(eventName, handler, element = window) {
     useEffect(
         () => {
             // Make sure element supports addEventListener
-            // On
-            const isSupported = element && element.addEventListener
-            if (!isSupported) {
+            if (!element?.addEventListener) {
+                console.warn(
+                    `Could not start listening to ${eventName} on ${(element as Element)?.localName ?? 'window'}!`
+                )
                 return
             }
-
             // Create event listener that calls handler function stored in ref
-            const eventListener = (event) => savedHandler.current(event)
-
+            const eventListener: EventHandler = (event) => savedHandler.current(event)
             // Add event listener
             element.addEventListener(eventName, eventListener)
-
             // Remove event listener on cleanup
             return () => {
                 element.removeEventListener(eventName, eventListener)


### PR DESCRIPTION
## Changes

A refactor of useEventListener to TypeScript. Just a side-effect of developing [react-cmd](https://github.com/PostHog/react-cmd) (our command palette extracted to its own package, 100% TS).