### PR TITLE
Fix 500 on enabling plugins

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -246,9 +246,11 @@ class PluginConfigSerializer(serializers.ModelSerializer):
 
         # Keep old value for secret fields if no new value in the request
         secret_fields = _get_secret_fields_for_plugin(plugin_config.plugin)
-        for key in secret_fields:
-            if validated_data["config"].get(key) is None:  # explicitly checking None to allow ""
-                validated_data["config"][key] = plugin_config.config.get(key)
+
+        if "config" in validated_data:
+            for key in secret_fields:
+                if validated_data["config"].get(key) is None:  # explicitly checking None to allow ""
+                    validated_data["config"][key] = plugin_config.config.get(key)
 
         response = super().update(plugin_config, validated_data)
         self._update_plugin_attachments(plugin_config)


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Updating the plugin config didn't always send a new config, sometimes it might send something like:

```
{enabled: true, order: 1}
```

Only affects plugins with secret fields.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
