### PR TITLE
Upgrade plugin server to 0.7.4

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.7.3"
+        "@posthog/plugin-server": "0.7.4"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -62,10 +62,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.7.3.tgz#f0ef9fe71357f8b4ae1e23414c054ad65c49de46"
-  integrity sha512-EqZKoocK68d0kf0HlN7eHIgmrQBduWuzxx1wOkaroSa5h+A5AipOnbXD7aVUCge174vd7gBvebEdhNpBppsfcQ==
+"@posthog/plugin-server@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.7.4.tgz#f1c7ab3f72ce5cf5cf0c154766f2701b860794ca"
+  integrity sha512-uAnS/1uga7UsSQ3VTTq1LuvU7/FMjZSvrBhio6HXkltGC6EepJmfbCJJ7LmOAX6oRqGvjhGgEKH7h/uAKfVKuA==
   dependencies:
     "@google-cloud/bigquery" "^5.5.0"
     "@posthog/clickhouse" "^1.7.0"


### PR DESCRIPTION
## Changes

- https://github.com/PostHog/plugin-server/compare/v0.7.3...v0.7.4
- Rounds "created_at" to the nearest second when inserting to "person" table in clickhouse
- Hopefully fixes [this bug](https://sentry.io/organizations/posthog/issues/2202614650/?project=5592816&query=is%3Aunresolved)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
