### PR TITLE
Add ph-no-capture to relevant sections pt. 2

### DIFF
--- a/frontend/src/lib/components/CommandPalette/CommandInput.tsx
+++ b/frontend/src/lib/components/CommandPalette/CommandInput.tsx
@@ -3,7 +3,6 @@ import { SearchOutlined, EditOutlined } from '@ant-design/icons'
 import { useValues, useActions } from 'kea'
 import { commandPaletteLogic } from './commandPaletteLogic'
 import PostHogIcon from 'public/icon-white.svg'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 export function CommandInput(): JSX.Element {
     const { input, isSqueak, activeFlow } = useValues(commandPaletteLogic)
@@ -19,7 +18,7 @@ export function CommandInput(): JSX.Element {
                 <SearchOutlined className="palette__icon" />
             )}
             <input
-                className={`palette__display palette__input ${rrwebBlockClass}`}
+                className="palette__display palette__input ph-no-capture"
                 autoFocus
                 value={input}
                 onChange={(event) => {

--- a/frontend/src/lib/components/CopyToClipboard.tsx
+++ b/frontend/src/lib/components/CopyToClipboard.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Tooltip, Input } from 'antd'
 import { CopyOutlined } from '@ant-design/icons'
 import { copyToClipboard } from 'lib/utils'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 interface InlineProps {
     children: JSX.Element | string
@@ -34,7 +33,7 @@ export function CopyToClipboardInline({
     return (
         <Tooltip title={tooltipMessage}>
             <span
-                className={isValueSensitive ? 'ph-no-capture ' + rrwebBlockClass : ''}
+                className={isValueSensitive ? 'ph-no-capture' : ''}
                 style={{
                     cursor: 'pointer',
                     display: 'flex',
@@ -64,7 +63,7 @@ export function CopyToClipboardInput({
 }: InputProps): JSX.Element {
     return (
         <Input
-            className={isValueSensitive ? 'ph-no-capture ' + rrwebBlockClass : ''}
+            className={isValueSensitive ? 'ph-no-capture' : ''}
             type="text"
             value={value}
             placeholder={placeholder || 'nothing to show here'}

--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -7,6 +7,7 @@ import { personalAPIKeysLogic } from './personalAPIKeysLogic'
 import { PersonalAPIKeyType } from '~/types'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { CopyToClipboardInline } from '../CopyToClipboard'
+import { ColumnsType } from 'antd/lib/table'
 
 function CreateKeyModal({
     isVisible,
@@ -96,7 +97,7 @@ function PersonalAPIKeysTable(): JSX.Element {
     const { keys } = useValues(personalAPIKeysLogic) as { keys: PersonalAPIKeyType[] }
     const { deleteKey } = useActions(personalAPIKeysLogic)
 
-    const columns = [
+    const columns: ColumnsType<Record<string, any>> = [
         {
             title: 'Label',
             dataIndex: 'label',
@@ -106,6 +107,7 @@ function PersonalAPIKeysTable(): JSX.Element {
             title: 'Value',
             dataIndex: 'value',
             key: 'value',
+            className: 'ph-no-capture',
             render: RowValue,
         },
         {
@@ -118,7 +120,7 @@ function PersonalAPIKeysTable(): JSX.Element {
             title: 'Created',
             dataIndex: 'created_at',
             key: 'createdAt',
-            render: humanFriendlyDetailedTime,
+            render: (createdAt: string | null) => humanFriendlyDetailedTime(createdAt),
         },
         {
             title: '',

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -97,7 +97,7 @@ function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType
 
     const valueComponent = (
         <span
-            className={canEdit ? `editable` : ''}
+            className={canEdit ? 'editable ph-no-capture' : 'ph-no-capture'}
             onClick={() => canEdit && textBasedTypes.includes(valueType) && setEditing(true)}
         >
             {stringWithWBR(String(value))}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -3,7 +3,6 @@ import { Col, Row, Select, Tabs } from 'antd'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { cohortsModel } from '../../../models/cohortsModel'
 import { useValues, useActions } from 'kea'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { Link } from '../Link'
 import { PropertySelect } from './PropertySelect'
@@ -99,7 +98,6 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
     return (
         <>
             <SelectGradientOverflow
-                className={rrwebBlockClass}
                 style={{ width: '100%' }}
                 showSearch
                 optionFilterProp="children"
@@ -121,6 +119,7 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
             >
                 {cohorts.map((item, index) => (
                     <Select.Option
+                        className="ph-no-capture"
                         key={'cohort-filter-' + index}
                         value={item.id}
                         type="cohort"

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilterButton.tsx
@@ -16,7 +16,7 @@ const PropertyFilterButton: React.FunctionComponent<Props> = ({ item, onClick }:
 
     return (
         <Button type="primary" shape="round" style={{ maxWidth: '75%' }} onClick={onClick}>
-            <span style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            <span className="ph-no-capture" style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                 {formatPropertyLabel(item, cohorts, keyMapping)}
             </span>
         </Button>

--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Select } from 'antd'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { EventProperty } from 'scenes/userLogic'
 
@@ -21,10 +20,15 @@ interface PropertyOptionGroup {
     options: Array<{ value: string }>
 }
 
+interface SelectionOptionType {
+    key: string
+    value: string
+    type: 'event' | 'person' | 'element'
+}
+
 export function PropertySelect({ optionGroups, value, onChange, placeholder, autoOpenIfEmpty }: Props): JSX.Element {
     return (
         <SelectGradientOverflow
-            className={rrwebBlockClass}
             showSearch
             autoFocus={autoOpenIfEmpty && !value}
             defaultOpen={autoOpenIfEmpty && !value}
@@ -33,7 +37,8 @@ export function PropertySelect({ optionGroups, value, onChange, placeholder, aut
             labelInValue
             value={value || undefined}
             filterOption={(input, option) => option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
-            onChange={(_, { value, type }) => {
+            onChange={(_: null, selection) => {
+                const { value, type } = selection as SelectionOptionType
                 onChange(type, value.replace(/^(event_|person_|element_)/gi, ''))
             }}
             style={{ width: '100%' }}

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -86,12 +86,17 @@ export function PropertyValue({
                 allowClear={value}
             >
                 {input && (
-                    <Select.Option key={input} value={input}>
+                    <Select.Option key={input} value={input} className="ph-no-capture">
                         Specify: {input}
                     </Select.Option>
                 )}
                 {displayOptions.map(({ name, id }, index) => (
-                    <Select.Option key={id || name} value={id || name} data-attr={'prop-val-' + index}>
+                    <Select.Option
+                        key={id || name}
+                        value={id || name}
+                        data-attr={'prop-val-' + index}
+                        className="ph-no-capture"
+                    >
                         {name === true && 'true'}
                         {name === false && 'false'}
                         {name}

--- a/frontend/src/lib/utils/rrwebBlockClass.tsx
+++ b/frontend/src/lib/utils/rrwebBlockClass.tsx
@@ -1,3 +1,0 @@
-const rrwebBlockClass: string = 'ph-no-capture'
-
-export default rrwebBlockClass

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -12,6 +12,7 @@ import { userLogic } from 'scenes/userLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PlusOutlined } from '@ant-design/icons'
 import { createdByColumn } from 'lib/components/Table'
+import { AnnotationType } from '~/types'
 
 const { TextArea } = Input
 
@@ -23,15 +24,16 @@ function _Annotations(): JSX.Element {
     )
     const { createGlobalAnnotation } = useActions(annotationsModel)
     const [open, setOpen] = useState(false)
-    const [selectedAnnotation, setSelected] = useState(null)
+    const [selectedAnnotation, setSelected] = useState({} as AnnotationType)
 
     const columns = [
         {
             title: 'Annotation',
             key: 'annotation',
-            render: function RenderAnnotation(annotation): JSX.Element {
+            render: function RenderAnnotation(annotation: AnnotationType): JSX.Element {
                 return (
                     <span
+                        className="ph-no-capture"
                         style={{
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
@@ -48,25 +50,25 @@ function _Annotations(): JSX.Element {
         createdByColumn(annotations),
         {
             title: 'Date Marker',
-            render: function RenderDateMarker(annotation): JSX.Element {
+            render: function RenderDateMarker(annotation: AnnotationType): JSX.Element {
                 return <span>{moment(annotation.date_marker).format('YYYY-MM-DD')}</span>
             },
         },
         {
             title: 'Last Updated',
-            render: function RenderLastUpdated(annotation): JSX.Element {
+            render: function RenderLastUpdated(annotation: AnnotationType): JSX.Element {
                 return <span>{humanFriendlyDetailedTime(annotation.updated_at)}</span>
             },
         },
         {
             title: 'Status',
-            render: function RenderStatus(annotation): JSX.Element {
+            render: function RenderStatus(annotation: AnnotationType): JSX.Element {
                 return annotation.deleted ? <Tag color="red">Deleted</Tag> : <Tag color="green">Active</Tag>
             },
         },
         {
             title: 'Type',
-            render: function RenderType(annotation): JSX.Element {
+            render: function RenderType(annotation: AnnotationType): JSX.Element {
                 return annotation.scope !== 'dashboard_item' ? (
                     <Tag color="blue">Global</Tag>
                 ) : (
@@ -78,7 +80,7 @@ function _Annotations(): JSX.Element {
 
     function closeModal(): void {
         setOpen(false)
-        setTimeout(() => setSelected(null), 500)
+        setTimeout(() => setSelected({} as AnnotationType), 500)
     }
 
     return (
@@ -229,7 +231,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                                         key={AnnotationScope.Project}
                                         icon={<ProjectOutlined />}
                                     >
-                                        Project {user?.team.name}
+                                        Project {user?.team?.name}
                                     </Menu.Item>
                                 ) : (
                                     <Menu.Item
@@ -239,7 +241,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                                         key={AnnotationScope.Organization}
                                         icon={<DeploymentUnitOutlined />}
                                     >
-                                        Organization {user?.organization.name}
+                                        Organization {user?.organization?.name}
                                     </Menu.Item>
                                 )}
                             </Menu>
@@ -277,9 +279,9 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                     Date:
                     <DatePicker
                         style={{ marginTop: 16, marginLeft: 8, marginBottom: 16 }}
-                        getPopupContainer={(trigger): HTMLElement => trigger.parentElement}
+                        getPopupContainer={(trigger): HTMLElement => trigger.parentElement as HTMLElement}
                         value={selectedDate}
-                        onChange={(date): void => setDate(date)}
+                        onChange={(date): void => setDate(date as moment.Moment)}
                         allowClear={false}
                     />
                 </div>

--- a/frontend/src/scenes/dashboard/NewDashboard.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboard.tsx
@@ -3,7 +3,6 @@ import { Input, Button, Form, Select } from 'antd'
 import { useActions } from 'kea'
 import { slugify } from 'lib/utils'
 import { SaveOutlined } from '@ant-design/icons'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { dashboardsModel } from '~/models/dashboardsModel'
 
 export function NewDashboard(): JSX.Element {
@@ -21,17 +20,17 @@ export function NewDashboard(): JSX.Element {
             <Form.Item
                 name="name"
                 label="Dashboard name"
-                className={rrwebBlockClass}
                 rules={[{ required: true, message: 'Please give your dashboard a name.' }]}
             >
                 <Input
                     autoFocus={true}
                     onChange={(e) => form.setFieldsValue({ key: slugify(e.target.value) })}
                     data-attr="dashboard-name-input"
+                    className="ph-ignore-input"
                 />
             </Form.Item>
 
-            <Form.Item name="useTemplate" label="Start from" className={rrwebBlockClass}>
+            <Form.Item name="useTemplate" label="Start from">
                 <Select data-attr="copy-from-template" style={{ width: '100%' }}>
                     <Select.Option data-attr="dashboard-select-empty" value="">
                         Empty Dashboard

--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -10,7 +10,6 @@ import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { EventName } from 'scenes/actions/EventName'
 import { eventToName, toParams } from 'lib/utils'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import './EventsTable.scss'
 import { eventsTableLogic } from './eventsTableLogic'
 import { hot } from 'react-hot-loader/root'
@@ -98,10 +97,7 @@ function _EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                     return { props: { colSpan: 0 } }
                 }
                 return showLinkToPerson ? (
-                    <Link
-                        to={`/person/${encodeURIComponent(event.distinct_id)}`}
-                        className={'ph-no-capture ' + rrwebBlockClass}
-                    >
+                    <Link to={`/person/${encodeURIComponent(event.distinct_id)}`} className="ph-no-capture">
                         {event.person}
                     </Link>
                 ) : (
@@ -120,7 +116,7 @@ function _EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                 if (filtersEnabled) {
                     return (
                         <FilterPropertyLink
-                            className={'ph-no-capture ' + rrwebBlockClass}
+                            className="ph-no-capture"
                             property={param}
                             value={event.properties[param]}
                             filters={{ properties }}
@@ -216,7 +212,7 @@ function _EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                     loading={isLoading}
                     columns={columns}
                     size="small"
-                    className={rrwebBlockClass + ' ph-no-capture'}
+                    className="ph-no-capture"
                     locale={{
                         emptyText: (
                             <span>

--- a/frontend/src/scenes/events/EventsVolumeTable.tsx
+++ b/frontend/src/scenes/events/EventsVolumeTable.tsx
@@ -26,7 +26,10 @@ export function EventsVolumeTable(): JSX.Element {
                     </Tooltip>
                 )
             },
-            render: (item: EventUsageType) => humanizeNumber(item.volume),
+            // eslint-disable-next-line react/display-name
+            render: (
+                item: EventUsageType // https://stackoverflow.com/questions/55620562/eslint-component-definition-is-missing-displayname-react-display-name
+            ) => <span className="ph-no-capture">{humanizeNumber(item.volume)}</span>,
             sorter: (a: EventUsageType, b: EventUsageType) =>
                 a.volume == b.volume ? a.usage_count - b.usage_count : a.volume - b.volume,
         },
@@ -42,7 +45,8 @@ export function EventsVolumeTable(): JSX.Element {
                     </Tooltip>
                 )
             },
-            render: (item: EventUsageType) => humanizeNumber(item.usage_count),
+            // eslint-disable-next-line react/display-name
+            render: (item: EventUsageType) => <span className="ph-no-capture">{humanizeNumber(item.usage_count)}</span>,
             sorter: (a: EventUsageType, b: EventUsageType) =>
                 a.usage_count == b.usage_count ? a.volume - b.volume : a.usage_count - b.usage_count,
         },
@@ -50,17 +54,17 @@ export function EventsVolumeTable(): JSX.Element {
     const { user } = useValues(userLogic)
     return (
         <>
-            {user?.team.event_names_with_usage[0]?.volume === null && (
+            {user?.team?.event_names_with_usage[0]?.volume === null && (
                 <>
                     <Alert
                         type="warning"
-                        description="We haven't been able to get usage and volume data yet. Please check back later"
+                        message="We haven't been able to get usage and volume data yet. Please check back later"
                     />
                     <br />
                 </>
             )}
             <Table
-                dataSource={user?.team.event_names_with_usage}
+                dataSource={user?.team?.event_names_with_usage}
                 columns={columns}
                 rowKey="event"
                 size="small"

--- a/frontend/src/scenes/experimentation/EditFeatureFlag.js
+++ b/frontend/src/scenes/experimentation/EditFeatureFlag.js
@@ -5,7 +5,6 @@ import { slugify } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { DeleteOutlined, SaveOutlined } from '@ant-design/icons'
 import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { CloseButton } from 'lib/components/CloseButton'
 
 const editLogic = kea({
@@ -98,12 +97,12 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
             <Form.Item
                 name="name"
                 label="Name"
-                className={rrwebBlockClass}
                 rules={[
                     { required: true, message: 'Please give your feature flag a name, like "experimental feature".' },
                 ]}
             >
                 <Input
+                    className="ph-ignore-input"
                     autoFocus={isNew}
                     onChange={(e) => form.setFieldsValue({ key: slugify(e.target.value) })}
                     data-attr="feature-flag-name"
@@ -129,7 +128,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                     )
                 }
             >
-                <Input data-attr="feature-flag-key" />
+                <Input data-attr="feature-flag-key" className="ph-ignore-input" />
             </Form.Item>
 
             <Form.Item name="active" label="Feature flag is active" valuePropName="checked">
@@ -145,11 +144,7 @@ export function EditFeatureFlag({ featureFlag, logic, isNew }) {
                         />
                     )}
 
-                    <Form.Item
-                        className={rrwebBlockClass}
-                        label="Filter by user properties"
-                        style={{ position: 'relative' }}
-                    >
+                    <Form.Item label="Filter by user properties" style={{ position: 'relative' }}>
                         <PropertyFilters
                             pageKey={`feature-flag-${featureFlag.id}-${index}-${groups.length}`}
                             propertyFilters={group?.properties}

--- a/frontend/src/scenes/experimentation/FeatureFlags.js
+++ b/frontend/src/scenes/experimentation/FeatureFlags.js
@@ -4,7 +4,6 @@ import { useValues, useActions } from 'kea'
 import { featureFlagLogic } from './featureFlagLogic'
 import { Table, Switch, Drawer, Button } from 'antd'
 import { EditFeatureFlag } from './EditFeatureFlag'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { Link } from 'lib/components/Link'
 import { DeleteWithUndo } from 'lib/utils'
 import { ExportOutlined, PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons'
@@ -19,15 +18,17 @@ function _FeatureFlags() {
     const { featureFlags, featureFlagsLoading } = useValues(logic)
     const { updateFeatureFlag, loadFeatureFlags } = useActions(logic)
 
-    let columns = [
+    const columns = [
         {
             title: 'Name',
             dataIndex: 'name',
+            className: 'ph-no-capture',
             sorter: (a, b) => ('' + a.name).localeCompare(b.name),
         },
         {
             title: 'Key',
             dataIndex: 'key',
+            className: 'ph-no-capture',
             sorter: (a, b) => ('' + a.key).localeCompare(b.key),
         },
         createdAtColumn(),
@@ -122,7 +123,7 @@ function _FeatureFlags() {
                     onClick: () => setOpenFeatureFlag(featureFlag),
                 })}
                 size="small"
-                rowClassName={'cursor-pointer ' + rrwebBlockClass}
+                rowClassName="cursor-pointer"
                 data-attr="feature-flag-table"
             />
             <Drawer

--- a/frontend/src/scenes/me/Settings/ChangePassword.tsx
+++ b/frontend/src/scenes/me/Settings/ChangePassword.tsx
@@ -49,6 +49,7 @@ export function ChangePassword(): JSX.Element {
                     autoComplete="current-password"
                     disabled={!!user && !user.has_password}
                     placeholder={user && !user.has_password ? 'signed up with external login' : undefined}
+                    className="ph-ignore-input"
                 />
             </FormItem>
             <FormItem

--- a/frontend/src/scenes/persons/Cohorts.tsx
+++ b/frontend/src/scenes/persons/Cohorts.tsx
@@ -15,16 +15,17 @@ import api from 'lib/api'
 import './cohorts.scss'
 import Fuse from 'fuse.js'
 import { createdAtColumn, createdByColumn } from 'lib/components/Table'
+import { cohortsUrlLogicType } from './CohortsType'
 
-const cohortsUrlLogic = kea({
+const cohortsUrlLogic = kea<cohortsUrlLogicType<CohortType>>({
     actions: {
-        setOpenCohort: (cohort: CohortType) => ({ cohort }),
+        setOpenCohort: (cohort: CohortType | null) => ({ cohort }),
     },
     reducers: {
         openCohort: [
-            false,
+            null as null | CohortType,
             {
-                setOpenCohort: (_: null, { cohort }: { cohort: CohortType }) => cohort,
+                setOpenCohort: (_, { cohort }) => cohort,
             },
         ],
     },
@@ -32,8 +33,8 @@ const cohortsUrlLogic = kea({
         setOpenCohort: () => '/cohorts' + (values.openCohort ? '/' + (values.openCohort.id || 'new') : ''),
     }),
     urlToAction: ({ actions, values }) => ({
-        '/cohorts(/:cohortId)': async ({ cohortId }: Record<string, string>) => {
-            if (cohortId && cohortId !== 'new' && cohortId !== values.openCohort.id) {
+        '/cohorts(/:cohortId)': async ({ cohortId }: { cohortId: number | 'new' }) => {
+            if (cohortId && cohortId !== 'new' && Number(cohortId) !== values.openCohort?.id) {
                 const cohort = await api.get('api/cohort/' + cohortId)
                 actions.setOpenCohort(cohort)
             }
@@ -68,7 +69,7 @@ function _Cohorts(): JSX.Element {
         },
         {
             title: 'Users in cohort',
-            render: function RenderCount(_: null, cohort: CohortType) {
+            render: function RenderCount(_: any, cohort: CohortType) {
                 return cohort.count?.toLocaleString()
             },
             sorter: (a: CohortType, b: CohortType) => (a.count || 0) - (b.count || 0),
@@ -84,7 +85,7 @@ function _Cohorts(): JSX.Element {
                     </Tooltip>
                 </span>
             ),
-            render: function RenderCalculation(_: null, cohort: CohortType) {
+            render: function RenderCalculation(_: any, cohort: CohortType) {
                 if (cohort.is_static) {
                     return <>N/A</>
                 }
@@ -107,15 +108,17 @@ function _Cohorts(): JSX.Element {
                                 <ExportOutlined />
                             </Tooltip>
                         </a>
-                        <DeleteWithUndo
-                            endpoint="cohort"
-                            object={cohort}
-                            className="text-danger"
-                            style={{ marginLeft: 8 }}
-                            callback={loadCohorts}
-                        >
-                            <DeleteOutlined />
-                        </DeleteWithUndo>
+                        {cohort.id !== 'new' && (
+                            <DeleteWithUndo
+                                endpoint="cohort"
+                                object={{ name: cohort.name, id: cohort.id }}
+                                className="text-danger"
+                                style={{ marginLeft: 8 }}
+                                callback={loadCohorts}
+                            >
+                                <DeleteOutlined />
+                            </DeleteWithUndo>
+                        )}
                     </span>
                 )
             },
@@ -161,11 +164,11 @@ function _Cohorts(): JSX.Element {
                     dataSource={searchTerm ? searchCohorts(cohorts, searchTerm) : cohorts}
                 />
                 <Drawer
-                    title={openCohort.id === 'new' ? 'New cohort' : openCohort.name}
+                    title={openCohort?.id === 'new' ? 'New cohort' : openCohort?.name}
                     className="cohorts-drawer"
-                    onClose={() => setOpenCohort(false)}
+                    onClose={() => setOpenCohort(null)}
                     destroyOnClose={true}
-                    visible={openCohort}
+                    visible={!!openCohort}
                 >
                     {openCohort && <Cohort cohort={openCohort} />}
                 </Drawer>

--- a/frontend/src/scenes/persons/Cohorts.tsx
+++ b/frontend/src/scenes/persons/Cohorts.tsx
@@ -12,7 +12,6 @@ import { Cohort } from './Cohort'
 import { Drawer } from 'lib/components/Drawer'
 import { CohortType } from '~/types'
 import api from 'lib/api'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import './cohorts.scss'
 import Fuse from 'fuse.js'
 import { createdAtColumn, createdByColumn } from 'lib/components/Table'
@@ -25,7 +24,7 @@ const cohortsUrlLogic = kea({
         openCohort: [
             false,
             {
-                setOpenCohort: (_, { cohort }: { cohort: CohortType }) => cohort,
+                setOpenCohort: (_: null, { cohort }: { cohort: CohortType }) => cohort,
             },
         ],
     },
@@ -64,14 +63,15 @@ function _Cohorts(): JSX.Element {
             title: 'Name',
             dataIndex: 'name',
             key: 'name',
-            sorter: (a: CohortType, b: CohortType) => ('' + a.name).localeCompare(b.name),
+            className: 'ph-no-capture',
+            sorter: (a: CohortType, b: CohortType) => ('' + a.name).localeCompare(b.name as string),
         },
         {
             title: 'Users in cohort',
-            render: function RenderCount(_, cohort: CohortType) {
+            render: function RenderCount(_: null, cohort: CohortType) {
                 return cohort.count?.toLocaleString()
             },
-            sorter: (a: CohortType, b: CohortType) => a.count - b.count,
+            sorter: (a: CohortType, b: CohortType) => (a.count || 0) - (b.count || 0),
         },
         createdAtColumn(),
         createdByColumn(cohorts),
@@ -84,7 +84,7 @@ function _Cohorts(): JSX.Element {
                     </Tooltip>
                 </span>
             ),
-            render: function RenderCalculation(_, cohort: CohortType) {
+            render: function RenderCalculation(_: null, cohort: CohortType) {
                 if (cohort.is_static) {
                     return <>N/A</>
                 }
@@ -154,7 +154,7 @@ function _Cohorts(): JSX.Element {
                     loading={cohortsLoading}
                     rowKey="id"
                     pagination={{ pageSize: 100, hideOnSinglePage: true }}
-                    rowClassName={'cursor-pointer ' + rrwebBlockClass}
+                    rowClassName="cursor-pointer"
                     onRow={(cohort) => ({
                         onClick: () => setOpenCohort(cohort),
                     })}

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -1,7 +1,6 @@
 import { PersonType } from '~/types'
 import React from 'react'
 import { IconPerson } from 'lib/components/icons'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 
 export function PersonHeader({ person }: { person: PersonType }): JSX.Element {
     return (
@@ -12,7 +11,7 @@ export function PersonHeader({ person }: { person: PersonType }): JSX.Element {
                         <IconPerson />
                     </span>
                     {person.properties.email ? (
-                        <span className={`text-ellipsis ${rrwebBlockClass}`}>{person.properties.email}</span>
+                        <span className="text-ellipsis ph-no-capture">{person.properties.email}</span>
                     ) : (
                         <i>No email recorded</i>
                     )}

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -35,7 +35,7 @@ export function PluginField({
     return fieldConfig.type === 'attachment' ? (
         <UploadField value={value} onChange={onChange} />
     ) : fieldConfig.type === 'string' ? (
-        <Input value={value} onChange={onChange} autoFocus={editingSecret} />
+        <Input value={value} onChange={onChange} autoFocus={editingSecret} className="ph-ignore-input" />
     ) : fieldConfig.type === 'choice' ? (
         <Select dropdownMatchSelectWidth={false} value={value} onChange={onChange}>
             {fieldConfig.choices.map((choice) => (

--- a/frontend/src/scenes/plugins/edit/UploadField.tsx
+++ b/frontend/src/scenes/plugins/edit/UploadField.tsx
@@ -22,6 +22,7 @@ export function UploadField({
                 onChange?.(null)
                 return false
             }}
+            className="ph-ignore-input"
         >
             <Button icon={<UploadOutlined />}>Click to Upload</Button>
         </Upload>

--- a/frontend/src/scenes/sessions/SessionsPlay.tsx
+++ b/frontend/src/scenes/sessions/SessionsPlay.tsx
@@ -17,7 +17,6 @@ import { colorForString } from 'lib/utils'
 import { Loading } from 'lib/utils'
 import { sessionsPlayLogic } from './sessionsPlayLogic'
 import { IconExternalLink } from 'lib/components/icons'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 
 import './Sessions.scss'
@@ -122,17 +121,19 @@ function _SessionsPlay(): JSX.Element {
                             </>
                         )}
                     </div>
-                    <div className="ph-no-capture player-container">
+                    <div className="player-container">
                         {isLoadingSession ? (
                             <Loading />
                         ) : (
-                            <Player
-                                ref={playerRef}
-                                events={sessionPlayerData?.snapshots || []}
-                                onPlayerTimeChange={setCurrentPlayerTime}
-                                onNext={showNext ? goToNext : undefined}
-                                onPrevious={showPrev ? goToPrevious : undefined}
-                            />
+                            <span className="ph-no-capture">
+                                <Player
+                                    ref={playerRef}
+                                    events={sessionPlayerData?.snapshots || []}
+                                    onPlayerTimeChange={setCurrentPlayerTime}
+                                    onNext={showNext ? goToNext : undefined}
+                                    onPrevious={showPrev ? goToPrevious : undefined}
+                                />
+                            </span>
                         )}
                     </div>
                 </Col>
@@ -155,7 +156,7 @@ function _SessionsPlay(): JSX.Element {
                                         to={`/person/${encodeURIComponent(
                                             sessionPlayerData?.person?.distinct_ids[0] || ''
                                         )}`}
-                                        className={rrwebBlockClass + ' ph-no-capture'}
+                                        className="ph-no-capture"
                                         target="_blank"
                                         style={{ display: 'inline-flex', alignItems: 'center' }}
                                     >

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -18,7 +18,6 @@ import {
 } from '@ant-design/icons'
 import { SessionsPlayerButton, sessionPlayerUrl } from './SessionsPlayerButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
-import rrwebBlockClass from 'lib/utils/rrwebBlockClass'
 import { SessionsPlay } from './SessionsPlay'
 import { userLogic } from 'scenes/userLogic'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
@@ -85,10 +84,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
             key: 'person',
             render: function RenderSession(session: SessionType) {
                 return (
-                    <Link
-                        to={`/person/${encodeURIComponent(session.distinct_id)}`}
-                        className={rrwebBlockClass + ' ph-no-capture'}
-                    >
+                    <Link to={`/person/${encodeURIComponent(session.distinct_id)}`} className="ph-no-capture">
                         {session?.email || session.distinct_id}
                     </Link>
                 )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -278,7 +278,7 @@ export interface CohortType {
     created_by?: Record<string, any>
     created_at?: string
     deleted?: boolean
-    id: number
+    id: number | 'new'
     is_calculating?: boolean
     last_calculation?: string
     is_static?: boolean


### PR DESCRIPTION
## Changes

Supersedes #3156

- Adds `ph-no-capture` and `ph-ignore-input` to relevant sections with "surgical precision"
- Fixes a bunch of TS errors along the way

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
