### PR TITLE
Refactor & extend backend user identify

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -138,7 +138,7 @@ class OrganizationSignupSerializer(serializers.Serializer):
         posthoganalytics.capture(
             user.distinct_id,
             "user signed up",
-            properties={"is_instance_first_user": is_instance_first_user, "is_first_org_first_user": True},
+            properties={"is_first_user": is_instance_first_user, "is_organization_first_user": True},
         )
 
         return user

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -122,24 +122,23 @@ class OrganizationSignupSerializer(serializers.Serializer):
         return value
 
     def create(self, validated_data, **kwargs):
-        is_first_user: bool = not User.objects.exists()
-        realm: str = "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted"
+        is_instance_first_user: bool = not User.objects.exists()
 
         company_name = validated_data.pop("company_name", validated_data["first_name"])
         self._organization, self._team, self._user = User.objects.bootstrap(company_name=company_name, **validated_data)
         user = self._user
+
         login(
             self.context["request"], user, backend="django.contrib.auth.backends.ModelBackend",
         )
 
+        posthoganalytics.identify(
+            user.distinct_id, {"is_instance_first_user": is_instance_first_user, "is_first_org_first_user": True},
+        )
         posthoganalytics.capture(
             user.distinct_id,
             "user signed up",
-            properties={"is_first_user": is_first_user, "is_organization_first_user": True},
-        )
-
-        posthoganalytics.identify(
-            user.distinct_id, properties={"email": user.email, "realm": realm, "ee_available": settings.EE_AVAILABLE},
+            properties={"is_instance_first_user": is_instance_first_user, "is_first_org_first_user": True},
         )
 
         return user

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -133,7 +133,7 @@ class OrganizationSignupSerializer(serializers.Serializer):
         )
 
         posthoganalytics.identify(
-            user.distinct_id, {"is_instance_first_user": is_instance_first_user, "is_first_org_first_user": True},
+            user.distinct_id, {"is_first_user": is_instance_first_user, "is_organization_first_user": True},
         )
         posthoganalytics.capture(
             user.distinct_id,

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -77,7 +77,9 @@ class TestSignup(APIBaseTest):
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_capture.assert_called_once_with(
-            user.distinct_id, "user signed up", properties={"is_first_user": True, "is_organization_first_user": True},
+            user.distinct_id,
+            "user signed up",
+            properties={"is_instance_first_user": True, "is_first_org_first_user": True},
         )
 
         # Assert that the user is logged in
@@ -132,7 +134,9 @@ class TestSignup(APIBaseTest):
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_capture.assert_called_once_with(
-            user.distinct_id, "user signed up", properties={"is_first_user": True, "is_organization_first_user": True},
+            user.distinct_id,
+            "user signed up",
+            properties={"is_instance_first_user": True, "is_first_org_first_user": True},
         )
 
         # Assert that the user is logged in

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -42,9 +42,8 @@ class TestSignup(APIBaseTest):
 
     @tag("skip_on_multitenancy")
     @patch("posthog.api.organization.settings.EE_AVAILABLE", False)
-    @patch("posthog.api.organization.posthoganalytics.identify")
     @patch("posthog.api.organization.posthoganalytics.capture")
-    def test_api_sign_up(self, mock_capture, mock_identify):
+    def test_api_sign_up(self, mock_capture):
         response = self.client.post(
             "/api/signup/",
             {
@@ -79,10 +78,6 @@ class TestSignup(APIBaseTest):
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_capture.assert_called_once_with(
             user.distinct_id, "user signed up", properties={"is_first_user": True, "is_organization_first_user": True},
-        )
-
-        mock_identify.assert_called_once_with(
-            user.distinct_id, properties={"email": "hedgehog@posthog.com", "realm": "hosted", "ee_available": False},
         )
 
         # Assert that the user is logged in

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -77,9 +77,7 @@ class TestSignup(APIBaseTest):
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_capture.assert_called_once_with(
-            user.distinct_id,
-            "user signed up",
-            properties={"is_instance_first_user": True, "is_first_org_first_user": True},
+            user.distinct_id, "user signed up", properties={"is_first_user": True, "is_organization_first_user": True},
         )
 
         # Assert that the user is logged in
@@ -123,7 +121,7 @@ class TestSignup(APIBaseTest):
         organization = cast(Organization, user.organization)
         self.assertEqual(
             response.data,
-            {"id": user.pk, "distinct_id": user.distinct_id, "first_name": "Jane", "email": "hedgehog2@posthog.com",},
+            {"id": user.pk, "distinct_id": user.distinct_id, "first_name": "Jane", "email": "hedgehog2@posthog.com"},
         )
 
         # Assert that the user was properly created
@@ -134,9 +132,7 @@ class TestSignup(APIBaseTest):
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_capture.assert_called_once_with(
-            user.distinct_id,
-            "user signed up",
-            properties={"is_instance_first_user": True, "is_first_org_first_user": True},
+            user.distinct_id, "user signed up", properties={"is_first_user": True, "is_organization_first_user": True},
         )
 
         # Assert that the user is logged in

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -8,70 +8,7 @@ from posthog.test.base import APITransactionBaseTest, BaseTest
 
 
 class TestUser(BaseTest):
-    TESTS_API = True  # TODO: Remove once endpoint is refactored to DRF
-
-    def test_create_user_with_distinct_id(self):
-        with self.settings(TEST=False):
-            user = User.objects.create_user(first_name="Tim", email="tim@gmail.com", password=None)
-        self.assertNotEqual(user.distinct_id, "")
-        self.assertNotEqual(user.distinct_id, None)
-
-    def test_analytics_metadata(self):
-
-        # One org, one team, anonymized
-        organization, team, user = User.objects.bootstrap(
-            company_name="Test Org", email="test_org@posthog.com", password="12345678", anonymize_data=True,
-        )
-
-        with self.settings(EE_AVAILABLE=True, MULTI_TENANCY=True):
-            self.assertEqual(
-                user.get_analytics_metadata(),
-                {
-                    "realm": "cloud",
-                    "ee_available": True,
-                    "email_opt_in": False,
-                    "anonymize_data": True,
-                    "email": None,
-                    "is_signed_up": True,
-                    "organization_count": 1,
-                    "project_count": 1,
-                    "team_member_count_all": 1,
-                    "completed_onboarding_once": False,
-                    "billing_plan": None,
-                    "organization_id": str(organization.id),
-                    "project_id": str(team.uuid),
-                    "project_setup_complete": False,
-                },
-            )
-
-        # Multiple teams, multiple members, completed onboarding
-        user = User.objects.create(email="test_org_2@posthog.com", email_opt_in=True)
-        OrganizationMembership.objects.create(user=user, organization=self.organization)
-        Team.objects.create(organization=self.organization)
-        self.team.completed_snippet_onboarding = True
-        self.team.ingested_event = True
-        self.team.save()
-
-        with self.settings(EE_AVAILABLE=False, MULTI_TENANCY=False):
-            self.assertEqual(
-                user.get_analytics_metadata(),
-                {
-                    "realm": "hosted",
-                    "ee_available": False,
-                    "email_opt_in": True,
-                    "anonymize_data": False,
-                    "email": "test_org_2@posthog.com",
-                    "is_signed_up": True,
-                    "organization_count": 1,
-                    "project_count": 2,
-                    "team_member_count_all": 2,
-                    "completed_onboarding_once": True,
-                    "billing_plan": None,
-                    "organization_id": str(self.organization.id),
-                    "project_id": str(self.team.uuid),
-                    "project_setup_complete": True,
-                },
-            )
+    TESTS_API = True
 
     # TODO: Move to TestUserAPI once endpoint is refactored to DRF
     def test_user_team_update(self):
@@ -181,7 +118,7 @@ class TestUserAPI(APITransactionBaseTest):
             self.user.distinct_id,
             {
                 "realm": "hosted",
-                "ee_available": True,
+                "is_ee_available": True,
                 "email_opt_in": False,
                 "anonymize_data": False,
                 "email": "user1@posthog.com",

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -82,21 +82,6 @@ def user(request):
             user.email_opt_in = data["user"].get("email_opt_in", user.email_opt_in)
             user.anonymize_data = data["user"].get("anonymize_data", user.anonymize_data)
             user.toolbar_mode = data["user"].get("toolbar_mode", user.toolbar_mode)
-            posthoganalytics.identify(
-                user.distinct_id,
-                {
-                    "email_opt_in": user.email_opt_in,
-                    "anonymize_data": user.anonymize_data,
-                    "email": user.email if not user.anonymize_data else None,
-                    "is_signed_up": True,
-                    "toolbar_mode": user.toolbar_mode,
-                    "billing_plan": user.organization.billing_plan if user.organization is not None else None,
-                    "is_team_unique_user": team.users.count() == 1 if team is not None else None,
-                    "team_setup_complete": (team.completed_snippet_onboarding and team.ingested_event)
-                    if team is not None
-                    else None,
-                },
-            )
             user.save()
 
     return JsonResponse(
@@ -147,7 +132,6 @@ def user(request):
             "opt_out_capture": os.environ.get("OPT_OUT_CAPTURE"),
             "posthog_version": VERSION,
             "is_multi_tenancy": getattr(settings, "MULTI_TENANCY", False),
-            "is_staff": user.is_staff,
             "ee_available": settings.EE_AVAILABLE,
             "ee_enabled": is_ee_enabled(),
             "email_service_available": is_email_available(with_absolute_urls=True),

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import posthoganalytics
 from django.apps import AppConfig

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -159,7 +159,7 @@ class User(AbstractUser):
 
         return {
             "realm": "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted",
-            "ee_available": settings.EE_AVAILABLE,
+            "is_ee_available": settings.EE_AVAILABLE,
             "email_opt_in": self.email_opt_in,
             "anonymize_data": self.anonymize_data,
             "email": self.email if not self.anonymize_data else None,
@@ -174,9 +174,9 @@ class User(AbstractUser):
             "billing_plan": self.organization.billing_plan if self.organization else None,
             "organization_id": str(self.organization.id) if self.organization else None,
             "project_id": str(self.team.uuid) if self.team else None,
-            "project_setup_complete": (self.team.completed_snippet_onboarding and self.team.ingested_event)
-            if self.team
-            else False,
+            "project_setup_complete": bool(self.team)
+            and self.team.completed_snippet_onboarding
+            and self.team.ingested_event,
         }
 
     __repr__ = sane_repr("email", "first_name", "distinct_id")

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -63,7 +63,7 @@ class UserManager(BaseUserManager):
     ) -> "User":
         with transaction.atomic():
             user = self.create_user(email=email, password=password, first_name=first_name, **extra_fields)
-            membership = user.join(organization=organization, level=level)
+            user.join(organization=organization, level=level)
             return user
 
     def get_from_personal_api_key(self, key_value: str) -> Optional["User"]:
@@ -167,6 +167,9 @@ class User(AbstractUser):
             "organization_count": self.organization_memberships.count(),
             "project_count": self.teams.count(),
             "team_member_count_all": team_member_count_all,
+            "completed_onboarding_once": self.teams.filter(
+                completed_snippet_onboarding=True, ingested_event=True,
+            ).exists(),  # has completed the onboarding at least for one project
             # properties dependent on current project / org below
             "billing_plan": self.organization.billing_plan if self.organization else None,
             "organization_id": str(self.organization.id),

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -151,4 +151,27 @@ class User(AbstractUser):
                 )
                 self.save()
 
+    def get_analytics_metadata(self):
+
+        team_member_count_all: int = OrganizationMembership.objects.filter(
+            organization__in=self.organizations.all(),
+        ).values("user_id").distinct().count()
+
+        return {
+            "realm": "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted",
+            "ee_available": settings.EE_AVAILABLE,
+            "email_opt_in": self.email_opt_in,
+            "anonymize_data": self.anonymize_data,
+            "email": self.email if not self.anonymize_data else None,
+            "is_signed_up": True,
+            "organization_count": self.organization_memberships.count(),
+            "project_count": self.teams.count(),
+            "team_member_count_all": team_member_count_all,
+            # properties dependent on current project / org below
+            "billing_plan": self.organization.billing_plan if self.organization else None,
+            "organization_id": str(self.organization.id),
+            "project_id": str(self.team.uuid),
+            "project_setup_complete": (self.team.completed_snippet_onboarding and self.team.ingested_event),
+        }
+
     __repr__ = sane_repr("email", "first_name", "distinct_id")

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -172,9 +172,11 @@ class User(AbstractUser):
             ).exists(),  # has completed the onboarding at least for one project
             # properties dependent on current project / org below
             "billing_plan": self.organization.billing_plan if self.organization else None,
-            "organization_id": str(self.organization.id),
-            "project_id": str(self.team.uuid),
-            "project_setup_complete": (self.team.completed_snippet_onboarding and self.team.ingested_event),
+            "organization_id": str(self.organization.id) if self.organization else None,
+            "project_id": str(self.team.uuid) if self.team else None,
+            "project_setup_complete": (self.team.completed_snippet_onboarding and self.team.ingested_event)
+            if self.team
+            else False,
         }
 
     __repr__ = sane_repr("email", "first_name", "distinct_id")

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -157,6 +157,10 @@ class User(AbstractUser):
             organization__in=self.organizations.all(),
         ).values("user_id").distinct().count()
 
+        project_setup_complete = False
+        if self.team and self.team.completed_snippet_onboarding and self.team.ingested_event:
+            project_setup_complete = True
+
         return {
             "realm": "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted",
             "is_ee_available": settings.EE_AVAILABLE,
@@ -174,9 +178,7 @@ class User(AbstractUser):
             "billing_plan": self.organization.billing_plan if self.organization else None,
             "organization_id": str(self.organization.id) if self.organization else None,
             "project_id": str(self.team.uuid) if self.team else None,
-            "project_setup_complete": bool(self.team)
-            and self.team.completed_snippet_onboarding
-            and self.team.ingested_event,
+            "project_setup_complete": project_setup_complete,
         }
 
     __repr__ = sane_repr("email", "first_name", "distinct_id")

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -7,4 +7,5 @@ import posthog.tasks.process_event
 import posthog.tasks.session_recording_retention
 import posthog.tasks.status_report
 import posthog.tasks.update_cache
+import posthog.tasks.user_identify
 import posthog.tasks.webhooks

--- a/posthog/tasks/calculate_action.py
+++ b/posthog/tasks/calculate_action.py
@@ -3,8 +3,6 @@ import time
 
 from celery import shared_task
 
-from posthog.celery import app
-from posthog.ee import is_ee_enabled
 from posthog.models import Action
 
 logger = logging.getLogger(__name__)

--- a/posthog/tasks/user_identify.py
+++ b/posthog/tasks/user_identify.py
@@ -1,0 +1,11 @@
+import posthoganalytics
+
+from posthog.celery import app
+from posthog.models import User
+
+
+@app.task(ignore_result=True)
+def identify_task(user_id: int):
+
+    user = User.objects.get(id=user_id)
+    posthoganalytics.identify(user.distinct_id, user.get_analytics_metadata())

--- a/posthog/tasks/user_identify.py
+++ b/posthog/tasks/user_identify.py
@@ -5,7 +5,7 @@ from posthog.models import User
 
 
 @app.task(ignore_result=True)
-def identify_task(user_id: int):
+def identify_task(user_id: int) -> None:
 
     user = User.objects.get(id=user_id)
     posthoganalytics.identify(user.distinct_id, user.get_analytics_metadata())

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -92,4 +92,8 @@ class APIBaseTest(APITestMixin, APITestCase):
 
 
 class APITransactionBaseTest(APITestMixin, APITransactionTestCase):
+    """
+    Test class using Django REST Framework test suite.
+    """
+
     pass

--- a/posthog/test/test_user_model.py
+++ b/posthog/test/test_user_model.py
@@ -1,17 +1,15 @@
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.test import tag
 from django.utils.timezone import now
 from freezegun import freeze_time
 
+from posthog.models import OrganizationMembership, Team, User
 from posthog.test.base import BaseTest
 
 
 class TestUser(BaseTest):
-    TESTS_API = True
-
     @tag("ee")
     @patch("posthog.models.organization.License.PLANS", {"enterprise": ["whatever"]})
     @patch("ee.models.license.requests.post")
@@ -45,3 +43,66 @@ class TestUser(BaseTest):
 
         with freeze_time("2012-01-19T12:00:00.000Z"):
             self.assertFalse(self.organization.is_feature_available("whatever"))
+
+    def test_create_user_with_distinct_id(self):
+        with self.settings(TEST=False):
+            user = User.objects.create_user(first_name="Tim", email="tim@gmail.com", password=None)
+        self.assertNotEqual(user.distinct_id, "")
+        self.assertNotEqual(user.distinct_id, None)
+
+    def test_analytics_metadata(self):
+
+        # One org, one team, anonymized
+        organization, team, user = User.objects.bootstrap(
+            company_name="Test Org", email="test_org@posthog.com", password="12345678", anonymize_data=True,
+        )
+
+        with self.settings(EE_AVAILABLE=True, MULTI_TENANCY=True):
+            self.assertEqual(
+                user.get_analytics_metadata(),
+                {
+                    "realm": "cloud",
+                    "is_ee_available": True,
+                    "email_opt_in": False,
+                    "anonymize_data": True,
+                    "email": None,
+                    "is_signed_up": True,
+                    "organization_count": 1,
+                    "project_count": 1,
+                    "team_member_count_all": 1,
+                    "completed_onboarding_once": False,
+                    "billing_plan": None,
+                    "organization_id": str(organization.id),
+                    "project_id": str(team.uuid),
+                    "project_setup_complete": False,
+                },
+            )
+
+        # Multiple teams, multiple members, completed onboarding
+        user = User.objects.create(email="test_org_2@posthog.com", email_opt_in=True)
+        OrganizationMembership.objects.create(user=user, organization=self.organization)
+        Team.objects.create(organization=self.organization)
+        self.team.completed_snippet_onboarding = True
+        self.team.ingested_event = True
+        self.team.save()
+
+        with self.settings(EE_AVAILABLE=False, MULTI_TENANCY=False):
+            self.assertEqual(
+                user.get_analytics_metadata(),
+                {
+                    "realm": "hosted",
+                    "is_ee_available": False,
+                    "email_opt_in": True,
+                    "anonymize_data": False,
+                    "email": "test_org_2@posthog.com",
+                    "is_signed_up": True,
+                    "organization_count": 1,
+                    "project_count": 2,
+                    "team_member_count_all": 2,
+                    "completed_onboarding_once": True,
+                    "billing_plan": None,
+                    "organization_id": str(self.organization.id),
+                    "project_id": str(self.team.uuid),
+                    "project_setup_complete": True,
+                },
+            )

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -161,15 +161,6 @@ def signup_to_organization_view(request, invite_id):
             posthoganalytics.capture(
                 user.distinct_id, "user signed up", properties={"is_first_user": False, "first_team_user": False},
             )
-            posthoganalytics.identify(
-                user.distinct_id,
-                {
-                    "email": request.user.email if not request.user.anonymize_data else None,
-                    "company_name": organization.name,
-                    "organization_id": str(organization.id),
-                    "is_organization_first_user": False,
-                },
-            )
             return redirect("/")
     return render_template(
         "signup_to_organization.html",


### PR DESCRIPTION
## Changes

Previously we had the `$identify` logic for the backend all over the place. This PR refactors the logic so that:
a) it's kept in a single place.
b) it's called only in one place.
c) it's called **asynchronously** every time the user hits `/api/user/`. This was motivated because a ton of users are outdated and make it impossible to work on certain analyses.


The only exception is that we kept **a** identify call that sets the `is_first_user` & `is_organization_first_user` once.


The PR also adds more metadata to the request.

## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [X] Jest frontend tests. Not applicable.
- [X] Cypress end-to-end tests. Not applicable.
