### PR TITLE
Use plugin-server container in containerized deploys

### DIFF
--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -62,14 +62,6 @@ jobs:
                   container-name: posthog-production-worker
                   image: ${{ steps.build-image.outputs.image }}
 
-            - name: Fill in the new plugins image ID in the Amazon ECS task definition
-              id: task-def-plugins
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/task-definition.plugins.json
-                  container-name: posthog-production-plugins
-                  image: ${{ steps.build-image.outputs.image }}
-
             - name: Fill in the new migration image ID in the Amazon ECS task definition
               id: task-def-migrate
               uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -117,6 +109,6 @@ jobs:
             - name: Deploy Amazon ECS plugins task definition
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:
-                  task-definition: ${{ steps.task-def-plugins.outputs.task-definition }}
+                  task-definition: deploy/task-definition.plugins.json
                   service: posthog-production-plugins
                   cluster: posthog-production-cluster

--- a/ee/docker-compose.ch.test.yml
+++ b/ee/docker-compose.ch.test.yml
@@ -71,13 +71,8 @@ services:
             - db:db
             - redis:redis
     plugins:
-        build:
-            context: ../
-            dockerfile: production.Dockerfile
-        command: ./bin/plugin-server --no-restart-loop
+        image: posthog/plugin-server:0.11.1
         restart: on-failure
-        volumes:
-            - ..:/code
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_ENABLED: 'true'

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -70,13 +70,8 @@ services:
             - db:db
             - redis:redis
     plugins:
-        build:
-            context: ../
-            dockerfile: production.Dockerfile
-        command: ./bin/plugin-server --no-restart-loop
+        image: posthog/plugin-server:0.11.1
         restart: on-failure
-        volumes:
-            - ..:/code
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_ENABLED: 'true'

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -6,6 +6,7 @@
     "containerDefinitions": [
         {
             "name": "posthog-production-plugins",
+            "image": "public.ecr.aws/p1o5l3m0/posthog-plugin-server:0.11.1",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
@@ -94,8 +95,7 @@
                     "name": "STATSD_HOST",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
                 }
-            ],
-            "entryPoint": ["./bin/plugin-server"]
+            ]
         }
     ],
     "requiresCompatibilities": ["FARGATE"],


### PR DESCRIPTION
## Changes

We already used to do this, but came back to using plugin server from main repo to keep versions in sync. Since we sync plugin server versions with automated PRs now though, we can use the containerized plugin server again with no issues.