### PR TITLE
Try to fix bgbouncer error in django admin in production

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -327,6 +327,8 @@ else:
 
 if DATABASE_URL:
     DATABASES = {"default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600)}
+    if DISABLE_SERVER_SIDE_CURSORS:
+        DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
 elif os.environ.get("POSTHOG_DB_NAME"):
     DATABASES = {
         "default": {


### PR DESCRIPTION
## Changes

- Django admin is currently unusable for us, since we're using bgbouncer and the `DISABLE_SERVER_SIDE_CURSORS` is not set in production
- Fixes errors such as [this one](https://sentry.io/organizations/posthog/issues/2008799998/?project=1899813&query=is%3Aunresolved)

Tested and seems to work for me:

![image](https://user-images.githubusercontent.com/53387/103879751-8e91a600-50d8-11eb-9e5c-c8f0ef09751f.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
