### PR TITLE
Only show tooltips when you can actually click

### DIFF
--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -223,7 +223,7 @@ export function LineGraph({
                                           (percentage ? '%' : '')
                                       )
                                   },
-                                  footer: () => 'Click to see users related to the datapoint',
+                                  footer: () => (dashboardItemId ? '' : 'Click to see users related to the datapoint'),
                               },
                               itemSort: (a, b) => b.yLabel - a.yLabel,
                           },


### PR DESCRIPTION
## Changes

*Please describe.*  
- now dashboard items won't show a prompt to click when you can't

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
