### PR TITLE
Fix bug from query-selector-shadow-dom update

### DIFF
--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -134,7 +134,7 @@ export const elementsLogic = kea<
             (s) => [s.displayActionElements, actionsTabLogic.selectors.selectedEditedAction],
             (displayActionElements, selectedEditedAction): ElementWithMetadata[] => {
                 if (displayActionElements && selectedEditedAction?.steps) {
-                    const allElements = collectAllElementsDeep('', document, null)
+                    const allElements = collectAllElementsDeep('*', document)
                     const steps: ElementWithMetadata[] = []
                     selectedEditedAction.steps.forEach((step, index) => {
                         const element = getElementForStep(step, allElements)
@@ -187,7 +187,7 @@ export const elementsLogic = kea<
         actionsForElementMap: [
             (s) => [actionsLogic.selectors.sortedActions, s.rectUpdateCounter, toolbarLogic.selectors.buttonVisible],
             (sortedActions): ActionElementMap => {
-                const allElements = collectAllElementsDeep('', document, null)
+                const allElements = collectAllElementsDeep('*', document)
                 const actionsForElementMap = new Map<HTMLElement, ActionElementWithMetadata[]>()
                 sortedActions.forEach((action, index) => {
                     action.steps

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -79,7 +79,7 @@ export const heatmapLogic = kea<heatmapLogicType<ElementsEventType, CountedHTMLE
             (selectors) => [selectors.events],
             (events) => {
                 // cache all elements in shadow roots
-                const allElements = collectAllElementsDeep('', document, null)
+                const allElements = collectAllElementsDeep('*', document)
                 const elements: CountedHTMLElement[] = []
                 events.forEach((event) => {
                     let combinedSelector


### PR DESCRIPTION
## Changes

- Fixes a bug that came when I moved a library from `@mariusandra/query-selector-shadow-dom` to `query-selector-shadow-dom` in #2854
- Context: https://github.com/Georgegriff/query-selector-shadow-dom/issues/47
- Sentry: [1](https://sentry.io/organizations/posthog/issues/2132858322/?referrer=slack), [2](https://sentry.io/organizations/posthog/issues/2132757411/?referrer=slack)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
