### PR TITLE
fix more formula errors

### DIFF
--- a/ee/clickhouse/queries/trends/formula.py
+++ b/ee/clickhouse/queries/trends/formula.py
@@ -65,7 +65,7 @@ class ClickhouseTrendsFormula:
             )
             if filter.breakdown
             else "".join(
-                ["CROSS JOIN ({}) as sub_{}".format(query, letters[i + 1]) for i, query in enumerate(queries[1:])]
+                [" CROSS JOIN ({}) as sub_{}".format(query, letters[i + 1]) for i, query in enumerate(queries[1:])]
             ),
         )
         result = sync_execute(sql)

--- a/ee/clickhouse/queries/trends/test/test_formula.py
+++ b/ee/clickhouse/queries/trends/test/test_formula.py
@@ -227,3 +227,18 @@ class TestFormula(AbstractIntervalTest, APIBaseTest):
         self.assertEqual(
             self._run({"display": TRENDS_CUMULATIVE})[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 1200.0, 2550.0, 2550.0]
         )
+
+    def test_multiple_events(self):
+        # regression test
+        self.assertEqual(
+            self._run(
+                {
+                    "events": [
+                        {"id": "session start", "math": "sum", "math_property": "session duration"},
+                        {"id": "session start", "math": "avg", "math_property": "session duration"},
+                        {"id": "session start", "math": "avg", "math_property": "session duration"},
+                    ]
+                }
+            )[0]["data"],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1200.0, 135.0, 0.0],
+        )

--- a/frontend/src/scenes/insights/trendsLogic.ts
+++ b/frontend/src/scenes/insights/trendsLogic.ts
@@ -18,7 +18,6 @@ import {
 import { ViewType, insightLogic } from './insightLogic'
 import { insightHistoryLogic } from './InsightHistoryPanel/insightHistoryLogic'
 import { SESSIONS_WITH_RECORDINGS_FILTER } from 'scenes/sessions/filters/constants'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { ActionType, EntityType, FilterType, PersonType, PropertyFilter } from '~/types'
 import { trendsLogicType } from './trendsLogicType'
 import { ToastId } from 'react-toastify'
@@ -416,9 +415,7 @@ export const trendsLogic = kea<trendsLogicType<FilterType, ActionType, TrendPeop
                 if (!objectsEqual(cleanSearchParams, values.filters)) {
                     actions.setFilters(cleanSearchParams, false)
                 } else {
-                    /* Edge case when opening a trends graph from a dashboard or sometimes when trends are loaded
-                    with filters already set, `setAllFilters` action is not triggered, and therefore usage is not reported */
-                    eventUsageLogic.actions.reportInsightViewed(values.filters, values.isFirstLoad)
+                    insightLogic.actions.setAllFilters(values.filters)
                 }
 
                 handleLifecycleDefault(cleanSearchParams, (params) => actions.setFilters(params, false))


### PR DESCRIPTION
## Changes

If you got sent to a URL for trends and you'd try to save that to dashboards `filters` would be an empty object.

Also fixes an issue with 3 or more events in a single filter for formulas

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
