### PR TITLE
restore path custom events

### DIFF
--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -209,6 +209,10 @@ LIMIT %(limit)s
     tag_regex=EXTRACT_TAG_REGEX, text_regex=EXTRACT_TEXT_REGEX
 )
 
+GET_CUSTOM_EVENTS = """
+SELECT DISTINCT event FROM events where team_id = %(team_id)s AND event NOT IN ['$autocapture', '$pageview', '$identify', '$pageleave', '$screen']
+"""
+
 GET_PROPERTIES_VOLUME = """
     SELECT arrayJoin(array_property_keys) as key, count(1) as count FROM events_with_array_props_view WHERE team_id = %(team_id)s AND timestamp > %(timestamp)s GROUP BY key ORDER BY count DESC
 """

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -16,7 +16,12 @@ from ee.clickhouse.models.property import get_property_values_for_key, parse_pro
 from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording
 from ee.clickhouse.queries.sessions.list import SESSIONS_LIST_DEFAULT_LIMIT, ClickhouseSessionsList
 from ee.clickhouse.queries.util import parse_timestamps
-from ee.clickhouse.sql.events import SELECT_EVENT_WITH_ARRAY_PROPS_SQL, SELECT_EVENT_WITH_PROP_SQL, SELECT_ONE_EVENT_SQL
+from ee.clickhouse.sql.events import (
+    GET_CUSTOM_EVENTS,
+    SELECT_EVENT_WITH_ARRAY_PROPS_SQL,
+    SELECT_EVENT_WITH_PROP_SQL,
+    SELECT_ONE_EVENT_SQL,
+)
 from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
 from posthog.models.action import Action
@@ -108,7 +113,10 @@ class ClickhouseEventsViewSet(EventViewSet):
         team = self.team
         result = []
         flattened = []
-        if key:
+        if key == "custom_event":
+            events = sync_execute(GET_CUSTOM_EVENTS, {"team_id": team.pk})
+            return Response([{"name": event[0]} for event in events])
+        elif key:
             result = get_property_values_for_key(key, team, value=request.GET.get("value"))
             for value in result:
                 try:

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -128,6 +128,18 @@ def test_event_api_factory(event_factory, person_factory, action_factory):
             )
             return sign_up
 
+        def test_custom_event_values(self):
+            events = ["test", "new event", "another event"]
+            for event in events:
+                event_factory(
+                    distinct_id="bla",
+                    event=event,
+                    team=self.team,
+                    properties={"random_prop": "don't include", "some other prop": "with some text"},
+                )
+            response = self.client.get("/api/event/values/?key=custom_event").json()
+            self.assertListEqual(sorted(events), sorted([event["name"] for event in response]))
+
         def test_event_property_values(self):
 
             with freeze_time("2020-01-10"):


### PR DESCRIPTION
## Changes

*Please describe.*  
- custom events weren't included after api changes
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
