### PR TITLE
Updated where our enterprise terms are found

### DIFF
--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -6,7 +6,7 @@ With regard to the PostHog Software:
 This software and associated documentation files (the "Software") may only be
 used in production, if you (and any entity that you represent) have agreed to,
 and are in compliance with, the PostHog Subscription Terms of Service, available
-via email (hey@posthog.com) (the “Enterprise Terms”), or other
+at https://posthog.com/terms (the “Enterprise Terms”), or other
 agreement governing the use of the Software, as agreed by you and PostHog,
 and otherwise have a valid PostHog Enterprise license for the
 correct number of user seats. Subject to the foregoing sentence, you are free to


### PR DESCRIPTION
Updated the text to point people to our terms URL on posthog.com (rather than emailing hey@posthog.com to ask for them).
