### PR TITLE
Hotfix - Papercups chat collision

### DIFF
--- a/frontend/src/lib/components/Papercups.tsx
+++ b/frontend/src/lib/components/Papercups.tsx
@@ -17,6 +17,7 @@ export function Papercups({ user }: { user: UserType | null }): JSX.Element {
                     name: user.name,
                     external_id: user.distinct_id,
                     metadata: {
+                        user_id: user.id,
                         organization_name: user.organization?.name,
                         organization_id: user.organization?.id,
                         organization_plan: user.organization?.billing_plan,

--- a/frontend/src/lib/components/Papercups.tsx
+++ b/frontend/src/lib/components/Papercups.tsx
@@ -15,7 +15,7 @@ export function Papercups({ user }: { user: UserType | null }): JSX.Element {
                 user && {
                     email: user.email,
                     name: user.name,
-                    external_id: String(user.id),
+                    external_id: user.distinct_id,
                     metadata: {
                         organization_name: user.organization?.name,
                         organization_id: user.organization?.id,


### PR DESCRIPTION
## Changes

Full context on [Slack thread](https://posthogusers.slack.com/archives/G01ANKR34FJ/p1610324427001400).

Fixes a bug in which the way Papercups recognizes latest conversations from users using the provided `external_id`, as we were relying on the autoincremental user IDs, this caused Papercups conversations to be routed incorrectly. We now use the `distinct_id` which has a significant source of randomness.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
