### PR TITLE
Order tooltip by volume

### DIFF
--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -225,6 +225,7 @@ export function LineGraph({
                                   },
                                   footer: () => 'Click to see users related to the datapoint',
                               },
+                              itemSort: (a, b) => b.yLabel - a.yLabel,
                           },
                           hover: {
                               mode: 'nearest',


### PR DESCRIPTION
## Changes

*Please describe.* 
Fixes #2942. This changes the tooltip order by volume. Added a line to `LineGraph.js` to sort by descending order

*If this affects the frontend, include screenshots.*  
Before:
![image](https://user-images.githubusercontent.com/18711727/104797827-2ce3d280-578f-11eb-9a7a-b2d1e08c89a7.png)

After:
![image](https://user-images.githubusercontent.com/18711727/104797816-09b92300-578f-11eb-9381-6ced9a9a2b84.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
