### PR TITLE
[Suggestion] Parameterize backend tests 

### DIFF
--- a/posthog/queries/test/test_trend_combinations.py
+++ b/posthog/queries/test/test_trend_combinations.py
@@ -18,7 +18,6 @@ def setup_test(team: Team, payload):
                 Person.objects.create(team=team, **person_data)
 
 
-# ref: https://stackoverflow.com/questions/32899/how-do-you-generate-dynamic-parameterized-unit-tests-in-python
 # need to generate tests without using subtest so that the transactions will be cleared after each test
 class TestSequenceMeta(type):
     def __new__(mcs, name, bases, dict):

--- a/posthog/queries/test/test_trend_combinations.py
+++ b/posthog/queries/test/test_trend_combinations.py
@@ -1,12 +1,10 @@
-from django.db import transaction
-
 from posthog.models import Event, Person
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.test.trends import all_trend_tests
 from posthog.queries.test.trends.base import QueryTest
 from posthog.queries.trends import Trends
-from posthog.test.base import APIBaseTest, TransactionBaseTest
+from posthog.test.base import TransactionBaseTest
 
 
 # TODO: add more supported entities here

--- a/posthog/queries/test/test_trend_combinations.py
+++ b/posthog/queries/test/test_trend_combinations.py
@@ -1,0 +1,42 @@
+from django.db import transaction
+
+from posthog.models import Event, Person
+from posthog.models.filters.filter import Filter
+from posthog.models.team import Team
+from posthog.queries.test.trends import all_trend_tests
+from posthog.queries.test.trends.base import QueryTest
+from posthog.queries.trends import Trends
+from posthog.test.base import APIBaseTest, TransactionBaseTest
+
+
+# TODO: add more supported entities here
+def setup_test(team: Team, payload):
+    for entity, data in payload.items():
+        if entity == "events":
+            for event_data in data:
+                Event.objects.create(team=team, **event_data)
+        if entity == "people":
+            for person_data in data:
+                Person.objects.create(team=team, **person_data)
+
+
+# ref: https://stackoverflow.com/questions/32899/how-do-you-generate-dynamic-parameterized-unit-tests-in-python
+# need to generate tests without using subtest so that the transactions will be cleared after each test
+class TestSequenceMeta(type):
+    def __new__(mcs, name, bases, dict):
+        def generate_test(new_test: QueryTest):
+            def test(self):
+                setup_test(self.team, new_test.data)
+                res = Trends().run(Filter(data=new_test.filter_data), self.team)
+                self.assertEqual(res, new_test.result)
+
+            return test
+
+        for new_test in all_trend_tests:
+            test_name = "test_%s" % new_test.name
+            dict[test_name] = generate_test(new_test)
+        return type.__new__(mcs, name, bases, dict)
+
+
+class TestTrendsCombos(TransactionBaseTest, metaclass=TestSequenceMeta):
+    pass

--- a/posthog/queries/test/trends/__init__.py
+++ b/posthog/queries/test/trends/__init__.py
@@ -1,0 +1,3 @@
+from .interval import interval_test
+
+all_trend_tests = [*interval_test]

--- a/posthog/queries/test/trends/base.py
+++ b/posthog/queries/test/trends/base.py
@@ -1,0 +1,15 @@
+from typing import Dict, List, Union
+
+
+class QueryTest(object):
+    name: str
+    data: Dict
+    filter_data: Dict
+    result: Union[Dict, List]
+
+    def __init__(self, name: str, data: Dict, filter_data: Dict, result: Union[Dict, List]) -> None:
+        super().__init__()
+        self.name = name
+        self.data = data
+        self.filter_data = filter_data
+        self.result = result

--- a/posthog/queries/test/trends/interval.py
+++ b/posthog/queries/test/trends/interval.py
@@ -1,0 +1,158 @@
+from posthog.queries.test.trends.base import QueryTest
+
+_events = {
+    "events": [
+        {"event": "sign up", "distinct_id": "person1", "timestamp": "2020-01-01T00:00:00Z"},
+        {"event": "sign up", "distinct_id": "person1", "timestamp": "2020-01-02T00:00:00Z"},
+        {"event": "sign up", "distinct_id": "person1", "timestamp": "2020-01-03T00:00:00Z"},
+    ],
+    "people": [{"distinct_ids": ["person1"], "properties": {"$some_prop": "some_val"}},],
+}
+
+_minute_test = QueryTest(
+    name="minute interval",
+    data=_events,
+    filter_data={
+        "date_from": "2020-01-01T00:00:00Z",
+        "date_to": "2020-01-03T00:00:00Z",
+        "interval": "minute",
+        "events": [{"id": "sign up"}],
+    },
+    result=[
+        {
+            "action": {
+                "id": "sign up",
+                "type": "events",
+                "order": None,
+                "name": "sign up",
+                "math": None,
+                "math_property": None,
+                "properties": [],
+            },
+            "label": "sign up",
+            "count": 3,
+            "data": [1, 1, 1],
+            "labels": ["Wed. 1 January", "Thu. 2 January", "Fri. 3 January"],
+            "days": ["2020-01-01", "2020-01-02", "2020-01-03"],
+        }
+    ],
+)
+
+_hour_test = QueryTest(
+    name="hour interval",
+    data=_events,
+    filter_data={
+        "date_from": "2020-01-01T00:00:00Z",
+        "date_to": "2020-01-03T00:00:00Z",
+        "interval": "hour",
+        "events": [{"id": "sign up"}],
+    },
+    result=[
+        {
+            "action": {
+                "id": "sign up",
+                "type": "events",
+                "order": None,
+                "name": "sign up",
+                "math": None,
+                "math_property": None,
+                "properties": [],
+            },
+            "label": "sign up",
+            "count": 3,
+            "data": [1, 1, 1],
+            "labels": ["Wed. 1 January", "Thu. 2 January", "Fri. 3 January"],
+            "days": ["2020-01-01", "2020-01-02", "2020-01-03"],
+        }
+    ],
+)
+
+_day_test = QueryTest(
+    name="day interval",
+    data=_events,
+    filter_data={
+        "date_from": "2020-01-01T00:00:00Z",
+        "date_to": "2020-01-03T00:00:00Z",
+        "interval": "day",
+        "events": [{"id": "sign up"}],
+    },
+    result=[
+        {
+            "action": {
+                "id": "sign up",
+                "type": "events",
+                "order": None,
+                "name": "sign up",
+                "math": None,
+                "math_property": None,
+                "properties": [],
+            },
+            "label": "sign up",
+            "count": 3,
+            "data": [1, 1, 1],
+            "labels": ["Wed. 1 January", "Thu. 2 January", "Fri. 3 January"],
+            "days": ["2020-01-01", "2020-01-02", "2020-01-03"],
+        }
+    ],
+)
+
+_week_test = QueryTest(
+    name="week interval",
+    data=_events,
+    filter_data={
+        "date_from": "2020-01-01T00:00:00Z",
+        "date_to": "2020-01-03T00:00:00Z",
+        "interval": "week",
+        "events": [{"id": "sign up"}],
+    },
+    result=[
+        {
+            "action": {
+                "id": "sign up",
+                "type": "events",
+                "order": None,
+                "name": "sign up",
+                "math": None,
+                "math_property": None,
+                "properties": [],
+            },
+            "label": "sign up",
+            "count": 3,
+            "data": [1, 1, 1],
+            "labels": ["Wed. 1 January", "Thu. 2 January", "Fri. 3 January"],
+            "days": ["2020-01-01", "2020-01-02", "2020-01-03"],
+        }
+    ],
+)
+
+_month_test = QueryTest(
+    name="month interval",
+    data=_events,
+    filter_data={
+        "date_from": "2020-01-01T00:00:00Z",
+        "date_to": "2020-01-03T00:00:00Z",
+        "interval": "month",
+        "events": [{"id": "sign up"}],
+    },
+    result=[
+        {
+            "action": {
+                "id": "sign up",
+                "type": "events",
+                "order": None,
+                "name": "sign up",
+                "math": None,
+                "math_property": None,
+                "properties": [],
+            },
+            "label": "sign up",
+            "count": 3,
+            "data": [1, 1, 1],
+            "labels": ["Wed. 1 January", "Thu. 2 January", "Fri. 3 January"],
+            "days": ["2020-01-01", "2020-01-02", "2020-01-03"],
+        }
+    ],
+)
+
+
+interval_test = [_minute_test, _hour_test, _day_test, _week_test, _month_test]


### PR DESCRIPTION
## Changes

*Please describe.*  
- motivation: we need to handle more combinations of tests. all our query related tests have a very analogous setup (create some data, create a filter with correct params, run the test with the query class, check result)
- our current test pattern is dense as there's a lot of repeated initialization code that's required to setup the test data
- this would reduce the test to a concise object that just needs to be created so devs can focus on filling in the proper data and filter params

TODO:
- figure out best way to accomodate important filter combinations