### PR TITLE
Fix breaking down by "all" cohorts when no other cohorts

### DIFF
--- a/ee/clickhouse/queries/trends/clickhouse_trends.py
+++ b/ee/clickhouse/queries/trends/clickhouse_trends.py
@@ -50,7 +50,7 @@ class ClickhouseTrends(
             result = sync_execute(sql, params)
         except Exception as e:
             capture_exception(e)
-            if settings.TEST:
+            if settings.TEST or settings.DEBUG:
                 raise e
             result = []
         result = parse_function(result)


### PR DESCRIPTION
Fixes https://sentry.io/organizations/posthog/issues/2213824556/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
