### PR TITLE
Don't blow up if funnel has no steps

### DIFF
--- a/ee/clickhouse/queries/clickhouse_funnel.py
+++ b/ee/clickhouse/queries/clickhouse_funnel.py
@@ -162,6 +162,9 @@ class ClickhouseFunnel(Funnel):
         return [serialized]
 
     def run(self, *args, **kwargs) -> List[Dict[str, Any]]:
+        if len(self._filter.entities) == 0:
+            return []
+
         if self._filter.display == TRENDS_LINEAR:
             return self._get_trends()
 

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -276,6 +276,9 @@ class Funnel(BaseQuery):
         return steps
 
     def run(self, *args, **kwargs) -> List[Dict[str, Any]]:
+        if len(self._filter.entities) == 0:
+            return []
+
         if self._filter.display == TRENDS_LINEAR:
             return self._get_trends()
 

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -169,10 +169,8 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 funnel.run()
 
         def test_funnel_no_events(self):
-            funnel = self._basic_funnel()
-
-            # with self.assertNumQueries(3):
-            funnel.run()
+            funnel = Funnel(filter=Filter(data={"some": "prop"}), team=self.team)
+            self.assertEqual(funnel.run(), [])
 
         def test_funnel_skipped_step(self):
             funnel = self._basic_funnel()


### PR DESCRIPTION
If funnel has no steps, we still send query from frontend despite
showing no results. While we could change frontend, we can also make the
query more robust.

Sentry: https://sentry.io/organizations/posthog/issues/2201253144/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
