### PR TITLE
Remove any loaders errors

### DIFF
--- a/frontend/src/initKea.tsx
+++ b/frontend/src/initKea.tsx
@@ -12,7 +12,8 @@ export function initKea(): void {
             routerPlugin,
             loadersPlugin({
                 onFailure({ error }: { error: any }) {
-                    ;(window as any).Sentry ? (window as any).Sentry.captureException(error) : console.error(error)
+
+                    (window as any).Sentry ? (window as any).Sentry.captureException(error) : console.error(error)
                 },
             }),
         ],

--- a/frontend/src/initKea.tsx
+++ b/frontend/src/initKea.tsx
@@ -3,9 +3,6 @@ import localStoragePlugin from 'kea-localstorage'
 import { routerPlugin } from 'kea-router'
 import { loadersPlugin } from 'kea-loaders'
 import { windowValuesPlugin } from 'kea-window-values'
-import { toast } from 'react-toastify'
-import React from 'react'
-import { identifierToHuman } from 'lib/utils'
 
 export function initKea(): void {
     resetContext({
@@ -14,16 +11,7 @@ export function initKea(): void {
             windowValuesPlugin({ window: window }),
             routerPlugin,
             loadersPlugin({
-                onFailure({ error, reducerKey, actionKey }) {
-                    toast.error(
-                        <div>
-                            <h1>Error on {identifierToHuman(reducerKey)}</h1>
-                            <p>
-                                Attempting to {identifierToHuman(actionKey, false)} returned an error:{' '}
-                                <span className="error-details">{error.detail || 'Unknown exception.'}</span>
-                            </p>
-                        </div>
-                    )
+                onFailure({ error }) {
                     window['Sentry'] ? window['Sentry'].captureException(error) : console.error(error)
                 },
             }),

--- a/frontend/src/initKea.tsx
+++ b/frontend/src/initKea.tsx
@@ -12,8 +12,11 @@ export function initKea(): void {
             routerPlugin,
             loadersPlugin({
                 onFailure({ error }: { error: any }) {
-
-                    (window as any).Sentry ? (window as any).Sentry.captureException(error) : console.error(error)
+                    if ((window as any).Sentry) {
+                        ;(window as any).Sentry.captureException(error)
+                    } else {
+                        console.error(error)
+                    }
                 },
             }),
         ],

--- a/frontend/src/initKea.tsx
+++ b/frontend/src/initKea.tsx
@@ -11,8 +11,8 @@ export function initKea(): void {
             windowValuesPlugin({ window: window }),
             routerPlugin,
             loadersPlugin({
-                onFailure({ error }) {
-                    window['Sentry'] ? window['Sentry'].captureException(error) : console.error(error)
+                onFailure({ error }: { error: any }) {
+                    ;(window as any).Sentry ? (window as any).Sentry.captureException(error) : console.error(error)
                 },
             }),
         ],


### PR DESCRIPTION
## Changes

Our errors look really scary and are usually not that informative. Also often even if the error shows (most) of the app still works correctly. For any query related errors we now handle those differently. I'm proposing removing the toasts.

(Based on talking to a user who got scared off because he had some 'undefined' toasts pop up)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
