### PR TITLE
Fix filtering breakdown queries

### DIFF
--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -248,11 +248,10 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
                 self.team,
             )
 
-        self.assertEqual(event_response[0]["label"], "sign up - value")
-        self.assertEqual(event_response[1]["label"], "sign up - other_value")
+        self.assertEqual(event_response[0]["label"], "sign up - other_value")
 
-        self.assertEqual(sum(event_response[1]["data"]), 1)
-        self.assertEqual(event_response[1]["data"][5], 1)  # property not defined
+        self.assertEqual(sum(event_response[0]["data"]), 1)
+        self.assertEqual(event_response[0]["data"][5], 1)  # property not defined
 
         self.assertEntityResponseEqual(action_response, event_response)
 

--- a/ee/clickhouse/sql/trends/top_elements.py
+++ b/ee/clickhouse/sql/trends/top_elements.py
@@ -4,7 +4,8 @@ SELECT groupArray(value) FROM (
         JSONExtractRaw(properties, %(key)s) as value,
         count(*) as count
     FROM events e
-    WHERE team_id = %(team_id)s {parsed_date_from} {parsed_date_to}
+    WHERE
+        team_id = %(team_id)s {parsed_date_from} {parsed_date_to} {prop_filters}
      AND JSONHas(properties, %(key)s)
     GROUP BY value
     ORDER BY count DESC

--- a/ee/clickhouse/sql/trends/top_person_props.py
+++ b/ee/clickhouse/sql/trends/top_person_props.py
@@ -21,7 +21,9 @@ SELECT groupArray(value) FROM (
                 ARRAY JOIN array_property_keys, array_property_values
             ) ep
             WHERE key = %(key)s
-        ) ep ON person_id = ep.id WHERE e.team_id = %(team_id)s {parsed_date_from} {parsed_date_to}
+        ) ep ON person_id = ep.id
+    WHERE
+        e.team_id = %(team_id)s {parsed_date_from} {parsed_date_to} {prop_filters}
     GROUP BY value
     ORDER BY count DESC
     LIMIT %(limit)s


### PR DESCRIPTION
## Changes

If you filtered 'email does not contain @posthog.com', but an email with '@posthog.com' in it was in the top 20 in the first query it would still show up in the results (thought the data would be 0). Added filtering to the first query which fixed this.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
