### PR TITLE
reduce width so button isn't covered

### DIFF
--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -95,7 +95,7 @@ export function FunnelViz({
         }
         return steps && steps.length > 0 && steps[0].labels ? (
             <>
-                <div style={{ position: 'absolute', marginTop: -20, textAlign: 'center', width: '100%' }}>
+                <div style={{ position: 'absolute', marginTop: -20, textAlign: 'center', width: '90%' }}>
                     % of users converted between first and last step
                 </div>
                 <LineGraph

--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -74,6 +74,7 @@ const showChartFilter = function (activeView, featureFlags) {
         case ViewType.RETENTION:
             return true
         case ViewType.FUNNELS:
+            return true
             return featureFlags['funnel-trends-1269']
         case ViewType.LIFECYCLE:
         case ViewType.PATHS:

--- a/frontend/src/scenes/insights/Insights.js
+++ b/frontend/src/scenes/insights/Insights.js
@@ -74,7 +74,6 @@ const showChartFilter = function (activeView, featureFlags) {
         case ViewType.RETENTION:
             return true
         case ViewType.FUNNELS:
-            return true
             return featureFlags['funnel-trends-1269']
         case ViewType.LIFECYCLE:
         case ViewType.PATHS:


### PR DESCRIPTION
## Changes
Change in https://github.com/PostHog/posthog/pull/3704/files is blocking the refresh button.

Reducing the width – it's still generally centered but now doesn't block the refresh button.

<img width="1214" alt="Screen Shot 2021-03-23 at 4 39 29 PM" src="https://user-images.githubusercontent.com/5965891/112232794-6ead5100-8bf6-11eb-9dcb-63fe60d336c5.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
