### PR TITLE
Plugins required in preflight check

### DIFF
--- a/frontend/src/scenes/PreflightCheck/index.js
+++ b/frontend/src/scenes/PreflightCheck/index.js
@@ -65,7 +65,7 @@ function PreflightCheck() {
     const [state, setState] = useState({})
     const { preflight, preflightLoading } = useValues(preflightLogic)
     const { resetPreflight } = useActions(preflightLogic)
-    const isReady = preflight.django && preflight.db && preflight.redis && preflight.celery
+    const isReady = preflight.django && preflight.db && preflight.redis && preflight.celery && preflight.plugins
 
     const checks = [
         {
@@ -84,16 +84,14 @@ function PreflightCheck() {
             status: preflight.redis,
         },
         {
-            id: 'redis',
+            id: 'celery',
             name: 'Background Jobs (Celery)',
             status: preflight.celery,
         },
         {
-            id: 'redis',
+            id: 'plugins',
             name: 'Posthog Plugin Server',
             status: preflight.plugins,
-            caption: 'Not required if not using plugins',
-            failedState: 'not-required',
         },
         {
             id: 'frontend',

--- a/frontend/src/scenes/PreflightCheck/index.js
+++ b/frontend/src/scenes/PreflightCheck/index.js
@@ -65,7 +65,12 @@ function PreflightCheck() {
     const [state, setState] = useState({})
     const { preflight, preflightLoading } = useValues(preflightLogic)
     const { resetPreflight } = useActions(preflightLogic)
-    const isReady = preflight.django && preflight.db && preflight.redis && preflight.celery && preflight.plugins
+    const isReady =
+        preflight.django &&
+        preflight.db &&
+        preflight.redis &&
+        preflight.celery &&
+        (state.mode === 'Experimentation' || preflight.plugins)
 
     const checks = [
         {
@@ -92,6 +97,8 @@ function PreflightCheck() {
             id: 'plugins',
             name: 'Posthog Plugin Server',
             status: preflight.plugins,
+            caption: state.mode === 'Experimentation' ? 'Required in production environments' : '',
+            failedState: state.mode === 'Experimentation' ? 'warning' : 'error',
         },
         {
             id: 'frontend',

--- a/frontend/src/scenes/PreflightCheck/index.js
+++ b/frontend/src/scenes/PreflightCheck/index.js
@@ -85,25 +85,25 @@ function PreflightCheck() {
         },
         {
             id: 'redis',
-            name: 'Cache & Queue (Redis)',
+            name: 'Cache & queue (Redis)',
             status: preflight.redis,
         },
         {
             id: 'celery',
-            name: 'Background Jobs (Celery)',
+            name: 'Background jobs (Celery)',
             status: preflight.celery,
         },
         {
             id: 'plugins',
-            name: 'Posthog Plugin Server',
+            name: 'Plugin server (Node)',
             status: preflight.plugins,
             caption: state.mode === 'Experimentation' ? 'Required in production environments' : '',
             failedState: state.mode === 'Experimentation' ? 'warning' : 'error',
         },
         {
             id: 'frontend',
-            name: 'Frontend built (Webpack)',
-            status: true, // If this code is run, the front-end is already built
+            name: 'Frontend build (Webpack)',
+            status: true, // If this code is ran, the front-end is already built
         },
         {
             id: 'tls',


### PR DESCRIPTION
## Changes

Preflight check now:

1. Requires plugins to work in production mode
<img width="1212" alt="Screenshot 2021-01-26 at 00 10 14" src="https://user-images.githubusercontent.com/53387/105777627-ff571000-5f6a-11eb-8970-350399357a9c.png">

2. Displays a stricter warning in experimentation mode
<img width="1177" alt="Screenshot 2021-01-26 at 00 10 06" src="https://user-images.githubusercontent.com/53387/105777621-fbc38900-5f6a-11eb-9695-47dddb51c696.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
