### PR TITLE
fix funnel sortable

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
@@ -66,7 +66,7 @@ export function ActionFilter({
     return (
         <div>
             {localFilters ? (
-                sortable ? (
+                sortable !== undefined ? (
                     <SortableContainer onSortEnd={onSortEnd} useDragHandle lockAxis="y">
                         {localFilters.map((filter, index) => (
                             <SortableActionFilterRow


### PR DESCRIPTION
## Changes

We set `sortable` on the component but only did a simple check, not `sortable !== undefined` so it wouldn't show up.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
