### PR TITLE
Fix funnels loading message

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -56,6 +56,7 @@ export const funnelLogic = kea({
         clearFunnel: true,
         setFilters: (filters, refresh = false) => ({ filters, refresh }),
         saveFunnelInsight: (name) => ({ name }),
+        setStepsWithCountLoading: (stepsWithCountLoading) => ({ stepsWithCountLoading }),
     }),
 
     connect: {
@@ -65,6 +66,7 @@ export const funnelLogic = kea({
     loaders: ({ props, values, actions }) => ({
         results: {
             loadResults: async (refresh = false, breakpoint) => {
+                actions.setStepsWithCountLoading(true)
                 if (props.cachedResults && !refresh && values.filters === props.filters) {
                     return props.cachedResults
                 }
@@ -125,7 +127,7 @@ export const funnelLogic = kea({
         stepsWithCountLoading: [
             false,
             {
-                setSteps: () => false,
+                setStepsWithCountLoading: (_, { stepsWithCountLoading }) => stepsWithCountLoading,
             },
         ],
         people: {
@@ -162,6 +164,12 @@ export const funnelLogic = kea({
                 return result
             },
         ],
+        isValidFunnel: [
+            () => [selectors.stepsWithCount],
+            (stepsWithCount) => {
+                return stepsWithCount && stepsWithCount[0] && stepsWithCount[0].count > -1
+            },
+        ],
     }),
 
     listeners: ({ actions, values, props }) => ({
@@ -169,6 +177,7 @@ export const funnelLogic = kea({
             if (values.stepsWithCount[0]?.people?.length > 0) {
                 actions.loadPeople(values.stepsWithCount)
             }
+            actions.setStepsWithCountLoading(false)
         },
         setFilters: ({ refresh }) => {
             if (refresh) {

--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -339,7 +339,6 @@ const isFunnelEmpty = (filters) => {
 function FunnelInsight() {
     const { stepsWithCount, isValidFunnel, stepsWithCountLoading } = useValues(funnelLogic({}))
 
-    console.log(stepsWithCountLoading)
     return (
         <div style={{ height: 300, position: 'relative' }}>
             {stepsWithCountLoading && <Loading />}

--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -337,16 +337,16 @@ const isFunnelEmpty = (filters) => {
 }
 
 function FunnelInsight() {
-    const { stepsWithCount, resultsLoading } = useValues(funnelLogic({}))
+    const { stepsWithCount, isValidFunnel, stepsWithCountLoading } = useValues(funnelLogic({}))
 
+    console.log(stepsWithCountLoading)
     return (
         <div style={{ height: 300, position: 'relative' }}>
-            {resultsLoading && <Loading />}
-            {stepsWithCount && stepsWithCount[0] && stepsWithCount[0].count > -1 ? (
+            {stepsWithCountLoading && <Loading />}
+            {isValidFunnel ? (
                 <FunnelViz steps={stepsWithCount} />
             ) : (
-                !resultsLoading &&
-                !stepsWithCount && (
+                !stepsWithCountLoading && (
                     <div
                         style={{
                             textAlign: 'center',


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog/pull/3519 fixed an issue where just before the funnel loaded, a message would appear.

However, it caused another minor UI issue where changing steps in the funnel yields a blank screen with no feedback to the user.

Essentially, the kea-generated `resultsLoading` reducer was being set to false before we had the new `stepsWithCount`.

This leverages a previously-unused reducer (maybe an earlier attempt at fixing this?) to manually set when `stepsWithCount` has _actually_ updated and use that to show the message.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
