### PR TITLE
Polish Secret Plugin Field

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -1,22 +1,19 @@
 import React, { useEffect } from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
-import { Button, Form, Input, Popconfirm, Select, Switch, Tooltip } from 'antd'
+import { Button, Form, Popconfirm, Switch, Tooltip } from 'antd'
 import { DeleteOutlined, CodeOutlined, LockFilled } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from 'scenes/plugins/plugin/PluginImage'
 import { Link } from 'lib/components/Link'
 import { Drawer } from 'lib/components/Drawer'
 import { LocalPluginTag } from 'scenes/plugins/plugin/LocalPluginTag'
-import { UploadField } from './UploadField'
 import { defaultConfigForPlugin, getConfigSchemaArray } from 'scenes/plugins/utils'
 import Markdown from 'react-markdown'
 import { SourcePluginTag } from 'scenes/plugins/plugin/SourcePluginTag'
 import { PluginSource } from './PluginSource'
 import { PluginConfigChoice, PluginConfigSchema } from '@posthog/plugin-scaffold'
-import { Modal } from 'antd'
-import { ExclamationCircleOutlined } from '@ant-design/icons'
-import { UploadFile } from 'antd/es/upload/interface'
+import { PluginField } from 'scenes/plugins/edit/PluginField'
 
 function EnabledDisabledSwitch({
     value,
@@ -33,17 +30,23 @@ function EnabledDisabledSwitch({
     )
 }
 
+const SecretFieldIcon = (): JSX.Element => (
+    <>
+        <Tooltip
+            placement="topLeft"
+            title="This is a secret write-only field. Its value is not available after saving."
+        >
+            <LockFilled style={{ marginRight: 5 }} />
+        </Tooltip>
+    </>
+)
+
 export function PluginDrawer(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { editingPlugin, loading, editingSource, editingPluginInitialChanges, warningShown } = useValues(pluginsLogic)
-    const {
-        editPlugin,
-        savePluginConfig,
-        uninstallPlugin,
-        setEditingSource,
-        generateApiKeysIfNeeded,
-        setWarningShown,
-    } = useActions(pluginsLogic)
+    const { editingPlugin, loading, editingSource, editingPluginInitialChanges } = useValues(pluginsLogic)
+    const { editPlugin, savePluginConfig, uninstallPlugin, setEditingSource, generateApiKeysIfNeeded } = useActions(
+        pluginsLogic
+    )
     const [form] = Form.useForm()
 
     const canDelete = user?.plugin_access.install
@@ -72,69 +75,6 @@ export function PluginDrawer(): JSX.Element {
 
     const isValidField = (fieldConfig: PluginConfigSchema): boolean =>
         fieldConfig.type !== 'choice' || isValidChoiceConfig(fieldConfig)
-
-    const SecretFieldIcon = (): JSX.Element => (
-        <>
-            <Tooltip
-                placement="topLeft"
-                title="This is a secret write-only field. Its value is not available after saving."
-            >
-                <LockFilled style={{ marginRight: 5 }} />
-            </Tooltip>
-        </>
-    )
-
-    interface DisplayWarningProps {
-        e: React.MouseEvent | React.KeyboardEvent
-        value?: UploadFile | null
-        key?: string
-    }
-
-    function displayWarning({ e, value }: { e: React.MouseEvent; value: UploadFile | null }): void
-    function displayWarning({ e, key }: { e: React.KeyboardEvent; key: string }): void
-
-    function displayWarning({ e, value, key }: DisplayWarningProps): void {
-        let clonedNativeEvent: MouseEvent | KeyboardEvent
-        const { nativeEvent, target } = e
-
-        // Only show warning the first time a user tries to edit a secret field
-        if (warningShown) {
-            return
-        }
-
-        // Handle overload
-        if (key) {
-            // from input
-            if (form.getFieldsValue()[key || ''] !== '****************') {
-                return
-            }
-            clonedNativeEvent = new KeyboardEvent('keydown', nativeEvent)
-        } else {
-            // from file upload
-            if (value?.name !== 'Secret Attachment') {
-                return
-            }
-            clonedNativeEvent = new MouseEvent('click', nativeEvent)
-        }
-
-        // Prevent changes from happening if the user doesn't click 'ok'
-        e.stopPropagation()
-        e.preventDefault()
-        setWarningShown(true)
-
-        Modal.confirm({
-            title: 'Confirm Change',
-            icon: <ExclamationCircleOutlined />,
-            content: `You're about to change a field with an existing secret configuration. Are you sure you want to override the existing value?`,
-            okText: 'Yes',
-            cancelText: 'No',
-            onOk: () => {
-                target.dispatchEvent(clonedNativeEvent) // if user clicked ok, let the changes happen
-                return false
-            },
-            onCancel: () => setWarningShown(false), // show the warning again if the user didn't accept at first
-        })
-    }
 
     return (
         <>
@@ -264,29 +204,7 @@ export function PluginDrawer(): JSX.Element {
                                                 },
                                             ]}
                                         >
-                                            {fieldConfig.type === 'attachment' ? (
-                                                <UploadField displayWarning={displayWarning} />
-                                            ) : fieldConfig.type === 'string' ? (
-                                                <Input
-                                                    onKeyDown={(e) =>
-                                                        displayWarning({ e: e, key: fieldConfig.key ?? '' })
-                                                    }
-                                                />
-                                            ) : fieldConfig.type === 'choice' ? (
-                                                <Select dropdownMatchSelectWidth={false}>
-                                                    {fieldConfig.choices.map((choice) => (
-                                                        <Select.Option value={choice} key={choice}>
-                                                            {choice}
-                                                        </Select.Option>
-                                                    ))}
-                                                </Select>
-                                            ) : (
-                                                <strong style={{ color: 'var(--danger)' }}>
-                                                    Unknown field type "<code>{fieldConfig.type}</code>".
-                                                    <br />
-                                                    You may need to upgrade PostHog!
-                                                </strong>
-                                            )}
+                                            <PluginField fieldConfig={fieldConfig} />
                                         </Form.Item>
                                     ) : (
                                         <p style={{ color: 'var(--danger)' }}>

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -21,7 +21,7 @@ export function PluginField({
                     onChange?.('')
                 }}
             >
-                Edit secret field
+                Edit secret {fieldConfig.type === 'attachment' ? 'attachment' : 'field'}
             </Button>
         )
     }

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -2,6 +2,7 @@ import { UploadField } from 'scenes/plugins/edit/UploadField'
 import { Button, Input, Select } from 'antd'
 import React, { useState } from 'react'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold/src/types'
+import { SECRET_FIELD_VALUE } from 'scenes/plugins/utils'
 
 export function PluginField({
     value,
@@ -13,12 +14,17 @@ export function PluginField({
     fieldConfig: PluginConfigSchema
 }): JSX.Element {
     const [editingSecret, setEditingSecret] = useState(false)
-    if (fieldConfig.secret && !editingSecret && value) {
+    if (
+        fieldConfig.secret &&
+        !editingSecret &&
+        value &&
+        (value === SECRET_FIELD_VALUE || value.name === SECRET_FIELD_VALUE)
+    ) {
         return (
             <Button
                 onClick={() => {
+                    onChange?.(fieldConfig.default || '')
                     setEditingSecret(true)
-                    onChange?.('')
                 }}
             >
                 Edit secret {fieldConfig.type === 'attachment' ? 'attachment' : 'field'}

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -13,7 +13,7 @@ export function PluginField({
     fieldConfig: PluginConfigSchema
 }): JSX.Element {
     const [editingSecret, setEditingSecret] = useState(false)
-    if (!editingSecret && fieldConfig.secret && value === '****************') {
+    if (fieldConfig.secret && !editingSecret && value) {
         return (
             <Button
                 onClick={() => {

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -1,0 +1,48 @@
+import { UploadField } from 'scenes/plugins/edit/UploadField'
+import { Button, Input, Select } from 'antd'
+import React, { useState } from 'react'
+import { PluginConfigSchema } from '@posthog/plugin-scaffold/src/types'
+
+export function PluginField({
+    value,
+    onChange,
+    fieldConfig,
+}: {
+    value?: any
+    onChange?: (value: any) => void
+    fieldConfig: PluginConfigSchema
+}): JSX.Element {
+    const [editingSecret, setEditingSecret] = useState(false)
+    if (!editingSecret && fieldConfig.secret && value === '****************') {
+        return (
+            <Button
+                onClick={() => {
+                    setEditingSecret(true)
+                    onChange?.('')
+                }}
+            >
+                Edit secret field
+            </Button>
+        )
+    }
+
+    return fieldConfig.type === 'attachment' ? (
+        <UploadField value={value} onChange={onChange} />
+    ) : fieldConfig.type === 'string' ? (
+        <Input value={value} onChange={onChange} autoFocus={editingSecret} />
+    ) : fieldConfig.type === 'choice' ? (
+        <Select dropdownMatchSelectWidth={false} value={value} onChange={onChange}>
+            {fieldConfig.choices.map((choice) => (
+                <Select.Option value={choice} key={choice}>
+                    {choice}
+                </Select.Option>
+            ))}
+        </Select>
+    ) : (
+        <strong style={{ color: 'var(--danger)' }}>
+            Unknown field type "<code>{fieldConfig.type}</code>".
+            <br />
+            You may need to upgrade PostHog!
+        </strong>
+    )
+}

--- a/frontend/src/scenes/plugins/edit/UploadField.tsx
+++ b/frontend/src/scenes/plugins/edit/UploadField.tsx
@@ -6,11 +6,9 @@ import { UploadFile } from 'antd/es/upload/interface'
 export function UploadField({
     value,
     onChange,
-    displayWarning,
 }: {
     value?: UploadFile | null
     onChange?: (file?: UploadFile | null) => void
-    displayWarning: ({ e, value }: { e: React.MouseEvent; value: UploadFile | null }) => void
 }): JSX.Element {
     return (
         <Upload
@@ -25,18 +23,7 @@ export function UploadField({
                 return false
             }}
         >
-            <Button
-                icon={<UploadOutlined />}
-                onClick={(e) => {
-                    displayWarning({
-                        e: e,
-                        value: value ?? null,
-                    })
-                    return false
-                }}
-            >
-                Click to Upload
-            </Button>
+            <Button icon={<UploadOutlined />}>Click to Upload</Button>
         </Upload>
     )
 }

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -67,7 +67,6 @@ export const pluginsLogic = kea<
         }),
         savePluginOrders: (newOrders: Record<number, number>) => ({ newOrders }),
         cancelRearranging: true,
-        setWarningShown: (showWarning: boolean) => ({ showWarning }),
     },
 
     loaders: ({ actions, values }) => ({
@@ -304,12 +303,6 @@ export const pluginsLogic = kea<
                 return newPluginConfigs
             },
         },
-        warningShown: [
-            false,
-            {
-                setWarningShown: (_, { showWarning }) => showWarning,
-            },
-        ],
         pluginTab: [
             PluginTab.Installed as PluginTab,
             {

--- a/frontend/src/scenes/plugins/utils.ts
+++ b/frontend/src/scenes/plugins/utils.ts
@@ -1,6 +1,9 @@
 import { PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginTypeWithConfig } from 'scenes/plugins/types'
 
+// Keep this in sync with: posthog/api/plugin.py
+export const SECRET_FIELD_VALUE = '**************** POSTHOG SECRET FIELD ****************'
+
 export function getConfigSchemaArray(
     configSchema: Record<string, PluginConfigSchema> | PluginConfigSchema[]
 ): PluginConfigSchema[] {
@@ -58,7 +61,8 @@ export function getPluginConfigFormData(
             if (!value && editingPlugin.pluginConfig.config[key]) {
                 formData.append(`remove_attachment[${key}]`, 'true')
             }
-        } else {
+        } else if (!configSchema[key]?.secret || value !== SECRET_FIELD_VALUE) {
+            // Omit the field from formData if it's a filled yet unchanged secret field
             otherConfig[key] = value
         }
     }

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -1,7 +1,7 @@
 import json
 import os
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 import requests
 from dateutil import parser
@@ -342,6 +342,6 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         return Response(PluginConfigSerializer(plugin_configs, many=True).data)
 
 
-def _get_secret_fields_for_plugin(plugin: Plugin) -> set[str]:
+def _get_secret_fields_for_plugin(plugin: Plugin) -> Set[str]:
     secret_fields = set([field["key"] for field in plugin.config_schema if "secret" in field and field["secret"]])
     return secret_fields


### PR DESCRIPTION
## Changes

I gave it a go at simplifying this. I think the end result is a bit simpler compared to what was before, though all feedback is welcome.

- I removed the `displayWarning` system with its cloned events, which seemed very brittle and won't always work (for example try copy/pasting with the mouse... and I didn't try touch interfaces). Instead I used a simple button (feel free to change the copy): 
![image](https://user-images.githubusercontent.com/53387/109141926-8eb83480-775e-11eb-855f-2d85a6c954b4.png)
- I kept just one special `SECRET_FIELD_VALUE` key, which is much longer (hard to accidentally type the same) and never shown to the user.
- Refactored the form fields into their own component
- Secret fields that are not edited are just not sent to the server. So the `value === SECRET_FIELD_VALUE` check is in the frontend.
- Some other misc refactoring.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
