### PR TITLE
Add Google OAuth settings for Social Auth

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -322,6 +322,11 @@ SOCIAL_AUTH_GITLAB_KEY = os.environ.get("SOCIAL_AUTH_GITLAB_KEY")
 SOCIAL_AUTH_GITLAB_SECRET = os.environ.get("SOCIAL_AUTH_GITLAB_SECRET")
 SOCIAL_AUTH_GITLAB_API_URL = os.environ.get("SOCIAL_AUTH_GITLAB_API_URL", "https://gitlab.com")
 
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
+
+social_auth_domains = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS")
+SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS = [domain for domain in social_auth_domains.split(",")]
 
 # See https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS
 DISABLE_SERVER_SIDE_CURSORS = get_bool_from_env("USING_PGBOUNCER", False)

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -325,7 +325,7 @@ SOCIAL_AUTH_GITLAB_API_URL = os.environ.get("SOCIAL_AUTH_GITLAB_API_URL", "https
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
 
-social_auth_domains = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS")
+social_auth_domains = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS", "")
 SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS = [domain for domain in social_auth_domains.split(",")]
 
 # See https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS


### PR DESCRIPTION
## Changes

Based on config docs found here:
https://python-social-auth.readthedocs.io/en/latest/backends/google.html
https://developers.google.com/identity/protocols/oauth2?csw=1
https://stackoverflow.com/questions/38566799/limit-google-oauth-access-to-one-domain-using-hd-param-django-python-social



