### PR TITLE
Send 20% of events to plugin server

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -47,6 +47,9 @@ if [[ -n $DYNO_RAM ]]; then
   export WORKER_CONCURRENCY=$(( ($DYNO_RAM - 1) / 512 + 1 ))
 fi
 
+# Help debug redis connection issues
+export DEBUG=ioredis:*
+
 cd plugins
 
 echo "🧐 Verifying installed packages..."

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -210,7 +210,7 @@ def get_event(request):
             plugin_server_ingestion = settings.PLUGIN_SERVER_INGESTION and (
                 not getattr(settings, "MULTI_TENANCY", False)
                 or str(team.organization_id) in getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
-                or random() < 0.10
+                or random() < 0.20
             )
 
             if plugin_server_ingestion:


### PR DESCRIPTION
## Changes

- Doubles the load on the plugin server

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
