### PR TITLE
Wrap saved funnel name smarterly

### DIFF
--- a/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
+++ b/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
@@ -36,7 +36,9 @@ export function SavedFunnels(): JSX.Element {
                     <List.Item>
                         <Col style={{ whiteSpace: 'pre-line', width: '100%' }}>
                             <Row justify="space-between" align="middle">
-                                <Link to={'/insights?' + toParams(funnel.filters)}>{funnel.name}</Link>
+                                <Link to={'/insights?' + toParams(funnel.filters)} style={{ flex: 1 }}>
+                                    {funnel.name}
+                                </Link>
                                 <Popconfirm
                                     title={`Delete saved funnel "${funnel.name}"?`}
                                     okText="Delete Funnel"


### PR DESCRIPTION
## Changes

"Smarterly" sure is not a real word, but the improvement in wrapping behavior of Funnels Saved in Project is real.

Before change above, after change below:

<img width="294" alt="Before after" src="https://user-images.githubusercontent.com/4550621/106673134-72870480-65b1-11eb-9311-edfa5b2add6b.png">
