### PR TITLE
Improve Plugins page UX

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -118,9 +118,7 @@ export function PluginDrawer(): JSX.Element {
                     {editingPlugin ? (
                         <div>
                             <div style={{ display: 'flex', marginBottom: 16 }}>
-                                <div>
-                                    <PluginImage pluginType={editingPlugin.plugin_type} url={editingPlugin.url} />
-                                </div>
+                                <PluginImage pluginType={editingPlugin.plugin_type} url={editingPlugin.url} />
                                 <div style={{ flexGrow: 1, paddingLeft: 16 }}>
                                     {editingPlugin.description}
                                     {(editingPlugin.description?.length || 0) > 0 &&

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -76,7 +76,7 @@ export function PluginCard({
                 <Row align="middle" className="plugin-card-row">
                     {typeof order === 'number' && typeof maxOrder === 'number' ? (
                         <DragColumn>
-                            <div className={`arrow${order !== maxOrder ? ' hide' : ''}`}>
+                            <div className={`arrow${order === 1 ? ' hide' : ''}`}>
                                 <DownOutlined />
                             </div>
                             <div>
@@ -105,9 +105,7 @@ export function PluginCard({
                                 cancelText="No"
                                 disabled={switchDisabled}
                             >
-                                <div>
-                                    <Switch checked={pluginConfig.enabled} disabled={switchDisabled} />
-                                </div>
+                                <Switch checked={pluginConfig.enabled} disabled={switchDisabled} />
                             </Popconfirm>
                         </Col>
                     )}
@@ -118,7 +116,6 @@ export function PluginCard({
                         <div>
                             <strong style={{ marginRight: 8 }}>{name}</strong>
                             {maintainer && !pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
-                            {!description && !url ? <br /> : null}
                             {pluginConfig?.error ? (
                                 <PluginError
                                     error={pluginConfig.error}

--- a/frontend/src/scenes/plugins/plugin/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginImage.tsx
@@ -14,18 +14,15 @@ export function PluginImage({ url, pluginType }: { url?: string; pluginType?: Pl
         }
     }, [url])
 
-    return (
-        <div className="plugin-image">
-            {pluginType === 'source' ? (
-                <CodeOutlined style={{ fontSize: 40 }} />
-            ) : (
-                <img
-                    src={state.image}
-                    style={{ maxWidth: '100%', maxHeight: '100%' }}
-                    alt=""
-                    onError={() => setState({ ...state, image: imgPluginDefault })}
-                />
-            )}
-        </div>
+    return pluginType === 'source' ? (
+        <CodeOutlined style={{ fontSize: 80 }} className="plugin-image" />
+    ) : (
+        <img
+            className="plugin-image"
+            src={state.image}
+            style={{ maxWidth: 'calc(min(100%, 80px))', maxHeight: 'calc(min(100%, 120px))' }}
+            alt=""
+            onError={() => setState({ ...state, image: imgPluginDefault })}
+        />
     )
 }

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -65,6 +65,7 @@ export const pluginsLogic = kea<
             temporaryOrder,
             movedPluginId,
         }),
+        makePluginOrderSaveable: true,
         savePluginOrders: (newOrders: Record<number, number>) => ({ newOrders }),
         cancelRearranging: true,
     },
@@ -331,6 +332,14 @@ export const pluginsLogic = kea<
             {
                 checkForUpdates: () => true,
                 checkedForUpdates: () => false,
+            },
+        ],
+        pluginOrderSaveable: [
+            false,
+            {
+                makePluginOrderSaveable: () => true,
+                cancelRearranging: () => false,
+                savePluginOrdersSuccess: () => false,
             },
         ],
         rearranging: [

--- a/frontend/src/scenes/plugins/tabs/advanced/AdvancedTab.tsx
+++ b/frontend/src/scenes/plugins/tabs/advanced/AdvancedTab.tsx
@@ -35,7 +35,6 @@ export function AdvancedTab(): JSX.Element {
                 }
                 type="warning"
                 showIcon
-                closable
             />
             <Subtitle subtitle="Advanced Options" />
             <SourcePlugin />


### PR DESCRIPTION
## Changes

This cleans up a few things:

1. Plugin logos are sized better, with a limit of 80px width to avoid them overtaking the drawer.
    <img width="426" alt="plugin logo sizing" src="https://user-images.githubusercontent.com/4550621/110600391-2d438d00-8184-11eb-9118-4d86503b7685.png">
2. Title is now in line with badges for description-less plugins, same as description-ful ones.
    <img width="219" alt="inline badges" src="https://user-images.githubusercontent.com/4550621/110600396-2f0d5080-8184-11eb-8e9c-4d947fd3f1ee.png">
3. Enabled plugins between the first and the last ones now have arrows both above and below to better signify data flow.
    <img width="61" alt="Screen Shot 2021-03-10 at 09 33 03" src="https://user-images.githubusercontent.com/4550621/110600399-2f0d5080-8184-11eb-8592-fa2c801dde53.png">
4. There's now an "Edit order" button to aid discoverability of ordering.
    <img width="997" alt="edit order button" src="https://user-images.githubusercontent.com/4550621/110600400-2fa5e700-8184-11eb-853c-239ec359bfd6.png">
5. The "Enabled plugins" header is now more intuitively similar across config and rearranging modes. Also, "Save order" is only available once any plugin has been moved (this is only relevant to the new "Edit order" button).
    <img width="1006" alt="rearranging mode" src="https://user-images.githubusercontent.com/4550621/110600406-2fa5e700-8184-11eb-9649-cad2aeeda3fd.png">
