### PR TITLE
Fix cloud tests on main repo

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -251,6 +251,7 @@ jobs:
                   CLICKHOUSE_VERIFY: 'False'
               run: |
                   cd deploy
+                  source .env.template
                   pytest multi_tenancy messaging -m "not skip_on_multitenancy"
             - name: Run EE tests
               env:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -250,8 +250,8 @@ jobs:
                   CLICKHOUSE_SECURE: 'False'
                   CLICKHOUSE_VERIFY: 'False'
               run: |
-                  cd deploy
                   source .env.template
+                  cd deploy
                   pytest multi_tenancy messaging -m "not skip_on_multitenancy"
             - name: Run EE tests
               env:


### PR DESCRIPTION
## Changes

Fixes posthog-cloud tests on this repo. In some PR we accidentally dropped loading the required env vars to run posthog-cloud. Newly introduced tests no longer override behavior when testing and therefore rely on this required variables, that's why it surfaced today.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
