### PR TITLE
Switch user prompt location

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.js
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Select, Tooltip } from 'antd'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { Select } from 'antd'
 import {
     ACTIONS_LINE_GRAPH_LINEAR,
     ACTIONS_LINE_GRAPH_CUMULATIVE,
@@ -26,15 +25,7 @@ export function ChartFilter(props) {
     const pieDisabled = filters.session || filters.insight === ViewType.RETENTION
     const defaultDisplay = filters.retentionType ? ACTIONS_TABLE : ACTIONS_LINE_GRAPH_LINEAR
 
-    return [
-        (!filters.display ||
-            filters.display === ACTIONS_LINE_GRAPH_LINEAR ||
-            filters.display === ACTIONS_LINE_GRAPH_CUMULATIVE) && (
-            <Tooltip key="1" placement="right" title="Click on a point to see users related to the datapoint">
-                <InfoCircleOutlined className="info-indicator" />
-            </Tooltip>
-        ),
-
+    return (
         <Select
             key="2"
             defaultValue={displayMap[filters.display || defaultDisplay]}
@@ -65,6 +56,6 @@ export function ChartFilter(props) {
             <Select.Option value={ACTIONS_BAR_CHART} disabled={filters.session || filters.retentionType}>
                 Bar
             </Select.Option>
-        </Select>,
-    ]
+        </Select>
+    )
 }

--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -152,7 +152,7 @@ export function LineGraph({
                           datasetCopy.days = days
                           return processDataset(datasetCopy, index)
                       }),
-                      ...datasets.map((dataset) => {
+                      ...datasets.map((dataset, index) => {
                           let datasetCopy = Object.assign({}, dataset)
                           let datasetLength = datasetCopy.data.length
                           datasetCopy.dotted = true
@@ -168,7 +168,7 @@ export function LineGraph({
                                         idx === datasetLength - 1 || idx === datasetLength - 2 ? datum : null
                                     )
                                   : datasetCopy.data
-                          return processDataset(datasetCopy, idx)
+                          return processDataset(datasetCopy, index)
                       }),
                   ]
                 : datasets.map((dataset, index) => processDataset(dataset, index))

--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -223,7 +223,7 @@ export function LineGraph({
                                           (percentage ? '%' : '')
                                       )
                                   },
-                                  footer: () => 'Click on a point to see users related to the datapoint',
+                                  footer: () => 'Click to see users related to the datapoint',
                               },
                           },
                           hover: {

--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -142,17 +142,17 @@ export function LineGraph({
                       ...datasets.map((dataset, index) => {
                           let datasetCopy = Object.assign({}, dataset)
                           let data = [...dataset.data]
-                          let labels = [...dataset.labels]
+                          let _labels = [...dataset.labels]
                           let days = [...dataset.days]
                           data.pop()
-                          labels.pop()
+                          _labels.pop()
                           days.pop()
                           datasetCopy.data = data
-                          datasetCopy.labels = labels
+                          datasetCopy.labels = _labels
                           datasetCopy.days = days
                           return processDataset(datasetCopy, index)
                       }),
-                      ...datasets.map((dataset, index) => {
+                      ...datasets.map((dataset) => {
                           let datasetCopy = Object.assign({}, dataset)
                           let datasetLength = datasetCopy.data.length
                           datasetCopy.dotted = true
@@ -164,11 +164,11 @@ export function LineGraph({
 
                           datasetCopy.data =
                               datasetCopy.data.length > 2
-                                  ? datasetCopy.data.map((datum, index) =>
-                                        index === datasetLength - 1 || index === datasetLength - 2 ? datum : null
+                                  ? datasetCopy.data.map((datum, idx) =>
+                                        idx === datasetLength - 1 || idx === datasetLength - 2 ? datum : null
                                     )
                                   : datasetCopy.data
-                          return processDataset(datasetCopy, index)
+                          return processDataset(datasetCopy, idx)
                       }),
                   ]
                 : datasets.map((dataset, index) => processDataset(dataset, index))
@@ -203,9 +203,10 @@ export function LineGraph({
                               titleFontColor: '#ffffff',
                               labelFontSize: 23,
                               cornerRadius: 4,
-                              fontSize: 16,
+                              fontSize: 12,
                               footerSpacing: 0,
                               titleSpacing: 0,
+                              footerFontStyle: 'italic',
                               callbacks: {
                                   label: function (tooltipItem, data) {
                                       let entityData = data.datasets[tooltipItem.datasetIndex]
@@ -222,6 +223,7 @@ export function LineGraph({
                                           (percentage ? '%' : '')
                                       )
                                   },
+                                  footer: () => 'Click on a point to see users related to the datapoint',
                               },
                           },
                           hover: {
@@ -327,17 +329,17 @@ export function LineGraph({
                         return
                     }
 
-                    const leftExtent = myLineChart.current.scales['x-axis-0'].left
-                    const rightExtent = myLineChart.current.scales['x-axis-0'].right
+                    const _leftExtent = myLineChart.current.scales['x-axis-0'].left
+                    const _rightExtent = myLineChart.current.scales['x-axis-0'].right
                     const ticks = myLineChart.current.scales['x-axis-0'].ticks.length
-                    const delta = rightExtent - leftExtent
-                    const interval = delta / (ticks - 1)
-                    if (offsetX < leftExtent - interval / 2) {
+                    const delta = _rightExtent - _leftExtent
+                    const _interval = delta / (ticks - 1)
+                    if (offsetX < _leftExtent - _interval / 2) {
                         return
                     }
-                    const index = mapRange(offsetX, leftExtent - interval / 2, rightExtent + interval / 2, 0, ticks)
+                    const index = mapRange(offsetX, _leftExtent - _interval / 2, _rightExtent + _interval / 2, 0, ticks)
                     if (index >= 0 && index < ticks && offsetY >= topExtent - 30) {
-                        setLeft(index * interval + leftExtent)
+                        setLeft(index * _interval + _leftExtent)
                         setLabelIndex(index)
                     }
                 }


### PR DESCRIPTION
## Changes

*Please describe.*  
- place the prompt on the tooltip so the user is directly reminded to click on the datapoint
*If this affects the frontend, include screenshots.*  
<img width="448" alt="Screen Shot 2021-01-12 at 2 43 13 PM" src="https://user-images.githubusercontent.com/13127476/104364396-870d3b00-54e4-11eb-810a-aed6aa7fe542.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
