### PR TITLE
Instrumentation Feb-8

### DIFF
--- a/frontend/src/layout/navigation/DemoWarnings.tsx
+++ b/frontend/src/layout/navigation/DemoWarnings.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Alert } from 'antd'
 import { StarOutlined, SettingOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { LinkButton } from 'lib/components/LinkButton'
 import { Link } from 'lib/components/Link'
 import { navigationLogic } from './navigationLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface WarningInterface {
     message: JSX.Element | string
@@ -25,6 +26,7 @@ interface WarningsInterface {
 export function DemoWarnings(): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { demoWarning } = useValues(navigationLogic)
+    const { reportDemoWarningDismissed } = useActions(eventUsageLogic)
 
     const WARNINGS: WarningsInterface = {
         welcome: {
@@ -124,6 +126,7 @@ export function DemoWarnings(): JSX.Element | null {
                 action={WARNINGS[demoWarning].action}
                 closable
                 style={{ marginTop: 32 }}
+                onClose={() => reportDemoWarningDismissed(demoWarning)}
             />
         </>
     )

--- a/frontend/src/lib/components/RadioSelect/index.tsx
+++ b/frontend/src/lib/components/RadioSelect/index.tsx
@@ -13,6 +13,7 @@ interface RadioSelectProps {
     options: RadioSelectType[]
     selectedOption: null | string | string[]
     onOptionChanged: (key: string | string[] | null) => void
+    identifier: string // main identifier for the component (to support autocapture)
     multipleSelection?: boolean
     focusSelection?: boolean // will hide other choices after making a selection
 }
@@ -21,6 +22,7 @@ export function RadioSelect({
     options,
     selectedOption,
     onOptionChanged,
+    identifier,
     multipleSelection,
     focusSelection,
 }: RadioSelectProps): JSX.Element {
@@ -72,6 +74,8 @@ export function RadioSelect({
                                 className={`radio-option${isSelected(option) ? ' active' : ''}`}
                                 key={option.key}
                                 onClick={() => handleClick(option)}
+                                data-attr={`radio-select-${identifier}`}
+                                data-detail={`radio-select-${identifier}-${option.key}`}
                             >
                                 <div className="graphic">{option.icon}</div>
                                 <div className="label">{option.label}</div>

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -20,6 +20,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
         reportProjectCreationSubmitted: (projectCount, nameLength) => ({ projectCount, nameLength }),
         reportDemoWarningDismissed: (key) => ({ key }),
         reportOnboardingStepTriggered: (stepKey, extra_args) => ({ stepKey, extra_args }),
+        reportBulkInviteAttempted: (inviteesCount, namesCount) => ({ inviteesCount, namesCount }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }: { annotations: AnnotationType[] | null }, breakpoint) => {
@@ -190,6 +191,16 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
         }) => {
             // Fired after the user attempts to start an onboarding step (e.g. clicking on create project)
             posthog.capture('onboarding step triggered', { step: stepKey, ...extra_args })
+        },
+        reportBulkInviteAttempted: async ({
+            inviteesCount,
+            namesCount,
+        }: {
+            inviteesCount: number
+            namesCount: number
+        }) => {
+            // namesCount -> Number of invitees for which a name was provided
+            posthog.capture('bulk invite attempted', { invitees_count: inviteesCount, name_count: namesCount })
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -21,6 +21,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
         reportDemoWarningDismissed: (key) => ({ key }),
         reportOnboardingStepTriggered: (stepKey, extra_args) => ({ stepKey, extra_args }),
         reportBulkInviteAttempted: (inviteesCount, namesCount) => ({ inviteesCount, namesCount }),
+        reportInviteAttempted: (nameProvided, instanceEmailAvailable) => ({ nameProvided, instanceEmailAvailable }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }: { annotations: AnnotationType[] | null }, breakpoint) => {
@@ -201,6 +202,18 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
         }) => {
             // namesCount -> Number of invitees for which a name was provided
             posthog.capture('bulk invite attempted', { invitees_count: inviteesCount, name_count: namesCount })
+        },
+        reportInviteAttempted: async ({
+            nameProvided,
+            instanceEmailAvailable,
+        }: {
+            nameProvided: boolean
+            instanceEmailAvailable: boolean
+        }) => {
+            posthog.capture('team invite attempted', {
+                name_provided: nameProvided,
+                instance_email_available: instanceEmailAvailable,
+            })
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -13,7 +13,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<AnnotationType, FilterTyp
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
-        reportInsightViewed: (filters: FilterType, isFirstLoad: boolean) => ({ filters, isFirstLoad }),
+        reportInsightViewed: (filters: Partial<FilterType>, isFirstLoad: boolean) => ({ filters, isFirstLoad }),
         reportDashboardViewed: (dashboard: DashboardType, hasShareToken: boolean) => ({ dashboard, hasShareToken }),
         reportBookmarkletDragged: true,
         reportIngestionBookmarkletCollapsible: (activePanels: string[]) => ({ activePanels }),

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -9,22 +9,28 @@ import { ViewType } from 'scenes/insights/insightLogic'
 
 const keyMappingKeys = Object.keys(keyMapping.event)
 
-export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
+export const eventUsageLogic = kea<eventUsageLogicType<AnnotationType, FilterType, DashboardType, PersonType>>({
     actions: {
-        reportAnnotationViewed: (annotations) => ({ annotations }),
+        reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
-        reportInsightViewed: (filters, isFirstLoad) => ({ filters, isFirstLoad }),
-        reportDashboardViewed: (dashboard, hasShareToken) => ({ dashboard, hasShareToken }),
-        reportBookmarkletDragged: () => true,
-        reportIngestionBookmarkletCollapsible: (activePanels) => ({ activePanels }),
-        reportProjectCreationSubmitted: (projectCount, nameLength) => ({ projectCount, nameLength }),
-        reportDemoWarningDismissed: (key) => ({ key }),
-        reportOnboardingStepTriggered: (stepKey, extra_args) => ({ stepKey, extra_args }),
-        reportBulkInviteAttempted: (inviteesCount, namesCount) => ({ inviteesCount, namesCount }),
-        reportInviteAttempted: (nameProvided, instanceEmailAvailable) => ({ nameProvided, instanceEmailAvailable }),
+        reportInsightViewed: (filters: FilterType, isFirstLoad: boolean) => ({ filters, isFirstLoad }),
+        reportDashboardViewed: (dashboard: DashboardType, hasShareToken: boolean) => ({ dashboard, hasShareToken }),
+        reportBookmarkletDragged: true,
+        reportIngestionBookmarkletCollapsible: (activePanels: string[]) => ({ activePanels }),
+        reportProjectCreationSubmitted: (projectCount: number, nameLength: number) => ({ projectCount, nameLength }),
+        reportDemoWarningDismissed: (key: string) => ({ key }),
+        reportOnboardingStepTriggered: (stepKey: string, extra_args: Record<string, string | number | boolean>) => ({
+            stepKey,
+            extra_args,
+        }),
+        reportBulkInviteAttempted: (inviteesCount: number, namesCount: number) => ({ inviteesCount, namesCount }),
+        reportInviteAttempted: (nameProvided: boolean, instanceEmailAvailable: boolean) => ({
+            nameProvided,
+            instanceEmailAvailable,
+        }),
     },
     listeners: {
-        reportAnnotationViewed: async ({ annotations }: { annotations: AnnotationType[] | null }, breakpoint) => {
+        reportAnnotationViewed: async ({ annotations }, breakpoint) => {
             if (!annotations) {
                 // If value is `null` the component has been unmounted, don't report
                 return
@@ -70,10 +76,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
             }
             posthog.capture('person viewed', properties)
         },
-        reportInsightViewed: async (
-            { filters, isFirstLoad }: { filters: FilterType; isFirstLoad: boolean },
-            breakpoint
-        ) => {
+        reportInsightViewed: async ({ filters, isFirstLoad }, breakpoint) => {
             await breakpoint(500) // Debounce to avoid noisy events from changing filters multiple times
 
             // Reports `insight viewed` event
@@ -130,10 +133,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
 
             posthog.capture('insight viewed', properties)
         },
-        reportDashboardViewed: async (
-            { dashboard, hasShareToken }: { hasShareToken: boolean; dashboard: DashboardType },
-            breakpoint
-        ) => {
+        reportDashboardViewed: async ({ dashboard, hasShareToken }, breakpoint) => {
             await breakpoint(500) // Debounce to avoid noisy events from continuous navigation
             const { created_at, name, is_shared, pinned } = dashboard
             const properties: Record<string, any> = {
@@ -163,8 +163,8 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
             await breakpoint(500)
             posthog.capture('bookmarklet drag start')
         },
-        reportIngestionBookmarkletCollapsible: async ({ activePanels }: { activePanels: string[] }, breakpoint) => {
-            await breakpoint(500)
+        reportIngestionBookmarkletCollapsible: async ({ activePanels }, breakpoint) => {
+            breakpoint(500)
             const action = activePanels.includes('bookmarklet') ? 'shown' : 'hidden'
             posthog.capture(`ingestion bookmarklet panel ${action}`)
         },
@@ -180,16 +180,10 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
                 name_length: nameLength,
             })
         },
-        reportDemoWarningDismissed: async ({ key }: { key: string }) => {
+        reportDemoWarningDismissed: async ({ key }) => {
             posthog.capture('demo warning dismissed', { warning_key: key })
         },
-        reportOnboardingStepTriggered: async ({
-            stepKey,
-            extra_args,
-        }: {
-            stepKey: string
-            extra_args?: Record<string, any>
-        }) => {
+        reportOnboardingStepTriggered: async ({ stepKey, extra_args }) => {
             // Fired after the user attempts to start an onboarding step (e.g. clicking on create project)
             posthog.capture('onboarding step triggered', { step: stepKey, ...extra_args })
         },
@@ -203,13 +197,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
             // namesCount -> Number of invitees for which a name was provided
             posthog.capture('bulk invite attempted', { invitees_count: inviteesCount, name_count: namesCount })
         },
-        reportInviteAttempted: async ({
-            nameProvided,
-            instanceEmailAvailable,
-        }: {
-            nameProvided: boolean
-            instanceEmailAvailable: boolean
-        }) => {
+        reportInviteAttempted: async ({ nameProvided, instanceEmailAvailable }) => {
             posthog.capture('team invite attempted', {
                 name_provided: nameProvided,
                 instance_email_available: instanceEmailAvailable,

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -19,6 +19,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
         reportIngestionBookmarkletCollapsible: (activePanels) => ({ activePanels }),
         reportProjectCreationSubmitted: (projectCount, nameLength) => ({ projectCount, nameLength }),
         reportDemoWarningDismissed: (key) => ({ key }),
+        reportOnboardingStepTriggered: (stepKey, extra_args) => ({ stepKey, extra_args }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }: { annotations: AnnotationType[] | null }, breakpoint) => {
@@ -178,7 +179,17 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
             })
         },
         reportDemoWarningDismissed: async ({ key }: { key: string }) => {
-            posthog.capture('demo warning dismessed', { warning_key: key })
+            posthog.capture('demo warning dismissed', { warning_key: key })
+        },
+        reportOnboardingStepTriggered: async ({
+            stepKey,
+            extra_args,
+        }: {
+            stepKey: string
+            extra_args?: Record<string, any>
+        }) => {
+            // Fired after the user attempts to start an onboarding step (e.g. clicking on create project)
+            posthog.capture('onboarding step triggered', { step: stepKey, ...extra_args })
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -18,6 +18,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
         reportBookmarkletDragged: () => true,
         reportIngestionBookmarkletCollapsible: (activePanels) => ({ activePanels }),
         reportProjectCreationSubmitted: (projectCount, nameLength) => ({ projectCount, nameLength }),
+        reportDemoWarningDismissed: (key) => ({ key }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }: { annotations: AnnotationType[] | null }, breakpoint) => {
@@ -175,6 +176,9 @@ export const eventUsageLogic = kea<eventUsageLogicType<PersonType>>({
                 current_project_count: projectCount,
                 name_length: nameLength,
             })
+        },
+        reportDemoWarningDismissed: async ({ key }: { key: string }) => {
+            posthog.capture('demo warning dismessed', { warning_key: key })
         },
     },
 })

--- a/frontend/src/scenes/ingestion/panels/AutocapturePanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/AutocapturePanel.tsx
@@ -16,6 +16,15 @@ export function AutocapturePanel(): JSX.Element {
     const { setPlatform, setVerify } = useActions(ingestionLogic)
     const { user } = useValues(userLogic)
     const { reportIngestionBookmarkletCollapsible } = useActions(eventUsageLogic)
+
+    const handlePanelChange = (shownPanels: string | string[]): void => {
+        if (typeof shownPanels === 'string') {
+            reportIngestionBookmarkletCollapsible([shownPanels])
+        } else {
+            reportIngestionBookmarkletCollapsible(shownPanels)
+        }
+    }
+
     return (
         <CardContainer
             index={index}
@@ -25,7 +34,7 @@ export function AutocapturePanel(): JSX.Element {
             onBack={() => setPlatform(null)}
         >
             {user?.team && (
-                <Collapse onChange={(shownPanels) => reportIngestionBookmarkletCollapsible(shownPanels)}>
+                <Collapse onChange={handlePanelChange}>
                     <Collapse.Panel
                         header={
                             <>

--- a/frontend/src/scenes/onboarding/OnboardingSetup.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingSetup.tsx
@@ -23,6 +23,7 @@ import { userLogic } from 'scenes/userLogic'
 import { BulkInviteModal } from 'scenes/organization/TeamMembers/BulkInviteModal'
 import { LinkButton } from 'lib/components/LinkButton'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 const { Panel } = Collapse
 
@@ -36,7 +37,7 @@ function PanelHeader({
     stepNumber: number
 }): JSX.Element {
     return (
-        <div className="panel-title">
+        <div className="panel-title" data-attr={`setup-header-${stepNumber}`}>
             <div className="step-number">{stepNumber}</div>
             <div>
                 <h3 className="l3">{title}</h3>
@@ -56,6 +57,7 @@ function OnboardingStep({
     handleClick,
     caption,
     customActionElement,
+    analyticsExtraArgs,
 }: {
     label?: string
     title?: string
@@ -66,6 +68,7 @@ function OnboardingStep({
     handleClick?: () => void
     caption?: JSX.Element | string
     customActionElement?: JSX.Element
+    analyticsExtraArgs?: Record<string, any>
 }): JSX.Element {
     const actionElement = (
         <>
@@ -76,11 +79,20 @@ function OnboardingStep({
             )}
         </>
     )
+    const { reportOnboardingStepTriggered } = useActions(eventUsageLogic)
+
+    const onClick = (): void => {
+        if (disabled || completed || !handleClick) {
+            return
+        }
+        reportOnboardingStepTriggered(identifier, analyticsExtraArgs)
+        handleClick()
+    }
 
     return (
         <div
             className={`onboarding-step${disabled ? ' disabled' : ''}${completed ? ' completed' : ''}`}
-            onClick={() => !disabled && !completed && handleClick && handleClick()}
+            onClick={onClick}
             data-attr="onboarding-setup-step"
             data-step={identifier}
         >
@@ -230,6 +242,9 @@ function _OnboardingSetup(): JSX.Element {
                                             />
                                         </div>
                                     }
+                                    analyticsExtraArgs={{
+                                        new_session_recording_enabled: !user?.team?.session_recording_opt_in,
+                                    }}
                                 />
                                 <OnboardingStep
                                     title="Join us on Slack"
@@ -266,6 +281,7 @@ function _OnboardingSetup(): JSX.Element {
                                     type="default"
                                     onClick={completeOnboarding}
                                     loading={currentOrganizationLoading}
+                                    data-attr="onboarding-setup-complete"
                                 >
                                     Finish setup
                                 </Button>

--- a/frontend/src/scenes/onboarding/OnboardingSetup.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingSetup.tsx
@@ -57,7 +57,7 @@ function OnboardingStep({
     handleClick,
     caption,
     customActionElement,
-    analyticsExtraArgs,
+    analyticsExtraArgs = {},
 }: {
     label?: string
     title?: string
@@ -68,7 +68,7 @@ function OnboardingStep({
     handleClick?: () => void
     caption?: JSX.Element | string
     customActionElement?: JSX.Element
-    analyticsExtraArgs?: Record<string, any>
+    analyticsExtraArgs?: Record<string, string | number | boolean>
 }): JSX.Element {
     const actionElement = (
         <>

--- a/frontend/src/scenes/onboarding/Personalization.tsx
+++ b/frontend/src/scenes/onboarding/Personalization.tsx
@@ -43,6 +43,7 @@ function _Personalization(): JSX.Element {
                             1. <b>Your role</b> at company is (or closest to)
                         </div>
                         <RadioSelect
+                            identifier="personalization-role"
                             options={ROLES}
                             selectedOption={personalizationData.role}
                             onOptionChanged={(value) => {
@@ -61,6 +62,7 @@ function _Personalization(): JSX.Element {
                             2. Are you <b>technical</b>? (i.e. coding/developer expertise)
                         </div>
                         <RadioSelect
+                            identifier="personalization-technical"
                             options={IS_TECHNICAL}
                             selectedOption={personalizationData.technical}
                             onOptionChanged={(value) => appendPersonalizationData('technical', value)}
@@ -74,6 +76,7 @@ function _Personalization(): JSX.Element {
                         </div>
 
                         <RadioSelect
+                            identifier="personalization-products"
                             options={PRODUCTS}
                             selectedOption={personalizationData.products}
                             onOptionChanged={(value) => appendPersonalizationData('products', value)}

--- a/frontend/src/scenes/onboarding/personalizationLogic.ts
+++ b/frontend/src/scenes/onboarding/personalizationLogic.ts
@@ -33,7 +33,7 @@ export const personalizationLogic = kea<personalizationLogicType<Personalization
         },
         reportPersonalization: async ({ payload, step_completed_fully }) => {
             posthog.people.set_once(payload)
-            posthog.capture('personalization completed', {
+            posthog.capture('personalization finalized', {
                 step_completed_fully,
                 payload,
                 number_of_answers: Object.keys(payload).length,

--- a/frontend/src/scenes/organization/TeamMembers/BulkInviteModal.tsx
+++ b/frontend/src/scenes/organization/TeamMembers/BulkInviteModal.tsx
@@ -15,7 +15,7 @@ function InviteRow({ index }: { index: number }): JSX.Element {
     const name = PLACEHOLDER_NAMES[index % 2]
 
     const { invites } = useValues(bulkInviteLogic)
-    const { updateInviteAtIndex } = useActions(bulkInviteLogic)
+    const { updateInviteAtIndex, inviteTeamMembers } = useActions(bulkInviteLogic)
 
     return (
         <Row gutter={16} className="invite-row">
@@ -33,6 +33,11 @@ function InviteRow({ index }: { index: number }): JSX.Element {
                         updateInviteAtIndex({ email: e.target.value, isValid }, index)
                     }}
                     value={invites[index].email}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            inviteTeamMembers()
+                        }
+                    }}
                 />
             </Col>
             <Col xs={12}>
@@ -40,6 +45,11 @@ function InviteRow({ index }: { index: number }): JSX.Element {
                     placeholder={name}
                     onChange={(e) => {
                         updateInviteAtIndex({ first_name: e.target.value }, index)
+                    }}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            inviteTeamMembers()
+                        }
                     }}
                 />
             </Col>

--- a/frontend/src/scenes/organization/TeamMembers/bulkInviteLogic.ts
+++ b/frontend/src/scenes/organization/TeamMembers/bulkInviteLogic.ts
@@ -4,6 +4,7 @@ import { OrganizationInviteType } from '~/types'
 import api from 'lib/api'
 import { toast } from 'react-toastify'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface InviteType {
     email: string
@@ -67,15 +68,22 @@ export const bulkInviteLogic = kea<bulkInviteLogicType<BulkInviteResponse, Invit
                         }
                         payload.invites.push({ target_email: invite.email, first_name: invite.first_name })
                     }
+
+                    eventUsageLogic.actions.reportBulkInviteAttempted(
+                        payload.invites.length,
+                        payload.invites.filter((invite) => !!invite.first_name).length
+                    )
+
                     return await api.create('api/organizations/@current/invites/bulk/', payload)
                 },
             },
         ],
     }),
-    listeners: ({ values }) => ({
+    listeners: ({ values, actions }) => ({
         inviteTeamMembersSuccess: (): void => {
             toast.success(`Invites sent to ${values.invitedTeamMembers.invites.length} new team members.`)
             organizationLogic.actions.loadCurrentOrganization()
+            actions.resetInvites()
         },
     }),
 })

--- a/frontend/src/scenes/organization/TeamMembers/invitesLogic.tsx
+++ b/frontend/src/scenes/organization/TeamMembers/invitesLogic.tsx
@@ -5,6 +5,8 @@ import { toast } from 'react-toastify'
 import { CheckCircleOutlined } from '@ant-design/icons'
 import { OrganizationInviteType } from '~/types'
 import { invitesLogicType } from './invitesLogicType'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { userLogic } from 'scenes/userLogic'
 
 export const invitesLogic = kea<invitesLogicType>({
     loaders: ({ values }) => ({
@@ -40,6 +42,12 @@ export const invitesLogic = kea<invitesLogicType>({
             },
         },
     }),
+    listeners: {
+        createInviteSuccess: async () => {
+            const nameProvided = false // TODO: Change when adding support for names on invites
+            eventUsageLogic.actions.reportInviteAttempted(nameProvided, userLogic.values.user?.email_service_available)
+        },
+    },
     events: ({ actions }) => ({
         afterMount: actions.loadInvites,
     }),

--- a/frontend/src/scenes/organization/TeamMembers/invitesLogic.tsx
+++ b/frontend/src/scenes/organization/TeamMembers/invitesLogic.tsx
@@ -45,7 +45,10 @@ export const invitesLogic = kea<invitesLogicType>({
     listeners: {
         createInviteSuccess: async () => {
             const nameProvided = false // TODO: Change when adding support for names on invites
-            eventUsageLogic.actions.reportInviteAttempted(nameProvided, userLogic.values.user?.email_service_available)
+            eventUsageLogic.actions.reportInviteAttempted(
+                nameProvided,
+                !!userLogic.values.user?.email_service_available
+            )
         },
     },
     events: ({ actions }) => ({

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -92,7 +92,7 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, Person
                     if (!response.results.length) {
                         router.actions.push('/404')
                     }
-                    const person: PersonType | null = response.results[0]
+                    const person = response.results[0] as PersonType
                     person && actions.reportPersonDetailViewed(person)
                     return person
                 },

--- a/frontend/src/scenes/project/CreateProjectModal.tsx
+++ b/frontend/src/scenes/project/CreateProjectModal.tsx
@@ -35,7 +35,7 @@ export function CreateProjectModal({
     const handleSubmit = (): void => {
         const name = inputRef.current?.state.value?.trim()
         if (name) {
-            reportProjectCreationSubmitted(user?.organization?.teams && user.organization.teams.length, name.length)
+            reportProjectCreationSubmitted(user?.organization?.teams ? user.organization.teams.length : 0, name.length)
             setErrorMessage(null)
             createTeam(name)
             closeModal()

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -130,6 +130,8 @@ export const userLogic = kea<userLogicType<UserType, EventProperty, UserUpdateTy
                             posthog_version: user.posthog_version,
                             has_slack_webhook: !!user.team?.slack_incoming_webhook,
                             is_demo_project: user.team?.is_demo,
+                            has_billing_plan: !!user.billing?.plan,
+                            // :TODO: Add percentage usage logic
                         })
                     }
                 }

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -129,6 +129,7 @@ export const userLogic = kea<userLogicType<UserType, EventProperty, UserUpdateTy
                         posthog.register({
                             posthog_version: user.posthog_version,
                             has_slack_webhook: !!user.team?.slack_incoming_webhook,
+                            is_demo_project: user.team?.is_demo,
                         })
                     }
                 }

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -82,8 +82,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
     def get_membership_level(self, organization: Organization) -> Optional[OrganizationMembership.Level]:
         membership = OrganizationMembership.objects.filter(
-            organization=organization,
-            user=self.context["request"].user,
+            organization=organization, user=self.context["request"].user,
         ).first()
         return membership.level if membership is not None else None
 
@@ -96,8 +95,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
         non_demo_team_id = next((team.pk for team in instance.teams.filter(is_demo=False)), None)
         any_project_ingested_events = instance.teams.filter(is_demo=False, ingested_event=True).exists()
         any_project_completed_snippet_onboarding = instance.teams.filter(
-            is_demo=False,
-            completed_snippet_onboarding=True,
+            is_demo=False, completed_snippet_onboarding=True,
         ).exists()
 
         current_section = 1
@@ -178,9 +176,7 @@ class OrganizationSignupSerializer(serializers.Serializer):
         company_name = validated_data.pop("company_name", validated_data["first_name"])
 
         self._organization, self._team, self._user = User.objects.bootstrap(
-            company_name=company_name,
-            create_team=self.create_team,
-            **validated_data,
+            company_name=company_name, create_team=self.create_team, **validated_data,
         )
         user = self._user
 
@@ -190,9 +186,7 @@ class OrganizationSignupSerializer(serializers.Serializer):
             self._organization.save()
 
         login(
-            self.context["request"],
-            user,
-            backend="django.contrib.auth.backends.ModelBackend",
+            self.context["request"], user, backend="django.contrib.auth.backends.ModelBackend",
         )
 
         report_user_signed_up(

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -7,7 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.user import UserSerializer
 from posthog.email import is_email_available
-from posthog.event_usage import report_bulk_invited
+from posthog.event_usage import report_bulk_invited, report_team_member_invited
 from posthog.models import OrganizationInvite, OrganizationMembership
 from posthog.permissions import OrganizationAdminWritePermissions, OrganizationMemberPermissions
 from posthog.tasks.email import send_invite
@@ -44,10 +44,26 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
             organization_id=self.context["organization_id"], created_by=self.context["request"].user, **validated_data,
         )
+
         if is_email_available(with_absolute_urls=True):
             invite.emailing_attempt_made = True
             send_invite.delay(invite_id=invite.id)
             invite.save()
+
+        if not self.context.get("bulk_create"):
+            report_team_member_invited(
+                self.context["request"].user.distinct_id,
+                name_provided=bool(validated_data.get("first_name")),
+                current_invite_count=OrganizationInvite.objects.filter(
+                    organization_id=self.context["organization_id"],
+                ).count()
+                - 1,
+                current_member_count=OrganizationMembership.objects.filter(
+                    organization_id=self.context["organization_id"],
+                ).count(),
+                email_available=is_email_available(),
+            )
+
         return invite
 
 
@@ -70,11 +86,13 @@ class BulkCreateOrganizationSerializer(serializers.Serializer):
 
         with transaction.atomic():
             for invite in validated_data["invites"]:
-                if invite["first_name"]:
-                    name_count = name_count + 1
+                self.context["bulk_create"] = True
                 serializer = OrganizationInviteSerializer(data=invite, context=self.context)
                 serializer.is_valid(raise_exception=False)  # Don't raise, already validated before
                 output.append(serializer.save())
+
+                if invite["first_name"]:  # For analytics
+                    name_count = name_count + 1
 
         report_bulk_invited(
             self.context["request"].user.distinct_id,
@@ -82,7 +100,7 @@ class BulkCreateOrganizationSerializer(serializers.Serializer):
             name_count=name_count,
             current_invite_count=current_invite_count,
             current_member_count=OrganizationMembership.objects.filter(
-                organization_id=self.context["organization_id"]
+                organization_id=self.context["organization_id"],
             ).count(),
             email_available=is_email_available(),
         )

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -193,7 +193,7 @@ class TestSignup(APIBaseTest):
                 "is_organization_first_user": True,
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationSignupSerializer",
-                "social_provider": "",
+                "signup_social_provider": "",
             },
         )
 
@@ -264,7 +264,7 @@ class TestSignup(APIBaseTest):
                 "is_organization_first_user": True,
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationSignupSerializer",
-                "social_provider": "",
+                "signup_social_provider": "",
             },
         )
 

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -1,4 +1,5 @@
 import random
+from unittest.mock import patch
 
 from django.core import mail
 from rest_framework import status
@@ -43,7 +44,10 @@ class TestOrganizationInvitesAPI(APIBaseTest):
 
     def test_add_organization_invite_with_email(self):
         email = "x@x.com"
-        response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
+
+        with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
+            response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(OrganizationInvite.objects.exists())
         response_data = response.json()
@@ -62,7 +66,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
                     "first_name": self.user.first_name,
                 },
                 "is_expired": False,
-                "emailing_attempt_made": False,
+                "emailing_attempt_made": True,
             },
         )
 
@@ -92,7 +96,8 @@ class TestOrganizationInvitesAPI(APIBaseTest):
 
     # Bulk create invites
 
-    def test_allow_bulk_creating_invites(self):
+    @patch("posthoganalytics.capture")
+    def test_allow_bulk_creating_invites(self, mock_capture):
         count = OrganizationInvite.objects.count()
         payload = self.helper_generate_bulk_invite_payload(7)
 
@@ -118,6 +123,19 @@ class TestOrganizationInvitesAPI(APIBaseTest):
 
         # Emails should be sent
         self.assertEqual(len(mail.outbox), 7)
+
+        # Assert capture was called
+        mock_capture.assert_called_once_with(
+            self.user.distinct_id,
+            "bulk invite executed",
+            properties={
+                "invitee_count": 7,
+                "name_count": len(list(filter(lambda x: bool(x["first_name"]), payload))),
+                "current_invite_count": 0,
+                "current_member_count": 1,
+                "email_available": True,
+            },
+        )
 
     def test_maximum_20_invites_per_request(self):
         count = OrganizationInvite.objects.count()

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -146,7 +146,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
             "bulk invite executed",
             properties={
                 "invitee_count": 7,
-                "name_count": len(list(filter(lambda x: bool(x["first_name"]), payload))),
+                "name_count": sum(1 for user in payload if user["first_name"]),
                 "current_invite_count": 0,
                 "current_member_count": 1,
                 "email_available": True,

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -153,5 +153,9 @@ class TestUserAPI(APITransactionBaseTest):
                 "organization_id": str(self.organization.id),
                 "project_id": str(self.team.uuid),
                 "project_setup_complete": False,
+                "joined_at": self.user.date_joined,
+                "has_password_set": True,
+                "has_social_auth": False,
+                "social_providers": [],
             },
         )

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -39,9 +39,26 @@ def report_onboarding_completed(organization: Organization, current_user: User) 
     # TODO: This should be $set_once as user props.
     posthoganalytics.identify(current_user.distinct_id, {"onboarding_completed": True})
     posthoganalytics.capture(
-        current_user.distinct_id,
-        "onboarding completed",
+        current_user.distinct_id, "onboarding completed", properties={"team_members_count": team_members_count},
+    )
+
+
+def report_bulk_invited(
+    distinct_id: str,
+    invitee_count: int,
+    name_count: int,
+    current_invite_count: int,
+    current_member_count: int,
+    email_available: bool,
+) -> None:
+    posthoganalytics.capture(
+        distinct_id,
+        "bulk invite executed",
         properties={
-            "team_members_count": team_members_count,
+            "invitee_count": invitee_count,
+            "name_count": name_count,
+            "current_invite_count": current_invite_count,
+            "current_member_count": current_member_count,
+            "email_available": email_available,
         },
     )

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -21,7 +21,7 @@ def report_user_signed_up(
         "is_organization_first_user": is_organization_first_user,
         "new_onboarding_enabled": new_onboarding_enabled,
         "signup_backend_processor": backend_processor,
-        "social_provider": social_provider,
+        "signup_social_provider": social_provider,
     }
 
     # TODO: This should be $set_once as user props.

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -11,7 +11,7 @@ def report_user_signed_up(
     is_organization_first_user: bool,
     new_onboarding_enabled: bool = False,
     backend_processor: str = "",  # which serializer/view processed the request
-    login_provider: str = "",  # which third-party provider processed the login (empty = no third-party)
+    social_provider: str = "",  # which third-party provider processed the login (empty = no third-party)
 ) -> None:
 
     props = {
@@ -19,7 +19,7 @@ def report_user_signed_up(
         "is_organization_first_user": is_organization_first_user,
         "new_onboarding_enabled": new_onboarding_enabled,
         "signup_backend_processor": backend_processor,
-        "login_provider": login_provider,
+        "social_provider": social_provider,
     }
 
     # TODO: This should be $set_once as user props.

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -4,6 +4,8 @@ Module to centralize event reporting on the server-side.
 
 import posthoganalytics
 
+from posthog.models import Organization, User
+
 
 def report_user_signed_up(
     distinct_id: str,
@@ -25,3 +27,21 @@ def report_user_signed_up(
     # TODO: This should be $set_once as user props.
     posthoganalytics.identify(distinct_id, props)
     posthoganalytics.capture(distinct_id, "user signed up", properties=props)
+
+
+def report_onboarding_completed(organization: Organization, current_user: User) -> None:
+    """
+    Reports that the `new-onboarding-2822` has been completed.
+    """
+
+    team_members_count = organization.members.count()
+
+    # TODO: This should be $set_once as user props.
+    posthoganalytics.identify(current_user.distinct_id, {"onboarding_completed": True})
+    posthoganalytics.capture(
+        current_user.distinct_id,
+        "onboarding completed",
+        properties={
+            "team_members_count": team_members_count,
+        },
+    )

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -43,6 +43,21 @@ def report_onboarding_completed(organization: Organization, current_user: User) 
     )
 
 
+def report_team_member_invited(
+    distinct_id: str, name_provided: bool, current_invite_count: int, current_member_count: int, email_available: bool,
+) -> None:
+    posthoganalytics.capture(
+        distinct_id,
+        "team invite executed",
+        properties={
+            "name_provided": name_provided,
+            "current_invite_count": current_invite_count,
+            "current_member_count": current_member_count,
+            "email_available": email_available,
+        },
+    )
+
+
 def report_bulk_invited(
     distinct_id: str,
     invitee_count: int,

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -1,0 +1,27 @@
+"""
+Module to centralize event reporting on the server-side.
+"""
+
+import posthoganalytics
+
+
+def report_user_signed_up(
+    distinct_id: str,
+    is_instance_first_user: bool,
+    is_organization_first_user: bool,
+    new_onboarding_enabled: bool = False,
+    backend_processor: str = "",  # which serializer/view processed the request
+    login_provider: str = "",  # which third-party provider processed the login (empty = no third-party)
+) -> None:
+
+    props = {
+        "is_first_user": is_instance_first_user,
+        "is_organization_first_user": is_organization_first_user,
+        "new_onboarding_enabled": new_onboarding_enabled,
+        "signup_backend_processor": backend_processor,
+        "login_provider": login_provider,
+    }
+
+    # TODO: This should be $set_once as user props.
+    posthoganalytics.identify(distinct_id, props)
+    posthoganalytics.capture(distinct_id, "user signed up", properties=props)

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -196,7 +196,7 @@ class User(AbstractUser):
             "organization_id": str(self.organization.id) if self.organization else None,
             "project_id": str(self.team.uuid) if self.team else None,
             "project_setup_complete": project_setup_complete,
-            "joined_at": self.date_joined.timestamp(),  # integer timestamp to be filterable
+            "joined_at": self.date_joined,
             "has_password_set": self.has_usable_password(),
             "has_social_auth": self.social_auth.exists(),
             "social_providers": list(self.social_auth.values_list("provider", flat=True)),

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -52,8 +52,7 @@ class UserManager(BaseUserManager):
             else:
                 team = Team.objects.create_with_data(user=user, organization=organization, **(team_fields or {}))
             user.join(
-                organization=organization,
-                level=OrganizationMembership.Level.OWNER,
+                organization=organization, level=OrganizationMembership.Level.OWNER,
             )
             return organization, team, user
 
@@ -97,10 +96,7 @@ class User(AbstractUser):
 
     username = None  # type: ignore
     current_organization = models.ForeignKey(
-        "posthog.Organization",
-        models.SET_NULL,
-        null=True,
-        related_name="users_currently+",
+        "posthog.Organization", models.SET_NULL, null=True, related_name="users_currently+",
     )
     current_team = models.ForeignKey("posthog.Team", models.SET_NULL, null=True, related_name="teams_currently+")
     email = models.EmailField(_("email address"), unique=True)
@@ -137,10 +133,7 @@ class User(AbstractUser):
         return self.current_team
 
     def join(
-        self,
-        *,
-        organization: Organization,
-        level: OrganizationMembership.Level = OrganizationMembership.Level.MEMBER,
+        self, *, organization: Organization, level: OrganizationMembership.Level = OrganizationMembership.Level.MEMBER,
     ) -> OrganizationMembership:
         with transaction.atomic():
             membership = OrganizationMembership.objects.create(user=self, organization=organization, level=level)
@@ -165,9 +158,7 @@ class User(AbstractUser):
     def get_analytics_metadata(self):
 
         team_member_count_all: int = (
-            OrganizationMembership.objects.filter(
-                organization__in=self.organizations.all(),
-            )
+            OrganizationMembership.objects.filter(organization__in=self.organizations.all(),)
             .values("user_id")
             .distinct()
             .count()
@@ -188,8 +179,7 @@ class User(AbstractUser):
             "project_count": self.teams.count(),
             "team_member_count_all": team_member_count_all,
             "completed_onboarding_once": self.teams.filter(
-                completed_snippet_onboarding=True,
-                ingested_event=True,
+                completed_snippet_onboarding=True, ingested_event=True,
             ).exists(),  # has completed the onboarding at least for one project
             # properties dependent on current project / org below
             "billing_plan": self.organization.billing_plan if self.organization else None,

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -188,8 +188,8 @@ class User(AbstractUser):
             "project_setup_complete": project_setup_complete,
             "joined_at": self.date_joined,
             "has_password_set": self.has_usable_password(),
-            "has_social_auth": self.social_auth.exists(),
-            "social_providers": list(self.social_auth.values_list("provider", flat=True)),
+            "has_social_auth": self.social_auth.exists(),  # type: ignore
+            "social_providers": list(self.social_auth.values_list("provider", flat=True)),  # type: ignore
         }
 
     __repr__ = sane_repr("email", "first_name", "distinct_id")

--- a/posthog/test/test_user_model.py
+++ b/posthog/test/test_user_model.py
@@ -108,5 +108,9 @@ class TestUser(BaseTest):
                     "organization_id": str(self.organization.id),
                     "project_id": str(self.team.uuid),
                     "project_setup_complete": True,
+                    "has_password_set": True,
+                    "joined_at": user.date_joined,
+                    "has_social_auth": False,
+                    "social_providers": [],
                 },
             )

--- a/posthog/test/test_user_model.py
+++ b/posthog/test/test_user_model.py
@@ -75,6 +75,10 @@ class TestUser(BaseTest):
                     "organization_id": str(organization.id),
                     "project_id": str(team.uuid),
                     "project_setup_complete": False,
+                    "has_password_set": True,
+                    "joined_at": user.date_joined,
+                    "has_social_auth": False,
+                    "social_providers": [],
                 },
             )
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -31,6 +31,7 @@ from posthog.api import (
 )
 from posthog.demo import demo
 from posthog.email import is_email_available
+from posthog.event_usage import report_user_signed_up
 from posthog.models.organization import Organization
 
 from .api.organization import OrganizationSignupSerializer
@@ -159,9 +160,15 @@ def signup_to_organization_view(request, invite_id):
             user = User.objects.create_user(email, password, first_name=first_name, email_opt_in=email_opt_in)
             invite.use(user, prevalidated=True)
             login(request, user, backend="django.contrib.auth.backends.ModelBackend")
-            posthoganalytics.capture(
-                user.distinct_id, "user signed up", properties={"is_first_user": False, "first_team_user": False},
+
+            report_user_signed_up(
+                user.distinct_id,
+                is_instance_first_user=False,
+                is_organization_first_user=False,
+                new_onboarding_enabled=(not invite.organization.setup_section_2_completed),
+                backend_processor="signup_to_organization_view",
             )
+
             return redirect("/")
     return render_template(
         "signup_to_organization.html",
@@ -248,14 +255,13 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
             return HttpResponse(processed, status=401)
         invite.use(user, prevalidated=True)
 
-    posthoganalytics.capture(
-        user.distinct_id,
-        "user signed up",
-        properties={
-            "is_first_user": User.objects.count() == 1,
-            "is_first_team_user": not from_invite,
-            "login_provider": backend.name,
-        },
+    report_user_signed_up(
+        distinct_id=user.distinct_id,
+        is_instance_first_user=User.objects.count() == 1,
+        is_organization_first_user=not from_invite,
+        new_onboarding_enabled=False,
+        backend_processor="social_create_user",
+        login_provider=backend.name,
     )
 
     return {"is_new": True, "user": user}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -124,9 +124,7 @@ def signup_to_organization_view(request, invite_id):
                 )
             else:
                 posthoganalytics.capture(
-                    user.distinct_id,
-                    "user joined from invite",
-                    properties={"organization_id": organization.id},
+                    user.distinct_id, "user joined from invite", properties={"organization_id": organization.id},
                 )
                 return redirect("/")
         else:
@@ -235,19 +233,13 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
             try:
                 invite = TeamInviteSurrogate(invite_id)
             except Team.DoesNotExist:
-                processed = render_to_string(
-                    "auth_error.html",
-                    {"message": "Invalid invite link!"},
-                )
+                processed = render_to_string("auth_error.html", {"message": "Invalid invite link!"},)
                 return HttpResponse(processed, status=401)
 
         try:
             invite.validate(user=None, email=user_email)
         except ValueError as e:
-            processed = render_to_string(
-                "auth_error.html",
-                {"message": str(e)},
-            )
+            processed = render_to_string("auth_error.html", {"message": str(e)},)
             return HttpResponse(processed, status=401)
 
         try:
@@ -299,10 +291,7 @@ def authorize_and_redirect(request):
     return render_template(
         "authorize_and_redirect.html",
         request=request,
-        context={
-            "domain": urlparse(url).hostname,
-            "redirect_url": url,
-        },
+        context={"domain": urlparse(url).hostname, "redirect_url": url,},
     )
 
 
@@ -366,10 +355,7 @@ urlpatterns = [
         []
         if is_email_available()
         else [
-            path(
-                "accounts/password_reset/",
-                TemplateView.as_view(template_name="registration/password_no_smtp.html"),
-            )
+            path("accounts/password_reset/", TemplateView.as_view(template_name="registration/password_no_smtp.html"),)
         ]
     ),
     path(

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -124,7 +124,9 @@ def signup_to_organization_view(request, invite_id):
                 )
             else:
                 posthoganalytics.capture(
-                    user.distinct_id, "user joined from invite", properties={"organization_id": organization.id},
+                    user.distinct_id,
+                    "user joined from invite",
+                    properties={"organization_id": organization.id},
                 )
                 return redirect("/")
         else:
@@ -227,19 +229,25 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
         from_invite = True
         try:
             invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
-                "organization"
+                "organization",
             ).get(id=invite_id)
         except (OrganizationInvite.DoesNotExist, ValidationError):
             try:
                 invite = TeamInviteSurrogate(invite_id)
             except Team.DoesNotExist:
-                processed = render_to_string("auth_error.html", {"message": "Invalid invite link!"},)
+                processed = render_to_string(
+                    "auth_error.html",
+                    {"message": "Invalid invite link!"},
+                )
                 return HttpResponse(processed, status=401)
 
         try:
             invite.validate(user=None, email=user_email)
         except ValueError as e:
-            processed = render_to_string("auth_error.html", {"message": str(e)},)
+            processed = render_to_string(
+                "auth_error.html",
+                {"message": str(e)},
+            )
             return HttpResponse(processed, status=401)
 
         try:
@@ -261,7 +269,7 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
         is_organization_first_user=not from_invite,
         new_onboarding_enabled=False,
         backend_processor="social_create_user",
-        login_provider=backend.name,
+        social_provider=backend.name,
     )
 
     return {"is_new": True, "user": user}
@@ -291,7 +299,10 @@ def authorize_and_redirect(request):
     return render_template(
         "authorize_and_redirect.html",
         request=request,
-        context={"domain": urlparse(url).hostname, "redirect_url": url,},
+        context={
+            "domain": urlparse(url).hostname,
+            "redirect_url": url,
+        },
     )
 
 
@@ -355,7 +366,10 @@ urlpatterns = [
         []
         if is_email_available()
         else [
-            path("accounts/password_reset/", TemplateView.as_view(template_name="registration/password_no_smtp.html"),)
+            path(
+                "accounts/password_reset/",
+                TemplateView.as_view(template_name="registration/password_no_smtp.html"),
+            )
         ]
     ),
     path(

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -165,7 +165,7 @@ def signup_to_organization_view(request, invite_id):
                 user.distinct_id,
                 is_instance_first_user=False,
                 is_organization_first_user=False,
-                new_onboarding_enabled=(not invite.organization.setup_section_2_completed),
+                new_onboarding_enabled=(not organization.setup_section_2_completed),
                 backend_processor="signup_to_organization_view",
             )
 


### PR DESCRIPTION
## Changes

This PR introduces more instrumentation that will help improve our product.
- Introduces `event_usage.py` module to do the same function as `eventUsageLogic.ts` in the BE. Related to that, abstracted some event usage reporting logic here.
- Added more information on user `$identify` related to when the user's account was actually created and SSO usage.
- Builds up on #3174 to introduce event tracking to several points of the new onboarding process.
- Reports FE & BE events related to inviting team members.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
