### PR TITLE
Revert plugins ECS definition to use local image

### DIFF
--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -62,13 +62,13 @@ jobs:
                   container-name: posthog-production-worker
                   image: ${{ steps.build-image.outputs.image }}
 
-            - name: Fill in the public ECR plugin server image ID in the Amazon ECS task definition
+            - name: Fill in the new plugins image ID in the Amazon ECS task definition
               id: task-def-plugins
               uses: aws-actions/amazon-ecs-render-task-definition@v1
               with:
                   task-definition: deploy/task-definition.plugins.json
                   container-name: posthog-production-plugins
-                  image: public.ecr.aws/p1o5l3m0/posthog-plugin-server:latest
+                  image: ${{ steps.build-image.outputs.image }}
 
             - name: Fill in the new migration image ID in the Amazon ECS task definition
               id: task-def-migrate

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -62,7 +62,8 @@
                     "name": "STATSD_HOST",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
                 }
-            ]
+            ],
+            "entryPoint": ["./bin/plugin-server"]
         }
     ],
     "requiresCompatibilities": ["FARGATE"],


### PR DESCRIPTION
## Changes

- It's way too dangerous to run `posthog/posthog:latest` and `posthog/plugin-server:latest` unbounded together.
- This PR links posthog with a specific plugin server version, specified in plugins/package.json

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
