### PR TITLE
Fix hotkeys in textarea

### DIFF
--- a/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
@@ -123,6 +123,7 @@ export function AnnotationMarker({
                             rows={4}
                             value={textInput}
                             onChange={(e) => setTextInput(e.target.value)}
+                            autoFocus
                         />
                         <Checkbox
                             checked={applyAll}

--- a/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
@@ -286,7 +286,6 @@ export function AnnotationMarker({
                     zIndex: dynamic || hovered || elementId === currentDateMarker ? 999 : index,
                     boxShadow: dynamic ? '0 0 5px 4px rgba(0, 0, 0, 0.2)' : undefined,
                 }}
-                type="primary"
                 onClick={() => {
                     onClick?.()
                     setFocused(true)

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -9,6 +9,8 @@ export interface HotkeyInterface {
 
 export type Hotkeys = Partial<Record<Keys, HotkeyInterface>>
 
+const IGNORE_INPUTS = ['input', 'textarea'] // Inputs in which hotkey events will be ignored
+
 export function useKeyboardHotkeys(hotkeys: Hotkeys, deps?: DependencyList): void {
     useEventListener(
         'keydown',
@@ -16,7 +18,7 @@ export function useKeyboardHotkeys(hotkeys: Hotkeys, deps?: DependencyList): voi
             const key = (event as KeyboardEvent).key
 
             // Ignore typing on inputs (default behavior); except Esc key
-            if (key !== 'Escape' && (event.target as HTMLElement).tagName === 'INPUT') {
+            if (key !== 'Escape' && IGNORE_INPUTS.includes((event.target as HTMLElement).tagName.toLowerCase())) {
                 return
             }
 


### PR DESCRIPTION
## Changes

- Closes #3711. Hotkeys would interfere when typing annotations on dashboards.
- Autofocuses input when adding annotations to make the experience smoother.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
