### PR TITLE
Only grab recent events in Events list

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -1,6 +1,8 @@
 import json
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
+from django.utils.timezone import now
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -37,6 +39,8 @@ class ClickhouseEventsViewSet(EventViewSet):
         data = {}
         if request.GET.get("after"):
             data.update({"date_from": request.GET["after"]})
+        else:
+            data.update({"date_from": now() - timedelta(days=1)})
         if request.GET.get("before"):
             data.update({"date_to": request.GET["before"]})
         filter = Filter(data=data, request=request)


### PR DESCRIPTION
## Changes

Some clients had issues loading the events page on cloud. Massively limit what we try to sort to only the last 24 hours.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
