### PR TITLE
Reuse Postgres connections in Celery

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -414,6 +414,7 @@ if not REDIS_URL:
 CELERY_QUEUES = (Queue("celery", Exchange("celery"), "celery"),)
 CELERY_DEFAULT_QUEUE = "celery"
 CELERY_IMPORTS = ["posthog.tasks.webhooks"]  # required to avoid circular import
+CELERY_DB_REUSE_MAX = 100
 
 if PRIMARY_DB == RDBMS.CLICKHOUSE:
     try:


### PR DESCRIPTION
## Changes

Per [suggestion from user in the Users Slack community](https://posthogusers.slack.com/archives/C019E06QDG8/p1613602278079000?thread_ts=1613600511.076100&cid=C019E06QDG8), this sets `CELERY_DB_REUSE_MAX` to `100`.