### PR TITLE
Use KAFKA_HOSTS instead of KAFKA_URL in ECS dockerized plugin server

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -44,8 +44,8 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_TRUSTED_CERT_B64::"
                 },
                 {
-                    "name": "KAFKA_URL",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_URL::"
+                    "name": "KAFKA_HOSTS",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_HOSTS::"
                 },
                 {
                     "name": "POSTHOG_PERSONAL_API_KEY",


### PR DESCRIPTION
## Changes

Tiny update.