### PR TITLE
Fix filtering by user property in CH sessions list

### DIFF
--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -23,14 +23,14 @@ class ClickhouseSessionsList:
         offset = filter.pagination.get("offset", 0)
         filter = set_default_dates(filter)
 
-        filters, params = parse_prop_clauses(filter.person_filter_properties, team.pk)
+        person_filters, person_filter_params = parse_prop_clauses(filter.person_filter_properties, team.pk)
         filters_select_clause, filters_timestamps_clause, filters_having, action_filter_params = format_action_filters(
             filter
         )
 
         date_from, date_to, _ = parse_timestamps(filter, team.pk)
         params = {
-            **params,
+            **person_filter_params,
             **action_filter_params,
             "team_id": team.pk,
             "limit": limit,
@@ -40,7 +40,7 @@ class ClickhouseSessionsList:
         query = SESSION_SQL.format(
             date_from=date_from,
             date_to=date_to,
-            filters=filters,
+            person_filters=person_filters,
             filters_select_clause=filters_select_clause,
             filters_timestamps_clause=filters_timestamps_clause,
             filters_having=filters_having,

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -56,7 +56,6 @@ SESSION_SQL = """
                         AND event != '$feature_flag_called'
                         {date_from}
                         {date_to}
-                        {filters}
                         AND distinct_id IN (
                             SELECT distinct distinct_id
                             FROM
@@ -64,6 +63,7 @@ SESSION_SQL = """
                             WHERE team_id = %(team_id)s
                             {date_from}
                             {date_to}
+                            {person_filters}
                             ORDER BY timestamp DESC
                             LIMIT %(distinct_id_limit)s
                         )


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog/issues/3282

The problem was in pagination as expected.

Ran the query against our team in production clickhouse - it now returns
expected data and speed did not seem to change much.

Example full query:

```sql
SELECT distinct_id,
       gid,
       dateDiff('second', toDateTime(arrayReduce('min', groupArray(timestamp))), toDateTime(arrayReduce('max', groupArray(timestamp)))) AS elapsed,
       arrayReduce('min', groupArray(timestamp)) as start_time,
       groupArray(uuid) uuids,
       groupArray(event) events,
       groupArray(properties) properties,
       groupArray(timestamp) timestamps,
       groupArray(elements_chain) elements_chain,
       arrayReduce('max', groupArray(timestamp)) as end_time
  FROM (
        SELECT distinct_id,
               event,
               timestamp,
               uuid,
               properties,
               elements_chain,
               arraySum(arraySlice(gids, 1, idx)) AS gid
          FROM (
                SELECT groupArray(timestamp) as timestamps,
                       groupArray(event) as events,
                       groupArray(uuid) as uuids,
                       groupArray(properties) as property_list,
                       groupArray(elements_chain) as elements_chains,
                       groupArray(distinct_id) as distinct_ids,
                       groupArray(new_session) AS gids
                  FROM (
                        SELECT distinct_id,
                               uuid,
                               event,
                               properties,
                               elements_chain,
                               timestamp,
                               neighbor(distinct_id, -1) as possible_neighbor,
                               neighbor(timestamp, -1) as possible_prev,
                               if(possible_neighbor != distinct_id or dateDiff('minute', toDateTime(possible_prev), toDateTime(timestamp)) > 30, 1, 0) as new_session
                          FROM (
                                SELECT uuid,
                                       event,
                                       properties,
                                       timestamp,
                                       distinct_id,
                                       elements_chain
                                  FROM events
                                 WHERE team_id = 4
                                   AND event != '$feature_flag_called'
                                   and timestamp >= '2021-02-10 00:00:00'
                                   and timestamp <= '2021-02-10 23:59:59'
                                   AND distinct_id IN (
                                        SELECT distinct distinct_id
                                          FROM events
                                         WHERE team_id = 4
                                           and timestamp >= '2021-02-10 00:00:00'
                                           and timestamp <= '2021-02-10 23:59:59'
                                           AND distinct_id IN (
                                                SELECT distinct_id
                                                  FROM person_distinct_id
                                                 WHERE person_id IN (
                                                        SELECT id
                                                          FROM person
                                                         WHERE team_id = 4
                                                           AND trim(BOTH '"' FROM JSONExtractRaw(properties, 'project_id')) = 'xxx'
                                                       )
                                                   AND team_id = 4
                                               )
                                         ORDER BY timestamp DESC
                                         LIMIT 51
                                       )
                                 GROUP BY uuid,
                                          event,
                                          properties,
                                          timestamp,
                                          distinct_id,
                                          elements_chain
                                 ORDER BY distinct_id,
                                          timestamp
                               )
                       )
               ) ARRAY
          JOIN distinct_ids as distinct_id,
               events as event,
               timestamps as timestamp,
               uuids as uuid,
               property_list as properties,
               elements_chains as elements_chain,
               arrayEnumerate(gids) AS idx
       )
 GROUP BY distinct_id,
          gid
 ORDER BY end_time DESC
 LIMIT 0,
       51
```

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
