### PR TITLE
Tests, fix for createActionFromEvent, clean up sessions query

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -84,10 +84,7 @@ class ClickhouseEventsViewSet(EventViewSet):
         return Response({"next": next_url, "results": result})
 
     def retrieve(self, request: Request, pk: Optional[int] = None, *args: Any, **kwargs: Any) -> Response:
-
-        # TODO: implement getting elements
-        team = self.team
-        query_result = sync_execute(SELECT_ONE_EVENT_SQL, {"team_id": team.pk, "event_id": pk},)
+        query_result = sync_execute(SELECT_ONE_EVENT_SQL, {"team_id": self.team.pk, "event_id": pk},)
         result = ClickhouseEventSerializer(query_result[0], many=False).data
 
         return Response(result)

--- a/frontend/src/scenes/events/__snapshots__/createActionFromEvent.test.js.snap
+++ b/frontend/src/scenes/events/__snapshots__/createActionFromEvent.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createActionFromEvent() action did not exist directs to the action page and shows toast 1`] = `
+Array [
+  Array [
+    <span>
+      Action succesfully created.
+       
+      <a
+        href="#"
+        onClick={[Function]}
+      >
+        Click here to go back.
+      </a>
+    </span>,
+  ],
+]
+`;

--- a/frontend/src/scenes/events/createActionFromEvent.js
+++ b/frontend/src/scenes/events/createActionFromEvent.js
@@ -29,7 +29,7 @@ function elementsToAction(elements) {
     }
 }
 
-export async function createActionFromEvent(event, increment) {
+export async function createActionFromEvent(event, increment, recurse = createActionFromEvent) {
     let actionData = {
         steps: [
             {
@@ -55,12 +55,12 @@ export async function createActionFromEvent(event, increment) {
         actionData.steps[0].properties = [{ key: '$event_type', value: 'submit' }]
     }
 
-    let action = false
+    let action = {}
     try {
         action = await api.create('api/action', actionData)
     } catch (response) {
         if (response.detail === 'action-exists' && increment < 30) {
-            return createActionFromEvent(event, increment + 1)
+            return recurse(event, increment + 1, recurse)
         }
     }
     if (action.id) {

--- a/frontend/src/scenes/events/createActionFromEvent.test.js
+++ b/frontend/src/scenes/events/createActionFromEvent.test.js
@@ -1,0 +1,122 @@
+import api from 'lib/api'
+import { router } from 'kea-router'
+import { toast } from 'react-toastify'
+import { createActionFromEvent } from './createActionFromEvent'
+
+jest.mock('lib/api')
+jest.mock('react-toastify')
+jest.mock('kea-router', () => ({
+    router: { actions: { push: jest.fn() } },
+}))
+
+describe('createActionFromEvent()', () => {
+    given('subject', () => () => createActionFromEvent(given.event, given.increment, given.recurse))
+
+    given('increment', () => 0)
+    given('recurse', () => jest.fn())
+
+    given('event', () => ({
+        id: 123,
+        event: given.eventName,
+        properties: {
+            $current_url: 'http://foo.bar/some/path',
+            $event_type: given.eventType,
+        },
+        elements: given.elements,
+    }))
+
+    given('eventName', () => 'some-event')
+    given('elements', () => [])
+    given('createResponse', () => ({ id: 456 }))
+
+    beforeEach(() => {
+        api.get.mockImplementation(() => Promise.resolve(given.event))
+        api.create.mockImplementation(() => Promise.resolve(given.createResponse))
+    })
+
+    describe('action did not exist', () => {
+        it('creates the correct action', async () => {
+            await given.subject()
+
+            expect(api.create).toHaveBeenCalledWith('api/action', {
+                name: 'some-event event',
+                steps: [{ event: 'some-event', url: 'http://foo.bar/some/path', url_matching: 'exact' }],
+            })
+        })
+
+        it('directs to the action page and shows toast', async () => {
+            await given.subject()
+
+            expect(router.actions.push).toHaveBeenCalledWith('/action/456')
+            expect(toast.mock.calls).toMatchSnapshot()
+        })
+
+        it('handles increments', async () => {
+            given('increment', () => 4)
+
+            await given.subject()
+
+            expect(api.create).toHaveBeenCalledWith('api/action', {
+                name: 'some-event event 4',
+                steps: [{ event: 'some-event', url: 'http://foo.bar/some/path', url_matching: 'exact' }],
+            })
+        })
+
+        it('handles submit $autocapture events with elements', async () => {
+            given('eventName', () => '$autocapture')
+            given('eventType', () => 'submit')
+            given('elements', () => [{ tag_name: 'form', text: 'Submit form!' }, {}])
+
+            await given.subject()
+
+            expect(api.create).toHaveBeenCalledWith('api/action', {
+                name: 'submitted form with text "Submit form!"',
+                steps: [
+                    {
+                        event: '$autocapture',
+                        url: 'http://foo.bar/some/path',
+                        url_matching: 'exact',
+                        tag_name: 'form',
+                        text: 'Submit form!',
+                        properties: [{ key: '$event_type', value: 'submit' }],
+                    },
+                ],
+            })
+        })
+
+        it('handles $pageview events', async () => {
+            given('eventName', () => '$pageview')
+
+            await given.subject()
+
+            expect(api.create).toHaveBeenCalledWith('api/action', {
+                name: 'Pageview on /some/path',
+                steps: [{ event: '$pageview', url: 'http://foo.bar/some/path', url_matching: 'exact' }],
+            })
+        })
+    })
+
+    describe('action already exists', () => {
+        beforeEach(() => {
+            api.create.mockImplementation(() => {
+                throw { detail: 'action-exists' }
+            })
+        })
+
+        it('recurses with increment + 1', async () => {
+            await given.subject()
+
+            expect(given.recurse).toHaveBeenCalledWith(given.event, 1, given.recurse)
+            expect(toast).not.toHaveBeenCalled()
+        })
+
+        it('stops recursion if increment == 30', async () => {
+            given('increment', () => 30)
+
+            await given.subject()
+
+            expect(given.recurse).not.toHaveBeenCalled()
+            expect(toast).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -114,7 +114,8 @@ export default {
     // restoreMocks: false,
 
     // The root directory that Jest should scan for tests and modules within
-    // rootDir: undefined,
+    rootDir: 'frontend/src',
+    modulePaths: ['<rootDir>/'],
 
     // A list of paths to directories that Jest should use to search for files in
     // roots: [

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -40,27 +40,16 @@ class BaseSessions(BaseQuery):
         )
 
     def build_all_sessions_query(self, events: QuerySet, _date_gte=Q()) -> Tuple[Query, QueryParams]:
-        sessions = (
-            events.filter(_date_gte)
-            .annotate(
-                previous_timestamp=Window(
-                    expression=Lag("timestamp", default=None),
-                    partition_by=F("distinct_id"),
-                    order_by=F("timestamp").asc(),
-                )
-            )
-            .annotate(
-                previous_event=Window(
-                    expression=Lag("event", default=None), partition_by=F("distinct_id"), order_by=F("timestamp").asc(),
-                )
+        sessions = events.filter(_date_gte).annotate(
+            previous_timestamp=Window(
+                expression=Lag("timestamp", default=None), partition_by=F("distinct_id"), order_by=F("timestamp").asc(),
             )
         )
 
         sessions_sql, sessions_sql_params = sessions.query.sql_with_params()
         all_sessions = """
             SELECT *,
-                SUM(new_session) OVER (ORDER BY distinct_id, timestamp) AS global_session_id,
-                SUM(new_session) OVER (PARTITION BY distinct_id ORDER BY timestamp) AS user_session_id
+                SUM(new_session) OVER (ORDER BY distinct_id, timestamp) AS global_session_id
                 FROM (
                     SELECT
                         id, team_id, distinct_id, event, elements_hash, timestamp, properties,

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -57,15 +57,21 @@ class BaseSessions(BaseQuery):
         )
 
         sessions_sql, sessions_sql_params = sessions.query.sql_with_params()
-        all_sessions = "\
-            SELECT *,\
-                SUM(new_session) OVER (ORDER BY distinct_id, timestamp) AS global_session_id,\
-                SUM(new_session) OVER (PARTITION BY distinct_id ORDER BY timestamp) AS user_session_id\
-                FROM (SELECT id, team_id, distinct_id, event, elements_hash, timestamp, properties, CASE WHEN EXTRACT('EPOCH' FROM (timestamp - previous_timestamp)) >= (60 * 30)\
-                    OR previous_timestamp IS NULL \
-                    THEN 1 ELSE 0 END AS new_session \
-                    FROM ({}) AS inner_sessions\
-                ) AS outer_sessions".format(
+        all_sessions = """
+            SELECT *,
+                SUM(new_session) OVER (ORDER BY distinct_id, timestamp) AS global_session_id,
+                SUM(new_session) OVER (PARTITION BY distinct_id ORDER BY timestamp) AS user_session_id
+                FROM (
+                    SELECT
+                        id, team_id, distinct_id, event, elements_hash, timestamp, properties,
+                        CASE
+                            WHEN EXTRACT('EPOCH' FROM (timestamp - previous_timestamp)) >= (60 * 30) OR previous_timestamp IS NULL
+                            THEN 1
+                            ELSE 0
+                        END AS new_session
+                    FROM ({}) AS inner_sessions
+                ) AS outer_sessions
+        """.format(
             sessions_sql
         )
 


### PR DESCRIPTION
- Remove a dead TODO
- Make sessions query more readable
- Remove dead code from sessions
- Make it possible to test with imports in jest
- Fix a bug and add tests to createActionFromEvent

Original plan was to get rid of N+1 (#2848) by loading elements async. 

Some of the refactorings here are still worthwhile though.  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
