### PR TITLE
Event property calculation bugfix

### DIFF
--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -39,7 +39,7 @@ def calculate_event_property_usage_for_team(team_id: int) -> None:
                 event_names[event["id"]]["usage_count"] += 1
 
         for prop in item.filters.get("properties", []):
-            if prop.get("key") in event_properties:
+            if isinstance(prop, dict) and prop.get("key") in event_properties:
                 event_properties[prop["key"]]["usage_count"] += 1
 
     # intermittent save in case the heavier queries don't finish


### PR DESCRIPTION
## Changes

- On cloud this `prop` was also `"utm_medium__icontains"` and `"current_url__icontains"` instead of a dict. Not sure why (old broken dashboard items?), but safe to ignore I think.
- Fixes this [sentry error](https://sentry.io/organizations/posthog/issues/2251706068/?referrer=slack)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
