### PR TITLE
Fix organization settings

### DIFF
--- a/cypress/integration/organizationSettings.js
+++ b/cypress/integration/organizationSettings.js
@@ -3,6 +3,6 @@ describe('Organization settings', () => {
         cy.get('[data-attr=top-navigation-whoami]').click()
         cy.get('[data-attr=top-menu-item-org-settings]').click()
         cy.location('pathname').should('include', '/organization/settings')
-        cy.get('.gpage-title').should('contain', 'Organization')
+        cy.get('.page-title').should('contain', 'Organization')
     })
 })

--- a/cypress/integration/organizationSettings.js
+++ b/cypress/integration/organizationSettings.js
@@ -3,5 +3,6 @@ describe('Organization settings', () => {
         cy.get('[data-attr=top-navigation-whoami]').click()
         cy.get('[data-attr=top-menu-item-org-settings]').click()
         cy.location('pathname').should('include', '/organization/settings')
+        cy.get('.gpage-title').should('contain', 'Organization')
     })
 })


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog/pull/3586 committed an empty `index.js` file that would override `index.tsx` and thus break organization settings

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
