### PR TITLE
Remove unnecessary groupbys in session queries

### DIFF
--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -69,13 +69,6 @@ SESSION_SQL = """
                         {date_from}
                         {date_to}
                         AND distinct_id IN %(distinct_ids)s
-                    GROUP BY
-                        uuid,
-                        event,
-                        properties,
-                        timestamp,
-                        distinct_id,
-                        elements_chain
                     ORDER BY
                         distinct_id,
                         timestamp

--- a/ee/clickhouse/sql/sessions/no_events.py
+++ b/ee/clickhouse/sql/sessions/no_events.py
@@ -42,10 +42,6 @@ FROM
                 {date_from}
                 {date_to} 
                 {filters}
-            GROUP BY
-                uuid,
-                timestamp,
-                distinct_id
             ORDER BY
                 distinct_id ASC,
                 timestamp ASC


### PR DESCRIPTION
## Changes

*Please describe.*  
- the innermost section in session queries have a groupby that doesn't seem to be achieving anything
- this optimizes the runtime of the sessions queries

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
