### PR TITLE
Quick fix to limit time range on event prop query

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -144,7 +144,7 @@ def prop_filter_json_extract(
 def get_property_values_for_key(key: str, team: Team, value: Optional[str] = None):
 
     parsed_date_from = "AND timestamp >= '{}'".format(relative_date_parse("-7d").strftime("%Y-%m-%d 00:00:00"))
-    parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 00:00:00"))
+    parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 23:59:59"))
 
     if value:
         return sync_execute(

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
+from django.utils import timezone
+
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_int, is_json
@@ -8,6 +10,7 @@ from ee.clickhouse.sql.person import GET_DISTINCT_IDS_BY_PROPERTY_SQL
 from posthog.models.cohort import Cohort
 from posthog.models.property import Property
 from posthog.models.team import Team
+from posthog.utils import relative_date_parse
 
 
 def parse_prop_clauses(
@@ -139,8 +142,16 @@ def prop_filter_json_extract(
 
 
 def get_property_values_for_key(key: str, team: Team, value: Optional[str] = None):
+
+    parsed_date_from = "AND timestamp >= '{}'".format(relative_date_parse("-7d").strftime("%Y-%m-%d 00:00:00"))
+    parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 00:00:00"))
+
     if value:
         return sync_execute(
-            SELECT_PROP_VALUES_SQL_WITH_FILTER, {"team_id": team.pk, "key": key, "value": "%{}%".format(value)},
+            SELECT_PROP_VALUES_SQL_WITH_FILTER.format(parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to),
+            {"team_id": team.pk, "key": key, "value": "%{}%".format(value)},
         )
-    return sync_execute(SELECT_PROP_VALUES_SQL, {"team_id": team.pk, "key": key})
+    return sync_execute(
+        SELECT_PROP_VALUES_SQL.format(parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to),
+        {"team_id": team.pk, "key": key},
+    )

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -115,11 +115,11 @@ FROM events
 """
 
 SELECT_PROP_VALUES_SQL = """
-SELECT DISTINCT trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) FROM events where JSONHas(properties, %(key)s) AND team_id = %(team_id)s LIMIT 10
+SELECT DISTINCT trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) FROM events where JSONHas(properties, %(key)s) AND team_id = %(team_id)s {parsed_date_from} {parsed_date_to} LIMIT 10
 """
 
 SELECT_PROP_VALUES_SQL_WITH_FILTER = """
-SELECT DISTINCT trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) FROM events where team_id = %(team_id)s AND trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) LIKE %(value)s LIMIT 10
+SELECT DISTINCT trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) FROM events where team_id = %(team_id)s AND trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) LIKE %(value)s {parsed_date_from} {parsed_date_to} LIMIT 10
 """
 
 SELECT_EVENT_WITH_ARRAY_PROPS_SQL = """

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -214,7 +214,7 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         params.append(self.team_id)
         params.append(relative_date_parse("-7d").strftime("%Y-%m-%d 00:00:00"))
-        params.append(timezone.now().strftime("%Y-%m-%d 00:00:00"))
+        params.append(timezone.now().strftime("%Y-%m-%d 23:59:59"))
 
         # This samples a bunch of events with that property, and then orders them by most popular in that sample
         # This is much quicker than trying to do this over the entire table

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Any, Dict, List, Optional, Union, cast
 
 from django.db.models import Prefetch, QuerySet
+from django.utils import timezone
 from django.utils.timezone import now
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
@@ -19,7 +20,7 @@ from posthog.models.event import EventManager
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
 from posthog.queries.session_recording import SessionRecording
-from posthog.utils import convert_property_value, flatten
+from posthog.utils import convert_property_value, flatten, relative_date_parse
 
 
 class ElementSerializer(serializers.ModelSerializer):
@@ -212,6 +213,9 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             where = ""
 
         params.append(self.team_id)
+        params.append(relative_date_parse("-7d").strftime("%Y-%m-%d 00:00:00"))
+        params.append(timezone.now().strftime("%Y-%m-%d 00:00:00"))
+
         # This samples a bunch of events with that property, and then orders them by most popular in that sample
         # This is much quicker than trying to do this over the entire table
         values = Event.objects.raw(
@@ -225,7 +229,9 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                     "posthog_event"
                 WHERE
                     ("posthog_event"."properties" -> %s) IS NOT NULL {} AND
-                    ("posthog_event"."team_id" = %s)
+                    ("posthog_event"."team_id" = %s) AND
+                    ("posthog_event"."timestamp" >= %s) AND
+                    ("posthog_event"."timestamp" <= %s)
                 LIMIT 10000
             ) as "value"
             GROUP BY value

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -138,7 +138,7 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
                     properties={"random_prop": "don't include", "some other prop": "with some text"},
                 )
 
-            with freeze_time("2020-01-20"):
+            with freeze_time("2020-01-20 20:00:00"):
                 event_factory(
                     distinct_id="bla",
                     event="random event",

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -129,59 +129,78 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             return sign_up
 
         def test_event_property_values(self):
-            event_factory(
-                distinct_id="bla",
-                event="random event",
-                team=self.team,
-                properties={"random_prop": "asdf", "some other prop": "with some text"},
-            )
-            event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": "asdf"})
-            event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": "qwerty"})
-            event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": True})
-            event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": False})
-            event_factory(
-                distinct_id="bla",
-                event="random event",
-                team=self.team,
-                properties={"random_prop": {"first_name": "Mary", "last_name": "Smith"}},
-            )
-            event_factory(
-                distinct_id="bla", event="random event", team=self.team, properties={"something_else": "qwerty"}
-            )
-            event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": 565})
-            event_factory(
-                distinct_id="bla", event="random event", team=self.team, properties={"random_prop": ["item1", "item2"]}
-            )
-            event_factory(
-                distinct_id="bla", event="random event", team=self.team, properties={"random_prop": ["item3"]}
-            )
 
-            team2 = Team.objects.create()
-            event_factory(distinct_id="bla", event="random event", team=team2, properties={"random_prop": "abcd"})
-            response = self.client.get("/api/event/values/?key=random_prop").json()
+            with freeze_time("2020-01-10"):
+                event_factory(
+                    distinct_id="bla",
+                    event="random event",
+                    team=self.team,
+                    properties={"random_prop": "don't include", "some other prop": "with some text"},
+                )
 
-            keys = [resp["name"].replace(" ", "") for resp in response]
-            self.assertCountEqual(
-                keys,
-                [
-                    "asdf",
-                    "qwerty",
-                    "565",
-                    "false",
-                    "true",
-                    '{"first_name":"Mary","last_name":"Smith"}',
-                    "item1",
-                    "item2",
-                    "item3",
-                ],
-            )
-            self.assertEqual(len(response), 9)
+            with freeze_time("2020-01-20"):
+                event_factory(
+                    distinct_id="bla",
+                    event="random event",
+                    team=self.team,
+                    properties={"random_prop": "asdf", "some other prop": "with some text"},
+                )
+                event_factory(
+                    distinct_id="bla", event="random event", team=self.team, properties={"random_prop": "asdf"}
+                )
+                event_factory(
+                    distinct_id="bla", event="random event", team=self.team, properties={"random_prop": "qwerty"}
+                )
+                event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": True})
+                event_factory(
+                    distinct_id="bla", event="random event", team=self.team, properties={"random_prop": False}
+                )
+                event_factory(
+                    distinct_id="bla",
+                    event="random event",
+                    team=self.team,
+                    properties={"random_prop": {"first_name": "Mary", "last_name": "Smith"}},
+                )
+                event_factory(
+                    distinct_id="bla", event="random event", team=self.team, properties={"something_else": "qwerty"}
+                )
+                event_factory(distinct_id="bla", event="random event", team=self.team, properties={"random_prop": 565})
+                event_factory(
+                    distinct_id="bla",
+                    event="random event",
+                    team=self.team,
+                    properties={"random_prop": ["item1", "item2"]},
+                )
+                event_factory(
+                    distinct_id="bla", event="random event", team=self.team, properties={"random_prop": ["item3"]}
+                )
 
-            response = self.client.get("/api/event/values/?key=random_prop&value=qw").json()
-            self.assertEqual(response[0]["name"], "qwerty")
+                team2 = Team.objects.create()
+                event_factory(distinct_id="bla", event="random event", team=team2, properties={"random_prop": "abcd"})
+                response = self.client.get("/api/event/values/?key=random_prop").json()
 
-            response = self.client.get("/api/event/values/?key=random_prop&value=6").json()
-            self.assertEqual(response[0]["name"], "565")
+                keys = [resp["name"].replace(" ", "") for resp in response]
+                self.assertCountEqual(
+                    keys,
+                    [
+                        "asdf",
+                        "qwerty",
+                        "565",
+                        "false",
+                        "true",
+                        '{"first_name":"Mary","last_name":"Smith"}',
+                        "item1",
+                        "item2",
+                        "item3",
+                    ],
+                )
+                self.assertEqual(len(response), 9)
+
+                response = self.client.get("/api/event/values/?key=random_prop&value=qw").json()
+                self.assertEqual(response[0]["name"], "qwerty")
+
+                response = self.client.get("/api/event/values/?key=random_prop&value=6").json()
+                self.assertEqual(response[0]["name"], "565")
 
         def test_before_and_after(self):
             user = self._create_user("tim")

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -446,7 +446,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
-    # "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "PAGE_SIZE": 100,
 }
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -446,7 +446,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
-    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    # "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "PAGE_SIZE": 100,
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- log of long running queries
- hard limited the props to only show up from the past 7 days
- should follow up with a paginated solution
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
