### PR TITLE
Fix unmounted logic bug on shared dashboards

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -7,6 +7,7 @@ import { eventUsageLogicType } from './eventUsageLogicType'
 import { AnnotationType, FilterType, DashboardType, PersonType, DashboardMode } from '~/types'
 import { ViewType } from 'scenes/insights/insightLogic'
 import dayjs from 'dayjs'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
 
 const keyMappingKeys = Object.keys(keyMapping.event)
 
@@ -181,7 +182,7 @@ export const eventUsageLogic = kea<
             const { created_at, name, is_shared, pinned, creation_mode } = dashboard
             const properties: Record<string, any> = {
                 created_at,
-                name: userLogic.values.user?.is_multi_tenancy ? name : undefined, // Don't send name on self-hosted
+                name: preflightLogic.values.preflight?.cloud ? name : undefined, // Don't send name on self-hosted
                 is_shared,
                 pinned,
                 creation_mode,

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -7,7 +7,6 @@ import { eventUsageLogicType } from './eventUsageLogicType'
 import { AnnotationType, FilterType, DashboardType, PersonType, DashboardMode } from '~/types'
 import { ViewType } from 'scenes/insights/insightLogic'
 import dayjs from 'dayjs'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
 
 const keyMappingKeys = Object.keys(keyMapping.event)
 
@@ -179,10 +178,9 @@ export const eventUsageLogic = kea<
         },
         reportDashboardViewed: async ({ dashboard, hasShareToken }, breakpoint) => {
             await breakpoint(500) // Debounce to avoid noisy events from continuous navigation
-            const { created_at, name, is_shared, pinned, creation_mode } = dashboard
+            const { created_at, is_shared, pinned, creation_mode } = dashboard
             const properties: Record<string, any> = {
                 created_at,
-                name: preflightLogic.values.preflight?.cloud ? name : undefined, // Don't send name on self-hosted
                 is_shared,
                 pinned,
                 creation_mode,


### PR DESCRIPTION
## Changes

Fixes this bug https://sentry.io/organizations/posthog/issues/2275276580/ in which `userLogic` was accessed while unmounted. Happened when viewing a shared dashboard which is viewed anonymously.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
