### PR TITLE
Sorting UI improvements

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
@@ -6,6 +6,7 @@ import { ActionFilterRow } from './ActionFilterRow'
 import { Button } from 'antd'
 import { PlusCircleOutlined, EllipsisOutlined } from '@ant-design/icons'
 import { sortableContainer, sortableElement, sortableHandle } from 'react-sortable-hoc'
+import posthog from 'posthog-js'
 
 const DragHandle = sortableHandle(() => (
     <span className="action-filter-drag-handle">
@@ -50,13 +51,15 @@ export function ActionFilter({
     }, [filters])
 
     function onSortEnd({ oldIndex, newIndex }) {
-        console.log('sortEnd', oldIndex, newIndex)
         const move = (arr, from, to) => {
             const clone = [...arr]
             Array.prototype.splice.call(clone, to, 0, Array.prototype.splice.call(clone, from, 1)[0])
             return clone.map((child, order) => ({ ...child, order }))
         }
         setFilters(toFilters(move(localFilters, oldIndex, newIndex)))
+        if (oldIndex !== newIndex) {
+            posthog.capture('funnel step reordered')
+        }
     }
 
     return (

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
@@ -12,9 +12,9 @@ const DragHandle = sortableHandle(() => (
         <EllipsisOutlined />
     </span>
 ))
-const SortableActionFilterRow = sortableElement(({ logic, filter, filterIndex, hideMathSelector }) => (
+const SortableActionFilterRow = sortableElement(({ logic, filter, filterIndex, hideMathSelector, filterCount }) => (
     <div className="draggable-action-filter">
-        <DragHandle />
+        {filterCount > 1 && <DragHandle />}
         <ActionFilterRow
             logic={logic}
             filter={filter}
@@ -50,6 +50,7 @@ export function ActionFilter({
     }, [filters])
 
     function onSortEnd({ oldIndex, newIndex }) {
+        console.log('sortEnd', oldIndex, newIndex)
         const move = (arr, from, to) => {
             const clone = [...arr]
             Array.prototype.splice.call(clone, to, 0, Array.prototype.splice.call(clone, from, 1)[0])
@@ -71,6 +72,7 @@ export function ActionFilter({
                                 index={index}
                                 filterIndex={index}
                                 hideMathSelector={hideMathSelector}
+                                filterCount={localFilters.length}
                             />
                         ))}
                     </SortableContainer>

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
@@ -4,10 +4,14 @@ import { useActions, useValues } from 'kea'
 import { entityFilterLogic, toFilters } from './entityFilterLogic'
 import { ActionFilterRow } from './ActionFilterRow'
 import { Button } from 'antd'
-import { PlusCircleOutlined } from '@ant-design/icons'
+import { PlusCircleOutlined, EllipsisOutlined } from '@ant-design/icons'
 import { sortableContainer, sortableElement, sortableHandle } from 'react-sortable-hoc'
 
-const DragHandle = sortableHandle(() => <span className="action-filter-drag-handle">::</span>)
+const DragHandle = sortableHandle(() => (
+    <span className="action-filter-drag-handle">
+        <EllipsisOutlined />
+    </span>
+))
 const SortableActionFilterRow = sortableElement(({ logic, filter, filterIndex, hideMathSelector }) => (
     <div className="draggable-action-filter">
         <DragHandle />

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.scss
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.scss
@@ -1,10 +1,17 @@
+@import '~/vars';
+
 .draggable-action-filter {
     margin-top: 16px;
     display: flex;
 
     .action-filter-drag-handle {
         cursor: move;
-        padding-right: 6px;
+        padding-right: 2px;
+        color: $text_default;
+        font-size: 1.2em;
+        svg {
+            transform: rotate(90deg);
+        }
     }
     .ant-row.mt {
         margin-top: 0;


### PR DESCRIPTION
## Changes

- Switches the dragging handle to use an Ant icon.
<img width="229" alt="" src="https://user-images.githubusercontent.com/5864173/103966682-f8846c80-5125-11eb-8acd-c8eb7fe48174.png">
- Hides the dragging handle when there's only one step in the funnel. This also increases discoverability for the new functionality as you can visually see the switch of the dragging handles appearing on the screen when you add a new step.
- Adds custom event `funnel step reordered` when the user has used the feature.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
