### PR TITLE
Limit events correctly

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -169,15 +169,7 @@ def determine_event_conditions(conditions: Dict[str, Union[str, List[str]]]) -> 
     for idx, (k, v) in enumerate(conditions.items()):
         if not isinstance(v, str):
             continue
-        if k == "after":
-            timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
-            result += "AND timestamp > %(after)s"
-            params.update({"after": timestamp})
-        elif k == "before":
-            timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
-            result += "AND timestamp < %(before)s"
-            params.update({"before": timestamp})
-        elif k == "person_id":
+        if k == "person_id":
             result += """AND distinct_id IN (%(distinct_ids)s)"""
             distinct_ids = Person.objects.filter(pk=v)[0].distinct_ids
             distinct_ids = [distinct_id.__str__() for distinct_id in distinct_ids]

--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -163,13 +163,23 @@ class ClickhouseEventSerializer(serializers.Serializer):
         return event[6]
 
 
-def determine_event_conditions(conditions: Dict[str, Union[str, List[str]]]) -> Tuple[str, Dict]:
+def determine_event_conditions(
+    conditions: Dict[str, Union[str, List[str]]], long_date_from: bool = False
+) -> Tuple[str, Dict]:
     result = ""
     params: Dict[str, Union[str, List[str]]] = {}
     for idx, (k, v) in enumerate(conditions.items()):
         if not isinstance(v, str):
             continue
-        if k == "person_id":
+        if k == "after" and not long_date_from:
+            timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
+            result += "AND timestamp > %(after)s"
+            params.update({"after": timestamp})
+        elif k == "before":
+            timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
+            result += "AND timestamp < %(before)s"
+            params.update({"before": timestamp})
+        elif k == "person_id":
             result += """AND distinct_id IN (%(distinct_ids)s)"""
             distinct_ids = Person.objects.filter(pk=v)[0].distinct_ids
             distinct_ids = [distinct_id.__str__() for distinct_id in distinct_ids]

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -38,7 +38,7 @@ def format_ch_timestamp(timestamp: datetime, filter, default_hour_min: str = " 0
     is_hour_or_min = (filter.interval and filter.interval.lower() == "hour") or (
         filter.interval and filter.interval.lower() == "minute"
     )
-    return timestamp.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if is_hour_or_min else default_hour_min))
+    return timestamp.strftime("%Y-%m-%d{}".format(" %H:%M:%S.%f" if is_hour_or_min else default_hour_min))
 
 
 def get_earliest_timestamp(team_id: int) -> datetime:

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -1,6 +1,8 @@
 import json
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
+from django.utils.timezone import now
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -37,6 +39,8 @@ class ClickhouseEventsViewSet(EventViewSet):
         data = {}
         if request.GET.get("after"):
             data.update({"date_from": request.GET["after"]})
+        else:
+            data.update({"date_from": now() - timedelta(days=1)})
         if request.GET.get("before"):
             data.update({"date_to": request.GET["before"]})
         filter = Filter(data=data, request=request)

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -45,7 +45,7 @@ class ClickhouseEventsViewSet(EventViewSet):
         if request.GET.get("action_id"):
             action = Action.objects.get(pk=request.GET["action_id"])
             if action.steps.count() == 0:
-                return Response({"next": False, "results": []})
+                return []
             action_query, params = format_action_filter(action)
             prop_filters += " AND {}".format(action_query)
             prop_filter_params = {**prop_filter_params, **params}

--- a/ee/clickhouse/views/test/test_clickhouse_event.py
+++ b/ee/clickhouse/views/test/test_clickhouse_event.py
@@ -1,7 +1,10 @@
 from uuid import uuid4
 
+from freezegun import freeze_time
+
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.api.test.base import TransactionBaseTest
 from posthog.api.test.test_event import test_event_api_factory
 from posthog.models import Action, ActionStep, Event, Person
 

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -348,9 +348,6 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             )
             event_factory(event="pageview", timestamp=timezone.now(), team=self.team, distinct_id="user1")
             response = self.client.get("/api/event/").json()
-            import ipdb
-
-            ipdb.set_trace()
             self.assertEqual(len(response["results"]), 2)
 
     return TestEvents

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -246,8 +246,7 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
                     team=self.team,
                     event="some event",
                     distinct_id="1",
-                    timestamp=timezone.datetime(2019, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-                    + relativedelta(days=idx, seconds=idx),
+                    timestamp=timezone.now() - relativedelta(months=11) + relativedelta(days=idx, seconds=idx),
                 )
             response = self.client.get("/api/event/?distinct_id=1").json()
             self.assertEqual(len(response["results"]), 100)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -338,6 +339,19 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
                 response_person_1 = self.client.get("/api/event/sessions/?distinct_id=1",).json()
 
             self.assertEqual(len(response_person_1["result"]), 1)
+
+        def test_optimize_query(self):
+            #  For ClickHouse we normally only query the last day,
+            # but if a user doesn't have many events we still want to return events that are older
+            event_factory(
+                event="pageview", timestamp=timezone.now() - timedelta(days=25), team=self.team, distinct_id="user1"
+            )
+            event_factory(event="pageview", timestamp=timezone.now(), team=self.team, distinct_id="user1")
+            response = self.client.get("/api/event/").json()
+            import ipdb
+
+            ipdb.set_trace()
+            self.assertEqual(len(response["results"]), 2)
 
     return TestEvents
 


### PR DESCRIPTION
## Changes

We'll now try to only get events for the last day, if that doesn't return enough data we fall back to the last year.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
