### PR TITLE
Fix get_available_timezones_with_offsets DST change edge case

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from freezegun import freeze_time
 
-from posthog.utils import mask_email_address, relative_date_parse
+from posthog.utils import get_available_timezones_with_offsets, mask_email_address, relative_date_parse
 
 
 class TestGeneralUtils(TestCase):
@@ -16,6 +16,10 @@ class TestGeneralUtils(TestCase):
         with self.assertRaises(ValueError) as e:
             mask_email_address("not an email")
         self.assertEqual(str(e.exception), "Please provide a valid email address.")
+
+    def test_available_timezones(self):
+        timezones = get_available_timezones_with_offsets()
+        self.assertEqual(timezones.get("Europe/Moscow"), 3)
 
 
 class TestRelativeDateParse(TestCase):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -647,7 +647,10 @@ def get_available_timezones_with_offsets() -> Dict[str, float]:
     now = dt.datetime.now()
     result = {}
     for tz in pytz.common_timezones:
-        offset = pytz.timezone(tz).utcoffset(now)
+        try:
+            offset = pytz.timezone(tz).utcoffset(now)
+        except:
+            offset = pytz.timezone(tz).utcoffset(now + dt.timedelta(hours=2))
         if offset is None:
             continue
         offset_hours = int(offset.total_seconds()) / 3600


### PR DESCRIPTION
## Changes

In typical timezone oddity fashion, Israel being in the middle of a DST switch caused listing of timezones with offsets to fail. Fixes #3759 for Israel as well as for other places. :)

## Checklist

- [x] Django backend tests