### PR TITLE
Fix exception when using a bad selector to select actions

### DIFF
--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -397,7 +397,6 @@ export const elementsLogic = kea<
             if (element?.attributes) {
                 for (let i = 0; i < element.attributes.length; i++) {
                     const name = element.attributes.item(i)?.nodeName
-                    console.log(element.attributes.item(i), name)
                     if (name && name.indexOf('data-') > -1) {
                         data_attributes.push(name)
                     }

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -246,7 +246,7 @@ export function getElementForStep(step: ActionStepForm, allElements?: HTMLElemen
         elements = [...((querySelectorAllDeep(selector || '*', document, allElements) as unknown) as HTMLElement[])]
     } catch (e) {
         console.error('Can not use selector:', selector)
-        throw e
+        return null
     }
 
     if (hasText && step?.text) {


### PR DESCRIPTION
## Changes

- Fix the toolbar crashing when trying to use an incorrect selector to find an action (`[id="sign-up-cta"] > ` in this case)
- Removes random `console.log`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
