### PR TITLE
Make pies listen to color changes and update

### DIFF
--- a/frontend/src/scenes/insights/ActionsPie.js
+++ b/frontend/src/scenes/insights/ActionsPie.js
@@ -36,7 +36,7 @@ export function ActionsPie({ dashboardItemId, view, filters: filtersParam, color
 
     useEffect(() => {
         updateData()
-    }, [results])
+    }, [results, color])
 
     return data && !resultsLoading ? (
         data[0] && data[0].labels ? (


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Our pie chart panels in dashboards weren't listening to updates in the color so their inner colors were only updating after a refresh.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
