### PR TITLE
e2e-test-runner: Only start webpack if not already running

### DIFF
--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -6,7 +6,10 @@ createdb posthog_e2e_test
 DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py migrate &&
 DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py setup_dev &
 yarn add cypress-terminal-report
-./bin/start-frontend &
+
+# Only start webpack if not already running
+nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
+
 CYPRESS_BASE_URL=http://localhost:8080 npx cypress open --config-file cypress.e2e.json &
 DEBUG=1 TEST=1 AUTO_LOGIN=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py runserver 8080
 yarn remove cypress-terminal-report


### PR DESCRIPTION
## Changes

Got annoyed by needing to edit the file each time.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
