### PR TITLE
Add url encoding to pg password on plugin-server start script

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -21,8 +21,20 @@ while test $# -gt 0; do
   esac
 done
 
+urlencode() {
+    local length="${#1}"
+    for (( i = 0; i < length; i++ )); do
+        local c="${1:i:1}"
+        case $c in
+            [a-zA-Z0-9.~_-]) printf "$c" ;;
+            *) printf '%s' "$c" | xxd -p -c1 |
+                   while read c; do printf '%%%s' "$c"; done ;;
+        esac
+    done
+}
+
 if [[ -n $POSTHOG_DB_NAME ]]; then
-  [[ -n $POSTHOG_DB_PASSWORD ]] && DB_PASSWORD_COMPONENT=":$POSTHOG_DB_PASSWORD"
+  [[ -n $POSTHOG_DB_PASSWORD ]] && DB_PASSWORD_COMPONENT=":$(urlencode "$POSTHOG_DB_PASSWORD")"
   export DATABASE_URL="postgres://${POSTHOG_DB_USER:-"postgres"}${DB_PASSWORD_COMPONENT}@${POSTHOG_POSTGRES_HOST:-"localhost"}:${POSTHOG_POSTGRES_PORT:-"5432"}/${POSTHOG_DB_NAME}"
 fi
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- unfamiliar with best practices with bash but I added a native bash urlencoding function that will url encode the postgres password to solve a connection issue a user was having
- `Percent-encoding may be used to include symbols with special meaning in any of the URI parts, e.g., replace = with %3D.` as stated on the [docs](https://www.postgresql.org/docs/10/libpq-connect.html)
- we could consider adding this to the rest of the string 

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
