### PR TITLE
Temporarily bring back individual refresh in dashboard items

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -6,8 +6,7 @@ import { DashboardHeader } from 'scenes/dashboard/DashboardHeader'
 import { DashboardItems } from 'scenes/dashboard/DashboardItems'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { CalendarOutlined, ReloadOutlined } from '@ant-design/icons'
-import dayjs from 'dayjs'
+import { CalendarOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
 import './Dashboard.scss'
 import { useKeyboardHotkeys } from '../../lib/hooks/useKeyboardHotkeys'
@@ -28,11 +27,9 @@ export function Dashboard({ id, shareToken }: Props): JSX.Element {
 }
 
 function DashboardView(): JSX.Element {
-    const { dashboard, itemsLoading, items, lastRefreshed, filters: dashboardFilters, dashboardMode } = useValues(
-        dashboardLogic
-    )
+    const { dashboard, itemsLoading, items, filters: dashboardFilters, dashboardMode } = useValues(dashboardLogic)
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { refreshAllDashboardItems, setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
+    const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
 
     useKeyboardHotkeys(
         dashboardMode === DashboardMode.Public
@@ -89,6 +86,7 @@ function DashboardView(): JSX.Element {
             {items && items.length ? (
                 <div>
                     <div className="dashboard-items-actions">
+                        {/* :TODO: Bring this back when addressing https://github.com/PostHog/posthog/issues/3609
                         <div className="left-item">
                             Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b>
                             {dashboardMode !== DashboardMode.Public && (
@@ -97,6 +95,7 @@ function DashboardView(): JSX.Element {
                                 </Button>
                             )}
                         </div>
+                         */}
                         {dashboardMode !== DashboardMode.Public && (
                             <DateFilter
                                 defaultValue="Custom"

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -24,6 +24,7 @@ import {
     DeliveredProcedureOutlined,
     BarChartOutlined,
     SaveOutlined,
+    ReloadOutlined,
 } from '@ant-design/icons'
 import { dashboardColorNames, dashboardColors } from 'lib/colors'
 import { useLongPress } from 'lib/hooks/useLongPress'
@@ -214,6 +215,7 @@ export function DashboardItem({
         preventLoading,
     }
 
+    const { loadResults } = useActions(logicFromInsight(item.filters.insight, logicProps))
     const { results, resultsLoading } = useValues(logicFromInsight(item.filters.insight, logicProps))
     const previousLoading = usePrevious(resultsLoading)
 
@@ -293,6 +295,20 @@ export function DashboardItem({
                                         />
                                     </Tooltip>
                                 ))}
+                            {/* :TODO: Remove individual refresh when addressing https://github.com/PostHog/posthog/issues/3609  */}
+                            <Tooltip
+                                title={
+                                    <i>
+                                        Last updated:{' '}
+                                        {item.last_refresh ? dayjs(item.last_refresh).fromNow() : 'recently'}
+                                    </i>
+                                }
+                            >
+                                <ReloadOutlined
+                                    style={{ cursor: 'pointer', marginTop: -3 }}
+                                    onClick={() => loadResults(true)}
+                                />
+                            </Tooltip>
                             <Dropdown
                                 placement="bottomRight"
                                 trigger={['click']}

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -300,8 +300,9 @@ export const dashboardLogic = kea({
             api.update(`api/insight/${id}`, { color })
         },
         refreshAllDashboardItems: async (_, breakpoint) => {
-            await breakpoint(200)
+            await breakpoint(100)
             dashboardItemsModel.actions.refreshAllDashboardItems({})
+
             eventUsageLogic.actions.reportDashboardRefreshed(values.lastRefreshed)
         },
         updateAndRefreshDashboard: async (_, breakpoint) => {


### PR DESCRIPTION
## Changes

Re-enables individually refreshing dashboard items. Full context here, https://github.com/PostHog/posthog/issues/3609

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
