### PR TITLE
Lower the bar to report bugs in plugins

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -136,13 +136,12 @@ export function PluginDrawer(): JSX.Element {
                                             >
                                                 <Button size="small">Learn more</Button>
                                             </Link>
-                                            {'  '}
                                             {editingPlugin.url.includes('github') ? (
                                                 <Link
                                                     to={`${editingPlugin.url}/issues/new`}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
-                                                    style={{ whiteSpace: 'nowrap' }}
+                                                    style={{ whiteSpace: 'nowrap', marginLeft: 5 }}
                                                 >
                                                     <Button size="small">Report Bug</Button>
                                                 </Link>

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -127,17 +127,27 @@ export function PluginDrawer(): JSX.Element {
                                 <div style={{ flexGrow: 1, paddingLeft: 16 }}>
                                     {endWithPunctation(editingPlugin.description)}
                                     {editingPlugin.url ? (
-                                        <>
-                                            {editingPlugin.description ? ' ' : ''}
+                                        <p style={{ marginTop: 2 }}>
                                             <Link
                                                 to={editingPlugin.url}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 style={{ whiteSpace: 'nowrap' }}
                                             >
-                                                Learn more.
+                                                <Button size="small">Learn more</Button>
                                             </Link>
-                                        </>
+                                            {'  '}
+                                            {editingPlugin.url.includes('github') ? (
+                                                <Link
+                                                    to={`${editingPlugin.url}/issues/new`}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    style={{ whiteSpace: 'nowrap' }}
+                                                >
+                                                    <Button size="small">Report Bug</Button>
+                                                </Link>
+                                            ) : null}
+                                        </p>
                                     ) : null}
                                     <div style={{ marginTop: 5 }}>
                                         {editingPlugin?.plugin_type === 'local' && editingPlugin.url ? (

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -5,7 +5,6 @@ import { Button, Checkbox, Form, Popconfirm, Switch, Tooltip } from 'antd'
 import { DeleteOutlined, CodeOutlined, LockFilled } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from 'scenes/plugins/plugin/PluginImage'
-import { Link } from 'lib/components/Link'
 import { Drawer } from 'lib/components/Drawer'
 import { LocalPluginTag } from 'scenes/plugins/plugin/LocalPluginTag'
 import { defaultConfigForPlugin, getConfigSchemaArray } from 'scenes/plugins/utils'
@@ -14,8 +13,9 @@ import { SourcePluginTag } from 'scenes/plugins/plugin/SourcePluginTag'
 import { PluginSource } from './PluginSource'
 import { PluginConfigChoice, PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginField } from 'scenes/plugins/edit/PluginField'
-import { endWithPunctation } from '../../../lib/utils'
+import { endWithPunctation } from 'lib/utils'
 import { canGloballyManagePlugins, canInstallPlugins } from '../access'
+import { ExtraPluginButtons } from '../plugin/PluginCard'
 
 function EnabledDisabledSwitch({
     value,
@@ -123,37 +123,20 @@ export function PluginDrawer(): JSX.Element {
                     {editingPlugin ? (
                         <div>
                             <div style={{ display: 'flex', marginBottom: 16 }}>
-                                <PluginImage pluginType={editingPlugin.plugin_type} url={editingPlugin.url} />
+                                <PluginImage
+                                    pluginType={editingPlugin.plugin_type}
+                                    url={editingPlugin.url}
+                                    size="large"
+                                />
                                 <div style={{ flexGrow: 1, paddingLeft: 16 }}>
                                     {endWithPunctation(editingPlugin.description)}
-                                    {editingPlugin.url ? (
-                                        <p style={{ marginTop: 2 }}>
-                                            <Link
-                                                to={editingPlugin.url}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                style={{ whiteSpace: 'nowrap' }}
-                                            >
-                                                <Button size="small">Learn more</Button>
-                                            </Link>
-                                            {editingPlugin.url.includes('github') ? (
-                                                <Link
-                                                    to={`${editingPlugin.url}/issues/new`}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    style={{ whiteSpace: 'nowrap', marginLeft: 5 }}
-                                                >
-                                                    <Button size="small">Report Bug</Button>
-                                                </Link>
-                                            ) : null}
-                                        </p>
-                                    ) : null}
                                     <div style={{ marginTop: 5 }}>
                                         {editingPlugin?.plugin_type === 'local' && editingPlugin.url ? (
                                             <LocalPluginTag url={editingPlugin.url} title="Installed Locally" />
                                         ) : editingPlugin.plugin_type === 'source' ? (
                                             <SourcePluginTag />
                                         ) : null}
+                                        {editingPlugin.url && <ExtraPluginButtons url={editingPlugin.url} />}
                                     </div>
                                     <div style={{ display: 'flex', alignItems: 'center', marginTop: 5 }}>
                                         <Form.Item
@@ -179,7 +162,7 @@ export function PluginDrawer(): JSX.Element {
                                 </div>
                             ) : null}
 
-                            {canGloballyManagePlugins(user?.organization) && !user?.is_multi_tenancy && (
+                            {canGloballyManagePlugins(user?.organization) && user?.is_multi_tenancy && (
                                 // Currently this is only shown on Cloud, but the feature works on all deployments
                                 <>
                                     <h3 className="l3" style={{ marginTop: 32 }}>

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Col, Popconfirm, Row, Switch, Tag } from 'antd'
+import { Button, Card, Col, Popconfirm, Row, Space, Switch, Tag } from 'antd'
 import { useActions, useValues } from 'kea'
 import React from 'react'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
@@ -9,10 +9,11 @@ import {
     LoadingOutlined,
     SettingOutlined,
     WarningOutlined,
+    InfoCircleOutlined,
+    MessageOutlined,
     DownOutlined,
     GlobalOutlined,
 } from '@ant-design/icons'
-import { Link } from 'lib/components/Link'
 import { PluginImage } from './PluginImage'
 import { PluginError } from './PluginError'
 import { LocalPluginTag } from './LocalPluginTag'
@@ -23,6 +24,24 @@ import { UpdateAvailable } from 'scenes/plugins/plugin/UpdateAvailable'
 import { userLogic } from 'scenes/userLogic'
 import { endWithPunctation } from '../../../lib/utils'
 import { canInstallPlugins } from '../access'
+import { LinkButton } from '../../../lib/components/LinkButton'
+
+export function ExtraPluginButtons({ url }: { url: string }): JSX.Element {
+    return (
+        <Space>
+            <LinkButton to={url} target="_blank" rel="noopener noreferrer">
+                <InfoCircleOutlined />
+                <span className="show-over-500">About</span>
+            </LinkButton>
+            {url.includes('github') && (
+                <LinkButton to={`${url}/issues/new`} target="_blank" rel="noopener noreferrer">
+                    <MessageOutlined />
+                    <span className="show-over-500">Feedback</span>
+                </LinkButton>
+            )}
+        </Space>
+    )
+}
 
 interface PluginCardProps {
     plugin: Partial<PluginTypeWithConfig>
@@ -157,67 +176,50 @@ export function PluginCard({
                                 </>
                             )}
                         </div>
-                        <div>
-                            {endWithPunctation(description)}
-                            {url && (
-                                <p style={{ marginTop: 2 }}>
-                                    <Link
-                                        to={url}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        style={{ whiteSpace: 'nowrap' }}
-                                    >
-                                        <Button size="small">Learn more</Button>
-                                    </Link>
-                                    {url.includes('github') ? (
-                                        <Link
-                                            to={`${url}/issues/new`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            style={{ whiteSpace: 'nowrap', marginLeft: 5 }}
-                                        >
-                                            <Button size="small">Report Bug</Button>
-                                        </Link>
-                                    ) : null}
-                                </p>
-                            )}
-                        </div>
+                        <div>{endWithPunctation(description)}</div>
                     </Col>
                     <Col>
-                        {showUpdateButton && pluginId ? (
-                            <Button
-                                type={updateStatus?.updated ? 'default' : 'primary'}
-                                className="padding-under-500"
-                                onClick={() => (updateStatus?.updated ? editPlugin(pluginId) : updatePlugin(pluginId))}
-                                loading={!!updatingPlugin}
-                                icon={updateStatus?.updated ? <CheckOutlined /> : <CloudDownloadOutlined />}
-                            >
-                                <span className="show-over-500">{updateStatus?.updated ? 'Updated' : 'Update'}</span>
-                            </Button>
-                        ) : pluginId ? (
-                            <Button
-                                type="primary"
-                                className="padding-under-500"
-                                disabled={rearranging}
-                                onClick={() => editPlugin(pluginId)}
-                            >
-                                <span className="show-over-500">Configure</span>
-                                <span className="hide-over-500">
+                        <Space>
+                            {url && <ExtraPluginButtons url={url} />}
+                            {showUpdateButton && pluginId ? (
+                                <Button
+                                    type={updateStatus?.updated ? 'default' : 'primary'}
+                                    className="padding-under-500"
+                                    onClick={() =>
+                                        updateStatus?.updated ? editPlugin(pluginId) : updatePlugin(pluginId)
+                                    }
+                                    loading={!!updatingPlugin}
+                                    icon={updateStatus?.updated ? <CheckOutlined /> : <CloudDownloadOutlined />}
+                                >
+                                    <span className="show-over-500">
+                                        {updateStatus?.updated ? 'Updated' : 'Update'}
+                                    </span>
+                                </Button>
+                            ) : pluginId ? (
+                                <Button
+                                    type="primary"
+                                    className="padding-under-500"
+                                    disabled={rearranging}
+                                    onClick={() => editPlugin(pluginId)}
+                                >
                                     <SettingOutlined />
-                                </span>
-                            </Button>
-                        ) : !pluginId ? (
-                            <Button
-                                type="primary"
-                                className="padding-under-500"
-                                loading={loading && installingPluginUrl === url}
-                                disabled={loading && installingPluginUrl !== url}
-                                onClick={url ? () => installPlugin(url, PluginInstallationType.Repository) : undefined}
-                                icon={<CloudDownloadOutlined />}
-                            >
-                                <span className="show-over-500">Install</span>
-                            </Button>
-                        ) : null}
+                                    <span className="show-over-500">Configure</span>
+                                </Button>
+                            ) : !pluginId ? (
+                                <Button
+                                    type="primary"
+                                    className="padding-under-500"
+                                    loading={loading && installingPluginUrl === url}
+                                    disabled={loading && installingPluginUrl !== url}
+                                    onClick={
+                                        url ? () => installPlugin(url, PluginInstallationType.Repository) : undefined
+                                    }
+                                    icon={<CloudDownloadOutlined />}
+                                >
+                                    <span className="show-over-500">Install</span>
+                                </Button>
+                            ) : null}
+                        </Space>
                     </Col>
                 </Row>
             </Card>

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -160,17 +160,27 @@ export function PluginCard({
                         <div>
                             {endWithPunctation(description)}
                             {url && (
-                                <span>
-                                    {description ? ' ' : ''}
+                                <p style={{ marginTop: 2 }}>
                                     <Link
                                         to={url}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         style={{ whiteSpace: 'nowrap' }}
                                     >
-                                        Learn more.
+                                        <Button size="small">Learn more</Button>
                                     </Link>
-                                </span>
+                                    {'  '}
+                                    {url.includes('github') ? (
+                                        <Link
+                                            to={`${url}/issues/new`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            style={{ whiteSpace: 'nowrap' }}
+                                        >
+                                            <Button size="small">Report Bug</Button>
+                                        </Link>
+                                    ) : null}
+                                </p>
                             )}
                         </div>
                     </Col>

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -169,13 +169,12 @@ export function PluginCard({
                                     >
                                         <Button size="small">Learn more</Button>
                                     </Link>
-                                    {'  '}
                                     {url.includes('github') ? (
                                         <Link
                                             to={`${url}/issues/new`}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            style={{ whiteSpace: 'nowrap' }}
+                                            style={{ whiteSpace: 'nowrap', marginLeft: 5 }}
                                         >
                                             <Button size="small">Report Bug</Button>
                                         </Link>

--- a/frontend/src/scenes/plugins/plugin/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginImage.tsx
@@ -14,7 +14,7 @@ export function PluginImage({
     size?: 'medium' | 'large'
 }): JSX.Element {
     const [state, setState] = useState({ image: imgPluginDefault })
-    const pixelSize = size === 'large' ? 120 : 60
+    const pixelSize = size === 'large' ? 100 : 60
 
     useEffect(() => {
         if (url?.includes('github.com')) {

--- a/frontend/src/scenes/plugins/plugin/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginImage.tsx
@@ -4,8 +4,17 @@ import { CodeOutlined } from '@ant-design/icons'
 import imgPluginDefault from 'public/plugin-default.svg'
 import { PluginInstallationType } from 'scenes/plugins/types'
 
-export function PluginImage({ url, pluginType }: { url?: string; pluginType?: PluginInstallationType }): JSX.Element {
+export function PluginImage({
+    url,
+    pluginType,
+    size = 'medium',
+}: {
+    url?: string
+    pluginType?: PluginInstallationType
+    size?: 'medium' | 'large'
+}): JSX.Element {
     const [state, setState] = useState({ image: imgPluginDefault })
+    const pixelSize = size === 'large' ? 120 : 60
 
     useEffect(() => {
         if (url?.includes('github.com')) {
@@ -15,13 +24,17 @@ export function PluginImage({ url, pluginType }: { url?: string; pluginType?: Pl
     }, [url])
 
     return pluginType === 'source' ? (
-        <CodeOutlined style={{ fontSize: 80 }} className="plugin-image" />
+        <CodeOutlined style={{ fontSize: pixelSize }} className="plugin-image" />
     ) : (
-        <img
+        <div
             className="plugin-image"
-            src={state.image}
-            style={{ maxWidth: 'calc(min(100%, 80px))', maxHeight: 'calc(min(100%, 120px))' }}
-            alt=""
+            style={{
+                width: pixelSize,
+                height: pixelSize,
+                backgroundImage: `url(${state.image})`,
+                backgroundSize: 'contain',
+                backgroundRepeat: 'no-repeat',
+            }}
             onError={() => setState({ ...state, image: imgPluginDefault })}
         />
     )

--- a/frontend/src/scenes/plugins/tabs/installed/InstalledTab.tsx
+++ b/frontend/src/scenes/plugins/tabs/installed/InstalledTab.tsx
@@ -114,9 +114,14 @@ export function InstalledTab(): JSX.Element {
     ) : (
         <Tooltip
             title={
-                enabledPlugins.length <= 1
-                    ? 'At least two plugins need to be enabled for reordering.'
-                    : 'Order matters because event processing with plugins works like a pipe: the event is processed by every enabled plugin in sequence.'
+                enabledPlugins.length <= 1 ? (
+                    'At least two plugins need to be enabled for reordering.'
+                ) : (
+                    <>
+                        Order matters because event processing with plugins works like a pipe: the event is processed by
+                        every enabled plugin <b>in sequence</b>.
+                    </>
+                )
             }
             placement="bottom"
         >


### PR DESCRIPTION
## Changes

Making it super easy to report a bug on a plugin so we can really get good feedback.

<img width="938" alt="Screenshot 2021-03-18 at 18 11 23" src="https://user-images.githubusercontent.com/38760734/111675816-71363200-8815-11eb-8c2e-12ebe5595fce.png">

Clocking off for the day so this is quick first pass before I forget - happy to iterate

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
