### PR TITLE
Send 33% of events to plugin server

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -210,7 +210,7 @@ def get_event(request):
             plugin_server_ingestion = settings.PLUGIN_SERVER_INGESTION and (
                 not getattr(settings, "MULTI_TENANCY", False)
                 or str(team.organization_id) in getattr(settings, "PLUGINS_CLOUD_WHITELISTED_ORG_IDS", [])
-                or random() < 0.20
+                or random() < 0.33
             )
 
             if plugin_server_ingestion:


### PR DESCRIPTION
## Changes

- Increases the % of events going to the plugin server for ingestion from 20% to 33%

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
