### PR TITLE
Fix paths background color in dashboard

### DIFF
--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -166,9 +166,15 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
             .attr('id', 'dropoff-gradient')
             .attr('gradientTransform', 'rotate(90)')
 
-        dropOffGradient.append('stop').attr('offset', '0%').attr('stop-color', 'rgba(220,53,69,0.7)')
+        dropOffGradient
+            .append('stop')
+            .attr('offset', '0%')
+            .attr('stop-color', color === 'white' ? 'rgba(220,53,69,0.7)' : 'rgb(220,53,69)')
 
-        dropOffGradient.append('stop').attr('offset', '100%').attr('stop-color', '#ffffff')
+        dropOffGradient
+            .append('stop')
+            .attr('offset', '100%')
+            .attr('stop-color', color === 'white' ? '#fff' : 'var(--item-background)')
 
         const link = svg
             .append('g')
@@ -238,11 +244,11 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
                 }
             })
             .style('cursor', loadedFilter.path_type === AUTOCAPTURE ? 'pointer' : 'auto')
-            .style('fill', color === 'white' ? '#000' : '#d4d4d4')
+            .style('fill', color === 'white' ? '#000' : '#fff')
 
         textSelection
             .append('tspan')
-            .attr('fill-opacity', 0.7)
+            .attr('fill-opacity', 0.8)
             .text((d) => ` ${d.value.toLocaleString()}`)
 
         textSelection.append('title').text((d) => stripHTTP(d.name))

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -79,7 +79,7 @@ function NoData() {
 
 const DEFAULT_PATHS_ID = 'default_paths'
 
-export function Paths({ dashboardItemId = null, filters = null }) {
+export function Paths({ dashboardItemId = null, filters = null, color = 'white' }) {
     const canvas = useRef(null)
     const size = useWindowSize()
     const { paths, loadedFilter, resultsLoading: pathsLoading } = useValues(pathsLogic({ dashboardItemId, filters }))
@@ -89,7 +89,7 @@ export function Paths({ dashboardItemId = null, filters = null }) {
 
     useEffect(() => {
         renderPaths()
-    }, [paths, !pathsLoading, size])
+    }, [paths, !pathsLoading, size, color])
 
     function renderPaths() {
         const elements = document
@@ -106,9 +106,10 @@ export function Paths({ dashboardItemId = null, filters = null }) {
         let svg = d3
             .select(canvas.current)
             .append('svg')
-            .style('background', '#fff')
+            .style('background', 'var(--item-background)')
             .style('width', width)
             .style('height', height)
+
         let sankey = new Sankey.sankey()
             .nodeId((d) => d.name)
             .nodeAlign(Sankey.sankeyLeft)
@@ -147,7 +148,13 @@ export function Paths({ dashboardItemId = null, filters = null }) {
                         }
                     }
                 }
-                return (d3.color(c) || d3.color('#dddddd')).darker(0.5)
+
+                const startNodeColor = d3.color(c)
+                    ? d3.color(c)
+                    : color === 'white'
+                    ? d3.color('#dddddd')
+                    : d3.color('#191919')
+                return startNodeColor.darker(0.5)
             })
             .attr('opacity', 0.5)
             .append('title')
@@ -169,9 +176,8 @@ export function Paths({ dashboardItemId = null, filters = null }) {
             .selectAll('g')
             .data(links)
             .join('g')
-            .attr('stroke', () => 'var(--primary)')
-            .attr('opacity', 0.3)
-            .style('mix-blend-mode', 'multiply')
+            .attr('stroke', () => (color === 'white' ? 'var(--primary)' : 'var(--item-lighter'))
+            .attr('opacity', 0.4)
 
         link.append('path')
             .attr('d', Sankey.sankeyLinkHorizontal())
@@ -232,6 +238,7 @@ export function Paths({ dashboardItemId = null, filters = null }) {
                 }
             })
             .style('cursor', loadedFilter.path_type === AUTOCAPTURE ? 'pointer' : 'auto')
+            .style('fill', color === 'white' ? '#000' : '#d4d4d4')
 
         textSelection
             .append('tspan')


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Closes #3019 

Listen to changes to the color prop passed to dashboard items via `Element` and react accordingly.

### Before

<img width="976" alt="Screenshot 2021-01-26 at 16 02 56" src="https://user-images.githubusercontent.com/38760734/105870485-3ae7ed80-5ff0-11eb-9053-b8d62a07b52f.png">


### After 
<img width="1068" alt="Screenshot 2021-01-26 at 16 02 47" src="https://user-images.githubusercontent.com/38760734/105870499-3e7b7480-5ff0-11eb-964f-6fa9129cb75e.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
