### PR TITLE
Make feature flag query faster

### DIFF
--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.models.expressions import ExpressionWrapper
 from django.db.models.fields import BooleanField
 from django.db.models.query import QuerySet
+from django.db.models.query_utils import Q
 from django.dispatch import receiver
 from django.utils import timezone
 
@@ -95,7 +96,9 @@ class FeatureFlagMatcher:
     @cached_property
     def query_groups(self) -> List[List[bool]]:
         query: QuerySet = Person.objects.filter(
-            team_id=self.feature_flag.team_id, persondistinctid__distinct_id=self.distinct_id
+            team_id=self.feature_flag.team_id,
+            persondistinctid__distinct_id=self.distinct_id,
+            persondistinctid__team_id=self.feature_flag.team_id,
         )
 
         fields = []


### PR DESCRIPTION
It was not filtering by team_id on a subquery. Hotfix which changes the
query to

```
SELECT (EXISTS(SELECT U0."id" FROM "posthog_cohortpeople" U0 WHERE (U0."cohort_id" = 1 AND U0."person_id" = "posthog_person"."id")) AND "posthog_person"."team_id" = 1) AS "group_0"
  FROM "posthog_person"
 INNER JOIN "posthog_persondistinctid"
    ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
 WHERE ("posthog_persondistinctid"."distinct_id" = 'foobra' AND "posthog_persondistinctid"."team_id" = 1 AND "posthog_person"."team_id" = 1)
```

This slowed down /decide endpoint significantly

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
