### PR TITLE
Fix/replace setTimeout in logics

### DIFF
--- a/frontend/src/lib/components/SelectBox.tsx
+++ b/frontend/src/lib/components/SelectBox.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, Fragment } from 'react'
-import { BuiltLogicAdditions, useActions, useValues } from 'kea'
+import { BuiltLogic, useActions, useValues } from 'kea'
 import { Col, Row, Input, Divider } from 'antd'
 import { List } from 'antd'
 import { DownOutlined, RightOutlined } from '@ant-design/icons'
@@ -103,7 +103,7 @@ export function SelectUnit({
 }: {
     group: SelectBoxItem
     dataSource: SelectedItem[]
-    dropdownLogic: selectBoxLogicType<SelectedItem, SelectBoxItem> & BuiltLogicAdditions
+    dropdownLogic: selectBoxLogicType<SelectedItem, SelectBoxItem> & BuiltLogic
 }): JSX.Element {
     const [isCollapsed, setIsCollapsed] = useState(false)
     const { setSelectedItem, clickSelectedItem } = useActions(dropdownLogic)

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -198,4 +198,9 @@ export const insightLogic = kea<insightLogicType>({
             }
         },
     }),
+    events: ({ values }) => ({
+        beforeUnmount: () => {
+            clearTimeout(values.timeout || undefined)
+        },
+    }),
 })

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "fast-deep-equal": "^3.1.3",
         "funnel-graph-js": "^1.4.1",
         "fuse.js": "^6.4.1",
-        "kea": "^2.2.2",
+        "kea": "^2.3.2",
         "kea-loaders": "^0.3.0",
         "kea-localstorage": "^1.0.2",
         "kea-router": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8222,10 +8222,10 @@ kea-window-values@^0.0.1:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-0.0.1.tgz#918eee6647507e2d3d5d19466b9561261e7bc8d7"
   integrity sha512-60SfOqHrmnCC8hSD2LALMJemYcohQ8tGcTHlA5u4rQy0l0wFFE4gqH1WbKd+73j9m4f6zdoOk07rwJf+P8maiQ==
 
-kea@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-2.2.2.tgz#2a58ca5089b95fcc463224e6d08d95f05fac7af7"
-  integrity sha512-9qtmm/J0kz+wSrST1ljsxuoKoIpAhynkV0Rht8OQkAHvX7KEtABNVVdX/r6AgK1BOsjACF4t6tcMnYXG51GEZQ==
+kea@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-2.3.2.tgz#1f536f27114e0902c8664b7ab943fbad3ceb665f"
+  integrity sha512-15e45vjSwxuMr6IMatM/aeu8KKNf1ngP2c4WKXsfSi1tM/sIl68EqAUQ9TN0m8jFuFD5ZFXBGZHz73nEKfFBuA==
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Update kea to 2.3.2
- Use breakpoint over setTimeout()
- Clear timeout before unmount

Related sentry issue: https://sentry.io/organizations/posthog/issues/2212704003/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

Couldn't replace the insight one since it was used across multiple listeners -> instead handled unmount cleanly

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
