### PR TITLE
Handle webhooks better

### DIFF
--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -4,6 +4,8 @@ import requests
 import statsd
 from celery import Task
 from django.conf import settings
+from django.db.utils import DataError
+from sentry_sdk import capture_exception
 
 from ee.clickhouse.models.element import chain_to_elements
 from posthog.celery import app
@@ -43,7 +45,17 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
                 actionFilters["post_to_slack"] = True  # We only need to fire for actions that are posted to webhook URL
 
         for action in cast(Sequence[Action], Action.objects.filter(**actionFilters).all()):
-            qs = Event.objects.filter(pk=ephemeral_postgres_event.pk).query_db_by_action(action)
+            try:
+                # Wrapped in len to evaluate right away
+                qs = len(Event.objects.filter(pk=ephemeral_postgres_event.pk).query_db_by_action(action))
+            except DataError as e:
+                # Ignore invalid regex errors, which are user mistakes
+                if not "invalid regular expression" in str(e):
+                    capture_exception(e)
+                continue
+            except:
+                capture_exception()
+                continue
             if not qs:
                 continue
             # REST hooks

--- a/ee/tasks/webhooks_ee.py
+++ b/ee/tasks/webhooks_ee.py
@@ -35,7 +35,7 @@ def post_event_to_webhook_ee(self: Task, event: Dict[str, Any], team_id: int, si
     try:
         is_zapier_available = team.organization.is_feature_available("zapier")
 
-        actionFilters = {"team_id": team_id}
+        actionFilters = {"team_id": team_id, "deleted": False}
         if not is_zapier_available:
             if not team.slack_incoming_webhook:
                 return  # Exit this task if neither Zapier nor webhook URL are available


### PR DESCRIPTION
## Changes

This solves 2 issues:
1. Webhooks being fired for soft-deleted actions.
2. Regex errors in action definitions, caused by users, not being handled gracefully.

