### PR TITLE
Check if cache is safe, delete if not

### DIFF
--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -1,6 +1,6 @@
 import json
 
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -13,7 +13,7 @@ class DebugCHQueries(viewsets.ViewSet):
     """
 
     def list(self, request):
-        return Response(json.loads(cache.get("save_query_{}".format(request.user.pk)) or "[]"))
+        return Response(json.loads(get_safe_cache("save_query_{}".format(request.user.pk)) or "[]"))
 
     def get(self, request):
         return Response([{"hey": "hi"}])

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -10,7 +10,7 @@ from asgiref.sync import async_to_sync
 from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
 from django.conf import settings as app_settings
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from django.utils.timezone import now
 from sentry_sdk.api import capture_exception
 
@@ -159,7 +159,7 @@ def save_query(sql: str, params: Dict, execution_time: float) -> None:
 
     try:
         key = "save_query_{}".format(_save_query_user_id)
-        queries = json.loads(cache.get(key) or "[]")
+        queries = json.loads(get_safe_cache(key) or "[]")
 
         queries.insert(
             0, {"timestamp": now().isoformat(), "query": format_sql(sql, params), "execution_time": execution_time}

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -3,7 +3,7 @@ from distutils.util import strtobool
 from typing import Any, Dict, Optional, cast
 
 import posthoganalytics
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from django.db.models import Model, Prefetch, QuerySet
 from django.db.models.query_utils import Q
 from django.http import HttpRequest
@@ -200,7 +200,7 @@ class DashboardItemSerializer(serializers.ModelSerializer):
         if not dashboard_item.filters_hash:
             return None
 
-        result = cache.get(dashboard_item.filters_hash)
+        result = get_safe_cache(dashboard_item.filters_hash)
         if not result or result.get("task_id", None):
             return None
         return result["result"]

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -2,7 +2,7 @@ import json
 import warnings
 from typing import Any, Dict, List, Optional, Union
 
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from django.db.models import Count, Func, Prefetch, Q, QuerySet
 from django_filters import rest_framework as filters
 from rest_framework import request, response, serializers, viewsets
@@ -210,7 +210,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             return response.Response({})
 
         offset_value = int(offset)
-        cached_result = cache.get(reference_id)
+        cached_result = get_safe_cache(reference_id)
         if cached_result:
             return response.Response(
                 {

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -2,7 +2,7 @@ from enum import Enum
 from functools import wraps
 from typing import Callable, cast
 
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from django.http.request import HttpRequest
 from django.utils.timezone import now
 
@@ -40,7 +40,7 @@ def cached_function():
             payload = {"filter": filter.toJSON(), "team_id": team.pk}
             # return cached result if possible
             if not request.GET.get("refresh", False):
-                cached_result = cache.get(cache_key)
+                cached_result = get_safe_cache(cache_key)
                 if cached_result and cached_result.get("result"):
                     return cached_result["result"]
             # call function being wrapped

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from django.utils.timezone import now
 
 from posthog.models import Dashboard, DashboardItem, Event, Filter
@@ -63,8 +63,8 @@ class TestUpdateCache(BaseTest):
         self.assertIsNotNone(DashboardItem.objects.get(pk=item.pk).last_refresh)
         self.assertIsNotNone(DashboardItem.objects.get(pk=item_to_cache.pk).last_refresh)
         self.assertIsNotNone(DashboardItem.objects.get(pk=item_do_not_cache.pk).last_refresh)
-        self.assertEqual(cache.get(item_key)["result"][0]["count"], 0)
-        self.assertEqual(cache.get(funnel_key)["result"][0]["count"], 0)
+        self.assertEqual(get_safe_cache(item_key)["result"][0]["count"], 0)
+        self.assertEqual(get_safe_cache(funnel_key)["result"][0]["count"], 0)
 
     def _test_refresh_dashboard_cache_types(
         self, filter: FilterType, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock,
@@ -84,7 +84,7 @@ class TestUpdateCache(BaseTest):
             update_cache_item(*call_item[0])
 
         item_key = generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk))
-        self.assertIsNotNone(cache.get(item_key))
+        self.assertIsNotNone(get_safe_cache(item_key))
 
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from celery import group
 from dateutil.relativedelta import relativedelta
-from django.core.cache import cache
+from posthog.utils import get_safe_cache
 from django.db.models import Prefetch, Q
 from django.db.models.expressions import F, Subquery
 from django.utils import timezone

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -525,7 +525,7 @@ def get_daterange(
 
 def get_safe_cache(cache_key: str):
     try:
-        cached_result = get_safe_cache(cache_key) # get_safe_cache is safe in most cases
+        cached_result = cache.get(cache_key) # get_safe_cache is safe in most cases
         return cached_result
     except: # if it errors out, the cache is probably corrupted
         try:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -33,7 +33,7 @@ from django.template.loader import get_template
 from django.utils import timezone
 from rest_framework.exceptions import APIException
 from sentry_sdk import capture_exception, push_scope
-from posthog.utils import get_safe_cache
+from django.core.cache import cache
 
 from posthog.redis import get_client
 from posthog.settings import print_warning
@@ -532,4 +532,4 @@ def get_safe_cache(cache_key: str):
             cache.delete(cache_key) # in that case, try to delete the cache
         except:
             pass
-        return None
+    return None


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

We currently assume (probably rightfully so) that our trying to use the Django cache is safe, and the worst case is that we just won't have a cache for that key.

However, #3034 caused an issue where updating the instance would lead to problems due to cache that relied on `numpy` which is now gone. 

What we can then do is make sure we handle the case where getting the cache causes the server to fail and try to delete the corrupted cache if that's the case.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
