### PR TITLE
Avoid `TypeError` when assets have been regenerated loading a scene

### DIFF
--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -282,6 +282,7 @@ export const sceneLogic = kea<sceneLogicType>({
                             // We were on another page (not the first loaded scene)
                             console.error('App assets regenerated. Reloading this page.')
                             window.location.reload()
+                            return
                         } else {
                             // First scene, show an error page
                             console.error('App assets regenerated. Showing error page.')


### PR DESCRIPTION
This caused the following sentry error: https://sentry.io/organizations/posthog/issues/2019430827/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d

Problem came from not initializing `importedScene` which is used below

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
