### PR TITLE
Closes #3524 filters do not reset

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
@@ -100,7 +100,11 @@ export const propertyFilterLogic = kea({
                 searchParams.properties = cleanedFilters
 
                 if (!objectsEqual(properties, cleanedFilters)) {
-                    router.actions.push(pathname, searchParams)
+                    if (searchParams.properties.length !== 0) {
+                        router.actions.push(pathname, searchParams)
+                    } else {
+                        router.actions.push(pathname)
+                    }
                 }
             }
         },


### PR DESCRIPTION
Before this, the events table did not update when the last filter
was deleted.

## Changes

https://user-images.githubusercontent.com/24317622/109537454-90b82580-7ac7-11eb-9b26-e4d92b97068b.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
