### PR TITLE
Revert "Move adding feature flags to event to capture endpoint"

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -18,7 +18,12 @@ from posthog.models.element import Element
 from posthog.models.person import Person
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.tasks.process_event import handle_identify_or_alias, sanitize_event_name, store_names_and_properties
+from posthog.tasks.process_event import (
+    _add_missing_feature_flags,
+    handle_identify_or_alias,
+    sanitize_event_name,
+    store_names_and_properties,
+)
 
 if settings.STATSD_HOST is not None:
     statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
@@ -59,6 +64,7 @@ def _capture_ee(
         properties["$ip"] = ip
 
     event = sanitize_event_name(event)
+    _add_missing_feature_flags(properties, team, distinct_id)
     store_names_and_properties(team=team, event=event, properties=properties)
 
     if not Person.objects.distinct_ids_exist(team_id=team_id, distinct_ids=[str(distinct_id)]):


### PR DESCRIPTION
Reverts PostHog/posthog#3090, which is causing an odd Django ORM bug in production: https://sentry.io/organizations/posthog/issues/2180207937/