### PR TITLE
Improve Saved Funnels UX

### DIFF
--- a/frontend/src/models/funnelsModel.ts
+++ b/frontend/src/models/funnelsModel.ts
@@ -4,7 +4,6 @@ import { toParams } from 'lib/utils'
 import { ViewType } from 'scenes/insights/insightLogic'
 import { DashboardItemType, SavedFunnel } from '~/types'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
-import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { funnelsModelType } from './funnelsModelType'
 
 const parseSavedFunnel = (result: Record<string, any>): SavedFunnel => {
@@ -20,7 +19,7 @@ const parseSavedFunnel = (result: Record<string, any>): SavedFunnel => {
 }
 
 export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>>({
-    loaders: ({ actions }) => ({
+    loaders: ({ values, actions }) => ({
         funnels: {
             __default: [] as SavedFunnel[],
             loadFunnels: async () => {
@@ -37,10 +36,14 @@ export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>
                 actions.setNext(response.next)
                 return result
             },
+            deleteFunnel: async (funnelId: number) => {
+                await api.delete(`api/insight/${funnelId}`)
+                return values.funnels.filter((funnel) => funnel.id !== funnelId)
+            },
         },
     }),
     connect: {
-        actions: [insightHistoryLogic, ['updateInsight'], funnelLogic, ['saveFunnelInsight']],
+        actions: [insightHistoryLogic, ['updateInsight']],
     },
     reducers: () => ({
         next: [
@@ -73,7 +76,6 @@ export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>
             actions.appendFunnels(result)
         },
         updateInsight: () => actions.loadFunnels(),
-        saveFunnelInsight: () => actions.loadFunnels(),
     }),
     events: ({ actions }) => ({
         afterMount: actions.loadFunnels,

--- a/frontend/src/models/funnelsModel.ts
+++ b/frontend/src/models/funnelsModel.ts
@@ -32,9 +32,9 @@ export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>
                             insight: ViewType.FUNNELS,
                         })
                 )
-                const result = response.results.map((result: Record<string, any>) => parseSavedFunnel(result))
+                const results = response.results.map((result: Record<string, any>) => parseSavedFunnel(result))
                 actions.setNext(response.next)
-                return result
+                return results
             },
             deleteFunnel: async (funnelId: number) => {
                 await api.delete(`api/insight/${funnelId}`)
@@ -71,9 +71,9 @@ export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>
     listeners: ({ values, actions }) => ({
         loadNext: async () => {
             const response = await api.get(values.next)
-            const result = response.results.map((result: Record<string, any>) => parseSavedFunnel(result))
+            const results = response.results.map((result: Record<string, any>) => parseSavedFunnel(result))
             actions.setNext(response.next)
-            actions.appendFunnels(result)
+            actions.appendFunnels(results)
         },
         updateInsight: () => actions.loadFunnels(),
     }),

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -3,6 +3,7 @@ import api from 'lib/api'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
 import { objectsEqual, toParams } from 'lib/utils'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
+import { funnelsModel } from '../../models/funnelsModel'
 
 function wait(ms = 1000) {
     return new Promise((resolve) => {
@@ -50,7 +51,14 @@ export const funnelLogic = kea({
     }),
 
     connect: {
-        actions: [insightLogic, ['setAllFilters'], insightHistoryLogic, ['createInsight']],
+        actions: [
+            insightLogic,
+            ['setAllFilters'],
+            insightHistoryLogic,
+            ['createInsight'],
+            funnelsModel,
+            ['loadFunnels'],
+        ],
     },
 
     loaders: () => ({
@@ -157,6 +165,7 @@ export const funnelLogic = kea({
                 name,
                 saved: true,
             })
+            actions.loadFunnels()
         },
         clearFunnel: async () => {
             actions.setAllFilters({})

--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -13,7 +13,7 @@ import { PersonModal } from './PersonModal'
 import { PageHeader } from 'lib/components/PageHeader'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
-import { Tabs, Row, Col, Tooltip, Card, Button } from 'antd'
+import { Tabs, Row, Col, Card, Button } from 'antd'
 import {
     ACTIONS_LINE_GRAPH_LINEAR,
     ACTIONS_LINE_GRAPH_CUMULATIVE,
@@ -43,7 +43,6 @@ import { trendsLogic } from './trendsLogic'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { InsightHistoryPanel } from './InsightHistoryPanel'
 import { SavedFunnels } from './SavedCard'
-import { InfoCircleOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { insightCommandLogic } from './insightCommandLogic'
 
@@ -197,19 +196,7 @@ function _Insights() {
                                 </Card>
                                 {activeView === ViewType.FUNNELS && (
                                     <Card
-                                        title={
-                                            <Row align="middle">
-                                                <span>Saved Funnels</span>
-                                                <Tooltip
-                                                    key="1"
-                                                    getPopupContainer={(trigger) => trigger.parentElement}
-                                                    placement="right"
-                                                    title="These consist of funnels by you and the rest of the team"
-                                                >
-                                                    <InfoCircleOutlined className="info-indicator" />
-                                                </Tooltip>
-                                            </Row>
-                                        }
+                                        title={<Row align="middle">Funnels Saved in Project</Row>}
                                         style={{ marginTop: 16 }}
                                     >
                                         <SavedFunnels />

--- a/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
+++ b/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
 import { funnelsModel } from '~/models/funnelsModel'
-import { List, Col, Row, Spin, Button } from 'antd'
+import { List, Col, Row, Button, Popconfirm } from 'antd'
+import { DeleteOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
+import { red } from '@ant-design/colors'
 import { Link } from 'lib/components/Link'
 import { toParams } from 'lib/utils'
 
-export const SavedFunnels: React.FC = () => {
+export function SavedFunnels(): JSX.Element {
     const { funnels, funnelsLoading, next, loadingMore } = useValues(funnelsModel)
-    const { loadNext } = useActions(funnelsModel)
+    const { deleteFunnel, loadNext } = useActions(funnelsModel)
 
     const loadMoreFunnels = next ? (
         <div
@@ -18,7 +20,9 @@ export const SavedFunnels: React.FC = () => {
                 lineHeight: '32px',
             }}
         >
-            {loadingMore ? <Spin /> : <Button onClick={loadNext}>Load more</Button>}
+            <Button onClick={loadNext} loading={loadingMore}>
+                Load more
+            </Button>
         </div>
     ) : null
 
@@ -27,13 +31,24 @@ export const SavedFunnels: React.FC = () => {
             loading={funnelsLoading}
             dataSource={funnels}
             loadMore={loadMoreFunnels}
-            pagination={{ pageSize: 5, hideOnSinglePage: true }}
             renderItem={(funnel) => {
                 return (
                     <List.Item>
                         <Col style={{ whiteSpace: 'pre-line', width: '100%' }}>
                             <Row justify="space-between" align="middle">
                                 <Link to={'/insights?' + toParams(funnel.filters)}>{funnel.name}</Link>
+                                <Popconfirm
+                                    title={`Delete saved funnel "${funnel.name}"?`}
+                                    okText="Delete Funnel"
+                                    okType="danger"
+                                    icon={<ExclamationCircleOutlined style={{ color: red.primary }} />}
+                                    placement="left"
+                                    onConfirm={() => {
+                                        deleteFunnel(funnel.id)
+                                    }}
+                                >
+                                    <DeleteOutlined className="text-danger" />
+                                </Popconfirm>
                             </Row>
                         </Col>
                     </List.Item>

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -4,14 +4,14 @@ import posthog from 'posthog-js'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightLogicType } from './insightLogicType'
 
-export const ViewType = {
-    TRENDS: 'TRENDS',
-    STICKINESS: 'STICKINESS',
-    LIFECYCLE: 'LIFECYCLE',
-    SESSIONS: 'SESSIONS',
-    FUNNELS: 'FUNNELS',
-    RETENTION: 'RETENTION',
-    PATHS: 'PATHS',
+export enum ViewType {
+    TRENDS = 'TRENDS',
+    STICKINESS = 'STICKINESS',
+    LIFECYCLE = 'LIFECYCLE',
+    SESSIONS = 'SESSIONS',
+    FUNNELS = 'FUNNELS',
+    RETENTION = 'RETENTION',
+    PATHS = 'PATHS',
 }
 
 /*

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,8 @@
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginInstallationType } from 'scenes/plugins/types'
+import { ViewType } from 'scenes/insights/insightLogic'
+
 export interface UserType {
     anonymize_data: boolean
     distinct_id: string
@@ -276,6 +278,7 @@ export interface InsightHistory {
     name?: string
     createdAt: string
     saved: boolean
+    type: typeof ViewType
 }
 
 export interface SavedFunnel extends InsightHistory {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -278,7 +278,7 @@ export interface InsightHistory {
     name?: string
     createdAt: string
     saved: boolean
-    type: typeof ViewType
+    type: ViewType
 }
 
 export interface SavedFunnel extends InsightHistory {


### PR DESCRIPTION
## Changes

Per a user report via chat, this improves Saved Funnels UX significantly, by:
- inverting async action dependency of `funnelsModel.values.funnels` on `funnelLogic.actions.saveFunnelInsight`, which resulted in funnels that were just saved not appearing in the list of saved funnels
- removing pagination on the list of saved funnels - unfortunately `List`'s `loadMore` collides with `pagination` in a way that hides the latter, making for a confusing user experience
- adding the missing way to delete saved funnels right from the saved funnels list (instead of using Insights History as a hard-to-discover workaround)
- replacing an improperly rendered (due to excessive text width) and not user-friendly tooltip with just a clearer heading

After changes:
<img width="368" alt="Enhanced Saved Funnels" src="https://user-images.githubusercontent.com/4550621/106537508-c1be2e00-64fa-11eb-998e-f9ed317656bd.png">