### PR TITLE
Disable PLUGIN_SERVER_INGESTION

### DIFF
--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -87,6 +87,10 @@
                     "value": "https://app.posthog.com"
                 },
                 {
+                    "name": "PLUGIN_SERVER_INGESTION",
+                    "value": "false"
+                },
+                {
                     "name": "PLUGINS_CLOUD_WHITELISTED_ORG_IDS",
                     "value": "4dc8564d-bd82-1065-2f40-97f7c50f67cf,2f3a6d88-4789-027b-6205-7b9a0e12217d"
                 },


### PR DESCRIPTION
## Changes

We are currently experiencing significantly reduced throughput in the plugin server ingestion side of things, this brings back direct ingestion via Python to let plugin servers catch up to the the events backlog.
