### PR TITLE
Add element matching for multiple values on text/href

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Tuple
 
 from django.forms.models import model_to_dict
 
-from ee.clickhouse.models.property import filter_element
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Action, Entity, Filter
 from posthog.models.action_step import ActionStep
@@ -23,6 +22,8 @@ def format_action_filter(
         conditions: List[str] = []
         # filter element
         if step.event == AUTOCAPTURE_EVENT:
+            from ee.clickhouse.models.property import filter_element  # prevent circular import
+
             el_conditions, element_params = filter_element(
                 model_to_dict(step), "{}_{}{}".format(action.pk, index, prepend)
             )

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -1,12 +1,11 @@
-import re
 from typing import Dict, List, Tuple
 
 from django.forms.models import model_to_dict
 
+from ee.clickhouse.models.property import filter_element
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Action, Entity, Filter
 from posthog.models.action_step import ActionStep
-from posthog.models.event import Selector
 
 
 def format_action_filter(
@@ -81,59 +80,6 @@ def filter_event(step: ActionStep, prepend: str = "event", index: int = 0) -> Tu
     conditions.append("event = %({}_{})s".format(prepend, index))
 
     return conditions, params
-
-
-def _create_regex(selector: Selector) -> str:
-    regex = r""
-    for idx, tag in enumerate(selector.parts):
-        if tag.data.get("tag_name") and isinstance(tag.data["tag_name"], str):
-            if tag.data["tag_name"] == "*":
-                regex += ".+"
-            else:
-                regex += tag.data["tag_name"]
-        if tag.data.get("attr_class__contains"):
-            regex += r".*?\.{}".format(r"\..*?".join(sorted(tag.data["attr_class__contains"])))
-        if tag.ch_attributes:
-            regex += ".*?"
-            for key, value in sorted(tag.ch_attributes.items()):
-                regex += '{}="{}".*?'.format(key, value)
-        regex += r"([-_a-zA-Z0-9\.]*?)?($|;|:([^;^\s]*(;|$|\s)))"
-        if tag.direct_descendant:
-            regex += ".*"
-    return regex
-
-
-def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
-    params = {}
-    conditions = []
-
-    if filters.get("selector"):
-        selector = Selector(filters["selector"], escape_slashes=False)
-        params["{}selector_regex".format(prepend)] = _create_regex(selector)
-        conditions.append("match(elements_chain, %({}selector_regex)s)".format(prepend))
-
-    if filters.get("tag_name"):
-        params["{}tag_name_regex".format(prepend)] = r"(^|;){}(\.|$|;|:)".format(filters["tag_name"])
-        conditions.append("match(elements_chain, %({}tag_name_regex)s)".format(prepend))
-
-    attributes: Dict[str, List] = {}
-
-    for key in ["href", "text"]:
-        vals = filters.get(key)
-        if filters.get(key):
-            attributes[key] = [re.escape(vals)] if isinstance(vals, str) else [re.escape(text) for text in filters[key]]
-
-    if len(attributes.keys()) > 0:
-        or_conditions = []
-        for key, value_list in attributes.items():
-            for idx, value in enumerate(value_list):
-                params["{}_{}_{}_attributes_regex".format(prepend, key, idx)] = ".*?({}).*?".format(
-                    ".*?".join(['{}="{}"'.format(key, value)])
-                )
-                or_conditions.append("match(elements_chain, %({}_{}_{}_attributes_regex)s)".format(prepend, key, idx))
-            conditions.append(" OR ".join(or_conditions))
-
-    return (conditions, params)
 
 
 def format_entity_filter(entity: Entity, prepend: str = "action", filter_by_team=True) -> Tuple[str, Dict]:

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -149,6 +149,10 @@ class EventManager(models.QuerySet):
 
         for key in ["tag_name", "text", "href"]:
             values = filters.get(key, [])
+
+            if not values:
+                continue
+
             values = values if isinstance(values, list) else [values]
             if len(values) == 0:
                 continue

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -146,11 +146,15 @@ class EventManager(models.QuerySet):
             filter = {}
 
         for key in ["tag_name", "text", "href"]:
-            if filters.get(key):
-                filter["element__{}".format(key)] = filters[key]
-
-        if not filter:
-            return {}
+            vals = filters.get(key)
+            if vals:
+                if isinstance(vals, str):
+                    filter["element__{}".format(key)] = filters[key]
+                elif isinstance(vals, list):
+                    _filter_conditions = Q()
+                    for val in vals:
+                        _filter_conditions |= Q(**{"element__{}".format(key): val})
+                    groups = groups.filter(_filter_conditions)
 
         groups = groups.filter(**filter)
         return {"elements_hash__in": groups.values_list("hash", flat=True)}

--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -137,6 +137,7 @@ class EventManager(models.QuerySet):
 
     def filter_by_element(self, filters: Dict, team_id: int):
         groups = ElementGroup.objects.filter(team_id=team_id)
+        did_filter = False
 
         if filters.get("selector"):
             selector = Selector(filters["selector"])
@@ -155,6 +156,10 @@ class EventManager(models.QuerySet):
                     for val in vals:
                         _filter_conditions |= Q(**{"element__{}".format(key): val})
                     groups = groups.filter(_filter_conditions)
+                    did_filter = True  # check if filtering in place
+
+        if not filter and not did_filter:
+            return {}
 
         groups = groups.filter(**filter)
         return {"elements_hash__in": groups.values_list("hash", flat=True)}

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -317,7 +317,6 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
             events = filter_events(filter, self.team)
             import pprint
 
-            pprint.pprint(events)
             self.assertEqual(events[0]["id"], event2.pk)
 
         def test_is_not_true_false(self):

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -378,10 +378,27 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
                     Element.objects.create(tag_name="div"),
                 ],
             )
+
+            event3 = event_factory(
+                team=self.team,
+                event="$autocapture",
+                distinct_id="distinct_id",
+                elements=[
+                    Element.objects.create(tag_name="a", text="some other text"),
+                    Element.objects.create(tag_name="div"),
+                ],
+            )
+
             event2 = event_factory(team=self.team, event="$autocapture", distinct_id="distinct_id")
-            filter = Filter(data={"properties": [{"key": "text", "value": "some text", "type": "element"}]})
+            filter = Filter(
+                data={"properties": [{"key": "text", "value": ["some text", "some other text"], "type": "element"}]}
+            )
             events = filter_events(filter=filter, team=self.team)
-            self.assertEqual(len(events), 1)
+            self.assertEqual(len(events), 2)
+
+            filter2 = Filter(data={"properties": [{"key": "text", "value": "some text", "type": "element"}]})
+            events_response_2 = filter_events(filter=filter2, team=self.team)
+            self.assertEqual(len(events_response_2), 1)
 
         def test_filter_out_team_members(self):
             person1 = person_factory(

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -315,7 +315,6 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
 
             filter = Filter(data={"properties": {"is_first": ["true"]}})
             events = filter_events(filter, self.team)
-            import pprint
 
             self.assertEqual(events[0]["id"], event2.pk)
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- Previously, if you try to use an element filter on events with multiple values, the query would fail because the filter function could only handle single values
- this implements support for multiple values and updates tests to reflect changes
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
