### PR TITLE
Plugin server 0.9.1

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.8.3"
+        "@posthog/plugin-server": "0.9.1"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
+"@babel/standalone@^7.12.16":
+  version "7.12.16"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.16.tgz#2a6dbb54ffc36f5873136d8f8ff9d056b6d01078"
+  integrity sha512-QAJjWYSZYICtMtuJQCAlnhyhwPXMgnl2Bqp9MyxKfiE6u5/GTuEdw3Ay47re2DLxSiYVaST5uRLjyhE0igkXeQ==
+
 "@google-cloud/bigquery@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/bigquery/-/bigquery-5.5.0.tgz#cfe72f8d056abd9c8289c724150d1082a0a6367d"
@@ -62,11 +67,12 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.8.3.tgz#11d0bc9449cde01369c6c4497908565f5fe5bd4d"
-  integrity sha512-19qnNVRyQuityJi16FdHLz7aYFYWuzIw0xMbkku+O3dm9rbrBrcHo4j41y/lIo8y6mRxlwMeiJabaZkwLDPHaA==
+"@posthog/plugin-server@0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.1.tgz#f6a7db0776c6fe369bae422cbe2e981db4fb453a"
+  integrity sha512-Mp0nkcY5H0zE0FslQREBv2tYILCQBhAhQGdM3m2MjlrkNS/L+5BSja9vIUto2KGrFsYvVzF2Wj1G1aBnBovCZg==
   dependencies:
+    "@babel/standalone" "^7.12.16"
     "@google-cloud/bigquery" "^5.5.0"
     "@posthog/clickhouse" "^1.7.0"
     "@sentry/node" "^5.29.0"

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -41,10 +41,6 @@
                     "value": "true"
                 },
                 {
-                    "name": "KAFKA_BATCH_PARALELL_PROCESSING",
-                    "value": "true"
-                },
-                {
                     "name": "BILLING_TRIAL_DAYS",
                     "value": "0"
                 },


### PR DESCRIPTION
## Changes

- Plenty of changes: https://github.com/PostHog/plugin-server/compare/v0.8.3...v0.9.1
- Most notably: better timeout protection in the kafka queue.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
