### PR TITLE
Enable plugin server ingestion on Cloud but only for $snapshot

### DIFF
--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -104,7 +104,7 @@
                 },
                 {
                     "name": "PLUGIN_SERVER_INGESTION",
-                    "value": "false"
+                    "value": "true"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

This will bring back plugin server ingestion on Cloud, but for pure performance-monitoring purposes and to avoid ClickHouse issues, only for session recording `$snapshot` events.
**To be merged after the production backlog of events in Kafka is fully processed.**
