### PR TITLE
Fix more z-index wonkiness

### DIFF
--- a/frontend/src/lib/components/CommandPalette/index.scss
+++ b/frontend/src/lib/components/CommandPalette/index.scss
@@ -1,7 +1,7 @@
 @import '~/vars';
 
 .palette__overlay {
-    z-index: 2147483021;
+    z-index: $z_command_palette;
     position: fixed;
     top: 0;
     left: 0;

--- a/frontend/src/lib/components/Drawer.tsx
+++ b/frontend/src/lib/components/Drawer.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren, useEffect } from 'react'
 import { Drawer as AntDrawer } from 'antd'
 import { DrawerProps } from 'antd/lib/drawer'
+import styles from '~/vars.scss'
 
 /**
  * Ant Drawer extended to add class 'drawer-open' to <body> when drawer is out. Used to alter Papercups widget position.
@@ -16,5 +17,5 @@ export function Drawer(props: PropsWithChildren<DrawerProps>): JSX.Element {
         }
     }, [visible])
 
-    return <AntDrawer {...props} />
+    return <AntDrawer {...props} zIndex={styles.zDrawer} />
 }

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -197,12 +197,11 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                     <span>
                         <LinkButton
                             to={firstRecordingId ? sessionPlayerUrl(firstRecordingId) : '#'}
-                            icon={<PlaySquareOutlined />}
                             type="primary"
                             data-attr="play-all-recordings"
                             disabled={firstRecordingId === null} // We allow playback of previously recorded sessions even if new recordings are disabled
                         >
-                            Play all
+                            <PlaySquareOutlined /> Play all
                         </LinkButton>
                     </span>
                 </Tooltip>

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Button, Spin, Space, Tooltip, Drawer } from 'antd'
+import { Table, Button, Spin, Space, Tooltip } from 'antd'
 import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP } from '~/lib/utils'
@@ -27,6 +27,7 @@ import { LinkButton } from 'lib/components/LinkButton'
 import { SessionsFilterBox } from 'scenes/sessions/filters/SessionsFilterBox'
 import { EditFiltersPanel } from 'scenes/sessions/filters/EditFiltersPanel'
 import { SearchAllBox } from 'scenes/sessions/filters/SearchAllBox'
+import { Drawer } from 'lib/components/Drawer'
 
 interface SessionsTableProps {
     personIds?: string[]

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -66,3 +66,4 @@ $z_top_navigation: 1000;
 $z_mobile_nav_overlay: 1031;
 $z_main_nav: 1048;
 $z_pinned_dashboards_popup: 1062;
+$z_command_palette: 1875;

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -62,8 +62,14 @@ $radius: 2px;
 $top_nav_height: 50px;
 
 // Z-indexes
-$z_top_navigation: 1000;
-$z_mobile_nav_overlay: 1031;
-$z_main_nav: 1048;
-$z_pinned_dashboards_popup: 1062;
+$z_top_navigation: 800;
+$z_mobile_nav_overlay: 931;
+$z_main_nav: 948;
+$z_pinned_dashboards_popup: 962;
+$z_drawer: 1000;
 $z_command_palette: 1875;
+
+// Export variables for TS access
+:export {
+    zDrawer: $z_drawer;
+}

--- a/frontend/src/vars.scss.d.ts
+++ b/frontend/src/vars.scss.d.ts
@@ -1,0 +1,7 @@
+interface styleInterface {
+    zDrawer: number
+}
+
+const styles: styleInterface
+
+export default styles


### PR DESCRIPTION
## Changes

- Fixes [issue](https://posthog.slack.com/archives/C01EMTKLTSS/p1612476234000600) that caused main navigation bar to show on top of drawers.
- Drawers now use a deliberate z-index.
- Command palette z-index as a variable.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
