### PR TITLE
fix plugin invalid config error

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -209,9 +209,13 @@ export function PluginDrawer(): JSX.Element {
                                             )}
                                         </Form.Item>
                                     ) : (
-                                        <p style={{ color: 'var(--danger)' }}>
-                                            Invalid config field <i>{fieldConfig.name || fieldConfig.key}</i>.
-                                        </p>
+                                        <>
+                                            {fieldConfig.type ? (
+                                                <p style={{ color: 'var(--danger)' }}>
+                                                    Invalid config field <i>{fieldConfig.name || fieldConfig.key}</i>.
+                                                </p>
+                                            ) : null}
+                                        </>
                                     )}
                                 </React.Fragment>
                             ))}


### PR DESCRIPTION
## Changes

Pure markdown config fields were telling the user the config was invalid, affected quite a few plugins.

<img width="367" alt="Screenshot 2021-03-01 at 16 27 51" src="https://user-images.githubusercontent.com/38760734/109526992-18dc0200-7aab-11eb-9ab3-e386fe8d30ef.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
