### PR TITLE
Only cache new items for 1 day

### DIFF
--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -9,7 +9,7 @@ from django.utils.timezone import now
 from posthog.models import Filter, Team, User
 from posthog.models.dashboard_item import DashboardItem
 from posthog.models.filters.utils import get_filter
-from posthog.settings import CACHED_RESULTS_TTL
+from posthog.settings import TEMP_CACHE_RESULTS_TTL
 from posthog.utils import generate_cache_key
 
 from .utils import generate_cache_key
@@ -49,7 +49,7 @@ def cached_function():
             # cache new data
             if result is not None and (not isinstance(result, dict) or not result.get("loading")):
                 cache.set(
-                    cache_key, {"result": result, "details": payload,}, CACHED_RESULTS_TTL,
+                    cache_key, {"result": result, "details": payload,}, TEMP_CACHE_RESULTS_TTL,
                 )
                 if filter:
                     dashboard_items = DashboardItem.objects.filter(team_id=team.pk, filters_hash=cache_key)

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -399,7 +399,7 @@ CELERY_IGNORE_RESULT = True  # only applies to delay(), must do @shared_task(ign
 REDBEAT_LOCK_TIMEOUT = 45  # keep distributed beat lock for 45sec
 
 CACHED_RESULTS_TTL = 7 * 24 * 60 * 60  # how long to keep cached results for
-TEMP_CACHE_RESULTS_TTL = 60  # how long to keep non dashboard cached results for
+TEMP_CACHE_RESULTS_TTL = 24 * 60 * 60  # how long to keep non dashboard cached results for
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -399,6 +399,7 @@ CELERY_IGNORE_RESULT = True  # only applies to delay(), must do @shared_task(ign
 REDBEAT_LOCK_TIMEOUT = 45  # keep distributed beat lock for 45sec
 
 CACHED_RESULTS_TTL = 7 * 24 * 60 * 60  # how long to keep cached results for
+TEMP_CACHE_RESULTS_TTL = 60  # how long to keep non dashboard cached results for
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
## Changes

*Please describe.*  
- currently caching everything for a week. changing this to only cache new items for 60 seconds and only caching for a week if the item is on dashboard
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
