### PR TITLE
Update plugin server to 0.9.10

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.9.7"
+        "@posthog/plugin-server": "0.9.10"
     },
     "scripts": {
         "start": "posthog-plugin-server"


### PR DESCRIPTION
## Changes

Plugin server version 0.9.10 has been released. This updates PostHog to use it.

https://github.com/PostHog/plugin-server/compare/0.9.9...0.9.10 • [GitHub releases](https://github.com/PostHog/plugin-server/releases) • [npm releases](https://www.npmjs.com/package/@posthog/plugin-server?activeTab=version)