### PR TITLE
Make action null safe

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -52,7 +52,10 @@ class ClickhouseEventsViewSet(EventViewSet):
         prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
 
         if request.GET.get("action_id"):
-            action = Action.objects.get(pk=request.GET["action_id"])
+            try:
+                action = Action.objects.get(pk=request.GET["action_id"])
+            except:
+                return []
             if action.steps.count() == 0:
                 return []
             action_query, params = format_action_filter(action)

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -53,7 +53,7 @@ class ClickhouseEventsViewSet(EventViewSet):
 
         if request.GET.get("action_id"):
             try:
-                action = Action.objects.get(pk=request.GET["action_id"])
+                action = Action.objects.get(pk=request.GET["action_id"], team_id=team.pk)
             except:
                 return []
             if action.steps.count() == 0:

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -54,7 +54,7 @@ class ClickhouseEventsViewSet(EventViewSet):
         if request.GET.get("action_id"):
             try:
                 action = Action.objects.get(pk=request.GET["action_id"], team_id=team.pk)
-            except:
+            except Action.DoesNotExist:
                 return []
             if action.steps.count() == 0:
                 return []


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes this https://sentry.io/organizations/posthog/issues/2139615280/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&sort=freq&statsPeriod=14d

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
