### PR TITLE
Fix session tests

### DIFF
--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -69,6 +69,13 @@ SESSION_SQL = """
                         {date_from}
                         {date_to}
                         AND distinct_id IN %(distinct_ids)s
+                    GROUP BY
+                        uuid,
+                        event,
+                        properties,
+                        timestamp,
+                        distinct_id,
+                        elements_chain
                     ORDER BY
                         distinct_id,
                         timestamp

--- a/ee/clickhouse/sql/sessions/no_events.py
+++ b/ee/clickhouse/sql/sessions/no_events.py
@@ -1,27 +1,17 @@
 SESSIONS_NO_EVENTS_SQL = """
 SELECT
-    distinct_id,
-    uuid,
-    session_uuid,
     session_duration_seconds,
-    timestamp,
-    session_end_ts
+    timestamp
 FROM
 (
     SELECT
-        distinct_id,
-        uuid,
-        if(is_new_session, uuid, NULL) AS session_uuid,
         is_new_session,
         is_end_session,
         if(is_end_session AND is_new_session, 0, if(is_new_session AND (NOT is_end_session), dateDiff('second', toDateTime(timestamp), toDateTime(neighbor(timestamp, 1))), NULL)) AS session_duration_seconds,
-        timestamp,
-        if(is_end_session AND is_new_session, timestamp, if(is_new_session AND (NOT is_end_session), neighbor(timestamp, 1), NULL)) AS session_end_ts
+        timestamp
     FROM
     (
         SELECT
-            distinct_id,
-            uuid,
             timestamp,
             neighbor(distinct_id, -1) AS start_possible_neighbor,
             neighbor(timestamp, -1) AS start_possible_prev_ts,
@@ -42,6 +32,10 @@ FROM
                 {date_from}
                 {date_to} 
                 {filters}
+            GROUP BY
+                uuid,
+                timestamp,
+                distinct_id
             ORDER BY
                 distinct_id ASC,
                 timestamp ASC

--- a/ee/clickhouse/sql/sessions/no_events.py
+++ b/ee/clickhouse/sql/sessions/no_events.py
@@ -22,7 +22,6 @@ FROM
         FROM
         (
             SELECT
-                uuid,
                 timestamp,
                 distinct_id
             FROM events
@@ -33,7 +32,6 @@ FROM
                 {date_to} 
                 {filters}
             GROUP BY
-                uuid,
                 timestamp,
                 distinct_id
             ORDER BY


### PR DESCRIPTION
## Changes

Removing the ordering caused flaky tests. I did find some optimizations for the no_events query.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
