### PR TITLE
Limit to one organization in private instances

### DIFF
--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -23,13 +23,14 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
         )
 
     def test_delete_second_managed_organization(self):
-        organization, _, team = Organization.objects.bootstrap(self.user, name="X")
-        self.assertTrue(Organization.objects.filter(id=organization.id).exists())
-        self.assertTrue(Team.objects.filter(id=team.id).exists())
-        response = self.client.delete(f"/api/organizations/{organization.id}")
-        self.assertEqual(response.status_code, 204)
-        self.assertFalse(Organization.objects.filter(id=organization.id).exists())
-        self.assertFalse(Team.objects.filter(id=team.id).exists())
+        with self.settings(MULTI_TENANCY=True):
+            organization, _, team = Organization.objects.bootstrap(self.user, name="X")
+            self.assertTrue(Organization.objects.filter(id=organization.id).exists())
+            self.assertTrue(Team.objects.filter(id=team.id).exists())
+            response = self.client.delete(f"/api/organizations/{organization.id}")
+            self.assertEqual(response.status_code, 204)
+            self.assertFalse(Organization.objects.filter(id=organization.id).exists())
+            self.assertFalse(Team.objects.filter(id=team.id).exists())
 
     def test_no_delete_last_organization(self):
         org_id = self.organization.id

--- a/frontend/src/layout/TopContent/TopSelectors.tsx
+++ b/frontend/src/layout/TopContent/TopSelectors.tsx
@@ -55,7 +55,6 @@ export function User(): JSX.Element {
 
 export function Organization(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { showUpgradeModal } = useActions(sceneLogic)
     const [isModalVisible, setIsModalVisible] = useState(false)
 
     return (
@@ -84,29 +83,19 @@ export function Organization(): JSX.Element {
                                     </Menu.Item>
                                 )
                         )}
-                        <Menu.Item>
-                            <a
-                                href="#"
-                                onClick={() => {
-                                    guardPremiumFeature(
-                                        user,
-                                        showUpgradeModal,
-                                        'organizations_projects',
-                                        'multiple organizations',
-                                        () => {
-                                            setIsModalVisible(true)
-                                        },
-                                        {
-                                            cloud: false,
-                                            selfHosted: true,
-                                        }
-                                    )
-                                }}
-                            >
-                                <PlusOutlined size={1} style={{ marginRight: '0.5rem' }} />
-                                <i>New Organization</i>
-                            </a>
-                        </Menu.Item>
+                        {user.is_multi_tenancy && (
+                            <Menu.Item>
+                                <a
+                                    href="#"
+                                    onClick={() => {
+                                        setIsModalVisible(true)
+                                    }}
+                                >
+                                    <PlusOutlined size={1} style={{ marginRight: '0.5rem' }} />
+                                    <i>New Organization</i>
+                                </a>
+                            </Menu.Item>
+                        )}
                     </Menu>
                 }
             >

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -79,26 +79,16 @@ export function _TopNavigation(): JSX.Element {
                         </a>
                     )
                 })}
-                <a
-                    style={{ color: 'var(--muted)', display: 'flex', justifyContent: 'center' }}
-                    onClick={() =>
-                        guardPremiumFeature(
-                            user,
-                            showUpgradeModal,
-                            'organizations_projects',
-                            'multiple organizations',
-                            () => {
-                                setOrganizationModalShown(true)
-                            },
-                            {
-                                cloud: false,
-                                selfHosted: true,
-                            }
-                        )
-                    }
-                >
-                    <PlusOutlined style={{ marginRight: 8, fontSize: 18 }} /> New organization
-                </a>
+                {user.is_multi_tenancy && (
+                    <a
+                        style={{ color: 'var(--muted)', display: 'flex', justifyContent: 'center' }}
+                        onClick={() => {
+                            setOrganizationModalShown(true)
+                        }}
+                    >
+                        <PlusOutlined style={{ marginRight: 8, fontSize: 18 }} /> New organization
+                    </a>
+                )}
             </div>
             <div className="divider mb-05" />
             <div className="text-center">

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -77,6 +77,8 @@ class TestFeatureFlag(TransactionBaseTest):
 
 
 class TestAPIFeatureFlag(APIBaseTest):
+    CONFIG_BOOTSTRAP = False
+
     def setUp(self):
         super().setUp()
         self.organization, self.team, self.user = User.objects.bootstrap("Feature Flags", "ff@posthog.com", None)

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -15,6 +15,11 @@ except ImportError:
     License = None  # type: ignore
 
 
+class OnlyOnePrivateOrgAllowed(Exception):
+    def __init__(self):
+        super().__init__("Private instances can only have one organization! Join the existing one.")
+
+
 class OrganizationManager(models.Manager):
     def bootstrap(
         self, user: Any, *, team_fields: Optional[Dict[str, Any]] = None, **kwargs
@@ -37,7 +42,7 @@ class OrganizationManager(models.Manager):
 
     def create(self, *args, **kwargs) -> "Organization":
         if not settings.MULTI_TENANCY and Organization.objects.exists():
-            raise Exception("Private instances can only have one organization! Join the existing one.")
+            raise OnlyOnePrivateOrgAllowed()
         return super().create(*args, **kwargs)
 
 

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -35,6 +35,11 @@ class OrganizationManager(models.Manager):
                 user.save()
         return organization, organization_membership, team
 
+    def create(self, *args, **kwargs) -> "Organization":
+        if not settings.MULTI_TENANCY and Organization.objects.exists():
+            raise Exception("Private instances can only have one organization! Join the existing one.")
+        return super().create(*args, **kwargs)
+
 
 class Organization(UUIDModel):
     members: models.ManyToManyField = models.ManyToManyField(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -5,7 +5,16 @@ from typing import List
 from freezegun import freeze_time
 
 from posthog.constants import TRENDS_LIFECYCLE, TRENDS_TABLE
-from posthog.models import Action, ActionStep, Cohort, Event, Filter, Organization, Person
+from posthog.models import (
+    Action,
+    ActionStep,
+    Cohort,
+    Event,
+    Filter,
+    Person,
+    Team,
+    organization,
+)
 from posthog.queries.abstract_test.test_interval import AbstractIntervalTest
 from posthog.queries.abstract_test.test_timerange import AbstractTimerangeTest
 from posthog.queries.trends import Trends
@@ -21,7 +30,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             person = person_factory(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
             )
-            _, _, secondTeam = Organization.objects.bootstrap(None, team_fields={"api_token": "token456"})
+            secondTeam = Team.objects.create(organization=self.organization, api_token="token456")
 
             freeze_without_time = ["2019-12-24", "2020-01-01", "2020-01-02"]
             freeze_with_time = [

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -61,6 +61,7 @@ class APITestMixin(ErrorResponsesMixin):
     Test API using Django REST Framework test suite.
     """
 
+    CONFIG_BOOTSTRAP: bool = True
     CONFIG_ORGANIZATION_NAME: str = "Test"
     CONFIG_USER_EMAIL: Optional[str] = "user1@posthog.com"
     CONFIG_PASSWORD: Optional[str] = "testpassword12345"
@@ -77,6 +78,11 @@ class APITestMixin(ErrorResponsesMixin):
         )
 
     def setUp(self):
+        super().setUp()  # type: ignore
+        if self.CONFIG_BOOTSTRAP:
+            self.bootstrap()
+
+    def bootstrap(self):
         super().setUp()  # type: ignore
         self.organization: Organization = Organization.objects.create(name=self.CONFIG_ORGANIZATION_NAME)
         self.team: Team = Team.objects.create(organization=self.organization, api_token=self.CONFIG_API_TOKEN)


### PR DESCRIPTION
## Changes

Until we institute better restrictions to prevent unauthorized users from using up private instances' resources, we should disallow creating more than one organization on such deployments.
