### PR TITLE
Fix path for demo data generation

### DIFF
--- a/posthog/demo/web_data_generator.py
+++ b/posthog/demo/web_data_generator.py
@@ -187,7 +187,7 @@ class WebDataGenerator(DataGenerator):
             return super().make_person(index)
 
     @cached_property
-    def demo_data(_):
+    def demo_data(self):
         with open(os.path.join(__location__, "demo_data.json"), "r") as demo_data_file:
             return json.load(demo_data_file)
 

--- a/posthog/demo/web_data_generator.py
+++ b/posthog/demo/web_data_generator.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 import secrets
 from datetime import timedelta
@@ -14,6 +15,9 @@ from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.utils import UUIDT
 
 SCREEN_OPTIONS = ("settings", "profile", "movies", "downloads")
+
+# https://stackoverflow.com/questions/4060221/how-to-reliably-open-a-file-in-the-same-directory-as-a-python-script
+__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
 class WebDataGenerator(DataGenerator):
@@ -184,11 +188,11 @@ class WebDataGenerator(DataGenerator):
             return super().make_person(index)
 
     @cached_property
-    def demo_data(self):
-        with open(Path("posthog/demo/demo_data.json").resolve(), "r") as demo_data_file:
+    def demo_data(_):
+        with open(os.path.join(__location__, "demo_data.json"), "r") as demo_data_file:
             return json.load(demo_data_file)
 
     @cached_property
     def demo_recording(self):
-        with open(Path("posthog/demo/demo_session_recording.json").resolve(), "r") as demo_session_file:
+        with open(os.path.join(__location__, "demo_session_recording.json"), "r") as demo_session_file:
             return json.load(demo_session_file)

--- a/posthog/demo/web_data_generator.py
+++ b/posthog/demo/web_data_generator.py
@@ -3,7 +3,6 @@ import os
 import random
 import secrets
 from datetime import timedelta
-from pathlib import Path
 
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now


### PR DESCRIPTION
## Changes

- Fixes a path issue that prevented demo data from being generated on PostHog cloud (because the main path was under deploy/).

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
