### PR TITLE
Fix first time retention people query

### DIFF
--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -190,10 +190,9 @@ class ClickhouseRetention(Retention):
         trunc_func = get_trunc_func_ch(period)
         prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
 
-        returning_entity = filter.returning_entity if filter.selected_interval > 0 else filter.target_entity
         target_query, target_params = self._get_condition(filter.target_entity, table="e")
         target_query_formatted = "AND {target_query}".format(target_query=target_query)
-        return_query, return_params = self._get_condition(returning_entity, table="e", prepend="returning")
+        return_query, return_params = self._get_condition(filter.returning_entity, table="e", prepend="returning")
         return_query_formatted = "AND {return_query}".format(return_query=return_query)
 
         first_event_sql = (

--- a/ee/clickhouse/sql/retention/people_in_period.py
+++ b/ee/clickhouse/sql/retention/people_in_period.py
@@ -70,5 +70,5 @@ pdi.person_id as person_id
 from events e JOIN (SELECT person_id, distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s) pdi on e.distinct_id = pdi.distinct_id
 WHERE e.team_id = %(team_id)s {target_query} {filters} 
 GROUP BY person_id HAVING
-min({trunc_func}(e.timestamp)) >= {trunc_func}(toDateTime(%(start_date)s))
+min({trunc_func}(e.timestamp)) = {trunc_func}(toDateTime(%(start_date)s))
 """

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -492,6 +492,43 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
             self.assertEqual(result[1]["person"]["id"], person1.pk)
             self.assertEqual(result[1]["appearances"], [1, 0, 0, 1, 1, 0, 0, 0, 0])
 
+        def test_retention_people_in_period_first_time(self):
+            _, _, p3, _ = self._create_first_time_retention_events()
+            # even if set to hour 6 it should default to beginning of day and include all pageviews above
+            target_entity = json.dumps({"id": "$user_signed_up", "type": TREND_FILTER_TYPE_EVENTS})
+            result1 = retention().people_in_period(
+                RetentionFilter(
+                    data={
+                        "date_to": self._date(10, hour=6),
+                        RETENTION_TYPE: RETENTION_FIRST_TIME,
+                        "target_entity": target_entity,
+                        "returning_entity": {"id": "$pageview", "type": "events"},
+                        "selected_interval": 0,
+                    }
+                ),
+                self.team,
+            )
+
+            self.assertEqual(len(result1), 1)
+            self.assertEqual(result1[0]["person"]["id"], p3.pk)
+            self.assertEqual(result1[0]["appearances"], [1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0])
+
+            # Make sure later people aren't included
+            result2 = retention().people_in_period(
+                RetentionFilter(
+                    data={
+                        "date_to": self._date(10, hour=6),
+                        RETENTION_TYPE: RETENTION_FIRST_TIME,
+                        "target_entity": target_entity,
+                        "returning_entity": {"id": "$pageview", "type": "events"},
+                        "selected_interval": -1,
+                    }
+                ),
+                self.team,
+            )
+
+            self.assertEqual(len(result2), 2)
+
         def test_retention_multiple_events(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
             person_factory(team_id=self.team.pk, distinct_ids=["person2"])


### PR DESCRIPTION
## Changes

*Please describe.*  
- there was a bad operator in the query for first time retention
- there wasn't a test for people under first time retention
- addresses the query count issue of #2794 where there sometimes seemed to be way more results than the count at the top of the table (there is a separate issue with person id misfires)

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
