### PR TITLE
Set Once

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -124,6 +124,8 @@ if is_ee_enabled():
         properties = data.get("properties", {})
         if data.get("$set"):
             properties["$set"] = data["$set"]
+        if data.get("$set_once"):
+            properties["$set_once"] = data["$set_once"]
 
         person_uuid = UUIDT()
         ts = handle_timestamp(data, now, sent_at)

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -207,7 +207,9 @@ def _update_person_properties(team_id: int, distinct_id: str, properties: Dict, 
                 team_id=team_id, persondistinctid__team_id=team_id, persondistinctid__distinct_id=str(distinct_id)
             )
     if set_once:
-        person.properties = properties.update(person.properties)
+        new_properties = properties.copy()
+        new_properties.update(person.properties)
+        person.properties = new_properties
     else:
         person.properties.update(properties)
     person.save()
@@ -287,6 +289,8 @@ def process_event(
     properties = data.get("properties", {})
     if data.get("$set"):
         properties["$set"] = data["$set"]
+    if data.get("$set_once"):
+        properties["$set_once"] = data["$set_once"]
 
     handle_identify_or_alias(data["event"], properties, distinct_id, team_id)
 

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -202,11 +202,13 @@ def _update_person_properties(team_id: int, distinct_id: str, properties: Dict, 
         try:
             person = Person.objects.create(team_id=team_id, distinct_ids=[str(distinct_id)])
         # Catch race condition where in between getting and creating, another request already created this person
-        except:
+        except Exception:
             person = Person.objects.get(
                 team_id=team_id, persondistinctid__team_id=team_id, persondistinctid__distinct_id=str(distinct_id)
             )
     if set_once:
+        # Set properties on a user record, only if they do not yet exist.
+        # Unlike $set, this will not overwrite existing people property values.
         new_properties = properties.copy()
         new_properties.update(person.properties)
         person.properties = new_properties

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -193,7 +193,7 @@ def get_or_create_person(team_id: int, distinct_id: str) -> Tuple[Person, bool]:
     return person, created
 
 
-def _update_person_properties(team_id: int, distinct_id: str, properties: Dict) -> None:
+def _update_person_properties(team_id: int, distinct_id: str, properties: Dict, set_once: bool = False) -> None:
     try:
         person = Person.objects.get(
             team_id=team_id, persondistinctid__team_id=team_id, persondistinctid__distinct_id=str(distinct_id)
@@ -206,7 +206,10 @@ def _update_person_properties(team_id: int, distinct_id: str, properties: Dict) 
             person = Person.objects.get(
                 team_id=team_id, persondistinctid__team_id=team_id, persondistinctid__distinct_id=str(distinct_id)
             )
-    person.properties.update(properties)
+    if set_once:
+        person.properties = properties.update(person.properties)
+    else:
+        person.properties.update(properties)
     person.save()
 
 
@@ -270,6 +273,10 @@ def handle_identify_or_alias(event: str, properties: dict, distinct_id: str, tea
             )
         if properties.get("$set"):
             _update_person_properties(team_id=team_id, distinct_id=distinct_id, properties=properties["$set"])
+        if properties.get("$set_once"):
+            _update_person_properties(
+                team_id=team_id, distinct_id=distinct_id, properties=properties["$set_once"], set_once=True
+            )
         _set_is_identified(team_id=team_id, distinct_id=distinct_id)
 
 

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -593,7 +593,7 @@ def test_process_event_factory(
                     "properties": {
                         "token": self.team.api_token,
                         "distinct_id": "distinct_id",
-                        "$set": {"a_prop": "test-2", "b_prop": "test-2"},
+                        "$set": {"a_prop": "test-2", "b_prop": "test-2b"},
                     },
                 },
                 self.team.pk,
@@ -603,7 +603,7 @@ def test_process_event_factory(
 
             self.assertEqual(len(get_events()), 2)
             self.assertEqual(
-                Person.objects.get().properties, {"a_prop": "test-2", "b_prop": "test-2", "c_prop": "test-1"}
+                Person.objects.get().properties, {"a_prop": "test-2", "b_prop": "test-2b", "c_prop": "test-1"}
             )
 
         def test_identify_set_once(self) -> None:

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -561,7 +561,7 @@ def test_process_event_factory(
             Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
 
             process_event(
-                "new_distinct_id",
+                "distinct_id",
                 "",
                 "",
                 {
@@ -569,7 +569,7 @@ def test_process_event_factory(
                     "properties": {
                         "token": self.team.api_token,
                         "distinct_id": "distinct_id",
-                        "$set_once": {"a_prop": "test-1", "c_prop": "test-1"},
+                        "$set": {"a_prop": "test-1", "c_prop": "test-1"},
                     },
                 },
                 self.team.pk,
@@ -580,12 +580,12 @@ def test_process_event_factory(
             self.assertEqual(len(get_events()), 1)
             self.assertEqual(get_events()[0].properties["$set"], {"a_prop": "test-1", "c_prop": "test-1"})
             person = Person.objects.get()
-            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
             self.assertEqual(person.properties, {"a_prop": "test-1", "c_prop": "test-1"})
 
             # check no errors as this call can happen multiple times
             process_event(
-                "new_distinct_id",
+                "distinct_id",
                 "",
                 "",
                 {
@@ -593,7 +593,7 @@ def test_process_event_factory(
                     "properties": {
                         "token": self.team.api_token,
                         "distinct_id": "distinct_id",
-                        "$set_once": {"a_prop": "test-2", "b_prop": "test-2"},
+                        "$set": {"a_prop": "test-2", "b_prop": "test-2"},
                     },
                 },
                 self.team.pk,
@@ -604,14 +604,14 @@ def test_process_event_factory(
             self.assertEqual(len(get_events()), 2)
             self.assertEqual(get_events()[1].properties["$set"], {"a_prop": "test-2", "b_prop": "test-2"})
             person = Person.objects.get()
-            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
-            self.assertEqual(person.properties, {"a_prop": "test-2", "b-prop": "test-2", "c_prop": "test-1"})
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-2", "b_prop": "test-2", "c_prop": "test-1"})
 
         def test_identify_set_once(self) -> None:
             Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
 
             process_event(
-                "new_distinct_id",
+                "distinct_id",
                 "",
                 "",
                 {
@@ -628,14 +628,14 @@ def test_process_event_factory(
             )
 
             self.assertEqual(len(get_events()), 1)
-            self.assertEqual(get_events()[0].properties["$set"], {"a_prop": "test-1", "c_prop": "test-1"})
+            self.assertEqual(get_events()[0].properties["$set_once"], {"a_prop": "test-1", "c_prop": "test-1"})
             person = Person.objects.get()
-            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
             self.assertEqual(person.properties, {"a_prop": "test-1", "c_prop": "test-1"})
 
             # check no errors as this call can happen multiple times
             process_event(
-                "new_distinct_id",
+                "distinct_id",
                 "",
                 "",
                 {
@@ -652,10 +652,10 @@ def test_process_event_factory(
             )
 
             self.assertEqual(len(get_events()), 2)
-            self.assertEqual(get_events()[1].properties["$set"], {"a_prop": "test-2", "b_prop": "test-2"})
+            self.assertEqual(get_events()[1].properties["$set_once"], {"a_prop": "test-2", "b_prop": "test-2"})
             person = Person.objects.get()
-            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
-            self.assertEqual(person.properties, {"a_prop": "test-1", "b-prop": "test-2", "c_prop": "test-1"})
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-1", "b_prop": "test-2", "c_prop": "test-1"})
 
         def test_distinct_with_anonymous_id(self) -> None:
             Person.objects.create(team=self.team, distinct_ids=["anonymous_id"])

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -557,6 +557,106 @@ def test_process_event_factory(
             self.assertEqual(event.distinct_id, "some-id")
             self.assertEqual(event.snapshot_data, {"timestamp": 123,})
 
+        def test_identify_set(self) -> None:
+            Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
+
+            process_event(
+                "new_distinct_id",
+                "",
+                "",
+                {
+                    "event": "$identify",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set_once": {"a_prop": "test-1", "c_prop": "test-1"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 1)
+            self.assertEqual(get_events()[0].properties["$set"], {"a_prop": "test-1", "c_prop": "test-1"})
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-1", "c_prop": "test-1"})
+
+            # check no errors as this call can happen multiple times
+            process_event(
+                "new_distinct_id",
+                "",
+                "",
+                {
+                    "event": "$identify",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set_once": {"a_prop": "test-2", "b_prop": "test-2"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 2)
+            self.assertEqual(get_events()[1].properties["$set"], {"a_prop": "test-2", "b_prop": "test-2"})
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-2", "b-prop": "test-2", "c_prop": "test-1"})
+
+        def test_identify_set_once(self) -> None:
+            Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
+
+            process_event(
+                "new_distinct_id",
+                "",
+                "",
+                {
+                    "event": "$identify",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set_once": {"a_prop": "test-1", "c_prop": "test-1"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 1)
+            self.assertEqual(get_events()[0].properties["$set"], {"a_prop": "test-1", "c_prop": "test-1"})
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-1", "c_prop": "test-1"})
+
+            # check no errors as this call can happen multiple times
+            process_event(
+                "new_distinct_id",
+                "",
+                "",
+                {
+                    "event": "$identify",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set_once": {"a_prop": "test-2", "b_prop": "test-2"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 2)
+            self.assertEqual(get_events()[1].properties["$set"], {"a_prop": "test-2", "b_prop": "test-2"})
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["anonymous_id", "new_distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-1", "b-prop": "test-2", "c_prop": "test-1"})
+
         def test_distinct_with_anonymous_id(self) -> None:
             Person.objects.create(team=self.team, distinct_ids=["anonymous_id"])
 

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -602,10 +602,9 @@ def test_process_event_factory(
             )
 
             self.assertEqual(len(get_events()), 2)
-            self.assertEqual(get_events()[1].properties["$set"], {"a_prop": "test-2", "b_prop": "test-2"})
-            person = Person.objects.get()
-            self.assertEqual(person.distinct_ids, ["distinct_id"])
-            self.assertEqual(person.properties, {"a_prop": "test-2", "b_prop": "test-2", "c_prop": "test-1"})
+            self.assertEqual(
+                Person.objects.get().properties, {"a_prop": "test-2", "b_prop": "test-2", "c_prop": "test-1"}
+            )
 
         def test_identify_set_once(self) -> None:
             Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
@@ -652,10 +651,9 @@ def test_process_event_factory(
             )
 
             self.assertEqual(len(get_events()), 2)
-            self.assertEqual(get_events()[1].properties["$set_once"], {"a_prop": "test-2", "b_prop": "test-2"})
-            person = Person.objects.get()
-            self.assertEqual(person.distinct_ids, ["distinct_id"])
-            self.assertEqual(person.properties, {"a_prop": "test-1", "b_prop": "test-2", "c_prop": "test-1"})
+            self.assertEqual(
+                Person.objects.get().properties, {"a_prop": "test-1", "b_prop": "test-2", "c_prop": "test-1"}
+            )
 
         def test_distinct_with_anonymous_id(self) -> None:
             Person.objects.create(team=self.team, distinct_ids=["anonymous_id"])


### PR DESCRIPTION
## Changes

- Supports the `$set_once` property on `$identify` events, which works like `$set`, but doesn't override existing keys on Persons.
- Fixes https://github.com/PostHog/posthog-js/issues/85
- Closes #2684

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
