### PR TITLE
Fix relative dates filters

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -67,6 +67,7 @@ def insight_test_factory(event_factory, person_factory):
                     "filters": {
                         "events": [{"id": "$pageview"}],
                         "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                        "date_from": "-90d",
                     },
                 },
                 content_type="application/json",
@@ -75,6 +76,7 @@ def insight_test_factory(event_factory, person_factory):
             response = DashboardItem.objects.all()
             self.assertEqual(len(response), 1)
             self.assertEqual(response[0].filters["events"][0]["id"], "$pageview")
+            self.assertEqual(response[0].filters["date_from"], "-90d")
 
         # BASIC TESTING OF ENDPOINTS. /queries as in depth testing for each insight
 

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -139,10 +139,16 @@ class Filter(PropertyMixin):
                 continue
             if not isinstance(value, list) and not value:
                 continue
-            if key == "date_from" and not self._date_from:
-                continue
-            if key == "date_to" and not self._date_to:
-                continue
+            if key == "date_from":
+                if self._date_from:
+                    value = self._date_from
+                else:
+                    continue
+            if key == "date_to":
+                if self._date_to:
+                    value = self._date_to
+                else:
+                    continue
             if isinstance(value, datetime.datetime):
                 value = value.isoformat()
             if not isinstance(value, (list, bool, int, float, str)):


### PR DESCRIPTION
## Changes

With the move to saving all filters using to_dict, every relative date would be converted to an absolute date.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
