### PR TITLE
Finish the purge on curly-less if statements

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,7 +3,9 @@
 
 const plugins = [require('autoprefixer')] // postCSS modules here
 
-if (process.env.NODE_ENV === 'production') plugins.push(require('cssnano'))
+if (process.env.NODE_ENV === 'production') {
+    plugins.push(require('cssnano'))
+}
 
 module.exports = {
     plugins,


### PR DESCRIPTION
## Changes

Not that this is very important, but found a bracketless if statement that wasn't caught by the purge in https://github.com/PostHog/posthog/pull/2505


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
