### PR TITLE
Upgrade to plugin server 0.6.4

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "posthog-plugin-server": "0.6.2"
+        "posthog-plugin-server": "0.6.4"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -931,10 +931,10 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-posthog-plugin-server@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/posthog-plugin-server/-/posthog-plugin-server-0.6.2.tgz#310844d51fc636f3e6bd33fe795e97df2f0b5d64"
-  integrity sha512-0V0pE+4zilezeQOZnBPgH3+FcBE39xjw6e2yzXeETlm8LlBeYgbJ/IHyv9OBT5/hl6YVBW2p902DdOKsrDLyvQ==
+posthog-plugin-server@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/posthog-plugin-server/-/posthog-plugin-server-0.6.4.tgz#1146ce135e960a4e7a6220816b866474e5cdb29b"
+  integrity sha512-icLJaR879ksv1EPMJjO2enR2gvfWIfWV2WqsJ447rB6AptgCWdkVEv57xcvyVZbNYjzZP4mM1UdDKcUghJolyw==
   dependencies:
     "@google-cloud/bigquery" "^5.5.0"
     "@sentry/node" "^5.29.0"


### PR DESCRIPTION
## Changes

Apprarently running "yarn publish" is a bad idea. It skipped most of the required files in `dist/` for some reason. [npm publish](https://github.com/PostHog/posthog-plugin-server/pull/91) did the trick.

- Closes #2892
- Closes #2889

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
