### PR TITLE
Add `<wbr />` to allow very long strings to split nicely

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -6,6 +6,7 @@ import { NumberOutlined, CalendarOutlined, BulbOutlined, StopOutlined, DeleteOut
 import { isURL } from 'lib/utils'
 import { IconExternalLink, IconText } from 'lib/components/icons'
 import './PropertiesTable.scss'
+import stringWithWBR from 'lib/utils/stringWithWBR'
 
 type HandledType = 'string' | 'string, parsable as datetime' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
 type Type = HandledType | 'symbol' | 'object' | 'function'
@@ -99,7 +100,7 @@ function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType
             className={canEdit ? `editable` : ''}
             onClick={() => canEdit && textBasedTypes.includes(valueType) && setEditing(true)}
         >
-            {String(value)}
+            {stringWithWBR(String(value))}
         </span>
     )
 

--- a/frontend/src/lib/utils/stringWithWBR.tsx
+++ b/frontend/src/lib/utils/stringWithWBR.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+export default function stringWithWBR(text: string): JSX.Element {
+    const addWBRAfter = [',', '.', '/', '\\']
+    const naturalSplit = [' ', '-']
+
+    const returnArray: JSX.Element[] = []
+    let final = ''
+    let sinceSplit = 0
+    let i = 0
+
+    text.split('').forEach((letter) => {
+        if (addWBRAfter.indexOf(letter) >= 0 || sinceSplit >= 30) {
+            sinceSplit = 0
+            final += letter
+            returnArray.push(<span key={i++}>{final}</span>)
+            returnArray.push(<wbr key={i++} />)
+            final = ''
+        } else if (naturalSplit.indexOf(letter) >= 0) {
+            sinceSplit = 0
+            final += letter
+        } else {
+            sinceSplit += 1
+            final += letter
+        }
+    })
+
+    if (final) {
+        returnArray.push(<span key={i++}>{final}</span>)
+    }
+
+    return <span>{returnArray}</span>
+}


### PR DESCRIPTION
## Changes

- Fixes #3554
- Adds a [`<wbr />` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr) inside long string in the properties table every 30 characters (and after some special chars like `&`). It won't make it any different to copy/paste the value, just gives a hint to the browser to break it up if needed.

Before:
<img width="870" alt="Screenshot 2021-03-04 at 14 30 23" src="https://user-images.githubusercontent.com/53387/109971916-06560880-7cf7-11eb-8cce-70c5fae893b8.png">

After:
![image](https://user-images.githubusercontent.com/53387/109972112-42896900-7cf7-11eb-9f0c-0ab338fdcac3.png)



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
