### PR TITLE
Add support for SOCIAL_AUTH_REDIRECT_IS_HTTPS

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -286,9 +286,7 @@ WSGI_APPLICATION = "posthog.wsgi.application"
 
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
-SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env(
-    "SOCIAL_AUTH_REDIRECT_IS_HTTPS", IS_BEHIND_PROXY or not DEBUG, type_cast=strtobool
-)
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", not DEBUG, type_cast=strtobool)
 
 AUTHENTICATION_BACKENDS = (
     "axes.backends.AxesBackend",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -286,7 +286,9 @@ WSGI_APPLICATION = "posthog.wsgi.application"
 
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
-SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", IS_BEHIND_PROXY, type_cast=strtobool)
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env(
+    "SOCIAL_AUTH_REDIRECT_IS_HTTPS", IS_BEHIND_PROXY or not DEBUG, type_cast=strtobool
+)
 
 AUTHENTICATION_BACKENDS = (
     "axes.backends.AxesBackend",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -285,6 +285,7 @@ WSGI_APPLICATION = "posthog.wsgi.application"
 
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", False, type_cast=strtobool)
 
 AUTHENTICATION_BACKENDS = (
     "axes.backends.AxesBackend",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -116,7 +116,8 @@ if not TEST:
 if get_from_env("DISABLE_SECURE_SSL_REDIRECT", False, type_cast=strtobool):
     SECURE_SSL_REDIRECT = False
 
-if get_from_env("IS_BEHIND_PROXY", False, type_cast=strtobool):
+IS_BEHIND_PROXY = get_from_env("IS_BEHIND_PROXY", False, type_cast=strtobool)
+if IS_BEHIND_PROXY:
     USE_X_FORWARDED_HOST = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
@@ -285,7 +286,7 @@ WSGI_APPLICATION = "posthog.wsgi.application"
 
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
-SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", False, type_cast=strtobool)
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", IS_BEHIND_PROXY, type_cast=strtobool)
 
 AUTHENTICATION_BACKENDS = (
     "axes.backends.AxesBackend",


### PR DESCRIPTION
## Changes

This simple setting should allow us to force HTTPS on social auth redirects when needed (as in some routing cases the redirects may be mistakenly HTTPS). [Social auth docs.](https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html#processing-redirects-and-urlopen)