### PR TITLE
Add missing param to retention payload

### DIFF
--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -45,6 +45,7 @@ function defaultFilters(filters: Record<string, any>): Record<string, any> {
         retention_type: filters.retention_type || RETENTION_FIRST_TIME,
         display: filters.display || ACTIONS_TABLE,
         properties: filters.properties || [],
+        insight: ViewType.RETENTION,
     }
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- retention requests need `insight` field to be filled out so the cache logic in the decorator can successfully retrieve the corresponding filter
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
