### PR TITLE
Properly delete annotations

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -110,6 +110,11 @@ export function deleteWithUndo({ undo = false, ...props }: Record<string, any>):
             onClick: () => {
                 deleteWithUndo({ undo: true, ...props })
             },
+            onClose: () => {
+                if (props.endpoint === 'annotation') {
+                    api.delete(`api/${props.endpoint}/${props.object.id}`)
+                }
+            },
         })
     })
 }

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -111,9 +111,7 @@ export function deleteWithUndo({ undo = false, ...props }: Record<string, any>):
                 deleteWithUndo({ undo: true, ...props })
             },
             onClose: () => {
-                if (props.endpoint === 'annotation') {
-                    api.delete(`api/${props.endpoint}/${props.object.id}`)
-                }
+                api.delete(`api/${props.endpoint}/${props.object.id}`)
             },
         })
     })

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -76,12 +76,6 @@ function _Annotations(): JSX.Element {
             },
         },
         {
-            title: 'Status',
-            render: function RenderStatus(annotation): JSX.Element {
-                return annotation.deleted ? <Tag color="red">Deleted</Tag> : <Tag color="green">Active</Tag>
-            },
-        },
-        {
             title: 'Type',
             render: function RenderType(annotation): JSX.Element {
                 return annotation.scope !== 'dashboard_item' ? (

--- a/frontend/src/scenes/annotations/logic.js
+++ b/frontend/src/scenes/annotations/logic.js
@@ -7,7 +7,8 @@ export const annotationsTableLogic = kea({
         annotations: {
             __default: [],
             loadAnnotations: async () => {
-                const response = await api.get('api/annotation/?' + toParams({ order: '-updated_at' }))
+                const params = { order: '-updated_at', deleted: false }
+                const response = await api.get('api/annotation/?' + toParams(params))
                 actions.setNext(response.next)
                 return response.results
             },


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Supersedes #2834 

Deletes annotations for good if the deletion isn't undone. Could be added to other endpoints but I've targeted only annotations for now, unsure if implementing for all would break anything

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
