### PR TITLE
Fix infinites in formula

### DIFF
--- a/ee/clickhouse/queries/trends/formula.py
+++ b/ee/clickhouse/queries/trends/formula.py
@@ -78,7 +78,9 @@ class ClickhouseTrendsFormula:
                 additional_values["data"] = []
                 additional_values["aggregated_value"] = item[1][0]
             else:
-                additional_values["data"] = [round(number, 2) if not math.isnan(number) else 0.0 for number in item[1]]
+                additional_values["data"] = [
+                    round(number, 2) if not math.isnan(number) and not math.isinf(number) else 0.0 for number in item[1]
+                ]
                 if filter.display == TRENDS_CUMULATIVE:
                     additional_values["data"] = list(accumulate(additional_values["data"]))
             additional_values["count"] = float(sum(additional_values["data"]))

--- a/ee/clickhouse/queries/trends/test/test_formula.py
+++ b/ee/clickhouse/queries/trends/test/test_formula.py
@@ -155,6 +155,9 @@ class TestFormula(AbstractIntervalTest, APIBaseTest):
         self.assertEqual(self._run({"formula": "(A/3600)/B"})[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
         self.assertEqual(self._run({"formula": "(A/3600)/B"})[0]["count"], 0)
 
+        self.assertEqual(self._run({"formula": "A/0"})[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        self.assertEqual(self._run({"formula": "A/0"})[0]["count"], 0)
+
     def test_breakdown(self):
         action_response = self._run({"formula": "A - B", "breakdown": "location"})
         self.assertEqual(action_response[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 450.0, 0.0])


### PR DESCRIPTION
## Changes

Previously if you divided by 0 (or something equally dumb) we would get this sentry error: https://sentry.io/organizations/posthog/issues/2071214374/?project=1899813&query=is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
