### PR TITLE
Show progress in retention table

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useValues, useActions } from 'kea'
 import { Table, Modal, Button, Spin } from 'antd'
 import { percentage } from 'lib/utils'
@@ -15,11 +15,16 @@ export function RetentionTable({ dashboardItemId = null }) {
         peopleLoading,
         people,
         loadingMore,
-        filters: { period },
+        filters: { period, date_to },
     } = useValues(logic)
     const { loadPeople, loadMore } = useActions(logic)
     const [modalVisible, setModalVisible] = useState(false)
     const [selectedRow, selectRow] = useState(0)
+    const [isLatestPeriod, setIsLatestPeriod] = useState(false)
+
+    useEffect(() => {
+        setIsLatestPeriod(periodIsLatest(date_to, period))
+    }, [date_to, period])
 
     let columns = [
         {
@@ -45,7 +50,11 @@ export function RetentionTable({ dashboardItemId = null }) {
                     if (dayIndex >= row.values.length) {
                         return ''
                     }
-                    return renderPercentage(row.values[dayIndex]['count'], row.values[0]['count'])
+                    return renderPercentage(
+                        row.values[dayIndex]['count'],
+                        row.values[0]['count'],
+                        isLatestPeriod && dayIndex === row.values.length - 1
+                    )
                 },
             })
         })
@@ -172,13 +181,31 @@ export function RetentionTable({ dashboardItemId = null }) {
     )
 }
 
-const renderPercentage = (value, total) => {
-    const percentage = total > 0 ? (100.0 * value) / total : 0
-    const backgroundColor = `hsl(212, 63%, ${30 + (100 - percentage) * 0.65}%)`
-    const color = percentage >= 65 ? 'hsl(0, 0%, 80%)' : undefined
+const renderPercentage = (value, total, latest = false) => {
+    const _percentage = total > 0 ? (100.0 * value) / total : 0
+    const backgroundColor = latest ? 'yellow' : `hsl(212, 63%, ${30 + (100 - _percentage) * 0.65}%)`
+    const color = _percentage >= 65 ? 'hsl(0, 0%, 80%)' : undefined
     return (
         <div style={{ backgroundColor, color }} className="percentage-cell">
-            {percentage.toFixed(1)}%
+            {_percentage.toFixed(1)}%
         </div>
     )
+}
+
+const periodIsLatest = (date_to, period) => {
+    if (!date_to) {
+        return true
+    }
+
+    const curr = moment(date_to)
+    if (
+        (period == 'Hour' && curr.isSame(moment(), 'hour')) ||
+        (period == 'Day' && curr.isSame(moment(), 'day')) ||
+        (period == 'Week' && curr.isSame(moment(), 'week')) ||
+        (period == 'Month' && curr.isSame(moment(), 'month'))
+    ) {
+        return true
+    } else {
+        return false
+    }
 }

--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -183,11 +183,11 @@ export function RetentionTable({ dashboardItemId = null }) {
 
 const renderPercentage = (value, total, latest = false) => {
     const _percentage = total > 0 ? (100.0 * value) / total : 0
-    const backgroundColor = latest ? 'yellow' : `hsl(212, 63%, ${30 + (100 - _percentage) * 0.65}%)`
+    const backgroundColor = `hsl(212, 63%, ${30 + (100 - _percentage) * 0.65}%)`
     const color = _percentage >= 65 ? 'hsl(0, 0%, 80%)' : undefined
     return (
-        <div style={{ backgroundColor, color }} className="percentage-cell">
-            {_percentage.toFixed(1)}%
+        <div style={{ backgroundColor, color }} className={`percentage-cell${latest ? ' period-in-progress' : ''}`}>
+            {_percentage.toFixed(1)}%{latest && '*'}
         </div>
     )
 }

--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Modal, Button, Spin } from 'antd'
+import { Table, Modal, Button, Spin, Tooltip } from 'antd'
 import { percentage } from 'lib/utils'
 import { Link } from 'lib/components/Link'
 import { retentionTableLogic } from './retentionTableLogic'
@@ -185,11 +185,13 @@ const renderPercentage = (value, total, latest = false) => {
     const _percentage = total > 0 ? (100.0 * value) / total : 0
     const backgroundColor = `hsl(212, 63%, ${30 + (100 - _percentage) * 0.65}%)`
     const color = _percentage >= 65 ? 'hsl(0, 0%, 80%)' : undefined
-    return (
+
+    const numberCell = (
         <div style={{ backgroundColor, color }} className={`percentage-cell${latest ? ' period-in-progress' : ''}`}>
             {_percentage.toFixed(1)}%{latest && '*'}
         </div>
     )
+    return latest ? <Tooltip title="Period in progress">{numberCell}</Tooltip> : numberCell
 }
 
 const periodIsLatest = (date_to, period) => {

--- a/frontend/src/scenes/retention/RetentionTable.scss
+++ b/frontend/src/scenes/retention/RetentionTable.scss
@@ -8,6 +8,14 @@
     .percentage-cell {
         padding: 8px;
     }
+
+    .period-in-progress {
+        background: repeating-linear-gradient(-45deg, #e4edf9, #e4edf9 10px, #f8fbfe 10px, #f8fbfe 20px);
+        color: #7d7d7d;
+        /* OPTION 2 */
+        //border: 2px $border_dark dashed;
+        //border-radius: $radius;
+    }
 }
 
 .retention-success {

--- a/frontend/src/scenes/retention/RetentionTable.scss
+++ b/frontend/src/scenes/retention/RetentionTable.scss
@@ -11,10 +11,7 @@
 
     .period-in-progress {
         background: repeating-linear-gradient(-45deg, #e4edf9, #e4edf9 10px, #f8fbfe 10px, #f8fbfe 20px);
-        color: #7d7d7d;
-        /* OPTION 2 */
-        //border: 2px $border_dark dashed;
-        //border-radius: $radius;
+        color: #555555;
     }
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- retention table will now show a different color or texture when the period is still in progress
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
