### PR TITLE
Lessen the language in the plugin opt-in warning

### DIFF
--- a/frontend/src/scenes/plugins/OptInPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptInPlugins.tsx
@@ -32,24 +32,14 @@ export function OptInPlugins(): JSX.Element {
                 Plugins enable you to extend PostHog's core functionality. For example by adding geographical
                 information to your events, normalizing your revenue information to a single currency, etc.
             </div>
-            <div style={{ marginBottom: 20 }}>
-                Plugins are currently in an <strong>experimental</strong> stage. You must opt-in to use them in{' '}
-                <b>each project.</b>
-            </div>
             {!user?.is_multi_tenancy && (
                 <>
                     <div style={{ marginBottom: 20 }}>
                         Plugin support requires the cooperation of the main PostHog application and the new NodeJS-based{' '}
-                        <a
-                            href="https://github.com/PostHog/posthog-plugin-server"
-                            target="_blank"
-                            rel="noreferrer noopener"
-                        >
-                            <code>posthog-plugin-server</code>
+                        <a href="https://github.com/PostHog/plugin-server" target="_blank" rel="noreferrer noopener">
+                            <code>plugin-server</code>
                         </a>
-                        . In case the plugin server is not properly configured, you <em>might</em> experience data loss.
-                        If you do not wish to take this risk we recommend waiting a few weeks until this functionality
-                        is fully released.
+                        , which must be properly configured.
                     </div>
                     <div style={{ marginBottom: 20 }}>
                         Plugin server:{' '}
@@ -69,7 +59,7 @@ export function OptInPlugins(): JSX.Element {
             )}
             <div style={{ marginBottom: 20 }}>
                 <Checkbox checked={optIn} onChange={() => setOptIn(!optIn)} disabled={serverStatus !== 'online'}>
-                    I understand the risks and wish to try this beta feature now for <b>{user?.team?.name}</b>.
+                    I wish to enable plugins for <b>{user?.team?.name}</b>.
                 </Checkbox>
             </div>
             <div>

--- a/frontend/src/scenes/plugins/OptInPlugins.tsx
+++ b/frontend/src/scenes/plugins/OptInPlugins.tsx
@@ -35,11 +35,11 @@ export function OptInPlugins(): JSX.Element {
             {!user?.is_multi_tenancy && (
                 <>
                     <div style={{ marginBottom: 20 }}>
-                        Plugin support requires the cooperation of the main PostHog application and the new NodeJS-based{' '}
+                        Plugin support requires the cooperation of the main PostHog application and the{' '}
                         <a href="https://github.com/PostHog/plugin-server" target="_blank" rel="noreferrer noopener">
-                            <code>plugin-server</code>
+                            <code>PostHog plugin server</code>
                         </a>
-                        , which must be properly configured.
+                        , which must be properly set up.
                     </div>
                     <div style={{ marginBottom: 20 }}>
                         Plugin server:{' '}

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -45,7 +45,7 @@ function _Plugins(): JSX.Element {
                         </sup>
                     </>
                 }
-                caption="Plugins enable you to extend PostHog's core functionality."
+                caption={user.team?.plugins_opt_in ? "Plugins enable you to extend PostHog's core functionality." : ''}
                 buttons={user.team?.plugins_opt_in && <OptOutPlugins />}
             />
 


### PR DESCRIPTION
## Changes

- When the plugin server properly configured and is online, it works quite well. 
- This PR lessens the "experimental" and "data loss" language in the opt-in screen in order to not scare people anymore.

Before:

<img width="968" alt="Screenshot 2021-01-18 at 13 18 22" src="https://user-images.githubusercontent.com/53387/104915372-d514b980-5990-11eb-8f72-14b4af72c0bc.png">

After:

![image](https://user-images.githubusercontent.com/53387/104915405-e067e500-5990-11eb-90c6-044a0d3728d7.png)



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
