### PR TITLE
Return a 400 when /decide called with invalid token

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -131,7 +131,7 @@ def get_event(request):
                     "code": "validation",
                     "message": "API key not provided. You can find your project API key in PostHog project settings.",
                 },
-                status=400,
+                status=401,
             ),
         )
     team = Team.objects.get_team_from_token(token)
@@ -151,13 +151,13 @@ def get_event(request):
                         "code": "validation",
                         "message": "Project API key invalid. You can find your project API key in PostHog project settings.",
                     },
-                    status=400,
+                    status=401,
                 ),
             )
         user = User.objects.get_from_personal_api_key(token)
         if user is None:
             return cors_response(
-                request, JsonResponse({"code": "validation", "message": "Personal API key invalid.",}, status=400,),
+                request, JsonResponse({"code": "validation", "message": "Personal API key invalid.",}, status=401,),
             )
         team = user.teams.get(id=project_id)
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -92,10 +92,23 @@ def get_decide(request: HttpRequest):
         team = Team.objects.get_team_from_token(token)
         if team is None and token:
             project_id = _get_project_id(data, request)
+
+            if not project_id:
+                return cors_response(
+                    request,
+                    JsonResponse(
+                        {
+                            "code": "validation",
+                            "message": "Project API key invalid. You can find your project API key in PostHog project settings.",
+                        },
+                        status=400,
+                    ),
+                )
+
             user = User.objects.get_from_personal_api_key(token)
             if user is None:
                 return cors_response(
-                    request, JsonResponse({"code": "validation", "message": "Invalid personal API key.",}, status=400,),
+                    request, JsonResponse({"code": "validation", "message": "Personal API key invalid.",}, status=400,),
                 )
             team = user.teams.get(id=project_id)
         if team:

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -101,14 +101,14 @@ def get_decide(request: HttpRequest):
                             "code": "validation",
                             "message": "Project API key invalid. You can find your project API key in PostHog project settings.",
                         },
-                        status=400,
+                        status=401,
                     ),
                 )
 
             user = User.objects.get_from_personal_api_key(token)
             if user is None:
                 return cors_response(
-                    request, JsonResponse({"code": "validation", "message": "Personal API key invalid.",}, status=400,),
+                    request, JsonResponse({"code": "validation", "message": "Personal API key invalid.",}, status=401,),
                 )
             team = user.teams.get(id=project_id)
         if team:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -355,7 +355,7 @@ class TestCapture(BaseTest):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json()["message"],
             "Project API key invalid. You can find your project API key in PostHog project settings.",
@@ -368,7 +368,7 @@ class TestCapture(BaseTest):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json()["message"],
             "API key not provided. You can find your project API key in PostHog project settings.",

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -17,7 +17,7 @@ class TestDecide(BaseTest):
             "/decide/",
             {"data": self._dict_to_b64(data or {"token": self.team.api_token, "distinct_id": "example_id"})},
             HTTP_ORIGIN=origin,
-        ).json()
+        )
 
     def test_user_on_own_site_enabled(self):
         user = self.organization.members.first()
@@ -70,13 +70,13 @@ class TestDecide(BaseTest):
 
     def test_user_session_recording_opt_in(self):
         # :TRICKY: Test for regression around caching
-        response = self._post_decide()
+        response = self._post_decide().json()
         self.assertEqual(response["sessionRecording"], False)
 
         self.team.session_recording_opt_in = True
         self.team.save()
 
-        response = self._post_decide()
+        response = self._post_decide().json()
         self.assertEqual(response["sessionRecording"], {"endpoint": "/s/"})
         self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
 
@@ -85,10 +85,10 @@ class TestDecide(BaseTest):
         self.team.session_recording_opt_in = True
         self.team.save()
 
-        response = self._post_decide(origin="evil.site.com")
+        response = self._post_decide(origin="evil.site.com").json()
         self.assertEqual(response["sessionRecording"], False)
 
-        response = self._post_decide(origin="https://example.com")
+        response = self._post_decide(origin="https://example.com").json()
         self.assertEqual(response["sessionRecording"], {"endpoint": "/s/"})
 
     def test_feature_flags(self):
@@ -118,11 +118,11 @@ class TestDecide(BaseTest):
             created_by=self.user,
         )
         with self.assertNumQueries(5):
-            response = self._post_decide()
+            response = self._post_decide().json()
         self.assertEqual(response["featureFlags"][0], "beta-feature")
 
         with self.assertNumQueries(5):
-            response = self._post_decide({"token": self.team.api_token, "distinct_id": "another_id"})
+            response = self._post_decide({"token": self.team.api_token, "distinct_id": "another_id"}).json()
         self.assertEqual(len(response["featureFlags"]), 0)
 
     def test_feature_flags_with_personal_api_key(self):
@@ -132,5 +132,19 @@ class TestDecide(BaseTest):
         FeatureFlag.objects.create(
             team=self.team, rollout_percentage=100, name="Test", key="test", created_by=self.user,
         )
-        response = self._post_decide({"distinct_id": "example_id", "api_key": key.value, "project_id": self.team.id})
+        response = self._post_decide(
+            {"distinct_id": "example_id", "api_key": key.value, "project_id": self.team.id}
+        ).json()
         self.assertEqual(len(response["featureFlags"]), 1)
+
+    def test_personal_api_key_without_project_id(self):
+        key = PersonalAPIKey(label="X", user=self.user)
+        key.save()
+        Person.objects.create(team=self.team, distinct_ids=["example_id"])
+
+        response = self._post_decide({"distinct_id": "example_id", "api_key": key.value})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["message"],
+            "Project API key invalid. You can find your project API key in PostHog project settings.",
+        )

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -143,7 +143,7 @@ class TestDecide(BaseTest):
         Person.objects.create(team=self.team, distinct_ids=["example_id"])
 
         response = self._post_decide({"distinct_id": "example_id", "api_key": key.value})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json()["message"],
             "Project API key invalid. You can find your project API key in PostHog project settings.",


### PR DESCRIPTION
Sentry: https://sentry.io/organizations/posthog/issues/2133194501/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d

The error messages are now in sync with /capture endpoints as well.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
