### PR TITLE
Use the correct boolean on cohort update

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -131,7 +131,7 @@ class CohortSerializer(serializers.ModelSerializer):
             cohort.is_calculating = True
         cohort.save()
 
-        if not is_deletion_change:
+        if not deleted_state:
             if cohort.is_static:
                 self._handle_static(cohort, request)
             else:

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -51,6 +51,7 @@ class TestCohort(BaseTest):
                 "created_by": "something something",
                 "last_calculation": "some random date",
                 "errors_calculating": 100,
+                "deleted": False,
             },
             content_type="application/json",
         )


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses #3531 
- the boolean used to determine recalcluation was incorrect. We were checking the flag for whether or not it's a deletion change however the frontend passes `deleted: false` even when properties are being updated so the calculate task wasn't triggered because the logic was reading this update as a "deletion change"

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
