### PR TITLE
Ensure that a team's events always end up in the same Kafka partition

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -191,4 +191,4 @@ def log_event(
         "sent_at": sent_at.isoformat() if sent_at else "",
     }
     for topic in topics:
-        producer.produce(topic=topic, data=data)
+        producer.produce(topic=topic, data=data, key=team_id)

--- a/ee/kafka_client/client.py
+++ b/ee/kafka_client/client.py
@@ -18,7 +18,7 @@ class TestKafkaProducer:
     def __init__(self):
         pass
 
-    def send(self, topic: str, data: Any):
+    def send(self, topic: str, data: Any, key: Any = None):
         return
 
     def flush(self):
@@ -41,11 +41,13 @@ class _KafkaProducer:
         b = json.dumps(d).encode("utf-8")
         return b
 
-    def produce(self, topic: str, data: Any, value_serializer: Optional[Callable[[Any], Any]] = None):
+    def produce(
+        self, topic: str, data: Any, value_serializer: Optional[Callable[[Any], Any]] = None, *, key: Any = None
+    ):
         if not value_serializer:
             value_serializer = self.json_serializer
         b = value_serializer(data)
-        self.producer.send(topic, b)
+        self.producer.send(topic, b, key=key)
 
     def close(self):
         self.producer.flush()


### PR DESCRIPTION
## Changes

This should greatly improvement our batching of events at scale by ensuring that a team's events always end up in one partition. Otherwise batches easily end up just 1 event long when the load is spread across all partitions, which is what we see on Cloud.
On the other hand, my worry is that on private deployments (with few teams, maybe even only one that's seriously used) this could cause a significant imbalance in partitioning. How to proceed best?
@fuziontech