### PR TITLE
Set props to user on any event

### DIFF
--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -886,6 +886,107 @@ def test_process_event_factory(
             event = get_events()[0]
             self.assertEqual(len(event.event), 200)
 
+        def test_any_event_set(self) -> None:
+            Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
+
+            process_event(
+                "distinct_id",
+                "",
+                "",
+                {
+                    "event": "some_event",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set": {"a_prop": "test-1", "c_prop": "test-1"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 1)
+            self.assertEqual(get_events()[0].properties["$set"], {"a_prop": "test-1", "c_prop": "test-1"})
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-1", "c_prop": "test-1"})
+
+        def test_set_with_invalid_props(self) -> None:
+            Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
+
+            # invalid props should not be set and no errors should be thrown
+            process_event(
+                "distinct_id",
+                "",
+                "",
+                {
+                    "event": "some_event",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set": [{"a_prop": "test-1"}],
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 1)
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
+            self.assertEqual(person.properties, {})
+
+        def test_any_event_set_once(self) -> None:
+            Person.objects.create(team=self.team, distinct_ids=["distinct_id"])
+
+            process_event(
+                "distinct_id",
+                "",
+                "",
+                {
+                    "event": "some_event",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set_once": {"a_prop": "test-1", "c_prop": "test-1"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 1)
+            self.assertEqual(get_events()[0].properties["$set_once"], {"a_prop": "test-1", "c_prop": "test-1"})
+            person = Person.objects.get()
+            self.assertEqual(person.distinct_ids, ["distinct_id"])
+            self.assertEqual(person.properties, {"a_prop": "test-1", "c_prop": "test-1"})
+
+            # check no errors as this call can happen multiple times
+            process_event(
+                "distinct_id",
+                "",
+                "",
+                {
+                    "event": "some_other_event",
+                    "properties": {
+                        "token": self.team.api_token,
+                        "distinct_id": "distinct_id",
+                        "$set_once": {"a_prop": "test-2", "b_prop": "test-2"},
+                    },
+                },
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            self.assertEqual(len(get_events()), 2)
+            self.assertEqual(
+                Person.objects.get().properties, {"a_prop": "test-1", "b_prop": "test-2", "c_prop": "test-1"}
+            )
+
     return TestProcessEvent
 
 


### PR DESCRIPTION
> PR brought back as per a discussion on Slack about keeping parity between ingestion here and the plugin server

## Changes

### Main

The main change of this PR is allowing props to be set to the user on any event by using the `$set` property. It's a proposal really.

My use case here is setting properties on a user inside the plugin server without hitting the API (the plugin server currently only exposes `posthog.capture`).

However, while another solution would be to add `posthog.people.set` to the plugin server (probably will happen at some point), I see some benefits in this approach to others, namely that I don't have to hit 2 API endpoints if I'm sending an event and setting props.

In practice, here's what this might look like:

```js
// before the change
posthog.capture('some event', { eventProp: 1 })
posthog.people.set({ userProp: 2 })

// after the change
posthog.capture('some event', { eventProp: 1, $set: { userProp: 2 } } )
```

There could definitely be something here I'm missing though as for why this wasn't done before.

### Minor

This PR also:

1. Removes the unused `get_or_create_person`
2. Adds a type check before setting properties on a user

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests