### PR TITLE
Add team members to main nav

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -9,6 +9,7 @@ import {
     PushpinFilled,
     PlusOutlined,
     SettingOutlined,
+    TeamOutlined,
 } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
@@ -240,6 +241,13 @@ function _MainNavigation(): JSX.Element {
                         icon={<MessageOutlined />}
                         identifier="annotations"
                         to="/annotations"
+                    />
+                    <div className="divider" />
+                    <MenuItem
+                        title="Team"
+                        icon={<TeamOutlined />}
+                        identifier="organizationMembers"
+                        to="/organization/members"
                     />
                     <MenuItem
                         title="Project"

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -15,6 +15,7 @@ import {
     PlusOutlined,
     UpOutlined,
     SearchOutlined,
+    UserAddOutlined,
 } from '@ant-design/icons'
 import { guardPremiumFeature } from 'scenes/UpgradeModal'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -107,6 +108,12 @@ export function _TopNavigation(): JSX.Element {
                 >
                     <PlusOutlined style={{ marginRight: 8, fontSize: 18 }} /> New organization
                 </a>
+            </div>
+            <div className="divider mb-05" />
+            <div className="text-center mb-05">
+                <Link to="/organization/members" data-attr="top-menu-invite-team-members">
+                    <UserAddOutlined style={{ marginRight: 8, fontSize: 18 }} /> Invite team members
+                </Link>
             </div>
             <div className="divider mb-05" />
             <div className="text-center">

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -26,13 +26,20 @@ import { isMobile, platformCommandControlKey } from 'lib/utils'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { Link } from 'lib/components/Link'
 import { LinkButton } from 'lib/components/LinkButton'
+import { BulkInviteModal } from 'scenes/organization/TeamMembers/BulkInviteModal'
 
 export const TopNavigation = hot(_TopNavigation)
 export function _TopNavigation(): JSX.Element {
-    const { setMenuCollapsed, setChangelogModalOpen, updateCurrentOrganization, updateCurrentProject } = useActions(
+    const {
+        setMenuCollapsed,
+        setChangelogModalOpen,
+        updateCurrentOrganization,
+        updateCurrentProject,
+        setInviteMembersModalOpen,
+    } = useActions(navigationLogic)
+    const { menuCollapsed, systemStatus, updateAvailable, changelogModalOpen, inviteMembersModalOpen } = useValues(
         navigationLogic
     )
-    const { menuCollapsed, systemStatus, updateAvailable, changelogModalOpen } = useValues(navigationLogic)
     const { user } = useValues(userLogic)
     const { logout } = useActions(userLogic)
     const { showUpgradeModal } = useActions(sceneLogic)
@@ -111,9 +118,9 @@ export function _TopNavigation(): JSX.Element {
             </div>
             <div className="divider mb-05" />
             <div className="text-center mb-05">
-                <Link to="/organization/members" data-attr="top-menu-invite-team-members">
+                <a onClick={() => setInviteMembersModalOpen(true)} data-attr="top-menu-invite-team-members">
                     <UserAddOutlined style={{ marginRight: 8, fontSize: 18 }} /> Invite team members
-                </Link>
+                </a>
             </div>
             <div className="divider mb-05" />
             <div className="text-center">
@@ -230,6 +237,7 @@ export function _TopNavigation(): JSX.Element {
                     </Dropdown>
                 </div>
             </div>
+            <BulkInviteModal visible={inviteMembersModalOpen} onClose={() => setInviteMembersModalOpen(false)} />
             <CreateProjectModal isVisible={projectModalShown} setIsVisible={setProjectModalShown} />
             <CreateOrganizationModal isVisible={organizationModalShown} setIsVisible={setOrganizationModalShown} />
             {changelogModalOpen && <ChangelogModal onDismiss={() => setChangelogModalOpen(false)} />}

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -25,6 +25,7 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
         updateCurrentProject: (id: number, dest: string) => ({ id, dest }),
         setToolbarModalOpen: (isOpen: boolean) => ({ isOpen }),
         setPinnedDashboardsVisible: (visible: boolean) => ({ visible }),
+        setInviteMembersModalOpen: (isOpen: boolean) => ({ isOpen }),
     },
     reducers: {
         menuCollapsed: [
@@ -43,6 +44,12 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
             false,
             {
                 setToolbarModalOpen: (_, { isOpen }) => isOpen,
+            },
+        ],
+        inviteMembersModalOpen: [
+            false,
+            {
+                setInviteMembersModalOpen: (_, { isOpen }) => isOpen,
             },
         ],
         pinnedDashboardsVisible: [


### PR DESCRIPTION
## Changes

- Adds a "Team" menu item to the main navigation. Context: [Slack thread](https://posthog.slack.com/archives/C018RGRS10S/p1613410001001200)
- We still want to address the settings page on #3324 and gauge if it still makes sense to have this menu item.

<img width="562" alt="" src="https://user-images.githubusercontent.com/5864173/107978887-2a89b980-6f83-11eb-80b9-a0a3c7334ccf.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
