### PR TITLE
Make PLUGIN_SERVER_INGESTION True by default

### DIFF
--- a/ee/docker-compose.ch.test.yml
+++ b/ee/docker-compose.ch.test.yml
@@ -35,7 +35,6 @@ services:
             SECRET_KEY: 'alsdfjiosdajfklalsdjkf'
             DEBUG: 'true'
             PRIMARY_DB: 'clickhouse'
-            PLUGIN_SERVER_INGESTION: 'true'
             TEST: 'true'
         depends_on:
             - db
@@ -83,7 +82,6 @@ services:
             KAFKA_ENABLED: 'true'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
-            PLUGIN_SERVER_INGESTION: 'true'
         depends_on:
             - db
             - redis

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -35,7 +35,6 @@ services:
             SECRET_KEY: 'alsdfjiosdajfklalsdjkf'
             DEBUG: 'true'
             PRIMARY_DB: 'clickhouse'
-            PLUGIN_SERVER_INGESTION: 'true'
         depends_on:
             - db
             - redis

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -155,7 +155,7 @@ PRIMARY_DB = os.getenv("PRIMARY_DB", RDBMS.POSTGRES)  # type: str
 
 EE_AVAILABLE = False
 
-PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", True, type_cast=strtobool)
+PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", not TEST, type_cast=strtobool)
 
 ASYNC_EVENT_ACTION_MAPPING = get_from_env("ASYNC_EVENT_ACTION_MAPPING", False, type_cast=strtobool)
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -155,7 +155,7 @@ PRIMARY_DB = os.getenv("PRIMARY_DB", RDBMS.POSTGRES)  # type: str
 
 EE_AVAILABLE = False
 
-PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", False, type_cast=strtobool)
+PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", True, type_cast=strtobool)
 
 ASYNC_EVENT_ACTION_MAPPING = get_from_env("ASYNC_EVENT_ACTION_MAPPING", False, type_cast=strtobool)
 

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -103,10 +103,6 @@
                     "value": "issampledevent,currentscreen,objectname"
                 },
                 {
-                    "name": "PLUGIN_SERVER_INGESTION",
-                    "value": "true"
-                },
-                {
                     "name": "BILLING_TRIAL_DAYS",
                     "value": "0"
                 },


### PR DESCRIPTION
## Changes

We held off on doing this due to some reliability issues on Cloud, but these have been resolved now, and we've just merged PostHog/plugin-server#213. Therefore we will be moving to making plugin server ingestion _the_ ingestion approach.