### PR TITLE
Capture rageclicks (via posthog-js)

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -3,9 +3,13 @@ import * as Sentry from '@sentry/browser'
 
 export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        posthog.init(window.JS_POSTHOG_API_KEY, { api_host: window.JS_POSTHOG_HOST, _capture_metrics: true })
+        posthog.init(window.JS_POSTHOG_API_KEY, {
+            api_host: window.JS_POSTHOG_HOST,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            _capture_metrics: true,
+            rageclick: true,
+        })
         // Make sure we have access to the object in window for debugging
         window.posthog = posthog
     } else {


### PR DESCRIPTION
We created a rageclick functionality a while ago. Now filters are approaching finality, let's test them out.

If it works, we can perhaps include it next release.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
