### PR TITLE
Parse retention timestamps to local time

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -44,8 +44,12 @@ export function RetentionTable({
         {
             title: 'Date',
             key: 'date',
-            render: (row) => moment.utc(row.date).format(period === 'h' ? 'MMM D, h a' : 'MMM D'),
-            align: 'center',
+            render: (row) =>
+                moment
+                    .utc(row.date)
+                    .local()
+                    .format(period === 'Hour' ? 'MMM D, h a' : 'MMM D'),
+            align: period === 'Hour' ? 'left' : 'center',
         },
         {
             title: 'Cohort Size',


### PR DESCRIPTION
## Changes

*Please describe.*  
- retention table timestamps were UTC formatted
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
