### PR TITLE
Update posthog-js 1.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "kea-router": "^0.5.1",
         "kea-window-values": "^0.0.1",
         "moment": "^2.24.0",
-        "posthog-js": "1.8.3",
+        "posthog-js": "^1.8.6",
         "posthog-js-lite": "^0.0.3",
         "posthog-react-rrweb-player": "^1.0.12",
         "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8575,10 +8575,10 @@ posthog-js-lite@^0.0.3:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.3.tgz#87e373706227a849c4e7c6b0cb2066a64ad5b6ed"
   integrity sha512-wEOs8DEjlFBwgd7l19grosaF7mTlliZ9G9pL0Qji189FDg2ukY5IegUxTyTs7gsTGt6WK9W47BF5yXA5+bwvZg==
 
-posthog-js@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.8.3.tgz#cafe8a4a8cb9ab86e105f99bdc747fa8b51e9045"
-  integrity sha512-2O/rKQrfnSgQzGFU6E3/EM2je6o8FXbErbYZh6T2bOTSNGs6sB+lDogjwrCjPo/rcH83LIMBP8l4caVMhU3GPg==
+posthog-js@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.8.6.tgz#62dba716bf5f008859e25238d432df5fa72d5218"
+  integrity sha512-wT6+J2/Mms5Yqb0l9/oaL7XBrXS4U7gVk64vHHn6/wfaUgjDTc4WIDSqvNz9aE5J+S8aEPugMcptJdR6m/LOPw==
   dependencies:
     fflate "^0.4.1"
 


### PR DESCRIPTION
## Changes

bump version to 1.8.6, includes changes to identify to stop people identifying as the users they log in as

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
