### PR TITLE
Plugins page UX improvement

### DIFF
--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -37,7 +37,7 @@ export function PluginCard({
     const { loading, installingPluginUrl } = useValues(pluginsLogic)
 
     const canConfigure = pluginId && !pluginConfig?.global
-    const switchDisabled = pluginConfig && pluginConfig.global
+    const switchDisabled = pluginConfig?.global
 
     return (
         <Col

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -56,7 +56,7 @@ export function PluginCard({
                                 onConfirm={() =>
                                     pluginConfig.id
                                         ? toggleEnabled({ id: pluginConfig.id, enabled: !pluginConfig.enabled })
-                                        : editPlugin(pluginId || null)
+                                        : editPlugin(pluginId || null, { __enabled: true })
                                 }
                                 okText="Yes"
                                 cancelText="No"

--- a/frontend/src/scenes/plugins/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/PluginCard.tsx
@@ -37,7 +37,7 @@ export function PluginCard({
     const { loading, installingPluginUrl } = useValues(pluginsLogic)
 
     const canConfigure = pluginId && !pluginConfig?.global
-    const switchDisabled = (pluginConfig && pluginConfig.global) || !pluginConfig || !pluginConfig.id
+    const switchDisabled = pluginConfig && pluginConfig.global
 
     return (
         <Col
@@ -53,18 +53,17 @@ export function PluginCard({
                                 title={`Are you sure you wish to ${
                                     pluginConfig.enabled ? 'disable' : 'enable'
                                 } this plugin?`}
-                                onConfirm={() => toggleEnabled({ id: pluginConfig.id, enabled: !pluginConfig.enabled })}
+                                onConfirm={() =>
+                                    pluginConfig.id
+                                        ? toggleEnabled({ id: pluginConfig.id, enabled: !pluginConfig.enabled })
+                                        : editPlugin(pluginId || null)
+                                }
                                 okText="Yes"
                                 cancelText="No"
                                 disabled={switchDisabled}
                             >
                                 <div>
                                     <Switch checked={pluginConfig.enabled} disabled={switchDisabled} />
-                                    {pluginConfig.global && (
-                                        <span style={{ marginLeft: 10, fontSize: 11 }} className="text-muted">
-                                            Globally enabled
-                                        </span>
-                                    )}
                                 </div>
                             </Popconfirm>
                         </Col>

--- a/frontend/src/scenes/plugins/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/PluginDrawer.tsx
@@ -31,7 +31,7 @@ function EnabledDisabledSwitch({
 
 export function PluginDrawer(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { editingPlugin, loading, editingSource } = useValues(pluginsLogic)
+    const { editingPlugin, editingPluginInitialChanges, loading, editingSource } = useValues(pluginsLogic)
     const { editPlugin, savePluginConfig, uninstallPlugin, setEditingSource } = useActions(pluginsLogic)
     const [form] = Form.useForm()
 
@@ -42,6 +42,7 @@ export function PluginDrawer(): JSX.Element {
             form.setFieldsValue({
                 ...(editingPlugin.pluginConfig.config || {}),
                 __enabled: editingPlugin.pluginConfig.enabled,
+                ...editingPluginInitialChanges,
             })
         } else {
             form.resetFields()

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -159,7 +159,9 @@ export const pluginsLogic = kea<
                     const results = await api.get('api/organizations/@current/plugins/repository')
                     const repository: Record<string, PluginRepositoryEntry> = {}
                     for (const plugin of results as PluginRepositoryEntry[]) {
-                        repository[plugin.url] = plugin
+                        if (plugin.url) {
+                            repository[plugin.url.replace(/\/+$/, '')] = plugin
+                        }
                     }
                     return repository
                 },

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -159,7 +159,7 @@ export const pluginsLogic = kea<
                     const results = await api.get('api/organizations/@current/plugins/repository')
                     const repository: Record<string, PluginRepositoryEntry> = {}
                     for (const plugin of results as PluginRepositoryEntry[]) {
-                        repository[plugin.name] = plugin
+                        repository[plugin.url] = plugin
                     }
                     return repository
                 },
@@ -279,22 +279,24 @@ export const pluginsLogic = kea<
                     .map((plugin, index) => ({ ...plugin, order: index + 1 }))
             },
         ],
-        installedPluginNames: [
+        installedPluginUrls: [
             (s) => [s.installedPlugins],
             (installedPlugins) => {
                 const names: Record<string, boolean> = {}
                 installedPlugins.forEach((plugin) => {
-                    names[plugin.name] = true
+                    if (plugin.url) {
+                        names[plugin.url.replace(/\/+$/, '')] = true
+                    }
                 })
                 return names
             },
         ],
         uninstalledPlugins: [
-            (s) => [s.installedPluginNames, s.repository],
-            (installedPluginNames, repository) => {
+            (s) => [s.installedPluginUrls, s.repository],
+            (installedPluginUrls, repository) => {
                 return Object.keys(repository)
-                    .filter((name) => !installedPluginNames[name])
-                    .map((name) => repository[name])
+                    .filter((url) => !installedPluginUrls[url.replace(/\/+$/, '')])
+                    .map((url) => repository[url.replace(/\/+$/, '')])
             },
         ],
         editingPlugin: [

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -189,6 +189,7 @@ export const pluginsLogic = kea<
             {} as Record<string, any>,
             {
                 editPlugin: (_, { pluginConfigChanges }) => pluginConfigChanges,
+                installPluginSuccess: () => ({ __enabled: true }),
             },
         ],
         editingSource: [

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -27,7 +27,7 @@ export const pluginsLogic = kea<
     >
 >({
     actions: {
-        editPlugin: (id: number | null) => ({ id }),
+        editPlugin: (id: number | null, pluginConfigChanges: Record<string, any> = {}) => ({ id, pluginConfigChanges }),
         savePluginConfig: (pluginConfigChanges: Record<string, any>) => ({ pluginConfigChanges }),
         installPlugin: (pluginUrl: string, pluginType: PluginInstallationType) => ({ pluginUrl, pluginType }),
         uninstallPlugin: (name: string) => ({ name }),
@@ -183,6 +183,12 @@ export const pluginsLogic = kea<
                 savePluginConfigSuccess: () => null,
                 uninstallPluginSuccess: () => null,
                 installPluginSuccess: (_, { plugins }) => Object.values(plugins).pop()?.id || null,
+            },
+        ],
+        editingPluginInitialChanges: [
+            {} as Record<string, any>,
+            {
+                editPlugin: (_, { pluginConfigChanges }) => pluginConfigChanges,
             },
         ],
         editingSource: [

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -56,8 +56,8 @@ class PluginSerializer(serializers.ModelSerializer):
             raise ValidationError("Plugin installation via the web is disabled!")
         if validated_data.get("plugin_type", None) != Plugin.PluginType.SOURCE:
             self._update_validated_data_from_url(validated_data, validated_data["url"])
-        if len(Plugin.objects.filter(name=validated_data["name"])) > 0:
-            raise ValidationError('Plugin with name "{}" already installed!'.format(validated_data["name"]))
+            if len(Plugin.objects.filter(url=validated_data["url"])) > 0:
+                raise ValidationError('Plugin from URL "{}" already installed!'.format(validated_data["url"]))
         validated_data["organization_id"] = self.context["organization_id"]
         plugin = super().create(validated_data)
         reload_plugins_on_workers()


### PR DESCRIPTION
## Changes

- Followup on #2939
- Previously if a plugin was installed, but never configured, the switch in the beginning of the line was disabled without an explanation
- Now it will work normally, but instead of directly enabling the plugin it will open the configuration drawer so you could update the required fields, etc
![image](https://user-images.githubusercontent.com/53387/105147265-3d82a880-5b01-11eb-9585-04169d1f3296.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
