### PR TITLE
Fix interval persons bug for trends

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -77,9 +77,7 @@ class ClickhouseActionsViewSet(ActionViewSet):
                 {"date_to": (date_from + relativedelta(months=1) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")}
             )
         elif filter.interval == "week":
-            data.update(
-                {"date_to": (date_from + relativedelta(months=1) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")}
-            )
+            data.update({"date_to": (date_from + relativedelta(weeks=1)).strftime("%Y-%m-%d %H:%M:%S")})
         elif filter.interval == "hour":
             data.update({"date_to": date_from + timedelta(hours=1)})
         elif filter.interval == "minute":


### PR DESCRIPTION
## Changes

*Please describe.*  
- as part of #2794, when clicking on datapoints for weekly trends, the logic was filtering by month. The test wasn't catching it because it didn't have the write data setup

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
