### PR TITLE
Update plugin server to

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "0.9.12"
+        "@posthog/plugin-server": ""
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -67,7 +67,7 @@
   resolved "https://registry.yarnpkg.com/@posthog/clickhouse/-/clickhouse-1.7.0.tgz#21fa1e8cfa0637b688f91964e0efeedbf4cf7a3c"
   integrity sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==
 
-"@posthog/plugin-server@0.9.12":
+"@posthog/plugin-server@":
   version "0.9.12"
   resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-0.9.12.tgz#eb4b523a1b70fe0149c43b64b3f73109924da7be"
   integrity sha512-602G7yZohacPt+ho1EtjuZE8FK2if0YceTzK3hE4+3jhOzB3PHQpfPgxMUImn3OCItxA8QRjifcqmzn41P5JTQ==


### PR DESCRIPTION
## Changes

Plugin server version  has been released. This updates PostHog to use it.

https://github.com/PostHog/plugin-server/compare/v...v • [GitHub releases](https://github.com/PostHog/plugin-server/releases) • [npm releases](https://www.npmjs.com/package/@posthog/plugin-server?activeTab=version)