### PR TITLE
feat: allow setting Sentry environment by using the SENTRY_ENVIRONMENT env variable

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -104,6 +104,7 @@ if not TEST:
             integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],
             request_bodies="always",
             send_default_pii=True,
+            environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
         )
 
 if get_bool_from_env("DISABLE_SECURE_SSL_REDIRECT", False):


### PR DESCRIPTION
## Changes

I'd like to set the environment, so I can separate my deployments of PostHog (production, test) in Sentry
See Sentry documentation https://docs.sentry.io/platforms/python/configuration/environments/

This way it should not change the current behavior, the default value is "production" even now.
