### PR TITLE
Improve project deletion

### DIFF
--- a/frontend/src/scenes/project/CreateProjectModal.tsx
+++ b/frontend/src/scenes/project/CreateProjectModal.tsx
@@ -80,7 +80,7 @@ export function CreateProjectModal({
                     }}
                 />
             </div>
-            {errorMessage && <Alert message={errorMessage} type="error" style={{ marginTop: '1rem' }} />}
+            {errorMessage && <Alert message={errorMessage} type="error" />}
         </Modal>
     )
 }

--- a/frontend/src/scenes/project/Settings/DangerZone.tsx
+++ b/frontend/src/scenes/project/Settings/DangerZone.tsx
@@ -24,10 +24,7 @@ export function DangerZone(): JSX.Element {
                 'data-attr': 'delete-project-ok',
             },
             cancelText: 'Cancel',
-            onOk() {
-                deleteCurrentTeam()
-                location.reload()
-            },
+            onOk: deleteCurrentTeam,
         })
     }
 

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -2,6 +2,7 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { teamLogicType } from './teamLogicType'
 import { TeamType } from '~/types'
+import { toast } from 'react-toastify'
 
 export const teamLogic = kea<teamLogicType<TeamType>>({
     actions: {
@@ -29,7 +30,9 @@ export const teamLogic = kea<teamLogicType<TeamType>>({
     listeners: ({ values }) => ({
         deleteCurrentTeam: async () => {
             if (values.currentTeam) {
-                api.delete(`api/projects/${values.currentTeam.id}`)
+                toast('Deleting project...')
+                await api.delete(`api/projects/${values.currentTeam.id}`)
+                location.reload()
             }
         },
         createTeamSuccess: () => {


### PR DESCRIPTION
I noticed that we immediately reload after project gets deleted - before
the actual request completes and any data is deleted, making it seem it
did not work.

This fixes that, showing a toast while the request is outgoing.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
