### PR TITLE
Ingest all teams via the plugin server

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -207,10 +207,7 @@ def get_event(request):
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
 
-            # TODO: remove team.organization_id in ... for full rollout of Plugins on EE/Cloud
-            ingest_via_plugin_server = settings.PLUGIN_SERVER_INGESTION and str(team.organization_id) in getattr(
-                settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", []
-            )
+            ingest_via_plugin_server = settings.PLUGIN_SERVER_INGESTION
 
             if ingest_via_plugin_server:
                 log_topics.append(KAFKA_EVENTS_PLUGIN_INGESTION)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -207,9 +207,8 @@ def get_event(request):
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
 
-            ingest_via_plugin_server = settings.PLUGIN_SERVER_INGESTION
 
-            if ingest_via_plugin_server:
+            if settings.PLUGIN_SERVER_INGESTION:
                 log_topics.append(KAFKA_EVENTS_PLUGIN_INGESTION)
                 statsd.Counter("%s_posthog_cloud_plugin_server_ingestion" % (settings.STATSD_PREFIX,)).increment()
 
@@ -226,7 +225,7 @@ def get_event(request):
             )
 
             # must done after logging because process_event_ee modifies the event, e.g. by removing $elements
-            if not ingest_via_plugin_server:
+            if not settings.PLUGIN_SERVER_INGESTION:
                 process_event_ee(
                     distinct_id=distinct_id,
                     ip=get_ip_address(request),

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -207,7 +207,6 @@ def get_event(request):
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
 
-
             if settings.PLUGIN_SERVER_INGESTION:
                 log_topics.append(KAFKA_EVENTS_PLUGIN_INGESTION)
                 statsd.Counter("%s_posthog_cloud_plugin_server_ingestion" % (settings.STATSD_PREFIX,)).increment()

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -66,16 +66,12 @@ def system_status(request):
         }
     )
 
-    plugins_cloud_whitelisted_org_ids = getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
     plugin_server_ingestion = getattr(settings, "PLUGIN_SERVER_INGESTION", False)
-    plugin_sever_enabled = plugin_server_ingestion and (
-        not is_ee_enabled() or (str(team.organization_id) in plugins_cloud_whitelisted_org_ids)
-    )
     metrics.append(
         {
             "key": "ingestion_server",
             "metric": "Event ingestion via",
-            "value": "Plugin Server" if plugin_sever_enabled else "Django",
+            "value": "Plugin Server" if plugin_server_ingestion else "Django",
         }
     )
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -66,12 +66,11 @@ def system_status(request):
         }
     )
 
-    plugin_server_ingestion = getattr(settings, "PLUGIN_SERVER_INGESTION", False)
     metrics.append(
         {
             "key": "ingestion_server",
             "metric": "Event ingestion via",
-            "value": "Plugin Server" if plugin_server_ingestion else "Django",
+            "value": "Plugin Server" if settings.PLUGIN_SERVER_INGESTION else "Django",
         }
     )
 


### PR DESCRIPTION
## Changes

- Removes `PLUGINS_CLOUD_WHITELISTED_ORG_IDS` check for which teams get ingested via the plugin server and which don't
- Keeps the check for which orgs have access to install plugins
- Should be enabled only after https://github.com/PostHog/plugin-server/pull/132 and https://github.com/PostHog/plugin-server/pull/144 land in posthog and are tested to work in production without `this` PR for a little while.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
