### PR TITLE
change frequency of cohort calculation

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -72,7 +72,7 @@ def setup_periodic_tasks(sender, **kwargs):
         sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
         sender.add_periodic_task(120, clickhouse_part_count.s(), name="clickhouse table parts count")
 
-    sender.add_periodic_task(60, calculate_cohort.s(), name="recalculate cohorts")
+    sender.add_periodic_task(120, calculate_cohort.s(), name="recalculate cohorts")
 
     if settings.ASYNC_EVENT_ACTION_MAPPING:
         sender.add_periodic_task(

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -13,7 +13,7 @@ from posthog.models import Cohort
 logger = logging.getLogger(__name__)
 
 MAX_AGE_MINUTES = 15
-PARALLEL_COHORTS = int(os.environ.get("PARALLEL_COHORTS", 5))
+PARALLEL_COHORTS = int(os.environ.get("PARALLEL_COHORTS", 2))
 
 
 def calculate_cohorts() -> None:
@@ -23,7 +23,7 @@ def calculate_cohorts() -> None:
         Cohort.objects.filter(
             is_calculating=False,
             last_calculation__lte=timezone.now() - relativedelta(minutes=MAX_AGE_MINUTES),
-            errors_calculating__lte=2,
+            errors_calculating__lte=20,
         )
         .exclude(is_static=True)
         .order_by(F("last_calculation").asc(nulls_first=True))[0:PARALLEL_COHORTS]


### PR DESCRIPTION
## Changes

*Please describe.*  
- doing less parallel calculations and changed cron job to be longer interval. We don't have that many cohorts so this should still be sufficient. Also right now, more cohorts are uncalculated/stale so the higher frequency settings don't even matter

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
