### PR TITLE
Always show non-anonymous distinct id first

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -22,7 +22,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, get_safe_cache, relative_date_parse
+from posthog.utils import convert_property_value, get_safe_cache, is_valid_uuid4, relative_date_parse
 
 
 class PersonCursorPagination(CursorPagination):
@@ -49,7 +49,7 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         if person.properties.get("email"):
             return person.properties["email"]
         if len(person.distinct_ids) > 0:
-            return person.distinct_ids[-1]
+            return sorted(person.distinct_ids, key=lambda x: 1 if is_valid_uuid4(x) else 0)[0]
         return person.pk
 
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1,4 +1,5 @@
 import json
+from uuid import uuid4
 
 from django.test.utils import freeze_time
 from django.utils import timezone
@@ -302,6 +303,13 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
                 person[0].properties, {"$browser": "whatever", "$os": "Mac OS X", "random_prop": "asdf", "oh": "hello"}
             )
             self.assertEqual(person[0].created_at, person3.created_at)
+
+        def test_return_non_anonymous_name(self) -> None:
+            person_factory(
+                team=self.team, distinct_ids=["distinct_id", str(uuid4())],
+            )
+            response = self.client.get("/api/person/").json()
+            self.assertEqual(response["results"][0]["name"], "distinct_id")
 
     return TestPerson
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -541,3 +541,15 @@ def get_safe_cache(cache_key: str):
         except:
             pass
     return None
+
+
+def is_valid_uuid4(uuid_string: str) -> bool:
+    try:
+        val = uuid.UUID(uuid_string, version=4)
+    except ValueError:
+        return False
+    # If the uuid_string is a valid hex code,
+    # but an invalid uuid4,
+    # the UUID.__init__ will convert it to a
+    # valid uuid4. This is bad for validation purposes.
+    return val.hex == uuid_string


### PR DESCRIPTION
## Changes

Previously the list of distinct ids would be unordered and thus we would be picking randomly. If a customer hadn't sent an email for that person we would show an anonymous ID instead of a more useful identified distinct id.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
