### PR TITLE
Add link to plugin troubleshooting if server offline

### DIFF
--- a/frontend/src/scenes/plugins/OptInPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptInPlugins.tsx
@@ -61,9 +61,9 @@ export function OptInPlugins(): JSX.Element {
                             </span>
                         ) : (
                             <span style={{ color: 'var(--red)' }}>
-                                <WarningOutlined /> Offline{' '}
+                                <WarningOutlined /> Offline –{' '}
                                 <a
-                                    href="https://posthog.com/docs/plugins/enabling"
+                                    href="https://posthog.com/docs/plugins/enabling#plugin-server-is-offline"
                                     target="_blank"
                                     rel="noreferrer noopener"
                                 >

--- a/frontend/src/scenes/plugins/OptInPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptInPlugins.tsx
@@ -61,7 +61,14 @@ export function OptInPlugins(): JSX.Element {
                             </span>
                         ) : (
                             <span style={{ color: 'var(--red)' }}>
-                                <WarningOutlined /> Offline
+                                <WarningOutlined /> Offline{' '}
+                                <a
+                                    href="https://posthog.com/docs/plugins/enabling"
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                >
+                                    Why could this be?
+                                </a>
                             </span>
                         )}
                     </div>


### PR DESCRIPTION
## Changes

Adds a link to the plugin troubleshooting page if the server is offline

<img width="950" alt="Screenshot 2021-01-13 at 22 53 00" src="https://user-images.githubusercontent.com/53387/104514869-456ab600-55f2-11eb-9b8e-336bda77a078.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
