### PR TITLE
Fix multiple actions in funnel

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -9,7 +9,7 @@ from posthog.models.action_step import ActionStep
 from posthog.models.event import Selector
 
 
-def format_action_filter(action: Action, prepend: str = "action", index=0, use_loop: bool = False) -> Tuple[str, Dict]:
+def format_action_filter(action: Action, prepend: str = "action", use_loop: bool = False) -> Tuple[str, Dict]:
     # get action steps
     params = {"team_id": action.team.pk}
     steps = action.steps.all()
@@ -22,12 +22,12 @@ def format_action_filter(action: Action, prepend: str = "action", index=0, use_l
         conditions: List[str] = []
         # filter element
         if step.event == AUTOCAPTURE_EVENT:
-            el_conditions, element_params = filter_element(step, "{}{}".format(index, prepend))
+            el_conditions, element_params = filter_element(step, "{}_{}{}".format(action.pk, index, prepend))
             params = {**params, **element_params}
             conditions += el_conditions
 
         # filter event conditions (ie URL)
-        event_conditions, event_params = filter_event(step, "{}{}".format(index, prepend), index)
+        event_conditions, event_params = filter_event(step, "{}_{}{}".format(action.pk, index, prepend), index)
         params = {**params, **event_params}
         conditions += event_conditions
 
@@ -37,7 +37,7 @@ def format_action_filter(action: Action, prepend: str = "action", index=0, use_l
             prop_query, prop_params = parse_prop_clauses(
                 Filter(data={"properties": step.properties}).properties,
                 action.team.pk,
-                prepend="action_props_{}".format(index),
+                prepend="action_props_{}".format(action.pk),
             )
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -29,7 +29,7 @@ def format_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
     for group_idx, group in enumerate(cohort.groups):
         if group.get("action_id"):
             action = Action.objects.get(pk=group["action_id"], team_id=cohort.team.pk)
-            action_filter_query, action_params = format_action_filter(action, index=group_idx)
+            action_filter_query, action_params = format_action_filter(action, prepend="_{}_action".format(group_idx))
             extract_person = "SELECT distinct_id FROM events WHERE team_id = %(team_id)s AND {query}".format(
                 query=action_filter_query
             )

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -23,7 +23,7 @@ def _create_event(**kwargs) -> Event:
 
 
 def query_action(action: Action) -> Optional[List]:
-    formatted_query, params = format_action_filter(action, "", 0)
+    formatted_query, params = format_action_filter(action, "")
 
     query = ACTION_QUERY.format(action_filter=formatted_query)
 

--- a/ee/clickhouse/queries/test/test_funnel.py
+++ b/ee/clickhouse/queries/test/test_funnel.py
@@ -17,5 +17,5 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
-class TestClickhouseFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
+class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
     pass

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -299,8 +299,36 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[1]["count"], 1)
             self.assertEqual(result[2]["count"], 1)
 
+        def test_funnel_multiple_actions(self):
+            # we had an issue on clickhouse where multiple actions with different property filters would incorrectly grab only the last
+            # properties.
+            # This test prevents a regression
+            person_factory(distinct_ids=["person1"], team_id=self.team.pk)
+            event_factory(distinct_id="person1", event="event1", team=self.team)
+            event_factory(distinct_id="person1", event="event2", properties={"test_prop": "a"}, team=self.team)
+
+            action1 = Action.objects.create(team_id=self.team.pk, name="event2")
+            ActionStep.objects.create(action=action1, event="event2", properties=[{"key": "test_prop", "value": "a"}])
+            action1.calculate_events()
+            action2 = Action.objects.create(team_id=self.team.pk, name="event2")
+            ActionStep.objects.create(action=action2, event="event2", properties=[{"key": "test_prop", "value": "c"}])
+            action2.calculate_events()
+
+            result = Funnel(
+                filter=Filter(
+                    data={
+                        "events": [{"id": "event1", "order": 0}],
+                        "actions": [{"id": action1.pk, "order": 1,}, {"id": action2.pk, "order": 2,},],
+                    }
+                ),
+                team=self.team,
+            ).run()
+            self.assertEqual(result[0]["count"], 1)
+            self.assertEqual(result[1]["count"], 1)
+            self.assertEqual(result[2]["count"], 0)
+
     return TestGetFunnel
 
 
-class DjangoFunnelTest(funnel_test_factory(Funnel, Event.objects.create, Person.objects.create)):  # type: ignore
+class TestFunnel(funnel_test_factory(Funnel, Event.objects.create, Person.objects.create)):  # type: ignore
     pass


### PR DESCRIPTION
## Changes

we had an issue on clickhouse where multiple actions with different property filters would incorrectly grab only the properties of the last action

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
