### PR TITLE
Improve django admin for organizations

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from posthog.models import (
@@ -52,12 +53,73 @@ class UserAdmin(DjangoUserAdmin):
         (_("PostHog"), {"fields": ("temporary_token",)}),
     )
     add_fieldsets = ((None, {"classes": ("wide",), "fields": ("email", "password1", "password2"),}),)
-    list_display = ("email", "first_name", "last_name", "is_staff")
+    list_display = ("email", "first_name", "last_name", "organization_name", "is_staff")
     list_filter = ("is_staff", "is_active", "groups")
     search_fields = ("email", "first_name", "last_name")
     ordering = ("email",)
 
+    def organization_name(self, user: User):
+        try:
+            return mark_safe(
+                '<a href="/admin/posthog/organization/%s/change/">%s</a>' % (user.organization.pk, user.organization)
+            )
+        except Team.DoesNotExist:
+            return "no team"
+
+
+class OrganizationMemberInline(admin.TabularInline):
+    extra = 0
+    model = Organization.members.through
+
+
+class OrganizationTeamInline(admin.TabularInline):
+    extra = 0
+    model = Team
+
 
 @admin.register(Organization)
+class OrganizationAdmin(admin.ModelAdmin):
+    fields = [
+        "name",
+        "personalization",
+        "setup_section_2_completed",
+        "created_at",
+        "updated_at",
+        "billing_plan",
+        "organization_billing_link",
+        "usage",
+    ]
+    inlines = [
+        OrganizationTeamInline,
+        OrganizationMemberInline,
+    ]
+    readonly_fields = ["created_at", "updated_at", "billing_plan", "organization_billing_link", "usage"]
+    search_fields = ("name", "members__email")
+    list_display = ("name", "created_at", "members_count", "first_member", "organization_billing_link")
+
+    def members_count(self, organization: Organization):
+        return organization.members.count()
+
+    def first_member(self, organization: Organization):
+        user = organization.members.order_by("id").first()
+        return mark_safe('<a href="/admin/posthog/user/%s/change/">%s</a>' % (user.pk, user.email))
+
+    def organization_billing_link(self, organization: Organization) -> str:
+        try:
+            from multi_tenancy.models import OrganizationBilling  # type: ignore
+
+            billing = OrganizationBilling.objects.get(organization_id=organization.pk)
+            return mark_safe("/admin/multi_tenancy/organizationbilling/%s/change/" % billing.pk)
+        except:
+            return "-"
+
+    def usage(self, organization: Organization):
+        return mark_safe(
+            '<a href="/insights?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B%22id%22%3A%22%24pageview%22%2C%22name%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math%22%3A%22dau%22%7D%5D&properties=%5B%7B%22key%22%3A%22organization_id%22%2C%22value%22%3A%22{}%22%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D&actions=%5B%5D&new_entity=%5B%5D">See usage on PostHog</a>'.format(
+                organization.id
+            )
+        )
+
+
 class OrganizationBillingAdmin(admin.ModelAdmin):
     search_fields = ("name", "members__email")

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -46,7 +46,7 @@ class UserAdmin(DjangoUserAdmin):
     change_form_template = "loginas/change_form.html"
 
     fieldsets = (
-        (None, {"fields": ("email", "password")}),
+        (None, {"fields": ("email", "password", "organization_name")}),
         (_("Personal info"), {"fields": ("first_name", "last_name")}),
         (_("Permissions"), {"fields": ("is_active", "is_staff", "groups", "user_permissions",)},),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
@@ -56,6 +56,7 @@ class UserAdmin(DjangoUserAdmin):
     list_display = ("email", "first_name", "last_name", "organization_name", "is_staff")
     list_filter = ("is_staff", "is_active", "groups")
     search_fields = ("email", "first_name", "last_name")
+    readonly_fields = ["organization_name"]
     ordering = ("email",)
 
     def organization_name(self, user: User):

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -67,12 +67,12 @@ class UserAdmin(DjangoUserAdmin):
     ordering = ("email",)
 
     def organization_name(self, user: User):
-        try:
-            return mark_safe(
-                '<a href="/admin/posthog/organization/%s/change/">%s</a>' % (user.organization.pk, user.organization)
-            )
-        except Team.DoesNotExist:
-            return "no team"
+        if not user.organization:
+            return "No Organization"
+
+        return mark_safe(
+            f'<a href="/admin/posthog/organization/{user.organization.pk}/change/">{user.organization.name}</a>',
+        )
 
     def org_count(self, user: User) -> int:
         return user.organization_memberships.count()

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -116,13 +116,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         return mark_safe('<a href="/admin/posthog/user/%s/change/">%s</a>' % (user.pk, user.email))
 
     def organization_billing_link(self, organization: Organization) -> str:
-        try:
-            from multi_tenancy.models import OrganizationBilling  # type: ignore
-
-            billing = OrganizationBilling.objects.get(organization_id=organization.pk)
-            return mark_safe("/admin/multi_tenancy/organizationbilling/%s/change/" % billing.pk)
-        except:
-            return "-"
+        return mark_safe(f'<a href="/admin/multi_tenancy/organizationbilling/{organization.pk}/change/">Billing →</a>')
 
     def usage(self, organization: Organization):
         return mark_safe(

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -48,7 +48,7 @@ class UserAdmin(DjangoUserAdmin):
     fieldsets = (
         (None, {"fields": ("email", "password", "organization_name")}),
         (_("Personal info"), {"fields": ("first_name", "last_name")}),
-        (_("Permissions"), {"fields": ("is_active", "is_staff", "groups", "user_permissions",)},),
+        (_("Permissions"), {"fields": ("is_active", "is_staff",)},),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
         (_("PostHog"), {"fields": ("temporary_token",)}),
     )

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -120,7 +120,7 @@ class OrganizationAdmin(admin.ModelAdmin):
 
     def usage(self, organization: Organization):
         return mark_safe(
-            '<a href="/insights?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B%22id%22%3A%22%24pageview%22%2C%22name%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math%22%3A%22dau%22%7D%5D&properties=%5B%7B%22key%22%3A%22organization_id%22%2C%22value%22%3A%22{}%22%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D&actions=%5B%5D&new_entity=%5B%5D">See usage on PostHog</a>'.format(
+            '<a target="_blank" href="/insights?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B%22id%22%3A%22%24pageview%22%2C%22name%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math%22%3A%22dau%22%7D%5D&properties=%5B%7B%22key%22%3A%22organization_id%22%2C%22value%22%3A%22{}%22%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D&actions=%5B%5D&new_entity=%5B%5D">See usage on PostHog →</a>'.format(
                 organization.id
             )
         )

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -46,17 +46,24 @@ class UserAdmin(DjangoUserAdmin):
     change_form_template = "loginas/change_form.html"
 
     fieldsets = (
-        (None, {"fields": ("email", "password", "organization_name")}),
+        (None, {"fields": ("email", "password", "organization_name", "org_count")}),
         (_("Personal info"), {"fields": ("first_name", "last_name")}),
         (_("Permissions"), {"fields": ("is_active", "is_staff",)},),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
         (_("PostHog"), {"fields": ("temporary_token",)}),
     )
     add_fieldsets = ((None, {"classes": ("wide",), "fields": ("email", "password1", "password2"),}),)
-    list_display = ("email", "first_name", "last_name", "organization_name", "is_staff")
+    list_display = (
+        "email",
+        "first_name",
+        "last_name",
+        "organization_name",
+        "org_count",
+        "is_staff",
+    )
     list_filter = ("is_staff", "is_active", "groups")
     search_fields = ("email", "first_name", "last_name")
-    readonly_fields = ["organization_name"]
+    readonly_fields = ["organization_name", "org_count"]
     ordering = ("email",)
 
     def organization_name(self, user: User):
@@ -66,6 +73,9 @@ class UserAdmin(DjangoUserAdmin):
             )
         except Team.DoesNotExist:
             return "no team"
+
+    def org_count(self, user: User) -> int:
+        return user.organization_memberships.count()
 
 
 class OrganizationMemberInline(admin.TabularInline):

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth import login, password_validation
 from django.db import transaction
 from django.db.models import QuerySet
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.urls.base import reverse
 from rest_framework import exceptions, generics, permissions, response, serializers, status, viewsets
 from rest_framework.request import Request

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -6,6 +6,7 @@ from django.db import models, transaction
 from django.db.models.query import QuerySet
 from django.dispatch import receiver
 from django.utils import timezone
+from django.utils.safestring import mark_safe
 from rest_framework import exceptions
 
 from .utils import UUIDModel, sane_repr
@@ -108,6 +109,15 @@ class Organization(UUIDModel):
         self.setup_section_2_completed = True
         self.save()
         return self
+
+    def organization_billing_link(self) -> str:
+        try:
+            from multi_tenancy.models import OrganizationBilling  # type: ignore
+
+            billing = OrganizationBilling.objects.get(organization_id=self.pk)
+            return mark_safe("/admin/multi_tenancy/organizationbilling/%s/change/" % billing.pk)
+        except:
+            return "-"
 
 
 class OrganizationMembership(UUIDModel):

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -6,7 +6,6 @@ from django.db import models, transaction
 from django.db.models.query import QuerySet
 from django.dispatch import receiver
 from django.utils import timezone
-from django.utils.safestring import mark_safe
 from rest_framework import exceptions
 
 from .utils import UUIDModel, sane_repr

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -110,15 +110,6 @@ class Organization(UUIDModel):
         self.save()
         return self
 
-    def organization_billing_link(self) -> str:
-        try:
-            from multi_tenancy.models import OrganizationBilling  # type: ignore
-
-            billing = OrganizationBilling.objects.get(organization_id=self.pk)
-            return mark_safe("/admin/multi_tenancy/organizationbilling/%s/change/" % billing.pk)
-        except:
-            return "-"
-
 
 class OrganizationMembership(UUIDModel):
     class Level(models.IntegerChoices):


### PR DESCRIPTION
## Changes

Show a bunch more info, allow searching (even on email), team management, user management etc. Should make doing admin stuff around billing etc a lot easier.

![image](https://user-images.githubusercontent.com/1727427/108503782-38a64580-72b5-11eb-89af-9629716cc841.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
