### PR TITLE
Fix axis labels color on bar charts

### DIFF
--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -243,7 +243,7 @@ export function LineGraph({
                           scales: {
                               xAxes: [
                                   type === 'bar'
-                                      ? { stacked: true }
+                                      ? { stacked: true, ticks: { fontColor: axisLabelColor } }
                                       : {
                                             display: true,
                                             gridLines: { lineWidth: 0, color: axisLineColor, zeroLineColor: axisColor },
@@ -259,7 +259,7 @@ export function LineGraph({
                               ],
                               yAxes: [
                                   type === 'bar'
-                                      ? { stacked: true }
+                                      ? { stacked: true, ticks: { fontColor: axisLabelColor } }
                                       : {
                                             display: true,
                                             gridLines: { color: axisLineColor, zeroLineColor: axisColor },


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Reported by user.

We weren't updating the color of axis labels for bar charts in dashboards

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
