### PR TITLE
Add missing `await`s to breakpoint(X) calls

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -156,11 +156,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             posthog.capture('viewed dashboard', properties)
         },
         reportBookmarkletDragged: async (_, breakpoint) => {
-            breakpoint(500)
+            await breakpoint(500)
             posthog.capture('bookmarklet drag start')
         },
         reportIngestionBookmarkletCollapsible: async ({ activePanels }: { activePanels: string[] }, breakpoint) => {
-            breakpoint(500)
+            await breakpoint(500)
             const action = activePanels.includes('bookmarklet') ? 'shown' : 'hidden'
             posthog.capture(`ingestion bookmarklet panel ${action}`)
         },


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/2185594460/?project=1899813&query=is%3Aunresolved+is%3Aunassigned+kea&statsPeriod=14d

According to marius, breakpoint() can be called without await, but when
passing milliseconds await is always needed.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
