### PR TITLE
Fix broken url in paths

### DIFF
--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -47,7 +47,14 @@ function rounded_rect(x, y, w, h, r, tl, tr, bl, br) {
 function pageUrl(d) {
     const incomingUrls = d.targetLinks
         .map((l) => l?.source?.name?.replace(/(^[0-9]+_)/, ''))
-        .filter((a) => a)
+        .filter((a) => {
+            try {
+                new URL(a)
+            } catch {
+                return false
+            }
+            return a
+        })
         .map((a) => new URL(a))
     const incomingDomains = [...new Set(incomingUrls.map((url) => url.origin))]
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes [this sentry error](https://sentry.io/organizations/posthog/issues/2187036495/?project=5613116&query=is%3Aunresolved)
- we parse the domains to shorten the URLs, but if the url is broken for some reason when trying to use the URL class, just ignore it

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
