### PR TITLE
Add 'cohorts' tab to Person page

### DIFF
--- a/cypress/integration/cohorts.js
+++ b/cypress/integration/cohorts.js
@@ -2,6 +2,7 @@ describe('Cohorts', () => {
     beforeEach(() => {
         cy.get('[data-attr=menu-item-cohorts]').click()
     })
+
     it('Cohorts new and list', () => {
         // load an empty page
         cy.get('h1').should('contain', 'Cohorts')
@@ -31,5 +32,18 @@ describe('Cohorts', () => {
         // back to cohorts
         cy.get('.ant-drawer-close').click({ force: true })
         cy.get('.ant-table-tbody').contains('Test Cohort')
+
+        // Navigate to person and back again
+        cy.log('Can navigate to person and back again')
+
+        cy.get('[data-test-cohort-row]').first().click()
+        cy.get('[data-test-goto-person]').first().click()
+        cy.url().should('include', '/person/')
+
+        cy.get('[data-attr="persons-cohorts-tab"]').click()
+        cy.get('[data-test-cohort-row]').first().click()
+
+        cy.url().should('include', '/cohorts/')
+        cy.get('[data-attr="cohort-name"]').should('have.value', 'Test Cohort')
     })
 })

--- a/frontend/src/scenes/persons/Cohorts.tsx
+++ b/frontend/src/scenes/persons/Cohorts.tsx
@@ -161,6 +161,7 @@ export function Cohorts(): JSX.Element {
                     rowClassName="cursor-pointer"
                     onRow={(cohort) => ({
                         onClick: () => setOpenCohort(cohort),
+                        'data-test-cohort-row': cohort.id,
                     })}
                     dataSource={searchTerm ? searchCohorts(cohorts, searchTerm) : cohorts}
                 />

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -11,6 +11,7 @@ import { midEllipsis } from 'lib/utils'
 import { DownOutlined, DeleteOutlined, MergeCellsOutlined, LoadingOutlined } from '@ant-design/icons'
 import dayjs from 'dayjs'
 import { MergePerson } from './MergePerson'
+import { PersonCohorts } from './PersonCohorts'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { NewPropertyComponent } from './NewPropertyComponent'
 
@@ -22,6 +23,7 @@ const { TabPane } = Tabs
 
 export function Person(): JSX.Element {
     const [activeTab, setActiveTab] = useState('events')
+    const [activeCardTab, setActiveCardTab] = useState('properties')
     const [mergeModalOpen, setMergeModalOpen] = useState(false)
 
     const { person, personLoading, deletedPersonLoading, hasNewKeys } = useValues(personsLogic)
@@ -131,26 +133,39 @@ export function Person(): JSX.Element {
                         {!person && personLoading && <Skeleton paragraph={{ rows: 4 }} active />}
                     </Card>
                     <Card className="card-elevated person-properties" style={{ marginTop: 16 }}>
-                        <Tabs>
+                        <Tabs
+                            defaultActiveKey={activeCardTab}
+                            onChange={(tab) => {
+                                setActiveCardTab(tab)
+                            }}
+                        >
                             <TabPane
                                 tab={<span data-attr="persons-properties-tab">Properties</span>}
                                 key="properties"
                                 disabled={personLoading}
                             />
+                            <TabPane
+                                tab={<span data-attr="persons-cohorts-tab">Cohorts</span>}
+                                key="cohorts"
+                                disabled={personLoading}
+                            />
                         </Tabs>
-                        {person && (
-                            <div style={{ maxWidth: '100%', overflow: 'hidden' }}>
-                                <NewPropertyComponent />
-                                <h3 className="l3">Properties list</h3>
-                                <PropertiesTable
-                                    properties={person.properties}
-                                    onEdit={editProperty}
-                                    sortProperties={!hasNewKeys}
-                                    onDelete={(key) => editProperty(key, undefined)}
-                                    className="persons-page-props-table"
-                                />
-                            </div>
-                        )}
+                        {person &&
+                            (activeCardTab == 'properties' ? (
+                                <div style={{ maxWidth: '100%', overflow: 'hidden' }}>
+                                    <NewPropertyComponent />
+                                    <h3 className="l3">Properties list</h3>
+                                    <PropertiesTable
+                                        properties={person.properties}
+                                        onEdit={editProperty}
+                                        sortProperties={!hasNewKeys}
+                                        onDelete={(key) => editProperty(key, undefined)}
+                                        className="persons-page-props-table"
+                                    />
+                                </div>
+                            ) : (
+                                <PersonCohorts />
+                            ))}
                         {!person && personLoading && <Skeleton paragraph={{ rows: 6 }} active />}
                     </Card>
                 </Col>

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react'
+import { useActions, useValues } from 'kea'
+import { personsLogic } from './personsLogic'
+import Skeleton from 'antd/lib/skeleton'
+import { Table } from 'antd'
+import { CohortType } from '~/types'
+
+export function PersonCohorts(): JSX.Element {
+    const { cohorts, cohortsLoading } = useValues(personsLogic)
+    const { loadCohorts, navigateToCohort } = useActions(personsLogic)
+
+    useEffect(() => {
+        if (cohorts === null && !cohortsLoading) {
+            loadCohorts()
+        }
+    }, [cohorts, cohortsLoading])
+
+    if (cohortsLoading) {
+        return <Skeleton paragraph={{ rows: 2 }} active />
+    }
+
+    const columns = [
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            className: 'ph-no-capture',
+            sorter: (a: CohortType, b: CohortType) => ('' + a.name).localeCompare(b.name as string),
+        },
+        {
+            title: 'Users in cohort',
+            render: function RenderCount(_: any, cohort: CohortType) {
+                return cohort.count?.toLocaleString()
+            },
+            sorter: (a: CohortType, b: CohortType) => (a.count || 0) - (b.count || 0),
+        },
+    ]
+
+    return (
+        <Table
+            dataSource={cohorts || []}
+            loading={cohortsLoading}
+            columns={columns}
+            rowClassName="cursor-pointer"
+            rowKey="id"
+            pagination={{ pageSize: 100, hideOnSinglePage: true }}
+            onRow={(cohort) => ({
+                onClick: () => navigateToCohort(cohort),
+            })}
+            locale={{ emptyText: 'Person belongs to no cohorts' }}
+        />
+    )
+}

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -46,6 +46,7 @@ export function PersonCohorts(): JSX.Element {
             pagination={{ pageSize: 100, hideOnSinglePage: true }}
             onRow={(cohort) => ({
                 onClick: () => navigateToCohort(cohort),
+                'data-test-cohort-row': cohort.id,
             })}
             locale={{ emptyText: 'Person belongs to no cohorts' }}
         />

--- a/frontend/src/scenes/persons/PersonsTable.tsx
+++ b/frontend/src/scenes/persons/PersonsTable.tsx
@@ -98,7 +98,7 @@ export function PersonsTable({
         render: function Render(_: string, person: PersonType, index: number) {
             return (
                 <>
-                    <Link to={linkToPerson(person)} data-attr={'goto-person-arrow-' + index}>
+                    <Link to={linkToPerson(person)} data-attr={'goto-person-arrow-' + index} data-test-goto-person>
                         <ArrowRightOutlined />
                         {allColumns ? ' view' : ''}
                     </Link>

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -3,7 +3,7 @@ import { router } from 'kea-router'
 import api from 'lib/api'
 import { toast } from 'react-toastify'
 import { personsLogicType } from './personsLogicType'
-import { PersonType } from '~/types'
+import { CohortType, PersonType } from '~/types'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface PersonPaginatedResponse {
@@ -14,7 +14,7 @@ interface PersonPaginatedResponse {
 
 const FILTER_WHITELIST: string[] = ['is_identified', 'search', 'cohort']
 
-export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, PersonType>>({
+export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, PersonType, CohortType>>({
     connect: {
         actions: [eventUsageLogic, ['reportPersonDetailViewed']],
     },
@@ -22,6 +22,7 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, Person
         setListFilters: (payload) => ({ payload }),
         editProperty: (key: string, newValue?: string | number | boolean | null) => ({ key, newValue }),
         setHasNewKeys: true,
+        navigateToCohort: (cohort: CohortType) => ({ cohort }),
     },
     reducers: {
         listFilters: [
@@ -97,6 +98,9 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, Person
                 )
             }
         },
+        navigateToCohort: ({ cohort }) => {
+            router.actions.push(`/cohorts/${cohort.id}`)
+        },
     }),
     loaders: ({ values, actions }) => ({
         persons: [
@@ -134,6 +138,15 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, Person
                 setPerson: (person: PersonType): PersonType => {
                     // Used after merging persons to update the view without an additional request
                     return person
+                },
+            },
+        ],
+        cohorts: [
+            null as CohortType[] | null,
+            {
+                loadCohorts: async (): Promise<CohortType[] | null> => {
+                    const response = await api.get(`api/person/cohorts/?person_id=${values.person?.id}`)
+                    return response.results
                 },
             },
         ],


### PR DESCRIPTION
- Add a cohort tab to Person page
- Add E2E test navigating from cohort -> person -> back

Closes #3743

![image](https://user-images.githubusercontent.com/148820/112474512-65e48880-8d78-11eb-83c7-eaf61acc37ff.png)
![image](https://user-images.githubusercontent.com/148820/112474578-7dbc0c80-8d78-11eb-83a7-0ea9b8a72fb3.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
