### PR TITLE
Update docker compose dev port

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
         ports:
-            - '5439:5432'
+            - '5432:5432'
     redis:
         image: 'redis:5-alpine'
         container_name: posthog_redis


### PR DESCRIPTION
## Changes

Looking to make things easier for contributors to run FOSS with as little config as possible (e.g. setting `DATABASE_URL`).

Seems like the reason we had this at 5439 was conflict in @fuziontech's env? Happy to keep the CH files on 5439 but would like to have this on 5432 if possible so contributors can do:

```
docker-compose -f docker-compose.dev.yml up db redis
```

To run the dbs with Docker instead of `brew`

cc @macobo 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
