### PR TITLE
Filter disappearing bug + more

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -52,7 +52,7 @@ const FilterRow = React.memo(function FilterRow({
                     onClick={() => {
                         remove(index)
                     }}
-                    style={{ cursor: 'pointer', float: 'none' }}
+                    style={{ cursor: 'pointer', float: 'none', marginLeft: 5 }}
                 />
             )}
             {key && showConditionBadge && index + 1 < totalCount && (

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.js
@@ -100,11 +100,7 @@ export const propertyFilterLogic = kea({
                 searchParams.properties = cleanedFilters
 
                 if (!objectsEqual(properties, cleanedFilters)) {
-                    if (searchParams.properties.length !== 0) {
-                        router.actions.push(pathname, searchParams)
-                    } else {
-                        router.actions.push(pathname)
-                    }
+                    router.actions.push(pathname, searchParams)
                 }
             }
         },

--- a/frontend/src/scenes/events/eventsTableLogic.js
+++ b/frontend/src/scenes/events/eventsTableLogic.js
@@ -185,10 +185,7 @@ export const eventsTableLogic = kea({
                 return
             }
 
-            if (
-                !objectsEqual(searchParams?.properties, []) &&
-                !objectsEqual(searchParams.properties || {}, values.properties)
-            ) {
+            if (!objectsEqual(searchParams.properties || {}, values.properties)) {
                 actions.setProperties(searchParams.properties || {})
             }
         },

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -69,7 +69,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                             <InfoCircleOutlined className="info-indicator" />
                         </Tooltip>
                     </h4>
-                    <Row>
+                    <Row align="middle">
                         <BreakdownFilter
                             filters={filters}
                             onChange={(breakdown: string, breakdown_type: string): void =>
@@ -79,7 +79,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         {filters.breakdown && (
                             <CloseButton
                                 onClick={(): void => setFilters({ breakdown: false, breakdown_type: null })}
-                                style={{ marginTop: 1, marginLeft: 10 }}
+                                style={{ marginTop: 1, marginLeft: 5 }}
                             />
                         )}
                     </Row>


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes bug where removing the last property filter will remove all other filters/entities introduced in #3532 
- fixed the bug that was trying to be addressed in #3532 by altering the eventTableLogic to update params even when properties is empty so it will trigger a table refresh
- adjusted spacing of close button so property filters and breakdown filters both have centered and consistent spacing
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
