### PR TITLE
Create cohorts from users

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -91,7 +91,8 @@ style files without adding already imported styles. */
 }
 
 .text-right {
-    text-align: right;
+    display: flex;
+    justify-content: space-between;
 }
 
 .text-left {

--- a/frontend/src/scenes/persons/Cohort.tsx
+++ b/frontend/src/scenes/persons/Cohort.tsx
@@ -2,11 +2,18 @@ import React from 'react'
 import { CohortGroup } from './CohortGroup'
 import { cohortLogic } from './cohortLogic'
 import { Button, Card, Col, Divider, Input, Row } from 'antd'
-import { AimOutlined, ArrowLeftOutlined, InboxOutlined, UnorderedListOutlined } from '@ant-design/icons'
+import {
+    AimOutlined,
+    ArrowLeftOutlined,
+    InboxOutlined,
+    UnorderedListOutlined,
+    UsergroupAddOutlined,
+} from '@ant-design/icons'
 import { useValues, useActions, BuiltLogic } from 'kea'
 import { CohortGroupType, CohortType } from '~/types'
 import { Persons } from './Persons'
 import Dragger from 'antd/lib/upload/Dragger'
+import { router } from 'kea-router'
 
 const isSubmitDisabled = (cohort: CohortType): boolean => {
     if (cohort && cohort.csv) {
@@ -106,7 +113,7 @@ function DynamicCohort({ logic }: { logic: BuiltLogic }): JSX.Element {
 
 function CohortChoice({ setCohort, cohort }: { setCohort: CallableFunction; cohort: CohortType }): JSX.Element {
     return (
-        <Row gutter={24}>
+        <Row gutter={[24, 24]}>
             <Col sm={12}>
                 <Card
                     title="Dynamic cohort"
@@ -126,7 +133,7 @@ function CohortChoice({ setCohort, cohort }: { setCohort: CallableFunction; coho
             </Col>
             <Col sm={12}>
                 <Card
-                    title="Static cohort"
+                    title="Static cohort by CSV"
                     size="small"
                     className="clickable-card"
                     data-attr="cohort-choice-upload-csv"
@@ -138,6 +145,23 @@ function CohortChoice({ setCohort, cohort }: { setCohort: CallableFunction; coho
                     </div>
                     <div className="cohort-type-description">
                         Upload a list of users to create cohort with a specific set of users.
+                    </div>
+                </Card>
+            </Col>
+            <Col sm={12}>
+                <Card
+                    title="Static cohort by selection"
+                    size="small"
+                    className="clickable-card"
+                    data-attr="cohort-choice-by-person-selection"
+                    onClick={() => router.actions.push('/persons')}
+                    style={{ height: '100%' }}
+                >
+                    <div style={{ textAlign: 'center', fontSize: 40 }}>
+                        <UsergroupAddOutlined />
+                    </div>
+                    <div className="cohort-type-description">
+                        Select users that have been tracked in the persons tab
                     </div>
                 </Card>
             </Col>

--- a/frontend/src/scenes/persons/ManualCreateCohortDrawer.tsx
+++ b/frontend/src/scenes/persons/ManualCreateCohortDrawer.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { manualCohortCreationLogic } from './manualCohortCreationLogic'
+import { Drawer } from 'lib/components/Drawer'
+import { useValues, useActions } from 'kea'
+import { Input, Button, Divider } from 'antd'
+import { PersonsTable } from './PersonsTable'
+import { DeleteOutlined } from '@ant-design/icons'
+
+interface Props {
+    visible: boolean
+    onClose: () => void
+    onSubmit: () => void
+}
+
+export function ManualCreateCohortDrawer({ visible, onClose, onSubmit }: Props): JSX.Element {
+    const { selectedPeople, cohortName } = useValues(manualCohortCreationLogic)
+    const { clearCohort, removeId, setCohortName, saveCohort } = useActions(manualCohortCreationLogic)
+
+    return (
+        <Drawer
+            title={'New cohort'}
+            className="cohorts-drawer"
+            onClose={onClose}
+            destroyOnClose={false}
+            visible={visible}
+            width={750}
+        >
+            <form
+                onSubmit={(e): void => {
+                    e.preventDefault()
+                    saveCohort()
+                    clearCohort()
+                    onSubmit()
+                }}
+            >
+                <div className="mb">
+                    <Input
+                        required
+                        autoFocus
+                        placeholder="Cohort name..."
+                        value={cohortName}
+                        data-attr="cohort-name"
+                        onChange={(e) => setCohortName(e.target.value)}
+                    />
+                </div>
+                <div className="mt">
+                    <Button
+                        type="primary"
+                        htmlType="submit"
+                        disabled={false}
+                        data-attr="save-cohort"
+                        style={{ marginTop: '1rem' }}
+                    >
+                        Save cohort
+                    </Button>
+                </div>
+            </form>
+            <Divider />
+            <PersonsTable
+                people={selectedPeople}
+                moreActions={[
+                    {
+                        title: 'Actions',
+                        render: function RenderActions(_: string, person: PersonType) {
+                            return (
+                                <Button danger type="link" onClick={() => removeId(person.id)}>
+                                    <DeleteOutlined />
+                                </Button>
+                            )
+                        },
+                    },
+                ]}
+            />
+        </Drawer>
+    )
+}

--- a/frontend/src/scenes/persons/ManualCreateCohortDrawer.tsx
+++ b/frontend/src/scenes/persons/ManualCreateCohortDrawer.tsx
@@ -5,6 +5,7 @@ import { useValues, useActions } from 'kea'
 import { Input, Button, Divider } from 'antd'
 import { PersonsTable } from './PersonsTable'
 import { DeleteOutlined } from '@ant-design/icons'
+import { PersonType } from '~/types'
 
 interface Props {
     visible: boolean

--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -60,7 +60,6 @@ function PersonsV1({ cohort }: { cohort: CohortType }): JSX.Element {
                     }}
                     style={{ maxWidth: 400, width: 'initial', flexGrow: 1 }}
                 />
-
                 <Button
                     type="default"
                     icon={<ExportOutlined />}

--- a/frontend/src/scenes/persons/PersonsTableV2.tsx
+++ b/frontend/src/scenes/persons/PersonsTableV2.tsx
@@ -19,6 +19,10 @@ interface PersonsTableType {
     loadNext?: () => void
     allColumns?: boolean // whether to show all columns or not
     cohort?: CohortType
+    isCreatingCohort?: boolean
+    onSelectRow?: (id: number) => void
+    selectedRows?: number[]
+    moreActions?: any
 }
 
 export function PersonsTable({
@@ -30,6 +34,10 @@ export function PersonsTable({
     loadNext,
     allColumns,
     cohort,
+    isCreatingCohort,
+    onSelectRow,
+    selectedRows,
+    moreActions,
 }: PersonsTableType): JSX.Element {
     const linkToPerson = (person: PersonType): string => {
         const backTo = cohort
@@ -88,20 +96,24 @@ export function PersonsTable({
         })
     }
 
-    columns.push({
-        key: 'actions',
-        title: '',
-        render: function Render(_: string, person: PersonType, index: number) {
-            return (
-                <>
-                    <Link to={linkToPerson(person)} data-attr={'goto-person-arrow-' + index}>
-                        <ArrowRightOutlined />
-                        {allColumns ? ' view' : ''}
-                    </Link>
-                </>
-            )
-        },
-    })
+    if (moreActions) {
+        columns.push(...moreActions)
+    } else {
+        columns.push({
+            key: 'actions',
+            title: '',
+            render: function Render(_: string, person: PersonType, index: number) {
+                return (
+                    <>
+                        <Link to={linkToPerson(person)} data-attr={'goto-person-arrow-' + index}>
+                            <ArrowRightOutlined />
+                            {allColumns ? ' view' : ''}
+                        </Link>
+                    </>
+                )
+            },
+        })
+    }
 
     return (
         <>
@@ -118,6 +130,15 @@ export function PersonsTable({
                     },
                     rowExpandable: ({ properties }) => Object.keys(properties).length > 0,
                 }}
+                {...(isCreatingCohort
+                    ? {
+                          rowSelection: {
+                              type: 'checkbox',
+                              selectedRowKeys: selectedRows || [],
+                              onSelect: (record: PersonType) => onSelectRow && onSelectRow(record.id),
+                          },
+                      }
+                    : {})}
                 dataSource={people}
                 className="persons-table"
             />

--- a/frontend/src/scenes/persons/PersonsTableV2.tsx
+++ b/frontend/src/scenes/persons/PersonsTableV2.tsx
@@ -21,6 +21,7 @@ interface PersonsTableType {
     cohort?: CohortType
     isCreatingCohort?: boolean
     onSelectRow?: (id: number) => void
+    onSelectAll?: (selected: boolean, changedIds: number[]) => void
     selectedRows?: number[]
     moreActions?: any
 }
@@ -36,6 +37,7 @@ export function PersonsTable({
     cohort,
     isCreatingCohort,
     onSelectRow,
+    onSelectAll,
     selectedRows,
     moreActions,
 }: PersonsTableType): JSX.Element {
@@ -136,6 +138,12 @@ export function PersonsTable({
                               type: 'checkbox',
                               selectedRowKeys: selectedRows || [],
                               onSelect: (record: PersonType) => onSelectRow && onSelectRow(record.id),
+                              onSelectAll: (selected, _, changedRows) =>
+                                  onSelectAll &&
+                                  onSelectAll(
+                                      selected,
+                                      changedRows.map((row) => row.id)
+                                  ),
                           },
                       }
                     : {})}

--- a/frontend/src/scenes/persons/PersonsV2.tsx
+++ b/frontend/src/scenes/persons/PersonsV2.tsx
@@ -170,6 +170,9 @@ export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
                     onSubmit={(e): void => {
                         e.preventDefault()
                         saveCohort()
+                        setCreateCohortDrawerIsOpen(false)
+                        clearCohort()
+                        setIsCreatingCohort(false)
                     }}
                 >
                     <div className="mb">

--- a/frontend/src/scenes/persons/PersonsV2.tsx
+++ b/frontend/src/scenes/persons/PersonsV2.tsx
@@ -157,7 +157,7 @@ export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
                     }}
                     onSelectAll={(selected: boolean, changedIds: number[]) => {
                         if (selected) {
-                            setSelectedIds([...new Set([...selectedIds, ...changedIds])])
+                            setSelectedIds([...selectedIds, ...changedIds])
                         } else {
                             setSelectedIds(selectedIds.filter((item) => !changedIds.includes(item)))
                         }

--- a/frontend/src/scenes/persons/PersonsV2.tsx
+++ b/frontend/src/scenes/persons/PersonsV2.tsx
@@ -19,8 +19,8 @@ export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
     const { persons, listFilters, personsLoading, exampleEmail } = useValues(personsLogic)
     const [searchTerm, setSearchTerm] = useState('') // Not on Kea because it's a component-specific store & to avoid changing the URL on every keystroke
     const [isCreatingCohort, setIsCreatingCohort] = useState<boolean>(false)
-    const { selectedIds, selectedPeople } = useValues(manualCohortCreationLogic)
-    const { selectId, clearCohort, removeId } = useActions(manualCohortCreationLogic)
+    const { selectedIds, selectedPeople, cohortName } = useValues(manualCohortCreationLogic)
+    const { selectId, clearCohort, removeId, setCohortName, saveCohort } = useActions(manualCohortCreationLogic)
     const [createCohortDrawerIsOpen, setCreateCohortDrawerIsOpen] = useState(false)
 
     useEffect(() => {
@@ -169,6 +169,7 @@ export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
                 <form
                     onSubmit={(e): void => {
                         e.preventDefault()
+                        saveCohort()
                     }}
                 >
                     <div className="mb">
@@ -176,9 +177,9 @@ export function PersonsV2({ cohort }: { cohort: CohortType }): JSX.Element {
                             required
                             autoFocus
                             placeholder="Cohort name..."
-                            value={''}
+                            value={cohortName}
                             data-attr="cohort-name"
-                            onChange={() => {}}
+                            onChange={(e) => setCohortName(e.target.value)}
                         />
                     </div>
                     <div className="mt">

--- a/frontend/src/scenes/persons/cohortLogic.js
+++ b/frontend/src/scenes/persons/cohortLogic.js
@@ -50,7 +50,6 @@ export const cohortLogic = kea({
     listeners: ({ sharedListeners, actions, values }) => ({
         saveCohort: async ({ cohortParams, filterParams }, breakpoint) => {
             let cohort = { ...values.cohort, ...cohortParams }
-            console.log(cohort)
             const cohortFormData = new FormData()
             for (const [key, value] of Object.entries(cohort)) {
                 if (key === 'groups') {

--- a/frontend/src/scenes/persons/cohortLogic.js
+++ b/frontend/src/scenes/persons/cohortLogic.js
@@ -50,6 +50,7 @@ export const cohortLogic = kea({
     listeners: ({ sharedListeners, actions, values }) => ({
         saveCohort: async ({ cohortParams, filterParams }, breakpoint) => {
             let cohort = { ...values.cohort, ...cohortParams }
+            console.log(cohort)
             const cohortFormData = new FormData()
             for (const [key, value] of Object.entries(cohort)) {
                 if (key === 'groups') {

--- a/frontend/src/scenes/persons/manualCohortCreationLogic.ts
+++ b/frontend/src/scenes/persons/manualCohortCreationLogic.ts
@@ -1,0 +1,39 @@
+import { kea } from 'kea'
+import { manualCohortCreationLogicType } from './manualCohortCreationLogicType'
+import { PersonType } from '~/types'
+import api from 'lib/api'
+
+export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<PersonType>>({
+    actions: {
+        selectId: (id: number) => ({ id }),
+        removeId: (idToRemove: number) => ({ idToRemove }),
+        fetchPeople: true,
+        setPeople: (people: PersonType[]) => ({ people }),
+        clearCohort: true,
+    },
+    reducers: {
+        selectedIds: [
+            [] as number[],
+            {
+                selectId: (state, { id }) => [...state, id],
+                removeId: (state, { idToRemove }) => state.filter((id) => id !== idToRemove),
+                clearCohort: () => [],
+            },
+        ],
+        selectedPeople: [
+            [] as PersonType[],
+            {
+                setPeople: ({}, { people }) => people,
+                clearCohort: () => [],
+            },
+        ],
+    },
+    listeners: ({ actions, values }) => ({
+        selectId: async () => actions.fetchPeople(),
+        removeId: async () => actions.fetchPeople(),
+        fetchPeople: async () => {
+            const result = await api.get('api/person?id=' + values.selectedIds.join(','))
+            actions.setPeople(result.results)
+        },
+    }),
+})

--- a/frontend/src/scenes/persons/manualCohortCreationLogic.ts
+++ b/frontend/src/scenes/persons/manualCohortCreationLogic.ts
@@ -7,6 +7,7 @@ import { cohortLogic } from 'scenes/persons/cohortLogic'
 export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<PersonType>>({
     actions: {
         selectId: (id: number) => ({ id }),
+        setSelectedIds: (ids: number[]) => ({ ids }),
         removeId: (idToRemove: number) => ({ idToRemove }),
         fetchPeople: true,
         setPeople: (people: PersonType[]) => ({ people }),
@@ -21,6 +22,7 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
                 selectId: (state, { id }) => [...state, id],
                 removeId: (state, { idToRemove }) => state.filter((id) => id !== idToRemove),
                 clearCohort: () => [],
+                setSelectedIds: ({}, { ids }) => ids,
             },
         ],
         selectedPeople: [
@@ -41,6 +43,7 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
     listeners: ({ actions, values }) => ({
         selectId: async () => actions.fetchPeople(),
         removeId: async () => actions.fetchPeople(),
+        setSelectedIds: async () => actions.fetchPeople(),
         fetchPeople: async () => {
             if (values.selectedIds.length) {
                 const result = await api.get('api/person?id=' + values.selectedIds.join(','))

--- a/frontend/src/scenes/persons/manualCohortCreationLogic.ts
+++ b/frontend/src/scenes/persons/manualCohortCreationLogic.ts
@@ -2,6 +2,7 @@ import { kea } from 'kea'
 import { manualCohortCreationLogicType } from './manualCohortCreationLogicType'
 import { PersonType } from '~/types'
 import api from 'lib/api'
+import { cohortLogic } from 'scenes/persons/cohortLogic'
 
 export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<PersonType>>({
     actions: {
@@ -10,6 +11,8 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
         fetchPeople: true,
         setPeople: (people: PersonType[]) => ({ people }),
         clearCohort: true,
+        saveCohort: true,
+        setCohortName: (cohortName: string) => ({ cohortName }),
     },
     reducers: {
         selectedIds: [
@@ -27,6 +30,12 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
                 clearCohort: () => [],
             },
         ],
+        cohortName: [
+            '' as string,
+            {
+                setCohortName: ({}, { cohortName }) => cohortName,
+            },
+        ],
     },
     listeners: ({ actions, values }) => ({
         selectId: async () => actions.fetchPeople(),
@@ -34,6 +43,20 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
         fetchPeople: async () => {
             const result = await api.get('api/person?id=' + values.selectedIds.join(','))
             actions.setPeople(result.results)
+        },
+        saveCohort: () => {
+            const cohortParams = {
+                name: values.cohortName,
+                is_static: true,
+                users: values.selectedIds,
+            }
+            console.log(cohortParams)
+            cohortLogic({
+                cohort: {
+                    id: 'new',
+                    groups: [],
+                },
+            }).actions.saveCohort(cohortParams)
         },
     }),
 })

--- a/frontend/src/scenes/persons/manualCohortCreationLogic.ts
+++ b/frontend/src/scenes/persons/manualCohortCreationLogic.ts
@@ -42,8 +42,12 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
         selectId: async () => actions.fetchPeople(),
         removeId: async () => actions.fetchPeople(),
         fetchPeople: async () => {
-            const result = await api.get('api/person?id=' + values.selectedIds.join(','))
-            actions.setPeople(result.results)
+            if (values.selectedIds.length) {
+                const result = await api.get('api/person?id=' + values.selectedIds.join(','))
+                actions.setPeople(result.results)
+            } else {
+                actions.setPeople([])
+            }
         },
         saveCohort: () => {
             const cohortParams = {

--- a/frontend/src/scenes/persons/manualCohortCreationLogic.ts
+++ b/frontend/src/scenes/persons/manualCohortCreationLogic.ts
@@ -34,6 +34,7 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
             '' as string,
             {
                 setCohortName: ({}, { cohortName }) => cohortName,
+                clearCohort: () => '',
             },
         ],
     },
@@ -50,7 +51,6 @@ export const manualCohortCreationLogic = kea<manualCohortCreationLogicType<Perso
                 is_static: true,
                 users: values.selectedIds,
             }
-            console.log(cohortParams)
             cohortLogic({
                 cohort: {
                     id: 'new',

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -14,7 +14,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.user import UserSerializer
 from posthog.api.utils import get_target_entity
 from posthog.constants import TRENDS_STICKINESS
-from posthog.models import Cohort, Entity, Person
+from posthog.models import Cohort, Entity, Person, PersonDistinctId
 from posthog.models.event import Event
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.stickiness_filter import StickinessFilter
@@ -87,6 +87,7 @@ class CohortSerializer(serializers.ModelSerializer):
             ids = [
                 person.distinct_ids[0]
                 for person in Person.objects.filter(id__in=parsed_ids, team_id=self.context["team_id"])
+                if len(person.distinct_ids)
             ]
             self._calculate_static_by_people(ids, cohort)
         else:

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -82,7 +82,7 @@ class CohortSerializer(serializers.ModelSerializer):
         if request.FILES.get("csv"):
             self._calculate_static_by_csv(request.FILES["csv"], cohort)
         elif request.data.get("users"):
-            userIds = request.data.get("users")
+            userIds = request.data.get("users", [])
             parsed_ids = [int(id) for id in userIds.split(",")]
             ids = [
                 person.distinct_ids[0]


### PR DESCRIPTION
## Changes

*Please describe.*  
- adds functionality on persons page that allows you to initiate creating a cohort. User will be able to select from persons list who should be in a cohort and then confirm cohort creation
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
