### PR TITLE
Fix multiple group feature flag

### DIFF
--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -117,11 +117,11 @@ class TestDecide(BaseTest):
             key="filer-by-property-2",
             created_by=self.user,
         )
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(7):
             response = self._post_decide()
         self.assertEqual(response["featureFlags"][0], "beta-feature")
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(7):
             response = self._post_decide({"token": self.team.api_token, "distinct_id": "another_id"})
         self.assertEqual(len(response["featureFlags"]), 0)
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -45,7 +45,7 @@ class TestFeatureFlag(BaseTest):
             filters={
                 "groups": [
                     {"rollout_percentage": 0},
-                    {"properties": [{"key": "email", "value": "example@example.com"}]},
+                    {"properties": [{"key": "email", "value": "example@example.com"}], "rollout_percentage": 100},
                 ]
             }
         )

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -49,8 +49,7 @@ class TestFeatureFlag(BaseTest):
                 ]
             }
         )
-        # with self.assertNumQueries(0):
-        #     feature_flag.distinct_id_matches("example_id")
+        self.assertFalse(feature_flag.distinct_id_matches("example_id"))
         with self.assertNumQueries(1):
             self.assertTrue(feature_flag.distinct_id_matches("another_id"))
         self.assertFalse(feature_flag.distinct_id_matches("false_id"))


### PR DESCRIPTION
## Changes

*Please describe.*  
- when you create a feature flag with multiple groups where one of the groups only has rollout percentages and no properties, the check fails and [this sentry error occurs](https://sentry.io/organizations/posthog/issues/2180478883/?project=1899813&referrer=slack). This is because the `query_groups` query tries to put in a null subquery if a group only has rollout percentage
- @macobo leaving this here for you. I think there's an easy fix to what you originally put down but my brain is running slow and I couldn't figure out the dummy condition using ORM to place in the query so incase you need an ASAP fix here it is! The test is useful too

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
