### PR TITLE
Update plugin server to 0.9.6

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.9.5"
+        "@posthog/plugin-server": "0.9.6"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.9.5":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.5.tgz#2dfe0ea73a7cfb4ee5d0f59f6f63df1bef6d29f3"
-  integrity sha512-rV3WSU95mZ1ZeM4Jrb7nw8eu1fF8GYdgGFI2KAcizAMVklf8iQ2B3sNG449CP6cmTg8+54SB7u/0CfQ5H67xow==
+"@posthog/plugin-server@0.9.6":
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.6.tgz#2248be0e3c919b64b188f2dcb14d5780358d77de"
+  integrity sha512-P6wDeeMl9A5RaLUz0qASjvMwp4ShRmAZBLH4mVdHuAZp34acDaAR7LupeneEPgz+vSoh5/ZiTVbZg28SaGQp/A==
   dependencies:
     "@babel/standalone" "^7.12.16"
     "@google-cloud/bigquery" "^5.5.0"


### PR DESCRIPTION
## Changes

Plugin server version 0.9.6 has been released. This updates PostHog to use it.

[npm releases](https://www.npmjs.com/package/@posthog/plugin-server?activeTab=version) • [GitHub releases](https://github.com/PostHog/plugin-server/releases) • [commit history](https://github.com/PostHog/plugin-server/commits/)