### PR TITLE
Alert if plugin server down

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -66,7 +66,7 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
                 if (statusLoading) {
                     return true
                 }
-                const aliveMetrics = ['redis_alive', 'db_alive']
+                const aliveMetrics = ['redis_alive', 'db_alive', 'plugin_sever_alive']
                 let aliveSignals = 0
                 for (const metric of statusMetrics) {
                     if (metric.key && aliveMetrics.includes(metric.key) && metric.value) {

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -472,7 +472,7 @@ def is_plugin_server_alive() -> bool:
 def get_plugin_server_version() -> Optional[str]:
     cache_key_value = get_client().get("@posthog-plugin-server/version")
     if cache_key_value:
-        return cache_key_value.decode("utf-8")
+        return cache_key_value.decode("utf-8").strip('"')
     return None
 
 


### PR DESCRIPTION
## Changes

If the plugin server is down, we see this now:
![image](https://user-images.githubusercontent.com/53387/109084095-66511b80-7707-11eb-9743-a88bae14b581.png)

Previously the checkmark was green even though it was down on the system status page.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
