### PR TITLE
Fix update indicator on top navigation

### DIFF
--- a/frontend/src/layout/ChangelogModal.tsx
+++ b/frontend/src/layout/ChangelogModal.tsx
@@ -4,13 +4,13 @@ import { useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { navigationLogic } from './navigation/navigationLogic'
 
-export function ChangelogModal({ onDismiss }: { onDismiss: () => void }): JSX.Element {
+export function ChangelogModal({ onDismiss }: { onDismiss: () => void }): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { latestVersion } = useValues(navigationLogic)
 
     if (user?.is_multi_tenancy) {
         // The changelog is not available on cloud
-        return <></>
+        return null
     }
 
     return (

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -196,7 +196,7 @@ export function _TopNavigation(): JSX.Element {
                             <Badge
                                 data-attr="update-indicator-badge"
                                 type={updateAvailable ? 'warning' : undefined}
-                                tooltip={updateAvailable ? 'New version available' : undefined}
+                                tooltip={updateAvailable ? 'New version available' : 'PostHog is up-to-date'}
                                 icon={<UpOutlined />}
                                 onClick={() => setChangelogModalOpen(true)}
                             />

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -192,13 +192,15 @@ export function _TopNavigation(): JSX.Element {
                                 className="mr"
                             />
                         )}
-                        <Badge
-                            data-attr="update-indicator-badge"
-                            type={updateAvailable ? 'warning' : undefined}
-                            tooltip={updateAvailable ? 'New version available' : undefined}
-                            icon={<UpOutlined />}
-                            onClick={() => setChangelogModalOpen(true)}
-                        />
+                        {!user?.is_multi_tenancy && (
+                            <Badge
+                                data-attr="update-indicator-badge"
+                                type={updateAvailable ? 'warning' : undefined}
+                                tooltip={updateAvailable ? 'New version available' : undefined}
+                                icon={<UpOutlined />}
+                                onClick={() => setChangelogModalOpen(true)}
+                            />
+                        )}
                     </div>
                 </div>
                 <div className="project-chooser">

--- a/frontend/src/lib/components/Badge.tsx
+++ b/frontend/src/lib/components/Badge.tsx
@@ -23,7 +23,7 @@ export function Badge({ icon, type, className, onClick, tooltip, ...props }: Bad
     }, [type])
 
     return (
-        <Tooltip title={tooltip} color={type ? `var(--${type})` : undefined}>
+        <Tooltip title={tooltip} color={type ? `var(--${type})` : undefined} placement="bottom">
             <div
                 className={`badge${className ? ` ${className}` : ''}${onClick ? ' cursor-pointer' : ''}`}
                 style={type ? { backgroundColor: `var(--${type})` } : {}}


### PR DESCRIPTION
## Changes

- Hides the update indicator in the top navigation when on cloud.
- Fixes this positioning bug with the top navigation tooltips when scrolled.
    **Before:**
    <img width="520" alt="" src="https://user-images.githubusercontent.com/5864173/107355308-91b0f500-6acf-11eb-87ce-1070440c2f80.png">
    **After:**
    <img width="463" alt="" src="https://user-images.githubusercontent.com/5864173/107355317-92e22200-6acf-11eb-99b6-19aef6fc8672.png">
- Adds a tooltip to the update indicator even when the instance is on the latest version.
<img width="310" alt="" src="https://user-images.githubusercontent.com/5864173/107355383-ab523c80-6acf-11eb-8e1d-3d2f121c440d.png">





## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
