### PR TITLE
Remove ancient ".map" redirect

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -39,8 +39,8 @@ from .views import health, preflight_check, stats, system_status
 
 
 def home(request, **kwargs):
-    if request.path.endswith(".map") or request.path.endswith(".map.js"):
-        return redirect("/static%s" % request.path)
+    # if request.path.endswith(".map") or request.path.endswith(".map.js"):
+    #     return redirect("/static%s" % request.path)
     return render_template("index.html", request)
 
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -39,8 +39,6 @@ from .views import health, preflight_check, stats, system_status
 
 
 def home(request, **kwargs):
-    # if request.path.endswith(".map") or request.path.endswith(".map.js"):
-    #     return redirect("/static%s" % request.path)
     return render_template("index.html", request)
 
 


### PR DESCRIPTION
## Changes

- Removing something old that now creates an endless loop and keeps adding "/static" to the URL
- Makes it possible to see source maps again.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
