### PR TITLE
retention dashboard item refresh bug

### DIFF
--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -43,6 +43,7 @@ function defaultFilters(filters: Record<string, any>): Record<string, any> {
         period: filters.period || 'Day',
         retention_type: filters.retention_type || RETENTION_FIRST_TIME,
         display: filters.display || ACTIONS_TABLE,
+        properties: filters.properties || [],
     }
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- adds properties param to the cleaner function when props are passed from dashboard item into retentionlogic
- the missing params were causing the refresh button to load retention without any property filters

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
