### PR TITLE
Better breakdown error messages

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates.tsx
@@ -6,17 +6,21 @@ import imgEmptyLineGraphDark from 'public/empty-line-graph-dark.svg'
 import { QuestionCircleOutlined, LoadingOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { IllustrationDanger } from 'lib/components/icons'
+import { trendsLogic } from 'scenes/insights/trendsLogic.js'
+import { ViewType } from './insightLogic'
 
 export function LineGraphEmptyState({ color }: { color: string }): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { filters } = useValues(trendsLogic({ dashboard: null, view: ViewType.TRENDS }))
+    const { breakdown } = filters
+
+    const breakdownErrorMessage = `We were unable to process this query.
+    If you are breaking down data by high volume properties like emails or Distinct IDs, try limiting your dataset with additional filters.
+    Otherwise, try changing dates or pick another action or event. `
+
     return (
         <>
-            {!featureFlags['1694-dashboards'] && (
-                <p style={{ textAlign: 'center', paddingTop: '4rem' }}>
-                    We couldn't find any matching events. Try changing dates or pick another action or event.
-                </p>
-            )}
-            {featureFlags['1694-dashboards'] && (
+            {featureFlags['1694-dashboards'] ? (
                 <div className="text-center" style={{ height: '100%' }}>
                     <img
                         src={color === 'white' ? imgEmptyLineGraphDark : imgEmptyLineGraph}
@@ -24,7 +28,7 @@ export function LineGraphEmptyState({ color }: { color: string }): JSX.Element {
                         style={{ maxHeight: '100%', maxWidth: '80%', opacity: 0.5 }}
                     />
                     <div style={{ textAlign: 'center', fontWeight: 'bold', marginTop: 16 }}>
-                        Seems like there's no data to show this graph yet{' '}
+                        {breakdown ? breakdownErrorMessage : `Seems like there's no data to show this graph yet. `}
                         <a
                             target="_blank"
                             href="https://posthog.com/docs/features/trends"
@@ -34,6 +38,12 @@ export function LineGraphEmptyState({ color }: { color: string }): JSX.Element {
                         </a>
                     </div>
                 </div>
+            ) : (
+                <p style={{ textAlign: 'center', paddingTop: '4rem' }}>
+                    {breakdown
+                        ? breakdownErrorMessage
+                        : `We couldn't find any events that match your query. Try changing dates or pick another action or event.`}
+                </p>
             )}
         </>
     )


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Here's me breaking down pageviews by email on app:

<img width="1440" alt="Screenshot 2021-02-02 at 15 51 38" src="https://user-images.githubusercontent.com/38760734/106625506-9d039e00-656e-11eb-9693-d41fd3ef6a95.png">

It tells me there are no events, but I know for sure that there are.

Hence this PR with better error messages specific to breakdowns with too much data.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
