### PR TITLE
Reload our feature flags after changing them

### DIFF
--- a/frontend/src/scenes/experimentation/featureFlagLogic.js
+++ b/frontend/src/scenes/experimentation/featureFlagLogic.js
@@ -2,6 +2,7 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { toast } from 'react-toastify'
 import { deleteWithUndo } from 'lib/utils'
+import posthog from 'posthog-js'
 
 export const featureFlagLogic = kea({
     key: (props) => props.id || 'new',
@@ -87,6 +88,7 @@ export const featureFlagLogic = kea({
             if (featureFlags) {
                 toast('Feature flag saved.')
                 props.closeDrawer()
+                posthog.featureFlags.reloadFeatureFlags()
             }
         },
         createFeatureFlagSuccess: ({ featureFlags }) => {
@@ -94,9 +96,11 @@ export const featureFlagLogic = kea({
                 return null
             }
             props.closeDrawer(), toast('Feature flag saved.')
+            posthog.featureFlags.reloadFeatureFlags()
         },
         deleteFeatureFlagSuccess: () => {
             props.closeDrawer()
+            posthog.featureFlags.reloadFeatureFlags()
         },
     }),
     events: ({ actions }) => ({


### PR DESCRIPTION
This only "affects" our team and local development. I got tired of
needing to reload after toggling a feature flag locally. This makes it
so that the newly edited flag is applied immediately.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
