### PR TITLE
Make migration for person_email index only if not exists

### DIFF
--- a/posthog/migrations/0121_person_email_index.py
+++ b/posthog/migrations/0121_person_email_index.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "CREATE INDEX CONCURRENTLY posthog_person_email ON posthog_person((properties->>'email'));",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS posthog_person_email ON posthog_person((properties->>'email'));",
             reverse_sql='DROP INDEX "posthog_person_email";',
         )
     ]


### PR DESCRIPTION
This is blocking migrations right now because this index exists on prod already
