### PR TITLE
Fixes email from address

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -79,6 +79,10 @@
                 {
                     "name": "SITE_URL",
                     "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "EMAIL_DEFAULT_FROM",
+                    "value": "hey@posthog.com"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -79,6 +79,10 @@
                 {
                     "name": "SITE_URL",
                     "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "EMAIL_DEFAULT_FROM",
+                    "value": "hey@posthog.com"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Closes #2863. What was happening was that #2846 added the missing config var for emails to be sent via hey@posthog.com instead of `root@localhost` but this addressed emails being sent by the web worker (sync). This PR adds the required vars to the plugins & background worker as custom PostHog emails (e.g. team invites & weekly email report) are sent async.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
