### PR TITLE
Autofocus on email instead of first name on signup

### DIFF
--- a/frontend/src/scenes/onboarding/index.js
+++ b/frontend/src/scenes/onboarding/index.js
@@ -87,6 +87,7 @@ function Signup() {
                                 type="email"
                                 value={formState.email.value}
                                 onChange={(e) => updateForm('email', e.target)}
+                                autoFocus
                                 required
                                 disabled={accountLoading}
                                 id="signupEmail"
@@ -115,7 +116,6 @@ function Signup() {
                             <label htmlFor="signupFirstName">First Name</label>
                             <Input
                                 placeholder="Jane"
-                                autoFocus
                                 value={formState.firstName.value}
                                 onChange={(e) => updateForm('firstName', e.target)}
                                 required


### PR DESCRIPTION
## Changes

It annoyed me that every time i signed up it would autofocus on first name, I'd then have to use my _mouse_ to fill in email and password.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
