### PR TITLE
Bump plugin server to 0.8.1

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.8.0"
+        "@posthog/plugin-server": "0.8.1"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -62,10 +62,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.8.0.tgz#c1054ee0d93faa6c698556a1226a01997e09f983"
-  integrity sha512-aSsBZKvHu2jzWBOEuaxbmf79ksKS5nlyfsX8b6R+z4hr9AAFR1tziqzzO11dWiiV2qKaZYSyPClxYIEZ5N9Zfw==
+"@posthog/plugin-server@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.8.1.tgz#b0d397f9c597a326a533cf8114a3dcb8126d131b"
+  integrity sha512-sdQSXjeB3LRgE7iINVSFZDvXXtEz0EXRPwCD3uXqdAh+lP1637pTbGLNEswwgpTlcZvR1rz++GEVJOvE6PhiHQ==
   dependencies:
     "@google-cloud/bigquery" "^5.5.0"
     "@posthog/clickhouse" "^1.7.0"


### PR DESCRIPTION
## Changes

- https://github.com/PostHog/plugin-server/compare/v0.8.0...v0.8.1
- Fix a few things, silence some logs and add instrumentation to try catch a few bugs

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
