### PR TITLE
Support different Reply-To header for most emails

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -63,7 +63,11 @@ def _send_email(
             records.append(record)
 
             email_message = mail.EmailMultiAlternatives(
-                subject=subject, body=txt_body, to=[dest["recipient"]], headers=headers,
+                subject=subject,
+                body=txt_body,
+                to=[dest["recipient"]],
+                headers=headers,
+                reply_to=settings.EMAIL_REPLY_TO,
             )
 
             email_message.attach_alternative(html_body, "text/html")

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -463,6 +463,7 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = get_bool_from_env("EMAIL_USE_TLS", False)
 EMAIL_USE_SSL = get_bool_from_env("EMAIL_USE_SSL", False)
 DEFAULT_FROM_EMAIL = os.environ.get("EMAIL_DEFAULT_FROM", os.environ.get("DEFAULT_FROM_EMAIL", "root@localhost"))
+EMAIL_REPLY_TO = os.environ.get("EMAIL_REPLY_TO")
 
 MULTI_TENANCY = False  # overriden by posthog-production
 

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -89,6 +89,10 @@
                 {
                     "name": "PLUGINS_CLOUD_WHITELISTED_ORG_IDS",
                     "value": "4dc8564d-bd82-1065-2f40-97f7c50f67cf,57543eee-fe77-11ea-b810-0902baec2d39"
+                },
+                {
+                    "name": "EMAIL_DEFAULT_FROM",
+                    "value": "hey@posthog.com"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

- Supports settings a custom `Reply-To` header on emails for PostHog emails via `EMAIL_REPLY_TO` environment variable (won't affect native Django emails, like for password reset).
- Adds a missing env var to the ECS task definition to make sure emails are properly sent.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
