### PR TITLE
Fix webhook on foss

### DIFF
--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -105,7 +105,7 @@ def post_event_to_webhook(self: Task, event_id: int, site_url: str) -> None:
     try:
         event = Event.objects.get(pk=event_id)
         team = event.team
-        actions = [action for action in event.action_set.all() if action.post_to_slack]
+        actions = [action for action in event.actions if action.post_to_slack]
 
         if not site_url:
             site_url = settings.SITE_URL


### PR DESCRIPTION
## Changes

I believe this PR in the plugin server: https://github.com/PostHog/plugin-server/pull/233 + this minor change should:

- Get webhooks working again on FOSS
- Prevent the event action mapping issues on FOSS

It comes at the cost of webhooks firing before an event is associated with an action, but nothing immediately comes to mind in terms of larger potential issues.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
