### PR TITLE
Fix debug toolbar sql panel

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -554,7 +554,12 @@ if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
 
 
 def show_toolbar(request):
-    return request.path.startswith("/api/") or request.path.startswith("/decide/") or request.path.startswith("/e/")
+    return (
+        request.path.startswith("/api/")
+        or request.path.startswith("/decide/")
+        or request.path.startswith("/e/")
+        or request.path.startswith("/__debug__")
+    )
 
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
## Changes

small issue, clicking the SQL panel on the django debug toolbar didn't work, now it does.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
