### PR TITLE
Allow rolling feature flags out to multiple groups

### DIFF
--- a/cypress/integration/featureFlags.js
+++ b/cypress/integration/featureFlags.js
@@ -10,7 +10,7 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-key').should('have.value', 'beta-feature')
 
         // select "add filter" and "property"
-        cy.get('[data-attr=new-prop-filter-feature-flag-undefined').click()
+        cy.get('[data-attr=new-prop-filter-feature-flag-undefined-0-1').click()
 
         // select the first property
         cy.get('[data-attr=property-filter-dropdown]').click()

--- a/cypress/integration/featureFlags.js
+++ b/cypress/integration/featureFlags.js
@@ -23,7 +23,7 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-switch').click()
         cy.get('[data-attr=feature-flag-submit').click()
         cy.get('[data-attr=feature-flag-table').should('contain', 'beta feature')
-        cy.get('[data-attr=rollout-percentage').should('contain', '30%')
+        cy.get('[data-attr=feature-flag-table').should('contain', '30%')
         cy.get('[data-attr=feature-flag-table').should('contain', 'is_demo')
 
         cy.get('[data-attr=feature-flag-table] tr:first-child td:first-child').click()

--- a/frontend/src/lib/components/PropertyFilters/PropertyFiltersDisplay.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFiltersDisplay.tsx
@@ -1,14 +1,15 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import { PropertyFilter } from '~/types'
 import PropertyFilterButton from './PropertyFilterButton'
 
 type Props = {
     filters: PropertyFilter[]
+    style?: CSSProperties
 }
 
-const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters }: Props) => {
+const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style }: Props) => {
     return (
-        <div className="mb">
+        <div className="mb" style={style}>
             {filters &&
                 filters.map((item) => {
                     return <PropertyFilterButton key={item.key} item={item} />

--- a/frontend/src/scenes/experimentation/EditFeatureFlag.js
+++ b/frontend/src/scenes/experimentation/EditFeatureFlag.js
@@ -1,32 +1,53 @@
 import React, { useState } from 'react'
-import { Input, Button, Form, Switch, Slider } from 'antd'
+import { Input, Button, Form, Switch, Slider, Card } from 'antd'
 import { kea, useActions, useValues } from 'kea'
 import { slugify } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { DeleteOutlined, SaveOutlined } from '@ant-design/icons'
 import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
 import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
+import { CloseButton } from 'lib/components/CloseButton'
 
 const editLogic = kea({
     actions: () => ({
-        setRolloutPercentage: (rollout_percentage) => ({ rollout_percentage }),
-        setFilters: (filters) => ({ filters }),
+        setProperties: (index, properties) => ({ index, properties }),
+        setRolloutPercentage: (index, rollout_percentage) => ({ index, rollout_percentage }),
+        addGroup: true,
+        removeGroup: (index) => ({ index }),
     }),
     reducers: ({ props }) => ({
-        filters: [
-            props.featureFlag?.filters ? props.featureFlag.filters : {},
+        groups: [
+            props.featureFlag?.filters?.groups || [{}],
             {
-                setFilters: (_, { filters }) => filters,
+                setProperties: (state, { index, properties }) => updateAtIndex(state, index, { properties }),
+                setRolloutPercentage: (state, { index, rollout_percentage }) =>
+                    updateAtIndex(state, index, { rollout_percentage }),
+                addGroup: (state) => state.concat([{}]),
+                removeGroup: (state, { index }) => {
+                    const groups = [...state]
+                    groups.splice(index, 1)
+                    return groups
+                },
             },
         ],
-        rollout_percentage: [
-            props.featureFlag ? props.featureFlag.rollout_percentage : null,
-            {
-                setRolloutPercentage: (_, { rollout_percentage }) => rollout_percentage,
-            },
+    }),
+    selectors: () => ({
+        hasRollout: [
+            (s) => [s.groups],
+            (groups) => groups.filter(({ rollout_percentage }) => rollout_percentage != null).length > 0,
+        ],
+        hasProperties: [
+            (s) => [s.groups],
+            (groups) => groups.filter(({ properties }) => properties != null).length > 0,
         ],
     }),
 })
+
+function updateAtIndex(state, index, update) {
+    const newState = [...state]
+    newState[index] = { ...state[index], ...update }
+    return newState
+}
 
 function Snippet({ flagKey }) {
     return (
@@ -45,11 +66,11 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
     const { updateFeatureFlag, createFeatureFlag, deleteFeatureFlag } = useActions(logic)
 
     const _editLogic = editLogic({ featureFlag })
-    const { filters, rollout_percentage } = useValues(_editLogic)
-    const { setFilters, setRolloutPercentage } = useActions(_editLogic)
+    const { groups, hasRollout, hasProperties } = useValues(_editLogic)
+    const { setProperties, setRolloutPercentage, addGroup, removeGroup } = useActions(_editLogic)
     const [hasKeyChanged, setHasKeyChanged] = useState(false)
 
-    let submitDisabled = rollout_percentage === null && (!filters?.properties || filters.properties.length === 0)
+    const submitDisabled = !hasRollout && !hasProperties
 
     return (
         <Form
@@ -66,7 +87,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                     : noop
             }
             onFinish={(values) => {
-                const updatedFlag = { ...featureFlag, ...values, rollout_percentage, filters }
+                const updatedFlag = { ...featureFlag, ...values, filters: { groups } }
                 if (isNew) {
                     createFeatureFlag(updatedFlag)
                 } else {
@@ -93,9 +114,9 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                 name="key"
                 label="Key"
                 rules={[{ required: true }]}
-                validateStatus={!!rollout_percentage && hasKeyChanged ? 'warning' : ''}
+                validateStatus={!!hasRollout && hasKeyChanged ? 'warning' : ''}
                 help={
-                    !!rollout_percentage && hasKeyChanged ? (
+                    !!hasRollout && hasKeyChanged ? (
                         <small>
                             Changing this key will
                             <a href="https://posthog.com/docs/features/feature-flags#feature-flag-persistence">
@@ -115,36 +136,63 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                 <Switch />
             </Form.Item>
 
-            <Form.Item className={rrwebBlockClass} label="Filter by user properties" style={{ position: 'relative' }}>
-                <PropertyFilters
-                    pageKey={'feature-flag-' + featureFlag.id}
-                    propertyFilters={filters?.properties}
-                    onChange={(properties) => setFilters({ properties })}
-                    endpoint="person"
-                    showConditionBadge
-                />
-            </Form.Item>
+            {groups.map((group, index) => (
+                <Card style={{ position: 'relative', marginBottom: 32 }} key={`${index}-${groups.length}`}>
+                    {groups.length !== 1 && (
+                        <CloseButton
+                            style={{ position: 'absolute', top: 0, right: 0, margin: 4 }}
+                            onClick={() => removeGroup(index)}
+                        />
+                    )}
 
-            <Form.Item name="rollout" label="Roll out feature to percentage of users">
-                <Switch
-                    id="rollout"
-                    checked={!!rollout_percentage}
-                    onChange={(checked) => (checked ? setRolloutPercentage(30) : setRolloutPercentage(null))}
-                    data-attr="feature-flag-switch"
-                />
-                {rollout_percentage !== null && (
-                    <Slider
-                        tooltipPlacement="bottom"
-                        tipFormatter={(value) => value + '%'}
-                        tooltipVisible={true}
-                        value={rollout_percentage}
-                        onChange={(value) => {
-                            setRolloutPercentage(value)
-                        }}
-                    />
-                )}
-                <br />
-            </Form.Item>
+                    <Form.Item
+                        className={rrwebBlockClass}
+                        label="Filter by user properties"
+                        style={{ position: 'relative' }}
+                    >
+                        <PropertyFilters
+                            pageKey={`feature-flag-${featureFlag.id}-${index}-${groups.length}`}
+                            propertyFilters={group?.properties}
+                            onChange={(properties) => setProperties(index, properties)}
+                            endpoint="person"
+                            showConditionBadge
+                        />
+                    </Form.Item>
+
+                    <Form.Item
+                        name="rollout"
+                        label="Roll out feature to percentage of users"
+                        style={{ marginBottom: 0 }}
+                    >
+                        <Switch
+                            id="rollout"
+                            checked={!!group.rollout_percentage}
+                            onChange={(checked) =>
+                                checked ? setRolloutPercentage(index, 30) : setRolloutPercentage(index, null)
+                            }
+                            data-attr="feature-flag-switch"
+                        />
+                        {group.rollout_percentage != null && (
+                            <Slider
+                                tooltipPlacement="bottom"
+                                tipFormatter={(value) => value + '%'}
+                                tooltipVisible={true}
+                                value={group.rollout_percentage}
+                                onChange={(value) => {
+                                    setRolloutPercentage(index, value)
+                                }}
+                            />
+                        )}
+                        <br />
+                    </Form.Item>
+
+                    {index === groups.length - 1 && (
+                        <Button style={{ position: 'absolute', marginTop: 8 }} onClick={addGroup}>
+                            +
+                        </Button>
+                    )}
+                </Card>
+            ))}
 
             <Form.Item>
                 <Button

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -37,11 +37,11 @@ function _FeatureFlags() {
             render: function RenderRolloutPercentage(_, featureFlag) {
                 return (
                     <div data-attr="rollout-percentage">
-                        {featureFlag.rollout_percentage ? `${featureFlag.rollout_percentage}%` : 'N/A'}
+                        {rollout(featureFlag) != null ? `${rollout(featureFlag)}%` : 'N/A'}
                     </div>
                 )
             },
-            sorter: (a, b) => a.rollout_percentage - b.rollout_percentage,
+            sorter: (a, b) => rollout(a) - rollout(b),
         },
         {
             title: 'Filters',
@@ -150,4 +150,9 @@ function _FeatureFlags() {
             </Drawer>
         </div>
     )
+}
+
+function rollout(featureFlag) {
+    const groups = featureFlag.filters?.groups || []
+    return groups.length === 1 ? groups[0].rollout_percentage : null
 }

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -46,7 +46,8 @@ function _FeatureFlags() {
         {
             title: 'Filters',
             render: function RenderFilters(featureFlag) {
-                return <PropertyFiltersDisplay filters={featureFlag.filters?.properties} />
+                const properties = featureFlag.filters?.groups?.flatMap((group) => group.properties || []) || []
+                return <PropertyFiltersDisplay filters={properties} />
             },
         },
         {
@@ -132,7 +133,7 @@ function _FeatureFlags() {
             />
             <Drawer
                 title={openFeatureFlag === 'new' ? 'New feature flag' : openFeatureFlag.name}
-                width={400}
+                width={500}
                 onClose={() => setOpenFeatureFlag(false)}
                 destroyOnClose={true}
                 visible={openFeatureFlag}

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -68,11 +68,12 @@ class FeatureFlag(models.Model):
         return hash_val / __LONG_SCALE__
 
     def get_analytics_metadata(self) -> Dict:
-        filter_count: int = len(self.filters.get("properties", []),) if self.filters else 0
+        filter_count = sum(len(group.get("properties", [])) for group in self.groups)
 
         return {
-            "groups_count": self.rollout_percentage,
-            "has_filters": True if self.filters and self.filters.get("properties") else False,
+            "groups_count": len(self.groups),
+            "has_filters": filter_count > 0,
+            "has_rollout_percentage": any(group.get("rollout_percentage") for group in self.groups),
             "filter_count": filter_count,
             "created_at": self.created_at,
         }

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -80,12 +80,19 @@ class FeatureFlag(models.Model):
 
     @property
     def groups(self):
+        return self.get_filters().get("groups", [])
+
+    def get_filters(self):
         if "groups" in self.filters:
-            return self.filters.get("groups", [])
+            return self.filters
         else:
             # :TRICKY: Keep this backwards compatible.
             #   We don't want to migrate to avoid /decide endpoint downtime until this code has been deployed
-            return [{"properties": self.filters.get("properties", []), "rollout_percentage": self.rollout_percentage}]
+            return {
+                "groups": [
+                    {"properties": self.filters.get("properties", []), "rollout_percentage": self.rollout_percentage}
+                ]
+            }
 
 
 @receiver(models.signals.post_save, sender=FeatureFlag)

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1,36 +1,68 @@
-from posthog.models import Cohort, FeatureFlag, Person
+from posthog.models import Cohort, FeatureFlag, Person, feature_flag
 from posthog.test.base import BaseTest
 
 
 class TestFeatureFlag(BaseTest):
+    def test_blank_flag(self):
+        feature_flag = self.create_feature_flag()
+        self.assertFalse(feature_flag.distinct_id_matches("example_id"))
+        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+
     def test_rollout_percentage(self):
-        user = self._create_user("tim")
-        feature_flag = FeatureFlag.objects.create(
-            team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=user,
-        )
+        feature_flag = self.create_feature_flag(filters={"groups": [{"rollout_percentage": 50}]})
         self.assertTrue(feature_flag.distinct_id_matches("example_id"))
         self.assertFalse(feature_flag.distinct_id_matches("another_id"))
 
-    def test_property_filters(self):
-        user = self._create_user("tim")
+    def test_multi_property_filters(self):
         Person.objects.create(
             team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"},
         )
         Person.objects.create(
             team=self.team, distinct_ids=["another_id"], properties={"email": "example@example.com"},
         )
-        feature_flag = FeatureFlag.objects.create(
-            team=self.team,
-            filters={"properties": [{"key": "email", "value": "tim@posthog.com"}]},
-            name="Beta feature",
-            key="beta-feature",
-            created_by=user,
+        feature_flag = self.create_feature_flag(
+            filters={
+                "groups": [
+                    {"properties": [{"key": "email", "value": "tim@posthog.com"}]},
+                    {"properties": [{"key": "email", "value": "example@example.com"}]},
+                ]
+            }
         )
+        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
+        self.assertTrue(feature_flag.distinct_id_matches("another_id"))
+        self.assertFalse(feature_flag.distinct_id_matches("false_id"))
+
+    def test_user_in_cohort(self):
+        Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"})
+        cohort = Cohort.objects.create(
+            team=self.team, groups=[{"properties": {"$some_prop": "something"}}], name="cohort1"
+        )
+        cohort.calculate_people(use_clickhouse=False)
+
+        feature_flag = self.create_feature_flag(
+            filters={"groups": [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}]}
+        )
+
         self.assertTrue(feature_flag.distinct_id_matches("example_id"))
         self.assertFalse(feature_flag.distinct_id_matches("another_id"))
 
-    def test_rollout_and_property_filter(self):
-        user = self._create_user("tim")
+    def test_legacy_rollout_percentage(self):
+        feature_flag = self.create_feature_flag(rollout_percentage=50)
+        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
+        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+
+    def test_legacy_property_filters(self):
+        Person.objects.create(
+            team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"},
+        )
+        Person.objects.create(
+            team=self.team, distinct_ids=["another_id"], properties={"email": "example@example.com"},
+        )
+        feature_flag = self.create_feature_flag(filters={"properties": [{"key": "email", "value": "tim@posthog.com"}]},)
+        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
+        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+
+    def test_legacy_rollout_and_property_filter(self):
         Person.objects.create(
             team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"},
         )
@@ -40,37 +72,30 @@ class TestFeatureFlag(BaseTest):
         Person.objects.create(
             team=self.team, distinct_ids=["id_number_3"], properties={"email": "example@example.com"},
         )
-        feature_flag = FeatureFlag.objects.create(
-            team=self.team,
+        feature_flag = self.create_feature_flag(
             rollout_percentage=50,
             filters={"properties": [{"key": "email", "value": "tim@posthog.com", "type": "person"}]},
-            name="Beta feature",
-            key="beta-feature",
-            created_by=user,
         )
         with self.assertNumQueries(1):
             self.assertTrue(feature_flag.distinct_id_matches("example_id"))
         self.assertFalse(feature_flag.distinct_id_matches("another_id"))
         self.assertFalse(feature_flag.distinct_id_matches("id_number_3"))
 
-    def test_user_in_cohort(self):
-        user = self._create_user("tim")
-
-        person1 = Person.objects.create(
-            team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"}
-        )
+    def test_legacy_user_in_cohort(self):
+        Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"})
         cohort = Cohort.objects.create(
             team=self.team, groups=[{"properties": {"$some_prop": "something"}}], name="cohort1"
         )
         cohort.calculate_people(use_clickhouse=False)
 
-        feature_flag = FeatureFlag.objects.create(
-            team=self.team,
-            filters={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],},
-            name="Beta feature",
-            key="beta-feature",
-            created_by=user,
+        feature_flag = self.create_feature_flag(
+            filters={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}
         )
 
         self.assertTrue(feature_flag.distinct_id_matches("example_id"))
         self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+
+    def create_feature_flag(self, **kwargs):
+        return FeatureFlag.objects.create(
+            team=self.team, name="Beta feature", key="beta-feature", created_by=self.user, **kwargs
+        )

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1,4 +1,4 @@
-from posthog.models import Cohort, FeatureFlag, Person, feature_flag
+from posthog.models import Cohort, FeatureFlag, Person
 from posthog.test.base import BaseTest
 
 
@@ -28,8 +28,10 @@ class TestFeatureFlag(BaseTest):
                 ]
             }
         )
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertTrue(feature_flag.distinct_id_matches("another_id"))
+        with self.assertNumQueries(1):
+            self.assertTrue(feature_flag.distinct_id_matches("example_id"))
+        with self.assertNumQueries(1):
+            self.assertTrue(feature_flag.distinct_id_matches("another_id"))
         self.assertFalse(feature_flag.distinct_id_matches("false_id"))
 
     def test_user_in_cohort(self):


### PR DESCRIPTION
## Changes

This makes it possible to roll out feature flags in several groups. #3007 

Since feature flags are used by /decide endpoint, just doing a data migration would mean dropped requests while new servers are spinning up => I added application-level logic for handling that. This logic can be removed/migrated at a later date.

![2021-01-21_13-01](https://user-images.githubusercontent.com/148820/105342271-d17b6f80-5be8-11eb-98a5-cc315764d0c4.png)
![2021-01-21_13-00](https://user-images.githubusercontent.com/148820/105342274-d2ac9c80-5be8-11eb-8221-0cd5c1271f72.png)


## Commits

- Support multiple groups in feature flags model
- Update analytics_metadata method
- Allow defining multiple groups in frontend
- Allow sorting
- Update tests, allow submit without filters.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
