### PR TITLE
Fix authenticated invite signup

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -63,7 +63,7 @@ class Api {
         }
         return await getJSONOrThrow(response)
     }
-    async create(url, data) {
+    async create(url, data = undefined) {
         if (url.indexOf('http') !== 0) {
             url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }

--- a/frontend/src/scenes/onboarding/InviteSignup.tsx
+++ b/frontend/src/scenes/onboarding/InviteSignup.tsx
@@ -156,7 +156,7 @@ function AuthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite }): 
                             <Button
                                 type="primary"
                                 block
-                                onClick={() => acceptInvite(undefined)}
+                                onClick={() => acceptInvite()}
                                 disabled={acceptedInviteLoading}
                             >
                                 Accept invite

--- a/frontend/src/scenes/onboarding/InviteSignup.tsx
+++ b/frontend/src/scenes/onboarding/InviteSignup.tsx
@@ -156,7 +156,7 @@ function AuthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite }): 
                             <Button
                                 type="primary"
                                 block
-                                onClick={() => acceptInvite(null)}
+                                onClick={() => acceptInvite(undefined)}
                                 disabled={acceptedInviteLoading}
                             >
                                 Accept invite

--- a/frontend/src/scenes/onboarding/inviteSignupLogic.ts
+++ b/frontend/src/scenes/onboarding/inviteSignupLogic.ts
@@ -62,7 +62,7 @@ export const inviteSignupLogic = kea<
         acceptedInvite: [
             null,
             {
-                acceptInvite: async (payload: AcceptInvitePayloadInterface | null, breakpoint) => {
+                acceptInvite: async (payload: AcceptInvitePayloadInterface | undefined, breakpoint) => {
                     breakpoint()
 
                     if (!values.invite) {

--- a/frontend/src/scenes/onboarding/inviteSignupLogic.ts
+++ b/frontend/src/scenes/onboarding/inviteSignupLogic.ts
@@ -62,7 +62,7 @@ export const inviteSignupLogic = kea<
         acceptedInvite: [
             null,
             {
-                acceptInvite: async (payload: AcceptInvitePayloadInterface | undefined, breakpoint) => {
+                acceptInvite: async (payload?: AcceptInvitePayloadInterface, breakpoint?) => {
                     breakpoint()
 
                     if (!values.invite) {


### PR DESCRIPTION
## Changes

Fixes [this bug](https://posthog.slack.com/archives/C0113360FFV/p1614024617022500) in which logged in users couldn't accept invites to new orgs.

Additional context: Bug was caused by our `lib/api` module requiring a payload attribute on the `.create()` method. Previously we were sending a `null` value in the payload to `/api/signup/{id}/` instead of an empty payload, which caused the DRF serializer to try to validate the payload (which of course was invalid because didn't match any fields).

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
