### PR TITLE
Remove of needless space in properties table

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -118,7 +118,7 @@ function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType
                             {canEdit && boolNullTypes.includes(valueType) ? (
                                 <Dropdown overlay={boolNullSelect}>{valueComponent}</Dropdown>
                             ) : (
-                                <> {valueComponent}</>
+                                <>{valueComponent}</>
                             )}
 
                             {isURL(value) && (


### PR DESCRIPTION
## Changes

This space causes issues when copy/pasting:
![image](https://user-images.githubusercontent.com/53387/110455403-b0071200-80c8-11eb-80c3-33b37a5561a8.png)

Reported by a EE customer

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
