### PR TITLE
Support multiple entries for selector and tag_name filter for EE

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -220,13 +220,17 @@ def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
     conditions = []
 
     if filters.get("selector"):
-        selector = Selector(filters["selector"], escape_slashes=False)
-        params["{}selector_regex".format(prepend)] = _create_regex(selector)
-        conditions.append("match(elements_chain, %({}selector_regex)s)".format(prepend))
+        selectors = filters["selector"] if isinstance(filters["selector"], list) else [filters["selector"]]
+        for query in selectors:
+            selector = Selector(query, escape_slashes=False)
+            params["{}selector_regex".format(prepend)] = _create_regex(selector)
+            conditions.append("match(elements_chain, %({}selector_regex)s)".format(prepend))
 
     if filters.get("tag_name"):
-        params["{}tag_name_regex".format(prepend)] = r"(^|;){}(\.|$|;|:)".format(filters["tag_name"])
-        conditions.append("match(elements_chain, %({}tag_name_regex)s)".format(prepend))
+        tag_names = filters["tag_name"] if isinstance(filters["tag_name"], list) else [filters["tag_name"]]
+        for tag_name in tag_names:
+            params["{}tag_name_regex".format(prepend)] = r"(^|;){}(\.|$|;|:)".format(tag_name)
+            conditions.append("match(elements_chain, %({}tag_name_regex)s)".format(prepend))
 
     attributes: Dict[str, List] = {}
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -220,17 +220,25 @@ def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
     conditions = []
 
     if filters.get("selector"):
+        or_conditions = []
         selectors = filters["selector"] if isinstance(filters["selector"], list) else [filters["selector"]]
-        for query in selectors:
+        for idx, query in enumerate(selectors):
             selector = Selector(query, escape_slashes=False)
-            params["{}selector_regex".format(prepend)] = _create_regex(selector)
-            conditions.append("match(elements_chain, %({}selector_regex)s)".format(prepend))
+            key = "{}_{}_selector_regex".format(prepend, idx)
+            params[key] = _create_regex(selector)
+            or_conditions.append("match(elements_chain, %({})s)".format(key))
+        if len(or_conditions) > 0:
+            conditions.append("(" + (" OR ".join(or_conditions)) + ")")
 
     if filters.get("tag_name"):
+        or_conditions = []
         tag_names = filters["tag_name"] if isinstance(filters["tag_name"], list) else [filters["tag_name"]]
-        for tag_name in tag_names:
-            params["{}tag_name_regex".format(prepend)] = r"(^|;){}(\.|$|;|:)".format(tag_name)
-            conditions.append("match(elements_chain, %({}tag_name_regex)s)".format(prepend))
+        for idx, tag_name in enumerate(tag_names):
+            key = "{}_{}_tag_name_regex".format(prepend, idx)
+            params[key] = r"(^|;){}(\.|$|;|:)".format(tag_name)
+            or_conditions.append("match(elements_chain, %({})s)".format(key))
+        if len(or_conditions) > 0:
+            conditions.append("(" + (" OR ".join(or_conditions)) + ")")
 
     attributes: Dict[str, List] = {}
 
@@ -247,7 +255,8 @@ def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
                     ".*?".join(['{}="{}"'.format(key, value)])
                 )
                 or_conditions.append("match(elements_chain, %({}_{}_{}_attributes_regex)s)".format(prepend, key, idx))
-            conditions.append(" OR ".join(or_conditions))
+            if len(or_conditions) > 0:
+                conditions.append("(" + (" OR ".join(or_conditions)) + ")")
 
     return (conditions, params)
 


### PR DESCRIPTION
## Changes

- This filter didn't work because it wasn't expecting an array of options. Same for "tag name"
![image](https://user-images.githubusercontent.com/53387/112616286-d2689180-8e23-11eb-93dc-588dcf8dbeaa.png)
- [Sentry error](https://sentry.io/organizations/posthog/issues/2298600853/?project=1899813&referrer=slack)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
