### PR TITLE
Plugin server info on system status page

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import AuthenticationFailed
 
 from posthog.ee import is_ee_enabled
 from posthog.models import User
+from posthog.plugins import can_configure_plugins_via_api, can_install_plugins_via_api
 from posthog.settings import TEST
 from posthog.utils import (
     get_redis_info,
@@ -44,6 +45,7 @@ def stats(request):
 @never_cache
 @login_required
 def system_status(request):
+    team = request.user.team
     is_multitenancy: bool = getattr(settings, "MULTI_TENANCY", False)
 
     if is_multitenancy and not request.user.is_staff:
@@ -61,6 +63,19 @@ def system_status(request):
             "key": "analytics_database",
             "metric": "Analytics database in use",
             "value": "ClickHouse" if is_ee_enabled() else "Postgres",
+        }
+    )
+
+    plugins_cloud_whitelisted_org_ids = getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
+    plugin_server_ingestion = getattr(settings, "PLUGIN_SERVER_INGESTION", False)
+    plugin_sever_enabled = plugin_server_ingestion and (
+        not is_ee_enabled() or (str(team.organization_id) in plugins_cloud_whitelisted_org_ids)
+    )
+    metrics.append(
+        {
+            "key": "ingestion_server",
+            "metric": "Event ingestion via",
+            "value": "Plugin Server" if plugin_sever_enabled else "Django",
         }
     )
 
@@ -124,6 +139,22 @@ def system_status(request):
             metrics.append(
                 {"metric": "Redis metrics", "value": f"Redis connected but then failed to return metrics: {e}"}
             )
+
+    metrics.append({"key": "plugin_sever_alive", "metric": "Plugin server alive", "value": is_plugin_server_alive()})
+    metrics.append(
+        {
+            "key": "plugins_install",
+            "metric": "Plugin install access",
+            "value": can_install_plugins_via_api(team.organization),
+        }
+    )
+    metrics.append(
+        {
+            "key": "plugins_configure",
+            "metric": "Plugin configuration access",
+            "value": can_configure_plugins_via_api(team.organization),
+        }
+    )
 
     return JsonResponse({"results": metrics})
 


### PR DESCRIPTION
## Changes

- Adds a few plugin server-related pieces of data onto the system status page to help debug issues as they arise:
![image](https://user-images.githubusercontent.com/53387/107482521-16f3e280-6b80-11eb-9153-5203b0d3985c.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
