### PR TITLE
Fix ints saved as strings clickhouse

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -166,9 +166,6 @@ def prop_filter_json_extract(
         )
     else:
         if is_json(prop.value) and not is_denormalized:
-            import ipdb
-
-            ipdb.set_trace()
             clause = "AND replaceRegexpAll(visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s),' ', '') = replaceRegexpAll(toString(%(v{prepend}_{idx})s),' ', '')"
         else:
             clause = "AND {left} = toString(%(v{prepend}_{idx})s)"

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -139,7 +139,7 @@ def prop_filter_json_extract(
     elif operator == "gt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND toInt64OrNull(replaceRegexpAll({left}, ' ', '')) > %(v{prepend}_{idx})s".format(
+            "AND toInt64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) > %(v{prepend}_{idx})s".format(
                 idx=idx,
                 prepend=prepend,
                 left=denormalized
@@ -153,7 +153,7 @@ def prop_filter_json_extract(
     elif operator == "lt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND toInt64OrNull(replaceRegexpAll({left}, ' ', '')) < %(v{prepend}_{idx})s".format(
+            "AND toInt64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) < %(v{prepend}_{idx})s".format(
                 idx=idx,
                 prepend=prepend,
                 left=denormalized
@@ -165,14 +165,13 @@ def prop_filter_json_extract(
             params,
         )
     else:
-        if is_int(prop.value) and not is_denormalized:
-            clause = "AND JSONExtractInt({prop_var}, %(k{prepend}_{idx})s) = %(v{prepend}_{idx})s"
-        elif is_int(prop.value) and is_denormalized:
-            clause = "AND toInt64OrNull({left}) = %(v{prepend}_{idx})s"
-        elif is_json(prop.value) and not is_denormalized:
+        if is_json(prop.value) and not is_denormalized:
+            import ipdb
+
+            ipdb.set_trace()
             clause = "AND replaceRegexpAll(visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s),' ', '') = replaceRegexpAll(toString(%(v{prepend}_{idx})s),' ', '')"
         else:
-            clause = "AND {left} = %(v{prepend}_{idx})s"
+            clause = "AND {left} = toString(%(v{prepend}_{idx})s)"
 
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -26,6 +26,11 @@ def _create_person(**kwargs) -> Person:
 
 
 class TestPropFormat(ClickhouseTestMixin, BaseTest):
+    def _run_query(self, filter: Filter) -> List:
+        query, params = parse_prop_clauses(filter.properties, self.team.pk, allow_denormalized_props=True)
+        final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
+        return sync_execute(final_query, {**params, "team_id": self.team.pk})
+
     def test_prop_person(self):
 
         _create_person(
@@ -39,11 +44,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
 
         filter = Filter(data={"properties": [{"key": "email", "value": "test@posthog.com", "type": "person"}],})
-        query, params = parse_prop_clauses(filter.properties, self.team.pk)
-
-        final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
-        result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(self._run_query(filter)), 1)
 
     def test_prop_event(self):
 
@@ -56,12 +57,39 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
 
         filter = Filter(data={"properties": [{"key": "attr", "value": "some_val"}],})
-        query, params = parse_prop_clauses(filter.properties, self.team.pk)
-        final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
+        self.assertEqual(len(self._run_query(filter)), 1)
 
-        result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 1)
+    def test_prop_ints_saved_as_strings(self):
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": "0"},
+        )
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": "2"},
+        )
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": 2},
+        )
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": "string"},
+        )
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": "2"}],})
+        self.assertEqual(len(self._run_query(filter)), 2)
 
+        # value passed as string
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": "1", "operator": "gt"}],})
+        self.assertEqual(len(self._run_query(filter)), 2)
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": "3", "operator": "lt"}],})
+        self.assertEqual(len(self._run_query(filter)), 3)
+
+        # value passed as int
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": 1, "operator": "gt"}],})
+        self.assertEqual(len(self._run_query(filter)), 2)
+
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": 3, "operator": "lt"}],})
+        self.assertEqual(len(self._run_query(filter)), 3)
+
+
+class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
     def _run_query(self, filter: Filter) -> List:
         query, params = parse_prop_clauses(filter.properties, self.team.pk, allow_denormalized_props=True)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -75,6 +75,9 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         filter = Filter(data={"properties": [{"key": "test_prop", "value": "2"}],})
         self.assertEqual(len(self._run_query(filter)), 2)
 
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": 2}],})
+        self.assertEqual(len(self._run_query(filter)), 2)
+
         # value passed as string
         filter = Filter(data={"properties": [{"key": "test_prop", "value": "1", "operator": "gt"}],})
         self.assertEqual(len(self._run_query(filter)), 2)

--- a/ee/clickhouse/models/util.py
+++ b/ee/clickhouse/models/util.py
@@ -52,6 +52,11 @@ def is_json(val):
         return False
 
     try:
+        int(val)
+        return False
+    except:
+        pass
+    try:
         json.loads(val)
     except ValueError:
         return False


### PR DESCRIPTION
## Changes

User reported issues with querying ints that were saved as strings. I think there were 2 simultaneous issues:
- From the frontend everything would be passed as a string (even ints), which we would then convert to ints in the backend. It's easier to just query on strings instead
- For gt and lt operators we weren't trimming `"`, so ints stored as strings would be ignored.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
