### PR TITLE
Fix missing action when returning from dashboard

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -21,7 +21,7 @@ export function RetentionTab(): JSX.Element {
     const returningNode = useRef<HTMLElement>(null)
     const [open, setOpen] = useState<boolean>(false)
     const [returningOpen, setReturningOpen] = useState<boolean>(false)
-    const { filters } = useValues(retentionTableLogic({ dashboardItemId: null }))
+    const { filters, actionsLookup } = useValues(retentionTableLogic({ dashboardItemId: null }))
     const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: null }))
 
     const entityLogic = entityFilterLogic({
@@ -74,7 +74,9 @@ export function RetentionTab(): JSX.Element {
                 onClick={(): void => setOpen(!open)}
                 style={{ marginRight: 8 }}
             >
-                {filters.target_entity?.name || 'Select action'}
+                {filters.target_entity?.name ||
+                    (filters.target_entity.id && actionsLookup[filters.target_entity.id]) ||
+                    'Select action'}
                 <DownOutlined className="text-muted" style={{ marginRight: '-6px' }} />
             </Button>
             <Select
@@ -109,7 +111,9 @@ export function RetentionTab(): JSX.Element {
                 data-attr="retention-returning-action"
                 onClick={(): void => setReturningOpen(!returningOpen)}
             >
-                {filters.returning_entity?.name || 'Select action'}
+                {filters.returning_entity?.name ||
+                    (filters.returning_entity.id && actionsLookup[filters.returning_entity.id]) ||
+                    'Select action'}
                 <DownOutlined className="text-muted" style={{ marginRight: '-6px' }} />
             </Button>
             <ActionFilterDropdown

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -7,6 +7,8 @@ import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insight
 import { Moment } from 'moment'
 import { retentionTableLogicType } from 'types/scenes/retention/retentionTableLogicType'
 import { ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_TABLE } from 'lib/constants'
+import { actionsModel } from '~/models'
+import { ActionType } from '~/types'
 
 export const dateOptions = ['Hour', 'Day', 'Week', 'Month']
 
@@ -75,6 +77,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
     }),
     connect: {
         actions: [insightLogic, ['setAllFilters'], insightHistoryLogic, ['createInsight']],
+        values: [actionsModel, ['actions']],
     },
     actions: () => ({
         setFilters: (filters) => ({ filters }),
@@ -110,6 +113,12 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
             },
         ],
     }),
+    selectors: {
+        actionsLookup: [
+            (selectors) => [selectors.actions],
+            (actions: ActionType[]) => Object.assign({}, ...actions.map((action) => ({ [action.id]: action.name }))),
+        ],
+    },
     events: ({ actions, props }) => ({
         afterMount: () => props.dashboardItemId && actions.loadResults(),
     }),


### PR DESCRIPTION
## Changes

*Please describe.*  
- previously, when you went from a retention dashboard item to retention insight page, actions wouldn't be refilled

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
