### PR TITLE
Async action-event matching with postgres plugin server ingestion

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -30,7 +30,7 @@ app.autodiscover_tasks()
 app.conf.broker_pool_limit = 0
 
 # How frequently do we want to calculate action -> event relationships if async is enabled
-ACTION_EVENT_MAPPING_INTERVAL_MINUTES = 10
+ACTION_EVENT_MAPPING_INTERVAL_MINUTES = 5
 
 if settings.STATSD_HOST is not None:
     statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -120,11 +120,6 @@ if get_bool_from_env("IS_BEHIND_PROXY", False):
     USE_X_FORWARDED_HOST = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-ASYNC_EVENT_ACTION_MAPPING = False
-
-if get_bool_from_env("ASYNC_EVENT_ACTION_MAPPING", False):
-    ASYNC_EVENT_ACTION_MAPPING = True
-
 
 # Clickhouse Settings
 CLICKHOUSE_TEST_DB = "posthog_test"
@@ -166,6 +161,13 @@ if PRIMARY_DB == RDBMS.CLICKHOUSE:
     TEST_RUNNER = os.environ.get("TEST_RUNNER", "ee.clickhouse.clickhouse_test_runner.ClickhouseTestRunner")
 else:
     TEST_RUNNER = os.environ.get("TEST_RUNNER", "django.test.runner.DiscoverRunner")
+
+
+ASYNC_EVENT_ACTION_MAPPING = get_bool_from_env("ASYNC_EVENT_ACTION_MAPPING", False)
+
+# Enable if ingesting with the plugin server into postgres, as it's not able to calculate the mapping on the fly
+if PLUGIN_SERVER_INGESTION and PRIMARY_DB == RDBMS.POSTGRES:
+    ASYNC_EVENT_ACTION_MAPPING = True
 
 
 # IP block settings


### PR DESCRIPTION
## Changes

- Automatically enables async action-event matching when using postgres and ingesting events with the plugin server
- Sets the matching interval to every 5min instead of 10min

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
