### PR TITLE
Fix funnels with only events

### DIFF
--- a/cypress/integration/funnels.js
+++ b/cypress/integration/funnels.js
@@ -4,6 +4,14 @@ describe('Funnels', () => {
         cy.wait(200)
     })
 
+    it('Add only events to funnel', () => {
+        cy.get('[data-attr=add-action-event-button]').click()
+
+        cy.get('[data-attr=save-funnel-button]').click()
+
+        cy.get('[data-attr=funnel-viz]').should('exist')
+    })
+
     it('Add 1 action to funnel and navigate to persons', () => {
         cy.get('[data-attr=add-action-event-button]').click()
         cy.get('[data-attr=trend-element-subject-0]').click()

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -81,8 +81,8 @@ export const funnelLogic = kea({
 
                 insightLogic.actions.startQuery()
 
-                const eventCount = params.events.length
-                const actionCount = params.actions.length
+                const eventCount = params.events?.length
+                const actionCount = params.actions?.length
                 const interval = params.interval
 
                 try {


### PR DESCRIPTION
## Changes

If you created a funnel with only events it would break b/c of @kpthatsme changes. Weirdly we had no tests catching this, and also despite this generating an error it didn't appear in sentry

![image](https://user-images.githubusercontent.com/1727427/110203468-bef28800-7e6e-11eb-84fa-166f42d564be.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
