### PR TITLE
Improve reordering funnel steps

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.js
@@ -67,7 +67,7 @@ export function ActionFilter({
         <div>
             {localFilters ? (
                 sortable ? (
-                    <SortableContainer onSortEnd={onSortEnd} useDragHandle lockAxis="y">
+                    <SortableContainer onSortEnd={onSortEnd} lockAxis="y" distance={5}>
                         {localFilters.map((filter, index) => (
                             <SortableActionFilterRow
                                 key={index}


### PR DESCRIPTION
You can now drag the whole "row" not just by the handle

distance now needs to be set not to interact badly with dropdown menus -
by default it would eat all the clicks.

Fixes #3410


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
