### PR TITLE
Fix FOSS webhook, update actions calculation

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -74,14 +74,6 @@ def setup_periodic_tasks(sender, **kwargs):
 
     sender.add_periodic_task(120, calculate_cohort.s(), name="recalculate cohorts")
 
-    if settings.ASYNC_EVENT_ACTION_MAPPING:
-        sender.add_periodic_task(
-            (60 * ACTION_EVENT_MAPPING_INTERVAL_MINUTES),
-            calculate_event_action_mappings.s(),
-            name="calculate event action mappings",
-            expires=(60 * ACTION_EVENT_MAPPING_INTERVAL_MINUTES),
-        )
-
     if settings.ASYNC_EVENT_PROPERTY_USAGE:
         sender.add_periodic_task(60, calculate_event_property_usage.s(), name="calculate event property usage")
 
@@ -200,13 +192,6 @@ def run_session_recording_retention():
     from posthog.tasks.session_recording_retention import session_recording_retention_scheduler
 
     session_recording_retention_scheduler()
-
-
-@app.task(ignore_result=True)
-def calculate_event_action_mappings():
-    from posthog.tasks.calculate_action import calculate_actions_from_last_calculation
-
-    calculate_actions_from_last_calculation()
 
 
 @app.task(ignore_result=True)

--- a/posthog/tasks/calculate_action.py
+++ b/posthog/tasks/calculate_action.py
@@ -1,9 +1,10 @@
 import logging
 import time
 
-from celery import shared_task
+from celery import current_app, shared_task
 
-from posthog.models import Action
+from posthog.celery import app
+from posthog.models import Action, Event
 
 logger = logging.getLogger(__name__)
 
@@ -16,10 +17,17 @@ def calculate_action(action_id: int) -> None:
     logger.info("Calculating action {} took {:.2f} seconds".format(action.pk, (time.time() - start_time)))
 
 
-def calculate_actions_from_last_calculation() -> None:
-    actions = Action.objects.filter(deleted=False).only("pk")
-    for action in actions:
+@app.task(ignore_result=True)
+def calculate_actions_for_event(event_id: str, site_url: str) -> None:
+    event = Event.objects.get(pk=event_id)
+    event_should_trigger_webhook = False
+
+    for action in event.actions:
         start_time = time.time()
         action.calculate_events(start=action.last_calculated_at)
-
         logger.info("Calculating action {} took {:.2f} seconds".format(action.pk, (time.time() - start_time)))
+        if action.post_to_slack:
+            event_should_trigger_webhook = True
+
+    if event_should_trigger_webhook:
+        current_app.send_task("posthog.tasks.webhooks.post_event_to_webhook", args=[event_id, site_url])

--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -105,6 +105,7 @@ def post_event_to_webhook(self: Task, event_id: int, site_url: str) -> None:
     try:
         event = Event.objects.get(pk=event_id)
         team = event.team
+
         actions = [action for action in event.action_set.all() if action.post_to_slack]
 
         if not site_url:


### PR DESCRIPTION
## Changes

Works in conjunction with https://github.com/PostHog/plugin-server/pull/233

On PostHog FOSS:
- Calculates actions for an event when that event is ingested rather than instance-wide periodically
- Triggers the webhook after the calculation if the event should trigger a webhook

Discussion about the approach on Slack.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
