### PR TITLE
Extra test features for posthog-js E2E test

### DIFF
--- a/posthog/management/commands/setup_dev.py
+++ b/posthog/management/commands/setup_dev.py
@@ -5,11 +5,16 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from posthog.demo import ORGANIZATION_NAME, TEAM_NAME, create_demo_data
-from posthog.models import User
+from posthog.models import PersonalAPIKey, User
 
 
 class Command(BaseCommand):
     help = "Set up the instance for development/review with demo data"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-data", action="store_true", help="Create demo account without data",
+        )
 
     def handle(self, *args, **options):
         with transaction.atomic():
@@ -21,14 +26,17 @@ class Command(BaseCommand):
                 is_staff=True,
                 team_fields={
                     "name": TEAM_NAME,
+                    "api_token": "e2e_token_1239",
                     "completed_snippet_onboarding": True,
                     "ingested_event": True,
                     "event_names": ["$pageview", "$autocapture"],
                     "event_properties": ["$current_url", "$browser", "$os"],
                 },
             )
+            PersonalAPIKey.objects.create(user=user, label="e2e_demo_api_key key", value="e2e_demo_api_key")
             heroku_app_name = os.getenv("HEROKU_APP_NAME")
             base_url = (
                 f"https://{heroku_app_name}.herokuapp.com/demo/" if heroku_app_name else f"{settings.SITE_URL}/demo/"
             )
-            create_demo_data(team)
+            if not options["no_data"]:
+                create_demo_data(team)

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -366,6 +366,17 @@ if settings.DEBUG:
 
     urlpatterns.append(path("debug/", debug))
 
+if settings.TEST:
+
+    @csrf_exempt
+    def delete_events(request):
+        from posthog.models import Event
+
+        Event.objects.all().delete()
+        return HttpResponse()
+
+    urlpatterns.append(path("delete_events/", delete_events))
+
 # Routes added individually to remove login requirement
 frontend_unauthenticated_routes = ["preflight", "signup"]
 for route in frontend_unauthenticated_routes:


### PR DESCRIPTION
In https://github.com/PostHog/posthog-js/pull/180, I am adding a E2E test for posthog-js, which:

- Runs in multiple browsers (including IE11)
- Interacts with a real browser page, sending events to a live posthog instance and checking 
  whether ingestion works.

To make this work I've:
- Added testcafe support for setup_dev, setting up custom tokens and not setting up demo data
- Add TEST delete data route (run after every test)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
