### PR TITLE
Remove unnecessary action properties iterating on sessionsparams

### DIFF
--- a/frontend/src/scenes/insights/trendsLogic.js
+++ b/frontend/src/scenes/insights/trendsLogic.js
@@ -230,7 +230,7 @@ export const trendsLogic = kea({
                 }
 
                 const { action, day, breakdown_value } = people
-                const properties = [...filters.properties, ...action.properties]
+                const properties = [...filters.properties]
                 if (filters.breakdown) {
                     properties.push({ key: filters.breakdown, value: breakdown_value, type: filters.breakdown_type })
                 }


### PR DESCRIPTION
## Changes

*Please describe.*  
- clicking on a datapoint on sessions was crashing because of unnecessary iterating
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
