### PR TITLE
Add $device_type tooltip text

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.js
+++ b/frontend/src/lib/components/PropertyKeyInfo.js
@@ -163,10 +163,15 @@ export const keyMapping = {
             description: 'Direct link to the exception in Sentry',
             examples: ['https://sentry.io/...'],
         },
-        $device: {
-            label: 'Device',
-            description: 'The mobile device that was used.',
-            examples: ['iPad', 'iPhone', 'Android'],
+        $device_type: {
+            label: 'Device Type',
+            description: 'The type of device that was used (last-touch).',
+            examples: ['Mobile', 'Tablet', 'Desktop'],
+        },
+        $initial_device_type: {
+            label: 'Initial Device Type',
+            description: 'The initial type of device that was used (first-touch).',
+            examples: ['Mobile', 'Tablet', 'Desktop'],
         },
 
         // UTM tags


### PR DESCRIPTION
## Changes

- Companion to PRs: https://github.com/PostHog/posthog-js/pull/198 and https://github.com/PostHog/plugin-server/pull/228
- Adds nice text about the `$device_type` and `$initial_device_type` properties.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
