### PR TITLE
Update plugin server to 0.9.4

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "plugins",
-    "version": "0.0.0",
-    "license": "MIT",
-    "private": true,
-    "dependencies": {
-        "@posthog/plugin-server": "0.9.3"
-    },
-    "scripts": {
-        "start": "posthog-plugin-server"
-    }
+  "name": "plugins",
+  "version": "0.0.0",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "@posthog/plugin-server": "0.9.4"
+  },
+  "scripts": {
+    "start": "posthog-plugin-server"
+  }
 }

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "plugins",
-  "version": "0.0.0",
-  "license": "MIT",
-  "private": true,
-  "dependencies": {
-    "@posthog/plugin-server": "0.9.4"
-  },
-  "scripts": {
-    "start": "posthog-plugin-server"
-  }
+    "name": "plugins",
+    "version": "0.0.0",
+    "license": "MIT",
+    "private": true,
+    "dependencies": {
+        "@posthog/plugin-server": "0.9.4"
+    },
+    "scripts": {
+        "start": "posthog-plugin-server"
+    }
 }

--- a/plugins/package.old.json
+++ b/plugins/package.old.json
@@ -1,0 +1,12 @@
+{
+    "name": "plugins",
+    "version": "0.0.0",
+    "license": "MIT",
+    "private": true,
+    "dependencies": {
+        "@posthog/plugin-server": "0.9.3"
+    },
+    "scripts": {
+        "start": "posthog-plugin-server"
+    }
+}

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.3.tgz#a8b65e9aa7bfc48fcb03f79cad4c49a3be4174db"
-  integrity sha512-isinr4D5pCGhgIlbOkT9Jb01qvPky0ieTTIOhMEI6UDK4kAizeeS5bpf3mccP+4Fy3CR9D79GfwOUL0dMBGGbw==
+"@posthog/plugin-server@0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.4.tgz#b408a653c251dd6736ac195bba2dd722f56e2de6"
+  integrity sha512-FXWsohlMlAoRtR+VTA0Knjd93zAOcuqhhHS5M75N9Z5SpqzJbxUjUT5vXIU2o6jRbE1e9xHAwSVjb/FUplkHDw==
   dependencies:
     "@babel/standalone" "^7.12.16"
     "@google-cloud/bigquery" "^5.5.0"

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -210,7 +210,7 @@ def get_event(request):
             plugin_server_ingestion = settings.PLUGIN_SERVER_INGESTION and (
                 not getattr(settings, "MULTI_TENANCY", False)
                 or str(team.organization_id) in getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
-                or random() < 0.01
+                or random() < 0.03
             )
 
             if plugin_server_ingestion:


### PR DESCRIPTION
## Changes

Plugin server version 0.9.4 has been released. This updates PostHog to use it.

[npm releases](https://www.npmjs.com/package/@posthog/plugin-server?activeTab=version) • [GitHub releases](https://github.com/PostHog/plugin-server/releases) • [commit history](https://github.com/PostHog/plugin-server/commits/)