### PR TITLE
Bump plugin server to 0.8.3

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.8.2"
+        "@posthog/plugin-server": "0.8.3"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -62,10 +62,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.8.2.tgz#60f4a855e0c2267443651b40c7f223eced9f11cb"
-  integrity sha512-EOdzgTG10L4uiGpSpY1I1UyFJilNtieQ9zpBzDg8si0Zk4XlSEBUA9piuF/t+jwhBefIGiYnoGoKQNe/iYkKhg==
+"@posthog/plugin-server@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.8.3.tgz#11d0bc9449cde01369c6c4497908565f5fe5bd4d"
+  integrity sha512-19qnNVRyQuityJi16FdHLz7aYFYWuzIw0xMbkku+O3dm9rbrBrcHo4j41y/lIo8y6mRxlwMeiJabaZkwLDPHaA==
   dependencies:
     "@google-cloud/bigquery" "^5.5.0"
     "@posthog/clickhouse" "^1.7.0"


### PR DESCRIPTION
## Changes

- https://github.com/PostHog/plugin-server/compare/v0.8.2...v0.8.3
- Fixes a divide by zero issue
- Sets ingestion to run in Promise.all await batches of 100.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
