### PR TITLE
Set default for social auth to redirect to https

### DIFF
--- a/ee/settings.py
+++ b/ee/settings.py
@@ -18,6 +18,7 @@ HOOK_FINDER = "ee.models.hook.find_and_fire_hook"
 HOOK_DELIVERER = "ee.models.hook.deliver_hook_wrapper"
 
 # Social auth
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.getenv("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.getenv("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
 if "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS" in os.environ:


### PR DESCRIPTION
Currently python social auth redirects to http which is not great. We are depending on forced strong http to https redirection.

This defaults the redirect url to be https which it should be by default, otherwise people are using our product wrong.

https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html#processing-redirects-and-urlopen
