### PR TITLE
Async event mapping for all Postgres instances

### DIFF
--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -265,6 +265,8 @@ class EventManager(models.QuerySet):
                     should_post_webhook and team and team.slack_incoming_webhook and not is_ee_enabled()
                 ):  # ee will handle separately
                     celery.current_app.send_task("posthog.tasks.webhooks.post_event_to_webhook", (event.pk, site_url))
+            else:
+                celery.current_app.send_task("posthog.tasks.webhooks.post_event_to_webhook", (event.pk, site_url))
 
             return event
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -160,7 +160,7 @@ PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", not TEST, type
 ASYNC_EVENT_ACTION_MAPPING = get_from_env("ASYNC_EVENT_ACTION_MAPPING", False, type_cast=strtobool)
 
 # Enable if ingesting with the plugin server into postgres, as it's not able to calculate the mapping on the fly
-if PLUGIN_SERVER_INGESTION and PRIMARY_DB == RDBMS.POSTGRES:
+if PRIMARY_DB == RDBMS.POSTGRES:
     ASYNC_EVENT_ACTION_MAPPING = True
 
 ASYNC_EVENT_PROPERTY_USAGE = get_from_env("ASYNC_EVENT_PROPERTY_USAGE", True, type_cast=strtobool)


### PR DESCRIPTION
## Changes

- Enable async event-action mapping for FOSS users who are using plugins (and thus ingesting via them, yet don't explicitly have the ingestion env set)
- Also sends the webhook task even if ingesting via django and mapping async

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
