### PR TITLE
Remove clickhouse pooler from sync execute path

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -107,8 +107,7 @@ else:
     def sync_execute(query, args=None, settings=None):
         start_time = time()
         try:
-            with ch_sync_pool.get_client() as client:
-                result = client.execute(query, args, settings=settings)
+            result = ch_client.execute(query, args, settings=settings)
         finally:
             execution_time = time() - start_time
             if app_settings.SHELL_PLUS_PRINT_SQL:


### PR DESCRIPTION
this may blow things up so I will be monitoring active connections on the cluster