### PR TITLE
Filp PLUGIN_SERVER_INGESTION on

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -35,6 +35,10 @@
                 {
                     "name": "SITE_URL",
                     "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "PLUGIN_SERVER_INGESTION",
+                    "value": "true"
                 }
             ],
             "secrets": [

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -104,7 +104,7 @@
                 },
                 {
                     "name": "PLUGIN_SERVER_INGESTION",
-                    "value": "false"
+                    "value": "true"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

This should enable actual plugin ingestion on cloud for the Kea and PostHog organizations. Fingers crossed! 🤞 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
