### PR TITLE
Add created by tag to individual dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.js
+++ b/frontend/src/scenes/dashboard/DashboardHeader.js
@@ -52,9 +52,13 @@ export function DashboardHeader({ logic }) {
                                     {dash.name || <span style={{ color: 'var(--gray)' }}>Untitled</span>}
                                 </Select.Option>
                             ))}
-
                             <Select.Option value="new">+ New Dashboard</Select.Option>
                         </Select>
+                        {dashboard.created_by ? (
+                            <small className="dashboard-header-created-by">
+                                Created by: {dashboard.created_by.first_name || dashboard.created_by.email || '-'}
+                            </small>
+                        ) : null}
                     </div>
                     {dashboard ? (
                         <div className="dashboard-meta">
@@ -72,7 +76,6 @@ export function DashboardHeader({ logic }) {
                                     </Button>
                                 </Tooltip>
                             ) : null}
-
                             <Tooltip title={'Share dashboard.'}>
                                 <Button
                                     className="button-box-when-small enable-dragging-button"

--- a/frontend/src/scenes/dashboard/DashboardHeader.js
+++ b/frontend/src/scenes/dashboard/DashboardHeader.js
@@ -20,6 +20,7 @@ import {
     ShareAltOutlined,
 } from '@ant-design/icons'
 import { FullScreen } from 'lib/components/FullScreen'
+import moment from 'moment'
 
 export function DashboardHeader({ logic }) {
     const { dashboard, draggingEnabled } = useValues(logic)
@@ -56,7 +57,8 @@ export function DashboardHeader({ logic }) {
                         </Select>
                         {dashboard.created_by ? (
                             <small className="dashboard-header-created-by">
-                                Created by: {dashboard.created_by.first_name || dashboard.created_by.email || '-'}
+                                Created by {dashboard.created_by.first_name || dashboard.created_by.email || '-'} on{' '}
+                                {moment(dashboard.created_at).format('MMMM Do YYYY')}
                             </small>
                         ) : null}
                     </div>

--- a/frontend/src/scenes/dashboard/DashboardHeader.js
+++ b/frontend/src/scenes/dashboard/DashboardHeader.js
@@ -58,7 +58,9 @@ export function DashboardHeader({ logic }) {
                         {dashboard.created_by ? (
                             <small className="dashboard-header-created-by">
                                 Created by {dashboard.created_by.first_name || dashboard.created_by.email || '-'} on{' '}
-                                {moment(dashboard.created_at).format('MMMM Do YYYY')}
+                                {moment(dashboard.created_at).format(
+                                    moment(dashboard.created_at).year() === moment().year() ? 'MMMM Do' : 'MMMM Do YYYY'
+                                )}
                             </small>
                         ) : null}
                     </div>

--- a/frontend/src/scenes/dashboard/DashboardHeader.js
+++ b/frontend/src/scenes/dashboard/DashboardHeader.js
@@ -56,12 +56,12 @@ export function DashboardHeader({ logic }) {
                             <Select.Option value="new">+ New Dashboard</Select.Option>
                         </Select>
                         {dashboard.created_by ? (
-                            <small className="dashboard-header-created-by">
+                            <div className="dashboard-header-created-by">
                                 Created by {dashboard.created_by.first_name || dashboard.created_by.email || '-'} on{' '}
                                 {moment(dashboard.created_at).format(
                                     moment(dashboard.created_at).year() === moment().year() ? 'MMMM Do' : 'MMMM Do YYYY'
                                 )}
-                            </small>
+                            </div>
                         ) : null}
                     </div>
                     {dashboard ? (

--- a/frontend/src/scenes/dashboard/DashboardHeader.scss
+++ b/frontend/src/scenes/dashboard/DashboardHeader.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .dashboard-header {
     display: flex;
     justify-content: space-between;
@@ -58,4 +60,12 @@
             display: none;
         }
     }
+}
+
+.dashboard-header-created-by {
+    padding: 5px;
+    background: $primary;
+    border-radius: 4px;
+    color: white;
+    opacity: 0.9;
 }

--- a/frontend/src/scenes/dashboard/DashboardHeader.scss
+++ b/frontend/src/scenes/dashboard/DashboardHeader.scss
@@ -57,10 +57,6 @@
     }
 
     .dashboard-header-created-by {
-        background: $primary;
-        border-radius: 4px;
-        color: white;
-        opacity: 0.9;
         display: inline-block;
         padding-left: 5px;
         padding-right: 5px;

--- a/frontend/src/scenes/dashboard/DashboardHeader.scss
+++ b/frontend/src/scenes/dashboard/DashboardHeader.scss
@@ -55,17 +55,26 @@
             }
         }
     }
+
+    .dashboard-header-created-by {
+        background: $primary;
+        border-radius: 4px;
+        color: white;
+        opacity: 0.9;
+        display: inline-block;
+        padding-left: 5px;
+        padding-right: 5px;
+        position: relative;
+        bottom: 2px;
+    }
+
     @media (max-width: 750px) {
         .hide-when-small {
             display: none;
         }
-    }
-}
 
-.dashboard-header-created-by {
-    padding: 5px;
-    background: $primary;
-    border-radius: 4px;
-    color: white;
-    opacity: 0.9;
+        .dashboard-header-created-by {
+            display: none; /* header is already too crowded on mobile */
+        }
+    }
 }

--- a/frontend/src/scenes/dashboard/DashboardHeader.scss
+++ b/frontend/src/scenes/dashboard/DashboardHeader.scss
@@ -57,11 +57,8 @@
     }
 
     .dashboard-header-created-by {
-        display: inline-block;
-        padding-left: 5px;
-        padding-right: 5px;
-        position: relative;
-        bottom: 2px;
+        margin-top: $default_spacing / 2;
+        color: $text_muted;
     }
 
     @media (max-width: 750px) {


### PR DESCRIPTION
## Changes

Given the call we had just now, I realized that a good way to get context on a dashboard is to know who created it (at least while we don't have anything else).

We already do this, on the dashboards table view, just didn't do it on the dashboard itself.

Quick PR because PRs over issues, but definitely not attached to styles or anything here, happy to completely change placement and styling.


<img width="1440" alt="Screenshot 2021-02-17 at 17 14 39" src="https://user-images.githubusercontent.com/38760734/108241613-f01b4a80-7143-11eb-8ce5-9880ebb6ece1.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
