### PR TITLE
Fix non-anonymous ids

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -22,7 +22,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, get_safe_cache, is_anonymous_id, is_valid_uuid, relative_date_parse
+from posthog.utils import convert_property_value, get_safe_cache, is_anonymous_id, relative_date_parse
 
 
 class PersonCursorPagination(CursorPagination):

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -22,7 +22,7 @@ from posthog.queries.base import properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
-from posthog.utils import convert_property_value, get_safe_cache, is_valid_uuid, relative_date_parse
+from posthog.utils import convert_property_value, get_safe_cache, is_anonymous_id, is_valid_uuid, relative_date_parse
 
 
 class PersonCursorPagination(CursorPagination):
@@ -50,7 +50,7 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
             return person.properties["email"]
         if len(person.distinct_ids) > 0:
             # Prefer non-UUID distinct IDs (presumably from user identification) over UUIDs
-            return sorted(person.distinct_ids, key=is_valid_uuid)[0]
+            return sorted(person.distinct_ids, key=is_anonymous_id)[0]
         return person.pk
 
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -306,10 +306,12 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
 
         def test_return_non_anonymous_name(self) -> None:
             person_factory(
-                team=self.team, distinct_ids=["distinct_id1", "c4d86f06-25d8-47ac-8e15-c052c48b6c81"],
+                team=self.team,
+                distinct_ids=["distinct_id1", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
             )
             person_factory(
-                team=self.team, distinct_ids=["0451E507-9619-4330-9DAD-68588B8045D6", "distinct_id2"],
+                team=self.team,
+                distinct_ids=["17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c", "distinct_id2"],
             )
 
             response = self.client.get("/api/person/").json()

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -310,8 +310,7 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
                 distinct_ids=["distinct_id1", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
             )
             person_factory(
-                team=self.team,
-                distinct_ids=["17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c", "distinct_id2"],
+                team=self.team, distinct_ids=["17787c327b-0e8f623ea9-336473-1aeaa0-17787c30995b7c", "distinct_id2"],
             )
 
             response = self.client.get("/api/person/").json()

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -547,4 +547,5 @@ ANONYMOUS_REGEX = r"^([a-z0-9]+\-){4}([a-z0-9]+)$"
 
 
 def is_anonymous_id(distinct_id: str) -> bool:
+    # Our anonymous ids are _not_ uuids, but a random collection of strings
     return bool(re.match(ANONYMOUS_REGEX, distinct_id))

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -543,8 +543,8 @@ def get_safe_cache(cache_key: str):
     return None
 
 
-UUID_REGEX = r"^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
+ANONYMOUS_REGEX = r"^([a-z0-9]+\-){4}([a-z0-9]+)$"
 
 
-def is_valid_uuid(candidate: str) -> bool:
-    return bool(re.match(UUID_REGEX, candidate, flags=re.IGNORECASE))
+def is_anonymous_id(distinct_id: str) -> bool:
+    return bool(re.match(ANONYMOUS_REGEX, distinct_id))


### PR DESCRIPTION
## Changes

Reverting the incorrect changes made to #3272. Our anonymous ids are explicitely _not_ uuid

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
