### PR TITLE
Order distinct ids by anonymous

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -54,6 +54,11 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
             return sorted(person.distinct_ids, key=is_anonymous_id)[0]
         return person.pk
 
+    def to_representation(self, data):
+        data = super(PersonSerializer, self).to_representation(data)
+        data["distinct_ids"] = sorted(data["distinct_ids"], key=is_anonymous_id)
+        return data
+
 
 class PersonFilter(filters.FilterSet):
     email = filters.CharFilter(field_name="properties__email")

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -54,10 +54,10 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
             return sorted(person.distinct_ids, key=is_anonymous_id)[0]
         return person.pk
 
-    def to_representation(self, data):
-        data = super(PersonSerializer, self).to_representation(data)
-        data["distinct_ids"] = sorted(data["distinct_ids"], key=is_anonymous_id)
-        return data
+    def to_representation(self, instance: Person) -> Dict[str, Any]:
+        representation = super().to_representation(instance)
+        representation["distinct_ids"] = sorted(representation["distinct_ids"], key=is_anonymous_id)
+        return representation
 
 
 class PersonFilter(filters.FilterSet):

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -321,6 +321,15 @@ def test_person_factory(event_factory, person_factory, get_events, get_people):
             self.assertEqual(response["results"][0]["name"], "distinct_id2")
             self.assertEqual(response["results"][1]["name"], "distinct_id1")
 
+            self.assertEqual(
+                response["results"][0]["distinct_ids"],
+                ["distinct_id2", "17787c327b-0e8f623ea9-336473-1aeaa0-17787c30995b7c"],
+            )
+            self.assertEqual(
+                response["results"][1]["distinct_ids"],
+                ["distinct_id1", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
+            )
+
     return TestPerson
 
 


### PR DESCRIPTION
## Changes

I added some code to make the 'name' field on persons return a non-anonymous distinct id first, but in the 'new' PersonsTableV2 we the distinct_ids list. Fix the ordering for that as well.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
