### PR TITLE
Support for installing plugins from private GitLab repositories

### DIFF
--- a/posthog/plugins/test/mock.py
+++ b/posthog/plugins/test/mock.py
@@ -66,6 +66,10 @@ def mocked_plugin_requests_get(*args, **kwargs):
 
     if args[0] == "https://gitlab.com/mariusandra/helloworldplugin/-/archive/{}/helloworldplugin-{}.zip".format(
         HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
+    ) or args[
+        0
+    ] == "https://gitlab.com/api/v4/projects/mariusandra/helloworldplugin/repository/archive.zip?sha={}&private_token={}".format(
+        HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], "PRIVATE_TOKEN"
     ):
         return MockBase64Response(HELLO_WORLD_PLUGIN_GITLAB_ZIP[1], 200)
 

--- a/posthog/plugins/test/mock.py
+++ b/posthog/plugins/test/mock.py
@@ -68,7 +68,7 @@ def mocked_plugin_requests_get(*args, **kwargs):
         HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
     ) or args[
         0
-    ] == "https://gitlab.com/api/v4/projects/mariusandra/helloworldplugin/repository/archive.zip?sha={}&private_token={}".format(
+    ] == "https://gitlab.com/api/v4/projects/mariusandra%2Fhelloworldplugin/repository/archive.zip?sha={}&private_token={}".format(
         HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], "PRIVATE_TOKEN"
     ):
         return MockBase64Response(HELLO_WORLD_PLUGIN_GITLAB_ZIP[1], 200)

--- a/posthog/plugins/test/test_utils.py
+++ b/posthog/plugins/test/test_utils.py
@@ -97,6 +97,20 @@ class TestPluginsUtils(BaseTest):
         self.assertEqual(parsed_url["project"], "gitlab-org/gl-openshift/openshift-demos/openshift-custom-pipeline")
         self.assertEqual(parsed_url["tag"], "master")
 
+        # private tokens
+        parsed_url = parse_url("https://gitlab.com/mariusandra/helloworldplugin?private_token=PRIVATE")
+        self.assertEqual(parsed_url["type"], "gitlab")
+        self.assertEqual(parsed_url["project"], "mariusandra/helloworldplugin")
+        self.assertEqual(parsed_url.get("tag", None), None)
+        self.assertEqual(parsed_url["private_token"], "PRIVATE")
+
+        parsed_url = parse_url(
+            "https://gitlab.com/gitlab-org/gl-openshift/openshift-demos/openshift-custom-pipeline/-/commit/2b6494bdf8ad35073aafe36ca8a1bdfaf3dc72d1?private_token=PRIVATE"
+        )
+        self.assertEqual(parsed_url["project"], "gitlab-org/gl-openshift/openshift-demos/openshift-custom-pipeline")
+        self.assertEqual(parsed_url["tag"], "2b6494bdf8ad35073aafe36ca8a1bdfaf3dc72d1")
+        self.assertEqual(parsed_url["private_token"], "PRIVATE")
+
     def test_parse_npm_urls(self, mock_get):
         parsed_url = parse_url("https://www.npmjs.com/package/posthog-helloworld-plugin")
         self.assertEqual(parsed_url["type"], "npm")
@@ -135,6 +149,12 @@ class TestPluginsUtils(BaseTest):
     def test_download_plugin_archive_gitlab(self, mock_get):
         plugin_gitlab = download_plugin_archive(
             "https://www.gitlab.com/mariusandra/helloworldplugin/-/commit/ff78cbe1d70316055c610a962a8355a4616d874b",
+            HELLO_WORLD_PLUGIN_GITLAB_ZIP[0],
+        )
+        self.assertEqual(plugin_gitlab, base64.b64decode(HELLO_WORLD_PLUGIN_GITLAB_ZIP[1]))
+
+        plugin_gitlab = download_plugin_archive(
+            "https://www.gitlab.com/mariusandra/helloworldplugin/-/commit/ff78cbe1d70316055c610a962a8355a4616d874b?private_token=PRIVATE_TOKEN",
             HELLO_WORLD_PLUGIN_GITLAB_ZIP[0],
         )
         self.assertEqual(plugin_gitlab, base64.b64decode(HELLO_WORLD_PLUGIN_GITLAB_ZIP[1]))


### PR DESCRIPTION
## Changes

- Enables support for gitlab private repositories if you add `?private_token=TOKEN` to the end of your Gitlab URL. For example: `https://gitlab.com/mariusandra/helloworldplugin?private_token=TOKENTOKEN`
- The Personal API token needs to have either the `api` or `read_api` scope
- Closes https://github.com/PostHog/posthog/issues/2941

![image](https://user-images.githubusercontent.com/53387/105047743-01046d80-5a6b-11eb-8b00-385463fb5dd7.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
