### PR TITLE
Avoid erroring when loading dashboards with no active project

### DIFF
--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -18,8 +18,12 @@ export const dashboardsModel = kea({
             {},
             {
                 loadDashboards: async () => {
-                    const { results } = await api.get('api/dashboard')
-                    return idToKey(results)
+                    try {
+                        const { results } = await api.get('api/dashboard')
+                        return idToKey(results)
+                    } catch {
+                        return {}
+                    }
                 },
             },
         ],

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -12,7 +12,7 @@ from django.utils.timezone import now
 from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework import authentication, response, serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 
@@ -120,6 +120,8 @@ class DashboardsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
         if self.request.GET.get("share_token"):
             return queryset.filter(share_token=self.request.GET["share_token"])
+        elif self.request.user.is_authenticated and not self.request.user.team:
+            raise NotFound()
         elif not self.request.user.is_authenticated or "team_id" not in self.get_parents_query_dict():
             raise AuthenticationFailed(detail="You're not logged in, but also not using add share_token.")
 
@@ -135,8 +137,7 @@ class DashboardsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         return response.Response(serializer.data)
 
     def get_parents_query_dict(self) -> Dict[str, Any]:  # to be moved to a separate Legacy*ViewSet Class
-
-        if not self.request.user.is_authenticated or "share_token" in self.request.GET:
+        if not self.request.user.is_authenticated or "share_token" in self.request.GET or not self.request.user.team:
             return {}
         return {"team_id": self.request.user.team.id}
 

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -60,6 +60,15 @@ class TestDashboard(TransactionBaseTest):
         dashboard = Dashboard.objects.get(pk=dashboard.pk)
         self.assertIsNotNone(dashboard.share_token)
 
+    def test_no_team_dashboards_list(self):
+        self.team.delete()
+
+        response = self.client.get("/api/dashboard/")
+        self.assertDictEqual(
+            response.json(), {"attr": None, "code": "not_found", "detail": "Not found.", "type": "invalid_request",},
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_return_cached_results(self):
         dashboard = Dashboard.objects.create(team=self.team, name="dashboard")
         filter_dict = {


### PR DESCRIPTION
Related sentry error: https://sentry.io/organizations/posthog/issues/2070730230/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
