### PR TITLE
Fix dashboard colors with non-white backgrounds

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-inferrable-types': 'off',
+        'no-shadow': 'warn',
         curly: 'error',
     },
     overrides: [

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -17,7 +17,7 @@ style files without adding already imported styles. */
     --muted: #{$text_muted};
     // Used for graph series
     --blue: #{$blue_500};
-    --purple: #{purple_500};
+    --purple: #{$purple_500};
     --salmon: #ff906e;
     --yellow: #ffc035;
     --green: #{$success};

--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -113,10 +113,10 @@ export function LineGraph({
 
     function processDataset(dataset, index) {
         const colorList = getChartColors(color || 'white')
-        const color = dataset?.status ? getBarColorFromStatus(dataset.status) : colorList[index]
+        const borderColor = dataset?.status ? getBarColorFromStatus(dataset.status) : colorList[index]
 
         return {
-            borderColor: color,
+            borderColor,
             backgroundColor: (type === 'bar' || type === 'doughnut') && color,
             fill: false,
             borderWidth: 1,


### PR DESCRIPTION
## Changes

- More details in #2662
- Fixes issue with redeclaring local variable that messed up dashboard colors
- Added an eslint rule to show warnings when redeclaring variables. This we could convert to an error some day.
![image](https://user-images.githubusercontent.com/53387/104171495-088c9c80-5403-11eb-8081-a830bffe231d.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
