### PR TITLE
Fix session recording breakage

### DIFF
--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -152,7 +152,9 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Ev
         session: [
             (selectors) => [selectors.sessionRecordingId, selectors.sessions],
             (id: SessionRecordingId, sessions: Array<SessionType>): SessionType | null => {
-                const [session] = sessions.filter((s) => (s.session_recording_ids || []).includes(id))
+                const [session] = sessions.filter(
+                    (s) => s.session_recordings.filter((recording) => id === recording.id).length > 0
+                )
                 return session
             },
         ],

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -130,6 +130,7 @@ export const sessionsTableLogic = kea<
                 date_to: values.selectedDateURLparam,
                 pagination: values.pagination,
                 distinct_id: props.personIds ? props.personIds[0] : '',
+                filters: values.filters,
                 properties: values.properties,
             })
             const response = await api.get(`api/event/sessions/?${params}`)


### PR DESCRIPTION
No strict typescript makes me sad. This property was gone during refactoring, probably broken due to parallel PRs.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
