### PR TITLE
Handle navigation race in insights logic

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -114,7 +114,9 @@ export const insightLogic = kea<insightLogicType>({
             const view = values.activeView
             actions.setTimeout(
                 setTimeout(() => {
-                    view == values.activeView && actions.setShowTimeoutMessage(true)
+                    if (values && view == values.activeView) {
+                        actions.setShowTimeoutMessage(true)
+                    }
                 }, SHOW_TIMEOUT_MESSAGE_AFTER)
             )
             actions.setIsLoading(true)


### PR DESCRIPTION
If user navigates away from the page before timeout occurs, the logic
gets unmounted and we would currently get an error:

```
TypeError
Cannot read property 'activeView' of undefined
```

Sentry error: https://sentry.io/organizations/posthog/issues/2181870161/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
