### PR TITLE
Support client-side compact number formatting & instrumentation

### DIFF
--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -1,4 +1,4 @@
-import { formatLabel, identifierToHuman, midEllipsis, isURL, capitalizeFirstLetter } from './utils'
+import { formatLabel, identifierToHuman, midEllipsis, isURL, capitalizeFirstLetter, compactNumber } from './utils'
 
 describe('capitalizeFirstLetter()', () => {
     it('returns the capitalized string', () => {
@@ -87,5 +87,17 @@ describe('isURL()', () => {
         expect(isURL(1)).toEqual(false)
         expect(isURL(true)).toEqual(false)
         expect(isURL(null)).toEqual(false)
+    })
+})
+
+describe('compactNumber()', () => {
+    it('formats number correctly', () => {
+        expect(compactNumber(10)).toEqual('10')
+        expect(compactNumber(293)).toEqual('293')
+        expect(compactNumber(5001)).toEqual('5K')
+        expect(compactNumber(5312)).toEqual('5.3K')
+        expect(compactNumber(5392)).toEqual('5.3K') // rounds down
+        expect(compactNumber(2833102, 2)).toEqual('2.83M')
+        expect(compactNumber(8283310234)).toEqual('8.2B')
     })
 })

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -96,8 +96,8 @@ describe('compactNumber()', () => {
         expect(compactNumber(293)).toEqual('293')
         expect(compactNumber(5001)).toEqual('5K')
         expect(compactNumber(5312)).toEqual('5.3K')
-        expect(compactNumber(5392)).toEqual('5.3K') // rounds down
+        expect(compactNumber(5392)).toEqual('5.4K')
         expect(compactNumber(2833102, 2)).toEqual('2.83M')
-        expect(compactNumber(8283310234)).toEqual('8.2B')
+        expect(compactNumber(8283310234)).toEqual('8.3B')
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -718,3 +718,27 @@ export function autocorrectInterval(filters: Partial<FilterType>): string {
         return filters.interval
     }
 }
+
+function suffixFormatted(value: number, base: number, suffix: string, maxDecimals: number): string {
+    /* Helper function for compactNumber */
+    const multiplier = 10 ** maxDecimals
+    return `${Math.floor((value * multiplier) / base) / multiplier}${suffix}`
+}
+
+export function compactNumber(value: number, maxDecimals: number = 1): string {
+    /*
+    Returns a number in a compact format with a thousands or millions suffix if applicable.
+    Server-side equivalent posthog_filters.py#compact_number
+    Example:
+      compactNumber(5500000)
+      =>  "5.5M"
+    */
+    if (value < 1000) {
+        return Math.floor(value).toString()
+    } else if (value < 1000000) {
+        return suffixFormatted(value, 1000, 'K', maxDecimals)
+    } else if (value < 1000000000) {
+        return suffixFormatted(value, 1000000, 'M', maxDecimals)
+    }
+    return suffixFormatted(value, 1000000000, 'B', maxDecimals)
+}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -722,7 +722,7 @@ export function autocorrectInterval(filters: Partial<FilterType>): string {
 function suffixFormatted(value: number, base: number, suffix: string, maxDecimals: number): string {
     /* Helper function for compactNumber */
     const multiplier = 10 ** maxDecimals
-    return `${Math.floor((value * multiplier) / base) / multiplier}${suffix}`
+    return `${Math.round((value * multiplier) / base) / multiplier}${suffix}`
 }
 
 export function compactNumber(value: number, maxDecimals: number = 1): string {

--- a/frontend/src/scenes/billing/CurrentUsage.tsx
+++ b/frontend/src/scenes/billing/CurrentUsage.tsx
@@ -1,5 +1,6 @@
 import { Card, Progress, Tooltip } from 'antd'
 import { useValues } from 'kea'
+import { compactNumber } from 'lib/utils'
 import React from 'react'
 import { userLogic } from 'scenes/userLogic'
 import { billingLogic } from './billingLogic'
@@ -9,15 +10,21 @@ export function CurrentUsage(): JSX.Element {
     const { user } = useValues(userLogic)
     const plan = user?.billing?.plan
 
+    // :TODO: Temporary support for legacy `FormattedNumber` type
+    const current_usage =
+        typeof user?.billing?.current_usage === 'number'
+            ? user.billing.current_usage
+            : user?.billing?.current_usage?.value
+
     return (
         <>
             <div className="space-top" />
             <Card title="Current monthly usage">
-                {user?.billing?.current_usage && (
+                {current_usage && (
                     <>
                         Your organization has used{' '}
-                        <Tooltip title={`${user.billing.current_usage.value.toLocaleString()} events`}>
-                            <b>{user.billing.current_usage.formatted}</b>
+                        <Tooltip title={`${current_usage.toLocaleString()} events`}>
+                            <b>{compactNumber(current_usage)}</b>
                         </Tooltip>{' '}
                         events this month.{' '}
                         {eventAllocation?.value && (

--- a/frontend/src/scenes/billing/CurrentUsage.tsx
+++ b/frontend/src/scenes/billing/CurrentUsage.tsx
@@ -15,25 +15,27 @@ export function CurrentUsage(): JSX.Element {
         typeof user?.billing?.current_usage === 'number'
             ? user.billing.current_usage
             : user?.billing?.current_usage?.value
+    const allocation = typeof eventAllocation === 'number' ? eventAllocation : eventAllocation?.value
 
     return (
         <>
             <div className="space-top" />
             <Card title="Current monthly usage">
-                {current_usage && (
+                {current_usage !== undefined ? (
                     <>
                         Your organization has used{' '}
                         <Tooltip title={`${current_usage.toLocaleString()} events`}>
                             <b>{compactNumber(current_usage)}</b>
                         </Tooltip>{' '}
                         events this month.{' '}
-                        {eventAllocation?.value && (
+                        {allocation && (
                             <>
-                                You can use up to <b>{eventAllocation.formatted}</b> events per month.
+                                You can use up to <b>{compactNumber(allocation)}</b> events per month.
                             </>
                         )}
                         {plan &&
-                            !plan.allowance &&
+                            !plan.allowance && // :TODO: DEPRECATED
+                            !plan.event_allowance &&
                             !plan.is_metered_billing &&
                             'Your current plan has an unlimited event allocation.'}
                         <Progress
@@ -50,8 +52,7 @@ export function CurrentUsage(): JSX.Element {
                             </div>
                         )}
                     </>
-                )}
-                {!user?.billing?.current_usage && (
+                ) : (
                     <div>
                         Currently we do not have information about your usage. Please check back again in a few minutes
                         or{' '}

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -13,7 +13,7 @@ export enum BillingAlertType {
     UsageNearLimit = 'usage_near_limit',
 }
 
-export const billingLogic = kea<billingLogicType<PlanInterface, BillingSubscription, UserType>>({
+export const billingLogic = kea<billingLogicType<PlanInterface, BillingSubscription, UserType, FormattedNumber>>({
     loaders: {
         plans: [
             [] as PlanInterface[],

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -41,9 +41,13 @@ export const billingLogic = kea<billingLogicType<PlanInterface, BillingSubscript
                 if (!eventAllocation || !user.billing?.current_usage) {
                     return null
                 }
-                // TODO: Temp support for legacy FormattedNumber
+                // :TODO: Temporary support for legacy FormattedNumber
                 const allocation = typeof eventAllocation === 'number' ? eventAllocation : eventAllocation.value
-                return Math.min(Math.round((user.billing.current_usage.value / allocation) * 100) / 100, 1)
+                const usage =
+                    typeof user.billing.current_usage === 'number'
+                        ? user.billing.current_usage
+                        : user.billing.current_usage.value
+                return Math.min(Math.round((usage / allocation) * 100) / 100, 1)
             },
         ],
         strokeColor: [
@@ -82,12 +86,17 @@ export const billingLogic = kea<billingLogicType<PlanInterface, BillingSubscript
                 }
 
                 // Priority 2: Event allowance near limit
+                // :TODO: Temporary support for legacy FormattedNumber
                 const allocation = typeof eventAllocation === 'number' ? eventAllocation : eventAllocation?.value
+                const usage =
+                    typeof user?.billing?.current_usage === 'number'
+                        ? user.billing.current_usage
+                        : user?.billing?.current_usage?.value
                 if (
                     scene !== Scene.Billing &&
                     allocation &&
-                    user.billing?.current_usage &&
-                    user.billing.current_usage.value / allocation >= ALLOCATION_THRESHOLD_ALERT
+                    usage &&
+                    usage / allocation >= ALLOCATION_THRESHOLD_ALERT
                 ) {
                     return BillingAlertType.UsageNearLimit
                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -327,6 +327,7 @@ export interface SessionType {
 }
 
 export interface FormattedNumber {
+    // :TODO: DEPRECATED, formatting will now happen client-side
     value: number
     formatted: string
 }
@@ -337,7 +338,7 @@ export interface OrganizationBilling {
     should_setup_billing?: boolean
     stripe_checkout_session?: string
     subscription_url?: string
-    event_allocation: FormattedNumber | null
+    event_allocation: FormattedNumber | number | null
 }
 
 export interface PlanInterface {
@@ -347,7 +348,7 @@ export interface PlanInterface {
     image_url: string
     self_serve: boolean
     is_metered_billing: boolean
-    allowance: FormattedNumber | null
+    allowance: FormattedNumber | number | null
     price_string: string
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -334,7 +334,7 @@ export interface FormattedNumber {
 
 export interface OrganizationBilling {
     plan: PlanInterface | null
-    current_usage: { value: number; formatted: string } | null
+    current_usage: FormattedNumber | number | null
     should_setup_billing?: boolean
     stripe_checkout_session?: string
     subscription_url?: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -348,7 +348,8 @@ export interface PlanInterface {
     image_url: string
     self_serve: boolean
     is_metered_billing: boolean
-    allowance: FormattedNumber | number | null
+    allowance: FormattedNumber | number | null // :TODO: DEPRECATED
+    event_allowance: number
     price_string: string
 }
 

--- a/posthog/templatetags/posthog_filters.py
+++ b/posthog/templatetags/posthog_filters.py
@@ -12,6 +12,7 @@ Number = Union[int, float]
 def compact_number(value: Number, max_decimals: int = 1) -> str:
     """
     Returns a number in a compact format with a thousands or millions suffix if applicable.
+    Client-side equivalent utils.tsx#compactNumber
     Example:
       {% compact_number 5500000 %}
       =>  "5.5M"


### PR DESCRIPTION
## Changes

- Following #3192 & https://github.com/PostHog/posthog-production/pull/69, implements the `compactNumber` filter on client-side with tests. (e.g. `50383233` becomes `50.4M`).
- Introduces support for plain numeric values for previously `FormattedNumber` props to start the transition to client-side formatting only. A sequential PR in posthog-production will change these values to plain numbers, and a subsequent PR here will remove legacy code.
    - Related to the above, deprecation notices added.
- Adds a bunch of properties related to cloud billing as event super-properties. This will help us understand things like: a) how is the behavior of paying vs. free users different, b) do users keep using PH after exceeding their event allocation, ...

## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User. **Not applicable**
- [X] Django backend tests. **Not applicable**
- [X] Jest frontend tests. **Not applicable**
- [ ] Cypress end-to-end tests
