### PR TITLE
Plugin server ingestion again

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.9.1"
+        "@posthog/plugin-server": "0.9.2"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.1.tgz#f6a7db0776c6fe369bae422cbe2e981db4fb453a"
-  integrity sha512-Mp0nkcY5H0zE0FslQREBv2tYILCQBhAhQGdM3m2MjlrkNS/L+5BSja9vIUto2KGrFsYvVzF2Wj1G1aBnBovCZg==
+"@posthog/plugin-server@0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.2.tgz#cd0d94ef6bd1b26120cc3d123025812f96718643"
+  integrity sha512-ClROfGLDNelAW3mOMb9RUSCj9KK3DSQMgRttK19l9x0Nnyc/5USw70CdOt9fVm12JmtCQpUXN5Afsv6/wre50g==
   dependencies:
     "@babel/standalone" "^7.12.16"
     "@google-cloud/bigquery" "^5.5.0"

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -207,7 +207,10 @@ def get_event(request):
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
 
-            if settings.PLUGIN_SERVER_INGESTION:
+            if settings.PLUGIN_SERVER_INGESTION and (
+                not getattr(settings, "MULTI_TENANCY", False)
+                or team.organization_id in getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
+            ):
                 log_topics.append(KAFKA_EVENTS_PLUGIN_INGESTION)
                 statsd.Counter("%s_posthog_cloud_plugin_server_ingestion" % (settings.STATSD_PREFIX,)).increment()
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -206,11 +206,12 @@ def get_event(request):
 
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
-
-            if settings.PLUGIN_SERVER_INGESTION and (
+            plugin_server_ingestion = settings.PLUGIN_SERVER_INGESTION and (
                 not getattr(settings, "MULTI_TENANCY", False)
                 or team.organization_id in getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
-            ):
+            )
+
+            if plugin_server_ingestion:
                 log_topics.append(KAFKA_EVENTS_PLUGIN_INGESTION)
                 statsd.Counter("%s_posthog_cloud_plugin_server_ingestion" % (settings.STATSD_PREFIX,)).increment()
 
@@ -227,7 +228,7 @@ def get_event(request):
             )
 
             # must done after logging because process_event_ee modifies the event, e.g. by removing $elements
-            if not settings.PLUGIN_SERVER_INGESTION:
+            if not plugin_server_ingestion:
                 process_event_ee(
                     distinct_id=distinct_id,
                     ip=get_ip_address(request),

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -104,7 +104,7 @@
                 },
                 {
                     "name": "PLUGIN_SERVER_INGESTION",
-                    "value": "false"
+                    "value": "true"
                 },
                 {
                     "name": "BILLING_TRIAL_DAYS",


### PR DESCRIPTION
## Changes

Re-enables plugin server ingestion for our teams

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
