### PR TITLE
Refactor properties_to_Q to not be tied to Filter objects

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -7,6 +7,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthentication
 from posthog.models import Element, ElementGroup, Event, Filter, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions
+from posthog.queries.base import properties_to_Q
 
 
 class ElementSerializer(serializers.ModelSerializer):
@@ -46,7 +47,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         events = (
             Event.objects.filter(team_id=team_id, event="$autocapture")
-            .filter(filter.properties_to_Q(team_id=team_id))
+            .filter(properties_to_Q(filter.properties, team_id=team_id))
             .filter(filter.date_filter_Q)
         )
 

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -19,6 +19,7 @@ from posthog.models.action import Action
 from posthog.models.event import EventManager
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
+from posthog.queries.base import properties_to_Q
 from posthog.queries.session_recording import SessionRecording
 from posthog.utils import convert_property_value, flatten, relative_date_parse
 
@@ -131,7 +132,7 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 queryset = queryset.filter_by_action(Action.objects.get(pk=value))  # type: ignore
             elif key == "properties":
                 filter = Filter(data={"properties": json.loads(value)})
-                queryset = queryset.filter(filter.properties_to_Q(team_id=self.team_id))
+                queryset = queryset.filter(properties_to_Q(filter.properties, team_id=self.team_id))
         return queryset
 
     def _prefetch_events(self, events: List[Event]) -> List[Event]:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -19,6 +19,7 @@ from posthog.models import Event, Filter, Person
 from posthog.models.filters import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
+from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
@@ -114,9 +115,8 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if request.GET.get("cohort"):
             queryset = queryset.filter(cohort__id=request.GET["cohort"])
         if request.GET.get("properties"):
-            queryset = queryset.filter(
-                Filter(data={"properties": json.loads(request.GET["properties"])}).properties_to_Q(team_id=self.team_id)
-            )
+            filter = Filter(data={"properties": json.loads(request.GET["properties"])})
+            queryset = queryset.filter(properties_to_Q(filter.properties, team_id=self.team_id))
 
         queryset = queryset.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
         return queryset

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from sentry_sdk import capture_exception
 
 from posthog.ee import is_ee_enabled
-from posthog.queries.base import properties_to_Q
 
 from .action import Action
 from .event import Event
@@ -107,6 +106,8 @@ class Cohort(models.Model):
         return Person.objects.filter(self._people_filter(), team=self.team)
 
     def _people_filter(self, extra_filter=None):
+        from posthog.queries.base import properties_to_Q
+
         filters = Q()
         for group in self.groups:
             if group.get("action_id"):

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from sentry_sdk import capture_exception
 
 from posthog.ee import is_ee_enabled
+from posthog.queries.base import properties_to_Q
 
 from .action import Action
 from .event import Event
@@ -129,7 +130,7 @@ class Cohort(models.Model):
                 filters |= Q(persondistinctid__distinct_id__in=events)
             elif group.get("properties"):
                 filter = Filter(data=group)
-                filters |= Q(filter.properties_to_Q(team_id=self.team_id, is_person_query=True))
+                filters |= Q(properties_to_Q(filter.properties, team_id=self.team_id, is_person_query=True))
         return filters
 
 

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -13,6 +13,7 @@ from django.forms.models import model_to_dict
 from django.utils import timezone
 
 from posthog.ee import is_ee_enabled
+from posthog.queries.base import properties_to_Q
 
 from .action import Action
 from .action_step import ActionStep
@@ -199,7 +200,7 @@ class EventManager(models.QuerySet):
             subquery = (
                 Event.objects.add_person_id(team_id=action.team_id)
                 .filter(
-                    Filter(data={"properties": step.properties}).properties_to_Q(team_id=action.team_id),
+                    properties_to_Q(step.properties, team_id=action.team_id),
                     pk=OuterRef("id"),
                     **self.filter_by_event(step),
                     **self.filter_by_element(model_to_dict(step), team_id=action.team_id),

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -198,10 +198,12 @@ class EventManager(models.QuerySet):
             return self.none()
 
         for step in steps:
+            step_filter = Filter(data={"properties": step.properties})
+
             subquery = (
                 Event.objects.add_person_id(team_id=action.team_id)
                 .filter(
-                    properties_to_Q(step.properties, team_id=action.team_id),
+                    properties_to_Q(step_filter.properties, team_id=action.team_id),
                     pk=OuterRef("id"),
                     **self.filter_by_event(step),
                     **self.filter_by_element(model_to_dict(step), team_id=action.team_id),

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -13,7 +13,6 @@ from django.forms.models import model_to_dict
 from django.utils import timezone
 
 from posthog.ee import is_ee_enabled
-from posthog.queries.base import properties_to_Q
 
 from .action import Action
 from .action_step import ActionStep
@@ -190,6 +189,8 @@ class EventManager(models.QuerySet):
         )
 
     def query_db_by_action(self, action, order_by="-timestamp", start=None, end=None) -> models.QuerySet:
+        from posthog.queries.base import properties_to_Q
+
         events = self
         any_step = Q()
         steps = action.steps.all()

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -7,6 +7,8 @@ from django.db import models
 from django.dispatch import receiver
 from django.utils import timezone
 
+from posthog.queries.base import properties_to_Q
+
 from .filters import Filter
 from .person import Person
 
@@ -43,9 +45,10 @@ class FeatureFlag(models.Model):
         return False
 
     def _match_distinct_id(self, distinct_id: str) -> bool:
+        filter = Filter(data=self.filters)
         return (
             Person.objects.filter(team_id=self.team_id, persondistinctid__distinct_id=distinct_id)
-            .filter(Filter(data=self.filters).properties_to_Q(team_id=self.team_id, is_person_query=True))
+            .filter(properties_to_Q(filter.properties, team_id=self.team_id, is_person_query=True))
             .exists()
         )
 

--- a/posthog/models/filters/mixins/property.py
+++ b/posthog/models/filters/mixins/property.py
@@ -1,12 +1,9 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple, Union
-
-from django.db.models import Exists, OuterRef, Q
+from typing import Any, List, Optional
 
 from posthog.constants import PROPERTIES
 from posthog.models.filters.mixins.base import BaseParamMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
-from posthog.models.person import Person
 from posthog.models.property import Property
 
 
@@ -16,64 +13,6 @@ class PropertyMixin(BaseParamMixin):
         _props = self._data.get(PROPERTIES)
         loaded_props = json.loads(_props) if isinstance(_props, str) else _props
         return self._parse_properties(loaded_props)
-
-    def properties_to_Q(self, team_id: int, is_person_query: bool = False) -> Q:
-        """
-        Converts a filter to Q, for use in Django ORM .filter()
-        If you're filtering a Person QuerySet, use is_person_query to avoid doing an unnecessary nested loop
-        """
-        filters = Q()
-
-        if len(self.properties) == 0:
-            return filters
-
-        if is_person_query:
-            for property in self.properties:
-                filters &= property.property_to_Q()
-            return filters
-
-        person_properties = [prop for prop in self.properties if prop.type == "person"]
-        if len(person_properties) > 0:
-            person_Q = Q()
-            for property in person_properties:
-                person_Q &= property.property_to_Q()
-            filters &= Q(Exists(Person.objects.filter(person_Q, id=OuterRef("person_id"),).only("pk")))
-
-        for property in [prop for prop in self.properties if prop.type == "event"]:
-            filters &= property.property_to_Q()
-
-        # importing from .event and .cohort below to avoid importing from partially initialized modules
-
-        element_properties = [prop for prop in self.properties if prop.type == "element"]
-        if len(element_properties) > 0:
-            from posthog.models.event import Event
-
-            filters &= Q(
-                Exists(
-                    Event.objects.filter(pk=OuterRef("id"))
-                    .filter(
-                        **Event.objects.filter_by_element(
-                            {item.key: item.value for item in element_properties}, team_id=team_id,
-                        )
-                    )
-                    .only("id")
-                )
-            )
-
-        cohort_properties = [prop for prop in self.properties if prop.type == "cohort"]
-        if len(cohort_properties) > 0:
-            from posthog.models.cohort import CohortPeople
-
-            for item in cohort_properties:
-                if item.key == "id":
-                    filters &= Q(
-                        Exists(
-                            CohortPeople.objects.filter(
-                                cohort_id=int(item.value), person_id=OuterRef("person_id"),
-                            ).only("id")
-                        )
-                    )
-        return filters
 
     def _parse_properties(self, properties: Optional[Any]) -> List[Property]:
         if isinstance(properties, list):

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -8,7 +8,8 @@ from freezegun.api import freeze_time
 
 from posthog.models import Cohort, Element, Event, Filter, Person
 from posthog.models.team import Team
-from posthog.test.base import BaseTest, properties_to_Q
+from posthog.queries.base import properties_to_Q
+from posthog.test.base import BaseTest
 
 
 class TestFilter(BaseTest):

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -8,7 +8,7 @@ from freezegun.api import freeze_time
 
 from posthog.models import Cohort, Element, Event, Filter, Person
 from posthog.models.team import Team
-from posthog.test.base import BaseTest
+from posthog.test.base import BaseTest, properties_to_Q
 
 
 class TestFilter(BaseTest):
@@ -45,7 +45,7 @@ class TestSelectors(BaseTest):
         )
         event2 = Event.objects.create(team=self.team, event="$autocapture")
         filter = Filter(data={"properties": [{"key": "selector", "value": "div > a", "type": "element"}]})
-        events = Event.objects.filter(filter.properties_to_Q(team_id=self.team.pk))
+        events = Event.objects.filter(properties_to_Q(filter.properties, team_id=self.team.pk))
         self.assertEqual(events.count(), 1)
 
 
@@ -325,7 +325,7 @@ def _filter_events(filter: Filter, team: Team, person_query: Optional[bool] = Fa
     if person_query:
         events = events.add_person_id(team.pk)
 
-    events = events.filter(filter.properties_to_Q(team_id=team.pk))
+    events = events.filter(properties_to_Q(filter.properties, team_id=team.pk))
     if order_by:
         events = events.order_by(order_by)
     return events.values()
@@ -344,7 +344,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_events, Event.o
 
         matched_person = (
             Person.objects.filter(team_id=self.team.pk, persondistinctid__distinct_id=person1_distinct_id)
-            .filter(filter.properties_to_Q(team_id=self.team.pk, is_person_query=True))
+            .filter(properties_to_Q(filter.properties, team_id=self.team.pk, is_person_query=True))
             .exists()
         )
         self.assertTrue(matched_person)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -5,9 +5,12 @@ from dateutil.relativedelta import relativedelta
 from django.db.models import Exists, OuterRef, Q, QuerySet
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
-from posthog.models import Entity, Event, Filter, Team
+from posthog.models.entity import Entity
+from posthog.models.event import Event
+from posthog.models.filters.filter import Filter
 from posthog.models.person import Person
 from posthog.models.property import Property
+from posthog.models.team import Team
 from posthog.utils import get_compare_period_dates
 
 """

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -2,11 +2,12 @@ import copy
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import Q, QuerySet
+from django.db.models import Exists, OuterRef, Q, QuerySet
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
 from posthog.models import Entity, Event, Filter, Team
-from posthog.models.filters.retention_filter import RetentionFilter
+from posthog.models.person import Person
+from posthog.models.property import Property
 from posthog.utils import get_compare_period_dates
 
 """
@@ -100,9 +101,68 @@ def filter_events(team_id: int, filter, entity: Optional[Entity] = None, include
     if include_dates:
         filters &= Q(timestamp__lte=filter.date_to + relativity)
     if filter.properties:
-        filters &= filter.properties_to_Q(team_id=team_id)
+        filters &= properties_to_Q(filter.properties, team_id=team_id)
     if entity and entity.properties:
-        filters &= entity.properties_to_Q(team_id=team_id)
+        filters &= properties_to_Q(entity.properties, team_id=team_id)
+    return filters
+
+
+def properties_to_Q(properties: List[Property], team_id: int, is_person_query: bool = False) -> Q:
+    """
+    Converts a filter to Q, for use in Django ORM .filter()
+    If you're filtering a Person QuerySet, use is_person_query to avoid doing an unnecessary nested loop
+    """
+    filters = Q()
+
+    if len(properties) == 0:
+        return filters
+
+    if is_person_query:
+        for property in properties:
+            filters &= property.property_to_Q()
+        return filters
+
+    person_properties = [prop for prop in properties if prop.type == "person"]
+    if len(person_properties) > 0:
+        person_Q = Q()
+        for property in person_properties:
+            person_Q &= property.property_to_Q()
+        filters &= Q(Exists(Person.objects.filter(person_Q, id=OuterRef("person_id"),).only("pk")))
+
+    for property in [prop for prop in properties if prop.type == "event"]:
+        filters &= property.property_to_Q()
+
+    # importing from .event and .cohort below to avoid importing from partially initialized modules
+
+    element_properties = [prop for prop in properties if prop.type == "element"]
+    if len(element_properties) > 0:
+        from posthog.models.event import Event
+
+        filters &= Q(
+            Exists(
+                Event.objects.filter(pk=OuterRef("id"))
+                .filter(
+                    **Event.objects.filter_by_element(
+                        {item.key: item.value for item in element_properties}, team_id=team_id,
+                    )
+                )
+                .only("id")
+            )
+        )
+
+    cohort_properties = [prop for prop in properties if prop.type == "cohort"]
+    if len(cohort_properties) > 0:
+        from posthog.models.cohort import CohortPeople
+
+        for item in cohort_properties:
+            if item.key == "id":
+                filters &= Q(
+                    Exists(
+                        CohortPeople.objects.filter(cohort_id=int(item.value), person_id=OuterRef("person_id"),).only(
+                            "id"
+                        )
+                    )
+                )
     return filters
 
 

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -12,7 +12,7 @@ from psycopg2 import sql
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
 from posthog.models import Action, Entity, Event, Filter, Person, Team
 from posthog.models.utils import namedtuplefetchall
-from posthog.queries.base import BaseQuery
+from posthog.queries.base import BaseQuery, properties_to_Q
 
 
 class Funnel(BaseQuery):
@@ -46,8 +46,8 @@ class Funnel(BaseQuery):
                         else {}
                     ),
                 )
-                .filter(self._filter.properties_to_Q(team_id=self._team.pk))
-                .filter(step.properties_to_Q(team_id=self._team.pk))
+                .filter(properties_to_Q(self._filter.properties, team_id=self._team.pk))
+                .filter(properties_to_Q(step.properties, team_id=self._team.pk))
             )
             with connection.cursor() as cursor:
                 event_string = cursor.mogrify(*event.query.sql_with_params())

--- a/posthog/queries/paths.py
+++ b/posthog/queries/paths.py
@@ -7,6 +7,7 @@ from django.db.models.functions import Lag
 
 from posthog.models import Event, Filter, Team
 from posthog.models.filters.path_filter import PathFilter
+from posthog.queries.base import properties_to_Q
 from posthog.utils import request_to_date_query
 
 from .base import BaseQuery
@@ -63,7 +64,7 @@ class Paths(BaseQuery):
                 if event is None
                 else Q()
             )
-            .filter(filter.properties_to_Q(team_id=team.pk) if filter and filter.properties else Q())
+            .filter(properties_to_Q(filter.properties, team_id=team.pk) if filter and filter.properties else Q())
             .annotate(
                 previous_timestamp=Window(
                     expression=Lag("timestamp", default=None),

--- a/posthog/queries/sessions.py
+++ b/posthog/queries/sessions.py
@@ -10,7 +10,7 @@ from django.utils.timezone import now
 
 from posthog.constants import SESSION_AVG
 from posthog.models import Event, Filter, Team
-from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter
+from posthog.queries.base import BaseQuery, convert_to_comparison, determine_compared_filter, properties_to_Q
 from posthog.utils import append_data, friendly_time
 
 DIST_LABELS = [
@@ -35,7 +35,7 @@ class BaseSessions(BaseQuery):
         return (
             Event.objects.filter(team=team)
             .add_person_id(team.pk)
-            .filter(filter.properties_to_Q(team_id=team.pk))
+            .filter(properties_to_Q(filter.properties, team_id=team.pk))
             .order_by("-timestamp")
         )
 


### PR DESCRIPTION
This way we can pass other kinds of property lists in there.

1) This is needed for session filters (due to different kinds of
property filters)
2) It makes the postgres codebase more consistent with ee which does a
similar thing.

No behavioral changes - pure code change. Splitting this out to keep main PR (more) managable + to run CI.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
