### PR TITLE
Fix mobile menu z-index

### DIFF
--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -20,6 +20,7 @@
 .navigation-main {
     // General navigation bar styles (defaults to wide 180px)
     background-color: $bg_menu !important;
+    z-index: $z_main_nav;
 
     .navigation-inner {
         background-color: $bg_menu;
@@ -218,7 +219,7 @@
     @extend .mixin-elevated;
     position: fixed;
     top: 0;
-    z-index: 1000;
+    z-index: $z_top_navigation;
     color: $text_default;
 
     &.full-width {

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -62,5 +62,7 @@ $radius: 2px;
 $top_nav_height: 50px;
 
 // Z-indexes
+$z_top_navigation: 1000;
 $z_mobile_nav_overlay: 1031;
+$z_main_nav: 1048;
 $z_pinned_dashboards_popup: 1062;


### PR DESCRIPTION
## Changes

Fixes #3196.
<img width="364" alt="" src="https://user-images.githubusercontent.com/5864173/106904931-0b299b80-66fc-11eb-914f-9d4e7d1a2fea.png">

**With pinned dashboards overlay**
<img width="362" alt="" src="https://user-images.githubusercontent.com/5864173/106904922-095fd800-66fc-11eb-9e13-1f82021d54bf.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
