### PR TITLE
Fix Person page loading by email under persons-2353

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -120,9 +120,8 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
                 actions.loadPersons()
             }
         },
-        '/person/*': () => {
-            const destructuredPathname = window.location.pathname.split('/')
-            actions.loadPerson(destructuredPathname[destructuredPathname.length - 1])
+        '/person/*': ({ _ }: { _: string }) => {
+            actions.loadPerson(_) // underscore contains the wildcard
         },
     }),
 })

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -122,7 +122,6 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
         },
         '/person/*': () => {
             const destructuredPathname = window.location.pathname.split('/')
-            console.log(destructuredPathname)
             actions.loadPerson(destructuredPathname[destructuredPathname.length - 1])
         },
     }),

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -120,8 +120,10 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
                 actions.loadPersons()
             }
         },
-        '/person/:id': ({ id }: { id: string }) => {
-            actions.loadPerson(id)
+        '/person/*': () => {
+            const destructuredPathname = window.location.pathname.split('/')
+            console.log(destructuredPathname)
+            actions.loadPerson(destructuredPathname[destructuredPathname.length - 1])
         },
     }),
 })


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

So the problem described in #3137 happens because the kea router uses `url-pattern` under the hood and that doesn't process the `@` and `.` by default. 

To get this to work, we'd need to configure it with the option `segmentValueCharset` equal to `'a-zA-Z0-9-_~ %.@'` whereas the default is `'a-zA-Z0-9-_~ %'`. See [this test for example](https://github.com/snd/url-pattern/blob/c8e0a943bb62e6feeca2d2595da4e22782e617ed/test/match-fixtures.coffee#L166).

Essentially the best solution here would be for the kea router to allow me to pass options down to the url pattern lib but otherwise this here works. 

There are other ways to go about this too so happy to take it if someone has a better solution.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
