### PR TITLE
Standardize created at and by table columns

### DIFF
--- a/frontend/src/lib/components/Table.tsx
+++ b/frontend/src/lib/components/Table.tsx
@@ -44,13 +44,13 @@ export function createdByColumn(items: Record<string, any>[]): Record<string, an
             if (b.value === user?.id) {
                 return 10
             }
-            return (a.text + '').localeCompare(b.text)
+            return (a.text + '').localeCompare(b.text + '')
         }),
         onFilter: (value: string, item: Record<string, any>) =>
             (value === null && item.created_by === null) || item.created_by?.id === value,
         sorter: (a: Record<string, any>, b: Record<string, any>) =>
-            (a.created_by?.first_name || a.created_by?.email).localeCompare(
-                b.created_by?.first_name || b.created_by?.email
+            (a.created_by?.first_name || a.created_by?.email || '').localeCompare(
+                b.created_by?.first_name || b.created_by?.email || ''
             ),
     }
 }

--- a/frontend/src/lib/components/Table.tsx
+++ b/frontend/src/lib/components/Table.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { uniqueBy } from 'lib/utils'
+import { Created } from './Created'
+import { useValues } from 'kea'
+import { userLogic } from 'scenes/userLogic'
+
+export function createdAtColumn(): Record<string, any> {
+    return {
+        title: 'Created',
+        render: function RenderCreatedAt(_, item: Record<string, any>): JSX.Element | undefined | '' {
+            return item.created_at && <Created timestamp={item.created_at} />
+        },
+        sorter: (a: Record<string, any>, b: Record<string, any>) =>
+            new Date(a.created_at) > new Date(b.created_at) ? 1 : -1,
+    }
+}
+
+export function createdByColumn(items: Record<string, any>[]): Record<string, any> {
+    const { user } = useValues(userLogic)
+    return {
+        title: 'Created by',
+        render: function RenderCreatedBy(_, item: any) {
+            return item.created_by ? item.created_by.first_name || item.created_by.email : '-'
+        },
+        filters: uniqueBy(
+            items.map((item: Record<string, any>) => {
+                if (!item.created_by) {
+                    return {
+                        text: '(none)',
+                        value: null,
+                    }
+                }
+                return {
+                    text: item.created_by?.first_name || item.created_by?.email,
+                    value: item.created_by?.id,
+                }
+            }),
+            (item) => item?.value
+        ).sort((a, b) => {
+            // Current user first
+            if (a.value === user?.id) {
+                return -10
+            }
+            if (b.value === user?.id) {
+                return 10
+            }
+            return (a.text + '').localeCompare(b.text)
+        }),
+        onFilter: (value: string, item: Record<string, any>) =>
+            (value === null && item.created_by === null) || item.created_by?.id === value,
+        sorter: (a: Record<string, any>, b: Record<string, any>) =>
+            (a.created_by?.first_name || a.created_by?.email).localeCompare(
+                b.created_by?.first_name || b.created_by?.email
+            ),
+    }
+}

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -10,10 +10,10 @@ import { NewActionButton } from './NewActionButton'
 import imgGrouping from 'public/actions-tutorial-grouping.svg'
 import imgStandardized from 'public/actions-tutorial-standardized.svg'
 import imgRetroactive from 'public/actions-tutorial-retroactive.svg'
-import { Created } from 'lib/components/Created'
 import { ActionType } from '~/types'
 import Fuse from 'fuse.js'
 import { userLogic } from 'scenes/userLogic'
+import { createdAtColumn, createdByColumn } from 'lib/components/Table'
 
 const searchActions = (sources: ActionType[], search: string): ActionType[] => {
     return new Fuse(sources, {
@@ -107,22 +107,8 @@ export function ActionsTable(): JSX.Element {
                 )
             },
         },
-        {
-            title: 'Created by',
-            render: function RenderCreatedBy(_, action: ActionType) {
-                if (!action.created_by) {
-                    return 'Unknown'
-                }
-                return action.created_by.first_name || action.created_by.email
-            },
-        },
-        {
-            title: 'Created',
-            render: function RenderCreatedAt(_, action: ActionType) {
-                return <Created timestamp={action.created_at} />
-            },
-            sorter: (a: ActionType, b: ActionType) => (new Date(a.created_at) > new Date(b.created_at) ? 1 : -1),
-        },
+        createdAtColumn(),
+        createdByColumn(actions),
         {
             title: '',
             render: function RenderActions(action: ActionType) {

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -2,7 +2,6 @@ import { hot } from 'react-hot-loader/root'
 import React, { useState, useEffect, HTMLAttributes } from 'react'
 import { useValues, useActions } from 'kea'
 import { Table, Tag, Button, Modal, Input, DatePicker, Row, Spin, Menu, Dropdown } from 'antd'
-import { Link } from 'lib/components/Link'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import moment from 'moment'
 import { annotationsModel } from '~/models/annotationsModel'
@@ -10,9 +9,9 @@ import { annotationsTableLogic } from './logic'
 import { DeleteOutlined, RedoOutlined, ProjectOutlined, DeploymentUnitOutlined, DownOutlined } from '@ant-design/icons'
 import { AnnotationScope, annotationScopeToName } from 'lib/constants'
 import { userLogic } from 'scenes/userLogic'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PlusOutlined } from '@ant-design/icons'
+import { createdByColumn } from 'lib/components/Table'
 
 const { TextArea } = Input
 
@@ -46,23 +45,7 @@ function _Annotations(): JSX.Element {
             },
             ellipsis: true,
         },
-        {
-            title: 'Created By',
-            key: 'person',
-            render: function RenderPerson(annotation): JSX.Element {
-                const { created_by } = annotation
-
-                return (
-                    <Link
-                        to={`/person/${encodeURIComponent(created_by.id)}`}
-                        className={rrwebBlockClass + ' ph-no-capture'}
-                    >
-                        {created_by?.name || created_by?.email}
-                    </Link>
-                )
-            },
-            ellipsis: true,
-        },
+        createdByColumn(annotations),
         {
             title: 'Date Marker',
             render: function RenderDateMarker(annotation): JSX.Element {

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -10,6 +10,7 @@ import { PushpinFilled, PushpinOutlined, DeleteOutlined, AppstoreAddOutlined } f
 import { hot } from 'react-hot-loader/root'
 import { NewDashboard } from 'scenes/dashboard/NewDashboard'
 import { PageHeader } from 'lib/components/PageHeader'
+import { createdAtColumn, createdByColumn } from 'lib/components/Table'
 
 export const Dashboards = hot(_Dashboards)
 function _Dashboards(): JSX.Element {
@@ -17,6 +18,54 @@ function _Dashboards(): JSX.Element {
     const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard } = useActions(dashboardsModel)
     const { setNewDashboardDrawer } = useActions(dashboardsLogic)
     const { dashboards, newDashboardDrawer } = useValues(dashboardsLogic)
+
+    const columns = [
+        {
+            title: '',
+            width: 24,
+            align: 'center',
+            render: function RenderPin({ id, pinned }) {
+                return (
+                    <span
+                        onClick={() => (pinned ? unpinDashboard(id) : pinDashboard(id))}
+                        style={{ color: 'rgba(0, 0, 0, 0.85)', cursor: 'pointer' }}
+                    >
+                        {pinned ? <PushpinFilled /> : <PushpinOutlined />}
+                    </span>
+                )
+            },
+        },
+        {
+            title: 'Dashboard',
+            dataIndex: 'name',
+            key: 'name',
+            render: function RenderName(name: string, { id }: { id: number }, index: number) {
+                return (
+                    <Link data-attr={'dashboard-name-' + index} to={`/dashboard/${id}`}>
+                        {name || 'Untitled'}
+                    </Link>
+                )
+            },
+        },
+        createdAtColumn(),
+        createdByColumn(dashboards),
+        {
+            title: 'Actions',
+            align: 'center',
+            width: 120,
+            render: function RenderActions({ id }) {
+                return (
+                    <span
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => deleteDashboard({ id, redirect: false })}
+                        className="text-danger"
+                    >
+                        <DeleteOutlined /> Delete
+                    </span>
+                )
+            },
+        },
+    ]
 
     return (
         <div>
@@ -51,45 +100,8 @@ function _Dashboards(): JSX.Element {
                         rowKey="id"
                         size="small"
                         pagination={{ pageSize: 100, hideOnSinglePage: true }}
-                    >
-                        <Table.Column
-                            title=""
-                            width={24}
-                            align="center"
-                            render={({ id, pinned }) => (
-                                <span
-                                    onClick={() => (pinned ? unpinDashboard(id) : pinDashboard(id))}
-                                    style={{ color: 'rgba(0, 0, 0, 0.85)', cursor: 'pointer' }}
-                                >
-                                    {pinned ? <PushpinFilled /> : <PushpinOutlined />}
-                                </span>
-                            )}
-                        />
-                        <Table.Column
-                            title="Dashboard"
-                            dataIndex="name"
-                            key="name"
-                            render={(name, { id }, index) => (
-                                <Link data-attr={'dashboard-name-' + index} to={`/dashboard/${id}`}>
-                                    {name || 'Untitled'}
-                                </Link>
-                            )}
-                        />
-                        <Table.Column
-                            title="Actions"
-                            align="center"
-                            width={120}
-                            render={({ id }) => (
-                                <span
-                                    style={{ cursor: 'pointer' }}
-                                    onClick={() => deleteDashboard({ id, redirect: false })}
-                                    className="text-danger"
-                                >
-                                    <DeleteOutlined /> Delete
-                                </span>
-                            )}
-                        />
-                    </Table>
+                        columns={columns}
+                    />
                 ) : (
                     <div>
                         <p>Create your first dashboard:</p>

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -60,7 +60,7 @@ function _Dashboards(): JSX.Element {
                         onClick={() => deleteDashboard({ id, redirect: false })}
                         className="text-danger"
                     >
-                        <DeleteOutlined /> Delete
+                        <DeleteOutlined />
                     </span>
                 )
             },

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -2,8 +2,7 @@ import React, { useState } from 'react'
 import { hot } from 'react-hot-loader/root'
 import { useValues, useActions } from 'kea'
 import { featureFlagLogic } from './featureFlagLogic'
-import { Table, Switch, Drawer, Button, Tooltip } from 'antd'
-import moment from 'moment'
+import { Table, Switch, Drawer, Button } from 'antd'
 import { EditFeatureFlag } from './EditFeatureFlag'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { Link } from 'lib/components/Link'
@@ -11,6 +10,7 @@ import { DeleteWithUndo } from 'lib/utils'
 import { ExportOutlined, PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons'
 import { PageHeader } from 'lib/components/PageHeader'
 import PropertyFiltersDisplay from 'lib/components/PropertyFilters/PropertyFiltersDisplay'
+import { createdAtColumn, createdByColumn } from 'lib/components/Table'
 
 export const FeatureFlags = hot(_FeatureFlags)
 function _FeatureFlags() {
@@ -30,28 +30,8 @@ function _FeatureFlags() {
             dataIndex: 'key',
             sorter: (a, b) => ('' + a.key).localeCompare(b.key),
         },
-
-        {
-            title: 'Created',
-            render: function RenderCreatedAt(_, featureFlag) {
-                return (
-                    <Tooltip title={moment(featureFlag.created_at).format('LLL')}>
-                        {moment(featureFlag.created_at).fromNow()}
-                    </Tooltip>
-                )
-            },
-            sorter: (a, b) => (new Date(a.created_at) > new Date(b.created_at) ? 1 : -1),
-        },
-        {
-            title: 'Created by',
-            render: function RenderCreatedBy(_, featureFlag) {
-                return featureFlag.created_by.first_name || featureFlag.created_by.email
-            },
-            sorter: (a, b) =>
-                (a.created_by.first_name || a.created_by.email).localeCompare(
-                    b.created_by.first_name || b.created_by.email
-                ),
-        },
+        createdAtColumn(),
+        createdByColumn(featureFlags),
         {
             title: 'Rollout Percentage',
             render: function RenderRolloutPercentage(_, featureFlag) {

--- a/frontend/src/scenes/persons/Cohorts.tsx
+++ b/frontend/src/scenes/persons/Cohorts.tsx
@@ -8,7 +8,6 @@ import { useValues, useActions, kea } from 'kea'
 import { hot } from 'react-hot-loader/root'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PlusOutlined } from '@ant-design/icons'
-import { Created } from 'lib/components/Created'
 import { Cohort } from './Cohort'
 import { Drawer } from 'lib/components/Drawer'
 import { CohortType } from '~/types'
@@ -16,6 +15,7 @@ import api from 'lib/api'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import './cohorts.scss'
 import Fuse from 'fuse.js'
+import { createdAtColumn, createdByColumn } from 'lib/components/Table'
 
 const cohortsUrlLogic = kea({
     actions: {
@@ -73,23 +73,8 @@ function _Cohorts(): JSX.Element {
             },
             sorter: (a: CohortType, b: CohortType) => a.count - b.count,
         },
-        {
-            title: 'Created',
-            render: function RenderCreatedAt(_, cohort: CohortType): JSX.Element | undefined | '' {
-                return cohort.created_at && <Created timestamp={cohort.created_at} />
-            },
-            sorter: (a: CohortType, b: CohortType) => (new Date(a.created_at) > new Date(b.created_at) ? 1 : -1),
-        },
-        {
-            title: 'Created by',
-            render: function RenderCreatedBy(_, cohort: CohortType) {
-                return cohort.created_by ? cohort.created_by.first_name || cohort.created_by.email : '-'
-            },
-            sorter: (a: CohortType, b: CohortType) =>
-                (a.created_by?.first_name || a.created_by?.email).localeCompare(
-                    b.created_by?.first_name || b.created_by?.email
-                ),
-        },
+        createdAtColumn(),
+        createdByColumn(cohorts),
         {
             title: (
                 <span>

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -17,6 +17,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 
 from posthog.api.routing import StructuredViewSetMixin
+from posthog.api.user import UserSerializer
 from posthog.auth import PersonalAPIKeyAuthentication, PublicTokenAuthentication
 from posthog.constants import TRENDS_FUNNEL
 from posthog.helpers import create_dashboard_from_template
@@ -27,6 +28,7 @@ from posthog.utils import render_template
 
 class DashboardSerializer(serializers.ModelSerializer):
     items = serializers.SerializerMethodField()  # type: ignore
+    created_by = UserSerializer(required=False, read_only=True)
     use_template = serializers.CharField(write_only=True, allow_blank=True, required=False)
 
     class Meta:

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -19,7 +19,6 @@ from rest_framework.request import Request
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.user import UserSerializer
 from posthog.auth import PersonalAPIKeyAuthentication, PublicTokenAuthentication
-from posthog.constants import TRENDS_FUNNEL
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, DashboardItem, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions
@@ -28,7 +27,7 @@ from posthog.utils import render_template
 
 class DashboardSerializer(serializers.ModelSerializer):
     items = serializers.SerializerMethodField()  # type: ignore
-    created_by = UserSerializer(required=False, read_only=True)
+    created_by = UserSerializer(read_only=True)
     use_template = serializers.CharField(write_only=True, allow_blank=True, required=False)
 
     class Meta:

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -1,17 +1,23 @@
 import json
 
-from django.core.cache import cache
 from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 
 from posthog.models import Dashboard, DashboardItem, Filter, User
-from posthog.test.base import BaseTest, TransactionBaseTest
+from posthog.test.base import TransactionBaseTest
 from posthog.utils import generate_cache_key
 
 
 class TestDashboard(TransactionBaseTest):
     TESTS_API = True
+
+    def test_get_dashboard(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="private dashboard", created_by=self.user)
+        response = self.client.get(f"/api/dashboard/{dashboard.id}", content_type="application/json",)
+        self.assertEqual(response.json()["name"], "private dashboard")
+        self.assertEqual(response.json()["created_by"]["distinct_id"], self.user.distinct_id)
+        self.assertEqual(response.json()["created_by"]["first_name"], self.user.first_name)
 
     def test_create_dashboard_item(self):
         dashboard = Dashboard.objects.create(team=self.team, share_token="testtoken", name="public dashboard")


### PR DESCRIPTION
## Changes

We use created at and by in most tables (feature flags, cohorts, annotations etc) but they were all subtly different.

I've also added easy filtering on 'created by' and put current user first, so it's really easy to get a list of objects you created.
![image](https://user-images.githubusercontent.com/1727427/104806041-c41f4900-57d4-11eb-8761-84df3dd0f43a.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
