### PR TITLE
Move adding feature flags to event to capture endpoint

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -18,12 +18,7 @@ from posthog.models.element import Element
 from posthog.models.person import Person
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.tasks.process_event import (
-    _add_missing_feature_flags,
-    handle_identify_or_alias,
-    sanitize_event_name,
-    store_names_and_properties,
-)
+from posthog.tasks.process_event import handle_identify_or_alias, sanitize_event_name, store_names_and_properties
 
 if settings.STATSD_HOST is not None:
     statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
@@ -64,7 +59,6 @@ def _capture_ee(
         properties["$ip"] = ip
 
     event = sanitize_event_name(event)
-    _add_missing_feature_flags(properties, team, distinct_id)
     store_names_and_properties(team=team, event=event, properties=properties)
 
     if not Person.objects.distinct_ids_exist(team_id=team_id, distinct_ids=[str(distinct_id)]):

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -204,7 +204,9 @@ def get_event(request):
 
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
-            if settings.PLUGIN_SERVER_INGESTION_HANDOFF:
+            if settings.PLUGIN_SERVER_INGESTION_HANDOFF and team.organization_id in getattr(
+                settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", []
+            ):
                 log_topics.append(KAFKA_EVENTS_INGESTION_HANDOFF)
             else:
                 process_event_ee(

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -86,11 +86,7 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
 
 def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], team: Team, distinct_id: str):
     """If the event comes from web, ensure that it contains property $active_feature_flags."""
-    if (
-        event.get("properties")
-        and event["properties"].get("$lib") == "web"
-        and not event["properties"].get("$active_feature_flags")
-    ):
+    if event["properties"].get("$lib") == "web" and not event["properties"].get("$active_feature_flags"):
         event["properties"]["$active_feature_flags"] = get_active_feature_flags(team, distinct_id)
 
 
@@ -190,7 +186,7 @@ def get_event(request):
                     status=400,
                 ),
             )
-        if "event" not in event:
+        if not event.get("event"):
             return cors_response(
                 request,
                 JsonResponse(
@@ -198,6 +194,9 @@ def get_event(request):
                     status=400,
                 ),
             )
+
+        if not event.get("properties"):
+            event["properties"] = {}
 
         _ensure_web_feature_flags_in_properties(event, team, distinct_id)
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -85,9 +85,12 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
 
 
 def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], team: Team, distinct_id: str):
-    if event["properties"].get("$lib") == "web" and not event["properties"].get("$active_feature_flags"):
-        if not event.get("properties"):
-            event["properties"] = {}
+    """If the event comes from web, ensure that it contains property $active_feature_flags."""
+    if (
+        event.get("properties")
+        and event["properties"].get("$lib") == "web"
+        and not event["properties"].get("$active_feature_flags")
+    ):
         event["properties"]["$active_feature_flags"] = get_active_feature_flags(team, distinct_id)
 
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -85,10 +85,9 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
 
 
 def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], team: Team, distinct_id: str):
-    if not event.get("properties"):
-        event["properties"] = {}
-    # Only add missing feature flags on web
     if event["properties"].get("$lib") == "web" and not event["properties"].get("$active_feature_flags"):
+        if not event.get("properties"):
+            event["properties"] = {}
         event["properties"]["$active_feature_flags"] = get_active_feature_flags(team, distinct_id)
 
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from posthog.models import PersonalAPIKey
+from posthog.models.feature_flag import FeatureFlag
 
 from .base import BaseTest
 
@@ -525,3 +526,17 @@ class TestCapture(BaseTest):
         )
         arguments = self._to_arguments(patch_process_event_with_plugins)
         self.assertEqual(arguments["data"]["properties"]["distinct_id"], None)
+
+    @patch("posthog.api.capture.celery_app.send_task")
+    def test_add_feature_flags_if_missing(self, patch_process_event_with_plugins) -> None:
+        self.assertListEqual(self.team.event_properties_numerical, [])
+        FeatureFlag.objects.create(team=self.team, created_by=self.user, key="test-ff", rollout_percentage=100)
+        self.client.post(
+            "/track/",
+            data={
+                "data": json.dumps([{"event": "purchase", "properties": {"distinct_id": "xxx", "$lib": "web"}}]),
+                "api_key": self.team.api_token,
+            },
+        )
+        arguments = self._to_arguments(patch_process_event_with_plugins)
+        self.assertEqual(arguments["data"]["properties"]["$active_feature_flags"], ["test-ff"])

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -217,7 +217,7 @@ class TestCapture(BaseTest):
                 "distinct_id": "2",
                 "ip": "127.0.0.1",
                 "site_url": "http://testserver",
-                "data": data,
+                "data": {**data, "properties": {}},
                 "team_id": self.team.pk,
             },
         )
@@ -247,7 +247,7 @@ class TestCapture(BaseTest):
                 "distinct_id": "2",
                 "ip": "127.0.0.1",
                 "site_url": "http://testserver",
-                "data": data["batch"][0],
+                "data": {**data["batch"][0], "properties": {}},
                 "team_id": self.team.pk,
             },
         )
@@ -276,7 +276,7 @@ class TestCapture(BaseTest):
                 "distinct_id": "2",
                 "ip": "127.0.0.1",
                 "site_url": "http://testserver",
-                "data": data["batch"][0],
+                "data": {**data["batch"][0], "properties": {}},
                 "team_id": self.team.pk,
             },
         )
@@ -306,7 +306,7 @@ class TestCapture(BaseTest):
                 "distinct_id": "2",
                 "ip": "127.0.0.1",
                 "site_url": "http://testserver",
-                "data": data["batch"][0],
+                "data": {**data["batch"][0], "properties": {}},
                 "team_id": self.team.pk,
             },
         )

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -102,13 +102,6 @@ def store_names_and_properties(team: Team, event: str, properties: Dict) -> None
         team.save()
 
 
-def _add_missing_feature_flags(properties: Dict, team: Team, distinct_id: str) -> None:
-    # Only add missing feature flags on web
-    if not properties.get("$lib") == "web" or properties.get("$active_feature_flags"):
-        return
-    properties["$active_feature_flags"] = get_active_feature_flags(team, distinct_id)
-
-
 def _capture(
     ip: str,
     site_url: str,
@@ -150,7 +143,6 @@ def _capture(
         properties["$ip"] = ip
 
     event = sanitize_event_name(event)
-    _add_missing_feature_flags(properties, team, distinct_id)
 
     Event.objects.create(
         event=event,

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from numbers import Number
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import posthoganalytics
 from celery import shared_task
@@ -11,7 +11,6 @@ from django.db import IntegrityError
 from sentry_sdk import capture_exception
 
 from posthog.models import Element, Event, Person, SessionRecordingEvent, Team
-from posthog.models.feature_flag import FeatureFlag, get_active_feature_flags
 
 
 def _alias(previous_distinct_id: str, distinct_id: str, team_id: int, retry_if_failed: bool = True,) -> None:

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -847,21 +847,6 @@ def test_process_event_factory(
             self.assertListEqual(self.team.event_properties, ["price", "name", "$ip"])
             self.assertListEqual(self.team.event_properties_numerical, ["price"])
 
-        def test_add_feature_flags_if_missing(self) -> None:
-            self.assertListEqual(self.team.event_properties_numerical, [])
-            FeatureFlag.objects.create(team=self.team, created_by=self.user, key="test-ff", rollout_percentage=100)
-            with self.assertNumQueries(17):
-                process_event(
-                    "xxx",
-                    "",
-                    "",
-                    {"event": "purchase", "properties": {"$lib": "web"},},
-                    self.team.pk,
-                    now().isoformat(),
-                    now().isoformat(),
-                )
-            self.assertEqual(get_events()[0].properties["$active_feature_flags"], ["test-ff"])
-
         def test_event_name_dict_json(self) -> None:
             process_event(
                 "xxx",


### PR DESCRIPTION
## Changes

This will save us a ton of work by moving adding feature flags to event properties earlier in the Python part of the pipeline, instead of forcing us to redo this in JS.
