### PR TITLE
Earlier IP anonymization

### DIFF
--- a/ee/clickhouse/process_event.py
+++ b/ee/clickhouse/process_event.py
@@ -32,7 +32,7 @@ if settings.STATSD_HOST is not None:
 def _capture_ee(
     event_uuid: UUID,
     person_uuid: UUID,
-    ip: str,
+    ip: Optional[str],
     site_url: str,
     team_id: int,
     event: str,
@@ -60,7 +60,7 @@ def _capture_ee(
 
     team = Team.objects.select_related("organization").get(pk=team_id)
 
-    if not team.anonymize_ips and "$ip" not in properties:
+    if ip and not team.anonymize_ips and "$ip" not in properties:
         properties["$ip"] = ip
 
     event = sanitize_event_name(event)
@@ -116,7 +116,7 @@ if is_ee_enabled():
 
     def process_event_ee(
         distinct_id: str,
-        ip: str,
+        ip: Optional[str],
         site_url: str,
         data: dict,
         team_id: int,
@@ -165,7 +165,7 @@ else:
 
     def process_event_ee(
         distinct_id: str,
-        ip: str,
+        ip: Optional[str],
         site_url: str,
         data: dict,
         team_id: int,
@@ -179,7 +179,7 @@ else:
 
 def log_event(
     distinct_id: str,
-    ip: str,
+    ip: Optional[str],
     site_url: str,
     data: dict,
     team_id: int,

--- a/frontend/src/scenes/project/Settings/IPCapture.js
+++ b/frontend/src/scenes/project/Settings/IPCapture.js
@@ -20,7 +20,7 @@ export function IPCapture() {
                     marginLeft: '10px',
                 }}
             >
-                Anonymize client IP data
+                Do not save client IP data
             </label>
         </div>
     )

--- a/frontend/src/scenes/project/Settings/IPCapture.js
+++ b/frontend/src/scenes/project/Settings/IPCapture.js
@@ -20,7 +20,7 @@ export function IPCapture() {
                     marginLeft: '10px',
                 }}
             >
-                Do not save client IP data
+                Discard client IP data
             </label>
         </div>
     )

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -204,6 +204,7 @@ def get_event(request):
         _ensure_web_feature_flags_in_properties(event, team, distinct_id)
 
         event_uuid = UUIDT()
+        ip = get_ip_address(request) if team.anonymize_ips else None
 
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]
@@ -214,7 +215,7 @@ def get_event(request):
 
             log_event(
                 distinct_id=distinct_id,
-                ip=get_ip_address(request),
+                ip=ip,
                 site_url=request.build_absolute_uri("/")[:-1],
                 data=event,
                 team_id=team.id,
@@ -228,7 +229,7 @@ def get_event(request):
             if not settings.PLUGIN_SERVER_INGESTION:
                 process_event_ee(
                     distinct_id=distinct_id,
-                    ip=get_ip_address(request),
+                    ip=ip,
                     site_url=request.build_absolute_uri("/")[:-1],
                     data=event,
                     team_id=team.id,
@@ -247,15 +248,7 @@ def get_event(request):
             celery_app.send_task(
                 name=task_name,
                 queue=celery_queue,
-                args=[
-                    distinct_id,
-                    get_ip_address(request),
-                    request.build_absolute_uri("/")[:-1],
-                    event,
-                    team.id,
-                    now.isoformat(),
-                    sent_at,
-                ],
+                args=[distinct_id, ip, request.build_absolute_uri("/")[:-1], event, team.id, now.isoformat(), sent_at,],
             )
     timer.stop("event_endpoint")
     return cors_response(request, JsonResponse({"status": 1}))

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -204,7 +204,7 @@ def get_event(request):
         _ensure_web_feature_flags_in_properties(event, team, distinct_id)
 
         event_uuid = UUIDT()
-        ip = get_ip_address(request) if team.anonymize_ips else None
+        ip = None if team.anonymize_ips else get_ip_address(request)
 
         if is_ee_enabled():
             log_topics = [KAFKA_EVENTS_WAL]

--- a/posthog/tasks/process_event.py
+++ b/posthog/tasks/process_event.py
@@ -102,7 +102,7 @@ def store_names_and_properties(team: Team, event: str, properties: Dict) -> None
 
 
 def _capture(
-    ip: str,
+    ip: Optional[str],
     site_url: str,
     team_id: int,
     event: str,
@@ -138,7 +138,7 @@ def _capture(
         "ingested_event",
     ).get(pk=team_id)
 
-    if not team.anonymize_ips and "$ip" not in properties:
+    if ip and not team.anonymize_ips and "$ip" not in properties:
         properties["$ip"] = ip
 
     event = sanitize_event_name(event)
@@ -259,7 +259,7 @@ def handle_identify_or_alias(event: str, properties: dict, distinct_id: str, tea
 
 @shared_task(name="posthog.tasks.process_event.process_event", ignore_result=True)
 def process_event(
-    distinct_id: str, ip: str, site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str],
+    distinct_id: str, ip: Optional[str], site_url: str, data: dict, team_id: int, now: str, sent_at: Optional[str],
 ) -> None:
     properties = data.get("properties", {})
     if data.get("$set"):

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -205,6 +205,22 @@ def factory_test_process_event(
 
             self.assertLess(difference, 1)
 
+        def test_ip_none(self) -> None:
+            Person.objects.create(team=self.team, distinct_ids=["asdfasdfasdf"])
+
+            process_event(
+                "asdfasdfasdf",
+                None,
+                "",
+                {"event": "$pageview", "properties": {"distinct_id": "asdfasdfasdf", "token": self.team.api_token,},},
+                self.team.pk,
+                now().isoformat(),
+                now().isoformat(),
+            )
+
+            event = get_events()[0]
+            self.assertEqual(event.properties.get("$ip", None), None)
+
         def test_ip_capture(self) -> None:
             user = self._create_user("tim")
             Person.objects.create(team=self.team, distinct_ids=["asdfasdfasdf"])

--- a/posthog/tasks/test/test_process_event.py
+++ b/posthog/tasks/test/test_process_event.py
@@ -51,7 +51,7 @@ def factory_test_process_event(
             with self.assertNumQueries(num_queries):
                 process_event(
                     2,
-                    "",
+                    "127.0.0.1",
                     "",
                     {
                         "event": "$autocapture",
@@ -836,7 +836,7 @@ def factory_test_process_event(
             self.assertListEqual(self.team.event_properties_numerical, [])
             process_event(
                 "xxx",
-                "",
+                "127.0.0.1",
                 "",
                 {"event": "purchase", "properties": {"price": 299.99, "name": "AirPods Pro"},},
                 self.team.pk,


### PR DESCRIPTION
## Changes

- Under "Project" replace the checkbox "Anonymize client IP data" with "Discard client IP data", which better reflects what this checkbox does. "Anonymize" could also mean e.g. removing 8 random bits.
- Actually hides the IP before the task queues and plugins if the option is flipped, instead of just not storing it in the final ingestion stage
- Resolves https://github.com/PostHog/plugin-server/issues/119

This came out of the needs of a client who wants to use plugins to send events to BigQuery, yet found the IP stored even though they had the flag set.

Draft because:
- Requires corresponding changes to `plugin-server` and `plugin-scaffold`
- I want to test that nothing breaks

Misc question:
- Should we remove the check for `team.anonymize_ips` inside the process event functions after the queues?
  - Pros: gets rid of legacy code. 
  - Cons: there might be an edge case where an IP slips through when updating posthog for in-flight events

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
