### PR TITLE
Notice in toolbar if could not get a unique selector for the element

### DIFF
--- a/frontend/src/toolbar/elements/ActionAttribute.tsx
+++ b/frontend/src/toolbar/elements/ActionAttribute.tsx
@@ -34,8 +34,8 @@ export function ActionAttribute({ attribute, value }: { attribute: string; value
                 </span>
             ) : (
                 <span>
-                    Could not generate a unique selector for this element. Please instrument it with a unique <code>id</code>{' '}
-                    or <code>data-attr</code> attribute.
+                    Could not generate a unique selector for this element. Please instrument it with a unique{' '}
+                    <code>id</code> or <code>data-attr</code> attribute.
                 </span>
             )
         ) : (

--- a/frontend/src/toolbar/elements/ActionAttribute.tsx
+++ b/frontend/src/toolbar/elements/ActionAttribute.tsx
@@ -34,8 +34,8 @@ export function ActionAttribute({ attribute, value }: { attribute: string; value
                 </span>
             ) : (
                 <span>
-                    Could not generate a unique selector for this element. Please instrument with unique <code>id</code>{' '}
-                    or <code>data-attr</code> attributes.
+                    Could not generate a unique selector for this element. Please instrument it with a unique <code>id</code>{' '}
+                    or <code>data-attr</code> attribute.
                 </span>
             )
         ) : (

--- a/frontend/src/toolbar/elements/ActionAttribute.tsx
+++ b/frontend/src/toolbar/elements/ActionAttribute.tsx
@@ -30,7 +30,7 @@ export function ActionAttribute({ attribute, value }: { attribute: string; value
         ) : attribute === 'selector' ? (
             value ? (
                 <span style={{ fontFamily: 'monospace' }}>
-                    <SelectorString value={value || ''} />
+                    <SelectorString value={value} />
                 </span>
             ) : (
                 <span>

--- a/frontend/src/toolbar/elements/ActionAttribute.tsx
+++ b/frontend/src/toolbar/elements/ActionAttribute.tsx
@@ -28,9 +28,16 @@ export function ActionAttribute({ attribute, value }: { attribute: string; value
                 {value}
             </a>
         ) : attribute === 'selector' ? (
-            <span style={{ fontFamily: 'monospace' }}>
-                <SelectorString value={value || ''} />
-            </span>
+            value ? (
+                <span style={{ fontFamily: 'monospace' }}>
+                    <SelectorString value={value || ''} />
+                </span>
+            ) : (
+                <span>
+                    Could not generate a unique selector for this element. Please instrument with unique <code>id</code>{' '}
+                    or <code>data-attr</code> attributes.
+                </span>
+            )
         ) : (
             value
         )

--- a/frontend/src/toolbar/elements/ActionStep.tsx
+++ b/frontend/src/toolbar/elements/ActionStep.tsx
@@ -12,7 +12,9 @@ export function ActionStep({ actionStep }: ActionStepProps): JSX.Element {
     return (
         <div>
             {(['text', 'name', 'href', 'selector'] as ActionStepPropertyKey[]).map((attr) =>
-                actionStep[attr] ? <ActionAttribute key={attr} attribute={attr} value={actionStep[attr]} /> : null
+                actionStep[attr] || attr === 'selector' ? (
+                    <ActionAttribute key={attr} attribute={attr} value={actionStep[attr]} />
+                ) : null
             )}
         </div>
     )


### PR DESCRIPTION
## Changes

If we can not get a selector (via our patched simmerjs) that uniquely identifies the element in 10 steps or less, we now show this warning:

<img width="414" alt="Screenshot 2021-03-12 at 16 34 31" src="https://user-images.githubusercontent.com/53387/110962474-56fddf00-8351-11eb-98e8-0f63f7b2a183.png">

We used to just show the text and nothing for the selector, not even the icon, confusing users.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
