### PR TITLE
Better plugin globalization UX

### DIFF
--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -235,6 +235,20 @@ class TestPluginAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_cannot_delete_global_plugin(self, mock_get, mock_reload):
+        repo_url = "https://github.com/PostHog/helloworldplugin"
+        response = self.client.post(f"/api/organizations/@current/plugins/", {"url": repo_url, "is_global": True})
+
+        self.assertEqual(response.status_code, 201)
+
+        api_url = f"/api/organizations/@current/plugins/{response.data['id']}"  # type: ignore
+        response = self.client.delete(api_url)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json().get("detail"), "This plugin is marked as global! Make it local before uninstallation"
+        )
+
     def test_create_plugin_repo_url(self, mock_get, mock_reload):
         self.assertEqual(mock_reload.call_count, 0)
         response = self.client.post(


### PR DESCRIPTION
## Changes

This is now a button at the bottom instead of a checkbox. Makes it impossible to uninstall plugins while they're global, to avoid pain for users (as people's plugin configs would then be cascade deleted - don't want this happening on Cloud).

![Plugin](https://user-images.githubusercontent.com/4550621/111702455-925e4900-883c-11eb-8314-0656e5d62e3c.gif)

## Checklist

- [x] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests