### PR TITLE
Reduce calls to api/action

### DIFF
--- a/frontend/src/scenes/actions/Action.js
+++ b/frontend/src/scenes/actions/Action.js
@@ -71,7 +71,7 @@ function _Action({ id }) {
     const { push } = useActions(router)
     const { user } = useValues(userLogic)
     const { fetchEvents } = useActions(eventsTableLogic({ fixedFilters }))
-    const { isComplete } = useValues(actionLogic({ id, onComplete: fetchEvents }))
+    const { isComplete, action } = useValues(actionLogic({ id, onComplete: fetchEvents }))
     const { loadAction } = useActions(actionLogic({ id, onComplete: fetchEvents }))
 
     return (
@@ -80,6 +80,7 @@ function _Action({ id }) {
                 apiURL=""
                 actionId={id}
                 user={user}
+                action={action}
                 onSave={(action) => {
                     if (!id) {
                         push(`/action/${action.id}`)

--- a/frontend/src/scenes/actions/Action.js
+++ b/frontend/src/scenes/actions/Action.js
@@ -76,18 +76,20 @@ function _Action({ id }) {
 
     return (
         <div>
-            <ActionEdit
-                apiURL=""
-                actionId={id}
-                user={user}
-                action={action}
-                onSave={(action) => {
-                    if (!id) {
-                        push(`/action/${action.id}`)
-                    }
-                    loadAction()
-                }}
-            />
+            {(!id || action) && (
+                <ActionEdit
+                    apiURL=""
+                    actionId={id}
+                    user={user}
+                    action={action}
+                    onSave={(action) => {
+                        if (!id) {
+                            push(`/action/${action.id}`)
+                        }
+                        loadAction()
+                    }}
+                />
+            )}
             {id && !isComplete && (
                 <div style={{ marginBottom: '10rem' }}>
                     <h2 className="subtitle">Events</h2>
@@ -97,7 +99,7 @@ function _Action({ id }) {
             )}
             {isComplete && (
                 <div style={{ marginTop: 64 }}>
-                    <EventsTable key={isComplete} fixedFilters={fixedFilters} filtersEnabled={false} />
+                    {id && <EventsTable key={isComplete} fixedFilters={fixedFilters} filtersEnabled={false} />}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { uuid, Loading, deleteWithUndo } from 'lib/utils'
+import { uuid, deleteWithUndo } from 'lib/utils'
 import { Link } from 'lib/components/Link'
 import { useValues, useActions } from 'kea'
 import { actionEditLogic } from './actionEditLogic'
@@ -11,24 +11,20 @@ import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { actionsModel } from '~/models'
 
-export function ActionEdit({ action, actionId, apiURL, onSave, user, simmer, temporaryToken }) {
+export function ActionEdit({ action: loadedAction, actionId, apiURL, onSave, user, simmer, temporaryToken }) {
     let logic = actionEditLogic({
         id: actionId,
         apiURL,
-        action,
+        action: loadedAction,
         onSave: (action, createNew) => onSave(action, !actionId, createNew),
         temporaryToken,
     })
-    const { actionLoading, errorActionId } = useValues(logic)
+    const { action, errorActionId } = useValues(logic)
     const { setAction, saveAction } = useActions(logic)
     const { loadActions } = useActions(actionsModel)
 
     const [edited, setEdited] = useState(false)
     const slackEnabled = user?.team?.slack_incoming_webhook
-
-    if (actionLoading || !action) {
-        return <Loading />
-    }
 
     const newAction = () => {
         setAction({ ...action, steps: [...action.steps, { isNew: uuid() }] })

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -11,14 +11,15 @@ import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { actionsModel } from '~/models'
 
-export function ActionEdit({ actionId, apiURL, onSave, user, simmer, temporaryToken }) {
+export function ActionEdit({ action, actionId, apiURL, onSave, user, simmer, temporaryToken }) {
     let logic = actionEditLogic({
         id: actionId,
         apiURL,
+        action,
         onSave: (action, createNew) => onSave(action, !actionId, createNew),
         temporaryToken,
     })
-    const { action, actionLoading, errorActionId } = useValues(logic)
+    const { actionLoading, errorActionId } = useValues(logic)
     const { setAction, saveAction } = useActions(logic)
     const { loadActions } = useActions(actionsModel)
 

--- a/frontend/src/scenes/actions/actionEditLogic.js
+++ b/frontend/src/scenes/actions/actionEditLogic.js
@@ -12,17 +12,9 @@ export const actionEditLogic = kea({
         actionAlreadyExists: (actionId) => ({ actionId }),
     }),
 
-    loaders: ({ props }) => ({
-        action: {
-            loadAction: async () => {
-                return await api.get(props.apiURL + 'api/action/' + props.id)
-            },
-        },
-    }),
-
-    reducers: () => ({
+    reducers: ({ props }) => ({
         action: [
-            null,
+            props.action,
             {
                 setAction: (_, { action }) => action,
             },
@@ -70,15 +62,7 @@ export const actionEditLogic = kea({
 
     events: ({ actions, props }) => ({
         afterMount: async () => {
-            if (props.id) {
-                const action = await api.get(
-                    'api/action/' +
-                        props.id +
-                        '/?include_count=1' +
-                        (props.temporaryToken ? '&temporary_token=' + props.temporaryToken : '')
-                )
-                actions.setAction(action)
-            } else {
+            if (!props.id) {
                 actions.setAction({ name: '', steps: [{ isNew: uuid() }] })
             }
         },

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -97,8 +97,7 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
 
 
 def get_actions(queryset: QuerySet, params: dict, team_id: int) -> QuerySet:
-    if params.get("include_count"):
-        queryset = queryset.annotate(count=Count(TREND_FILTER_TYPE_EVENTS))
+    queryset = queryset.annotate(count=Count(TREND_FILTER_TYPE_EVENTS))
 
     queryset = queryset.prefetch_related(Prefetch("steps", queryset=ActionStep.objects.order_by("id")))
     return queryset.filter(team_id=team_id).order_by("-id")


### PR DESCRIPTION
## Changes

we were doing 2 identical calls when loading an action edit page. Reduce that to 1.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
