### PR TITLE
Revert "Reuse Postgres connections in Celery"

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -414,7 +414,6 @@ if not REDIS_URL:
 CELERY_QUEUES = (Queue("celery", Exchange("celery"), "celery"),)
 CELERY_DEFAULT_QUEUE = "celery"
 CELERY_IMPORTS = ["posthog.tasks.webhooks"]  # required to avoid circular import
-CELERY_DB_REUSE_MAX = 100
 
 if PRIMARY_DB == RDBMS.CLICKHOUSE:
     try:


### PR DESCRIPTION
Reverts PostHog/posthog#3379. Unfortunately it does seem to cause highly increased Postgres connection error incidence (https://sentry.io/organizations/posthog/issues/1905826905).