### PR TITLE
feat: set event root logger severity using the DJANGO_LOG_LEVEL env variable

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -563,7 +563,7 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "handlers": {"console": {"class": "logging.StreamHandler",},},
-    "root": {"handlers": ["console"], "level": "WARNING",},
+    "root": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING")},
     "loggers": {
         "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"), "propagate": True,},
     },


### PR DESCRIPTION
## Changes

Hi, I bit struggled with debugging some issues on local instance of PostHog but was not able to reproduce it in local environment, so I needed more information in logs in production environment. Hopefully the root logger will give use event more information.
