### PR TITLE
Add try statement for deleting persons incase the table is distributed

### DIFF
--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -156,8 +156,11 @@ def merge_people(team_id: int, target: Dict, old_id: UUID, old_props: Dict) -> N
 
 
 def delete_person(person_id: UUID, delete_events: bool = False, team_id: int = False) -> None:
-    if delete_events:
-        sync_execute(DELETE_PERSON_EVENTS_BY_ID, {"id": person_id, "team_id": team_id})
+    try:
+        if delete_events:
+            sync_execute(DELETE_PERSON_EVENTS_BY_ID, {"id": person_id, "team_id": team_id})
+    except:
+        pass  # cannot delete if the table is distributed
 
     sync_execute(DELETE_PERSON_BY_ID, {"id": person_id,})
     sync_execute(DELETE_PERSON_DISTINCT_ID_BY_PERSON_ID, {"id": person_id,})


### PR DESCRIPTION
## Changes

*Please describe.*  
- can't delete person on cloud because we have distributed tables now
- just pass if it doesn't work

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
