### PR TITLE
Exclude health from ip block

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -52,6 +52,7 @@ class AllowIP(object):
             "batch",
             "e",
             "static",
+            "_health",
         ]:
             return response
         ip = self.extract_client_ip(request)


### PR DESCRIPTION
## Changes

From a customer

```
When we attempt to set the  ALLOWED_IP_BLOCKS, then the health checks from the load balancer are rejected by fargate. 
Are we missing something? We've attempted to set the variables IS_BEHIND_PROXY and TRUST_ALL_PROXIES along with ALLOWED_IP_BLOCKS with no success. 
```

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
