### PR TITLE
Run all connections through clickhouse connection pooler

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ aioch==0.0.2
 celery==4.4.2
 celery-redbeat==0.13.0
 clickhouse-driver==0.2.0
+clickhouse-pool==0.4.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
 Django==3.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,9 @@ clickhouse-driver==0.2.0
     # via
     #   -r requirements.in
     #   aioch
+    #   clickhouse-pool
+clickhouse-pool==0.4.3
+    # via -r requirements.in
 cryptography==3.3.2
     # via
     #   kafka-helper


### PR DESCRIPTION
We used to run clickhouse connections through a connection pool which seemed to reduce the number of errors where the client gets packets that it didn't expect. This turned out to be a problem with netdata's instance especially. I would think that most VPC installations would have had this issue too.

Basically the problem is that clickhouse connections are not thread safe on clickhouse-driver. If you submit one query and immediately submit another query on the same instance (because async through gevent or something) you end up with a race condition where if the second query answers first to the first query it will think 'wtf is this?' and panic. Same thing with 'Pings' where the driver will ping the server to make sure the connection is alive. If it does this while a query is going on and it gets data back it panics because it was expecting a 'pong'.

We removed this somewhat arbitrarily because we didn't think we needed it and was causing other issues around running out of connections in the pool. Instead of bumping the client open connection limit we instead removed this library entirely because of simplicity.

Please feel free to shame me again for not including a summary 🥇 