### PR TITLE
Update clickhouse-driver

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,8 +6,8 @@ asgiref==3.2.7
 aioch==0.0.2
 celery==4.4.2
 celery-redbeat==0.13.0
-clickhouse-pool==0.4.0
-clickhouse-driver==0.1.4
+clickhouse-pool==0.4.3
+clickhouse-driver==0.2.0
 defusedxml==0.6.0
 dj-database-url==0.5.0
 Django==3.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,12 +32,12 @@ cffi==1.14.0
     # via cryptography
 chardet==3.0.4
     # via requests
-clickhouse-driver==0.1.4
+clickhouse-driver==0.2.0
     # via
     #   -r requirements.in
     #   aioch
     #   clickhouse-pool
-clickhouse-pool==0.4.0
+clickhouse-pool==0.4.3
     # via -r requirements.in
 cryptography==3.2
     # via


### PR DESCRIPTION
We're having a lot of clickhouse noise in sentry, keeping good hygene by
keeping up. Some perf improvements + CVE fix seem relevant.

Changelogs:
- https://github.com/mymarilyn/clickhouse-driver/blob/master/CHANGELOG.md
- https://github.com/ericmccarthy7/clickhouse-pool/releases/tag/v0.4.3

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
