### PR TITLE
add beta tag to trends, center title

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.js
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Select } from 'antd'
+import { Select, Tag } from 'antd'
 import {
     ACTIONS_LINE_GRAPH_LINEAR,
     ACTIONS_LINE_GRAPH_CUMULATIVE,
@@ -52,7 +52,12 @@ export function ChartFilter(props) {
             {filters.insight === ViewType.FUNNELS ? (
                 <>
                     <Select.Option value={FUNNEL_VIZ}>Steps</Select.Option>
-                    <Select.Option value={ACTIONS_LINE_GRAPH_LINEAR}>Trends</Select.Option>
+                    <Select.Option value={ACTIONS_LINE_GRAPH_LINEAR}>
+                        Trends
+                        <Tag color="orange" style={{ marginLeft: 8, fontSize: 10 }}>
+                            BETA
+                        </Tag>
+                    </Select.Option>
                 </>
             ) : (
                 <>

--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -95,7 +95,7 @@ export function FunnelViz({
         }
         return steps && steps.length > 0 && steps[0].labels ? (
             <>
-                <div style={{ position: 'absolute', left: 45, marginTop: -20 }}>
+                <div style={{ position: 'absolute', marginTop: -20, textAlign: 'center', width: '100%' }}>
                     % of users converted between first and last step
                 </div>
                 <LineGraph


### PR DESCRIPTION
## Changes

- Adds a Beta tag to funnel trends – this is still behind a feature flag
- @EDsCODE I noticed that titles on the left can sometimes feel noisy cause they're close the y-axis, so I'm centering the titles 


<img width="2069" alt="Screen Shot 2021-03-18 at 4 57 22 PM" src="https://user-images.githubusercontent.com/5965891/111712574-1e577d00-880b-11eb-8db2-d09108d3d502.png">
<img width="2107" alt="Screen Shot 2021-03-18 at 4 57 37 PM" src="https://user-images.githubusercontent.com/5965891/111712577-1f88aa00-880b-11eb-93f8-f49548700a1d.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
