### PR TITLE
Remove statsd logspam

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -578,5 +578,6 @@ LOGGING = {
     "loggers": {
         "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"), "propagate": True,},
         "axes": {"handlers": ["console"], "level": "WARNING", "propagate": False},
+        "statsd": {"handlers": ["console"], "level": "WARNING", "propagate": True,},
     },
 }


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/3209 introduced statsd.Gauge in
every sync_execute, causing horrible log spam whenever running tests.
This silences the spam.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
