### PR TITLE
Separate Jest from frontend code quality job

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     frontend-code-quality:
         name: Code quality checks
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v1
 
@@ -24,9 +24,23 @@ jobs:
             - name: Lint with ESLint
               run: yarn eslint
 
-            - name: Test with Jest
-              run: yarn test
-
             - name: Run typescript with strict
               run: |
                   ./bin/check-typescript-strict
+
+    jest:
+        name: Jest tests
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v1
+
+            - name: Set up Node 14
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 14
+
+            - name: Install package.json dependencies with Yarn
+              run: yarn
+
+            - name: Test with Jest
+              run: yarn test


### PR DESCRIPTION
## Changes

This puts Jest into its own GitHub Actions job, to separate stylistic and functionality concerns, analogously to the organization of backend-related jobs. Will also improve CI run times as we make more use of Jest.