### PR TITLE
Shared dashboards fix

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -23,6 +23,7 @@ export enum EventSource {
 export const eventUsageLogic = kea<
     eventUsageLogicType<AnnotationType, FilterType, DashboardType, PersonType, DashboardMode>
 >({
+    connect: [userLogic],
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
@@ -188,7 +189,7 @@ export const eventUsageLogic = kea<
                 sample_items_count: 0,
                 item_count: dashboard.items.length,
                 created_by_system: !dashboard.created_by,
-                has_share_token: hasShareToken,
+                has_share_token: hasShareToken, // if the dashboard is being viewed in `public` mode
             }
 
             for (const item of dashboard.items) {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -23,7 +23,6 @@ export enum EventSource {
 export const eventUsageLogic = kea<
     eventUsageLogicType<AnnotationType, FilterType, DashboardType, PersonType, DashboardMode>
 >({
-    connect: [userLogic],
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),

--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { delay, idToKey } from 'lib/utils'
+import { delay, idToKey, toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import React from 'react'
 import { toast } from 'react-toastify'
@@ -20,9 +20,10 @@ export const dashboardsModel = kea({
         rawDashboards: [
             {},
             {
-                loadDashboards: async () => {
+                loadDashboards: async (shareToken = undefined, breakpoint) => {
+                    await breakpoint(50)
                     try {
-                        const { results } = await api.get('api/dashboard')
+                        const { results } = await api.get(`api/dashboard?${toParams({ share_token: shareToken })}`)
                         return idToKey(results)
                     } catch {
                         return {}

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -91,23 +91,27 @@ function DashboardView(): JSX.Element {
                     <div className="dashboard-items-actions">
                         <div className="left-item">
                             Last updated <b>{lastRefreshed ? moment(lastRefreshed).fromNow() : 'a while ago'}</b>
-                            <Button type="link" icon={<ReloadOutlined />} onClick={refreshAllDashboardItems}>
-                                Refresh
-                            </Button>
-                        </div>
-                        <DateFilter
-                            defaultValue="Custom"
-                            showCustom
-                            dateFrom={dashboardFilters?.date_from}
-                            dateTo={dashboardFilters?.date_to}
-                            onChange={setDates}
-                            makeLabel={(key) => (
-                                <>
-                                    <CalendarOutlined />
-                                    <span className="hide-when-small"> {key}</span>
-                                </>
+                            {dashboardMode !== DashboardMode.Public && (
+                                <Button type="link" icon={<ReloadOutlined />} onClick={refreshAllDashboardItems}>
+                                    Refresh
+                                </Button>
                             )}
-                        />
+                        </div>
+                        {dashboardMode !== DashboardMode.Public && (
+                            <DateFilter
+                                defaultValue="Custom"
+                                showCustom
+                                dateFrom={dashboardFilters?.date_from}
+                                dateTo={dashboardFilters?.date_to}
+                                onChange={setDates}
+                                makeLabel={(key) => (
+                                    <>
+                                        <CalendarOutlined />
+                                        <span className="hide-when-small"> {key}</span>
+                                    </>
+                                )}
+                            />
+                        )}
                     </div>
                     <DashboardItems inSharedMode={dashboardMode === DashboardMode.Public} />
                 </div>

--- a/frontend/src/scenes/dashboard/SharedDashboard.tsx
+++ b/frontend/src/scenes/dashboard/SharedDashboard.tsx
@@ -38,7 +38,14 @@ ReactDOM.render(
             </div>
 
             <div style={{ textAlign: 'center', paddingBottom: '4rem', marginTop: '1rem' }}>
-                Made with <a href="https://posthog.com">PostHog - Open Source Product Analytics</a>
+                Made with{' '}
+                <a
+                    href="https://posthog.com?utm_medium=in-product&utm_campaign=shared-dashboard"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    PostHog - Open Source Product Analytics
+                </a>
             </div>
         </div>
     </Provider>,

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -250,6 +250,7 @@ export const dashboardLogic = kea({
             actions.loadDashboardItems()
             if (props.shareToken) {
                 actions.setDashboardMode(DashboardMode.Public, EventSource.Browser)
+                dashboardsModel.actions.loadDashboards(props.shareToken)
             }
         },
         beforeUnmount: () => {


### PR DESCRIPTION
## Changes

- Apparently shared dashboards have not been working for some time (unsure when this stopped working), but when we loaded dashboards from the API (`/api/dashboard/`) we weren't passing the `share_token` therefore they never loaded. This PR fixes this.
- This PR also fixes this issue: https://sentry.io/organizations/posthog/issues/2275276580/
- Hides date controls & refresh button on shared dashboards as this can't be used unauthenticated.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
