### PR TITLE
Add team filter to cohort query to speed up

### DIFF
--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -128,8 +128,10 @@ class Cohort(models.Model):
                 batch = items[i : i + batchsize]
                 persons_query = (
                     Person.objects.filter(team_id=self.team_id)
-                    .filter(persondistinctid__team_id=self.team_id)
-                    .filter(Q(persondistinctid__distinct_id__in=batch) | Q(properties__email__in=batch))
+                    .filter(
+                        Q(persondistinctid__team_id=self.team_id, persondistinctid__distinct_id__in=batch)
+                        | Q(properties__email__in=batch)
+                    )
                     .exclude(cohort__id=self.id)
                 )
                 if use_clickhouse:

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -128,6 +128,7 @@ class Cohort(models.Model):
                 batch = items[i : i + batchsize]
                 persons_query = (
                     Person.objects.filter(team_id=self.team_id)
+                    .filter(persondistinctid__team_id=self.team_id)
                     .filter(Q(persondistinctid__distinct_id__in=batch) | Q(properties__email__in=batch))
                     .exclude(cohort__id=self.id)
                 )


### PR DESCRIPTION
## Changes

Fixes https://sentry.io/organizations/posthog/issues/1724065650/events/978ab72bad3344768ddb178d8054e5d7/?project=1899813&query=is%3Aunresolved&statsPeriod=14d

persondistinctid is indexed on team + distinct id, but we were doing a query only on distinct id which means we did a full table scan, causing timeouts.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
