### PR TITLE
Reduce axes logspam

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -575,5 +575,6 @@ LOGGING = {
     "root": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING")},
     "loggers": {
         "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"), "propagate": True,},
+        "axes": {"handlers": ["console"], "level": "WARNING", "propagate": False},
     },
 }


### PR DESCRIPTION
During tests it's making everything quite unreadable:

```
AXES: Cleaned up 0 expired access attempts from database that were older than 2021-01-26 07:30:23.776885+00:00
AXES: Successful login by {username: "user1@posthog.com", ip_address: "None", user_agent: "<unknown>", path_info: "<unknown>"}.
AXES: Cleaned up 0 expired access attempts from database that were older than 2021-01-26 07:30:23.786481+00:00
AXES: Successful logout by {username: "user1@posthog.com", ip_address: "None", user_agent: "<unknown>", path_info: "<unknown>"}.
```

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
