### PR TITLE
Rename posthog-production to posthog-cloud

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -161,9 +161,9 @@ jobs:
                     - '9009:9009'
 
         steps:
-            - name: Fetch posthog-production
+            - name: Fetch posthog-cloud
               run: |
-                  curl -L https://github.com/posthog/posthog-production/tarball/master | tar --strip-components=1 -xz --
+                  curl -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
                   mkdir deploy/
 
             - name: Checkout master
@@ -172,7 +172,7 @@ jobs:
                   ref: 'master'
                   path: 'deploy/'
 
-            - name: Link posthog-production at master
+            - name: Link posthog-cloud at master
               run: |
                   cp -r multi_tenancy deploy/
                   cp -r messaging deploy/
@@ -213,7 +213,7 @@ jobs:
               with:
                   path: 'deploy/'
 
-            - name: Link posthog-production at current branch
+            - name: Link posthog-cloud at current branch
               run: |
                   cp deploy/ee/conftest.py multi_tenancy/conftest.py
                   cp deploy/ee/conftest.py messaging/conftest.py
@@ -241,7 +241,7 @@ jobs:
                   touch frontend/dist/shared_dashboard.html
                   pytest posthog --reuse-db -m "not skip_on_multitenancy"
 
-            - name: Run cloud tests (posthog-production)
+            - name: Run cloud tests (posthog-cloud)
               env:
                   DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
                   PRIMARY_DB: 'clickhouse'

--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -22,9 +22,9 @@ jobs:
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v1
 
-            - name: Fetch posthog-production
+            - name: Fetch posthog-cloud
               run: |
-                  curl -L https://github.com/posthog/posthog-production/tarball/master | tar --strip-components=1 -xz --
+                  curl -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
                   mkdir deploy/
 
             - name: Checkout master

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -56,7 +56,7 @@ def setup_periodic_tasks(sender, **kwargs):
     if not getattr(settings, "MULTI_TENANCY", False):
         sender.add_periodic_task(crontab(day_of_week="mon", hour=0, minute=0), status_report.s())
 
-    # Cloud (posthog-production) cron jobs
+    # Cloud (posthog-cloud) cron jobs
     if getattr(settings, "MULTI_TENANCY", False):
         sender.add_periodic_task(crontab(hour=0, minute=0), calculate_billing_daily_usage.s())  # every day midnight UTC
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -496,7 +496,7 @@ EMAIL_USE_SSL = get_from_env("EMAIL_USE_SSL", False, type_cast=strtobool)
 DEFAULT_FROM_EMAIL = os.getenv("EMAIL_DEFAULT_FROM", os.getenv("DEFAULT_FROM_EMAIL", "root@localhost"))
 EMAIL_REPLY_TO = os.getenv("EMAIL_REPLY_TO")
 
-MULTI_TENANCY = False  # overriden by posthog-production
+MULTI_TENANCY = False  # overriden by posthog-cloud
 
 CACHES = {
     "default": {


### PR DESCRIPTION
## Changes

- Updates required referenced to `posthog-production` to use the new `posthog-cloud` name.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
