### PR TITLE
Add "AND" indicator to feature flag filters & update visuals

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -421,3 +421,20 @@ style files without adding already imported styles. */
         border-color: $primary;
     }
 }
+
+// Stateful badges
+
+.stateful-badge {
+    padding: 2px 8px;
+    border-radius: 2px;
+    font-weight: bold;
+
+    &.or {
+        background-color: $blue_300;
+    }
+
+    &.and {
+        background-color: $yellow_100;
+        color: $primary_alt;
+    }
+}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -56,10 +56,7 @@ const FilterRow = React.memo(function FilterRow({
                 />
             )}
             {key && showConditionBadge && index + 1 < totalCount && (
-                <span
-                    style={{ marginLeft: 16, right: 16, position: 'absolute' }}
-                    className="match-condition-badge mc-and"
-                >
+                <span style={{ marginLeft: 16, right: 16, position: 'absolute' }} className="stateful-badge and">
                     AND
                 </span>
             )}
@@ -72,7 +69,7 @@ export function PropertyFilters({
     propertyFilters = null,
     onChange = null,
     pageKey,
-    showConditionBadges = false,
+    showConditionBadge = false,
 }) {
     const logic = propertyFilterLogic({ propertyFilters, endpoint, onChange, pageKey })
     const { filters } = useValues(logic)
@@ -90,7 +87,7 @@ export function PropertyFilters({
                             totalCount={filters.length - 1} // empty state
                             filters={filters}
                             pageKey={pageKey}
-                            showConditionBadge={showConditionBadges}
+                            showConditionBadge={showConditionBadge}
                         />
                     )
                 })}

--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -214,7 +214,7 @@ export class ActionStep extends Component {
         const AndC = () => {
             return (
                 <div className="text-center">
-                    <span className="match-condition-badge mc-and">AND</span>
+                    <span className="stateful-badge and">AND</span>
                 </div>
             )
         }
@@ -276,7 +276,7 @@ export class ActionStep extends Component {
         return (
             <Col span={24} md={12}>
                 <Card className="action-step" style={{ overflow: 'visible' }}>
-                    {index > 0 && <div className="match-condition-badge mc-main mc-or">OR</div>}
+                    {index > 0 && <div className="stateful-badge mc-main or">OR</div>}
                     <div>
                         {!isOnlyStep && (
                             <div className="remove-wrapper">

--- a/frontend/src/scenes/experimentation/EditFeatureFlag.js
+++ b/frontend/src/scenes/experimentation/EditFeatureFlag.js
@@ -115,12 +115,13 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                 <Switch />
             </Form.Item>
 
-            <Form.Item className={rrwebBlockClass} label="Filter by user properties">
+            <Form.Item className={rrwebBlockClass} label="Filter by user properties" style={{ position: 'relative' }}>
                 <PropertyFilters
                     pageKey={'feature-flag-' + featureFlag.id}
                     propertyFilters={filters?.properties}
                     onChange={(properties) => setFilters({ properties })}
                     endpoint="person"
+                    showConditionBadge
                 />
             </Form.Item>
 

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -193,21 +193,6 @@ label.disabled {
     }
 }
 
-.match-condition-badge {
-    padding: 2px 8px;
-    border-radius: 2px;
-    color: white;
-    font-weight: bold;
-
-    &.mc-or {
-        background-color: #4263eb;
-    }
-
-    &.mc-and {
-        background-color: #f7a501;
-    }
-}
-
 .Papercups-toggleButtonContainer,
 .Papercups-chatWindowContainer {
     transition: transform 0.3s cubic-bezier(0.7, 0.3, 0.1, 1);

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -42,6 +42,11 @@ $blue_500: #597dce;
 $blue_300: #8da9e7;
 $blue_100: #b8cefd;
 
+// Yellow Swatch
+$yellow_500: #f8a523;
+$yellow_300: #ffc035;
+$yellow_100: #fbdd99;
+
 // Purple Swatch
 $purple_700: #7c4286;
 $purple_500: #c278cf;


### PR DESCRIPTION
## Changes

- Adds an "AND" tag to the feature flags filters to clarify the behavior of filters ([motivation](https://posthog.slack.com/archives/C0113360FFV/p1610739340095100))

    <img width="394" alt="" src="https://user-images.githubusercontent.com/5864173/104783889-a1e1e880-574c-11eb-8081-7b37b2f8fe05.png">

- Updates the visual styles of the AND & OR tags based on the new design components.
    ![image](https://user-images.githubusercontent.com/5864173/104783816-7a8b1b80-574c-11eb-8027-8b67ef5e2548.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
