### PR TITLE
Re-enable source maps in production.Dockerfile

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git build-
     && yarn cache clean \
     && apt-get purge -y curl build-essential \
     && rm -rf node_modules \
-	&& rm -rf /var/lib/apt/lists/* \
-    && rm -rf frontend/dist/*.map
+    && rm -rf /var/lib/apt/lists/*
 
 # install dependencies but ignore any we don't need for dev environment
 RUN pip install $(grep -ivE "psycopg2" requirements.txt | cut -d'#' -f1) --no-cache-dir --compile\


### PR DESCRIPTION
## Changes

- Fixes [a regression](https://github.com/PostHog/posthog/commit/3a943e1c1115215a88e3a63666ad9bdaa2ef45cf#diff-55d06c59f3552514747959fc163ad2940d33f0757fa48cf363580af437dee6a3R27) I made myself
- Adds 37MB of source maps to a build. Compressed in an image nobody will notice the size increase.
- Makes it possible to actually debug JS errors in sentry!

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
