### PR TITLE
Don't show legend if nothing to show

### DIFF
--- a/frontend/src/scenes/insights/TrendLegend.tsx
+++ b/frontend/src/scenes/insights/TrendLegend.tsx
@@ -27,11 +27,15 @@ function formatBreakdownLabel(breakdown_value: string | number | undefined, coho
     }
 }
 
-export function TrendLegend(): JSX.Element {
+export function TrendLegend(): JSX.Element | null {
     const { indexedResults, visibilityMap, filters } = useValues(trendsLogic)
     const { toggleVisibility } = useActions(trendsLogic)
     const { cohorts } = useValues(cohortsModel)
     const isSingleEntity = indexedResults.length === 1
+
+    if (indexedResults.length === 0) {
+        return null
+    }
 
     const columns = [
         {

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -238,7 +238,7 @@ export const trendsLogic = kea<
             },
         ],
         indexedResults: [
-            [],
+            [] as IndexedTrendResult[],
             {
                 setIndexedResults: ({}, { results }) => results,
             },


### PR DESCRIPTION
## Changes

It shows an empty table right now, which is ugly.

![image](https://user-images.githubusercontent.com/148820/112602537-7e0de380-8e1c-11eb-8a8f-e0859878882b.png)

This is when you skip the old onboarding

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
