### PR TITLE
Fix non-anonymous distinct id first

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -22,7 +22,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, get_safe_cache, is_anonymous_id, relative_date_parse
+from posthog.utils import convert_property_value, get_safe_cache, is_valid_uuid, relative_date_parse
 
 
 class PersonCursorPagination(CursorPagination):
@@ -49,7 +49,8 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         if person.properties.get("email"):
             return person.properties["email"]
         if len(person.distinct_ids) > 0:
-            return sorted(person.distinct_ids, key=lambda x: 1 if is_anonymous_id(x) else 0)[0]
+            # Prefer non-UUID distinct IDs (presumably from user identification) over UUIDs
+            return sorted(person.distinct_ids, key=is_valid_uuid)[0]
         return person.pk
 
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -22,7 +22,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, get_safe_cache, is_valid_uuid4, relative_date_parse
+from posthog.utils import convert_property_value, get_safe_cache, is_anonymous_id, relative_date_parse
 
 
 class PersonCursorPagination(CursorPagination):
@@ -49,7 +49,7 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         if person.properties.get("email"):
             return person.properties["email"]
         if len(person.distinct_ids) > 0:
-            return sorted(person.distinct_ids, key=lambda x: 1 if is_valid_uuid4(x) else 0)[0]
+            return sorted(person.distinct_ids, key=lambda x: 1 if is_anonymous_id(x) else 0)[0]
         return person.pk
 
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -306,17 +306,16 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
 
         def test_return_non_anonymous_name(self) -> None:
             person_factory(
-                team=self.team,
-                distinct_ids=["distinct_id", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
+                team=self.team, distinct_ids=["distinct_id1", "c4d86f06-25d8-47ac-8e15-c052c48b6c81"],
             )
             person_factory(
-                team=self.team, distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id"],
+                team=self.team, distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id2"],
             )
 
             response = self.client.get("/api/person/").json()
 
-            self.assertEqual(response["results"][0]["name"], "distinct_id")
-            self.assertEqual(response["results"][1]["name"], "distinct_id")
+            self.assertEqual(response["results"][0]["name"], "distinct_id2")
+            self.assertEqual(response["results"][1]["name"], "distinct_id1")
 
     return TestPerson
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -310,8 +310,7 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
                 distinct_ids=["distinct_id", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
             )
             person_factory(
-                team=self.team,
-                distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id"],
+                team=self.team, distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id"],
             )
 
             response = self.client.get("/api/person/").json()

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -313,9 +313,9 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
                 team=self.team,
                 distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id"],
             )
-            
+
             response = self.client.get("/api/person/").json()
-            
+
             self.assertEqual(response["results"][0]["name"], "distinct_id")
             self.assertEqual(response["results"][1]["name"], "distinct_id")
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -306,7 +306,8 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
 
         def test_return_non_anonymous_name(self) -> None:
             person_factory(
-                team=self.team, distinct_ids=["distinct_id", str(uuid4())],
+                team=self.team,
+                distinct_ids=["distinct_id", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
             )
             response = self.client.get("/api/person/").json()
             self.assertEqual(response["results"][0]["name"], "distinct_id")

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -309,8 +309,15 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
                 team=self.team,
                 distinct_ids=["distinct_id", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
             )
+            person_factory(
+                team=self.team,
+                distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id"],
+            )
+            
             response = self.client.get("/api/person/").json()
+            
             self.assertEqual(response["results"][0]["name"], "distinct_id")
+            self.assertEqual(response["results"][1]["name"], "distinct_id")
 
     return TestPerson
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -543,8 +543,8 @@ def get_safe_cache(cache_key: str):
     return None
 
 
-ANONYMOUS_REGEX = r"^([a-z0-9]+\-){4}([a-z0-9]+)$"
+UUID_REGEX = r"^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
 
 
-def is_anonymous_id(distinct_id: str) -> bool:
-    return re.match(ANONYMOUS_REGEX, distinct_id)
+def is_valid_uuid(candidate: str) -> bool:
+    return bool(re.match(UUID_REGEX, candidate, flags=re.IGNORECASE))

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -543,13 +543,8 @@ def get_safe_cache(cache_key: str):
     return None
 
 
-def is_valid_uuid4(uuid_string: str) -> bool:
-    try:
-        val = uuid.UUID(uuid_string, version=4)
-    except ValueError:
-        return False
-    # If the uuid_string is a valid hex code,
-    # but an invalid uuid4,
-    # the UUID.__init__ will convert it to a
-    # valid uuid4. This is bad for validation purposes.
-    return val.hex == uuid_string
+ANONYMOUS_REGEX = r"^([a-z0-9]+\-){4}([a-z0-9]+)$"
+
+
+def is_anonymous_id(distinct_id: str) -> bool:
+    return re.match(ANONYMOUS_REGEX, distinct_id)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -547,4 +547,4 @@ ANONYMOUS_REGEX = r"^([a-z0-9]+\-){4}([a-z0-9]+)$"
 
 
 def is_anonymous_id(distinct_id: str) -> bool:
-    return re.match(ANONYMOUS_REGEX, distinct_id)
+    return True if re.match(ANONYMOUS_REGEX, distinct_id) else False


### PR DESCRIPTION
## Changes

I thought we were using UUID4s in the frontend as anonymous IDs but it's actually something completely different. Check for that instead.
## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
