### PR TITLE
Fix loading billing plans on self-hosted

### DIFF
--- a/frontend/src/scenes/billing/BillingEnrollment.tsx
+++ b/frontend/src/scenes/billing/BillingEnrollment.tsx
@@ -10,7 +10,7 @@ function Plan({ plan, onSubscribe }: { plan: PlanInterface; onSubscribe: (plan: 
     const [isDetailLoading, setIsDetailLoading] = useState(true)
 
     const loadPlanDetail = async (key: string): Promise<void> => {
-        const response = await fetch(`/plans/${key}/template/`)
+        const response = await fetch(`/api/plans/${key}/template/`)
         if (response.ok) {
             setDetail(await response.text())
         }

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -94,7 +94,7 @@ export const billingLogic = kea<billingLogicType<PlanInterface, BillingSubscript
     events: ({ actions }) => ({
         afterMount: () => {
             const user = userLogic.values.user
-            if (!user?.billing?.plan) {
+            if (user?.is_multi_tenancy && !user?.billing?.plan) {
                 actions.loadPlans()
             }
         },

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -19,7 +19,7 @@ export const billingLogic = kea<billingLogicType<PlanInterface, BillingSubscript
             [] as PlanInterface[],
             {
                 loadPlans: async () => {
-                    const response = await api.get('plans?self_serve=1')
+                    const response = await api.get('api/plans?self_serve=1')
                     return response.results
                 },
             },


### PR DESCRIPTION
## Changes

- Fixes this bug in which plans were loaded even when on self-hosted (i.e. plans will no longer be loaded unless on cloud).
    <img width="1000" alt="" src="https://user-images.githubusercontent.com/5864173/108403420-4e980580-71e4-11eb-9753-48755db8a5c6.png">
- Updates plan endpoints based on https://github.com/PostHog/posthog-production/pull/83 to make sure that even if a request is performed, it'll be handled correctly.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
