### PR TITLE
Plugins Design Refresh

### DIFF
--- a/frontend/src/scenes/plugins/CommunityPluginTag.tsx
+++ b/frontend/src/scenes/plugins/CommunityPluginTag.tsx
@@ -2,12 +2,5 @@ import React from 'react'
 import { Tag } from 'antd'
 
 export function CommunityPluginTag({ isCommunity }: { isCommunity?: boolean }): JSX.Element {
-    return (
-        <Tag
-            color={isCommunity ? 'green' : 'blue'}
-            style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}
-        >
-            {isCommunity ? 'Community' : 'Core Team'}
-        </Tag>
-    )
+    return <Tag color={isCommunity ? 'green' : 'blue'}>{isCommunity ? 'Community' : 'Core Team'}</Tag>
 }

--- a/frontend/src/scenes/plugins/InstalledPlugins.tsx
+++ b/frontend/src/scenes/plugins/InstalledPlugins.tsx
@@ -1,29 +1,18 @@
 import React from 'react'
-import { Button, Col, Row } from 'antd'
-import { useActions, useValues } from 'kea'
+import { Col, Row } from 'antd'
+import { useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
-import { PlusOutlined } from '@ant-design/icons'
 import { PluginCard, PluginLoading } from './PluginCard'
-import { userLogic } from 'scenes/userLogic'
 import { Subtitle } from 'lib/components/PageHeader'
 
 export function InstalledPlugins(): JSX.Element {
     const { installedPlugins, loading } = useValues(pluginsLogic)
-    const { setPluginTab } = useActions(pluginsLogic)
-    const { user } = useValues(userLogic)
 
     return (
         <div>
             <Subtitle
                 subtitle={
                     'Installed' + (!loading || installedPlugins.length > 0 ? ` (${installedPlugins.length})` : '')
-                }
-                buttons={
-                    user?.plugin_access.install && (
-                        <Button type="primary" icon={<PlusOutlined />} onClick={() => setPluginTab('available')}>
-                            Install new plugin
-                        </Button>
-                    )
                 }
             />
             <Row gutter={16} style={{ marginTop: 16 }}>
@@ -40,7 +29,6 @@ export function InstalledPlugins(): JSX.Element {
                                     pluginType={plugin.plugin_type}
                                     pluginConfig={plugin.pluginConfig}
                                     error={plugin.error}
-                                    maintainer={plugin.maintainer || 'community'}
                                 />
                             )
                         })}

--- a/frontend/src/scenes/plugins/InstalledPlugins.tsx
+++ b/frontend/src/scenes/plugins/InstalledPlugins.tsx
@@ -12,7 +12,8 @@ export function InstalledPlugins(): JSX.Element {
         <div>
             <Subtitle
                 subtitle={
-                    'Installed' + (!loading || installedPlugins.length > 0 ? ` (${installedPlugins.length})` : '')
+                    'Installed Plugins' +
+                    (!loading || installedPlugins.length > 0 ? ` (${installedPlugins.length})` : '')
                 }
             />
             <Row gutter={16} style={{ marginTop: 16 }}>

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -34,7 +34,7 @@ export function PluginCard({
     maintainer,
 }: PluginCardProps): JSX.Element {
     const { editPlugin, toggleEnabled, installPlugin, resetPluginConfigError } = useActions(pluginsLogic)
-    const { loading } = useValues(pluginsLogic)
+    const { loading, installingPluginUrl } = useValues(pluginsLogic)
 
     const canConfigure = pluginId && !pluginConfig?.global
     const switchDisabled = (pluginConfig && pluginConfig.global) || !pluginConfig || !pluginConfig.id
@@ -122,7 +122,8 @@ export function PluginCard({
                             <Button
                                 type="primary"
                                 className="padding-under-500"
-                                loading={loading}
+                                loading={loading && installingPluginUrl === url}
+                                disabled={loading && installingPluginUrl !== url}
                                 onClick={url ? () => installPlugin(url, PluginInstallationType.Repository) : undefined}
                                 icon={<PlusOutlined />}
                             >

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -82,25 +82,16 @@ export function PluginCard({
                             ) : error ? (
                                 <PluginError error={error} />
                             ) : null}
-                            {url ? (
-                                <Link className="plugin-title-link" to={url} target="_blank" rel="noopener noreferrer">
-                                    <strong>{name}</strong>
-                                </Link>
-                            ) : (
-                                <strong>{name}</strong>
-                            )}
+                            <strong>{name}</strong>
                             {url?.startsWith('file:') ? (
                                 <LocalPluginTag url={url} title="Local" style={{ marginLeft: 10 }} />
                             ) : null}
-<<<<<<< HEAD
                             {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
                             {!pluginConfig && url && (
                                 <Link to={url} target="_blank" rel="noopener noreferrer" style={{ marginLeft: 10 }}>
                                     Learn more
                                 </Link>
                             )}
-=======
->>>>>>> plugin cards in mobile mode
                         </div>
                         <div>
                             {pluginType === 'source' ? <SourcePluginTag style={{ marginRight: 10 }} /> : null}

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -145,11 +145,8 @@ export function PluginLoading(): JSX.Element {
                 <Col key={i} style={{ marginBottom: 20, width: '100%' }}>
                     <Card className="plugin-card">
                         <Row align="middle" className="plugin-card-row">
-                            <Col style={{ width: 30 }}>
-                                <Skeleton title paragraph={false} active />
-                            </Col>
                             <Col className="hide-plugin-image-below-500">
-                                <Skeleton.Image style={{ width: 60, height: 60 }} />
+                                <Skeleton.Avatar active size="large" shape="square" />
                             </Col>
                             <Col style={{ flex: 1 }}>
                                 <Skeleton title={false} paragraph={{ rows: 2 }} active />

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -74,7 +74,7 @@ export function PluginCard({
                     </Col>
                     <Col style={{ flex: 1 }}>
                         <div>
-                            <strong style={{ marginRight: 10 }}>{name}</strong>
+                            <strong style={{ marginRight: 8 }}>{name}</strong>
                             {maintainer && !pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
                             {!description && !url ? <br /> : null}
                             {pluginConfig?.error ? (
@@ -92,7 +92,7 @@ export function PluginCard({
                             {description}
                             {url && (
                                 <span>
-                                    {description ? <> &nbsp; </> : ''}
+                                    {description ? ' ' : ''}
                                     <Link
                                         to={url}
                                         target="_blank"
@@ -101,6 +101,7 @@ export function PluginCard({
                                     >
                                         Learn more
                                     </Link>
+                                    .
                                 </span>
                             )}
                         </div>

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import React from 'react'
 import { pluginsLogic } from './pluginsLogic'
 import { PluginConfigType, PluginErrorType } from '~/types'
-import { PlusOutlined } from '@ant-design/icons'
+import { PlusOutlined, SettingOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
 import { PluginImage } from './PluginImage'
 import { PluginError } from 'scenes/plugins/PluginError'
@@ -44,13 +44,10 @@ export function PluginCard({
             style={{ width: '100%', marginBottom: 20 }}
             data-attr={`plugin-card-${pluginConfig ? 'installed' : 'available'}`}
         >
-            <Card
-                style={{ height: '100%', display: 'flex' }}
-                bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1, padding: 15 }}
-            >
-                <Row style={{ alignItems: 'center' }}>
+            <Card className="plugin-card">
+                <Row align="middle" className="plugin-card-row">
                     {pluginConfig && (
-                        <Col style={{ marginRight: 14 }}>
+                        <Col>
                             <Popconfirm
                                 placement="topLeft"
                                 title={`Are you sure you wish to ${
@@ -72,10 +69,10 @@ export function PluginCard({
                             </Popconfirm>
                         </Col>
                     )}
-                    <Col style={{ marginRight: 14 }}>
+                    <Col className={pluginConfig ? 'hide-plugin-image-below-500' : ''}>
                         <PluginImage pluginType={pluginType} url={url} />
                     </Col>
-                    <Col style={{ marginRight: 14, flex: 1 }}>
+                    <Col style={{ flex: 1 }}>
                         <div>
                             {pluginConfig?.error ? (
                                 <PluginError
@@ -85,37 +82,53 @@ export function PluginCard({
                             ) : error ? (
                                 <PluginError error={error} />
                             ) : null}
-                            <b>{name}</b>
+                            {url ? (
+                                <Link className="plugin-title-link" to={url} target="_blank" rel="noopener noreferrer">
+                                    <strong>{name}</strong>
+                                </Link>
+                            ) : (
+                                <strong>{name}</strong>
+                            )}
                             {url?.startsWith('file:') ? (
                                 <LocalPluginTag url={url} title="Local" style={{ marginLeft: 10 }} />
                             ) : null}
+<<<<<<< HEAD
                             {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
                             {!pluginConfig && url && (
                                 <Link to={url} target="_blank" rel="noopener noreferrer" style={{ marginLeft: 10 }}>
                                     Learn more
                                 </Link>
                             )}
+=======
+>>>>>>> plugin cards in mobile mode
                         </div>
                         <div>
                             {pluginType === 'source' ? <SourcePluginTag style={{ marginRight: 10 }} /> : null}
-
                             {description}
                         </div>
                     </Col>
                     <Col>
                         {canConfigure && (
-                            <Button type="primary" onClick={() => editPlugin(pluginId || null)}>
-                                Configure
+                            <Button
+                                type="primary"
+                                className="padding-under-500"
+                                onClick={() => editPlugin(pluginId || null)}
+                            >
+                                <span className="show-over-500">Configure</span>
+                                <span className="hide-over-500">
+                                    <SettingOutlined />
+                                </span>
                             </Button>
                         )}
                         {!pluginId && (
                             <Button
                                 type="primary"
+                                className="padding-under-500"
                                 loading={loading}
                                 onClick={url ? () => installPlugin(url, PluginInstallationType.Repository) : undefined}
                                 icon={<PlusOutlined />}
                             >
-                                Install
+                                <span className="show-over-500">Install</span>
                             </Button>
                         )}
                     </Col>
@@ -130,19 +143,24 @@ export function PluginLoading(): JSX.Element {
         <>
             {[1, 2, 3].map((i) => (
                 <Col key={i} style={{ marginBottom: 20, width: '100%' }}>
-                    <Card>
-                        <Row style={{ alignItems: 'center' }}>
-                            <Col style={{ marginRight: 14, width: 30 }}>
+                    <Card className="plugin-card">
+                        <Row align="middle" className="plugin-card-row">
+                            <Col style={{ width: 30 }}>
                                 <Skeleton title paragraph={false} active />
                             </Col>
-                            <Col style={{ marginRight: 14 }}>
+                            <Col className="hide-plugin-image-below-500">
                                 <Skeleton.Image style={{ width: 60, height: 60 }} />
                             </Col>
-                            <Col style={{ marginRight: 14, flex: 1 }}>
+                            <Col style={{ flex: 1 }}>
                                 <Skeleton title={false} paragraph={{ rows: 2 }} active />
                             </Col>
-                            <Col style={{ marginRight: 14 }}>
-                                <Skeleton.Button style={{ width: 100 }} />
+                            <Col>
+                                <span className="show-over-500">
+                                    <Skeleton.Button style={{ width: 100 }} />
+                                </span>
+                                <span className="hide-over-500">
+                                    <Skeleton.Button style={{ width: 32 }} />
+                                </span>
                             </Col>
                         </Row>
                     </Card>

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -20,7 +20,7 @@ interface PluginCardProps {
     pluginType?: PluginInstallationType
     pluginId?: number
     error?: PluginErrorType
-    maintainer: string
+    maintainer?: string
 }
 
 export function PluginCard({
@@ -75,7 +75,7 @@ export function PluginCard({
                     <Col style={{ flex: 1 }}>
                         <div>
                             <strong style={{ marginRight: 10 }}>{name}</strong>
-                            {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
+                            {maintainer && !pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
                             {!description && !url ? <br /> : null}
                             {pluginConfig?.error ? (
                                 <PluginError

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -85,9 +85,7 @@ export function PluginCard({
                             ) : error ? (
                                 <PluginError error={error} />
                             ) : null}
-                            {url?.startsWith('file:') ? (
-                                <LocalPluginTag url={url || 'file:/local/path'} title="Local" />
-                            ) : null}
+                            {url?.startsWith('file:') ? <LocalPluginTag url={url} title="Local" /> : null}
                             {pluginType === 'source' ? <SourcePluginTag /> : null}
                         </div>
                         <div>

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -74,6 +74,9 @@ export function PluginCard({
                     </Col>
                     <Col style={{ flex: 1 }}>
                         <div>
+                            <strong style={{ marginRight: 10 }}>{name}</strong>
+                            {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
+                            {!description && !url ? <br /> : null}
                             {pluginConfig?.error ? (
                                 <PluginError
                                     error={pluginConfig.error}
@@ -82,20 +85,26 @@ export function PluginCard({
                             ) : error ? (
                                 <PluginError error={error} />
                             ) : null}
-                            <strong>{name}</strong>
                             {url?.startsWith('file:') ? (
-                                <LocalPluginTag url={url} title="Local" style={{ marginLeft: 10 }} />
+                                <LocalPluginTag url={url || 'file:/local/path'} title="Local" />
                             ) : null}
-                            {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
-                            {!pluginConfig && url && (
-                                <Link to={url} target="_blank" rel="noopener noreferrer" style={{ marginLeft: 10 }}>
-                                    Learn more
-                                </Link>
-                            )}
+                            {pluginType === 'source' ? <SourcePluginTag /> : null}
                         </div>
                         <div>
-                            {pluginType === 'source' ? <SourcePluginTag style={{ marginRight: 10 }} /> : null}
                             {description}
+                            {url && (
+                                <span>
+                                    {description ? <> &nbsp; </> : ''}
+                                    <Link
+                                        to={url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        style={{ whiteSpace: 'nowrap' }}
+                                    >
+                                        Learn more
+                                    </Link>
+                                </span>
+                            )}
                         </div>
                     </Col>
                     <Col>

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -1,8 +1,7 @@
-import { Button, Card, Col, Popconfirm, Skeleton, Switch } from 'antd'
+import { Button, Card, Col, Popconfirm, Row, Skeleton, Switch } from 'antd'
 import { useActions, useValues } from 'kea'
 import React from 'react'
 import { pluginsLogic } from './pluginsLogic'
-import { someParentMatchesSelector } from 'lib/utils'
 import { PluginConfigType, PluginErrorType } from '~/types'
 import { PlusOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
@@ -38,65 +37,20 @@ export function PluginCard({
     const { loading } = useValues(pluginsLogic)
 
     const canConfigure = pluginId && !pluginConfig?.global
-    const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
-        if (someParentMatchesSelector(e.target as HTMLElement, '.ant-popover,.ant-tag')) {
-            return
-        }
-        if (canConfigure) {
-            editPlugin(pluginId || null)
-        }
-    }
-
     const switchDisabled = (pluginConfig && pluginConfig.global) || !pluginConfig || !pluginConfig.id
 
     return (
         <Col
-            sm={12}
-            md={12}
-            lg={8}
-            xl={6}
-            style={{ cursor: pluginConfig && canConfigure ? 'pointer' : 'inherit', width: '100%', marginBottom: 20 }}
-            onClick={handleClick}
+            style={{ width: '100%', marginBottom: 20 }}
             data-attr={`plugin-card-${pluginConfig ? 'installed' : 'available'}`}
         >
             <Card
-                style={{ height: '100%', display: 'flex', marginBottom: 20 }}
-                bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}
+                style={{ height: '100%', display: 'flex' }}
+                bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1, padding: 15 }}
             >
-                {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
-                {pluginType === 'source' ? (
-                    <SourcePluginTag style={{ position: 'absolute', top: 10, left: 10, cursor: 'pointer' }} />
-                ) : null}
-                {url?.startsWith('file:') ? (
-                    <LocalPluginTag
-                        url={url}
-                        title="Local"
-                        style={{ position: 'absolute', top: 10, left: 10, cursor: 'pointer' }}
-                    />
-                ) : null}
-                {pluginConfig?.error ? (
-                    <PluginError
-                        error={pluginConfig.error}
-                        reset={() => resetPluginConfigError(pluginConfig?.id || 0)}
-                    />
-                ) : error ? (
-                    <PluginError error={error} />
-                ) : null}
-                <PluginImage pluginType={pluginType} url={url} />
-                <div className="text-center mb" style={{ marginBottom: 16 }}>
-                    <b>{name}</b>
-                </div>
-                <div style={{ flexGrow: 1, paddingBottom: 16 }}>{description}</div>
-                <div style={{ display: 'flex', minHeight: 44, alignItems: 'center' }}>
-                    <div
-                        style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}
-                        onClick={(e) => {
-                            if (!switchDisabled) {
-                                e.stopPropagation()
-                            }
-                        }}
-                    >
-                        {pluginConfig && (
+                <Row style={{ alignItems: 'center' }}>
+                    {pluginConfig && (
+                        <Col style={{ marginRight: 14 }}>
                             <Popconfirm
                                 placement="topLeft"
                                 title={`Are you sure you wish to ${
@@ -116,17 +70,44 @@ export function PluginCard({
                                     )}
                                 </div>
                             </Popconfirm>
-                        )}
-                        {!pluginConfig && url && (
-                            <>
-                                <Link to={url} target="_blank" rel="noopener noreferrer">
+                        </Col>
+                    )}
+                    <Col style={{ marginRight: 14 }}>
+                        <PluginImage pluginType={pluginType} url={url} />
+                    </Col>
+                    <Col style={{ marginRight: 14, flex: 1 }}>
+                        <div>
+                            {pluginConfig?.error ? (
+                                <PluginError
+                                    error={pluginConfig.error}
+                                    reset={() => resetPluginConfigError(pluginConfig?.id || 0)}
+                                />
+                            ) : error ? (
+                                <PluginError error={error} />
+                            ) : null}
+                            <b>{name}</b>
+                            {url?.startsWith('file:') ? (
+                                <LocalPluginTag url={url} title="Local" style={{ marginLeft: 10 }} />
+                            ) : null}
+                            {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
+                            {!pluginConfig && url && (
+                                <Link to={url} target="_blank" rel="noopener noreferrer" style={{ marginLeft: 10 }}>
                                     Learn more
                                 </Link>
-                            </>
+                            )}
+                        </div>
+                        <div>
+                            {pluginType === 'source' ? <SourcePluginTag style={{ marginRight: 10 }} /> : null}
+
+                            {description}
+                        </div>
+                    </Col>
+                    <Col>
+                        {canConfigure && (
+                            <Button type="primary" onClick={() => editPlugin(pluginId || null)}>
+                                Configure
+                            </Button>
                         )}
-                    </div>
-                    <div>
-                        {canConfigure && <Button type="primary">Configure</Button>}
                         {!pluginId && (
                             <Button
                                 type="primary"
@@ -137,8 +118,8 @@ export function PluginCard({
                                 Install
                             </Button>
                         )}
-                    </div>
-                </div>
+                    </Col>
+                </Row>
             </Card>
         </Col>
     )
@@ -147,19 +128,26 @@ export function PluginCard({
 export function PluginLoading(): JSX.Element {
     return (
         <>
-            {[1, 2, 3].map((i) => {
-                return (
-                    <Col sm={12} md={12} lg={8} xl={6} key={i} style={{ marginBottom: 20 }}>
-                        <Card>
-                            <div className="text-center">
-                                <Skeleton.Image />
-                            </div>
-
-                            <Skeleton paragraph={{ rows: 4 }} active />
-                        </Card>
-                    </Col>
-                )
-            })}
+            {[1, 2, 3].map((i) => (
+                <Col key={i} style={{ marginBottom: 20, width: '100%' }}>
+                    <Card>
+                        <Row style={{ alignItems: 'center' }}>
+                            <Col style={{ marginRight: 14, width: 30 }}>
+                                <Skeleton title paragraph={false} active />
+                            </Col>
+                            <Col style={{ marginRight: 14 }}>
+                                <Skeleton.Image style={{ width: 60, height: 60 }} />
+                            </Col>
+                            <Col style={{ marginRight: 14, flex: 1 }}>
+                                <Skeleton title={false} paragraph={{ rows: 2 }} active />
+                            </Col>
+                            <Col style={{ marginRight: 14 }}>
+                                <Skeleton.Button style={{ width: 100 }} />
+                            </Col>
+                        </Row>
+                    </Card>
+                </Col>
+            ))}
         </>
     )
 }

--- a/frontend/src/scenes/plugins/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/PluginDrawer.tsx
@@ -95,9 +95,10 @@ export function PluginDrawer(): JSX.Element {
                                 </div>
                                 <div style={{ flexGrow: 1, paddingLeft: 16 }}>
                                     {editingPlugin.description}
+                                    {editingPlugin.description?.substr(-1) !== '.' ? '.' : ''}
                                     {editingPlugin.url ? (
                                         <span>
-                                            {editingPlugin.description ? <> &nbsp; </> : ''}
+                                            {editingPlugin.description ? ' ' : ''}
                                             <Link
                                                 to={editingPlugin.url}
                                                 target="_blank"
@@ -106,6 +107,7 @@ export function PluginDrawer(): JSX.Element {
                                             >
                                                 Learn More
                                             </Link>
+                                            .
                                         </span>
                                     ) : null}
                                     <div style={{ marginTop: 5 }}>

--- a/frontend/src/scenes/plugins/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/PluginDrawer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { Button, Form, Input, Popconfirm, Switch } from 'antd'
-import { DeleteOutlined, ArrowRightOutlined, CodeOutlined } from '@ant-design/icons'
+import { DeleteOutlined, ExportOutlined, CodeOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from './PluginImage'
 import { Link } from 'lib/components/Link'
@@ -102,7 +102,7 @@ export function PluginDrawer(): JSX.Element {
                                             <SourcePluginTag />
                                         ) : editingPlugin.url ? (
                                             <Link to={editingPlugin.url} target="_blank" rel="noopener noreferrer">
-                                                View plugin <ArrowRightOutlined />
+                                                View plugin <ExportOutlined />
                                             </Link>
                                         ) : null}
                                     </div>

--- a/frontend/src/scenes/plugins/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/PluginDrawer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { Button, Form, Input, Popconfirm, Switch } from 'antd'
-import { DeleteOutlined, ExportOutlined, CodeOutlined } from '@ant-design/icons'
+import { DeleteOutlined, CodeOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from './PluginImage'
 import { Link } from 'lib/components/Link'
@@ -95,15 +95,24 @@ export function PluginDrawer(): JSX.Element {
                                 </div>
                                 <div style={{ flexGrow: 1, paddingLeft: 16 }}>
                                     {editingPlugin.description}
+                                    {editingPlugin.url ? (
+                                        <span>
+                                            {editingPlugin.description ? <> &nbsp; </> : ''}
+                                            <Link
+                                                to={editingPlugin.url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                style={{ whiteSpace: 'nowrap' }}
+                                            >
+                                                Learn More
+                                            </Link>
+                                        </span>
+                                    ) : null}
                                     <div style={{ marginTop: 5 }}>
                                         {editingPlugin?.plugin_type === 'local' && editingPlugin.url ? (
                                             <LocalPluginTag url={editingPlugin.url} title="Installed Locally" />
                                         ) : editingPlugin.plugin_type === 'source' ? (
                                             <SourcePluginTag />
-                                        ) : editingPlugin.url ? (
-                                            <Link to={editingPlugin.url} target="_blank" rel="noopener noreferrer">
-                                                View plugin <ExportOutlined />
-                                            </Link>
                                         ) : null}
                                     </div>
                                     <div style={{ display: 'flex', alignItems: 'center', marginTop: 5 }}>

--- a/frontend/src/scenes/plugins/PluginError.tsx
+++ b/frontend/src/scenes/plugins/PluginError.tsx
@@ -38,7 +38,7 @@ export function PluginError({ error, reset }: { error: PluginErrorType; reset?: 
             trigger="click"
             placement="bottom"
         >
-            <Tag color="red" style={{ position: 'absolute', top: 10, right: 0, cursor: 'pointer' }}>
+            <Tag color="red" style={{ cursor: 'pointer' }}>
                 ERROR
             </Tag>
         </Popover>

--- a/frontend/src/scenes/plugins/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/PluginImage.tsx
@@ -17,17 +17,14 @@ export function PluginImage({ url, pluginType }: { url?: string; pluginType?: Pl
 
     return (
         <Card
-            /* TODO: when #2114 is merged className="card-elevated" */
             style={{
                 width: 60,
                 height: 60,
-                marginBottom: 24,
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
                 marginLeft: 'auto',
                 marginRight: 'auto',
-                boxShadow: '0px 80px 80px rgba(0, 0, 0, 0.075), 0px 10px 10px rgba(0, 0, 0, 0.035) !important',
             }}
             bodyStyle={{ padding: 4 }}
         >

--- a/frontend/src/scenes/plugins/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/PluginImage.tsx
@@ -1,4 +1,3 @@
-import { Card } from 'antd'
 import { parseGithubRepoURL } from 'lib/utils'
 import React, { useEffect, useState } from 'react'
 import { CodeOutlined } from '@ant-design/icons'
@@ -16,20 +15,9 @@ export function PluginImage({ url, pluginType }: { url?: string; pluginType?: Pl
     }, [url])
 
     return (
-        <Card
-            style={{
-                width: 60,
-                height: 60,
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                marginLeft: 'auto',
-                marginRight: 'auto',
-            }}
-            bodyStyle={{ padding: 4 }}
-        >
+        <div className="plugin-image">
             {pluginType === 'source' ? (
-                <CodeOutlined style={{ fontSize: 32 }} />
+                <CodeOutlined style={{ fontSize: 40 }} />
             ) : (
                 <img
                     src={state.image}
@@ -38,6 +26,6 @@ export function PluginImage({ url, pluginType }: { url?: string; pluginType?: Pl
                     onError={() => setState({ ...state, image: imgPluginDefault })}
                 />
             )}
-        </Card>
+        </div>
     )
 }

--- a/frontend/src/scenes/plugins/Plugins.scss
+++ b/frontend/src/scenes/plugins/Plugins.scss
@@ -1,0 +1,49 @@
+.plugins-scene {
+    padding-bottom: 60px;
+
+    .plugin-card {
+        > .ant-card-body {
+            padding: 15px;
+        }
+        .plugin-card-row > .ant-col {
+            margin-right: 14px;
+            &:last-child {
+                margin-right: 0;
+            }
+        }
+        a.plugin-title-link {
+            color: var(--color-text);
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+        .plugin-image {
+            width: 60px;
+            height: 60px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin-left: auto;
+            margin-right: auto;
+            border: none;
+            padding: 4px;
+        }
+        .hide-over-500 {
+            display: none;
+        }
+        @media (max-width: 500px) {
+            .show-over-500 {
+                display: none;
+            }
+            .hide-over-500 {
+                display: inline-block;
+            }
+            button.ant-btn.padding-under-500 {
+                padding: 4px 8px;
+            }
+            .hide-plugin-image-below-500 {
+                display: none;
+            }
+        }
+    }
+}

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -68,7 +68,9 @@ function _Plugins(): JSX.Element {
                                         message="Advanced Features Ahead"
                                         description={
                                             <>
-                                                Please check out the{' '}
+                                                Create and install your <b>own plugins</b> or plugins from{' '}
+                                                <b>third-parties</b>. If you're looking for officially supported
+                                                plugins, try the{' '}
                                                 <a
                                                     href="#"
                                                     onClick={(e) => {
@@ -77,15 +79,15 @@ function _Plugins(): JSX.Element {
                                                     }}
                                                 >
                                                     Plugin Repository
-                                                </a>{' '}
-                                                for a list of curated plugins you can directly install.
+                                                </a>
+                                                .
                                             </>
                                         }
                                         type="warning"
                                         showIcon
                                         closable
                                     />
-                                    <Subtitle subtitle="Install Custom Plugins" />
+                                    <Subtitle subtitle="Custom Plugins" />
                                     <SourcePlugin />
                                     <CustomPlugin />
                                     <LocalPlugin />

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -57,7 +57,7 @@ function _Plugins(): JSX.Element {
                             <InstalledPlugins />
                         </TabPane>
                         {user.plugin_access.install && (
-                            <TabPane tab="Available" key="available">
+                            <TabPane tab="Repository" key="available">
                                 <Subtitle subtitle="Plugin Repository" />
                                 <Repository />
                                 <Subtitle subtitle="Install Custom Plugins" />

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -1,3 +1,4 @@
+import './Plugins.scss'
 import React, { useEffect } from 'react'
 import { hot } from 'react-hot-loader/root'
 import { PluginDrawer } from 'scenes/plugins/PluginDrawer'
@@ -33,7 +34,7 @@ function _Plugins(): JSX.Element {
     }
 
     return (
-        <div>
+        <div className="plugins-scene">
             <PageHeader
                 title={
                     <>

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -7,7 +7,7 @@ import { InstalledPlugins } from 'scenes/plugins/InstalledPlugins'
 import { useActions, useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { pluginsLogic } from './pluginsLogic'
-import { Tabs, Tag } from 'antd'
+import { Alert, Tabs, Tag } from 'antd'
 import { OptInPlugins } from 'scenes/plugins/OptInPlugins'
 import { OptOutPlugins } from 'scenes/plugins/OptOutPlugins'
 import { CustomPlugin } from 'scenes/plugins/install/CustomPlugin'
@@ -64,6 +64,27 @@ function _Plugins(): JSX.Element {
                                     <Repository />
                                 </TabPane>
                                 <TabPane tab="Custom" key={PluginTab.Custom}>
+                                    <Alert
+                                        message="Advanced Features Ahead"
+                                        description={
+                                            <>
+                                                Please check out the{' '}
+                                                <a
+                                                    href="#"
+                                                    onClick={(e) => {
+                                                        e.preventDefault()
+                                                        setPluginTab(PluginTab.Repository)
+                                                    }}
+                                                >
+                                                    Plugin Repository
+                                                </a>{' '}
+                                                for a list of curated plugins you can directly install.
+                                            </>
+                                        }
+                                        type="warning"
+                                        showIcon
+                                        closable
+                                    />
                                     <Subtitle subtitle="Install Custom Plugins" />
                                     <SourcePlugin />
                                     <CustomPlugin />

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -12,7 +12,7 @@ import { OptOutPlugins } from 'scenes/plugins/OptOutPlugins'
 import { CustomPlugin } from 'scenes/plugins/install/CustomPlugin'
 import { LocalPlugin } from 'scenes/plugins/install/LocalPlugin'
 import { SourcePlugin } from 'scenes/plugins/install/SourcePlugin'
-import { PageHeader } from 'lib/components/PageHeader'
+import { PageHeader, Subtitle } from 'lib/components/PageHeader'
 
 export const Plugins = hot(_Plugins)
 function _Plugins(): JSX.Element {
@@ -57,7 +57,9 @@ function _Plugins(): JSX.Element {
                         </TabPane>
                         {user.plugin_access.install && (
                             <TabPane tab="Available" key="available">
+                                <Subtitle subtitle="Plugin Repository" />
                                 <Repository />
+                                <Subtitle subtitle="Install Custom Plugins" />
                                 <SourcePlugin />
                                 <CustomPlugin />
                                 <LocalPlugin />

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -14,6 +14,7 @@ import { CustomPlugin } from 'scenes/plugins/install/CustomPlugin'
 import { LocalPlugin } from 'scenes/plugins/install/LocalPlugin'
 import { SourcePlugin } from 'scenes/plugins/install/SourcePlugin'
 import { PageHeader, Subtitle } from 'lib/components/PageHeader'
+import { PluginTab } from 'scenes/plugins/types'
 
 export const Plugins = hot(_Plugins)
 function _Plugins(): JSX.Element {
@@ -52,19 +53,23 @@ function _Plugins(): JSX.Element {
 
             {user.team?.plugins_opt_in ? (
                 <>
-                    <Tabs activeKey={pluginTab} onChange={(activeKey) => setPluginTab(activeKey)}>
-                        <TabPane tab="Installed" key="installed">
+                    <Tabs activeKey={pluginTab} onChange={(activeKey) => setPluginTab(activeKey as PluginTab)}>
+                        <TabPane tab="Installed" key={PluginTab.Installed}>
                             <InstalledPlugins />
                         </TabPane>
                         {user.plugin_access.install && (
-                            <TabPane tab="Repository" key="available">
-                                <Subtitle subtitle="Plugin Repository" />
-                                <Repository />
-                                <Subtitle subtitle="Install Custom Plugins" />
-                                <SourcePlugin />
-                                <CustomPlugin />
-                                <LocalPlugin />
-                            </TabPane>
+                            <>
+                                <TabPane tab="Repository" key={PluginTab.Repository}>
+                                    <Subtitle subtitle="Plugin Repository" />
+                                    <Repository />
+                                </TabPane>
+                                <TabPane tab="Custom" key={PluginTab.Custom}>
+                                    <Subtitle subtitle="Install Custom Plugins" />
+                                    <SourcePlugin />
+                                    <CustomPlugin />
+                                    <LocalPlugin />
+                                </TabPane>
+                            </>
                         )}
                     </Tabs>
                     <PluginDrawer />

--- a/frontend/src/scenes/plugins/Repository.tsx
+++ b/frontend/src/scenes/plugins/Repository.tsx
@@ -3,14 +3,12 @@ import { Col, Row } from 'antd'
 import { useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { PluginCard, PluginLoading } from './PluginCard'
-import { Subtitle } from 'lib/components/PageHeader'
 
 export function Repository(): JSX.Element {
     const { repositoryLoading, uninstalledPlugins } = useValues(pluginsLogic)
 
     return (
         <div>
-            <Subtitle subtitle="Available" />
             <Row gutter={16} style={{ marginTop: 16 }}>
                 {(!repositoryLoading || uninstalledPlugins.length > 0) && (
                     <>

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -168,6 +168,14 @@ export const pluginsLogic = kea<
     }),
 
     reducers: {
+        installingPluginUrl: [
+            null as string | null,
+            {
+                installPlugin: (_, { pluginUrl }) => pluginUrl,
+                installPluginSuccess: () => null,
+                installPluginFailure: () => null,
+            },
+        ],
         editingPluginId: [
             null as number | null,
             {

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { pluginsLogicType } from 'types/scenes/plugins/pluginsLogicType'
 import api from 'lib/api'
 import { PluginConfigType, PluginType } from '~/types'
-import { PluginInstallationType, PluginRepositoryEntry, PluginTypeWithConfig } from './types'
+import { PluginInstallationType, PluginRepositoryEntry, PluginTab, PluginTypeWithConfig } from './types'
 import { userLogic } from 'scenes/userLogic'
 import { getConfigSchemaObject, getPluginConfigFormData } from 'scenes/plugins/utils'
 import posthog from 'posthog-js'
@@ -17,7 +17,14 @@ function capturePluginEvent(event: string, plugin: PluginType, type?: PluginInst
 }
 
 export const pluginsLogic = kea<
-    pluginsLogicType<PluginType, PluginConfigType, PluginRepositoryEntry, PluginTypeWithConfig, PluginInstallationType>
+    pluginsLogicType<
+        PluginType,
+        PluginConfigType,
+        PluginRepositoryEntry,
+        PluginTypeWithConfig,
+        PluginInstallationType,
+        PluginTab
+    >
 >({
     actions: {
         editPlugin: (id: number | null) => ({ id }),
@@ -27,7 +34,7 @@ export const pluginsLogic = kea<
         setCustomPluginUrl: (customPluginUrl: string) => ({ customPluginUrl }),
         setLocalPluginUrl: (localPluginUrl: string) => ({ localPluginUrl }),
         setSourcePluginName: (sourcePluginName: string) => ({ sourcePluginName }),
-        setPluginTab: (tab: string) => ({ tab }),
+        setPluginTab: (tab: PluginTab) => ({ tab }),
         setEditingSource: (editingSource: boolean) => ({ editingSource }),
         resetPluginConfigError: (id: number) => ({ id }),
         editPluginSource: (values: { id: number; name: string; source: string; configSchema: Record<string, any> }) =>
@@ -219,10 +226,10 @@ export const pluginsLogic = kea<
             },
         },
         pluginTab: [
-            'installed',
+            PluginTab.Installed as PluginTab,
             {
                 setPluginTab: (_, { tab }) => tab,
-                installPluginSuccess: () => 'installed',
+                installPluginSuccess: () => PluginTab.Installed,
             },
         ],
     },

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -222,6 +222,7 @@ export const pluginsLogic = kea<
             'installed',
             {
                 setPluginTab: (_, { tab }) => tab,
+                installPluginSuccess: () => 'installed',
             },
         ],
     },

--- a/frontend/src/scenes/plugins/types.ts
+++ b/frontend/src/scenes/plugins/types.ts
@@ -18,3 +18,9 @@ export enum PluginInstallationType {
     Repository = 'repository',
     Source = 'source',
 }
+
+export enum PluginTab {
+    Installed = 'installed',
+    Repository = 'repository',
+    Custom = 'custom',
+}


### PR DESCRIPTION
## Changes

In the spirit of PRs over Issues, here is a proposal to change some design elements on the plugins page:

![2021-01-14 10 58 01](https://user-images.githubusercontent.com/53387/104576029-fb1c2000-5657-11eb-8b1e-6361e4eb6568.gif)

The main reason for this is that very very soon we will need to add plugin ordering (e.g. I want to know that the bigquery export runs after the maxmind ip plugin) and that's really hard to do with a grid of boxes. 

The page is still broken on smaller/mobile screens. I'll fix that later once I get some confirmation that this is a good direction design wise.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
