### PR TITLE
Fix bin/tests

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -9,5 +9,5 @@ fi
 
 export REDIS_URL='redis:///'
 export TEST=1
-
-nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db $*; mypy posthog ee"
+psql posthog -c "drop database if exists test_posthog"
+nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db -s $*; mypy posthog ee"


### PR DESCRIPTION
## Changes

We were not dropping the db before (annoying if you are between migrations etc) and we weren't using `-s` which meant you couldn't use ipdb.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
