### PR TITLE
Update plugin repository URL

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -132,7 +132,7 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     def repository(self, request: request.Request, **kwargs):
         if not can_install_plugins_via_api(self.organization):
             raise ValidationError("Plugin installation via the web is disabled!")
-        url = "https://raw.githubusercontent.com/PostHog/plugins/main/repository.json"
+        url = "https://raw.githubusercontent.com/PostHog/plugin-repository/main/repository.json"
         plugins = requests.get(url)
         return Response(json.loads(plugins.text))
 

--- a/posthog/plugins/test/mock.py
+++ b/posthog/plugins/test/mock.py
@@ -66,7 +66,7 @@ def mocked_plugin_requests_get(*args, **kwargs):
     if args[0] == "https://registry.npmjs.org/posthog-helloworld-plugin/-/posthog-helloworld-plugin-0.0.0.tgz":
         return MockBase64Response(HELLO_WORLD_PLUGIN_NPM_TGZ[1], 200)
 
-    if args[0] == "https://raw.githubusercontent.com/PostHog/plugins/main/repository.json":
+    if args[0] == "https://raw.githubusercontent.com/PostHog/plugin-repository/main/repository.json":
         return MockTextResponse(
             json.dumps(
                 [


### PR DESCRIPTION
## Changes

Because we renamed the repo from `plugins` to `plugin-repository`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
