### PR TITLE
Rename DAU -> Active Users

### DIFF
--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -36,7 +36,7 @@ describe('formatLabel()', () => {
         given('action', () => ({ math: 'dau' }))
 
         it('is formatted', () => {
-            expect(given.subject).toEqual('some_event (DAU) ')
+            expect(given.subject).toEqual('some_event (Active Users) ')
         })
     })
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -234,7 +234,7 @@ export function formatLabel(
     }
 ): string {
     if (action.math === 'dau') {
-        label += ` (${action.math.toUpperCase()}) `
+        label += ` (Active Users) `
     } else if (['sum', 'avg', 'min', 'max', 'median', 'p90', 'p95', 'p99'].includes(action.math)) {
         label += ` (${action.math} of ${action.math_property}) `
     } else {


### PR DESCRIPTION
## Changes

Rename label on charts from DAU to Active Users.

This is some lingering legacy stuff that we never changed and confuses users.

'Active Users' is aligned with the terminology we now use on the "filter" anyway.

<img width="600" alt="Screenshot 2021-02-22 at 12 07 37" src="https://user-images.githubusercontent.com/38760734/108706465-9382ab80-7506-11eb-9c58-81d64396a128.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
