### PR TITLE
Add selection option to plugin config

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -54,9 +54,18 @@ export function PluginDrawer(): JSX.Element {
     }, [editingPlugin?.id])
 
     const isValidChoiceConfig = (configField: PluginConfigChoice): boolean => {
+        /*
+            Checks, in order, that `choices`:
+            1. Exists   
+            2. Is an array or object
+            3. Is not an object 
+            4. Is not an empty array
+            5. Is an array of strings only
+        */
         const invalid =
             !configField.choices ||
-            !(configField.choices instanceof Array) ||
+            typeof configField.choices !== 'object' ||
+            JSON.stringify(configField.choices)[0] === '{' ||
             !configField.choices.length ||
             [...configField.choices].filter((choice) => typeof choice === 'string').length != configField.choices.length
         return !invalid
@@ -196,10 +205,7 @@ export function PluginDrawer(): JSX.Element {
                                                 <Input />
                                             ) : fieldConfig.type === 'choice' ? (
                                                 isValidChoiceConfig(fieldConfig) ? (
-                                                    <Select
-                                                        defaultValue={fieldConfig.choices?.[0]}
-                                                        dropdownMatchSelectWidth={false}
-                                                    >
+                                                    <Select dropdownMatchSelectWidth={false}>
                                                         {fieldConfig.choices.map((choice) => (
                                                             <Select.Option value={choice} key={choice}>
                                                                 {choice}

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -179,7 +179,7 @@ export function PluginDrawer(): JSX.Element {
                                                 <Input />
                                             ) : fieldConfig.type === 'choice' ? (
                                                 <Select
-                                                    defaultValue={fieldConfig.choices[0]}
+                                                    defaultValue={fieldConfig.choices?.[0]}
                                                     dropdownMatchSelectWidth={false}
                                                 >
                                                     {fieldConfig.choices.map((choice) => (

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -177,14 +177,14 @@ export function PluginDrawer(): JSX.Element {
                                                 <UploadField />
                                             ) : fieldConfig.type === 'string' ? (
                                                 <Input />
-                                            ) : fieldConfig.type === 'selection' ? (
+                                            ) : fieldConfig.type === 'choice' ? (
                                                 <Select
-                                                    defaultValue={fieldConfig.options[0]}
+                                                    defaultValue={fieldConfig.choices[0]}
                                                     dropdownMatchSelectWidth={false}
                                                 >
-                                                    {fieldConfig.options.map((option) => (
-                                                        <Select.Option value={option} key={option}>
-                                                            {option}
+                                                    {fieldConfig.choices.map((choice) => (
+                                                        <Select.Option value={choice} key={choice}>
+                                                            {choice}
                                                         </Select.Option>
                                                     ))}
                                                 </Select>

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
-import { Button, Form, Input, Popconfirm, Switch } from 'antd'
+import { Button, Form, Input, Popconfirm, Select, Switch } from 'antd'
 import { DeleteOutlined, CodeOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from 'scenes/plugins/plugin/PluginImage'
@@ -177,6 +177,17 @@ export function PluginDrawer(): JSX.Element {
                                                 <UploadField />
                                             ) : fieldConfig.type === 'string' ? (
                                                 <Input />
+                                            ) : fieldConfig.type === 'selection' ? (
+                                                <Select
+                                                    defaultValue={fieldConfig.options[0]}
+                                                    dropdownMatchSelectWidth={false}
+                                                >
+                                                    {fieldConfig.options.map((option) => (
+                                                        <Select.Option value={option} key={option}>
+                                                            {option}
+                                                        </Select.Option>
+                                                    ))}
+                                                </Select>
                                             ) : (
                                                 <strong style={{ color: 'var(--red)' }}>
                                                     Unknown field type "<code>{fieldConfig.type}</code>".

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@babel/core": "^7.10.4",
         "@babel/runtime": "^7.10.4",
         "@papercups-io/chat-widget": "^1.1.5",
-        "@posthog/plugin-scaffold": "0.2.10",
+        "@posthog/plugin-scaffold": "0.2.11",
         "@posthog/simmerjs": "0.7.2-posthog.2",
         "@sentry/browser": "^6.0.4",
         "antd": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@babel/core": "^7.10.4",
         "@babel/runtime": "^7.10.4",
         "@papercups-io/chat-widget": "^1.1.5",
-        "@posthog/plugin-scaffold": "0.2.11",
+        "@posthog/plugin-scaffold": "0.2.12",
         "@posthog/simmerjs": "0.7.2-posthog.2",
         "@sentry/browser": "^6.0.4",
         "antd": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@babel/core": "^7.10.4",
         "@babel/runtime": "^7.10.4",
         "@papercups-io/chat-widget": "^1.1.5",
-        "@posthog/plugin-scaffold": "0.2.6",
+        "@posthog/plugin-scaffold": "0.2.10",
         "@posthog/simmerjs": "0.7.2-posthog.2",
         "@sentry/browser": "^6.0.4",
         "antd": "^4.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,10 +1331,10 @@
     theme-ui "^0.3.1"
     tinycolor2 "^1.4.1"
 
-"@posthog/plugin-scaffold@0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.6.tgz#5e27067e19ce42a78b67fbbafc001f816ccb0c70"
-  integrity sha512-W4Ata+n1Zsb+yAVlAQv3OEuHOmwz3Fp6en9iXq5dNNM0gxFoYtKAhzITvz7idAvIy15sa2244E8itSTbqEzzKA==
+"@posthog/plugin-scaffold@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.10.tgz#aa6e5232a1a4af55d1f1a7305345407e436c2153"
+  integrity sha512-0p5U1GBEFPko+UmtSbjVQ0wbIrk8tj8el6qUt6yHKImqD1pMyYKCDRqr5gjrXSgwa37/L2CDbmzvilwVsaF9EA==
 
 "@posthog/simmerjs@0.7.2-posthog.2":
   version "0.7.2-posthog.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,10 +1331,10 @@
     theme-ui "^0.3.1"
     tinycolor2 "^1.4.1"
 
-"@posthog/plugin-scaffold@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.10.tgz#aa6e5232a1a4af55d1f1a7305345407e436c2153"
-  integrity sha512-0p5U1GBEFPko+UmtSbjVQ0wbIrk8tj8el6qUt6yHKImqD1pMyYKCDRqr5gjrXSgwa37/L2CDbmzvilwVsaF9EA==
+"@posthog/plugin-scaffold@0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.11.tgz#f4f04d9eefd346d307a1580768eafb1a5276ae2a"
+  integrity sha512-vE/oV+8B0uIpFdNvSD0VTmV68tdIM+O0s9uu/HO0X73eyHe4DHwuMLdlzuy2RNTqTUTI4o8UkYEmQZcShnionQ==
 
 "@posthog/simmerjs@0.7.2-posthog.2":
   version "0.7.2-posthog.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,10 +1331,10 @@
     theme-ui "^0.3.1"
     tinycolor2 "^1.4.1"
 
-"@posthog/plugin-scaffold@0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.11.tgz#f4f04d9eefd346d307a1580768eafb1a5276ae2a"
-  integrity sha512-vE/oV+8B0uIpFdNvSD0VTmV68tdIM+O0s9uu/HO0X73eyHe4DHwuMLdlzuy2RNTqTUTI4o8UkYEmQZcShnionQ==
+"@posthog/plugin-scaffold@0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.12.tgz#3fc54881030ad6a51549e04f1d725644a1d1e0d5"
+  integrity sha512-MhTK21NvIokMCo4MdJ4iEwjRj/vMG73ucRQtpBmBqZNd1wvy9C7HMFyHmR0uxz1RsT3SCPWuuj1HDvoJsb+QQw==
 
 "@posthog/simmerjs@0.7.2-posthog.2":
   version "0.7.2-posthog.2"


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Allows the plugin config to specify a selection of valid values for the user to pick from:

<img width="416" alt="Screenshot 2021-02-07 at 12 51 14" src="https://user-images.githubusercontent.com/38760734/107146950-3baf4680-6943-11eb-9251-661961c7b400.png">

Currently just using strings so no backend changes needed. 

Would need to bump the version for `@posthog/plugin-scaffold` package once https://github.com/PostHog/plugin-scaffold/pull/7 gets in to get rid of TS errors.


Also see https://github.com/PostHog/taxonomy-plugin/pull/1 for an implementation of this.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
