### PR TITLE
Make flag explicit

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.js
+++ b/frontend/src/scenes/dashboard/DashboardItem.js
@@ -102,7 +102,7 @@ export const displayMap = {
         link: ({ id, dashboard, name, filters }) => {
             return combineUrl(
                 `/insights`,
-                { insight: ViewType.Retention, ...filters },
+                { insight: ViewType.RETENTION, ...filters },
                 { fromItem: id, fromItemName: name, fromDashboard: dashboard }
             ).url
         },

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -42,7 +42,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     <PropertyFilters pageKey="trends-filters" />
                 </>
             )}
-            {filters.insight === ViewType.TRENDS && (
+            {filters.insight !== ViewType.LIFECYCLE && filters.insight !== ViewType.STICKINESS && (
                 <>
                     <hr />
                     <h4 className="secondary">


### PR DESCRIPTION
## Changes

*Please describe.*  
- matching on trend wasn't working because `insight` is null on trends tab
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
