### PR TITLE
Add plugin server version to System Status

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -469,6 +469,10 @@ def is_plugin_server_alive() -> bool:
         return False
 
 
+def plugin_server_version() -> Optional[str]:
+    return get_client().get("@posthog-plugin-server/version")
+
+
 def get_redis_info() -> Mapping[str, Any]:
     return get_client().info()
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -469,7 +469,7 @@ def is_plugin_server_alive() -> bool:
         return False
 
 
-def plugin_server_version() -> Optional[str]:
+def get_plugin_server_version() -> Optional[str]:
     return get_client().get("@posthog-plugin-server/version")
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -470,7 +470,10 @@ def is_plugin_server_alive() -> bool:
 
 
 def get_plugin_server_version() -> Optional[str]:
-    return get_client().get("@posthog-plugin-server/version")
+    cache_key_value = get_client().get("@posthog-plugin-server/version")
+    if cache_key_value:
+        return str(cache_key_value)
+    return None
 
 
 def get_redis_info() -> Mapping[str, Any]:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -472,7 +472,7 @@ def is_plugin_server_alive() -> bool:
 def get_plugin_server_version() -> Optional[str]:
     cache_key_value = get_client().get("@posthog-plugin-server/version")
     if cache_key_value:
-        return str(cache_key_value)
+        return cache_key_value.decode("utf-8")
     return None
 
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -25,7 +25,7 @@ from posthog.utils import (
     is_redis_alive,
 )
 
-from .utils import get_celery_heartbeat
+from .utils import get_celery_heartbeat, get_plugin_server_version
 
 
 def login_required(view):
@@ -151,6 +151,13 @@ def system_status(request):
             )
 
     metrics.append({"key": "plugin_sever_alive", "metric": "Plugin server alive", "value": is_plugin_server_alive()})
+    metrics.append(
+        {
+            "key": "plugin_sever_version",
+            "metric": "Plugin server version",
+            "value": get_plugin_server_version() or "unknown",
+        }
+    )
     metrics.append(
         {
             "key": "plugins_install",


### PR DESCRIPTION
## Changes

Thanks to https://github.com/PostHog/plugin-server/pull/158, plugin server version can be viewed in PostHog System Status.
