### PR TITLE
Change 10% to 1% ingestion via the plugin server

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -210,7 +210,7 @@ def get_event(request):
             plugin_server_ingestion = settings.PLUGIN_SERVER_INGESTION and (
                 not getattr(settings, "MULTI_TENANCY", False)
                 or str(team.organization_id) in getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
-                or random() < 0.10
+                or random() < 0.01
             )
 
             if plugin_server_ingestion:


### PR DESCRIPTION
## Changes

At some point the plugin server gets stuck while ingesting events:

![image](https://user-images.githubusercontent.com/53387/108386078-9599f100-720c-11eb-94b6-6461e69980eb.png)

When I restart, it catches up and quickly, but then still stalls eventually. This change the ingestion percentage to a low % so we still have data to experiment with, yet much less of it.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
