### PR TITLE
Updated Go installation instructions

### DIFF
--- a/frontend/src/scenes/ingestion/frameworks/GoInstructions.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/GoInstructions.tsx
@@ -13,11 +13,10 @@ function GoSetupSnippet(): JSX.Element {
         <CodeSnippet language={Language.Go}>
             {`package main
 import (
-    "os"
     "github.com/posthog/posthog-go"
 )
 func main() {
-    client := posthog.NewWithConfig(os.Getenv("${user?.team?.api_token}"), posthog.Config{Endpoint: "${window.location.origin}"})
+    client, _ := posthog.NewWithConfig("${user?.team?.api_token}", posthog.Config{Endpoint: "${window.location.origin}"})
     defer client.Close()
 }`}
         </CodeSnippet>


### PR DESCRIPTION
posthog.NewWithConfig returns two values [1], updated the code to use (but ignore) the error.

os.GetEnv does not work this way, use the API key directly in a string.

1: https://pkg.go.dev/github.com/posthog/posthog-go#NewWithConfig