### PR TITLE
Plugin unique url with different private tokens & improve privacy

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, Optional
 import requests
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
-from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile
+from django.db.models import Q
 from django.utils.timezone import now
 from rest_framework import request, serializers, viewsets
 from rest_framework.decorators import action
@@ -32,6 +32,8 @@ from posthog.redis import get_client
 
 
 class PluginSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
     class Meta:
         model = Plugin
         fields = [
@@ -46,18 +48,28 @@ class PluginSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id"]
 
-    def get_error(self, plugin: Plugin) -> Optional[JSONField]:
-        if plugin.error and can_install_plugins_via_api(self.context["organization_id"]):
-            return plugin.error
-        return None
+    def get_url(self, plugin: Plugin) -> Optional[str]:
+        # remove ?private_token=... from url
+        return str(plugin.url).split("?")[0] if plugin.url else None
+
+    def _raise_if_plugin_installed(self, url: str) -> bool:
+        url_without_private_key = url.split("?")[0]
+        if (
+            len(
+                Plugin.objects.filter(
+                    Q(url=url_without_private_key) | Q(url__startswith="{}?".format(url_without_private_key))
+                )
+            )
+            > 0
+        ):
+            raise ValidationError('Plugin from URL "{}" already installed!'.format(url_without_private_key))
 
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> Plugin:
         if not can_install_plugins_via_api(self.context["organization_id"]):
             raise ValidationError("Plugin installation via the web is disabled!")
         if validated_data.get("plugin_type", None) != Plugin.PluginType.SOURCE:
             self._update_validated_data_from_url(validated_data, validated_data["url"])
-            if len(Plugin.objects.filter(url=validated_data["url"])) > 0:
-                raise ValidationError('Plugin from URL "{}" already installed!'.format(validated_data["url"]))
+            self._raise_if_plugin_installed(validated_data["url"])
         validated_data["organization_id"] = self.context["organization_id"]
         plugin = super().create(validated_data)
         reload_plugins_on_workers()

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -52,7 +52,7 @@ class PluginSerializer(serializers.ModelSerializer):
         # remove ?private_token=... from url
         return str(plugin.url).split("?")[0] if plugin.url else None
 
-    def _raise_if_plugin_installed(self, url: str) -> bool:
+    def _raise_if_plugin_installed(self, url: str):
         url_without_private_key = url.split("?")[0]
         if Plugin.objects.filter(
             Q(url=url_without_private_key) | Q(url__startswith="{}?".format(url_without_private_key))

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -111,7 +111,7 @@ class PluginSerializer(serializers.ModelSerializer):
                 validated_data["config_schema"] = plugin_json.get("config", {})
                 validated_data["source"] = None
             else:
-                raise ValidationError("Must be a GitHub repository or a NPM package URL!")
+                raise ValidationError("Must be a GitHub/GitLab repository or a npm package URL!")
 
             # Keep plugin type as "repository" or reset to "custom" if it was something else.
             if (

--- a/posthog/plugins/test/mock.py
+++ b/posthog/plugins/test/mock.py
@@ -98,6 +98,11 @@ def mocked_plugin_requests_get(*args, **kwargs):
                 HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
             )
         )
+        or args[0].startswith(
+            "https://gitlab.com/api/v4/projects/mariusandra%2Fhelloworldplugin-other/repository/archive.zip?sha={}&private_token=".format(
+                HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
+            )
+        )
     ):
         return MockBase64Response(HELLO_WORLD_PLUGIN_GITLAB_ZIP[1], 200)
     if args[0] == "https://registry.npmjs.org/posthog-helloworld-plugin/-/posthog-helloworld-plugin-0.0.0.tgz":

--- a/posthog/plugins/test/mock.py
+++ b/posthog/plugins/test/mock.py
@@ -53,6 +53,26 @@ def mocked_plugin_requests_get(*args, **kwargs):
             200,
         )
 
+    if args[0].startswith("https://gitlab.com/api/v4/projects/mariusandra%2Fhelloworldplugin/repository/commits"):
+        return MockJSONResponse(
+            [
+                {
+                    "web_url": "https://gitlab.com/mariusandra/helloworldplugin/-/commit/ff78cbe1d70316055c610a962a8355a4616d874b"
+                }
+            ],
+            200,
+        )
+
+    if args[0].startswith("https://gitlab.com/api/v4/projects/mariusandra%2Fhelloworldplugin-other/repository/commits"):
+        return MockJSONResponse(
+            [
+                {
+                    "web_url": "https://gitlab.com/mariusandra/helloworldplugin-other/-/commit/ff78cbe1d70316055c610a962a8355a4616d874b"
+                }
+            ],
+            200,
+        )
+
     if args[0] == "https://registry.npmjs.org/posthog-helloworld-plugin/latest":
         return MockJSONResponse({"pkg": "posthog-helloworld-plugin", "version": "MOCK"}, 200)
 
@@ -64,15 +84,22 @@ def mocked_plugin_requests_get(*args, **kwargs):
     ):
         return MockBase64Response(HELLO_WORLD_PLUGIN_GITHUB_ATTACHMENT_ZIP[1], 200)
 
-    if args[0] == "https://gitlab.com/mariusandra/helloworldplugin/-/archive/{}/helloworldplugin-{}.zip".format(
-        HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
-    ) or args[
-        0
-    ] == "https://gitlab.com/api/v4/projects/mariusandra%2Fhelloworldplugin/repository/archive.zip?sha={}&private_token={}".format(
-        HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], "PRIVATE_TOKEN"
+    if (
+        args[0]
+        == "https://gitlab.com/mariusandra/helloworldplugin/-/archive/{}/helloworldplugin-{}.zip".format(
+            HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
+        )
+        or args[0]
+        == "https://gitlab.com/mariusandra/helloworldplugin-other/-/archive/{}/helloworldplugin-other-{}.zip".format(
+            HELLO_WORLD_PLUGIN_GITLAB_ZIP[0], HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
+        )
+        or args[0].startswith(
+            "https://gitlab.com/api/v4/projects/mariusandra%2Fhelloworldplugin/repository/archive.zip?sha={}&private_token=".format(
+                HELLO_WORLD_PLUGIN_GITLAB_ZIP[0]
+            )
+        )
     ):
         return MockBase64Response(HELLO_WORLD_PLUGIN_GITLAB_ZIP[1], 200)
-
     if args[0] == "https://registry.npmjs.org/posthog-helloworld-plugin/-/posthog-helloworld-plugin-0.0.0.tgz":
         return MockBase64Response(HELLO_WORLD_PLUGIN_NPM_TGZ[1], 200)
 


### PR DESCRIPTION
## Changes

- Makes it so that the same gitlab repository with different private tokens in the URL is counted as the same repository (so can't install same thing twice with different keys)
- Removes the `private_token` from the plugin serializer --> can't leak potential secrets to posthog users in the API response

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
