### PR TITLE
Fix sessions length distribution dataindex

### DIFF
--- a/frontend/src/scenes/insights/ActionsTable.js
+++ b/frontend/src/scenes/insights/ActionsTable.js
@@ -34,7 +34,10 @@ export function ActionsTable({ dashboardItemId = null, view, filters: filtersPar
                             )
                         },
                     },
-                    { title: filters.session ? 'Value' : 'Count', dataIndex: 'aggregated_value' },
+                    {
+                        title: filters.session ? 'Value' : 'Count',
+                        dataIndex: filters.session ? 'count' : 'aggregated_value',
+                    },
                 ]}
                 rowKey="label"
                 pagination={{ pageSize: 9999, hideOnSinglePage: true }}


### PR DESCRIPTION
## Changes

*Please describe.*  
- session length distribution wasn't showing because dataindex was incorrect

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
