### PR TITLE
Fix filtering sessions by action with property filters

### DIFF
--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -148,7 +148,7 @@ def format_action_filters(filter: SessionsFilter) -> Tuple[str, str, str, Dict]:
 
 
 def format_action_filter_aggregate(entity: Entity, prepend: str):
-    filter_sql, params = format_entity_filter(entity, prepend=prepend)
+    filter_sql, params = format_entity_filter(entity, prepend=prepend, filter_by_team=False)
     if entity.properties:
         filters, filter_params = parse_prop_clauses(entity.properties, prepend=prepend, team_id=None)
         filter_sql += f" {filters}"


### PR DESCRIPTION
Fixes #3499

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
