### PR TITLE
Better deduping on Person table in CH

### DIFF
--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -32,7 +32,7 @@ PERSONS_TABLE_SQL = (
 """
 ).format(
     table_name=PERSONS_TABLE,
-    engine=table_engine(PERSONS_TABLE, "_timestamp"),
+    engine=table_engine(PERSONS_TABLE, "_offset"),
     extra_fields=KAFKA_COLUMNS,
     storage_policy=STORAGE_POLICY,
 )


### PR DESCRIPTION
## Changes

There was an issue with person updates getting clobbered in clickhouse where a person could be created with context added at the same second.
When this happend clickhouse would randomly choose which row to keep because the column to deplicate on only has second granularity.

The deduping column must be Int32 so a microsecond epoch or DateTime64 are out of the question.

The best indicator for which message is more recent is to rely on our old friend Kafka. This table will now use the offset from kafka to determine which update was the most fresh.
