### PR TITLE
Chunk session recordings

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -207,7 +207,7 @@ def get_event(request):
         else:
             split_events.append(event)
 
-    for event in events:
+    for event in split_events:
         try:
             distinct_id = _get_distinct_id(event)
         except KeyError:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -191,7 +191,8 @@ def get_event(request):
 
                 for index in range(len(chunks)):
                     new_event = deepcopy(split_event)
-                    new_event["properties"]["$snapshot_chunk"] = {
+                    new_event["properties"]["$snapshot_data"] = {
+                        "posthog_chunked": True,
                         "snapshot_id": snapshot_id,
                         "snapshot_length": len(snapshot_json),
                         "snapshot_type": snapshot_data["type"],

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -114,7 +114,6 @@ def _split_large_snapshot_events(events: List[Dict[str, Any]]):
                         "posthog_chunked": True,
                         "snapshot_id": snapshot_id,
                         "snapshot_length": len(snapshot_json),
-                        "snapshot_type": snapshot_data["type"],
                         "chunk_data": chunks[index],
                         "chunk_length": len(chunks[index]),
                         "chunk_index": index,

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -182,10 +182,9 @@ def get_event(request):
             snapshot_data = event["properties"]["$snapshot_data"]
             snapshot_json = json.dumps(snapshot_data)
 
-            max_chunk_length = 100
-            if len(snapshot_json) > max_chunk_length:
+            if len(snapshot_json) > settings.SESSION_RECORDING_CHUNK_SIZE:
                 snapshot_id = UUIDT()
-                chunks = chunk_string(snapshot_json, max_chunk_length)
+                chunks = chunk_string(snapshot_json, settings.SESSION_RECORDING_CHUNK_SIZE)
                 split_event = deepcopy(event)
                 del split_event["properties"]["$snapshot_data"]
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -108,14 +108,14 @@ def _split_large_snapshot_events(events: List[Dict[str, Any]]):
                 event_template = deepcopy(event)
                 event_template["properties"]["$snapshot_data"] = {}
 
-                for index in range(len(chunks)):
+                for index, chunk in enumerate(chunks):
                     new_event = deepcopy(event_template)
                     new_event["properties"]["$snapshot_data"] = {
                         "posthog_chunked": True,
                         "snapshot_id": snapshot_id,
                         "snapshot_length": len(snapshot_json),
-                        "chunk_data": chunks[index],
-                        "chunk_length": len(chunks[index]),
+                        "chunk_data": chunk,
+                        "chunk_length": len(chunk),
                         "chunk_index": index,
                         "chunk_count": len(chunks),
                     }

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -613,7 +613,6 @@ class TestCapture(BaseTest):
                             "posthog_chunked": True,
                             "snapshot_id": events[0]["properties"]["$snapshot_data"]["snapshot_id"],
                             "snapshot_length": 12159,
-                            "snapshot_type": 3,
                             "chunk_data": '{"data": {"adds": [{"node": {"id": 2040, "type": 2, "tagName": "div", "attributes": {}, "childNodes"',
                             "chunk_length": 100,
                             "chunk_index": 0,

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -564,8 +564,10 @@ class TestCapture(BaseTest):
     @patch("posthog.models.team.TEAM_CACHE", {})
     @patch("posthog.api.capture.celery_app.send_task")
     def test_split_session_recordings(self, patch_process_event_with_plugins):
-        with self.settings(SESSION_RECORDING_CHUNK_SIZE=500):
+        with self.settings(SESSION_RECORDING_CHUNK_SIZE=100):
             now = timezone.now()
+
+            # typical $snapshot_data property in a $snapshot event
             snapshot_data = {
                 "data": {
                     "adds": [
@@ -573,145 +575,9 @@ class TestCapture(BaseTest):
                             "node": {"id": 2040, "type": 2, "tagName": "div", "attributes": {}, "childNodes": []},
                             "nextId": None,
                             "parentId": 39,
-                        },
-                        {
-                            "node": {
-                                "id": 2041,
-                                "type": 2,
-                                "tagName": "div",
-                                "attributes": {"class": "ant-drawer ant-drawer-right", "tabindex": "-1"},
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2040,
-                        },
-                        {
-                            "node": {
-                                "id": 2042,
-                                "type": 2,
-                                "tagName": "div",
-                                "attributes": {
-                                    "class": "ant-drawer-content-wrapper",
-                                    "style": "transform: translateX(100%); width: min(90vw, 420px);",
-                                },
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2041,
-                        },
-                        {
-                            "node": {
-                                "id": 2043,
-                                "type": 2,
-                                "tagName": "div",
-                                "attributes": {"class": "ant-drawer-content"},
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2042,
-                        },
-                        {
-                            "node": {
-                                "id": 2044,
-                                "type": 2,
-                                "tagName": "div",
-                                "attributes": {"class": "ant-drawer-wrapper-body"},
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2043,
-                        },
-                        {
-                            "node": {
-                                "id": 2045,
-                                "type": 2,
-                                "tagName": "div",
-                                "attributes": {"class": "ant-drawer-footer"},
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2044,
-                        },
-                        {
-                            "node": {
-                                "id": 2699,
-                                "type": 2,
-                                "tagName": "span",
-                                "attributes": {"class": "show-over-500"},
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2698,
-                        },
-                        {
-                            "node": {
-                                "id": 2700,
-                                "type": 2,
-                                "tagName": "span",
-                                "attributes": {"role": "img", "class": "anticon anticon-plus", "aria-label": "plus"},
-                                "childNodes": [],
-                            },
-                            "nextId": 2699,
-                            "parentId": 2698,
-                        },
-                        {
-                            "node": {
-                                "id": 2701,
-                                "type": 2,
-                                "isSVG": True,
-                                "tagName": "svg",
-                                "attributes": {
-                                    "fill": "currentColor",
-                                    "class": "",
-                                    "width": "1em",
-                                    "height": "1em",
-                                    "viewBox": "64 64 896 896",
-                                    "data-icon": "plus",
-                                    "focusable": "false",
-                                    "aria-hidden": "true",
-                                },
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2700,
-                        },
-                        {
-                            "node": {
-                                "id": 2702,
-                                "type": 2,
-                                "isSVG": True,
-                                "tagName": "path",
-                                "attributes": {"d": "M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"},
-                                "childNodes": [],
-                            },
-                            "nextId": None,
-                            "parentId": 2701,
-                        },
-                        {
-                            "node": {
-                                "id": 2703,
-                                "type": 2,
-                                "isSVG": True,
-                                "tagName": "path",
-                                "attributes": {"d": "M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"},
-                                "childNodes": [],
-                            },
-                            "nextId": 2702,
-                            "parentId": 2701,
-                        },
-                        {
-                            "node": {
-                                "id": 2704,
-                                "type": 2,
-                                "isSVG": True,
-                                "tagName": "defs",
-                                "attributes": {},
-                                "childNodes": [],
-                            },
-                            "nextId": 2703,
-                            "parentId": 2701,
-                        },
+                        }
                     ]
+                    * 100
                 },
                 "type": 3,
                 "timestamp": 1611611017482,
@@ -726,23 +592,44 @@ class TestCapture(BaseTest):
                 },
                 "api_key": self.team.api_token,
             }
-
             self.client.get(
                 "/e/?_=%s&data=%s" % (int(now.timestamp()), quote(self._dict_to_json(data))),
                 content_type="application/json",
                 HTTP_ORIGIN="https://localhost",
             )
 
-            self.assertEqual(patch_process_event_with_plugins.call_count, 5)
-
             events = [call_args[1]["args"][3] for call_args in patch_process_event_with_plugins.call_args_list]
             snapshot_datas = [event["properties"]["$snapshot_data"] for event in events]
+
+            self.assertEqual(
+                json.loads(json.dumps(events[0])),
+                {
+                    "event": "$snapshot",
+                    "timestamp": now.isoformat(),
+                    "properties": {
+                        "$session_id": "session123",
+                        "distinct_id": "userid123",
+                        "$snapshot_data": {
+                            "posthog_chunked": True,
+                            "snapshot_id": events[0]["properties"]["$snapshot_data"]["snapshot_id"],
+                            "snapshot_length": 12159,
+                            "snapshot_type": 3,
+                            "chunk_data": '{"data": {"adds": [{"node": {"id": 2040, "type": 2, "tagName": "div", "attributes": {}, "childNodes"',
+                            "chunk_length": 100,
+                            "chunk_index": 0,
+                            "chunk_count": 122,
+                        },
+                    },
+                    "api_key": "token123",
+                },
+            )
 
             self.assertEqual(set([e["event"] for e in events]), {"$snapshot"})
             self.assertEqual(set([s["snapshot_id"] for s in snapshot_datas]), {snapshot_datas[0]["snapshot_id"]})
             self.assertEqual(set([s["posthog_chunked"] for s in snapshot_datas]), {True})
-            self.assertEqual(set([s["chunk_index"] for s in snapshot_datas]), {0, 1, 2, 3, 4})
-            self.assertEqual(set([s["chunk_count"] for s in snapshot_datas]), {5})
+            self.assertEqual(set([s["chunk_index"] for s in snapshot_datas]), set(range(122)))
+            self.assertEqual(set([s["chunk_count"] for s in snapshot_datas]), {122})
             self.assertEqual(sum([s["chunk_length"] for s in snapshot_datas]), snapshot_datas[0]["snapshot_length"])
 
+            # join all the chunks, assume they're in order
             self.assertEqual("".join([s["chunk_data"] for s in snapshot_datas]), json.dumps(snapshot_data))

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -79,6 +79,8 @@ PLUGINS_CONFIGURE_VIA_API = PLUGINS_INSTALL_VIA_API or get_from_env(
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
 
+SESSION_RECORDING_CHUNK_SIZE = int(os.getenv("SESSION_RECORDING_CHUNK_SIZE", 512 * 1024))  # 512 KB
+
 # Tokens used when installing plugins, for example to get the latest commit SHA or to download private repositories.
 # Used mainly to get around API limits and only if no ?private_token=TOKEN found in the plugin URL.
 GITLAB_TOKEN = os.getenv("GITLAB_TOKEN", None)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -614,5 +614,6 @@ def is_valid_regex(value: Any) -> bool:
         return False
 
 
-def chunk_string(string, length) -> List[str]:
-    return [string[0 + i : length + i] for i in range(0, len(string), length)]
+def chunk_string(string: str, chunk_length: int) -> List[str]:
+    """Split a string into chunk_length-sized elements. Reversal operation: `''.join()`."""
+    return [string[0 + offset : chunk_length + offset] for offset in range(0, len(string), chunk_length)]

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -612,3 +612,7 @@ def is_valid_regex(value: Any) -> bool:
         return True
     except re.error:
         return False
+
+
+def chunk_string(string, length) -> List[str]:
+    return [string[0 + i : length + i] for i in range(0, len(string), length)]


### PR DESCRIPTION
## Changes

- Chunks session recordings into blocks of 512KB when ingesting
- Combines the blocks when reading back from the database

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
