### PR TITLE
Add JSON view for events

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -739,3 +739,11 @@ export function compactNumber(value: number, maxDecimals: number = 1): string {
     }
     return suffixFormatted(value, 1000000000, 'B', maxDecimals)
 }
+
+export function sortedKeys(object: Record<string, any>): Record<string, any> {
+    const newObject: Record<string, any> = {}
+    for (const key of Object.keys(object).sort()) {
+        newObject[key] = object[key]
+    }
+    return newObject
+}

--- a/frontend/src/scenes/events/EventDetails.js
+++ b/frontend/src/scenes/events/EventDetails.js
@@ -6,6 +6,7 @@ import { Tabs, Button } from 'antd'
 
 import { createActionFromEvent } from './createActionFromEvent'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
+import { EventJSON } from 'scenes/events/EventJSON'
 const { TabPane } = Tabs
 
 export function EventDetails({ event }) {
@@ -61,6 +62,9 @@ export function EventDetails({ event }) {
                             </Button>
                         </small>
                     )}
+                </TabPane>
+                <TabPane tab="JSON" key="json">
+                    <EventJSON event={event} />
                 </TabPane>
                 {event.elements && event.elements.length > 0 && (
                     <TabPane tab="Elements" key="elements">

--- a/frontend/src/scenes/events/EventJSON.tsx
+++ b/frontend/src/scenes/events/EventJSON.tsx
@@ -20,9 +20,5 @@ export function EventJSON(props: { event: Record<string, any> }): JSX.Element {
         ...otherProps,
     }
 
-    return (
-        <div>
-            <CodeSnippet language={Language.JSON}>{JSON.stringify(newEvent, null, 4)}</CodeSnippet>
-        </div>
-    )
+    return <CodeSnippet language={Language.JSON}>{JSON.stringify(newEvent, null, 4)}</CodeSnippet>
 }

--- a/frontend/src/scenes/events/EventJSON.tsx
+++ b/frontend/src/scenes/events/EventJSON.tsx
@@ -1,13 +1,6 @@
 import React from 'react'
 import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
-
-function sortKeys(object: Record<string, any>): Record<string, any> {
-    const newObject: Record<string, any> = {}
-    for (const key of Object.keys(object).sort()) {
-        newObject[key] = object[key]
-    }
-    return newObject
-}
+import { sortedKeys } from 'lib/utils'
 
 export function EventJSON(props: { event: Record<string, any> }): JSX.Element {
     const { event, id, uuid, distinct_id, properties, elements, timestamp, person, ...otherProps } = props.event
@@ -22,16 +15,14 @@ export function EventJSON(props: { event: Record<string, any> }): JSX.Element {
         timestamp,
         event,
         distinct_id,
-        properties: sortKeys(properties),
+        properties: sortedKeys(properties),
         ...(elements && elements.length > 0 ? { elements } : null),
         ...otherProps,
     }
 
-    const eventJSON = JSON.stringify(newEvent, null, 4)
-
     return (
         <div>
-            <CodeSnippet language={Language.JSON}>{eventJSON}</CodeSnippet>
+            <CodeSnippet language={Language.JSON}>{JSON.stringify(newEvent, null, 4)}</CodeSnippet>
         </div>
     )
 }

--- a/frontend/src/scenes/events/EventJSON.tsx
+++ b/frontend/src/scenes/events/EventJSON.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
+
+function sortKeys(object: Record<string, any>): Record<string, any> {
+    const newObject: Record<string, any> = {}
+    for (const key of Object.keys(object).sort()) {
+        newObject[key] = object[key]
+    }
+    return newObject
+}
+
+export function EventJSON(props: { event: Record<string, any> }): JSX.Element {
+    const { event, id, uuid, distinct_id, properties, elements, timestamp, person, ...otherProps } = props.event
+
+    // We're discarding "person", which is a weirdly serialized foreign key (the api gives a string with an email)
+    void person
+
+    // const eventJson = event
+    const newEvent = {
+        ...(id ? { id } : null),
+        ...(uuid ? { uuid } : null),
+        timestamp,
+        event,
+        distinct_id,
+        properties: sortKeys(properties),
+        ...(elements && elements.length > 0 ? { elements } : null),
+        ...otherProps,
+    }
+
+    const eventJSON = JSON.stringify(newEvent, null, 4)
+
+    return (
+        <div>
+            <CodeSnippet language={Language.JSON}>{eventJSON}</CodeSnippet>
+        </div>
+    )
+}


### PR DESCRIPTION
## Changes

![image](https://user-images.githubusercontent.com/53387/109722639-40b38e80-7bad-11eb-9a3e-34830d4c2709.png)

- This adds an alternative view for events: JSON
- Also the option to copy that JSON (might be useful for plugin developers writing tests)
- This is useful for reading complicated JSON, as the default interface is clunky: 
![image](https://user-images.githubusercontent.com/53387/109722890-9e47db00-7bad-11eb-9587-c34f97c1b5aa.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
