### PR TITLE
Add refresh param to retention and paths

### DIFF
--- a/frontend/src/scenes/paths/pathsLogic.js
+++ b/frontend/src/scenes/paths/pathsLogic.js
@@ -52,7 +52,7 @@ export const pathsLogic = kea({
                     if (!refresh && (props.cachedResults || props.preventLoading)) {
                         return { paths: props.cachedResults, filter }
                     }
-                    const params = toParams(filter)
+                    const params = toParams({ ...filter, ...(refresh ? { refresh: true } : {}) })
                     const paths = await api.get(`api/insight/path${params ? `/?${params}` : ''}`)
                     breakpoint()
                     return { paths, filter }

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -52,7 +52,7 @@ export const retentionTableLogic = kea<retentionTableLogicType<Moment>>({
                 if (!refresh && (props.cachedResults || props.preventLoading)) {
                     return props.cachedResults
                 }
-                const urlParams = toParams(values.filters)
+                const urlParams = toParams({ ...values.filters, ...(refresh ? { refresh: true } : {}) })
                 const res = await api.get(`api/insight/retention/?${urlParams}`)
                 breakpoint()
                 return res.data


### PR DESCRIPTION
## Changes

*Please describe.*  
- should fix #3017. the refresh parameter wasn't included on retention and path dashboard items so the new values were never propagated to the cache
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
