### PR TITLE
Use utc moment for retention dates and fix modal title

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -25,7 +25,7 @@ export function RetentionTable({ dashboardItemId = null }) {
         {
             title: 'Date',
             key: 'date',
-            render: (row) => moment(row.date).format(period === 'h' ? 'MMM D, h a' : 'MMM D'),
+            render: (row) => moment.utc(row.date).format(period === 'h' ? 'MMM D, h a' : 'MMM D'),
             align: 'center',
         },
         {

--- a/frontend/src/scenes/retention/RetentionTable.js
+++ b/frontend/src/scenes/retention/RetentionTable.js
@@ -88,7 +88,7 @@ export function RetentionTable({ dashboardItemId = null }) {
                         minWidth: results[selectedRow]?.values[0]?.count === 0 ? '10%' : '90%',
                         fontSize: 16,
                     }}
-                    title={results[selectedRow]?.date}
+                    title={results[selectedRow] ? moment(results[selectedRow].date).format('MMMM d, YYYY') : ''}
                 >
                     {results && !peopleLoading ? (
                         <div>


### PR DESCRIPTION
## Changes

*Please describe.*  
- we use dates returned from server as markers for the week so we can force utc here on the moment object
- previously it was converting dates at midnight into local time so it would show up as the saturday instead of the sunday of that week
- also fixes modal title
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
