### PR TITLE
Handle event capture edge cases

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -175,7 +175,10 @@ def get_event(request):
     else:
         events = [data]
 
-    events = preprocess_session_recording_events(events)
+    try:
+        events = preprocess_session_recording_events(events)
+    except ValueError as e:
+        return cors_response(request, JsonResponse({"code": "validation", "message": str(e),}, status=400,),)
 
     for event in events:
         try:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -560,3 +560,24 @@ class TestCapture(BaseTest):
         )
         arguments = self._to_arguments(patch_process_event_with_plugins)
         self.assertEqual(arguments["data"]["properties"]["$active_feature_flags"], ["test-ff"])
+
+    def test_handle_lacking_event_name_field(self):
+        response = self.client.post(
+            "/e/",
+            data={"distinct_id": "abc", "properties": {"cost": 2}, "api_key": self.team.api_token},
+            content_type="application/json",
+        )
+        self.assertEqual(
+            response.json(), {"code": "validation", "message": 'All events must have the event name field "event"!'}
+        )
+
+    def test_handle_invalid_snapshot(self):
+        response = self.client.post(
+            "/e/",
+            data={"event": "$snapshot", "distinct_id": "abc", "api_key": self.team.api_token},
+            content_type="application/json",
+        )
+        self.assertEqual(
+            response.json(),
+            {"code": "validation", "message": '$snapshot events must contain property "$snapshot_data"!'},
+        )

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -4,7 +4,7 @@ import json
 from collections import defaultdict
 from typing import Dict, Generator, List
 
-from sentry_sdk.api import capture_message
+from sentry_sdk.api import capture_exception, capture_message
 
 from posthog.models import utils
 
@@ -93,6 +93,7 @@ def is_unchunked_snapshot(event: Dict) -> bool:
     try:
         return is_snapshot and "chunk_id" not in event["properties"]["$snapshot_data"]
     except KeyError:
+        capture_exception()
         raise ValueError('$snapshot events must contain property "$snapshot_data"!')
 
 

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -86,7 +86,14 @@ def chunk_string(string: str, chunk_length: int) -> List[str]:
 
 
 def is_unchunked_snapshot(event: Dict) -> bool:
-    return event["event"] == "$snapshot" and "chunk_id" not in event["properties"]["$snapshot_data"]
+    try:
+        is_snapshot = event["event"] == "$snapshot"
+    except KeyError:
+        raise ValueError('All events must have the event name field "event"!')
+    try:
+        return is_snapshot and "chunk_id" not in event["properties"]["$snapshot_data"]
+    except KeyError:
+        raise ValueError('$snapshot events must contain property "$snapshot_data"!')
 
 
 def compress_to_string(json_string: str) -> str:


### PR DESCRIPTION
## Changes

New $snapshot chunking logic introduced additional places for KeyErrors to occur, and previously they weren't handled.

## Checklist

- [x] Django backend tests
