### PR TITLE
Closes #3520 fix custom date filter dashboards

### DIFF
--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -94,7 +94,7 @@ class TestDashboard(TransactionBaseTest):
         self.assertAlmostEqual(item.last_refresh, now(), delta=timezone.timedelta(seconds=5))
         self.assertEqual(item.filters_hash, generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)))
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(12):
             response = self.client.get("/api/dashboard/%s/" % dashboard.pk).json()
 
         self.assertAlmostEqual(Dashboard.objects.get().last_accessed_at, now(), delta=timezone.timedelta(seconds=5))
@@ -238,17 +238,16 @@ class TestDashboard(TransactionBaseTest):
         DashboardItem.objects.create(
             dashboard=dashboard, filters=filter.to_dict(), team=self.team,
         )
-        response = self.client.get(
+        self.client.get(
             "/api/insight/trend/?events=%s&properties=%s&date_from=-7d"
             % (json.dumps(filter_dict["events"]), json.dumps(filter_dict["properties"]))
         )
-        print("POST")
-        response = self.client.patch(
+        patch_response = self.client.patch(
             "/api/dashboard/%s/" % dashboard.pk,
             data={"filters": {"date_from": "-24h",}},
             content_type="application/json",
         ).json()
-        self.assertEqual(response["items"][0]["result"], None)
+        self.assertEqual(patch_response["items"][0]["result"], None)
 
         # cache results
         response = self.client.get(

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -258,4 +258,4 @@ class TestDashboard(TransactionBaseTest):
         item = DashboardItem.objects.get(pk=item.pk)
         # Expecting this to only have one day as per the dashboard filter
         response = self.client.get("/api/dashboard/%s/" % dashboard.pk).json()
-        self.assertEqual(len(response["items"][0]["result"][0]["days"]), 2)
+        self.assertEqual(len(response["items"][0]["result"][0]["days"]), 2)  # type: ignore

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -223,3 +223,40 @@ class TestDashboard(TransactionBaseTest):
         )
         self.assertEqual(response.status_code, 201)
         self.assertGreater(DashboardItem.objects.count(), 1)
+
+    def test_return_cached_results_dashboard_has_filters(self):
+        # Regression test, we were
+        dashboard = Dashboard.objects.create(team=self.team, name="dashboard")
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+            "date_from": "-7d",
+        }
+        filter = Filter(data=filter_dict)
+
+        item = DashboardItem.objects.create(dashboard=dashboard, filters=filter_dict, team=self.team,)
+        DashboardItem.objects.create(
+            dashboard=dashboard, filters=filter.to_dict(), team=self.team,
+        )
+        response = self.client.get(
+            "/api/insight/trend/?events=%s&properties=%s&date_from=-7d"
+            % (json.dumps(filter_dict["events"]), json.dumps(filter_dict["properties"]))
+        )
+        print("POST")
+        response = self.client.patch(
+            "/api/dashboard/%s/" % dashboard.pk,
+            data={"filters": {"date_from": "-24h",}},
+            content_type="application/json",
+        ).json()
+        self.assertEqual(response["items"][0]["result"], None)
+
+        # cache results
+        response = self.client.get(
+            "/api/insight/trend/?events=%s&properties=%s&date_from=-24h"
+            % (json.dumps(filter_dict["events"]), json.dumps(filter_dict["properties"]))
+        )
+        self.assertEqual(response.status_code, 200)
+        item = DashboardItem.objects.get(pk=item.pk)
+        # Expecting this to only have one day as per the dashboard filter
+        response = self.client.get("/api/dashboard/%s/" % dashboard.pk).json()
+        self.assertEqual(len(response["items"][0]["result"][0]["days"]), 2)

--- a/posthog/models/dashboard_item.py
+++ b/posthog/models/dashboard_item.py
@@ -53,6 +53,7 @@ class DashboardItem(models.Model):
 def dashboard_saved(sender, instance: Dashboard, **kwargs):
     for item in instance.items.all():
         dashboard_item_saved(sender, item, dashboard=instance, **kwargs)
+        item.save()
 
 
 @receiver(pre_save, sender=DashboardItem)


### PR DESCRIPTION
## Changes

Closes #3520 we weren't actually saving the changes we made to dashboarditems.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
