### PR TITLE
Emit timing gauge to statsd for sync_execute on clickhouse

### DIFF
--- a/ee/bin/docker-ch-test
+++ b/ee/bin/docker-ch-test
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+mkdir -p frontend/dist
+touch frontend/dist/index.html
+touch frontend/dist/layout.html
+touch frontend/dist/shared_dashboard.html
+python manage.py test ee --testrunner="ee.clickhouse.clickhouse_test_runner.ClickhouseTestRunner"

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -15,7 +15,7 @@ from django.core.cache import cache
 from django.utils.timezone import now
 from sentry_sdk.api import capture_exception
 
-from posthog import redis, settings
+from posthog import redis
 from posthog.constants import RDBMS
 from posthog.settings import (
     CLICKHOUSE_ASYNC,
@@ -27,12 +27,15 @@ from posthog.settings import (
     CLICKHOUSE_USER,
     CLICKHOUSE_VERIFY,
     PRIMARY_DB,
+    STATSD_HOST,
+    STATSD_PORT,
+    STATSD_PREFIX,
     TEST,
 )
 from posthog.utils import get_safe_cache
 
-if settings.STATSD_HOST is not None:
-    statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
+if STATSD_HOST is not None:
+    statsd.Connection.set_defaults(host=STATSD_HOST, port=STATSD_PORT)
 
 CACHE_TTL = 60  # seconds
 
@@ -115,7 +118,7 @@ else:
             result = ch_client.execute(query, args, settings=settings)
         finally:
             execution_time = time() - start_time
-            g = statsd.Gauge("%s_clickhouse_sync_execution_time" % (settings.STATSD_PREFIX,))
+            g = statsd.Gauge("%s_clickhouse_sync_execution_time" % (STATSD_PREFIX,))
             g.send("clickhouse_sync_query_time", execution_time)
             if app_settings.SHELL_PLUS_PRINT_SQL:
                 print(format_sql(query, args))

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -115,11 +115,11 @@ else:
             result = ch_client.execute(query, args, settings=settings)
         finally:
             execution_time = time() - start_time
+            g = statsd.Gauge("%s_clickhouse_sync_execution_time" % (settings.STATSD_PREFIX,))
+            g.send("clickhouse_sync_query_time", execution_time)
             if app_settings.SHELL_PLUS_PRINT_SQL:
                 print(format_sql(query, args))
                 print("Execution time: %.6fs" % (execution_time,))
-                g = statsd.Gauge("%s_clickhouse_sync_execution_time" % (settings.STATSD_PREFIX,))
-                g.send("clickhouse_sync_query_time", execution_time)
             if _save_query_user_id:
                 save_query(query, args, execution_time)
         return result

--- a/ee/docker-compose.ch.test.yml
+++ b/ee/docker-compose.ch.test.yml
@@ -1,0 +1,117 @@
+version: '3'
+
+services:
+    db:
+        image: postgres:11-alpine
+        environment:
+            POSTGRES_USER: posthog
+            POSTGRES_DB: posthog
+            POSTGRES_PASSWORD: posthog
+        ports:
+            - '5439:5432'
+    redis:
+        image: 'redis:alpine'
+        ports:
+            - '6379:6379'
+    test:
+        build:
+            context: ../
+            dockerfile: dev.Dockerfile
+        command: ./ee/bin/docker-ch-test
+        volumes:
+            - ..:/code
+        ports:
+            - '8000:8000'
+            - '8234:8234'
+        environment:
+            IS_DOCKER: 'true'
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_DATABASE: 'posthog'
+            CLICKHOUSE_SECURE: 'false'
+            CLICKHOUSE_VERIFY: 'false'
+            KAFKA_URL: 'kafka://kafka'
+            REDIS_URL: 'redis://redis:6379/'
+            SECRET_KEY: 'alsdfjiosdajfklalsdjkf'
+            DEBUG: 'true'
+            PRIMARY_DB: 'clickhouse'
+            PLUGIN_SERVER_INGESTION: 'true'
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+        links:
+            - db:db
+            - redis:redis
+    worker:
+        build:
+            context: ../
+            dockerfile: dev.Dockerfile
+        command: ./bin/docker-worker-celery --with-scheduler
+        volumes:
+            - ..:/code
+        environment:
+            IS_DOCKER: 'true'
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_DATABASE: 'posthog'
+            CLICKHOUSE_SECURE: 'false'
+            CLICKHOUSE_VERIFY: 'false'
+            KAFKA_URL: 'kafka://kafka'
+            REDIS_URL: 'redis://redis:6379/'
+            SECRET_KEY: 'alsdfjiosdajfklalsdjkf'
+            DEBUG: 'true'
+            PRIMARY_DB: 'clickhouse'
+        depends_on:
+            - db
+            - redis
+        links:
+            - db:db
+            - redis:redis
+    plugins:
+        build:
+            context: ../
+            dockerfile: production.Dockerfile
+        command: ./bin/plugin-server --no-restart-loop
+        restart: on-failure
+        volumes:
+            - ..:/code
+        environment:
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            KAFKA_ENABLED: 'true'
+            KAFKA_HOSTS: 'kafka:9092'
+            REDIS_URL: 'redis://redis:6379/'
+            PLUGIN_SERVER_INGESTION: 'true'
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+        links:
+            - db:db
+            - redis:redis
+    clickhouse:
+        image: yandex/clickhouse-server
+        depends_on:
+            - kafka
+        ports:
+            - '8123:8123'
+            - '9000:9000'
+            - '9440:9440'
+            - '9009:9009'
+        volumes:
+            - ./idl:/idl
+            - ../docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+            - ../docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
+    zookeeper:
+        image: wurstmeister/zookeeper
+    kafka:
+        image: wurstmeister/kafka
+        depends_on:
+            - zookeeper
+        ports:
+            - '9092:9092'
+        environment:
+            KAFKA_ADVERTISED_HOST_NAME: kafka
+            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
