### PR TITLE
Make page not jumpy on initial load

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -94,7 +94,7 @@ function _App(): JSX.Element | null {
         ) : null
     }
 
-    if (!scene || sceneConfig.plain) {
+    if (sceneConfig.plain) {
         return (
             <Layout style={{ minHeight: '100vh' }}>
                 {!sceneConfig.hideTopNav && <TopNavigation />}
@@ -115,13 +115,15 @@ function _App(): JSX.Element | null {
                 <MainNavigation />
                 <Layout className={`${sceneConfig.dark ? 'bg-mid' : ''}`} style={{ minHeight: '100vh' }}>
                     {!sceneConfig.hideTopNav && <TopNavigation />}
-                    <Layout.Content className="main-app-content" data-attr="layout-content">
-                        {!sceneConfig.hideDemoWarnings && <DemoWarnings />}
+                    {scene ? (
+                        <Layout.Content className="main-app-content" data-attr="layout-content">
+                            {!sceneConfig.hideDemoWarnings && <DemoWarnings />}
 
-                        <BillingAlerts />
-                        <BackTo />
-                        <SceneComponent user={user} {...params} />
-                    </Layout.Content>
+                            <BillingAlerts />
+                            <BackTo />
+                            <SceneComponent user={user} {...params} />
+                        </Layout.Content>
+                    ) : null}
                 </Layout>
                 {essentialElements}
             </Layout>


### PR DESCRIPTION
By showing side nav even if scene has not loaded.

This fixes #3020

Before/after: https://imgur.com/a/k1zo7DG on a 3G connection

Posthog logo loads instantly on 2nd page load in production - caching rule set up in cloudflare

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
