### PR TITLE
Fix: funnels & retention person links, funnel calculations

### DIFF
--- a/cypress/integration/funnels.js
+++ b/cypress/integration/funnels.js
@@ -1,11 +1,10 @@
 describe('Funnels', () => {
     beforeEach(() => {
-        cy.visit('/')
         cy.get('[data-attr=insight-funnels-tab]').click()
         cy.wait(200)
     })
 
-    it('Add 1 action to funnel', () => {
+    it('Add 1 action to funnel and navigate to persons', () => {
         cy.get('[data-attr=add-action-event-button]').click()
         cy.get('[data-attr=trend-element-subject-0]').click()
 
@@ -16,6 +15,18 @@ describe('Funnels', () => {
         cy.get('[data-attr=save-funnel-button]').click()
 
         cy.get('[data-attr=funnel-viz]').should('exist')
+
+        cy.get('[data-attr="funnel-person"] a')
+            .filter(':contains("@")')
+            .first()
+            .then(($match) => {
+                const email = $match.text()
+
+                cy.wrap($match).click()
+
+                cy.url().should('include', '/person/')
+                cy.contains(email).should('exist')
+            })
     })
 
     it('Apply date filter to funnel', () => {

--- a/cypress/integration/retention.js
+++ b/cypress/integration/retention.js
@@ -1,15 +1,24 @@
 describe('Retention', () => {
     beforeEach(() => {
-        cy.visit('/')
         cy.get('[data-attr=insight-retention-tab]').click()
     })
 
-    it('Apply 1 overall filter', () => {
+    it('should apply filter and navigate to persons', () => {
         cy.get('[data-attr=new-prop-filter-insight-retention]').click()
         cy.get('[data-attr=property-filter-dropdown]').click()
         cy.get('[data-attr=prop-filter-person-0]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
         cy.get('[data-attr=prop-val-0]').click({ force: true })
         cy.get('[data-attr=retention-table').should('exist')
+
+        cy.get('.percentage-cell').last().click()
+
+        cy.get('[data-attr=retention-person-link]').its('length').should('eq', 1)
+        cy.get('[data-attr=retention-person-link]').contains('smith.nunez@gmail.com')
+
+        cy.get('[data-attr=retention-person-link]').click()
+
+        cy.url().should('include', '/person/')
+        cy.contains('smith.nunez@gmail.com').should('exist')
     })
 })

--- a/frontend/src/scenes/funnels/People.js
+++ b/frontend/src/scenes/funnels/People.js
@@ -48,7 +48,9 @@ export function People() {
                             peopleSorted.map((person) => (
                                 <tr key={person.id}>
                                     <td className="text-overflow">
-                                        <Link to={`/person_by_id/${person.id}`}>{person.name}</Link>
+                                        <Link to={`/person/${encodeURIComponent(person.distinct_ids[0])}`}>
+                                            {person.name}
+                                        </Link>
                                     </td>
                                     {stepsWithCount.map((step, index) => (
                                         <td

--- a/frontend/src/scenes/funnels/People.js
+++ b/frontend/src/scenes/funnels/People.js
@@ -46,7 +46,7 @@ export function People() {
                         </tr>
                         {peopleSorted &&
                             peopleSorted.map((person) => (
-                                <tr key={person.id}>
+                                <tr key={person.id} data-attr="funnel-person">
                                     <td className="text-overflow">
                                         <Link to={`/person/${encodeURIComponent(person.distinct_ids[0])}`}>
                                             {person.name}

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -158,6 +158,7 @@ export function RetentionTable({
                                                                 to={`/person/${encodeURIComponent(
                                                                     personAppearances.person.distinct_ids[0]
                                                                 )}`}
+                                                                data-attr="retention-person-link"
                                                             >
                                                                 {personAppearances.person.name}
                                                             </Link>

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -154,7 +154,11 @@ export function RetentionTable({
                                                 people.result.map((personAppearances: RetentionTableAppearanceType) => (
                                                     <tr key={personAppearances.person.id}>
                                                         <td className="text-overflow" style={{ minWidth: 200 }}>
-                                                            <Link to={`/person_by_id/${personAppearances.person.id}`}>
+                                                            <Link
+                                                                to={`/person/${encodeURIComponent(
+                                                                    personAppearances.person.distinct_ids[0]
+                                                                )}`}
+                                                            >
                                                                 {personAppearances.person.name}
                                                             </Link>
                                                         </td>

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -147,7 +147,6 @@ export const routes: Record<string, Scene> = {
     '/events': Scene.Events,
     '/events/*': Scene.Events,
     '/sessions': Scene.Sessions,
-    '/person_by_id/:id': Scene.Person,
     '/person/*': Scene.Person,
     '/persons': Scene.Persons,
     '/cohorts/:id': Scene.Cohorts,

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -250,8 +250,9 @@ class ActionViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         payload = {"filter": filter.toJSON(), "team_id": team.pk}
         task = update_cache_item_task.delay(cache_key, CacheType.FUNNEL, payload)
-        task_id = task.id
-        cache.set(cache_key, {"task_id": task_id}, 180)  # task will be live for 3 minutes
+        if not task.ready():
+            task_id = task.id
+            cache.set(cache_key, {"task_id": task_id}, 180)  # task will be live for 3 minutes
 
         if dashboard_id:
             DashboardItem.objects.filter(pk=dashboard_id).update(last_refresh=now())

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -222,8 +222,9 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         payload = {"filter": filter.toJSON(), "team_id": team.pk}
         task = update_cache_item_task.delay(cache_key, CacheType.FUNNEL, payload)
-        task_id = task.id
-        cache.set(cache_key, {"task_id": task_id}, 180)  # task will be live for 3 minutes
+        if not task.ready():
+            task_id = task.id
+            cache.set(cache_key, {"task_id": task_id}, 180)  # task will be live for 3 minutes
 
         self._refresh_dashboard(request=request)
         return {"result": result}

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -216,7 +216,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             if cached_result:
                 task_id = cached_result.get("task_id", None)
                 if not task_id:
-                    return cached_result["data"]
+                    return cached_result["result"]
                 else:
                     return {"result": result}
 


### PR DESCRIPTION
This PR ended up fixing a bunch of things:

- Retention table modal and funnels links did not work under Cloud https://github.com/PostHog/posthog/issues/3480
- Funnel cached calculations did not work on self-hosted, broken in https://github.com/PostHog/posthog/pull/3301
- Made sure cached/background calculations work on e2e test runner which evaluates celery tasks eagerly
- Added E2E tests for funnels/retention for navigating between pages
- Deleted a dead endpoint

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
