### PR TITLE
Onboarding personalisation adjustments (retention#9)

### DIFF
--- a/frontend/src/lib/components/RadioSelect/index.scss
+++ b/frontend/src/lib/components/RadioSelect/index.scss
@@ -20,7 +20,13 @@ $color-transition: color $transition_params;
             margin-left: 0;
         }
 
-        &:hover,
+        &:hover {
+            font-weight: bold;
+            .graphic {
+                background-color: $border;
+            }
+        }
+
         &.active {
             color: $primary;
             font-weight: bold;

--- a/frontend/src/lib/components/RadioSelect/index.scss
+++ b/frontend/src/lib/components/RadioSelect/index.scss
@@ -6,7 +6,7 @@ $color-transition: color $transition_params;
 .ph-radio-options {
     display: flex;
     justify-content: center;
-    padding: $default_spacing 0;
+    padding-bottom: $default_spacing;
 
     .radio-option {
         margin-left: $default_spacing * 2;

--- a/frontend/src/lib/components/RadioSelect/index.tsx
+++ b/frontend/src/lib/components/RadioSelect/index.tsx
@@ -9,18 +9,50 @@ export interface RadioSelectType {
 
 interface RadioSelectProps {
     options: RadioSelectType[]
-    selectedOption: null | string
-    onOptionChanged: (key: string | null) => void
+    selectedOption: null | string | string[]
+    onOptionChanged: (key: string | string[] | null) => void
+    multipleSelection?: boolean
 }
 
-export function RadioSelect({ options, selectedOption, onOptionChanged }: RadioSelectProps): JSX.Element {
+export function RadioSelect({
+    options,
+    selectedOption,
+    onOptionChanged,
+    multipleSelection,
+}: RadioSelectProps): JSX.Element {
+    const isSelected = (option: RadioSelectType): boolean => {
+        return multipleSelection && selectedOption
+            ? selectedOption?.includes(option.key)
+            : selectedOption === option.key
+    }
+
+    const handleClick = (option: RadioSelectType): void => {
+        if (multipleSelection) {
+            if (selectedOption instanceof Array) {
+                const _selectedOptions = selectedOption
+                const idx = _selectedOptions.indexOf(option.key)
+                if (idx > -1) {
+                    // Option was previously selected, remove
+                    _selectedOptions.splice(idx, 1)
+                } else {
+                    _selectedOptions.push(option.key)
+                }
+                onOptionChanged(_selectedOptions)
+            } else {
+                onOptionChanged([option.key])
+            }
+        } else {
+            onOptionChanged(selectedOption !== option.key ? option.key : null)
+        }
+    }
+
     return (
         <div className="ph-radio-options">
             {options.map((option) => (
                 <div
-                    className={`radio-option${selectedOption === option.key ? ' active' : ''}`}
+                    className={`radio-option${isSelected(option) ? ' active' : ''}`}
                     key={option.key}
-                    onClick={() => onOptionChanged(selectedOption !== option.key ? option.key : null)}
+                    onClick={() => handleClick(option)}
                 >
                     <div className="graphic">{option.icon}</div>
                     <div className="label">{option.label}</div>

--- a/frontend/src/lib/components/RadioSelect/index.tsx
+++ b/frontend/src/lib/components/RadioSelect/index.tsx
@@ -38,7 +38,7 @@ export function RadioSelect({
 
         if (multipleSelection) {
             if (selectedOption instanceof Array) {
-                const _selectedOptions = selectedOption
+                const _selectedOptions = [...selectedOption]
                 const idx = _selectedOptions.indexOf(option.key)
                 if (idx > -1) {
                     // Option was previously selected, remove

--- a/frontend/src/lib/components/RadioSelect/index.tsx
+++ b/frontend/src/lib/components/RadioSelect/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import { ArrowLeftOutlined } from '@ant-design/icons'
 import './index.scss'
+import { Button } from 'antd'
 
 export interface RadioSelectType {
     key: string
@@ -12,6 +14,7 @@ interface RadioSelectProps {
     selectedOption: null | string | string[]
     onOptionChanged: (key: string | string[] | null) => void
     multipleSelection?: boolean
+    focusSelection?: boolean // will hide other choices after making a selection
 }
 
 export function RadioSelect({
@@ -19,6 +22,7 @@ export function RadioSelect({
     selectedOption,
     onOptionChanged,
     multipleSelection,
+    focusSelection,
 }: RadioSelectProps): JSX.Element {
     const isSelected = (option: RadioSelectType): boolean => {
         return multipleSelection && selectedOption
@@ -26,7 +30,12 @@ export function RadioSelect({
             : selectedOption === option.key
     }
 
-    const handleClick = (option: RadioSelectType): void => {
+    const handleClick = (option: RadioSelectType | null): void => {
+        if (!option) {
+            onOptionChanged(null)
+            return
+        }
+
         if (multipleSelection) {
             if (selectedOption instanceof Array) {
                 const _selectedOptions = selectedOption
@@ -47,17 +56,30 @@ export function RadioSelect({
     }
 
     return (
-        <div className="ph-radio-options">
-            {options.map((option) => (
-                <div
-                    className={`radio-option${isSelected(option) ? ' active' : ''}`}
-                    key={option.key}
-                    onClick={() => handleClick(option)}
-                >
-                    <div className="graphic">{option.icon}</div>
-                    <div className="label">{option.label}</div>
+        <div className="mt">
+            {focusSelection && selectedOption && (
+                <div className="text-center">
+                    <Button type="link" icon={<ArrowLeftOutlined />} onClick={() => handleClick(null)}>
+                        change
+                    </Button>
                 </div>
-            ))}
+            )}
+            <div className="ph-radio-options">
+                {options.map((option) => {
+                    if (!focusSelection || !selectedOption || isSelected(option)) {
+                        return (
+                            <div
+                                className={`radio-option${isSelected(option) ? ' active' : ''}`}
+                                key={option.key}
+                                onClick={() => handleClick(option)}
+                            >
+                                <div className="graphic">{option.icon}</div>
+                                <div className="label">{option.label}</div>
+                            </div>
+                        )
+                    }
+                })}
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -123,7 +123,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     <InfoCircleOutlined className="info-indicator" />
                 </Tooltip>
             </h4>
-            <ShownAsFilter filters={filters} onChange={(filters: Partial<FilterType>): void => setFilters(filters)} />
+            <ShownAsFilter filters={filters} onChange={(_filters: Partial<FilterType>): void => setFilters(_filters)} />
         </>
     )
 }

--- a/frontend/src/scenes/onboarding/Personalization.scss
+++ b/frontend/src/scenes/onboarding/Personalization.scss
@@ -7,4 +7,17 @@
         text-align: center;
         margin-top: 32px;
     }
+
+    .toggle-question {
+        transition: all 1s ease-out;
+        opacity: 0;
+        visibility: hidden;
+        max-height: 0;
+
+        &.show {
+            max-height: 200px;
+            opacity: 1;
+            visibility: visible;
+        }
+    }
 }

--- a/frontend/src/scenes/onboarding/Personalization.tsx
+++ b/frontend/src/scenes/onboarding/Personalization.tsx
@@ -4,11 +4,10 @@ import { hot } from 'react-hot-loader/root'
 import { personalizationLogic } from './personalizationLogic'
 import { Row, Col, Button } from 'antd'
 import { RadioSelect } from 'lib/components/RadioSelect'
-import { ROLES, TEAM_SIZES } from './personalizationOptions'
+import { ROLES, PRODUCTS } from './personalizationOptions'
 import { Link } from 'lib/components/Link'
 import './Personalization.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { router } from 'kea-router'
 
 export const Personalization = hot(_Personalization)
 
@@ -20,43 +19,30 @@ function _Personalization(): JSX.Element {
     return (
         <Row className="personalization-screen">
             <Col xs={24}>{step === null && <StepOne />}</Col>
-            <Col xs={24}>{step === 2 && <StepTwo />}</Col>
         </Row>
     )
 }
 
 function StepOne(): JSX.Element {
-    const { push } = useActions(router)
-    return (
-        <div>
-            <h2 className="subtitle">Nothing to see here yet! Tap Continue</h2>
-            <Button type="primary" onClick={() => push('/personalization?step=2')}>
-                Continue
-            </Button>
-        </div>
-    )
-}
-
-function StepTwo(): JSX.Element {
     const { personalizationData, step } = useValues(personalizationLogic)
     const { appendPersonalizationData } = useActions(personalizationLogic)
     const { reportPersonalizationSkipped, reportPersonalization } = useActions(eventUsageLogic)
 
-    const handleOptionChanged = (attr: 'role' | 'team_size', value: string | null): void => {
+    const handleOptionChanged = (attr: 'role' | 'product' | 'technical', value: string | string[] | null): void => {
         appendPersonalizationData({ [attr]: value })
     }
 
     const handleContinue = (): void => {
         reportPersonalization(personalizationData, step, answeredQuestionCount === TOTAL_QUESTION_COUNT)
         // TODO: Update organization record
-        // :TODO: Is there a way to force default insights graph this without hard reload?
+        // TODO: Is there a way to force default insights graph this without hard reload?
         location.href = '/'
     }
 
     const answeredQuestionCount: number = personalizationData
         ? (!!personalizationData.role ? 1 : 0) + (!!personalizationData.team_size ? 1 : 0)
         : 0
-    const TOTAL_QUESTION_COUNT = 2
+    const TOTAL_QUESTION_COUNT = 3
 
     return (
         <div>
@@ -79,14 +65,17 @@ function StepTwo(): JSX.Element {
 
             <div style={{ marginTop: 32 }}>
                 <div>
-                    2. Company's <b>team size</b> is
+                    2. What <b>products</b> does your company/team have? <b>Select all that apply</b>
                 </div>
                 <RadioSelect
-                    options={TEAM_SIZES}
-                    selectedOption={personalizationData.team_size}
-                    onOptionChanged={(value) => handleOptionChanged('team_size', value)}
+                    options={PRODUCTS}
+                    selectedOption={personalizationData.product}
+                    onOptionChanged={(value) => handleOptionChanged('product', value)}
+                    multipleSelection
                 />
             </div>
+
+            {JSON.stringify(personalizationData)}
 
             <div className="section-continue">
                 {answeredQuestionCount === 0 ? (

--- a/frontend/src/scenes/onboarding/Personalization.tsx
+++ b/frontend/src/scenes/onboarding/Personalization.tsx
@@ -57,44 +57,38 @@ function StepOne(): JSX.Element {
             </div>
 
             <div style={{ marginTop: 32 }}>
-                <Row>
-                    <Col span={askTechnicalQuestion ? 12 : 24}>
-                        <div>
-                            1. <b>Your role</b> at company is (or closest to)
-                        </div>
-                        <RadioSelect
-                            options={ROLES}
-                            selectedOption={personalizationData.role}
-                            onOptionChanged={(value) => {
-                                if (value === 'engineer') {
-                                    // If user is an engineer, we assume technical by default
-                                    handleOptionChanged('technical', 'technical')
-                                } else {
-                                    handleOptionChanged('technical', null)
-                                }
-                                handleOptionChanged('role', value)
-                            }}
-                            focusSelection={askTechnicalQuestion}
-                        />
-                    </Col>
-                    {askTechnicalQuestion && (
-                        <Col span={12}>
-                            <div style={{ marginBottom: 16 + 22 }}>
-                                Are you <b>technical</b>? (i.e. coding/developer expertise)
-                            </div>
-                            <RadioSelect
-                                options={IS_TECHNICAL}
-                                selectedOption={personalizationData.technical}
-                                onOptionChanged={(value) => handleOptionChanged('technical', value)}
-                            />
-                        </Col>
-                    )}
-                </Row>
+                <div>
+                    1. <b>Your role</b> at company is (or closest to)
+                </div>
+                <RadioSelect
+                    options={ROLES}
+                    selectedOption={personalizationData.role}
+                    onOptionChanged={(value) => {
+                        if (value === 'engineer') {
+                            // If user is an engineer, we assume technical by default
+                            handleOptionChanged('technical', 'technical')
+                        } else {
+                            handleOptionChanged('technical', null)
+                        }
+                        handleOptionChanged('role', value)
+                    }}
+                />
+            </div>
+            <div style={{ marginTop: 32 }} className={`toggle-question${askTechnicalQuestion ? ' show' : ''}`}>
+                <div>
+                    2. Are you <b>technical</b>? (i.e. coding/developer expertise)
+                </div>
+                <RadioSelect
+                    options={IS_TECHNICAL}
+                    selectedOption={personalizationData.technical}
+                    onOptionChanged={(value) => handleOptionChanged('technical', value)}
+                />
             </div>
 
             <div style={{ marginTop: 32 }}>
                 <div>
-                    2. What <b>products</b> does your company/team have? Select <b>all</b> that apply
+                    {askTechnicalQuestion ? '3' : '2'}. What <b>products</b> does your company/team have? Select{' '}
+                    <b>all</b> that apply
                 </div>
                 <RadioSelect
                     options={PRODUCTS}

--- a/frontend/src/scenes/onboarding/Personalization.tsx
+++ b/frontend/src/scenes/onboarding/Personalization.tsx
@@ -28,7 +28,7 @@ function StepOne(): JSX.Element {
     const { appendPersonalizationData } = useActions(personalizationLogic)
     const { reportPersonalizationSkipped, reportPersonalization } = useActions(eventUsageLogic)
 
-    const handleOptionChanged = (attr: 'role' | 'product' | 'technical', value: string | string[] | null): void => {
+    const handleOptionChanged = (attr: 'role' | 'products' | 'technical', value: string | string[] | null): void => {
         appendPersonalizationData({ [attr]: value })
     }
 
@@ -40,7 +40,7 @@ function StepOne(): JSX.Element {
     }
 
     const answeredQuestionCount: number = personalizationData
-        ? (!!personalizationData.role ? 1 : 0) + (!!personalizationData.team_size ? 1 : 0)
+        ? (!!personalizationData.role ? 1 : 0) + (!!personalizationData.products ? 1 : 0)
         : 0
     const TOTAL_QUESTION_COUNT = 3
 
@@ -60,6 +60,7 @@ function StepOne(): JSX.Element {
                     options={ROLES}
                     selectedOption={personalizationData.role}
                     onOptionChanged={(value) => handleOptionChanged('role', value)}
+                    focusSelection
                 />
             </div>
 
@@ -69,8 +70,8 @@ function StepOne(): JSX.Element {
                 </div>
                 <RadioSelect
                     options={PRODUCTS}
-                    selectedOption={personalizationData.product}
-                    onOptionChanged={(value) => handleOptionChanged('product', value)}
+                    selectedOption={personalizationData.products}
+                    onOptionChanged={(value) => handleOptionChanged('products', value)}
                     multipleSelection
                 />
             </div>

--- a/frontend/src/scenes/onboarding/Personalization.tsx
+++ b/frontend/src/scenes/onboarding/Personalization.tsx
@@ -4,7 +4,7 @@ import { hot } from 'react-hot-loader/root'
 import { personalizationLogic } from './personalizationLogic'
 import { Row, Col, Button } from 'antd'
 import { RadioSelect } from 'lib/components/RadioSelect'
-import { ROLES, PRODUCTS } from './personalizationOptions'
+import { ROLES, PRODUCTS, IS_TECHNICAL } from './personalizationOptions'
 import { Link } from 'lib/components/Link'
 import './Personalization.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -40,12 +40,16 @@ function StepOne(): JSX.Element {
     }
 
     const answeredQuestionCount: number = personalizationData
-        ? (!!personalizationData.role ? 1 : 0) + (!!personalizationData.products ? 1 : 0)
+        ? (!!personalizationData.role ? 1 : 0) +
+          (!!personalizationData.products ? 1 : 0) +
+          (!!personalizationData.technical ? 1 : 0)
         : 0
     const TOTAL_QUESTION_COUNT = 3
 
+    const askTechnicalQuestion = !!personalizationData.role && personalizationData.role !== 'engineer' // Ask the user if they are technical?
+
     return (
-        <div>
+        <div style={{ marginBottom: 64 }}>
             <h2 className="subtitle">Great! Just a couple of questions and you're good to go</h2>
             <div>
                 You are welcome to skip any question, but filling them out will help us show you features and
@@ -53,20 +57,44 @@ function StepOne(): JSX.Element {
             </div>
 
             <div style={{ marginTop: 32 }}>
-                <div>
-                    1. <b>Your role</b> at company is (or closest to)
-                </div>
-                <RadioSelect
-                    options={ROLES}
-                    selectedOption={personalizationData.role}
-                    onOptionChanged={(value) => handleOptionChanged('role', value)}
-                    focusSelection
-                />
+                <Row>
+                    <Col span={askTechnicalQuestion ? 12 : 24}>
+                        <div>
+                            1. <b>Your role</b> at company is (or closest to)
+                        </div>
+                        <RadioSelect
+                            options={ROLES}
+                            selectedOption={personalizationData.role}
+                            onOptionChanged={(value) => {
+                                if (value === 'engineer') {
+                                    // If user is an engineer, we assume technical by default
+                                    handleOptionChanged('technical', 'technical')
+                                } else {
+                                    handleOptionChanged('technical', null)
+                                }
+                                handleOptionChanged('role', value)
+                            }}
+                            focusSelection={askTechnicalQuestion}
+                        />
+                    </Col>
+                    {askTechnicalQuestion && (
+                        <Col span={12}>
+                            <div style={{ marginBottom: 16 + 22 }}>
+                                Are you <b>technical</b>? (i.e. coding/developer expertise)
+                            </div>
+                            <RadioSelect
+                                options={IS_TECHNICAL}
+                                selectedOption={personalizationData.technical}
+                                onOptionChanged={(value) => handleOptionChanged('technical', value)}
+                            />
+                        </Col>
+                    )}
+                </Row>
             </div>
 
             <div style={{ marginTop: 32 }}>
                 <div>
-                    2. What <b>products</b> does your company/team have? <b>Select all that apply</b>
+                    2. What <b>products</b> does your company/team have? Select <b>all</b> that apply
                 </div>
                 <RadioSelect
                     options={PRODUCTS}
@@ -75,8 +103,6 @@ function StepOne(): JSX.Element {
                     multipleSelection
                 />
             </div>
-
-            {JSON.stringify(personalizationData)}
 
             <div className="section-continue">
                 {answeredQuestionCount === 0 ? (

--- a/frontend/src/scenes/onboarding/Personalization.tsx
+++ b/frontend/src/scenes/onboarding/Personalization.tsx
@@ -34,14 +34,14 @@ function StepOne(): JSX.Element {
 
     const handleContinue = (): void => {
         reportPersonalization(personalizationData, step, answeredQuestionCount === TOTAL_QUESTION_COUNT)
-        // TODO: Update organization record
-        // TODO: Is there a way to force default insights graph this without hard reload?
+        // :TODO: Update organization record
+        // :TODO: Is there a way to force default insights graph this without hard reload?
         location.href = '/'
     }
 
     const answeredQuestionCount: number = personalizationData
         ? (!!personalizationData.role ? 1 : 0) +
-          (!!personalizationData.products ? 1 : 0) +
+          (!!personalizationData.products && personalizationData.products.length ? 1 : 0) +
           (!!personalizationData.technical ? 1 : 0)
         : 0
     const TOTAL_QUESTION_COUNT = 3

--- a/frontend/src/scenes/onboarding/personalizationOptions.tsx
+++ b/frontend/src/scenes/onboarding/personalizationOptions.tsx
@@ -11,6 +11,13 @@ import {
     ToolOutlined,
     BlockOutlined,
     MessageOutlined,
+    CloudOutlined,
+    CoffeeOutlined,
+    CloudServerOutlined,
+    DatabaseOutlined,
+    MobileOutlined,
+    DesktopOutlined,
+    GlobalOutlined,
 } from '@ant-design/icons'
 
 export const ROLES: RadioSelectType[] = [
@@ -56,6 +63,49 @@ export const ROLES: RadioSelectType[] = [
         icon: <BlockOutlined />,
     },
 ]
+
+export const IS_TECHNICAL: RadioSelectType[] = [
+    {
+        key: 'technical',
+        label: 'Yes',
+        icon: <CloudOutlined />,
+    },
+    {
+        key: 'non_technical',
+        label: 'No',
+        icon: <CoffeeOutlined />,
+    },
+]
+
+export const PRODUCTS: RadioSelectType[] = [
+    {
+        key: 'web',
+        label: 'Web App',
+        icon: <GlobalOutlined />,
+    },
+    {
+        key: 'mobile',
+        label: 'Mobile App',
+        icon: <MobileOutlined />,
+    },
+    {
+        key: 'website',
+        label: 'Website',
+        icon: <DesktopOutlined />,
+    },
+    {
+        key: 'backend',
+        label: 'Backend Server',
+        icon: <CloudServerOutlined />,
+    },
+    {
+        key: 'data_pipeline',
+        label: 'Data Pipeline',
+        icon: <DatabaseOutlined />,
+    },
+]
+
+/* Currently out of circulation */
 
 export const TEAM_SIZES: RadioSelectType[] = [
     {

--- a/frontend/src/scenes/onboarding/personalizationOptions.tsx
+++ b/frontend/src/scenes/onboarding/personalizationOptions.tsx
@@ -11,7 +11,6 @@ import {
     ToolOutlined,
     BlockOutlined,
     MessageOutlined,
-    CloudOutlined,
     CoffeeOutlined,
     CloudServerOutlined,
     DatabaseOutlined,
@@ -68,7 +67,7 @@ export const IS_TECHNICAL: RadioSelectType[] = [
     {
         key: 'technical',
         label: 'Yes',
-        icon: <CloudOutlined />,
+        icon: <CodeOutlined />,
     },
     {
         key: 'non_technical',

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -197,11 +197,11 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
                 if (data.source.layer === 0) {
                     return
                 }
-                let height =
+                let _height =
                     data.source.y1 -
                     data.source.y0 -
                     data.source.sourceLinks.reduce((prev, curr) => prev + curr.width, 0)
-                return rounded_rect(0, 0, 30, height, Math.min(25, height), false, true, false, false)
+                return rounded_rect(0, 0, 30, _height, Math.min(25, _height), false, true, false, false)
             })
             .attr('fill', 'url(#dropoff-gradient)')
             .attr('stroke-width', 0)


### PR DESCRIPTION
## Changes

- Adjusts the personalization screen based on latest developments from https://github.com/postHog/retention/issues/9.
- Conditionally asks the user if they have technical expertise based on their role response.
- Allows multiple selection and focusing selection on the `RadioSelect` component.

![image](https://user-images.githubusercontent.com/5864173/106128150-72c17300-615f-11eb-9ebe-068fb53bd48c.gif)


