### PR TITLE
Don't install unused pandas and numpy

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from urllib.parse import quote
 
 import lzstring
-import numpy as np
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -520,7 +519,7 @@ class TestCapture(BaseTest):
         self.client.post(
             "/track/",
             data={
-                "data": json.dumps([{"event": "beep", "properties": {"distinct_id": np.nan}}]),
+                "data": json.dumps([{"event": "beep", "properties": {"distinct_id": float("nan")}}]),
                 "api_key": self.team.api_token,
             },
         )

--- a/preview.Dockerfile
+++ b/preview.Dockerfile
@@ -28,9 +28,7 @@ COPY requirements.txt /code/
 # install dependencies but ignore any we don't need for dev environment
 RUN pip install $(grep -ivE "tblib|psycopg2|ipdb|mypy|ipython|ipdb|pip|djangorestframework-stubs|django-stubs|ipython-genutils|mypy-extensions|Pygments|typed-ast|jedi" requirements.txt | cut -d'#' -f1) --no-cache-dir --compile\
     && pip install psycopg2-binary --no-cache-dir --compile\
-    && pip uninstall ipython-genutils pip -y \
-    && rm -rf /usr/local/lib/python3.8/site-packages/numpy/core/tests \
-    && rm -rf /usr/local/lib/python3.8/site-packages/pandas/tests
+    && pip uninstall ipython-genutils pip -y
 
 COPY package.json /code/
 COPY yarn.lock /code/

--- a/requirements.in
+++ b/requirements.in
@@ -32,8 +32,6 @@ kafka-python==2.0.1
 kafka-helper==0.2
 kombu==4.6.8
 lzstring==1.0.4
-numpy==1.18.1
-pandas==1.1.3
 parso==0.6.1
 pexpect==4.7.0
 pickleshare==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,83 +4,229 @@
 #
 #    pip-compile requirements.in
 #
-aioch==0.0.2              # via -r requirements.in
-amqp==2.5.2               # via -r requirements.in, kombu
-asgiref==3.2.7            # via -r requirements.in, django
-backoff==1.6.0            # via posthoganalytics
-billiard==3.6.3.0         # via celery
-celery-redbeat==0.13.0    # via -r requirements.in
-celery==4.4.2             # via -r requirements.in, celery-redbeat
-certifi==2019.11.28       # via requests, sentry-sdk
-cffi==1.14.0              # via cryptography
-chardet==3.0.4            # via requests
-clickhouse-driver==0.1.4  # via -r requirements.in, aioch, clickhouse-pool
-clickhouse-pool==0.4.0    # via -r requirements.in
-cryptography==3.2         # via kafka-helper, social-auth-core
-cssselect==1.1.0          # via toronado
-cssutils==1.0.2           # via toronado
-defusedxml==0.6.0         # via -r requirements.in, python3-openid, social-auth-core
-dj-database-url==0.5.0    # via -r requirements.in
-django-axes==5.9.0        # via -r requirements.in
-django-cors-headers==3.5.0  # via -r requirements.in
-django-deprecate-fields==0.1.0  # via -r requirements.in
-django-extensions==3.0.9  # via -r requirements.in
-django-filter==2.4.0      # via -r requirements.in
-django-ipware==3.0.2      # via django-axes
-django-loginas==0.3.9     # via -r requirements.in
-django-redis==4.12.1      # via -r requirements.in
-git+https://github.com/zapier/django-rest-hooks.git@v1.6.0  # via -r requirements.in
-django-statsd==2.5.2      # via -r requirements.in
-django==3.0.11            # via -r requirements.in, django-axes, django-cors-headers, django-deprecate-fields, django-filter, django-redis, django-rest-hooks, djangorestframework
-djangorestframework-csv==2.1.0  # via -r requirements.in
-djangorestframework==3.12.1  # via -r requirements.in, djangorestframework-csv, drf-exceptions-hog, drf-extensions
-drf-exceptions-hog==0.0.4  # via -r requirements.in
-drf-extensions==0.6.0     # via -r requirements.in
-future==0.18.2            # via lzstring
-grpcio==1.33.1            # via -r requirements.in
-gunicorn==20.0.4          # via -r requirements.in
-idna==2.8                 # via -r requirements.in, requests
-importlib-metadata==1.6.0  # via -r requirements.in
-infi.clickhouse-orm==2.1.0  # via -r requirements.in
-iso8601==0.1.12           # via infi.clickhouse-orm
-kafka-helper==0.2         # via -r requirements.in
-kafka-python==2.0.1       # via -r requirements.in
-kombu==4.6.8              # via -r requirements.in, celery
-lxml==4.6.2               # via toronado
-lzstring==1.0.4           # via -r requirements.in
-monotonic==1.5            # via posthoganalytics
-numpy==1.18.1             # via -r requirements.in, pandas
-oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-pandas==1.1.3             # via -r requirements.in
-parso==0.6.1              # via -r requirements.in
-pexpect==4.7.0            # via -r requirements.in
-pickleshare==0.7.5        # via -r requirements.in
-posthoganalytics==1.1.3   # via -r requirements.in
-protobuf==3.13.0          # via -r requirements.in
-psycopg2-binary==2.8.4    # via -r requirements.in
-ptyprocess==0.6.0         # via pexpect
-pycparser==2.20           # via cffi
-pyjwt==1.7.1              # via social-auth-core
-python-dateutil==2.8.1    # via -r requirements.in, celery-redbeat, pandas, posthoganalytics
-python-statsd==2.1.0      # via -r requirements.in, django-statsd
-python3-openid==3.1.0     # via -r requirements.in, social-auth-core
-pytz==2019.3              # via -r requirements.in, celery, clickhouse-driver, django, infi.clickhouse-orm, pandas, tzlocal
-redis==3.4.1              # via -r requirements.in, celery-redbeat, django-redis
-requests-oauthlib==1.3.0  # via -r requirements.in, social-auth-core
-requests==2.22.0          # via -r requirements.in, django-rest-hooks, infi.clickhouse-orm, posthoganalytics, requests-oauthlib, social-auth-core
-sentry-sdk==0.19.2        # via -r requirements.in
-six==1.14.0               # via cryptography, djangorestframework-csv, grpcio, posthoganalytics, protobuf, python-dateutil, social-auth-app-django, social-auth-core, tenacity
-social-auth-app-django==3.1.0  # via -r requirements.in
-social-auth-core==3.3.3   # via -r requirements.in, social-auth-app-django
-sqlparse==0.3.0           # via django
-tenacity==6.1.0           # via celery-redbeat
-toronado==0.0.11          # via -r requirements.in
-tzlocal==2.1              # via clickhouse-driver
-unicodecsv==0.14.1        # via djangorestframework-csv
-urllib3==1.25.8           # via requests, sentry-sdk
-vine==1.3.0               # via amqp, celery
-whitenoise==5.0.1         # via -r requirements.in
-zipp==3.1.0               # via importlib-metadata
+aioch==0.0.2
+    # via -r requirements.in
+amqp==2.5.2
+    # via
+    #   -r requirements.in
+    #   kombu
+asgiref==3.2.7
+    # via
+    #   -r requirements.in
+    #   django
+backoff==1.6.0
+    # via posthoganalytics
+billiard==3.6.3.0
+    # via celery
+celery-redbeat==0.13.0
+    # via -r requirements.in
+celery==4.4.2
+    # via
+    #   -r requirements.in
+    #   celery-redbeat
+certifi==2019.11.28
+    # via
+    #   requests
+    #   sentry-sdk
+cffi==1.14.0
+    # via cryptography
+chardet==3.0.4
+    # via requests
+clickhouse-driver==0.1.4
+    # via
+    #   -r requirements.in
+    #   aioch
+    #   clickhouse-pool
+clickhouse-pool==0.4.0
+    # via -r requirements.in
+cryptography==3.2
+    # via
+    #   kafka-helper
+    #   social-auth-core
+cssselect==1.1.0
+    # via toronado
+cssutils==1.0.2
+    # via toronado
+defusedxml==0.6.0
+    # via
+    #   -r requirements.in
+    #   python3-openid
+    #   social-auth-core
+dj-database-url==0.5.0
+    # via -r requirements.in
+django-axes==5.9.0
+    # via -r requirements.in
+django-cors-headers==3.5.0
+    # via -r requirements.in
+django-deprecate-fields==0.1.0
+    # via -r requirements.in
+django-extensions==3.0.9
+    # via -r requirements.in
+django-filter==2.4.0
+    # via -r requirements.in
+django-ipware==3.0.2
+    # via django-axes
+django-loginas==0.3.9
+    # via -r requirements.in
+django-redis==4.12.1
+    # via -r requirements.in
+git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
+    # via -r requirements.in
+django-statsd==2.5.2
+    # via -r requirements.in
+django==3.0.11
+    # via
+    #   -r requirements.in
+    #   django-axes
+    #   django-cors-headers
+    #   django-deprecate-fields
+    #   django-filter
+    #   django-redis
+    #   django-rest-hooks
+    #   djangorestframework
+djangorestframework-csv==2.1.0
+    # via -r requirements.in
+djangorestframework==3.12.1
+    # via
+    #   -r requirements.in
+    #   djangorestframework-csv
+    #   drf-exceptions-hog
+    #   drf-extensions
+drf-exceptions-hog==0.0.4
+    # via -r requirements.in
+drf-extensions==0.6.0
+    # via -r requirements.in
+future==0.18.2
+    # via lzstring
+grpcio==1.33.1
+    # via -r requirements.in
+gunicorn==20.0.4
+    # via -r requirements.in
+idna==2.8
+    # via
+    #   -r requirements.in
+    #   requests
+importlib-metadata==1.6.0
+    # via -r requirements.in
+infi.clickhouse-orm==2.1.0
+    # via -r requirements.in
+iso8601==0.1.12
+    # via infi.clickhouse-orm
+kafka-helper==0.2
+    # via -r requirements.in
+kafka-python==2.0.1
+    # via -r requirements.in
+kombu==4.6.8
+    # via
+    #   -r requirements.in
+    #   celery
+lxml==4.6.2
+    # via toronado
+lzstring==1.0.4
+    # via -r requirements.in
+monotonic==1.5
+    # via posthoganalytics
+oauthlib==3.1.0
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+parso==0.6.1
+    # via -r requirements.in
+pexpect==4.7.0
+    # via -r requirements.in
+pickleshare==0.7.5
+    # via -r requirements.in
+posthoganalytics==1.1.3
+    # via -r requirements.in
+protobuf==3.13.0
+    # via -r requirements.in
+psycopg2-binary==2.8.4
+    # via -r requirements.in
+ptyprocess==0.6.0
+    # via pexpect
+pycparser==2.20
+    # via cffi
+pyjwt==1.7.1
+    # via social-auth-core
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   celery-redbeat
+    #   posthoganalytics
+python-statsd==2.1.0
+    # via
+    #   -r requirements.in
+    #   django-statsd
+python3-openid==3.1.0
+    # via
+    #   -r requirements.in
+    #   social-auth-core
+pytz==2019.3
+    # via
+    #   -r requirements.in
+    #   celery
+    #   clickhouse-driver
+    #   django
+    #   infi.clickhouse-orm
+    #   tzlocal
+redis==3.4.1
+    # via
+    #   -r requirements.in
+    #   celery-redbeat
+    #   django-redis
+requests-oauthlib==1.3.0
+    # via
+    #   -r requirements.in
+    #   social-auth-core
+requests==2.22.0
+    # via
+    #   -r requirements.in
+    #   django-rest-hooks
+    #   infi.clickhouse-orm
+    #   posthoganalytics
+    #   requests-oauthlib
+    #   social-auth-core
+sentry-sdk==0.19.2
+    # via -r requirements.in
+six==1.14.0
+    # via
+    #   cryptography
+    #   djangorestframework-csv
+    #   grpcio
+    #   posthoganalytics
+    #   protobuf
+    #   python-dateutil
+    #   social-auth-app-django
+    #   social-auth-core
+    #   tenacity
+social-auth-app-django==3.1.0
+    # via -r requirements.in
+social-auth-core==3.3.3
+    # via
+    #   -r requirements.in
+    #   social-auth-app-django
+sqlparse==0.3.0
+    # via django
+tenacity==6.1.0
+    # via celery-redbeat
+toronado==0.0.11
+    # via -r requirements.in
+tzlocal==2.1
+    # via clickhouse-driver
+unicodecsv==0.14.1
+    # via djangorestframework-csv
+urllib3==1.25.8
+    # via
+    #   requests
+    #   sentry-sdk
+vine==1.3.0
+    # via
+    #   amqp
+    #   celery
+whitenoise==5.0.1
+    # via -r requirements.in
+zipp==3.1.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Changes

With #2997 out of the way we can speed up builds by not including these two.