### PR TITLE
Revamp and optimize hooks on EE

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -7,6 +7,7 @@ import pytz
 from dateutil.parser import isoparse
 from django.utils import timezone
 from rest_framework import serializers
+from sentry_sdk.api import capture_exception
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.element import chain_to_elements, elements_to_string
@@ -14,6 +15,7 @@ from ee.clickhouse.sql.events import GET_EVENTS_BY_TEAM_SQL, GET_EVENTS_SQL, INS
 from ee.idl.gen import events_pb2
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_EVENTS
+from posthog.models.action import Action
 from posthog.models.action_step import ActionStep
 from posthog.models.element import Element
 from posthog.models.person import Person
@@ -59,28 +61,24 @@ def create_event(
 
     p.produce_proto(sql=INSERT_EVENT_SQL, topic=KAFKA_EVENTS, data=pb_event)
 
-    if team.slack_incoming_webhook or team.organization.is_feature_available("zapier"):
-        # Do a little bit of pre-filtering
-        if event in ActionStep.objects.filter(action__team_id=team.pk, action__post_to_slack=True).values_list(
-            "event", flat=True
-        ):
-            try:
-                celery.current_app.send_task(
-                    "ee.tasks.webhooks_ee.post_event_to_webhook_ee",
-                    (
-                        {
-                            "event": event,
-                            "properties": properties,
-                            "distinct_id": distinct_id,
-                            "timestamp": timestamp,
-                            "elements_list": elements,
-                        },
-                        team.pk,
-                        site_url,
-                    ),
-                )
-            except:
-                pass
+    if Action.objects.exists():
+        try:
+            celery.current_app.send_task(
+                "ee.tasks.webhooks_ee.post_event_to_webhook_ee",
+                (
+                    {
+                        "event": event,
+                        "properties": properties,
+                        "distinct_id": distinct_id,
+                        "timestamp": timestamp,
+                        "elements_list": elements,
+                    },
+                    team.pk,
+                    site_url,
+                ),
+            )
+        except:
+            capture_exception()
 
     return str(event_uuid)
 

--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -61,7 +61,7 @@ def create_event(
 
     p.produce_proto(sql=INSERT_EVENT_SQL, topic=KAFKA_EVENTS, data=pb_event)
 
-    if Action.objects.exists():
+    if Action.objects.filter(team=team).exists():
         try:
             celery.current_app.send_task(
                 "ee.tasks.webhooks_ee.post_event_to_webhook_ee",

--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -12,8 +12,8 @@ from posthog.tasks.webhooks import determine_webhook_type, get_formatted_message
 
 @app.task(ignore_result=True, bind=True, max_retries=3)
 def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, site_url: str) -> None:
-    team = Team.objects.get(pk=team_id)
-    _event = Event.objects.create(
+    team = Team.objects.select_related("organization").get(pk=team_id)
+    postgres_event = Event.objects.create(
         event=event["event"],
         distinct_id=event["distinct_id"],
         properties=event["properties"],
@@ -22,31 +22,43 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
         **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
         **({"elements": event["elements_list"]} if event["elements_list"] else {})
     )
+    is_zapier_available = team.organization.is_feature_available("zapier")
+    actionFilters = {"team_id": team_id}
 
-    actions = cast(Sequence[Action], Action.objects.filter(team_id=team_id, post_to_slack=True).all())
+    if not is_zapier_available:
+        if not team.slack_incoming_webhook:
+            return  # Exit this task if neither Zapier nor webhook URL are available
+        else:
+            actionFilters["post_to_slack"] = True  # We only need to fire for events that are posted to webhook URL
+
+    actions = cast(Sequence[Action], Action.objects.filter(**actionFilters).all())
 
     if not site_url:
         site_url = settings.SITE_URL
 
-    for action in actions:
-        qs = Event.objects.filter(pk=_event.pk).query_db_by_action(action)
-        if not qs:
-            continue
-        # REST hooks
-        action.on_perform(_event)
-        # webhooks
-        if not team.slack_incoming_webhook:
-            continue
-        message_text, message_markdown = get_formatted_message(action, _event, site_url,)
-        if determine_webhook_type(team) == "slack":
-            message = {
-                "text": message_text,
-                "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message_markdown},},],
-            }
-        else:
-            message = {
-                "text": message_markdown,
-            }
-        requests.post(team.slack_incoming_webhook, verify=False, json=message)
-
-    _event.delete()
+    try:
+        for action in actions:
+            qs = Event.objects.filter(pk=postgres_event.pk).query_db_by_action(action)
+            if not qs:
+                continue
+            # REST hooks
+            if is_zapier_available:
+                action.on_perform(postgres_event)
+            # webhooks
+            if team.slack_incoming_webhook:
+                message_text, message_markdown = get_formatted_message(action, postgres_event, site_url,)
+                if determine_webhook_type(team) == "slack":
+                    message = {
+                        "text": message_text,
+                        "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message_markdown},},],
+                    }
+                else:
+                    message = {
+                        "text": message_markdown,
+                    }
+                requests.post(team.slack_incoming_webhook, verify=False, json=message)
+    except:
+        raise
+    finally:
+        # Ensure that the temporary Postgres event is deleted
+        postgres_event.delete()

--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -12,6 +12,8 @@ from posthog.tasks.webhooks import determine_webhook_type, get_formatted_message
 
 @app.task(ignore_result=True, bind=True, max_retries=3)
 def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, site_url: str) -> None:
+    if not site_url:
+        site_url = settings.SITE_URL
     postgres_event = None
     try:
         team = Team.objects.select_related("organization").get(pk=team_id)
@@ -25,18 +27,14 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
             **({"elements": event["elements_list"]} if event["elements_list"] else {})
         )
         is_zapier_available = team.organization.is_feature_available("zapier")
-        actionFilters = {"team_id": team_id}
 
+        actionFilters = {"team_id": team_id}
         if not is_zapier_available:
             if not team.slack_incoming_webhook:
                 return  # Exit this task if neither Zapier nor webhook URL are available
             else:
-                actionFilters["post_to_slack"] = True  # We only need to fire for events that are posted to webhook URL
-
+                actionFilters["post_to_slack"] = True  # We only need to fire for actions that are posted to webhook URL
         actions = cast(Sequence[Action], Action.objects.filter(**actionFilters).all())
-
-        if not site_url:
-            site_url = settings.SITE_URL
 
         for action in actions:
             qs = Event.objects.filter(pk=postgres_event.pk).query_db_by_action(action)

--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -1,9 +1,9 @@
-import re
 from typing import Any, Dict, Sequence, cast
 
 import requests
 from celery import Task
 from django.conf import settings
+from sentry_sdk import capture_exception
 
 from posthog.celery import app
 from posthog.models import Action, Event, Team
@@ -17,15 +17,6 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
     postgres_event = None
     try:
         team = Team.objects.select_related("organization").get(pk=team_id)
-        postgres_event = Event.objects.create(
-            event=event["event"],
-            distinct_id=event["distinct_id"],
-            properties=event["properties"],
-            team=team,
-            site_url=site_url,
-            **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
-            **({"elements": event["elements_list"]} if event["elements_list"] else {})
-        )
         is_zapier_available = team.organization.is_feature_available("zapier")
 
         actionFilters = {"team_id": team_id}
@@ -35,6 +26,16 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
             else:
                 actionFilters["post_to_slack"] = True  # We only need to fire for actions that are posted to webhook URL
         actions = cast(Sequence[Action], Action.objects.filter(**actionFilters).all())
+
+        postgres_event = Event.objects.create(
+            event=event["event"],
+            distinct_id=event["distinct_id"],
+            properties=event["properties"],
+            team=team,
+            site_url=site_url,
+            **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
+            **({"elements": event["elements_list"]} if event["elements_list"] else {})
+        )
 
         for action in actions:
             qs = Event.objects.filter(pk=postgres_event.pk).query_db_by_action(action)
@@ -57,6 +58,7 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
                     }
                 requests.post(team.slack_incoming_webhook, verify=False, json=message)
     except:
+        capture_exception()
         self.retry(countdown=(2 ** self.request.retries) / 2)
     finally:
         # Ensure that the temporary Postgres event is deleted

--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -12,31 +12,32 @@ from posthog.tasks.webhooks import determine_webhook_type, get_formatted_message
 
 @app.task(ignore_result=True, bind=True, max_retries=3)
 def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, site_url: str) -> None:
-    team = Team.objects.select_related("organization").get(pk=team_id)
-    postgres_event = Event.objects.create(
-        event=event["event"],
-        distinct_id=event["distinct_id"],
-        properties=event["properties"],
-        team=team,
-        site_url=site_url,
-        **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
-        **({"elements": event["elements_list"]} if event["elements_list"] else {})
-    )
-    is_zapier_available = team.organization.is_feature_available("zapier")
-    actionFilters = {"team_id": team_id}
-
-    if not is_zapier_available:
-        if not team.slack_incoming_webhook:
-            return  # Exit this task if neither Zapier nor webhook URL are available
-        else:
-            actionFilters["post_to_slack"] = True  # We only need to fire for events that are posted to webhook URL
-
-    actions = cast(Sequence[Action], Action.objects.filter(**actionFilters).all())
-
-    if not site_url:
-        site_url = settings.SITE_URL
-
+    postgres_event = None
     try:
+        team = Team.objects.select_related("organization").get(pk=team_id)
+        postgres_event = Event.objects.create(
+            event=event["event"],
+            distinct_id=event["distinct_id"],
+            properties=event["properties"],
+            team=team,
+            site_url=site_url,
+            **({"timestamp": event["timestamp"]} if event["timestamp"] else {}),
+            **({"elements": event["elements_list"]} if event["elements_list"] else {})
+        )
+        is_zapier_available = team.organization.is_feature_available("zapier")
+        actionFilters = {"team_id": team_id}
+
+        if not is_zapier_available:
+            if not team.slack_incoming_webhook:
+                return  # Exit this task if neither Zapier nor webhook URL are available
+            else:
+                actionFilters["post_to_slack"] = True  # We only need to fire for events that are posted to webhook URL
+
+        actions = cast(Sequence[Action], Action.objects.filter(**actionFilters).all())
+
+        if not site_url:
+            site_url = settings.SITE_URL
+
         for action in actions:
             qs = Event.objects.filter(pk=postgres_event.pk).query_db_by_action(action)
             if not qs:
@@ -58,7 +59,8 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
                     }
                 requests.post(team.slack_incoming_webhook, verify=False, json=message)
     except:
-        raise
+        self.retry(countdown=(2 ** self.request.retries) / 2)
     finally:
         # Ensure that the temporary Postgres event is deleted
-        postgres_event.delete()
+        if postgres_event is not None:
+            postgres_event.delete()

--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -103,7 +103,7 @@ def determine_webhook_type(team: Team) -> str:
 @app.task(ignore_result=True, bind=True, max_retries=3)
 def post_event_to_webhook(self: Task, event_id: int, site_url: str) -> None:
     try:
-        event = Event.objects.get(pk=event_id)
+        event = Event.objects.select_related("team").get(pk=event_id)
         team = event.team
         actions = [action for action in event.action_set.all() if action.post_to_slack]
 


### PR DESCRIPTION
## Changes

This is some changes to (REST|web)hooks to eliminate their wonkiness, optimize them a bit, and better prepare for working with plugin server ingestion.

May improve situation regarding #3110, as this should reduce the number of queries to `ee_license`.