### PR TITLE
Add "test account filters" filter to trends

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -47,6 +47,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     <hr />
                     <h4 className="secondary">Filters</h4>
                     <PropertyFilters pageKey="trends-filters" />
+                    <TestAccountFilter filters={filters} onChange={setFilters} />
                 </>
             )}
             {(!filters.insight || filters.insight === ViewType.TRENDS) &&
@@ -144,7 +145,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     placement="right"
                     title='
                                             Stickiness shows you how many days users performed an action within the timeframe. If a user
-                                            performed an action on Monday and again on Friday, it would be shown 
+                                            performed an action on Monday and again on Friday, it would be shown
                                             as "2 days".'
                 >
                     <InfoCircleOutlined className="info-indicator" />


### PR DESCRIPTION
This was added to one feature flag path but not the other, missing on
cloud.

After the change:
![image](https://user-images.githubusercontent.com/148820/112136705-fafc4b80-8bd7-11eb-814b-a20768ae02e0.png)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
