### PR TITLE
Add Community tag to plugins

### DIFF
--- a/frontend/src/scenes/plugins/CommunityPluginTag.tsx
+++ b/frontend/src/scenes/plugins/CommunityPluginTag.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Tag } from 'antd'
+
+export function CommunityPluginTag({ isCommunity }: { isCommunity?: boolean }): JSX.Element {
+    return (
+        <Tag
+            color={isCommunity ? 'green' : 'blue'}
+            style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}
+        >
+            {isCommunity ? 'Community' : 'Core Team'}
+        </Tag>
+    )
+}

--- a/frontend/src/scenes/plugins/InstalledPlugins.tsx
+++ b/frontend/src/scenes/plugins/InstalledPlugins.tsx
@@ -40,6 +40,7 @@ export function InstalledPlugins(): JSX.Element {
                                     pluginType={plugin.plugin_type}
                                     pluginConfig={plugin.pluginConfig}
                                     error={plugin.error}
+                                    maintainer={plugin.maintainer || 'community'}
                                 />
                             )
                         })}

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -11,6 +11,7 @@ import { PluginError } from 'scenes/plugins/PluginError'
 import { LocalPluginTag } from 'scenes/plugins/LocalPluginTag'
 import { PluginInstallationType } from 'scenes/plugins/types'
 import { SourcePluginTag } from 'scenes/plugins/SourcePluginTag'
+import { CommunityPluginTag } from './CommunityPluginTag'
 
 interface PluginCardProps {
     name: string
@@ -20,6 +21,7 @@ interface PluginCardProps {
     pluginType?: PluginInstallationType
     pluginId?: number
     error?: PluginErrorType
+    maintainer: string
 }
 
 export function PluginCard({
@@ -30,6 +32,7 @@ export function PluginCard({
     pluginConfig,
     pluginId,
     error,
+    maintainer,
 }: PluginCardProps): JSX.Element {
     const { editPlugin, toggleEnabled, installPlugin, resetPluginConfigError } = useActions(pluginsLogic)
     const { loading } = useValues(pluginsLogic)
@@ -60,6 +63,7 @@ export function PluginCard({
                 style={{ height: '100%', display: 'flex', marginBottom: 20 }}
                 bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}
             >
+                {!pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
                 {pluginType === 'source' ? (
                     <SourcePluginTag style={{ position: 'absolute', top: 10, left: 10, cursor: 'pointer' }} />
                 ) : null}

--- a/frontend/src/scenes/plugins/Repository.tsx
+++ b/frontend/src/scenes/plugins/Repository.tsx
@@ -21,6 +21,7 @@ export function Repository(): JSX.Element {
                                     name={plugin.name}
                                     url={plugin.url}
                                     description={plugin.description}
+                                    maintainer={plugin.maintainer}
                                 />
                             )
                         })}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -363,6 +363,7 @@ export interface PluginType {
     config_schema: Record<string, PluginConfigSchema> | PluginConfigSchema[]
     source?: string
     error?: PluginErrorType
+    maintainer?: string
 }
 
 export interface PluginConfigType {


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

I guess this conflicts with #2965 but just bringing this up because it's important to differentiate core team vs community plugins here too so users are aware of what they're installing and we can be more liberal with accepting community plugins into the list.

Style is consistent with the website plugin library.

![Screenshot 2021-01-18 at 12 26 26](https://user-images.githubusercontent.com/38760734/104934669-2b7dfa00-5989-11eb-91e8-4765f959a755.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
