### PR TITLE
Set undefined user properties as undefined in webhooks messages

### DIFF
--- a/posthog/tasks/test/test_webhook_message_formatting.py
+++ b/posthog/tasks/test/test_webhook_message_formatting.py
@@ -85,8 +85,8 @@ class TestWebhookMessage(BaseTest):
         action1 = Action.objects.create(team=self.team, name="action1", id=1)
 
         token_user_noprop = ["user", "notaproperty"]
-        with self.assertRaises(ValueError):
-            text, markdown = get_value_of_token(action1, event1, "http://localhost:8000", token_user_noprop)
+        text, markdown = get_value_of_token(action1, event1, "http://localhost:8000", token_user_noprop)
+        self.assertEqual(text, "undefined")
 
     def test_get_formatted_message(self) -> None:
         self.team.slack_incoming_webhook = "https://hooks.slack.com/services/"

--- a/posthog/tasks/test/test_webhook_message_formatting.py
+++ b/posthog/tasks/test/test_webhook_message_formatting.py
@@ -124,4 +124,4 @@ class TestWebhookMessage(BaseTest):
             slack_message_format="[user.name] did thing from browser [user.bbbrowzer]",
         )
         text, markdown = get_formatted_message(action1, event1, "https://localhost:8000")
-        self.assertIn("Error", text)
+        self.assertIn("undefined", text)

--- a/posthog/tasks/webhooks.py
+++ b/posthog/tasks/webhooks.py
@@ -50,8 +50,9 @@ def get_value_of_token(action: Action, event: Event, site_url: str, token_parts:
         else:
             user_property = event.properties.get("$" + token_parts[1])
             if user_property is None:
-                raise ValueError
-            text = markdown = user_property
+                text = markdown = "undefined"
+            else:
+                text = markdown = user_property
     elif token_parts[0] == "action":
         if token_parts[1] == "name":
             text, markdown = get_action_details(action, event, site_url)


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

This PR addresses the first part of #3659. When a `property` on `user` is undefined, it will be set as `undefined` in the webhooks message instead of raising a `ValueError`.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
