### PR TITLE
Fix numerical person properties turning to strings on save

### DIFF
--- a/frontend/src/scenes/persons/PersonV2.tsx
+++ b/frontend/src/scenes/persons/PersonV2.tsx
@@ -147,7 +147,7 @@ function _PersonV2(): JSX.Element {
                     </Card>
                 </Col>
             </Row>
-            {mergeModalOpen && (
+            {mergeModalOpen && person && (
                 <MergePerson person={person} onPersonChange={setPerson} closeModal={() => setMergeModalOpen(false)} />
             )}
         </div>

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -48,13 +48,15 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
         editProperty: async ({ key, newValue }) => {
             const person = values.person
             if (person) {
-                if (typeof person.properties[key] === 'number') {
-                    const parsedNumber = Number(newValue)
-                    if (!Number.isNaN(parsedNumber)) {
-                        newValue = parsedNumber
-                    }
+                let parsedValue = newValue
+
+                // If the property is a number, store it as a number
+                const attemptedParsedNumber = Number(newValue)
+                if (!Number.isNaN(attemptedParsedNumber)) {
+                    parsedValue = attemptedParsedNumber
                 }
-                person.properties[key] = newValue
+
+                person.properties[key] = parsedValue
                 actions.setPerson(person) // To update the UI immediately while the request is being processed
                 const response = await api.update(`api/person/${person.id}`, person)
                 actions.setPerson(response)

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -48,8 +48,13 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
         editProperty: async ({ key, newValue }) => {
             const person = values.person
             if (person) {
+                if (typeof person.properties[key] === 'number') {
+                    const parsedNumber = Number(newValue)
+                    if (!Number.isNaN(parsedNumber)) {
+                        newValue = parsedNumber
+                    }
+                }
                 person.properties[key] = newValue
-                console.log(person.properties)
                 actions.setPerson(person) // To update the UI immediately while the request is being processed
                 const response = await api.update(`api/person/${person.id}`, person)
                 actions.setPerson(response)

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -47,10 +47,13 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
         },
         editProperty: async ({ key, newValue }) => {
             const person = values.person
-            person.properties[key] = newValue
-            actions.setPerson(person) // To update the UI immediately while the request is being processed
-            const response = await api.update(`api/person/${person.id}`, person)
-            actions.setPerson(response)
+            if (person) {
+                person.properties[key] = newValue
+                console.log(person.properties)
+                actions.setPerson(person) // To update the UI immediately while the request is being processed
+                const response = await api.update(`api/person/${person.id}`, person)
+                actions.setPerson(response)
+            }
         },
     }),
     loaders: ({ values, actions }) => ({


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Close #3189

Tagging you @paolodamico because I wonder when we'll be releasing `persons-2353`. I'm not the biggest fan of all the UI updates but just the new logic is almost a necessity.

Spent more time than I'd like working on the old persons "logic" and decided it wasn't worth it from a prioritization standpoint.

Hence this fixes the logic on PersonV2 as I imagine we'll roll out the logic updates even if the experiment turns out bad from a UX perspective.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
