### PR TITLE
Handle corrupted cache

### DIFF
--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -1,6 +1,5 @@
 import json
 
-from django.core.cache import cache
 from rest_framework import viewsets
 from rest_framework.response import Response
 

--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 
 from posthog.models.team import Team
+from posthog.utils import get_safe_cache
 
 
 class DebugCHQueries(viewsets.ViewSet):
@@ -13,7 +14,7 @@ class DebugCHQueries(viewsets.ViewSet):
     """
 
     def list(self, request):
-        return Response(json.loads(cache.get("save_query_{}".format(request.user.pk)) or "[]"))
+        return Response(json.loads(get_safe_cache("save_query_{}".format(request.user.pk)) or "[]"))
 
     def get(self, request):
         return Response([{"hey": "hi"}])

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -28,6 +28,7 @@ from posthog.settings import (
     PRIMARY_DB,
     TEST,
 )
+from posthog.utils import get_safe_cache
 
 CACHE_TTL = 60  # seconds
 
@@ -159,7 +160,7 @@ def save_query(sql: str, params: Dict, execution_time: float) -> None:
 
     try:
         key = "save_query_{}".format(_save_query_user_id)
-        queries = json.loads(cache.get(key) or "[]")
+        queries = json.loads(get_safe_cache(key) or "[]")
 
         queries.insert(
             0, {"timestamp": now().isoformat(), "query": format_sql(sql, params), "execution_time": execution_time}

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -22,7 +22,7 @@ from posthog.auth import PersonalAPIKeyAuthentication, PublicTokenAuthentication
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, DashboardItem, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions
-from posthog.utils import render_template, get_safe_cache
+from posthog.utils import get_safe_cache, render_template
 
 
 class DashboardSerializer(serializers.ModelSerializer):

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -22,7 +22,7 @@ from posthog.auth import PersonalAPIKeyAuthentication, PublicTokenAuthentication
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, DashboardItem, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions
-from posthog.utils import render_template
+from posthog.utils import render_template, get_safe_cache
 
 
 class DashboardSerializer(serializers.ModelSerializer):
@@ -200,7 +200,7 @@ class DashboardItemSerializer(serializers.ModelSerializer):
         if not dashboard_item.filters_hash:
             return None
 
-        result = cache.get(dashboard_item.filters_hash)
+        result = get_safe_cache(dashboard_item.filters_hash)
         if not result or result.get("task_id", None):
             return None
         return result["result"]

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -23,7 +23,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions
 from posthog.queries import paths, retention, stickiness, trends
 from posthog.queries.sessions.sessions import Sessions
-from posthog.utils import generate_cache_key
+from posthog.utils import generate_cache_key, get_safe_cache
 
 
 class InsightSerializer(serializers.ModelSerializer):
@@ -74,7 +74,7 @@ class InsightSerializer(serializers.ModelSerializer):
     def get_result(self, dashboard_item: DashboardItem):
         if not dashboard_item.filters:
             return None
-        result = cache.get(dashboard_item.filters_hash)
+        result = get_safe_cache(dashboard_item.filters_hash)
         if not result or result.get("task_id", None):
             return None
         return result["result"]
@@ -207,7 +207,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if refresh:
             cache.delete(cache_key)
         else:
-            cached_result = cache.get(cache_key)
+            cached_result = get_safe_cache(cache_key)
             if cached_result:
                 task_id = cached_result.get("task_id", None)
                 if not task_id:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -2,7 +2,6 @@ import json
 import warnings
 from typing import Any, Dict, List, Optional, Union
 
-from django.core.cache import cache
 from django.db.models import Count, Func, Prefetch, Q, QuerySet
 from django_filters import rest_framework as filters
 from rest_framework import request, response, serializers, viewsets
@@ -23,7 +22,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, relative_date_parse, get_safe_cache
+from posthog.utils import convert_property_value, get_safe_cache, relative_date_parse
 
 
 class PersonCursorPagination(CursorPagination):

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -23,7 +23,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, relative_date_parse
+from posthog.utils import convert_property_value, relative_date_parse, get_safe_cache
 
 
 class PersonCursorPagination(CursorPagination):
@@ -210,7 +210,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             return response.Response({})
 
         offset_value = int(offset)
-        cached_result = cache.get(reference_id)
+        cached_result = get_safe_cache(reference_id)
         if cached_result:
             return response.Response(
                 {

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -12,7 +12,7 @@ from posthog.models.filters.utils import get_filter
 from posthog.settings import TEMP_CACHE_RESULTS_TTL
 from posthog.utils import generate_cache_key
 
-from .utils import generate_cache_key
+from .utils import generate_cache_key, get_safe_cache
 
 
 class CacheType(str, Enum):
@@ -40,7 +40,7 @@ def cached_function():
             payload = {"filter": filter.toJSON(), "team_id": team.pk}
             # return cached result if possible
             if not request.GET.get("refresh", False):
-                cached_result = cache.get(cache_key)
+                cached_result = get_safe_cache(cache_key)
                 if cached_result and cached_result.get("result"):
                     return cached_result["result"]
             # call function being wrapped

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -10,7 +10,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.tasks.update_cache import update_cache_item, update_cached_items
 from posthog.test.base import BaseTest
 from posthog.types import FilterType
-from posthog.utils import generate_cache_key
+from posthog.utils import generate_cache_key, get_safe_cache
 
 
 class TestUpdateCache(BaseTest):
@@ -63,8 +63,8 @@ class TestUpdateCache(BaseTest):
         self.assertIsNotNone(DashboardItem.objects.get(pk=item.pk).last_refresh)
         self.assertIsNotNone(DashboardItem.objects.get(pk=item_to_cache.pk).last_refresh)
         self.assertIsNotNone(DashboardItem.objects.get(pk=item_do_not_cache.pk).last_refresh)
-        self.assertEqual(cache.get(item_key)["result"][0]["count"], 0)
-        self.assertEqual(cache.get(funnel_key)["result"][0]["count"], 0)
+        self.assertEqual(get_safe_cache(item_key)["result"][0]["count"], 0)
+        self.assertEqual(get_safe_cache(funnel_key)["result"][0]["count"], 0)
 
     def _test_refresh_dashboard_cache_types(
         self, filter: FilterType, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock,
@@ -84,7 +84,7 @@ class TestUpdateCache(BaseTest):
             update_cache_item(*call_item[0])
 
         item_key = generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk))
-        self.assertIsNotNone(cache.get(item_key))
+        self.assertIsNotNone(get_safe_cache(item_key))
 
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.core.cache import cache
 from django.utils.timezone import now
 
 from posthog.models import Dashboard, DashboardItem, Event, Filter

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -26,6 +26,7 @@ import pytz
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.core.cache import cache
 from django.db.models.query import QuerySet
 from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse
@@ -521,13 +522,14 @@ def get_daterange(
             start_date = (start_date.replace(day=1) + delta).replace(day=1)
     return time_range
 
+
 def get_safe_cache(cache_key: str):
     try:
-        cached_result = cache.get(cache_key) # cache.get is safe in most cases
+        cached_result = cache.get(cache_key)  # cache.get is safe in most cases
         return cached_result
-    except: # if it errors out, the cache is probably corrupted
+    except:  # if it errors out, the cache is probably corrupted
         try:
-            cache.delete(cache_key) # in that case, try to delete the cache
+            cache.delete(cache_key)  # in that case, try to delete the cache
         except:
             pass
-    return None
+        return None

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -520,3 +520,14 @@ def get_daterange(
             time_range.append(start_date)
             start_date = (start_date.replace(day=1) + delta).replace(day=1)
     return time_range
+
+def get_safe_cache(cache_key: str):
+    try:
+        cached_result = cache.get(cache_key) # cache.get is safe in most cases
+        return cached_result
+    except: # if it errors out, the cache is probably corrupted
+        try:
+            cache.delete(cache_key) # in that case, try to delete the cache
+        except:
+            pass
+    return None

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -532,4 +532,4 @@ def get_safe_cache(cache_key: str):
             cache.delete(cache_key)  # in that case, try to delete the cache
         except:
             pass
-        return None
+    return None


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

We currently assume (probably rightfully so) that our trying to use the Django cache is safe, and the worst case is that we just won't have a cache for that key.

However, #3034 caused an issue where updating the instance would lead to problems due to cache that relied on numpy which is now gone.

What we can then do is make sure we handle the case where getting the cache causes the server to fail and try to delete the corrupted cache if that's the case.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
