### PR TITLE
Add missing feature flags

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -19,7 +19,7 @@ from posthog.models.element import Element
 from posthog.models.person import Person
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.tasks.process_event import handle_identify_or_alias, store_names_and_properties
+from posthog.tasks.process_event import _add_missing_feature_flags, handle_identify_or_alias, store_names_and_properties
 
 if settings.STATSD_HOST is not None:
     statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
@@ -59,6 +59,7 @@ def _capture_ee(
     if not team.anonymize_ips and "$ip" not in properties:
         properties["$ip"] = ip
 
+    _add_missing_feature_flags(properties, team, distinct_id)
     store_names_and_properties(team=team, event=event, properties=properties)
 
     if not Person.objects.distinct_ids_exist(team_id=team_id, distinct_ids=[str(distinct_id)]):

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from posthog.models import Team, User
-from posthog.tasks.process_event import get_active_feature_flags
+from posthog.models.feature_flag import get_active_feature_flags
 from posthog.utils import cors_response, load_data_from_request
 
 from .capture import _get_project_id, _get_token

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,13 +1,14 @@
 import json
 import secrets
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 from django.conf import settings
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
-from posthog.models import FeatureFlag, Team, User
+from posthog.models import Team, User
+from posthog.tasks.process_event import get_active_feature_flags
 from posthog.utils import cors_response, load_data_from_request
 
 from .capture import _get_project_id, _get_token
@@ -42,16 +43,6 @@ def decide_editor_params(request: HttpRequest) -> Tuple[Dict[str, Any], bool]:
         return response, not request.user.temporary_token
     else:
         return {}, False
-
-
-def feature_flags(request: HttpRequest, team: Team, data: Dict[str, Any]) -> List[str]:
-    flags_enabled = []
-    feature_flags = FeatureFlag.objects.filter(team=team, active=True, deleted=False)
-    for feature_flag in feature_flags:
-        # distinct_id will always be a string, but data can have non-string values ("Any")
-        if feature_flag.distinct_id_matches(data["distinct_id"]):
-            flags_enabled.append(feature_flag.key)
-    return flags_enabled
 
 
 def parse_domain(url: Any) -> Optional[str]:
@@ -105,7 +96,7 @@ def get_decide(request: HttpRequest):
                 )
             team = user.teams.get(id=project_id)
         if team:
-            response["featureFlags"] = feature_flags(request, team, data_from_request["data"])
+            response["featureFlags"] = get_active_feature_flags(team, data_from_request["data"]["distinct_id"])
             if team.session_recording_opt_in and (on_permitted_domain(team, request) or len(team.app_urls) == 0):
                 response["sessionRecording"] = {"endpoint": "/s/"}
     return cors_response(request, JsonResponse(response))

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -10,19 +10,7 @@ from django.db import IntegrityError
 from sentry_sdk import capture_exception
 
 from posthog.models import Element, Event, Person, SessionRecordingEvent, Team
-from posthog.models.feature_flag import FeatureFlag
-
-
-def get_active_feature_flags(team: Team, distinct_id: str) -> List[str]:
-    flags_enabled = []
-    feature_flags = FeatureFlag.objects.filter(team=team, active=True, deleted=False).only(
-        "id", "team_id", "filters", "key", "rollout_percentage"
-    )
-    for feature_flag in feature_flags:
-        # distinct_id will always be a string, but data can have non-string values ("Any")
-        if feature_flag.distinct_id_matches(distinct_id):
-            flags_enabled.append(feature_flag.key)
-    return flags_enabled
+from posthog.models.feature_flag import FeatureFlag, get_active_feature_flags
 
 
 def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_failed: bool = True,) -> None:

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -15,7 +15,9 @@ from posthog.models.feature_flag import FeatureFlag
 
 def get_active_feature_flags(team: Team, distinct_id: str) -> List[str]:
     flags_enabled = []
-    feature_flags = FeatureFlag.objects.filter(team=team, active=True, deleted=False).only("key", "rollout_percentage")
+    feature_flags = FeatureFlag.objects.filter(team=team, active=True, deleted=False).only(
+        "id", "team_id", "filters", "key", "rollout_percentage"
+    )
     for feature_flag in feature_flags:
         # distinct_id will always be a string, but data can have non-string values ("Any")
         if feature_flag.distinct_id_matches(distinct_id):

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -101,7 +101,7 @@ def store_names_and_properties(team: Team, event: str, properties: Dict) -> None
         team.save()
 
 
-def _add_missing_feature_flags(properties: Dict, team: Team, distinct_id: str):
+def _add_missing_feature_flags(properties: Dict, team: Team, distinct_id: str) -> None:
     # Only add missing feature flags on web
     if not properties.get("$lib") == "web" or properties.get("$active_feature_flags"):
         return

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -13,6 +13,7 @@ from posthog.models import (
     Element,
     ElementGroup,
     Event,
+    FeatureFlag,
     Organization,
     Person,
     SessionRecordingEvent,
@@ -747,6 +748,20 @@ def test_process_event_factory(
             self.team.refresh_from_db()
             self.assertListEqual(self.team.event_properties, ["price", "name", "$ip"])
             self.assertListEqual(self.team.event_properties_numerical, ["price"])
+
+        def test_add_feature_flags_if_missing(self) -> None:
+            self.assertListEqual(self.team.event_properties_numerical, [])
+            FeatureFlag.objects.create(team=self.team, created_by=self.user, key="test-ff", rollout_percentage=100)
+            process_event(
+                "xxx",
+                "",
+                "",
+                {"event": "purchase", "properties": {"$lib": "web"},},
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+            self.assertEqual(get_events()[0].properties["$active_feature_flags"], ["test-ff"])
 
     return TestProcessEvent
 

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -752,15 +752,16 @@ def test_process_event_factory(
         def test_add_feature_flags_if_missing(self) -> None:
             self.assertListEqual(self.team.event_properties_numerical, [])
             FeatureFlag.objects.create(team=self.team, created_by=self.user, key="test-ff", rollout_percentage=100)
-            process_event(
-                "xxx",
-                "",
-                "",
-                {"event": "purchase", "properties": {"$lib": "web"},},
-                self.team.pk,
-                now().isoformat(),
-                now().isoformat(),
-            )
+            with self.assertNumQueries(17):
+                process_event(
+                    "xxx",
+                    "",
+                    "",
+                    {"event": "purchase", "properties": {"$lib": "web"},},
+                    self.team.pk,
+                    now().isoformat(),
+                    now().isoformat(),
+                )
             self.assertEqual(get_events()[0].properties["$active_feature_flags"], ["test-ff"])
 
     return TestProcessEvent


### PR DESCRIPTION
## Changes

Quite often, /decide hasn't loaded yet by the time we've sent the first `$pageview` event. This means the data on feature flags looks wrong. See below pie chart. This is a feature flag that is set to 50% of users, so clearly we are losing quite a bit of data.

We also don't want to have $pageview events waiting for /decide, as that'll cause us to miss pageview events. 

This PR automatically adds those missing feature flags to the event. 

![image](https://user-images.githubusercontent.com/1727427/104590728-05481980-566c-11eb-86cc-221610bc3a12.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
