### PR TITLE
Add deployment environment variables

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -31,6 +31,7 @@
           DATABASE_URL: postgres://main:main@postgresdatabase.internal:5432/main
           REDIS_URL: redis://cache.internal:6379
           NODE_OPTIONS: --max_old_space_size=1536
+          DEPLOYMENT: Platform.sh
   workers:
     worker:
       commands:

--- a/app.json
+++ b/app.json
@@ -12,7 +12,8 @@
                 "SELF_CAPTURE": true,
                 "SECRET_KEY": {
                     "generator": "secret"
-                }
+                },
+                "DEPLOYMENT": "Heroku Review App"
             },
             "buildpacks": [{ "url": "heroku/nodejs" }, { "url": "heroku/python" }],
             "formation": {
@@ -65,6 +66,7 @@
     "env": {
         "SECRET_KEY": {
             "generator": "secret"
-        }
+        },
+        "DEPLOYMENT": "Heroku"
     }
 }

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -82,7 +82,7 @@
                 },
                 {
                     "name": "DEPLOYMENT",
-                    "value": "Production ECS"
+                    "value": "Posthog Cloud"
                 }
             ],
             "secrets": [

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -79,6 +79,10 @@
                 {
                     "name": "SITE_URL",
                     "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "DEPLOYMENT",
+                    "value": "Production ECS"
                 }
             ],
             "secrets": [

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -86,7 +86,7 @@
                 },
                 {
                     "name": "DEPLOYMENT",
-                    "value": "Production ECS"
+                    "value": "Posthog Cloud"
                 }
             ],
             "secrets": [

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -83,6 +83,10 @@
                 {
                     "name": "EMAIL_DEFAULT_FROM",
                     "value": "hey@posthog.com"
+                },
+                {
+                    "name": "DEPLOYMENT",
+                    "value": "Production ECS"
                 }
             ],
             "secrets": [

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -96,7 +96,7 @@
                 },
                 {
                     "name": "DEPLOYMENT",
-                    "value": "Production ECS"
+                    "value": "Posthog Cloud"
                 }
             ],
             "secrets": [

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -93,6 +93,10 @@
                 {
                     "name": "EMAIL_DEFAULT_FROM",
                     "value": "hey@posthog.com"
+                },
+                {
+                    "name": "DEPLOYMENT",
+                    "value": "Production ECS"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -86,7 +86,7 @@
                 },
                 {
                     "name": "DEPLOYMENT",
-                    "value": "Production ECS"
+                    "value": "Posthog Cloud"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -83,6 +83,10 @@
                 {
                     "name": "EMAIL_DEFAULT_FROM",
                     "value": "hey@posthog.com"
+                },
+                {
+                    "name": "DEPLOYMENT",
+                    "value": "Production ECS"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

The instance status report sends the variable [DEPLOYMENT](https://github.com/PostHog/posthog/blob/30cb3d60fe52683742e9fd3f035cc48ec5548071/posthog/tasks/status_report.py#L21). This is not set anywhere. This PR adds it to a few configured deployments.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
