### PR TITLE
Do not open people modal on retention panel in dashboard

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -88,7 +88,7 @@ export function RetentionTable({
                 size="small"
                 className="retention-table"
                 pagination={{ pageSize: 99999, hideOnSinglePage: true }}
-                rowClassName={!dashboardItemId ? 'cursor-pointer' : ''}
+                rowClassName={dashboardItemId ? '' : 'cursor-pointer'}
                 dataSource={results}
                 columns={columns}
                 rowKey="date"

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -88,14 +88,14 @@ export function RetentionTable({
                 size="small"
                 className="retention-table"
                 pagination={{ pageSize: 99999, hideOnSinglePage: true }}
-                rowClassName={'cursor-pointer'}
+                rowClassName={!dashboardItemId ? 'cursor-pointer' : ''}
                 dataSource={results}
                 columns={columns}
                 rowKey="date"
                 loading={resultsLoading}
                 onRow={(_, rowIndex: number | undefined) => ({
                     onClick: () => {
-                        if (rowIndex !== undefined) {
+                        if (!dashboardItemId && rowIndex !== undefined) {
                             loadPeople(rowIndex)
                             setModalVisible(true)
                             selectRow(rowIndex)


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Closes #3132

When I opened the issue I was in the middle of a demo so couldn't do the immediate fix.

Here it is now.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
