### PR TITLE
Fix REST hook deletion

### DIFF
--- a/ee/api/hooks.py
+++ b/ee/api/hooks.py
@@ -24,8 +24,7 @@ class HookViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     Retrieve, create, update or destroy webhooks.
     """
 
-    queryset = Hook.objects.none()
-    serializer_class = HookSerializer
+    queryset = Hook.objects.all()
     ordering = "-created_at"
     permission_classes = [IsAuthenticated, OrganizationMemberPermissions]
     serializer_class = HookSerializer

--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -46,3 +46,9 @@ class TestHooksAPI(APITransactionLicensedTest):
             },
             cast(dict, response.data),
         )
+
+    def test_delete_hook(self):
+        hook_id = "abc123"
+        Hook.objects.create(id=hook_id, user=self.user, team=self.team, resource_id=20)
+        response = self.client.delete(f"/api/projects/{self.team.id}/hooks/{hook_id}")
+        self.assertEqual(response.status_code, 204)

--- a/ee/tasks/hooks.py
+++ b/ee/tasks/hooks.py
@@ -1,10 +1,10 @@
 import json
-from typing import Optional
 
 import requests
 from celery.task import Task
 from django.core.serializers.json import DjangoJSONEncoder
-from rest_hooks.utils import get_hook_model
+
+from ee.models.hook import Hook
 
 
 class DeliverHook(Task):
@@ -20,7 +20,6 @@ class DeliverHook(Task):
             )
             if response.status_code == 410 and hook_id:
                 # Delete hook on our side if it's gone on Zapier's
-                Hook = get_hook_model()
                 Hook.objects.filter(id=hook_id).delete()
                 return
             if response.status_code >= 500:

--- a/ee/tasks/hooks.py
+++ b/ee/tasks/hooks.py
@@ -4,8 +4,6 @@ import requests
 from celery.task import Task
 from django.core.serializers.json import DjangoJSONEncoder
 
-from ee.models.hook import Hook
-
 
 class DeliverHook(Task):
     max_retries = 3
@@ -20,6 +18,8 @@ class DeliverHook(Task):
             )
             if response.status_code == 410 and hook_id:
                 # Delete hook on our side if it's gone on Zapier's
+                from ee.models.hook import Hook
+
                 Hook.objects.filter(id=hook_id).delete()
                 return
             if response.status_code >= 500:


### PR DESCRIPTION
## Changes

This is a fix for REST hook deletion.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests