### PR TITLE
Fix Funnel rendering on dashboards

### DIFF
--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -19,10 +19,10 @@ export function FunnelViz({
 }) {
     const container = useRef(null)
     const [steps, setSteps] = useState(stepsParam)
-    const logic = funnelLogic({ dashboardItemId, cachedResults })
+    const logic = funnelLogic({ dashboardItemId, cachedResults, filters: defaultFilters })
     const { results: stepsResult, resultsLoading: funnelLoading } = useValues(logic)
     const { loadResults: loadFunnel } = useActions(logic)
-    const { filters } = useValues(funnelLogic({ filters: defaultFilters }))
+    const { filters } = useValues(logic)
     const [{ fromItem }] = useState(router.values.hashParams)
 
     function buildChart() {

--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -20,9 +20,8 @@ export function FunnelViz({
     const container = useRef(null)
     const [steps, setSteps] = useState(stepsParam)
     const logic = funnelLogic({ dashboardItemId, cachedResults, filters: defaultFilters })
-    const { results: stepsResult, resultsLoading: funnelLoading } = useValues(logic)
+    const { results: stepsResult, resultsLoading: funnelLoading, filters } = useValues(logic)
     const { loadResults: loadFunnel } = useActions(logic)
-    const { filters } = useValues(logic)
     const [{ fromItem }] = useState(router.values.hashParams)
 
     function buildChart() {


### PR DESCRIPTION
## Changes
Fixes this https://github.com/PostHog/posthog/issues/3574

Dashboards that had two types of funnel displays were not rendering properly. Only one or the other was rendering.

Did some digging and saw that in the component itself we were using two logics – one keyed by the item and one not. That was causing filters to be cached and shared across since a key wasn't being passed in to the filter query.

Solution:
- Use the same logic for state ops within a component.

<img width="1538" alt="Screen Shot 2021-03-12 at 12 53 33 PM" src="https://user-images.githubusercontent.com/5965891/110997241-fca15600-8331-11eb-8976-0c82970deb06.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
