### PR TITLE
Adds backend instrumentation to actions & cohorts

### DIFF
--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -164,7 +164,7 @@ class ActionViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         self._calculate_action(action)
         posthoganalytics.capture(
             request.user.distinct_id,
-            "action created",
+            "action updated",
             {**action.get_analytics_metadata(), "updated_by_creator": request.user == action.created_by},
         )
         return Response(self.serializer_class(action, context={"request": request}).data)

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -45,6 +45,7 @@ class TestCreateAction(BaseTest):
                 "match_selector_count": 1,
                 "match_url_count": 1,
                 "has_properties": False,
+                "deleted": False,
             },
         )
 
@@ -119,6 +120,7 @@ class TestCreateAction(BaseTest):
                 "match_url_count": 0,
                 "has_properties": True,
                 "updated_by_creator": False,
+                "deleted": False,
             },
         )
 

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -1,18 +1,19 @@
 from unittest.mock import patch
 
-from posthog.models import Cohort, Person
+from posthog.models import Person
 from posthog.test.base import BaseTest
 
 
 class TestCohort(BaseTest):
     TESTS_API = True
 
+    @patch("posthoganalytics.capture")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort.delay")
-    def test_creating_update_and_calculating(self, patch_calculate_cohort):
+    def test_creating_update_and_calculating(self, patch_calculate_cohort, patch_capture):
         self.team.app_urls = ["http://somewebsite.com"]
         self.team.save()
-        person1 = Person.objects.create(team=self.team, properties={"team_id": 5})
-        person2 = Person.objects.create(team=self.team, properties={"team_id": 6})
+        Person.objects.create(team=self.team, properties={"team_id": 5})
+        Person.objects.create(team=self.team, properties={"team_id": 6})
 
         # Make sure the endpoint works with and without the trailing slash
         response = self.client.post(
@@ -24,6 +25,20 @@ class TestCohort(BaseTest):
         self.assertEqual(response.json()["created_by"]["id"], self.user.pk)
         self.assertEqual(patch_calculate_cohort.call_count, 1)
 
+        # Assert analytics are sent
+        patch_capture.assert_called_with(
+            self.user.distinct_id,
+            "cohort created",
+            {
+                "name_length": 8,
+                "person_count_precalc": 0,
+                "groups_count": 1,
+                "action_groups_count": 0,
+                "properties_groups_count": 1,
+                "deleted": False,
+            },
+        )
+
         response = self.client.patch(
             "/api/cohort/%s/" % response.json()["id"],
             data={"name": "whatever2", "groups": [{"properties": {"team_id": 6}}]},
@@ -32,3 +47,18 @@ class TestCohort(BaseTest):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(response.json()["name"], "whatever2")
         self.assertEqual(patch_calculate_cohort.call_count, 2)
+
+        # Assert analytics are sent
+        patch_capture.assert_called_with(
+            self.user.distinct_id,
+            "cohort updated",
+            {
+                "name_length": 9,
+                "person_count_precalc": 0,
+                "groups_count": 1,
+                "action_groups_count": 0,
+                "properties_groups_count": 1,
+                "deleted": False,
+                "updated_by_creator": True,
+            },
+        )

--- a/posthog/models/action.py
+++ b/posthog/models/action.py
@@ -118,4 +118,5 @@ class Action(models.Model):
             "match_selector_count": self.steps.exclude(Q(selector="") | Q(selector__isnull=True)).count(),
             "match_url_count": self.steps.exclude(Q(url="") | Q(url__isnull=True)).count(),
             "has_properties": self.steps.exclude(properties=[]).exists(),
+            "deleted": self.deleted,
         }

--- a/posthog/models/action.py
+++ b/posthog/models/action.py
@@ -111,7 +111,7 @@ class Action(models.Model):
             "post_to_slack": self.post_to_slack,
             "name_length": len(self.name),
             "custom_slack_message_format": self.slack_message_format != "",
-            "event_count": self.events.count(),
+            "event_count_precalc": self.events.count(),  # `precalc` because events are computed async
             "step_count": self.steps.count(),
             "match_text_count": self.steps.exclude(Q(text="") | Q(text__isnull=True)).count(),
             "match_href_count": self.steps.exclude(Q(href="") | Q(href__isnull=True)).count(),

--- a/posthog/models/action.py
+++ b/posthog/models/action.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.core.exceptions import EmptyResultSet
 from django.db import connection, models, transaction
+from django.db.models import Q
 from django.utils import timezone
 from rest_hooks.signals import raw_hook_event
 from sentry_sdk import capture_exception
@@ -71,7 +72,7 @@ class Action(models.Model):
         with transaction.atomic():
             try:
                 cursor.execute(query, params)
-            except:
+            except Exception:
                 capture_exception()
 
         self.is_calculating = False
@@ -104,3 +105,17 @@ class Action(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_analytics_metadata(self):
+        return {
+            "post_to_slack": self.post_to_slack,
+            "name_length": len(self.name),
+            "custom_slack_message_format": self.slack_message_format != "",
+            "event_count": self.events.count(),
+            "step_count": self.steps.count(),
+            "match_text_count": self.steps.exclude(Q(text="") | Q(text__isnull=True)).count(),
+            "match_href_count": self.steps.exclude(Q(href="") | Q(href__isnull=True)).count(),
+            "match_selector_count": self.steps.exclude(Q(selector="") | Q(selector__isnull=True)).count(),
+            "match_url_count": self.steps.exclude(Q(url="") | Q(url__isnull=True)).count(),
+            "has_properties": self.steps.exclude(properties=[]).exists(),
+        }

--- a/posthog/models/action_step.py
+++ b/posthog/models/action_step.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.fields import JSONField
-from django.db import connection, models, transaction
+from django.db import models
 
 
 class ActionStep(models.Model):
@@ -18,7 +18,7 @@ class ActionStep(models.Model):
     selector: models.CharField = models.CharField(max_length=65535, null=True, blank=True)
     url: models.CharField = models.CharField(max_length=65535, null=True, blank=True)
     url_matching: models.CharField = models.CharField(
-        max_length=400, choices=URL_MATCHING, default=CONTAINS, null=True, blank=True
+        max_length=400, choices=URL_MATCHING, default=CONTAINS, null=True, blank=True,
     )
     name: models.CharField = models.CharField(max_length=400, null=True, blank=True)
     event: models.CharField = models.CharField(max_length=400, null=True, blank=True)

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -65,10 +65,8 @@ class Cohort(models.Model):
         action_groups_count: int = 0
         properties_groups_count: int = 0
         for group in self.groups:
-            if group.get("action_id"):
-                action_groups_count += 1
-            elif group.get("properties"):
-                properties_groups_count += 1
+            action_groups_count += 1 if group.get("action_id") else 0
+            properties_groups_count += 1 if group.get("properties") else 0
 
         return {
             "name_length": len(self.name),

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -72,8 +72,8 @@ class Cohort(models.Model):
 
         return {
             "name_length": len(self.name),
-            "person_count": self.people.count(),
-            "groups_count": self.groups.count(),
+            "person_count_precalc": self.people.count(),
+            "groups_count": len(self.groups),
             "action_groups_count": action_groups_count,
             "properties_groups_count": properties_groups_count,
             "deleted": self.deleted,

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -61,6 +61,24 @@ class Cohort(models.Model):
 
     objects = CohortManager()
 
+    def get_analytics_metadata(self):
+        action_groups_count: int = 0
+        properties_groups_count: int = 0
+        for group in self.groups:
+            if group.get("action_id"):
+                action_groups_count += 1
+            elif group.get("properties"):
+                properties_groups_count += 1
+
+        return {
+            "name_length": len(self.name),
+            "person_count": self.people.count(),
+            "groups_count": self.groups.count(),
+            "action_groups_count": action_groups_count,
+            "properties_groups_count": properties_groups_count,
+            "deleted": self.deleted,
+        }
+
     def calculate_people(self, use_clickhouse=is_ee_enabled()):
         try:
             if not use_clickhouse:
@@ -87,7 +105,7 @@ class Cohort(models.Model):
                 self.last_calculation = timezone.now()
                 self.errors_calculating = 0
                 self.save()
-        except:
+        except Exception:
             self.is_calculating = False
             self.errors_calculating = F("errors_calculating") + 1
             self.save()


### PR DESCRIPTION
## Changes

Closes #1575.
- Implements `action created` & `action updated` server-side events with a bunch of metadata.
- Implements `cohort created` & `cohort updated` events.
- Removes some unused imports & other flake cleanup.

Particularly worth noting that there are no `{action|cohort} deleted` events because we currently only support soft-deleting these, which woudl trigger a `{action|cohort updated` event with a `deleted = True` attribute.


## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
