### PR TITLE
Expire Celery tasks after 4 days instead of 1

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -424,6 +424,7 @@ CELERY_BROKER_URL = REDIS_URL  # celery connects to redis
 CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # sleep max 30sec before checking for new periodic events
 CELERY_RESULT_BACKEND = REDIS_URL  # stores results for lookup when processing
 CELERY_IGNORE_RESULT = True  # only applies to delay(), must do @shared_task(ignore_result=True) for apply_async
+CELERY_RESULT_EXPIRES = timedelta(days=4)  # expire tasks after 4 days instead of the default 1
 REDBEAT_LOCK_TIMEOUT = 45  # keep distributed beat lock for 45sec
 
 CACHED_RESULTS_TTL = 7 * 24 * 60 * 60  # how long to keep cached results for


### PR DESCRIPTION
## Changes

Given Celery tasks being crucial to event ingestion in our Postgres-based pipeline, expiry should be longer than the default 1 day, so that a prolonged server outage is less likely to cause data to be lost. See https://github.com/PostHog/posthog/issues/3592#issuecomment-796697515.
