### PR TITLE
Fix options not loaded

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -41,7 +41,7 @@ export function PropertySelect({ optionGroups, value, onChange, placeholder, aut
         >
             {optionGroups.map(
                 (group) =>
-                    group.options.length > 0 && (
+                    group.options?.length > 0 && (
                         <Select.OptGroup key={group.type} label={group.label}>
                             {group.options.map((option, index) => (
                                 <Select.Option


### PR DESCRIPTION
## Changes

Fixes this sentry issue:
https://sentry.io/organizations/posthog/issues/2154409548/?project=1899813&query=is%3Aunresolved+length&statsPeriod=14d

Would occasionally blank screen when adding filters. Probably because person properties weren't loaded yet.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
