### PR TITLE
Support all event properties in webhook message

### DIFF
--- a/posthog/tasks/test/test_webhook_message_formatting.py
+++ b/posthog/tasks/test/test_webhook_message_formatting.py
@@ -90,16 +90,18 @@ class TestWebhookMessage(BaseTest):
 
     def test_get_formatted_message(self) -> None:
         self.team.slack_incoming_webhook = "https://hooks.slack.com/services/"
-        event1 = Event.objects.create(team=self.team, distinct_id="2", properties={"$browser": "Chrome"})
+        event1 = Event.objects.create(
+            team=self.team, distinct_id="2", properties={"$browser": "Chrome", "custom_prop_page": "Pricing"}
+        )
         action1 = Action.objects.create(
             team=self.team,
             name="action1",
             id=1,
-            slack_message_format="[user.name] did action from browser [user.browser]",
+            slack_message_format="[user.name] did action from browser [user.browser] on [event.properties.custom_prop_page] page",
         )
 
         text, markdown = get_formatted_message(action1, event1, "https://localhost:8000")
-        self.assertEqual(text, "2 did action from browser Chrome")
+        self.assertEqual(text, "2 did action from browser Chrome on Pricing page")
 
     def test_get_formatted_message_default(self) -> None:
         """

--- a/posthog/tasks/test/test_webhook_message_formatting.py
+++ b/posthog/tasks/test/test_webhook_message_formatting.py
@@ -101,7 +101,7 @@ class TestWebhookMessage(BaseTest):
         )
 
         text, markdown = get_formatted_message(action1, event1, "https://localhost:8000")
-        self.assertEqual(text, "2 from browser Chrome on Pricing page with undefined")
+        self.assertEqual(text, "2 from Chrome on Pricing page with undefined")
 
     def test_get_formatted_message_default(self) -> None:
         """

--- a/posthog/tasks/test/test_webhook_message_formatting.py
+++ b/posthog/tasks/test/test_webhook_message_formatting.py
@@ -91,17 +91,17 @@ class TestWebhookMessage(BaseTest):
     def test_get_formatted_message(self) -> None:
         self.team.slack_incoming_webhook = "https://hooks.slack.com/services/"
         event1 = Event.objects.create(
-            team=self.team, distinct_id="2", properties={"$browser": "Chrome", "custom_prop_page": "Pricing"}
+            team=self.team, distinct_id="2", properties={"$browser": "Chrome", "page_title": "Pricing"}
         )
         action1 = Action.objects.create(
             team=self.team,
             name="action1",
             id=1,
-            slack_message_format="[user.name] did action from browser [user.browser] on [event.properties.custom_prop_page] page",
+            slack_message_format="[user.name] from [user.browser] on [event.properties.page_title] page with [event.properties.fruit]",
         )
 
         text, markdown = get_formatted_message(action1, event1, "https://localhost:8000")
-        self.assertEqual(text, "2 did action from browser Chrome on Pricing page")
+        self.assertEqual(text, "2 from browser Chrome on Pricing page with undefined")
 
     def test_get_formatted_message_default(self) -> None:
         """

--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -58,9 +58,13 @@ def get_value_of_token(action: Action, event: Event, site_url: str, token_parts:
     elif token_parts[0] == "event":
         if token_parts[1] == "name":
             text = markdown = event.event
-        elif token_parts[1] == "properties" and len(token_parts) > 2 and token_parts[2] in event.properties:
-            property = event.properties.get(token_parts[2])
-            text = markdown = property if isinstance(property, str) else json.dumps(property)
+        elif token_parts[1] == "properties" and len(token_parts) > 2:
+            property_name = token_parts[2]
+            if property_name in event.properties:
+                property = event.properties[property_name]
+                text = markdown = property if isinstance(property, str) else json.dumps(property)
+            else:
+                text = markdown = "undefined"
 
     else:
         raise ValueError

--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Tuple
 
@@ -58,7 +59,8 @@ def get_value_of_token(action: Action, event: Event, site_url: str, token_parts:
         if token_parts[1] == "name":
             text = markdown = event.event
         elif token_parts[1] == "properties" and len(token_parts) > 2 and token_parts[2] in event.properties:
-            text = markdown = event.properties[token_parts[2]]
+            property = event.properties.get(token_parts[2])
+            text = markdown = property if isinstance(property, str) else json.dumps(property)
 
     else:
         raise ValueError

--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -57,6 +57,9 @@ def get_value_of_token(action: Action, event: Event, site_url: str, token_parts:
     elif token_parts[0] == "event":
         if token_parts[1] == "name":
             text = markdown = event.event
+        elif token_parts[1] == "properties" and len(token_parts) > 2 and token_parts[2] in event.properties:
+            text = markdown = event.properties[token_parts[2]]
+
     else:
         raise ValueError
     return text, markdown


### PR DESCRIPTION
## Changes

A quick change to support all event properties in webhook messages. 

I could definitely pick up https://github.com/PostHog/posthog/issues/1543 and re-do this message formatting logic at some point but working on other stuff right now. 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
