### PR TITLE
Fix getting earliest timestamp on EE with no events

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -154,19 +154,6 @@ class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
 
 
 @pytest.fixture
-def base_test_mixin_fixture():
-    kls = TestMixin()
-    kls.setUp()
-
-    return kls
-
-
-@pytest.fixture
-def team(base_test_mixin_fixture):
-    return base_test_mixin_fixture.team
-
-
-@pytest.fixture
 def test_events(db, team) -> List[UUID]:
     return [
         _create_event(event="$pageview", team=team, distinct_id="whatever", properties={"email": "test@posthog.com"},),

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+import pytz
+from freezegun.api import freeze_time
+
+from ee.clickhouse.models.event import create_event
+from ee.clickhouse.queries.util import get_earliest_timestamp
+from posthog.models.event import Event
+
+
+def _create_event(**kwargs):
+    pk = uuid4()
+    kwargs.update({"event_uuid": pk})
+    create_event(**kwargs)
+
+
+@freeze_time("2021-01-21")
+def test_get_earliest_timestamp(db, team):
+    _create_event(team=team, event="sign up", distinct_id="1", timestamp="2020-01-04T14:10:00Z")
+    _create_event(team=team, event="sign up", distinct_id="1", timestamp="2020-01-06T14:10:00Z")
+
+    assert get_earliest_timestamp(team.id) == datetime(2020, 1, 4, 14, 10, tzinfo=pytz.UTC)
+
+
+@freeze_time("2021-01-21")
+def test_get_earliest_timestamp_with_no_events(db, team):
+    assert get_earliest_timestamp(team.id) == datetime(2021, 1, 14, tzinfo=pytz.UTC)

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -1,12 +1,11 @@
 from datetime import datetime
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import GET_EARLIEST_TIMESTAMP_SQL
-from posthog.models.filters import Filter
-from posthog.models.filters.path_filter import PathFilter
+from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
 from posthog.queries.base import TIME_IN_SECONDS
 from posthog.types import FilterType
 
@@ -46,7 +45,11 @@ def format_ch_timestamp(timestamp: datetime, filter, default_hour_min: str = " 0
 
 
 def get_earliest_timestamp(team_id: int) -> datetime:
-    return sync_execute(GET_EARLIEST_TIMESTAMP_SQL, {"team_id": team_id})[0][0]
+    results = sync_execute(GET_EARLIEST_TIMESTAMP_SQL, {"team_id": team_id})
+    if len(results) > 0:
+        return results[0][0]
+    else:
+        return timezone.now() - DEFAULT_EARLIEST_TIME_DELTA
 
 
 def get_time_diff(

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -10,6 +10,7 @@ from posthog.settings import (
     CLICKHOUSE_USER,
     CLICKHOUSE_VERIFY,
 )
+from posthog.test.base import TestMixin
 
 
 @pytest.fixture(scope="package")
@@ -83,3 +84,16 @@ def db(db):
         sync_execute(PERSON_STATIC_COHORT_TABLE_SQL)
     except:
         pass
+
+
+@pytest.fixture
+def base_test_mixin_fixture():
+    kls = TestMixin()
+    kls.setUp()
+
+    return kls
+
+
+@pytest.fixture
+def team(base_test_mixin_fixture):
+    return base_test_mixin_fixture.team


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/2236839278/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
