### PR TITLE
Return 1 week of data when choosing 'all time' with no event data

### DIFF
--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -1,5 +1,7 @@
 from unittest.mock import call, patch
 
+from freezegun import freeze_time
+
 from posthog.models import Action, ActionStep, Element, ElementGroup, Event, Organization, Person
 from posthog.models.event import Selector
 from posthog.test.base import BaseTest
@@ -672,3 +674,21 @@ class TestSelectors(BaseTest):
         self.assertEqual(selector1.parts[1].data, {"tag_name": "div"})
         self.assertEqual(selector1.parts[1].direct_descendant, False)
         self.assertEqual(selector1.parts[1].unique_order, 1)
+
+
+class TestEventModel(BaseTest):
+    def test_earliest_timestamp(self):
+        with freeze_time("2012-01-15T02:44:00.000Z"):
+            Event.objects.create(
+                team=self.team, distinct_id="whatever",
+            )
+
+        with freeze_time("2012-01-14T03:21:34.000Z"):
+            Event.objects.create(
+                team=self.team, distinct_id="whatever",
+            )
+
+        with freeze_time("2012-01-16T03:21:34.000Z"):
+            self.assertEqual(Event.objects.earliest_timestamp(self.team.id), "2012-01-14T00:00:00+00:00")
+            # Team has no events
+            self.assertEqual(Event.objects.earliest_timestamp(team_id=-1), "2012-01-09T00:00:00+00:00")


### PR DESCRIPTION
Fixes sentry error: https://sentry.io/organizations/posthog/issues/2140049760/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&sort=freq&statsPeriod=14d

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
