### PR TITLE
Fix stickiness comparison

### DIFF
--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -70,7 +70,7 @@ class ClickhouseFunnel(Funnel):
             data.update({"date_from": relative_date_parse("-7d")})
         if not self._filter._date_to:
             data.update({"date_to": timezone.now()})
-        self._filter = Filter(data={**self._filter._data, **data})
+        self._filter = self._filter.with_data(data)
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(
             filter=self._filter, table="events.", team_id=self._team.pk

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -210,9 +210,7 @@ class ClickhouseRetention(Retention):
         date_from = filter.date_from + filter.selected_interval * filter.period_increment
         date_to = filter.date_to
 
-        new_data = filter._data
-        new_data.update({"total_intervals": filter.total_intervals - filter.selected_interval})
-        filter = RetentionFilter(data=new_data)
+        filter = filter.with_data({"total_intervals": filter.total_intervals - filter.selected_interval})
 
         query_result = sync_execute(
             RETENTION_PEOPLE_PER_PERIOD_SQL.format(

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -17,6 +17,7 @@ class BaseFilter(BaseParamMixin):
         elif not data:
             raise ValueError("You need to define either a data dict or a request")
         self._data = data
+        self.kwargs = kwargs
 
     def to_dict(self) -> Dict[str, Any]:
         ret = {}
@@ -29,3 +30,7 @@ class BaseFilter(BaseParamMixin):
 
     def toJSON(self):
         return json.dumps(self.to_dict(), default=lambda o: o.__dict__, sort_keys=True, indent=4)
+
+    def with_data(self, overrides: Dict[str, Any]):
+        "Allow making copy of filter whilst preserving the class"
+        return type(self)(data={**self._data, **overrides}, **self.kwargs)

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 from django.http import HttpRequest
 
 from posthog.models.filters.mixins.common import BaseParamMixin
+from posthog.models.utils import sane_repr
 
 
 class BaseFilter(BaseParamMixin):
@@ -34,3 +35,5 @@ class BaseFilter(BaseParamMixin):
     def with_data(self, overrides: Dict[str, Any]):
         "Allow making copy of filter whilst preserving the class"
         return type(self)(data={**self._data, **overrides}, **self.kwargs)
+
+    __repr__ = sane_repr("_data", "kwargs", include_id=False)

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -60,3 +60,4 @@ class Filter(
             raise ValueError("You need to define either a data dict or a request")
 
         self._data = data
+        self.kwargs = kwargs

--- a/posthog/models/filters/path_filter.py
+++ b/posthog/models/filters/path_filter.py
@@ -30,4 +30,4 @@ class PathFilter(
             data["insight"] = INSIGHT_PATHS
         else:
             data = {"insight": INSIGHT_PATHS}
-        super().__init__(data, request)
+        super().__init__(data, request, **kwargs)

--- a/posthog/models/filters/retention_filter.py
+++ b/posthog/models/filters/retention_filter.py
@@ -45,4 +45,4 @@ class RetentionFilter(
 ):
     def __init__(self, data: Dict[str, Any] = {}, request: Optional[HttpRequest] = None, **kwargs) -> None:
         data["insight"] = INSIGHT_RETENTION
-        super().__init__(data, request)
+        super().__init__(data, request, **kwargs)

--- a/posthog/models/filters/stickiness_filter.py
+++ b/posthog/models/filters/stickiness_filter.py
@@ -29,7 +29,7 @@ class StickinessFilter(
     team: Team
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
-        super().__init__(data, request)
+        super().__init__(data, request, **kwargs)
         team: Optional[Team] = kwargs.get("team", None)
         if not team:
             raise ValueError("Team must be provided to stickiness filter")

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -58,8 +58,8 @@ class UUIDModel(models.Model):
     id: models.UUIDField = models.UUIDField(primary_key=True, default=UUIDT, editable=False)
 
 
-def sane_repr(*attrs: str) -> Callable[[object], str]:
-    if "id" not in attrs and "pk" not in attrs:
+def sane_repr(*attrs: str, include_id=True) -> Callable[[object], str]:
+    if "id" not in attrs and "pk" not in attrs and include_id:
         attrs = ("id",) + attrs
 
     def _repr(self):

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -29,14 +29,11 @@ def process_entity_for_events(entity: Entity, team_id: int, order_by="-id") -> Q
     return QuerySet()
 
 
-def determine_compared_filter(filter):
+def determine_compared_filter(filter) -> Filter:
     if not filter.date_to or not filter.date_from:
         raise ValueError("You need date_from and date_to to compare")
     date_from, date_to = get_compare_period_dates(filter.date_from, filter.date_to)
-    compared_filter = filter.with_data(
-        {"date_from": date_from.date().isoformat(), "date_to": date_to.date().isoformat()}
-    )
-    return compared_filter
+    return filter.with_data({"date_from": date_from.date().isoformat(), "date_to": date_to.date().isoformat()})
 
 
 def convert_to_comparison(trend_entity: List[Dict[str, Any]], filter, label: str) -> List[Dict[str, Any]]:

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -33,8 +33,8 @@ def determine_compared_filter(filter):
     if not filter.date_to or not filter.date_from:
         raise ValueError("You need date_from and date_to to compare")
     date_from, date_to = get_compare_period_dates(filter.date_from, filter.date_to)
-    compared_filter = Filter(
-        data={**filter._data, "date_from": date_from.date().isoformat(), "date_to": date_to.date().isoformat()}
+    compared_filter = filter.with_data(
+        {"date_from": date_from.date().isoformat(), "date_to": date_to.date().isoformat()}
     )
     return compared_filter
 

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -384,9 +384,8 @@ class LifecycleTrend:
         interval_trunc, sub_interval = get_trunc_func(period=period)
 
         # include the before and after when filteirng all events
-        filter = Filter(
-            data={**filter._data, "date_from": prev_date_from.isoformat(), "date_to": after_date_to.isoformat()}
-        )
+
+        filter = filter.with_data({"date_from": prev_date_from.isoformat(), "date_to": after_date_to.isoformat()})
 
         filtered_events = Event.objects.filter(team_id=team_id).filter(filter_events(team_id, filter, entity))
         event_query, event_params = queryset_to_named_query(filtered_events, "events")
@@ -442,9 +441,7 @@ class LifecycleTrend:
         interval_trunc, sub_interval = get_trunc_func(period=period)
 
         # include the before and after when filteirng all events
-        filter = Filter(
-            data={**filter._data, "date_from": prev_date_from.isoformat(), "date_to": after_date_to.isoformat()}
-        )
+        filter = filter.with_data({"date_from": prev_date_from.isoformat(), "date_to": after_date_to.isoformat()})
 
         filtered_events = Event.objects.filter(team_id=team_id).filter(filter_events(team_id, filter, entity))
         event_query, event_params = queryset_to_named_query(filtered_events)

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -234,10 +234,7 @@ class Retention(BaseQuery):
         return results
 
     def _retrieve_people_in_period(self, filter: RetentionFilter, team: Team):
-
-        new_data = filter._data
-        new_data.update({"total_intervals": filter.total_intervals - filter.selected_interval})
-        filter = RetentionFilter(data=new_data)
+        filter = filter.with_data({"total_intervals": filter.total_intervals - filter.selected_interval})
 
         format_fields, params = self._determine_query_params(filter, team)
 

--- a/posthog/queries/sessions/sessions.py
+++ b/posthog/queries/sessions/sessions.py
@@ -58,9 +58,8 @@ class Sessions(BaseQuery):
 
         if filter.session == SESSION_AVG:
             if not filter.date_from:
-                filter = Filter(
-                    data={
-                        **filter._data,
+                filter = filter.with_data(
+                    {
                         "date_from": Event.objects.filter(team=team)
                         .order_by("timestamp")[0]
                         .timestamp.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -1,0 +1,13 @@
+from posthog.models.filters.path_filter import PathFilter
+from posthog.test.base import APIBaseTest
+
+
+class TestBase(APIBaseTest):
+    def test_determine_compared_filter(self):
+        from posthog.queries.base import determine_compared_filter
+
+        filter = PathFilter(data={"date_from": "2020-05-22", "date_to": "2020-05-29"})
+        compared_filter = determine_compared_filter(filter)
+
+        self.assertIsInstance(compared_filter, PathFilter)
+        self.assertDictContainsSubset({"date_from": "2020-05-15", "date_to": "2020-05-22",}, compared_filter.to_dict())

--- a/posthog/queries/test/test_stickiness.py
+++ b/posthog/queries/test/test_stickiness.py
@@ -7,13 +7,14 @@ from freezegun import freeze_time
 from posthog.api.test.base import APIBaseTest
 from posthog.models import Action, ActionStep, Event, Person, Team
 from posthog.models.filters.stickiness_filter import StickinessFilter
+from posthog.queries.abstract_test.test_compare import AbstractCompareTest
 from posthog.queries.stickiness import Stickiness
 from posthog.test.base import BaseTest
 
 
 # parameterize tests to reuse in EE
 def stickiness_test_factory(stickiness, event_factory, person_factory, action_factory, get_earliest_timestamp):
-    class TestStickiness(APIBaseTest):
+    class TestStickiness(APIBaseTest, AbstractCompareTest):
         def _create_multiple_people(self, period=timedelta(days=1)):
             base_time = datetime.fromisoformat("2020-01-01T12:00:00.000000")
             p1 = person_factory(team_id=self.team.id, distinct_ids=["person1"], properties={"name": "person1"})
@@ -340,7 +341,7 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
             second_result = self.client.get(result["next"]).json()
             self.assertEqual(len(second_result["results"][0]["people"]), 50)
 
-        def test_stickiness_compared(self):
+        def test_compare(self):
             self._create_multiple_people()
 
             filter = StickinessFilter(

--- a/posthog/queries/test/test_stickiness.py
+++ b/posthog/queries/test/test_stickiness.py
@@ -340,6 +340,29 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
             second_result = self.client.get(result["next"]).json()
             self.assertEqual(len(second_result["results"][0]["people"]), 50)
 
+        def test_stickiness_compared(self):
+            self._create_multiple_people()
+
+            filter = StickinessFilter(
+                data={
+                    "shown_as": "Stickiness",
+                    "date_from": "2020-01-01",
+                    "date_to": "2020-01-08",
+                    "compare": "true",
+                    "display": "ActionsLineGraph",
+                    "events": '[{"id":"watched movie","math":"dau","name":"watched movie","type":"events","order":null,"properties":[],"math_property":null}]',
+                    "insight": "TRENDS",
+                    "interval": "day",
+                    "properties": "[]",
+                    "shown_as": "Stickiness",
+                },
+                team=self.team,
+                get_earliest_timestamp=get_earliest_timestamp,
+            )
+            response = stickiness().run(filter, self.team)
+            self.assertEqual(response[0]["data"], [2, 1, 1, 0, 0, 0, 0, 0])
+            self.assertEqual(response[1]["data"], [3, 0, 0, 0, 0, 0, 0, 0])
+
     return TestStickiness
 
 


### PR DESCRIPTION
This blew up because comparison code was not initializing the right
subclass of filter.

https://sentry.io/organizations/posthog/issues/2137356539/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
