### PR TITLE
Closes #1688 add feature to duplicate dashboard

### DIFF
--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -41,6 +41,7 @@ export const dashboardsModel = kea({
                 }
                 return result
             },
+            duplicateDashboard: async ({ id }) => await api.create(`api/dashboard`, { duplicate: id }),
             renameDashboard: async ({ id, name }) => await api.update(`api/dashboard/${id}`, { name }),
             setIsSharedDashboard: async ({ id, isShared }) =>
                 await api.update(`api/dashboard/${id}`, { is_shared: isShared }),
@@ -61,6 +62,7 @@ export const dashboardsModel = kea({
         ],
         rawDashboards: {
             addDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
+            duplicateDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
             restoreDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
             renameDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
             setIsSharedDashboardSuccess: (state, { dashboard }) => ({ ...state, [dashboard.id]: dashboard }),
@@ -106,6 +108,10 @@ export const dashboardsModel = kea({
     listeners: ({ actions, values }) => ({
         addDashboardSuccess: ({ dashboard }) => {
             toast(`Dashboard "${dashboard.name}" created!`)
+        },
+
+        duplicateDashboardSuccess: ({ dashboard }) => {
+            toast(`Dashboard "${dashboard.name}" duplicated!`)
         },
 
         restoreDashboardSuccess: ({ dashboard }) => {

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { Button, Card, Col, Drawer, Row, Spin } from 'antd'
+import { Button, Card, Col, Drawer, Row, Spin, Tooltip } from 'antd'
 import { dashboardsLogic } from 'scenes/dashboard/dashboardsLogic'
 import { Link } from 'lib/components/Link'
 import { PlusOutlined } from '@ant-design/icons'
 import { Table } from 'antd'
-import { PushpinFilled, PushpinOutlined, DeleteOutlined, AppstoreAddOutlined } from '@ant-design/icons'
+import { PushpinFilled, PushpinOutlined, DeleteOutlined, AppstoreAddOutlined, CopyOutlined } from '@ant-design/icons'
 import { hot } from 'react-hot-loader/root'
 import { NewDashboard } from 'scenes/dashboard/NewDashboard'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -16,7 +16,9 @@ import { DashboardType } from '~/types'
 export const Dashboards = hot(_Dashboards)
 function _Dashboards(): JSX.Element {
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard } = useActions(dashboardsModel)
+    const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard, duplicateDashboard } = useActions(
+        dashboardsModel
+    )
     const { setNewDashboardDrawer } = useActions(dashboardsLogic)
     const { dashboards, newDashboardDrawer } = useValues(dashboardsLogic)
 
@@ -56,12 +58,18 @@ function _Dashboards(): JSX.Element {
             width: 120,
             render: function RenderActions({ id }: DashboardType) {
                 return (
-                    <span
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => deleteDashboard({ id, redirect: false })}
-                        className="text-danger"
-                    >
-                        <DeleteOutlined />
+                    <span>
+                        <DeleteOutlined
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => deleteDashboard({ id, redirect: false })}
+                            className="text-danger"
+                        />
+                        <Tooltip title={'Duplicate dashboard'}>
+                            <CopyOutlined
+                                style={{ cursor: 'pointer', marginLeft: 8 }}
+                                onClick={() => duplicateDashboard({ id })}
+                            />
+                        </Tooltip>
                     </span>
                 )
             },


### PR DESCRIPTION
## Changes

Add option to duplicate dashboard. I implemented it in the frontend. I did not write any test for this feature, but if this approach is good enough (since there are also some advantages of a backend solution), I will update this PR.

![image](https://user-images.githubusercontent.com/24317622/109525291-0a491700-7aba-11eb-812d-6159d8f6cbe4.png)
![image](https://user-images.githubusercontent.com/24317622/109525443-3369a780-7aba-11eb-96d5-c19830517098.png)
![image](https://user-images.githubusercontent.com/24317622/109525488-3d8ba600-7aba-11eb-8b24-8ad5566b9fdf.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
