### PR TITLE
Fix filtering on elements clickhouse

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -22,7 +22,9 @@ def format_action_filter(action: Action, prepend: str = "action", use_loop: bool
         conditions: List[str] = []
         # filter element
         if step.event == AUTOCAPTURE_EVENT:
-            el_conditions, element_params = filter_element(step, "{}_{}{}".format(action.pk, index, prepend))
+            el_conditions, element_params = filter_element(
+                model_to_dict(step), "{}_{}{}".format(action.pk, index, prepend)
+            )
             params = {**params, **element_params}
             conditions += el_conditions
 
@@ -99,8 +101,7 @@ def _create_regex(selector: Selector) -> str:
     return regex
 
 
-def filter_element(step: ActionStep, prepend: str = "") -> Tuple[List[str], Dict]:
-    filters = model_to_dict(step)
+def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
     params = {}
     conditions = []
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -48,8 +48,8 @@ def parse_prop_clauses(
             )
             params.update(filter_params)
         elif prop.type == "element":
-            filter_query, filter_params = filter_element({prop.key: prop.value}, prepend=idx)
-            final.append("AND {}".format(filter_query[0]))
+            query, filter_params = filter_element({prop.key: prop.value}, prepend=idx)
+            final.append("AND {}".format(query[0]))
             params.update(filter_params)
         else:
             filter_query, filter_params = prop_filter_json_extract(

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -48,7 +48,7 @@ def parse_prop_clauses(
             )
             params.update(filter_params)
         elif prop.type == "element":
-            query, filter_params = filter_element({prop.key: prop.value}, prepend=idx)
+            query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
             final.append("AND {}".format(query[0]))
             params.update(filter_params)
         else:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.action import filter_element
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_int, is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
@@ -45,6 +46,10 @@ def parse_prop_clauses(
                     filter_query=GET_DISTINCT_IDS_BY_PROPERTY_SQL.format(filters=filter_query), table_name=table_name
                 )
             )
+            params.update(filter_params)
+        elif prop.type == "element":
+            filter_query, filter_params = filter_element({prop.key: prop.value}, prepend=idx)
+            final.append("AND {}".format(filter_query[0]))
             params.update(filter_params)
         else:
             filter_query, filter_params = prop_filter_json_extract(

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -46,7 +46,7 @@ def _create_event(**kwargs):
     return Event(id=str(uuid))
 
 
-class TestClickhouseFiltering(
+class TestFiltering(
     ClickhouseTestMixin, property_to_Q_test_factory(_filter_events, _create_event, _create_person),  # type: ignore
 ):
     def test_person_cohort_properties(self):


### PR DESCRIPTION
## Changes

Filtering on any element attribute (text/tagname/selector) wasn't working in clickhouse. Added tests + that functionality

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
