### PR TITLE
Speed up filtering by events in sessions

### DIFF
--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -32,7 +32,7 @@ SESSION_SQL = """
             properties,
             elements_chain,
             arraySum(arraySlice(gids, 1, idx)) AS gid
-            {filters_timestamps_clause}
+            {matches_action_clauses}
         FROM (
             SELECT
                 groupArray(timestamp) as timestamps,

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -6,6 +6,7 @@ SESSIONS_DISTINCT_ID_SQL = """
     {date_from}
     {date_to}
     {person_filters}
+    {action_filters}
     ORDER BY timestamp DESC
     LIMIT %(distinct_id_limit)s
 """


### PR DESCRIPTION
- restructure the code
- Clean up complicated function using namedtuple
- Speed up action/event filtering in clickhouse

    For very rare events, filtering by them in sessions previously was slow.
    This was because the the distinct_id query contained a lot of users who
    hadn't done the action, resulting in more looping.

    This commit speeds things up by querying users who have done any events matching the
    event/action filter.

No benchmarks (sorry) since I did not have access to clickhouse outside of metabase.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
