### PR TITLE
Support multiple action filters in sessions

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -127,11 +127,11 @@ def filter_element(step: ActionStep, prepend: str = "") -> Tuple[List[str], Dict
     return (conditions, params)
 
 
-def format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
+def format_entity_filter(entity: Entity, prepend: str = "action") -> Tuple[str, Dict]:
     if entity.type == TREND_FILTER_TYPE_ACTIONS:
         try:
             action = Action.objects.get(pk=entity.id)
-            entity_filter, params = format_action_filter(action)
+            entity_filter, params = format_action_filter(action, prepend=prepend)
         except Action.DoesNotExist:
             raise ValueError("This action does not exist")
     else:

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -17,5 +17,5 @@ class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(Clickhou
     pass
 
 
-class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event, action_filters_enabled=False)):  # type: ignore
+class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event)):  # type: ignore
     pass

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -17,5 +17,5 @@ class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(Clickhou
     pass
 
 
-class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event, action_filter_enabled=True)):  # type: ignore
+class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event, action_filters_enabled=False)):  # type: ignore
     pass

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -9,8 +9,8 @@ SESSION_SQL = """
         groupArray(properties) properties,
         groupArray(timestamp) timestamps,
         groupArray(elements_chain) elements_chain,
-        arrayReduce('max', groupArray(timestamp)) as end_time,
-        groupArray(1)(action_filter_timestamp) as action_filter_timestamp
+        arrayReduce('max', groupArray(timestamp)) as end_time
+        {filters_select_clause}
     FROM (
         SELECT
             distinct_id,
@@ -19,8 +19,8 @@ SESSION_SQL = """
             uuid,
             properties,
             elements_chain,
-            arraySum(arraySlice(gids, 1, idx)) AS gid,
-            ({action_filter_timestamp}) as action_filter_timestamp
+            arraySum(arraySlice(gids, 1, idx)) AS gid
+            {filters_timestamps_clause}
         FROM (
             SELECT
                 groupArray(timestamp) as timestamps,
@@ -92,8 +92,7 @@ SESSION_SQL = """
     GROUP BY
         distinct_id,
         gid
-    HAVING
-        notEmpty(action_filter_timestamp)
+    {filters_having}
     ORDER BY
         end_time DESC
     {sessions_limit}

--- a/posthog/models/filters/mixins/sessions.py
+++ b/posthog/models/filters/mixins/sessions.py
@@ -52,10 +52,6 @@ class SessionsFiltersMixin(BaseParamMixin):
         ]
 
     @cached_property
-    def action_filter(self) -> Optional[Entity]:
-        return self.action_filters[0] if len(self.action_filters) > 0 else None
-
-    @cached_property
     def person_filter_properties(self) -> List[Property]:
         return [
             Property(**filter)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -179,6 +179,13 @@ def properties_to_Q(properties: List[Property], team_id: int, is_person_query: b
     return filters
 
 
+def entity_to_Q(entity: Entity, team_id: int) -> Q:
+    result = Q(action__pk=entity.id) if entity.type == TREND_FILTER_TYPE_ACTIONS else Q(event=entity.id)
+    if entity.properties:
+        result &= properties_to_Q(entity.properties, team_id)
+    return result
+
+
 class BaseQuery:
     """
         Run needs to be implemented in the individual Query class. It takes in a Filter, Team


### PR DESCRIPTION
Depends on https://github.com/PostHog/posthog/pull/2934

- Make it possible to filter by (multiple) action filters in postgres
- Clickhouse: support multiple action filters
- Remove dead code

After this it's possible to filter by multiple action filters in both clickhouse and cloud.

We return timestamps for when user performed the action as well, this can be used 
to highlight rows as below and show shortcuts in session recording.

![2021-01-14_16-26](https://user-images.githubusercontent.com/148820/104603624-47318980-5685-11eb-83a1-8db2eaff7af6.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
