### PR TITLE
Proper interval rounding on normal trends

### DIFF
--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -22,7 +22,7 @@ class ClickhouseSessionsAvg:
         filters, params = parse_prop_clauses(filter.properties, team.pk)
 
         interval_notation = get_trunc_func_ch(filter.interval)
-        num_intervals, seconds_in_interval = get_time_diff(
+        num_intervals, seconds_in_interval, _ = get_time_diff(
             filter.interval or "day", filter.date_from, filter.date_to, team.pk
         )
 

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -34,7 +34,34 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
+# override tests from test facotry if intervals are different
 class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTrends, _create_event, Person.objects.create, _create_action, _create_cohort)):  # type: ignore
+    def test_interval_rounding(self):
+        self._test_events_with_dates(
+            dates=["2020-11-01", "2020-11-10", "2020-11-11", "2020-11-18"],
+            interval="week",
+            date_from="2020-11-04",
+            date_to="2020-11-24",
+            result=[
+                {
+                    "action": {
+                        "id": "event_name",
+                        "type": "events",
+                        "order": None,
+                        "name": "event_name",
+                        "math": None,
+                        "math_property": None,
+                        "properties": [],
+                    },
+                    "label": "event_name",
+                    "count": 4.0,
+                    "data": [1.0, 2.0, 1.0, 0.0],
+                    "labels": ["Sun. 1 November", "Sun. 8 November", "Sun. 15 November", "Sun. 22 November"],
+                    "days": ["2020-11-01", "2020-11-08", "2020-11-15", "2020-11-22"],
+                }
+            ],
+        )
+
     def test_breakdown_by_person_property(self):
         person1, person2, person3, person4 = self._create_multiple_people()
         action = _create_action(name="watched movie", team=self.team)

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -8,7 +8,7 @@ from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.trends.util import parse_response, process_math
-from ee.clickhouse.queries.util import get_time_diff, get_trunc_func_ch, parse_timestamps
+from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
 from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL, NULL_BREAKDOWN_SQL, NULL_SQL
 from ee.clickhouse.sql.person import GET_LATEST_PERSON_SQL
 from ee.clickhouse.sql.trends.breakdown import (
@@ -56,10 +56,10 @@ class ClickhouseTrendsBreakdown:
         # process params
         params: Dict[str, Any] = {"team_id": team_id}
         interval_annotation = get_trunc_func_ch(filter.interval)
-        num_intervals, seconds_in_interval, _ = get_time_diff(
+        num_intervals, seconds_in_interval, round_interval = get_time_diff(
             filter.interval or "day", filter.date_from, filter.date_to, team_id
         )
-        parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
+        _, parsed_date_to, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, table_name="e")
@@ -90,10 +90,11 @@ class ClickhouseTrendsBreakdown:
             **action_params,
             "event": entity.id,
             "key": filter.breakdown,
+            **date_params,
         }
 
         breakdown_filter_params = {
-            "parsed_date_from": parsed_date_from,
+            "parsed_date_from": date_from_clause(interval_annotation, round_interval),
             "parsed_date_to": parsed_date_to,
             "actions_query": "AND {}".format(action_query) if action_query else "",
             "event_filter": "AND event = %(event)s" if not action_query else "",

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -56,7 +56,7 @@ class ClickhouseTrendsBreakdown:
         # process params
         params: Dict[str, Any] = {"team_id": team_id}
         interval_annotation = get_trunc_func_ch(filter.interval)
-        num_intervals, seconds_in_interval = get_time_diff(
+        num_intervals, seconds_in_interval, _ = get_time_diff(
             filter.interval or "day", filter.date_from, filter.date_to, team_id
         )
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -41,7 +41,7 @@ class ClickhouseLifecycle(LifecycleTrend):
             date_from = get_earliest_timestamp(team_id)
 
         interval = filter.interval or "day"
-        num_intervals, seconds_in_interval = get_time_diff(interval, filter.date_from, filter.date_to, team_id)
+        num_intervals, seconds_in_interval, _ = get_time_diff(interval, filter.date_from, filter.date_to, team_id)
         interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
         trunc_func = get_trunc_func_ch(interval)
         event_query = ""
@@ -104,7 +104,9 @@ class ClickhouseLifecycle(LifecycleTrend):
             date_from = get_earliest_timestamp(team_id)
 
         interval = filter.interval or "day"
-        num_intervals, seconds_in_interval = get_time_diff(interval, filter.date_from, filter.date_to, team_id=team_id)
+        num_intervals, seconds_in_interval, _ = get_time_diff(
+            interval, filter.date_from, filter.date_to, team_id=team_id
+        )
         interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
         trunc_func = get_trunc_func_ch(interval)
         event_query = ""

--- a/ee/clickhouse/queries/trends/normal.py
+++ b/ee/clickhouse/queries/trends/normal.py
@@ -28,7 +28,7 @@ class ClickhouseTrendsNormal:
         num_intervals, seconds_in_interval = get_time_diff(
             filter.interval or "day", filter.date_from, filter.date_to, team_id=team_id
         )
-        parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
+        _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
@@ -36,13 +36,11 @@ class ClickhouseTrendsNormal:
         aggregate_operation, join_condition, math_params = process_math(entity)
 
         params: Dict = {"team_id": team_id}
-        params = {**params, **prop_filter_params, **math_params}
+        params = {**params, **prop_filter_params, **math_params, **date_params}
         content_sql_params = {
             "interval": interval_annotation,
             "timestamp": "timestamp",
             "team_id": team_id,
-            "parsed_date_from": parsed_date_from,
-            "parsed_date_to": parsed_date_to,
             "filters": prop_filters,
             "event_join": join_condition,
             "aggregate_operation": aggregate_operation,

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -7,6 +7,7 @@ from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import GET_EARLIEST_TIMESTAMP_SQL
 from posthog.models.filters import Filter
 from posthog.models.filters.path_filter import PathFilter
+from posthog.queries.base import TIME_IN_SECONDS
 from posthog.types import FilterType
 
 
@@ -55,18 +56,10 @@ def get_time_diff(
     _start_time = start_time or get_earliest_timestamp(team_id)
     _end_time = end_time or timezone.now()
 
-    time_diffs: Dict[str, Any] = {
-        "minute": 60,
-        "hour": 3600,
-        "day": 3600 * 24,
-        "week": 3600 * 24 * 7,
-        "month": 3600 * 24 * 30,
-    }
-
     diff = _end_time - _start_time
-    round_interval = diff.total_seconds() >= time_diffs[interval] * 2
+    round_interval = diff.total_seconds() >= TIME_IN_SECONDS[interval] * 2
 
-    return int(diff.total_seconds() / time_diffs[interval]) + 1, time_diffs[interval], round_interval
+    return int(diff.total_seconds() / TIME_IN_SECONDS[interval]) + 1, TIME_IN_SECONDS[interval], round_interval
 
 
 PERIOD_TRUNC_MINUTE = "toStartOfMinute"

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -64,7 +64,7 @@ def get_time_diff(
     }
 
     diff = _end_time - _start_time
-    round_interval = diff.total_seconds() < time_diffs[interval]
+    round_interval = diff.total_seconds() >= time_diffs[interval] * 2
 
     return int(diff.total_seconds() / time_diffs[interval]) + 1, time_diffs[interval], round_interval
 
@@ -93,3 +93,10 @@ def get_trunc_func_ch(period: Optional[str]) -> str:
         return PERIOD_TRUNC_MONTH
     else:
         raise ValueError(f"Period {period} is unsupported.")
+
+
+def date_from_clause(interval_annotation: str, round_interval: bool) -> str:
+    if round_interval:
+        return "AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s))".format(interval=interval_annotation)
+    else:
+        return "AND timestamp >= %(date_from)s"

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -50,7 +50,7 @@ def get_earliest_timestamp(team_id: int) -> datetime:
 
 def get_time_diff(
     interval: str, start_time: Optional[datetime], end_time: Optional[datetime], team_id: int
-) -> Tuple[int, int]:
+) -> Tuple[int, int, bool]:
 
     _start_time = start_time or get_earliest_timestamp(team_id)
     _end_time = end_time or timezone.now()
@@ -64,7 +64,9 @@ def get_time_diff(
     }
 
     diff = _end_time - _start_time
-    return int(diff.total_seconds() / time_diffs[interval]) + 1, time_diffs[interval]
+    round_interval = diff.total_seconds() < time_diffs[interval]
+
+    return int(diff.total_seconds() / time_diffs[interval]) + 1, time_diffs[interval], round_interval
 
 
 PERIOD_TRUNC_MINUTE = "toStartOfMinute"

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -38,7 +38,7 @@ def format_ch_timestamp(timestamp: datetime, filter, default_hour_min: str = " 0
     is_hour_or_min = (filter.interval and filter.interval.lower() == "hour") or (
         filter.interval and filter.interval.lower() == "minute"
     )
-    return timestamp.strftime("%Y-%m-%d{}".format(" %H:%M:%S.%f" if is_hour_or_min else default_hour_min))
+    return timestamp.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if is_hour_or_min else default_hour_min))
 
 
 def get_earliest_timestamp(team_id: int) -> datetime:

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -1,15 +1,15 @@
 VOLUME_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and event = %(event)s {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
 """
 
 VOLUME_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= toDateTime(%(date_to)s) GROUP BY {interval}({timestamp})
 """
 
 VOLUME_TOTAL_AGGREGATE_SQL = """
-SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and event = %(event)s {filters} {parsed_date_from} {parsed_date_to}
+SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s
 """
 
 VOLUME__TOTAL_AGGREGATE_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and {actions_query} {filters} {parsed_date_from} {parsed_date_to}
+SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s
 """

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -1,15 +1,15 @@
 VOLUME_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {date_from_clause} AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
 """
 
 VOLUME_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {date_from_clause} AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
 """
 
 VOLUME_TOTAL_AGGREGATE_SQL = """
-SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s
+SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {date_from_clause} AND timestamp <= %(date_to)s
 """
 
 VOLUME__TOTAL_AGGREGATE_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s
+SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {date_from_clause} AND timestamp <= %(date_to)s
 """

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -1,15 +1,15 @@
 VOLUME_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {date_from_clause} AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and event = %(event)s {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
 """
 
 VOLUME_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {date_from_clause} AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
 """
 
 VOLUME_TOTAL_AGGREGATE_SQL = """
-SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and event = %(event)s {filters} AND {date_from_clause} AND timestamp <= %(date_to)s
+SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and event = %(event)s {filters} {parsed_date_from} {parsed_date_to}
 """
 
 VOLUME__TOTAL_AGGREGATE_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {date_from_clause} AND timestamp <= %(date_to)s
+SELECT {aggregate_operation} as total from events {event_join} where team_id = {team_id} and {actions_query} {filters} {parsed_date_from} {parsed_date_to}
 """

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -3,7 +3,7 @@ SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC'
 """
 
 VOLUME_ACTIONS_SQL = """
-SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= toDateTime(%(date_to)s) GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as total, toDateTime({interval}({timestamp}), 'UTC') as day_start from events {event_join} where team_id = {team_id} and {actions_query} {filters} AND {interval}(timestamp) >= {interval}(toDateTime(%(date_from)s)) AND timestamp <= %(date_to)s GROUP BY {interval}({timestamp})
 """
 
 VOLUME_TOTAL_AGGREGATE_SQL = """

--- a/posthog/queries/abstract_test/test_interval.py
+++ b/posthog/queries/abstract_test/test_interval.py
@@ -21,3 +21,7 @@ class AbstractIntervalTest(ABC):
     @abstractmethod
     def test_month_interval(self):
         pass
+
+    @abstractmethod
+    def test_interval_rounding(self):
+        pass

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -83,12 +83,22 @@ def handle_compare(filter, func: Callable, team: Team, **kwargs) -> List:
     return entities_list
 
 
+TIME_IN_SECONDS: Dict[str, Any] = {
+    "minute": 60,
+    "hour": 3600,
+    "day": 3600 * 24,
+    "week": 3600 * 24 * 7,
+    "month": 3600 * 24 * 30,
+}
+
 """
 filter_events takes team_id, filter, entity and generates a Q objects that you can use to filter a QuerySet
 """
 
 
-def filter_events(team_id: int, filter, entity: Optional[Entity] = None, include_dates: bool = True) -> Q:
+def filter_events(
+    team_id: int, filter, entity: Optional[Entity] = None, include_dates: bool = True, interval_annotation=None
+) -> Q:
     filters = Q()
     if filter.date_from and include_dates:
         filters &= Q(timestamp__gte=filter.date_from)

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -11,7 +11,7 @@ from posthog.models.entity import Entity
 from posthog.models.event import Event
 from posthog.models.filters import Filter
 from posthog.models.person import Person
-from posthog.queries.base import filter_events
+from posthog.queries.base import TIME_IN_SECONDS, filter_events
 from posthog.utils import queryset_to_named_query
 
 LIFECYCLE_SQL = """
@@ -347,18 +347,11 @@ def get_time_diff(
 
     _end_time = end_time or timezone.now()
 
-    time_diffs: Dict[str, Any] = {
-        "minute": 60,
-        "hour": 3600,
-        "day": 3600 * 24,
-        "week": 3600 * 24 * 7,
-        "month": 3600 * 24 * 30,
-    }
     interval_diff = get_interval(interval)
 
     diff = _end_time - _start_time
     return (
-        int(diff.total_seconds() / time_diffs[interval]) + 1,
+        int(diff.total_seconds() / TIME_IN_SECONDS[interval]) + 1,
         _start_time - interval_diff,
         _start_time,
         _end_time,

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -321,6 +321,61 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
         def test_minute_interval(self):
             pass
 
+        # ensure that the first interval is properly rounded acoording to the specified period
+        def test_interval_rounding(self):
+            Person.objects.create(
+                team=self.team, distinct_ids=["person1", "alias1"], properties={"email": "person1@test.com"},
+            )
+            Person.objects.create(
+                team=self.team, distinct_ids=["person2"], properties={"email": "person2@test.com"},
+            )
+
+            self._create_events(
+                [
+                    ("person1", self._date(0)),
+                    ("person2", self._date(0)),
+                    ("person1", self._date(1)),
+                    ("person2", self._date(1)),
+                    ("person1", self._date(7)),
+                    ("person2", self._date(7)),
+                    ("person1", self._date(14)),
+                    ("person1", self._date(month=1, day=-6)),
+                    ("person2", self._date(month=1, day=-6)),
+                    ("person2", self._date(month=1, day=1)),
+                    ("person1", self._date(month=1, day=1)),
+                    ("person2", self._date(month=1, day=15)),
+                ]
+            )
+
+            result = retention().run(
+                RetentionFilter(
+                    data={"date_to": self._date(14, month=1, hour=0), "period": "Week", "total_intervals": 7}
+                ),
+                self.team,
+            )
+
+            self.assertEqual(
+                self.pluck(result, "label"), ["Week 0", "Week 1", "Week 2", "Week 3", "Week 4", "Week 5", "Week 6"],
+            )
+
+            self.assertEqual(
+                self.pluck(result, "values", "count"),
+                [[2, 2, 1, 2, 2, 0, 1], [2, 1, 2, 2, 0, 1], [1, 1, 1, 0, 0], [2, 2, 0, 1], [2, 0, 1], [0, 0], [1],],
+            )
+
+            self.assertEqual(
+                self.pluck(result, "date"),
+                [
+                    datetime(2020, 6, 7, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 6, 14, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 6, 21, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 6, 28, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 7, 5, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 7, 12, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 7, 19, 0, tzinfo=pytz.UTC),
+                ],
+            )
+
         def test_retention_people(self):
             person1 = person_factory(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
             person2 = person_factory(team_id=self.team.pk, distinct_ids=["person2"])

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -676,6 +676,32 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 ],
             )
 
+        def test_interval_rounding(self):
+            self._test_events_with_dates(
+                dates=["2020-11-01", "2020-11-10", "2020-11-11", "2020-11-18"],
+                interval="week",
+                date_from="2020-11-04",
+                date_to="2020-11-24",
+                result=[
+                    {
+                        "action": {
+                            "id": "event_name",
+                            "type": "events",
+                            "order": None,
+                            "name": "event_name",
+                            "math": None,
+                            "math_property": None,
+                            "properties": [],
+                        },
+                        "label": "event_name",
+                        "count": 4.0,
+                        "data": [1.0, 2.0, 1.0, 0.0],
+                        "labels": ["Sun. 1 November", "Sun. 8 November", "Sun. 15 November", "Sun. 22 November"],
+                        "days": ["2020-11-01", "2020-11-08", "2020-11-15", "2020-11-22"],
+                    }
+                ],
+            )
+
         def test_today_timerange(self):
             self._test_events_with_dates(
                 dates=["2020-11-01 10:20:00", "2020-11-01 10:22:00", "2020-11-01 10:25:00"],

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -694,10 +694,10 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                             "properties": [],
                         },
                         "label": "event_name",
-                        "count": 4.0,
-                        "data": [1.0, 2.0, 1.0, 0.0],
-                        "labels": ["Sun. 1 November", "Sun. 8 November", "Sun. 15 November", "Sun. 22 November"],
-                        "days": ["2020-11-01", "2020-11-08", "2020-11-15", "2020-11-22"],
+                        "count": 3.0,
+                        "data": [2.0, 1.0, 0.0],
+                        "labels": ["Sun. 8 November", "Sun. 15 November", "Sun. 22 November"],
+                        "days": ["2020-11-08", "2020-11-15", "2020-11-22"],
                     }
                 ],
             )


### PR DESCRIPTION
## Changes

*Please describe.*  
- the first interval on weekly or monthly interval wouldn't always be accurate because the date comparison wasn't properly rounded when applied

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] need to make similar adjustment to breakdown query
- [ ] cover with tests
