### PR TITLE
Only aggregate breakdown if it's a table or pie chart

### DIFF
--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1313,6 +1313,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["count"], 4.0)
             self.assertEqual(response[1]["label"], "sign up - 80.0")
             self.assertEqual(response[1]["count"], 1.0)
+            self.assertTrue("aggregated_value" not in response[0])
 
         def test_breakdown_filtering_limit(self):
             self._create_breakdown_events()

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1313,7 +1313,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["count"], 4.0)
             self.assertEqual(response[1]["label"], "sign up - 80.0")
             self.assertEqual(response[1]["count"], 1.0)
-            self.assertTrue("aggregated_value" not in response[0])
+            self.assertTrue(
+                "aggregated_value" not in response[0]
+            )  # should not have aggregated value unless it's a table or pie query
 
         def test_breakdown_filtering_limit(self):
             self._create_breakdown_events()

--- a/posthog/queries/trends.py
+++ b/posthog/queries/trends.py
@@ -357,13 +357,14 @@ class Trends(LifecycleTrend, BaseQuery):
             new_dict = append_data(dates_filled=list(item.items()), interval=filter.interval)
             if value != "Total":
                 new_dict.update(breakdown_label(entity, value))
-            new_dict.update(
-                {
-                    "aggregated_value": get_aggregate_breakdown_total(
-                        filtered_events, filter, entity, team_id, new_dict["breakdown_value"]
-                    )
-                }
-            )
+            if filter.display == TRENDS_TABLE or filter.display == TRENDS_PIE:
+                new_dict.update(
+                    {
+                        "aggregated_value": get_aggregate_breakdown_total(
+                            filtered_events, filter, entity, team_id, new_dict["breakdown_value"]
+                        )
+                    }
+                )
             formatted_entities.append(new_dict)
 
         return formatted_entities


### PR DESCRIPTION
## Changes

*Please describe.*  
- the breakdown query was unnecessarily aggregating counts on line chart queries
- should alleviate #3010 

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
