### PR TITLE
Hide plugins from nav in Cloud 

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -31,6 +31,8 @@ import { navigationLogic } from './navigationLogic'
 import { ToolbarModal } from '~/layout/ToolbarModal/ToolbarModal'
 import { dashboardsModel } from '~/models'
 import { DashboardType } from '~/types'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userLogic } from 'scenes/userLogic'
 
 // to show the right page in the sidebar
 const sceneOverride: Record<string, string> = {
@@ -77,6 +79,8 @@ const MenuItem = ({ title, icon, identifier, to, onClick }: MenuItemProps): JSX.
 
 export const MainNavigation = hot(_MainNavigation)
 function _MainNavigation(): JSX.Element {
+    const { user } = useValues(userLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { menuCollapsed, toolbarModalOpen, pinnedDashboardsVisible } = useValues(navigationLogic)
     const { setMenuCollapsed, collapseMenu, setToolbarModalOpen, setPinnedDashboardsVisible } = useActions(
         navigationLogic
@@ -220,7 +224,9 @@ function _MainNavigation(): JSX.Element {
                         to="/feature_flags"
                     />
                     <div className="divider" />
-                    <MenuItem title="Plugins" icon={<ApiFilled />} identifier="plugins" to="/project/plugins" />
+                    {featureFlags['plugins-cloud'] || user?.realm !== 'cloud' ? (
+                        <MenuItem title="Plugins" icon={<ApiFilled />} identifier="plugins" to="/project/plugins" />
+                    ) : null}
                     <MenuItem
                         title="Annotations"
                         icon={<MessageOutlined />}

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -31,7 +31,6 @@ import { navigationLogic } from './navigationLogic'
 import { ToolbarModal } from '~/layout/ToolbarModal/ToolbarModal'
 import { dashboardsModel } from '~/models'
 import { DashboardType } from '~/types'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userLogic } from 'scenes/userLogic'
 
 // to show the right page in the sidebar
@@ -80,7 +79,6 @@ const MenuItem = ({ title, icon, identifier, to, onClick }: MenuItemProps): JSX.
 export const MainNavigation = hot(_MainNavigation)
 function _MainNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { menuCollapsed, toolbarModalOpen, pinnedDashboardsVisible } = useValues(navigationLogic)
     const { setMenuCollapsed, collapseMenu, setToolbarModalOpen, setPinnedDashboardsVisible } = useActions(
         navigationLogic
@@ -224,7 +222,7 @@ function _MainNavigation(): JSX.Element {
                         to="/feature_flags"
                     />
                     <div className="divider" />
-                    {featureFlags['plugins-cloud'] || user?.realm !== 'cloud' ? (
+                    {user?.plugin_access.configure ? (
                         <MenuItem title="Plugins" icon={<ApiFilled />} identifier="plugins" to="/project/plugins" />
                     ) : null}
                     <MenuItem

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -118,7 +118,7 @@ function _App(): JSX.Element | null {
         <>
             <UpgradeModal />
             <Layout>
-                {featureFlags['navigation-1775'] ? (
+                {true ? (
                     <MainNavigation />
                 ) : (
                     <Sidebar

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -118,7 +118,7 @@ function _App(): JSX.Element | null {
         <>
             <UpgradeModal />
             <Layout>
-                {true ? (
+                {featureFlags['navigation-1775'] ? (
                     <MainNavigation />
                 ) : (
                     <Sidebar

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,6 +24,7 @@ export interface UserType {
     is_debug: boolean
     is_impersonated: boolean
     email_service_available: boolean
+    realm: 'cloud' | 'hosted'
 }
 
 /* Type for User objects in nested serializers (e.g. created_by) */


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Uses the same filter as the Plugins scene to determine if the nav item should appear.

Comes after 2 users reported clicking it on the new nav and not being able to access it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
