### PR TITLE
Don't null IPs for teams who toggled an ancient field

### DIFF
--- a/posthog/migrations/0127_stricter_team_data.py
+++ b/posthog/migrations/0127_stricter_team_data.py
@@ -12,6 +12,8 @@ def adjust_teams_for_stricter_requirements(apps, schema_editor):
     else:
         Team.objects.filter(organization_id__isnull=True).delete()
     Team.objects.filter(models.Q(name__isnull=True) | models.Q(name="")).update(name="Project X")
+    for team in Team.objects.filter(opt_out_capture=True):
+        team.organization.members.update(anonymize_data=True)
 
 
 class Migration(migrations.Migration):

--- a/posthog/migrations/0127_stricter_team_data.py
+++ b/posthog/migrations/0127_stricter_team_data.py
@@ -11,7 +11,6 @@ def adjust_teams_for_stricter_requirements(apps, schema_editor):
         Team.objects.filter(organization_id__isnull=True).update(organization_id=first_organization.id)
     else:
         Team.objects.filter(organization_id__isnull=True).delete()
-    Team.objects.filter(opt_out_capture=True).update(anonymize_ips=True)
     Team.objects.filter(models.Q(name__isnull=True) | models.Q(name="")).update(name="Project X")
 
 


### PR DESCRIPTION
## Changes

It's normally not good practice to change old migrations, but since we're working with releases and this hasn't gone out yet, might as well.

I think this line is wrong (passed my review, sorry). `team.anonymize_ips` means we just don't store IP information with events. `team.opt_out_capture` was an old flag to disable tracking on self-hosted instances. They don't mean the same thing.

The impact is probably zero users so far, but if we release with this line, then after upgrading to 1.22, some really old and still running installations that had flipped this switch will suddenly stop seeing IP addresses with their event properties. Best to revert I think.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
