### PR TITLE
Global hotkey navigation

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -531,8 +531,8 @@ code.code {
 
 // Hotkey styles
 .hotkey {
-    padding: 0 6px;
-    min-width: 22px;
+    width: 22px;
+    height: 22px;
     border-radius: $radius;
     font-weight: bold;
     margin-left: 6px;
@@ -543,5 +543,7 @@ code.code {
     border: 1px solid $border_light;
     margin-bottom: 2px;
     font-size: 0.85rem;
-    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -532,6 +532,7 @@ code.code {
 // Hotkey styles
 .hotkey {
     padding: 0 6px;
+    min-width: 22px;
     border-radius: $radius;
     font-weight: bold;
     margin-left: 6px;
@@ -542,4 +543,5 @@ code.code {
     border: 1px solid $border_light;
     margin-bottom: 2px;
     font-size: 0.85rem;
+    text-align: center;
 }

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -238,6 +238,7 @@ code.code {
 }
 
 // Toasts
+
 .Toastify__toast-container {
     opacity: 1;
     transform: none;
@@ -294,11 +295,13 @@ code.code {
 }
 
 // Table styles
+
 .table-bordered td {
     border: 1px solid $border;
 }
 
 // Card styles
+
 .ant-card-body > :first-child {
     margin-top: 0;
 }
@@ -308,6 +311,7 @@ code.code {
 }
 
 // Form & input styles
+
 .input-set {
     padding-bottom: $default_spacing;
     color: $text_default;
@@ -350,6 +354,7 @@ code.code {
 }
 
 // Button styles
+
 .btn-close {
     color: $text_muted;
 }
@@ -394,6 +399,7 @@ code.code {
 }
 
 // Overlays styles
+
 #bottom-notice {
     z-index: 10500;
     display: flex;
@@ -521,4 +527,19 @@ code.code {
         background-color: $hc_light_lilac;
         color: $hc_navy;
     }
+}
+
+// Hotkey styles
+.hotkey {
+    padding: 0 6px;
+    border-radius: $radius;
+    font-weight: bold;
+    margin-left: 6px;
+    background-color: white;
+    color: $primary;
+    text-shadow: none;
+    text-transform: uppercase;
+    border: 1px solid $border_light;
+    margin-bottom: 2px;
+    font-size: 0.85rem;
 }

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -30,10 +30,13 @@ import {
 import { navigationLogic } from './navigationLogic'
 import { ToolbarModal } from '~/layout/ToolbarModal/ToolbarModal'
 import { dashboardsModel } from '~/models'
-import { DashboardType } from '~/types'
+import { DashboardType, HotKeys } from '~/types'
 import { userLogic } from 'scenes/userLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { canViewPlugins } from '../../scenes/plugins/access'
+import { useGlobalKeyboardHotkeys, useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { router } from 'kea-router'
 
 // to show the right page in the sidebar
 const sceneOverride: Record<string, string> = {
@@ -47,12 +50,15 @@ interface MenuItemProps {
     icon: JSX.Element
     identifier: string
     to: string
+    hotkey?: HotKeys
     onClick?: () => void
 }
 
-const MenuItem = ({ title, icon, identifier, to, onClick }: MenuItemProps): JSX.Element => {
+const MenuItem = ({ title, icon, identifier, to, hotkey, onClick }: MenuItemProps): JSX.Element => {
     const { scene, loadingScene } = useValues(sceneLogic)
-    const { collapseMenu } = useActions(navigationLogic)
+    const { hotkeyNavigationEngaged } = useValues(navigationLogic)
+    const { collapseMenu, setHotkeyNavigationEngaged } = useActions(navigationLogic)
+    const { push } = useActions(router)
 
     function activeScene(): string {
         const nominalScene = loadingScene || scene
@@ -63,7 +69,25 @@ const MenuItem = ({ title, icon, identifier, to, onClick }: MenuItemProps): JSX.
     function handleClick(): void {
         onClick?.()
         collapseMenu()
+        setHotkeyNavigationEngaged(false)
     }
+
+    useKeyboardHotkeys(
+        hotkeyNavigationEngaged && hotkey
+            ? {
+                  [hotkey]: {
+                      action: () => {
+                          handleClick()
+                          if (to) {
+                              push(to)
+                          }
+                      },
+                  },
+              }
+            : {},
+        undefined,
+        true
+    )
 
     return (
         <Link to={to} onClick={handleClick}>
@@ -73,6 +97,7 @@ const MenuItem = ({ title, icon, identifier, to, onClick }: MenuItemProps): JSX.
             >
                 {icon}
                 <span className="menu-title text-center">{title}</span>
+                {hotkeyNavigationEngaged && hotkey}
             </div>
         </Link>
     )
@@ -141,12 +166,19 @@ function PinnedDashboards(): JSX.Element {
 export function MainNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
     const { currentOrganization } = useValues(organizationLogic)
-    const { menuCollapsed, toolbarModalOpen, pinnedDashboardsVisible } = useValues(navigationLogic)
-    const { setMenuCollapsed, collapseMenu, setToolbarModalOpen, setPinnedDashboardsVisible } = useActions(
+    const { menuCollapsed, toolbarModalOpen, pinnedDashboardsVisible, hotkeyNavigationEngaged } = useValues(
         navigationLogic
     )
+    const {
+        setMenuCollapsed,
+        collapseMenu,
+        setToolbarModalOpen,
+        setPinnedDashboardsVisible,
+        setHotkeyNavigationEngaged,
+    } = useActions(navigationLogic)
     const navRef = useRef<HTMLDivElement | null>(null)
     const [canScroll, setCanScroll] = useState(false)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     useEscapeKey(collapseMenu, [menuCollapsed])
 
@@ -166,6 +198,12 @@ export function MainNavigation(): JSX.Element {
     useEffect(() => {
         setCanScroll(calcCanScroll(navRef.current))
     }, [navRef])
+
+    useGlobalKeyboardHotkeys(
+        featureFlags['hotkeys-3740']
+            ? { g: { action: () => setHotkeyNavigationEngaged(!hotkeyNavigationEngaged) } }
+            : {}
+    )
 
     return (
         <>
@@ -208,6 +246,7 @@ export function MainNavigation(): JSX.Element {
                                 identifier="dashboards"
                                 to="/dashboard"
                                 onClick={() => setPinnedDashboardsVisible(false)}
+                                hotkey="d"
                             />
                         </div>
                     </Popover>
@@ -216,12 +255,13 @@ export function MainNavigation(): JSX.Element {
                         icon={<IconInsights />}
                         identifier="insights"
                         to="/insights?insight=TRENDS"
+                        hotkey="i"
                     />
                     <div className="divider" />
-                    <MenuItem title="Events" icon={<IconEvents />} identifier="events" to="/events" />
+                    <MenuItem title="Events" icon={<IconEvents />} identifier="events" to="/events" hotkey="e" />
                     <MenuItem title="Sessions" icon={<ClockCircleFilled />} identifier="sessions" to="/sessions" />
                     <div className="divider" />
-                    <MenuItem title="Persons" icon={<IconPerson />} identifier="persons" to="/persons" />
+                    <MenuItem title="Persons" icon={<IconPerson />} identifier="persons" to="/persons" hotkey="p" />
                     <MenuItem title="Cohorts" icon={<IconCohorts />} identifier="cohorts" to="/cohorts" />
                     <div className="divider" />
                     <MenuItem
@@ -239,6 +279,7 @@ export function MainNavigation(): JSX.Element {
                         icon={<MessageOutlined />}
                         identifier="annotations"
                         to="/annotations"
+                        hotkey="a"
                     />
                     <MenuItem
                         title="Project"

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -37,6 +37,7 @@ import { canViewPlugins } from '../../scenes/plugins/access'
 import { useGlobalKeyboardHotkeys, useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { router } from 'kea-router'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 // to show the right page in the sidebar
 const sceneOverride: Record<string, string> = {
@@ -60,6 +61,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
     const { hotkeyNavigationEngaged } = useValues(navigationLogic)
     const { collapseMenu, setHotkeyNavigationEngaged } = useActions(navigationLogic)
     const { push } = useActions(router)
+    const { reportHotkeyNavigation } = useActions(eventUsageLogic)
 
     function activeScene(): string {
         const nominalScene = loadingScene || scene
@@ -82,6 +84,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
                           if (to) {
                               push(to)
                           }
+                          reportHotkeyNavigation('global', hotkey)
                       },
                   },
               }

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -97,7 +97,9 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, onClick }: MenuItemProp
             >
                 {icon}
                 <span className="menu-title text-center">{title}</span>
-                {hotkeyNavigationEngaged && hotkey}
+                {hotkey && (
+                    <span className={`hotkey${hotkeyNavigationEngaged ? '' : ' hide'}`}>{hotkey.toUpperCase()}</span>
+                )}
             </div>
         </Link>
     )
@@ -228,7 +230,13 @@ export function MainNavigation(): JSX.Element {
                         </Link>
                     </div>
                     {currentOrganization?.setup.is_active && (
-                        <MenuItem title="Setup" icon={<SettingOutlined />} identifier="onboardingSetup" to="/setup" />
+                        <MenuItem
+                            title="Setup"
+                            icon={<SettingOutlined />}
+                            identifier="onboardingSetup"
+                            to="/setup"
+                            hotkey="u"
+                        />
                     )}
                     <Popover
                         content={PinnedDashboards}
@@ -259,20 +267,33 @@ export function MainNavigation(): JSX.Element {
                     />
                     <div className="divider" />
                     <MenuItem title="Events" icon={<IconEvents />} identifier="events" to="/events" hotkey="e" />
-                    <MenuItem title="Sessions" icon={<ClockCircleFilled />} identifier="sessions" to="/sessions" />
+                    <MenuItem
+                        title="Sessions"
+                        icon={<ClockCircleFilled />}
+                        identifier="sessions"
+                        to="/sessions"
+                        hotkey="s"
+                    />
                     <div className="divider" />
                     <MenuItem title="Persons" icon={<IconPerson />} identifier="persons" to="/persons" hotkey="p" />
-                    <MenuItem title="Cohorts" icon={<IconCohorts />} identifier="cohorts" to="/cohorts" />
+                    <MenuItem title="Cohorts" icon={<IconCohorts />} identifier="cohorts" to="/cohorts" hotkey="c" />
                     <div className="divider" />
                     <MenuItem
                         title="Feat. Flags"
                         icon={<IconFeatureFlags />}
                         identifier="featureFlags"
                         to="/feature_flags"
+                        hotkey="f"
                     />
                     <div className="divider" />
                     {canViewPlugins(user?.organization) && (
-                        <MenuItem title="Plugins" icon={<ApiFilled />} identifier="plugins" to="/project/plugins" />
+                        <MenuItem
+                            title="Plugins"
+                            icon={<ApiFilled />}
+                            identifier="plugins"
+                            to="/project/plugins"
+                            hotkey="l"
+                        />
                     )}
                     <MenuItem
                         title="Annotations"
@@ -286,6 +307,7 @@ export function MainNavigation(): JSX.Element {
                         icon={<ProjectFilled />}
                         identifier="projectSettings"
                         to="/project/settings"
+                        hotkey="j"
                     />
                     <div className="divider" />
                     <MenuItem
@@ -293,6 +315,7 @@ export function MainNavigation(): JSX.Element {
                         icon={<IconToolbar />}
                         identifier="toolbar"
                         to=""
+                        hotkey="t"
                         onClick={() => setToolbarModalOpen(true)}
                     />
                     <div className={`scroll-indicator ${canScroll ? '' : 'hide'}`} onClick={scrollToBottom}>

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react'
-import { Layout, Menu, Modal, Popover } from 'antd'
+import { Layout, Menu, Modal, Popover, Tooltip } from 'antd'
 import {
     ProjectFilled,
     ApiFilled,
@@ -51,10 +51,11 @@ interface MenuItemProps {
     identifier: string
     to: string
     hotkey?: HotKeys
+    tooltip?: string
     onClick?: () => void
 }
 
-const MenuItem = ({ title, icon, identifier, to, hotkey, onClick }: MenuItemProps): JSX.Element => {
+const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: MenuItemProps): JSX.Element => {
     const { scene, loadingScene } = useValues(sceneLogic)
     const { hotkeyNavigationEngaged } = useValues(navigationLogic)
     const { collapseMenu, setHotkeyNavigationEngaged } = useActions(navigationLogic)
@@ -91,16 +92,36 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, onClick }: MenuItemProp
 
     return (
         <Link to={to} onClick={handleClick}>
-            <div
-                className={`menu-item${activeScene() === identifier ? ' menu-item-active' : ''}`}
-                data-attr={`menu-item-${identifier}`}
+            <Tooltip
+                title={
+                    tooltip ? (
+                        <>
+                            {tooltip}
+                            {hotkey && (
+                                <div className="mt-05">
+                                    <i>Keyboard navigation: </i>
+                                    <span className="hotkey">G</span>
+                                    <span className="hotkey">{hotkey.toUpperCase()}</span>
+                                </div>
+                            )}
+                        </>
+                    ) : undefined
+                }
+                placement="left"
             >
-                {icon}
-                <span className="menu-title text-center">{title}</span>
-                {hotkey && (
-                    <span className={`hotkey${hotkeyNavigationEngaged ? '' : ' hide'}`}>{hotkey.toUpperCase()}</span>
-                )}
-            </div>
+                <div
+                    className={`menu-item${activeScene() === identifier ? ' menu-item-active' : ''}`}
+                    data-attr={`menu-item-${identifier}`}
+                >
+                    {icon}
+                    <span className="menu-title text-center">{title}</span>
+                    {hotkey && (
+                        <span className={`hotkey${hotkeyNavigationEngaged ? '' : ' hide'}`}>
+                            {hotkey.toUpperCase()}
+                        </span>
+                    )}
+                </div>
+            </Tooltip>
         </Link>
     )
 }
@@ -264,19 +285,42 @@ export function MainNavigation(): JSX.Element {
                         identifier="insights"
                         to="/insights?insight=TRENDS"
                         hotkey="i"
+                        tooltip="Answers to all your analytics questions."
                     />
                     <div className="divider" />
-                    <MenuItem title="Events" icon={<IconEvents />} identifier="events" to="/events" hotkey="e" />
+                    <MenuItem
+                        title="Events"
+                        icon={<IconEvents />}
+                        identifier="events"
+                        to="/events"
+                        hotkey="e"
+                        tooltip="List of events and actions"
+                    />
                     <MenuItem
                         title="Sessions"
                         icon={<ClockCircleFilled />}
                         identifier="sessions"
                         to="/sessions"
                         hotkey="s"
+                        tooltip="Understand interactions based by visits and watch session recordings"
                     />
                     <div className="divider" />
-                    <MenuItem title="Persons" icon={<IconPerson />} identifier="persons" to="/persons" hotkey="p" />
-                    <MenuItem title="Cohorts" icon={<IconCohorts />} identifier="cohorts" to="/cohorts" hotkey="c" />
+                    <MenuItem
+                        title="Persons"
+                        icon={<IconPerson />}
+                        identifier="persons"
+                        to="/persons"
+                        hotkey="p"
+                        tooltip="Understand your users individually"
+                    />
+                    <MenuItem
+                        title="Cohorts"
+                        icon={<IconCohorts />}
+                        identifier="cohorts"
+                        to="/cohorts"
+                        hotkey="c"
+                        tooltip="Group users for easy filtering"
+                    />
                     <div className="divider" />
                     <MenuItem
                         title="Feat. Flags"
@@ -284,6 +328,7 @@ export function MainNavigation(): JSX.Element {
                         identifier="featureFlags"
                         to="/feature_flags"
                         hotkey="f"
+                        tooltip="Controlled feature releases"
                     />
                     <div className="divider" />
                     {canViewPlugins(user?.organization) && (
@@ -293,6 +338,7 @@ export function MainNavigation(): JSX.Element {
                             identifier="plugins"
                             to="/project/plugins"
                             hotkey="l"
+                            tooltip="Extend your analytics functionality"
                         />
                     )}
                     <MenuItem

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -13,7 +13,7 @@ import {
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { triggerResizeAfterADelay } from 'lib/utils'
+import { isMobile, triggerResizeAfterADelay } from 'lib/utils'
 import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import lgLogo from 'public/posthog-logo-white.svg'
 import smLogo from 'public/icon-white.svg'
@@ -62,6 +62,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
     const { collapseMenu, setHotkeyNavigationEngaged } = useActions(navigationLogic)
     const { push } = useActions(router)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     function activeScene(): string {
         const nominalScene = loadingScene || scene
@@ -97,7 +98,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
         <Link to={to} onClick={handleClick}>
             <Tooltip
                 title={
-                    tooltip ? (
+                    tooltip && featureFlags['hotkeys-3740'] && !isMobile() ? (
                         <>
                             {tooltip}
                             {hotkey && (

--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -27,7 +27,7 @@
         position: fixed;
         width: 180px;
         height: 100%;
-        overflow: auto;
+        overflow-y: auto;
         padding-bottom: 32px;
         scroll-behavior: smooth;
     }
@@ -59,6 +59,7 @@
         margin-top: 8px;
         margin-left: 6px;
         margin-right: 6px;
+        position: relative;
 
         .anticon {
             line-height: 0;
@@ -80,6 +81,18 @@
         &.menu-item-active {
             background-color: $primary;
             transition: background-color 300ms cubic-bezier(0.645, 0.045, 0.355, 1);
+        }
+
+        .hotkey {
+            position: absolute;
+            right: -4px;
+            bottom: -4px;
+            transform: scale(1);
+            transition: transform 0.2s ease-out;
+
+            &.hide {
+                transform: scale(0);
+            }
         }
     }
 

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -6,6 +6,7 @@ import { navigationLogicType } from './navigationLogicType'
 import { OrganizationType, SystemStatus, UserType } from '~/types'
 import { organizationLogic } from 'scenes/organizationLogic'
 import dayjs from 'dayjs'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 type WarningType =
     | 'welcome'
@@ -155,6 +156,7 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
         },
         setHotkeyNavigationEngaged: async ({ hotkeyNavigationEngaged }, breakpoint) => {
             if (hotkeyNavigationEngaged) {
+                eventUsageLogic.actions.reportHotkeyNavigation('global', 'g')
                 await breakpoint(3000)
                 actions.setHotkeyNavigationEngaged(false)
             }

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -26,6 +26,7 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
         setToolbarModalOpen: (isOpen: boolean) => ({ isOpen }),
         setPinnedDashboardsVisible: (visible: boolean) => ({ visible }),
         setInviteMembersModalOpen: (isOpen: boolean) => ({ isOpen }),
+        setHotkeyNavigationEngaged: (hotkeyNavigationEngaged: boolean) => ({ hotkeyNavigationEngaged }),
     },
     reducers: {
         menuCollapsed: [
@@ -56,6 +57,12 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
             false,
             {
                 setPinnedDashboardsVisible: (_, { visible }) => visible,
+            },
+        ],
+        hotkeyNavigationEngaged: [
+            false,
+            {
+                setHotkeyNavigationEngaged: (_, { hotkeyNavigationEngaged }) => hotkeyNavigationEngaged,
             },
         ],
     },
@@ -145,6 +152,12 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
                 user: { current_team_id: id },
             })
             location.href = dest
+        },
+        setHotkeyNavigationEngaged: async ({ hotkeyNavigationEngaged }, breakpoint) => {
+            if (hotkeyNavigationEngaged) {
+                await breakpoint(3000)
+                actions.setHotkeyNavigationEngaged(false)
+            }
         },
     }),
     events: ({ actions }) => ({

--- a/frontend/src/lib/components/HotkeyButton/index.scss
+++ b/frontend/src/lib/components/HotkeyButton/index.scss
@@ -6,18 +6,4 @@
             border: 0;
         }
     }
-
-    .hotkey {
-        padding: 0 6px;
-        border-radius: $radius;
-        font-weight: bold;
-        margin-left: 6px;
-        background-color: white;
-        color: $primary;
-        text-shadow: none;
-        text-transform: uppercase;
-        border: 1px solid $border_light;
-        margin-bottom: 2px;
-        font-size: 0.85rem;
-    }
 }

--- a/frontend/src/lib/components/HotkeyButton/index.tsx
+++ b/frontend/src/lib/components/HotkeyButton/index.tsx
@@ -1,10 +1,10 @@
 import { Button, ButtonProps } from 'antd'
 import React from 'react'
-import { Keys } from '~/types'
+import { HotKeys } from '~/types'
 import './index.scss'
 
 interface HotkeyButtonProps extends ButtonProps {
-    hotkey: Keys
+    hotkey: HotKeys
 }
 
 export function HotkeyButton({ hotkey, children, ...props }: HotkeyButtonProps): JSX.Element {

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { Select } from 'antd'
 import api from '../../api'
-import { isOperatorFlag, isOperatorMulti, isOperatorRegex, isValidRegex } from 'lib/utils'
+import { isMobile, isOperatorFlag, isOperatorMulti, isOperatorRegex, isValidRegex } from 'lib/utils'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 
 export function PropertyValue({
@@ -20,27 +20,27 @@ export function PropertyValue({
     const [optionsCache, setOptionsCache] = useState({})
     const [options, setOptions] = useState({})
 
-    function loadPropertyValues(value) {
+    function loadPropertyValues(_value) {
         if (type === 'cohort') {
             return
         }
         let key = propertyKey.split('__')[0]
         setOptions({ [propertyKey]: { ...options[propertyKey], status: 'loading' }, ...options })
-        setOptionsCache({ ...optionsCache, [value]: 'loading' })
+        setOptionsCache({ ...optionsCache, [_value]: 'loading' })
         if (outerOptions) {
             setOptions({
                 [propertyKey]: { values: [...new Set([...outerOptions.map((option) => option)])], status: true },
                 ...options,
             })
-            setOptionsCache({ ...optionsCache, [value]: true })
+            setOptionsCache({ ...optionsCache, [_value]: true })
         } else {
-            api.get(endpoint || 'api/' + type + '/values/?key=' + key + (value ? '&value=' + value : '')).then(
+            api.get(endpoint || 'api/' + type + '/values/?key=' + key + (_value ? '&value=' + _value : '')).then(
                 (propValues) => {
                     setOptions({
                         [propertyKey]: { values: [...new Set([...propValues.map((option) => option)])], status: true },
                         ...options,
                     })
-                    setOptionsCache({ ...optionsCache, [value]: true })
+                    setOptionsCache({ ...optionsCache, [_value]: true })
                 }
             )
         }
@@ -62,11 +62,11 @@ export function PropertyValue({
             <SelectGradientOverflow
                 mode={isOperatorMulti(operator) ? 'multiple' : undefined}
                 showSearch
-                autoFocus={!value}
+                autoFocus={!value && !isMobile()}
                 style={{ width: '100%', ...style }}
                 onChange={(_, payload) => {
                     if (isOperatorMulti(operator) && payload.length > 0) {
-                        onSet(payload.map(({ value }) => value))
+                        onSet(payload.map(({ _value }) => _value))
                     } else {
                         onSet((payload && payload.value) || null)
                     }
@@ -84,6 +84,11 @@ export function PropertyValue({
                 bordered={bordered}
                 placeholder={placeholder}
                 allowClear={value}
+                onKeyDown={(e) => {
+                    if (e.key === 'Escape') {
+                        e.target.blur()
+                    }
+                }}
             >
                 {input && (
                     <Select.Option key={input} value={input} className="ph-no-capture">

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -20,27 +20,27 @@ export function PropertyValue({
     const [optionsCache, setOptionsCache] = useState({})
     const [options, setOptions] = useState({})
 
-    function loadPropertyValues(_value) {
+    function loadPropertyValues(newInput) {
         if (type === 'cohort') {
             return
         }
         let key = propertyKey.split('__')[0]
         setOptions({ [propertyKey]: { ...options[propertyKey], status: 'loading' }, ...options })
-        setOptionsCache({ ...optionsCache, [_value]: 'loading' })
+        setOptionsCache({ ...optionsCache, [newInput]: 'loading' })
         if (outerOptions) {
             setOptions({
                 [propertyKey]: { values: [...new Set([...outerOptions.map((option) => option)])], status: true },
                 ...options,
             })
-            setOptionsCache({ ...optionsCache, [_value]: true })
+            setOptionsCache({ ...optionsCache, [newInput]: true })
         } else {
-            api.get(endpoint || 'api/' + type + '/values/?key=' + key + (_value ? '&value=' + _value : '')).then(
+            api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
                 (propValues) => {
                     setOptions({
                         [propertyKey]: { values: [...new Set([...propValues.map((option) => option)])], status: true },
                         ...options,
                     })
-                    setOptionsCache({ ...optionsCache, [_value]: true })
+                    setOptionsCache({ ...optionsCache, [newInput]: true })
                 }
             )
         }
@@ -66,7 +66,7 @@ export function PropertyValue({
                 style={{ width: '100%', ...style }}
                 onChange={(_, payload) => {
                     if (isOperatorMulti(operator) && payload.length > 0) {
-                        onSet(payload.map(({ _value }) => _value))
+                        onSet(payload.map(({ value: val }) => val))
                     } else {
                         onSet((payload && payload.value) || null)
                     }

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 interface DashboardItemAttributes {
-    type: string
+    type?: string
     entity: TrendPayload | FunnelPayload
 }
 

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -17,6 +17,11 @@ export function useKeyboardHotkeys(hotkeys: Hotkeys, deps?: DependencyList): voi
         (event) => {
             const key = (event as KeyboardEvent).key
 
+            // Ignore if the key is pressed with a meta or control key (these are general browser commands; e.g. Cmd + R)
+            if ((event as KeyboardEvent).metaKey || (event as KeyboardEvent).ctrlKey) {
+                return
+            }
+
             // Ignore typing on inputs (default behavior); except Esc key
             if (key !== 'Escape' && IGNORE_INPUTS.includes((event.target as HTMLElement).tagName.toLowerCase())) {
                 return

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -22,7 +22,7 @@ export const useKeyboardHotkeys = (
  */
 type GlobalHotkeysInterface = Partial<Record<GlobalHotKeys, HotkeyInterface>>
 export const useGlobalKeyboardHotkeys = (hotkeys: GlobalHotkeysInterface, deps?: DependencyList): void =>
-    _useKeyboardHotkeys(hotkeys, deps)
+    _useKeyboardHotkeys(hotkeys, deps, true)
 
 type AllHotKeys = GlobalHotKeys | HotKeys
 type AllHotkeysInterface = Partial<Record<AllHotKeys, HotkeyInterface>>

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -42,7 +42,11 @@ function _useKeyboardHotkeys(hotkeys: AllHotkeysInterface, deps?: DependencyList
             const key = (event as KeyboardEvent).key
 
             // Ignore if the key is pressed with a meta or control key (these are general browser commands; e.g. Cmd + R)
-            if ((event as KeyboardEvent).metaKey || (event as KeyboardEvent).ctrlKey) {
+            if (
+                (event as KeyboardEvent).metaKey ||
+                (event as KeyboardEvent).ctrlKey ||
+                (event as KeyboardEvent).altKey
+            ) {
                 return
             }
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -4,7 +4,7 @@ import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import posthog from 'posthog-js'
 import { userLogic } from 'scenes/userLogic'
 import { eventUsageLogicType } from './eventUsageLogicType'
-import { AnnotationType, FilterType, DashboardType, PersonType, DashboardMode } from '~/types'
+import { AnnotationType, FilterType, DashboardType, PersonType, DashboardMode, HotKeys, GlobalHotKeys } from '~/types'
 import { ViewType } from 'scenes/insights/insightLogic'
 import dayjs from 'dayjs'
 
@@ -74,6 +74,7 @@ export const eventUsageLogic = kea<
         reportDashboardRenamed: (originalLength: number, newLength: number) => ({ originalLength, newLength }),
         reportDashboardShareToggled: (isShared: boolean) => ({ isShared }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
+        reportHotkeyNavigation: (scope: 'global' | 'insights', hotkey: HotKeys | GlobalHotKeys) => ({ scope, hotkey }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -276,8 +277,8 @@ export const eventUsageLogic = kea<
                 date_to: dateTo?.toString(),
             })
         },
-        reportDashboardPinToggled: async ({ pinned, source }) => {
-            posthog.capture(`dashboard pin toggled`, { pinned: pinned, source })
+        reportDashboardPinToggled: async (payload) => {
+            posthog.capture(`dashboard pin toggled`, payload)
         },
         reportDashboardDropdownNavigation: async () => {
             /* Triggered when a user navigates using the dropdown in the header.
@@ -290,8 +291,11 @@ export const eventUsageLogic = kea<
         reportDashboardShareToggled: async ({ isShared }) => {
             posthog.capture(`dashboard share toggled`, { is_shared: isShared })
         },
-        reportUpgradeModalShown: async ({ featureName }) => {
-            posthog.capture('upgrade modal shown', { featureName })
+        reportUpgradeModalShown: async (payload) => {
+            posthog.capture('upgrade modal shown', payload)
+        },
+        reportHotkeyNavigation: async (payload) => {
+            posthog.capture('hotkey navigation', payload)
         },
     },
 })

--- a/frontend/src/scenes/funnels/FunnelViz.js
+++ b/frontend/src/scenes/funnels/FunnelViz.js
@@ -11,10 +11,10 @@ import { IllustrationDanger } from 'lib/components/icons'
 
 export function FunnelViz({
     steps: stepsParam,
-    filters: defaultFilters,
-    dashboardItemId,
-    cachedResults,
-    inSharedMode,
+    filters: defaultFilters = undefined,
+    dashboardItemId = undefined,
+    cachedResults = undefined,
+    inSharedMode = undefined,
     color = 'white',
 }) {
     const container = useRef(null)

--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -22,7 +22,7 @@ const InsightHistoryType = {
 const { TabPane } = Tabs
 
 interface InsightHistoryPanelProps {
-    onChange: () => void
+    onChange?: () => void
 }
 
 function InsightPane({

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -6,7 +6,7 @@
     height: 100%;
 }
 
-.actions-graph {
+.insights-page {
     .top-bar {
         .ant-tabs,
         .ant-tabs-nav-list {
@@ -18,6 +18,26 @@
     }
     hr {
         margin: 1rem 0;
+    }
+
+    .hotkey {
+        margin-bottom: 0;
+        padding-top: 2px;
+        padding-bottom: 2px;
+    }
+
+    .ant-tabs-tab:hover {
+        .hotkey {
+            background-color: #fafafa;
+        }
+    }
+
+    .ant-tabs-tab-active {
+        .hotkey {
+            background-color: $primary;
+            border: 0;
+            color: white;
+        }
     }
 }
 

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -22,11 +22,9 @@
 
     .hotkey {
         margin-bottom: 0;
-        padding-top: 2px;
-        padding-bottom: 2px;
     }
 
-    .ant-tabs-tab:hover {
+    .ant-tabs-tab:not(.ant-tabs-tab-active):hover {
         .hotkey {
             background-color: #fafafa;
         }
@@ -35,7 +33,7 @@
     .ant-tabs-tab-active {
         .hotkey {
             background-color: $primary;
-            border: 0;
+            border-color: $primary;
             color: white;
         }
     }

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -46,7 +46,7 @@ import { TrendLegend } from './TrendLegend'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { TZIndicator } from 'lib/components/TimezoneAware'
-import { DisplayType, FilterType, Keys } from '~/types'
+import { DisplayType, FilterType, HotKeys } from '~/types'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 
 dayjs.extend(relativeTime)
@@ -105,7 +105,7 @@ const showComparePrevious = {
     [`${ViewType.PATHS}`]: false,
 }
 
-function InsightHotkey({ hotkey }: { hotkey: Keys }): JSX.Element {
+function InsightHotkey({ hotkey }: { hotkey: HotKeys }): JSX.Element {
     /* Temporary element to only show hotkeys when feature flag is active */
     const { featureFlags } = useValues(featureFlagLogic)
     return featureFlags['hotkeys-3740'] ? <span className="hotkey">{hotkey}</span> : <></>

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -46,11 +46,12 @@ import { TrendLegend } from './TrendLegend'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { TZIndicator } from 'lib/components/TimezoneAware'
+import { DisplayType, FilterType } from '~/types'
 
 dayjs.extend(relativeTime)
 const { TabPane } = Tabs
 
-const showIntervalFilter = function (activeView, filter) {
+const showIntervalFilter = function (activeView: ViewType, filter: FilterType): boolean {
     switch (activeView) {
         case ViewType.FUNNELS:
             return filter.display === ACTIONS_LINE_GRAPH_LINEAR
@@ -62,11 +63,11 @@ const showIntervalFilter = function (activeView, filter) {
         case ViewType.LIFECYCLE:
         case ViewType.SESSIONS:
         default:
-            return ![ACTIONS_PIE_CHART, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE].includes(filter.display) // sometimes insights aren't set for trends
+            return ![ACTIONS_PIE_CHART, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE].includes(filter.display || '') // sometimes insights aren't set for trends
     }
 }
 
-const showChartFilter = function (activeView, featureFlags) {
+const showChartFilter = function (activeView: ViewType, featureFlags: Record<string, boolean>): boolean {
     switch (activeView) {
         case ViewType.TRENDS:
         case ViewType.STICKINESS:
@@ -103,7 +104,7 @@ const showComparePrevious = {
     [`${ViewType.PATHS}`]: false,
 }
 
-export function Insights() {
+export function Insights(): JSX.Element {
     useMountedLogic(insightCommandLogic)
     const [{ fromItem }] = useState(router.values.hashParams)
     const { clearAnnotationsToCreate } = useActions(annotationsLogic({ pageKey: fromItem }))
@@ -133,7 +134,7 @@ export function Insights() {
                     tabBarExtraContent={{
                         right: (
                             <Button
-                                type={activeView === 'history' && 'primary'}
+                                type={activeView === 'history' ? 'primary' : undefined}
                                 data-attr="insight-history-button"
                                 onClick={() => setActiveView('history')}
                             >
@@ -165,7 +166,7 @@ export function Insights() {
                 {activeView === 'history' ? (
                     <Col xs={24} xl={24}>
                         <Card className="" style={{ overflow: 'visible' }}>
-                            <InsightHistoryPanel onChange={() => setOpenHistory(false)} />
+                            <InsightHistoryPanel />
                         </Card>
                     </Col>
                 ) : (
@@ -182,14 +183,14 @@ export function Insights() {
                                               [`${ViewType.TRENDS}`]: <TrendTab view={ViewType.TRENDS} />,
                                               [`${ViewType.STICKINESS}`]: <TrendTab view={ViewType.STICKINESS} />,
                                               [`${ViewType.LIFECYCLE}`]: <TrendTab view={ViewType.LIFECYCLE} />,
-                                              [`${ViewType.SESSIONS}`]: <SessionTab view={ViewType.SESSIONS} />,
+                                              [`${ViewType.SESSIONS}`]: <SessionTab />,
                                               [`${ViewType.FUNNELS}`]: <FunnelTab />,
                                               [`${ViewType.RETENTION}`]: <RetentionTab />,
                                               [`${ViewType.PATHS}`]: <PathTab />,
                                           }[activeView]
                                         : {
                                               [`${ViewType.TRENDS}`]: <TrendTab view={ViewType.TRENDS} />,
-                                              [`${ViewType.SESSIONS}`]: <SessionTab view={ViewType.SESSIONS} />,
+                                              [`${ViewType.SESSIONS}`]: <SessionTab />,
                                               [`${ViewType.FUNNELS}`]: <FunnelTab />,
                                               [`${ViewType.RETENTION}`]: <RetentionTab />,
                                               [`${ViewType.PATHS}`]: <PathTab />,
@@ -216,11 +217,11 @@ export function Insights() {
                                         <TZIndicator style={{ float: 'left' }} />
                                         <div style={{ width: '100%', textAlign: 'right' }}>
                                             {showIntervalFilter(activeView, allFilters) && (
-                                                <IntervalFilter filters={allFilters} view={activeView} />
+                                                <IntervalFilter view={activeView} />
                                             )}
                                             {showChartFilter(activeView, featureFlags) && (
                                                 <ChartFilter
-                                                    onChange={(display) => {
+                                                    onChange={(display: DisplayType) => {
                                                         if (
                                                             display === ACTIONS_TABLE ||
                                                             display === ACTIONS_PIE_CHART
@@ -339,11 +340,11 @@ export function Insights() {
     )
 }
 
-const isFunnelEmpty = (filters) => {
+const isFunnelEmpty = (filters: FilterType): boolean => {
     return (!filters.actions && !filters.events) || (filters.actions?.length === 0 && filters.events?.length === 0)
 }
 
-function FunnelInsight() {
+function FunnelInsight(): JSX.Element {
     const { stepsWithCount, isValidFunnel, stepsWithCountLoading } = useValues(funnelLogic({}))
 
     return (
@@ -368,7 +369,7 @@ function FunnelInsight() {
     )
 }
 
-function FunnelPeople() {
+function FunnelPeople(): JSX.Element {
     const { stepsWithCount } = useValues(funnelLogic())
     if (stepsWithCount && stepsWithCount.length > 0) {
         return <People />

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -48,6 +48,7 @@ import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { TZIndicator } from 'lib/components/TimezoneAware'
 import { DisplayType, FilterType, HotKeys } from '~/types'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 dayjs.extend(relativeTime)
 const { TabPane } = Tabs
@@ -121,34 +122,40 @@ export function Insights(): JSX.Element {
     )
     const { setActiveView } = useActions(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { reportHotkeyNavigation } = useActions(eventUsageLogic)
 
     const { loadResults } = useActions(logicFromInsight(activeView, { dashboardItemId: null, filters: allFilters }))
     const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
+
+    const handleHotkeyNavigation = (view: ViewType, hotkey: HotKeys): void => {
+        setActiveView(view)
+        reportHotkeyNavigation('insights', hotkey)
+    }
 
     useKeyboardHotkeys(
         featureFlags['hotkeys-3740']
             ? {
                   t: {
-                      action: () => setActiveView(ViewType.TRENDS),
+                      action: () => handleHotkeyNavigation(ViewType.TRENDS, 't'),
                   },
                   f: {
-                      action: () => setActiveView(ViewType.FUNNELS),
+                      action: () => handleHotkeyNavigation(ViewType.FUNNELS, 'f'),
                   },
                   s: {
-                      action: () => setActiveView(ViewType.SESSIONS),
+                      action: () => handleHotkeyNavigation(ViewType.SESSIONS, 's'),
                   },
                   r: {
-                      action: () => setActiveView(ViewType.RETENTION),
+                      action: () => handleHotkeyNavigation(ViewType.RETENTION, 'r'),
                   },
                   p: {
-                      action: () => setActiveView(ViewType.PATHS),
+                      action: () => handleHotkeyNavigation(ViewType.PATHS, 'p'),
                   },
                   k: {
-                      action: () => setActiveView(ViewType.STICKINESS),
+                      action: () => handleHotkeyNavigation(ViewType.STICKINESS, 'k'),
                       disabled: !featureFlags['remove-shownas'],
                   },
                   l: {
-                      action: () => setActiveView(ViewType.LIFECYCLE),
+                      action: () => handleHotkeyNavigation(ViewType.LIFECYCLE, 'l'),
                       disabled: !featureFlags['remove-shownas'],
                   },
               }

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useActions, useMountedLogic, useValues, BindLogic } from 'kea'
 
-import { Loading } from 'lib/utils'
+import { isMobile, Loading } from 'lib/utils'
 import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
@@ -109,7 +109,7 @@ const showComparePrevious = {
 function InsightHotkey({ hotkey }: { hotkey: HotKeys }): JSX.Element {
     /* Temporary element to only show hotkeys when feature flag is active */
     const { featureFlags } = useValues(featureFlagLogic)
-    return featureFlags['hotkeys-3740'] ? <span className="hotkey">{hotkey}</span> : <></>
+    return featureFlags['hotkeys-3740'] && !isMobile() ? <span className="hotkey">{hotkey}</span> : <></>
 }
 
 export function Insights(): JSX.Element {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -48,7 +48,7 @@ export const insightLogic = kea<insightLogicType>({
         setCachedUrl: (type, url) => ({ type, url }),
         setAllFilters: (filters) => ({ filters }),
         startQuery: true,
-        endQuery: (view: string, lastRefresh: null | boolean, exception?: Record<string, any>) => ({
+        endQuery: (view: string, lastRefresh: string | null, exception?: Record<string, any>) => ({
             view,
             lastRefresh,
             exception,
@@ -58,7 +58,7 @@ export const insightLogic = kea<insightLogicType>({
         setShowErrorMessage: (showErrorMessage: boolean) => ({ showErrorMessage }),
         setIsLoading: (isLoading: boolean) => ({ isLoading }),
         setTimeout: (timeout) => ({ timeout }),
-        setLastRefresh: (lastRefresh: null | boolean) => ({ lastRefresh }),
+        setLastRefresh: (lastRefresh: string | null) => ({ lastRefresh }),
         setNotFirstLoad: () => {},
     }),
 
@@ -103,7 +103,7 @@ export const insightLogic = kea<insightLogicType>({
         ],
         timeout: [null, { setTimeout: (_, { timeout }) => timeout }],
         lastRefresh: [
-            null as null | boolean,
+            null as string | null,
             {
                 setLastRefresh: (_, { lastRefresh }) => lastRefresh,
                 setActiveView: () => null,

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -7,6 +7,7 @@ import { retentionTableLogic } from 'scenes/retention/retentionTableLogic'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
 import { trendsLogic } from '../trends/trendsLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
+import { FilterType } from '~/types'
 
 export enum ViewType {
     TRENDS = 'TRENDS',
@@ -47,7 +48,7 @@ export const insightLogic = kea<insightLogicType>({
         setCachedUrl: (type, url) => ({ type, url }),
         setAllFilters: (filters) => ({ filters }),
         startQuery: true,
-        endQuery: (view: string, lastRefresh: string | boolean, exception?: Record<string, any>) => ({
+        endQuery: (view: string, lastRefresh: null | boolean, exception?: Record<string, any>) => ({
             view,
             lastRefresh,
             exception,
@@ -57,7 +58,7 @@ export const insightLogic = kea<insightLogicType>({
         setShowErrorMessage: (showErrorMessage: boolean) => ({ showErrorMessage }),
         setIsLoading: (isLoading: boolean) => ({ isLoading }),
         setTimeout: (timeout) => ({ timeout }),
-        setLastRefresh: (lastRefresh: string | boolean): { lastRefresh: string | boolean } => ({ lastRefresh }),
+        setLastRefresh: (lastRefresh: null | boolean) => ({ lastRefresh }),
         setNotFirstLoad: () => {},
     }),
 
@@ -102,10 +103,10 @@ export const insightLogic = kea<insightLogicType>({
         ],
         timeout: [null, { setTimeout: (_, { timeout }) => timeout }],
         lastRefresh: [
-            false as boolean | string,
+            null as null | boolean,
             {
-                setLastRefresh: (_, { lastRefresh }): string | boolean => lastRefresh,
-                setActiveView: () => false,
+                setLastRefresh: (_, { lastRefresh }) => lastRefresh,
+                setActiveView: () => null,
             },
         ],
         isLoading: [
@@ -118,7 +119,7 @@ export const insightLogic = kea<insightLogicType>({
         allfilters is passed to components that are shared between the different insight features
         */
         allFilters: [
-            {} as Record<string, any>,
+            {} as FilterType,
             {
                 setAllFilters: (_, { filters }) => filters,
             },
@@ -141,7 +142,7 @@ export const insightLogic = kea<insightLogicType>({
         startQuery: () => {
             actions.setShowTimeoutMessage(false)
             actions.setShowErrorMessage(false)
-            actions.setLastRefresh(false)
+            actions.setLastRefresh(null)
             values.timeout && clearTimeout(values.timeout || undefined)
             const view = values.activeView
             actions.setTimeout(
@@ -158,7 +159,7 @@ export const insightLogic = kea<insightLogicType>({
             if (view === values.activeView) {
                 actions.setShowTimeoutMessage(values.maybeShowTimeoutMessage)
                 actions.setShowErrorMessage(values.maybeShowErrorMessage)
-                actions.setLastRefresh(lastRefresh || false)
+                actions.setLastRefresh(lastRefresh || null)
                 actions.setIsLoading(false)
                 if (values.maybeShowTimeoutMessage) {
                     posthog.capture('insight timeout message shown', { insight: values.activeView, ...exception })

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -75,7 +75,7 @@ export const pathsLogic = kea<pathsLogicType<PathResult, PropertyFilter, FilterT
                 try {
                     paths = await api.get(`api/insight/path${params ? `/?${params}` : ''}`)
                 } catch (e) {
-                    insightLogic.actions.endQuery(ViewType.PATHS, false, e)
+                    insightLogic.actions.endQuery(ViewType.PATHS, null, e)
                     return { paths: [], filter, error: true }
                 }
                 breakpoint()

--- a/frontend/src/scenes/retention/RetentionContainer.tsx
+++ b/frontend/src/scenes/retention/RetentionContainer.tsx
@@ -6,10 +6,10 @@ import { ACTIONS_LINE_GRAPH_LINEAR } from 'lib/constants'
 import { RetentionTable } from './RetentionTable'
 
 export function RetentionContainer(props: {
-    dashboardItemId: number
-    filters: Record<string, any>
-    color: string
-    inSharedMode: boolean
+    dashboardItemId?: number
+    filters?: Record<string, any>
+    color?: string
+    inSharedMode?: boolean
 }): JSX.Element {
     const logic = retentionTableLogic({ dashboardItemId: props.dashboardItemId, filters: props.filters })
     const { filters } = useValues(logic)

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -75,7 +75,7 @@ export const retentionTableLogic = kea<
                 try {
                     res = await api.get(`api/insight/retention/?${urlParams}`)
                 } catch (e) {
-                    insightLogic.actions.endQuery(ViewType.RETENTION, false, e)
+                    insightLogic.actions.endQuery(ViewType.RETENTION, null, e)
                     return []
                 }
                 breakpoint()

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -167,7 +167,7 @@ export const trendsLogic = kea<
                     }
                 } catch (e) {
                     breakpoint()
-                    insightLogic.actions.endQuery(values.filters.insight || ViewType.TRENDS, false, e)
+                    insightLogic.actions.endQuery(values.filters.insight || ViewType.TRENDS, null, e)
                     return []
                 }
                 breakpoint()

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -606,14 +606,17 @@ export enum DashboardMode { // Default mode is null
     Public = 'public', // When viewing the dashboard publicly via a shareToken
 }
 
-export type Keys =
+// Reserved hotkeys globally available
+export type GlobalHotKeys = 'g'
+
+// Hotkeys for local (component) actions
+export type HotKeys =
     | 'a'
     | 'b'
     | 'c'
     | 'd'
     | 'e'
     | 'f'
-    | 'g'
     | 'h'
     | 'i'
     | 'j'


### PR DESCRIPTION
## Changes

This PR introduces global hotkey navigation to make our overall experience smoother for power users. Everything is behind feature flag `hotkeys-3740`.
- Closes #2907.
- Allows navigating to any of the scenes accessed through the main navigation (press "G" anywhere to try out).
    ![image](https://user-images.githubusercontent.com/5864173/112406278-1f881e80-8cd1-11eb-8226-aa0dd7daa6eb.gif)
- Allows navigating between the insights views (fully supports lifecycle & stickiness if `remove-shownas` is enabled).
    <img width="1354" alt="" src="https://user-images.githubusercontent.com/5864173/112406384-47778200-8cd1-11eb-8382-8c38608c3267.png">
- Introduces a tooltip description to menu items to increase feature discoverability. This is also the basis for global keyboard navigation discoverability.
    <img width="410" alt="" src="https://user-images.githubusercontent.com/5864173/112406428-637b2380-8cd1-11eb-8a6a-5939f25df4be.png">

In addition this PR:
- Converts `Insights.tsx` to Typescript and fixes a bunch of Typescript errors.
- Standardizes and makes styles for hotkeys global.
- Usage is fully instrumented.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
