### PR TITLE
Update demo data warning styles

### DIFF
--- a/frontend/src/antd.less
+++ b/frontend/src/antd.less
@@ -1,5 +1,5 @@
 /* This file sets theming configuration on Ant Design for PostHog. Ant uses LESS which is incompatible
-with SASS, which is why configuration is duplicated. To change any variable here, please update vars.scss too  */
+with SASS, leading to duplicated config. When changing any variable here, please remember to update vars.scss too  */
 @import 'antd/lib/style/themes/default.less';
 @import 'antd/dist/antd.less';
 

--- a/frontend/src/layout/navigation/DemoWarning.tsx
+++ b/frontend/src/layout/navigation/DemoWarning.tsx
@@ -17,11 +17,12 @@ export function DemoWarning(): JSX.Element | null {
         <>
             <Alert
                 type="warning"
-                message={`Get started using Posthog, ${user?.name}`}
+                message={`Get started using Posthog, ${user?.name}!`}
+                className="demo-warning"
                 description={
                     <span>
                         You're currently viewing <b>demo data</b>. Go to <Link to="/setup">setup</Link> to start sending
-                        your own data!
+                        your own data
                     </span>
                 }
                 icon={<StarOutlined />}

--- a/frontend/src/layout/navigation/DemoWarning.tsx
+++ b/frontend/src/layout/navigation/DemoWarning.tsx
@@ -5,9 +5,11 @@ import { StarOutlined, SettingOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { LinkButton } from 'lib/components/LinkButton'
 import { Link } from 'lib/components/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export function DemoWarning(): JSX.Element | null {
     const { user, demoOnlyProject } = useValues(userLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     if (!demoOnlyProject) {
         return null
@@ -33,6 +35,7 @@ export function DemoWarning(): JSX.Element | null {
                     </LinkButton>
                 }
                 closable
+                style={featureFlags['navigation-1775'] ? { marginTop: 32 } : undefined}
             />
         </>
     )

--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -373,3 +373,18 @@
         width: 100%;
     }
 }
+
+.demo-warning {
+    display: flex;
+    align-items: center;
+
+    .ant-alert-message {
+        font-weight: bold;
+    }
+
+    .ant-alert-close-icon .anticon-close svg {
+        height: 14px;
+        width: 14px;
+        margin-left: $default_spacing;
+    }
+}

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -46,6 +46,7 @@ $blue_100: #b8cefd;
 $yellow_500: #f8a523;
 $yellow_300: #ffc035;
 $yellow_100: #fbdd99;
+$yellow_50: #fdedc9;
 
 // Purple Swatch
 $purple_700: #7c4286;


### PR DESCRIPTION
Left-over from https://github.com/PostHog/posthog/pull/3103

![2021-01-28_15-36](https://user-images.githubusercontent.com/148820/106145816-a6f85c00-617e-11eb-84bb-228fe5714c64.png)

The star is aligned differently - not quite sure what it was supposed to be aligned with, looks ok to my eyes :)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
