### PR TITLE
Fix setting up test databases on clickhouse

### DIFF
--- a/ee/management/commands/setup_test_environment.py
+++ b/ee/management/commands/setup_test_environment.py
@@ -7,10 +7,33 @@ class Command(BaseCommand):
     help = "Set up databases for non-Python tests that depend on the Django server"
 
     def handle(self, *args, **options):
-        if is_ee_enabled():
-            from ee.clickhouse.clickhouse_test_runner import ClickhouseTestRunner as TestRunner
-        else:
-            from django.test.runner import DiscoverRunner as TestRunner
+        from django.test.runner import DiscoverRunner as TestRunner
+
         test_runner = TestRunner(interactive=False)
         test_runner.setup_databases()
         test_runner.setup_test_environment()
+
+        if is_ee_enabled():
+            from infi.clickhouse_orm import Database  # type: ignore
+
+            from posthog.settings import (
+                CLICKHOUSE_DATABASE,
+                CLICKHOUSE_HTTP_URL,
+                CLICKHOUSE_PASSWORD,
+                CLICKHOUSE_USER,
+                CLICKHOUSE_VERIFY,
+            )
+
+            database = Database(
+                CLICKHOUSE_DATABASE,
+                db_url=CLICKHOUSE_HTTP_URL,
+                username=CLICKHOUSE_USER,
+                password=CLICKHOUSE_PASSWORD,
+                verify_ssl_cert=CLICKHOUSE_VERIFY,
+            )
+
+            try:
+                database.create_database()
+            except:
+                pass
+            database.migrate("ee.clickhouse.migrations")


### PR DESCRIPTION
This was used by plugin server

Example failed test run: https://github.com/PostHog/plugin-server/pull/208/checks?check_run_id=1968879332
Successful run: https://github.com/PostHog/plugin-server/pull/208/checks?check_run_id=1968970261

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
