### PR TITLE
Fix system status page plugin metrics

### DIFF
--- a/posthog/plugins/access.py
+++ b/posthog/plugins/access.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from django.conf import settings
 
-from posthog.models import organization
 from posthog.models.organization import Organization
 
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.cache import never_cache
 from rest_framework.exceptions import AuthenticationFailed
 
 from posthog.ee import is_ee_enabled
-from posthog.models import User, organization
+from posthog.models import User
 from posthog.plugins import can_configure_plugins_via_api, can_install_plugins_via_api
 from posthog.settings import AUTO_LOGIN, TEST
 from posthog.utils import (

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -60,7 +60,6 @@ def stats(request):
 @never_cache
 @login_required
 def system_status(request):
-    organization = request.user.organization
     is_multitenancy: bool = getattr(settings, "MULTI_TENANCY", False)
 
     if is_multitenancy and not request.user.is_staff:
@@ -156,20 +155,6 @@ def system_status(request):
             "key": "plugin_sever_version",
             "metric": "Plugin server version",
             "value": get_plugin_server_version() or "unknown",
-        }
-    )
-    metrics.append(
-        {
-            "key": "plugins_install",
-            "metric": "Plugins can be installed",
-            "value": can_install_plugins_via_api(organization),
-        }
-    )
-    metrics.append(
-        {
-            "key": "plugins_configure",
-            "metric": "Plugins can be configured",
-            "value": can_configure_plugins_via_api(organization),
         }
     )
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.cache import never_cache
 from rest_framework.exceptions import AuthenticationFailed
 
 from posthog.ee import is_ee_enabled
-from posthog.models import User
+from posthog.models import User, organization
 from posthog.plugins import can_configure_plugins_via_api, can_install_plugins_via_api
 from posthog.settings import AUTO_LOGIN, TEST
 from posthog.utils import (
@@ -60,7 +60,7 @@ def stats(request):
 @never_cache
 @login_required
 def system_status(request):
-    team = request.user.team
+    organization = request.user.organization
     is_multitenancy: bool = getattr(settings, "MULTI_TENANCY", False)
 
     if is_multitenancy and not request.user.is_staff:
@@ -162,14 +162,14 @@ def system_status(request):
         {
             "key": "plugins_install",
             "metric": "Plugins can be installed",
-            "value": can_install_plugins_via_api(team.organization),
+            "value": can_install_plugins_via_api(organization),
         }
     )
     metrics.append(
         {
             "key": "plugins_configure",
             "metric": "Plugins can be configured",
-            "value": can_configure_plugins_via_api(team.organization),
+            "value": can_configure_plugins_via_api(organization),
         }
     )
 


### PR DESCRIPTION
## Changes

Fixes [a bug](https://sentry.io/share/issue/718481fe0c8f427799e0a4020154df56/) in which when the user has no orgnization, the system status page crashes.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
