### PR TITLE
funnel trend fix white screen and remove description

### DIFF
--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -93,11 +93,8 @@ export function FunnelViz({
                 </div>
             )
         }
-        return steps && steps.length > 0 ? (
+        return steps && steps.length > 0 && steps[0].labels ? (
             <>
-                <div style={{ position: 'absolute', right: 24, marginTop: -20 }}>
-                    % of users converted between first and last step
-                </div>
                 <LineGraph
                     pageKey="trends-annotations"
                     data-attr="trend-line-graph-funnel"

--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -95,6 +95,9 @@ export function FunnelViz({
         }
         return steps && steps.length > 0 && steps[0].labels ? (
             <>
+                <div style={{ position: 'absolute', left: 45, marginTop: -20 }}>
+                    % of users converted between first and last step
+                </div>
                 <LineGraph
                     pageKey="trends-annotations"
                     data-attr="trend-line-graph-funnel"


### PR DESCRIPTION
## Changes

*Please describe.*  
- the description needs to go in a different place as it was overlapping with the refresh button (open for suggestions)
- addresses #3667 there's a lag in the 'steps' variable being updated by useEffect while `filter.display` had already changed, so the linegraph was being populated with funnel data and missing proper variables. Added an extra condition to wait for the proper payload

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
