### PR TITLE
Add missing paths viz condition

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.js
+++ b/frontend/src/scenes/dashboard/DashboardItem.js
@@ -156,7 +156,12 @@ export function DashboardItem({
     const [showSaveModal, setShowSaveModal] = useState(false)
 
     const _type =
-        item.filters.insight === ViewType.RETENTION ? 'RetentionContainer' : item.filters.display || 'ActionsLineGraph'
+        item.filters.insight === ViewType.RETENTION
+            ? 'RetentionContainer'
+            : item.filters.insight === ViewType.PATHS
+            ? 'PathsViz'
+            : item.filters.display || 'ActionsLineGraph'
+
     const className = displayMap[_type].className
     const Element = displayMap[_type].element
     const Icon = displayMap[_type].icon


### PR DESCRIPTION
## Changes

Fixes dashboard path item not appearing

*Please describe.*  
- after filter cleanup, we missed the insight type condition for paths

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
