### PR TITLE
Misc instrumentation & tiny tweaks

### DIFF
--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -112,9 +112,9 @@ export function TZIndicator({ style }: { style?: React.CSSProperties }): JSX.Ele
         <div className="tz-label-popover">
             <TZConversionHeader />
             <p style={{ maxWidth: 320 }}>
-                All graphs are calculated and presented in UTC.
+                All graphs are calculated and presented in UTC (GTM timezone).
                 <br />
-                Conversion of your local timezones are shown below.
+                Conversion to your local timezones are shown below.
             </p>
             <div className="divider" />
             <div className="timezones">

--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -6,11 +6,12 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { ProjectOutlined, LaptopOutlined, GlobalOutlined, SettingOutlined } from '@ant-design/icons'
 import { Link } from '../Link'
 import { humanTzOffset, shortTimeZone } from 'lib/utils'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 const BASE_OUTPUT_FORMAT = 'ddd, MMM D, YYYY HH:mm'
 
@@ -39,6 +40,14 @@ export function TZLabel({ time, showSeconds }: { time: string | dayjs.Dayjs; sho
 
     const DATE_OUTPUT_FORMAT = !showSeconds ? BASE_OUTPUT_FORMAT : `${BASE_OUTPUT_FORMAT}:ss`
     const timeStyle = showSeconds ? { minWidth: 192 } : undefined
+
+    const { reportTimezoneComponentViewed } = useActions(eventUsageLogic)
+
+    const handleVisibleChange = (visible: boolean): void => {
+        if (visible) {
+            reportTimezoneComponentViewed('label', currentTeam?.timezone, shortTimeZone())
+        }
+    }
 
     const PopoverContent = (
         <div className="tz-label-popover">
@@ -81,7 +90,7 @@ export function TZLabel({ time, showSeconds }: { time: string | dayjs.Dayjs; sho
     )
 
     return (
-        <Popover content={PopoverContent}>
+        <Popover content={PopoverContent} onVisibleChange={handleVisibleChange}>
             <span className="tz-label">{parsedTime.fromNow()}</span>
         </Popover>
     )
@@ -90,13 +99,22 @@ export function TZLabel({ time, showSeconds }: { time: string | dayjs.Dayjs; sho
 /** Return an explainer component for analytics visualization pages. */
 export function TZIndicator({ style }: { style?: React.CSSProperties }): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
+
+    const { reportTimezoneComponentViewed } = useActions(eventUsageLogic)
+
+    const handleVisibleChange = (visible: boolean): void => {
+        if (visible) {
+            reportTimezoneComponentViewed('indicator', currentTeam?.timezone, shortTimeZone())
+        }
+    }
+
     const PopoverContent = (
         <div className="tz-label-popover">
             <TZConversionHeader />
             <p style={{ maxWidth: 320 }}>
-                Times presented in visualizations are UTC.
+                All graphs are calculated and presented in UTC.
                 <br />
-                Conversion of your local timezones to UTC below.
+                Conversion of your local timezones are shown below.
             </p>
             <div className="divider" />
             <div className="timezones">
@@ -125,7 +143,7 @@ export function TZIndicator({ style }: { style?: React.CSSProperties }): JSX.Ele
     )
 
     return (
-        <Popover content={PopoverContent}>
+        <Popover content={PopoverContent} onVisibleChange={handleVisibleChange}>
             <span className="tz-indicator" style={style}>
                 <GlobalOutlined /> UTC
             </span>

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -767,7 +767,7 @@ export function endWithPunctation(text?: string | null): string {
  */
 export function shortTimeZone(timeZone?: string, atDate: Date = new Date()): string {
     const localeTimeString = new Date(atDate).toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone })
-    return localeTimeString.split(' ')[2].replace('GMT', 'UTC')
+    return localeTimeString.split(' ')[2]
 }
 
 export function humanTzOffset(timezone?: string): string {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -75,6 +75,11 @@ export const eventUsageLogic = kea<
         reportDashboardShareToggled: (isShared: boolean) => ({ isShared }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
         reportHotkeyNavigation: (scope: 'global' | 'insights', hotkey: HotKeys | GlobalHotKeys) => ({ scope, hotkey }),
+        reportTimezoneComponentViewed: (
+            component: 'label' | 'indicator',
+            project_timezone?: string,
+            device_timezone?: string
+        ) => ({ component, project_timezone, device_timezone }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -300,6 +305,9 @@ export const eventUsageLogic = kea<
         },
         reportHotkeyNavigation: async (payload) => {
             posthog.capture('hotkey navigation', payload)
+        },
+        reportTimezoneComponentViewed: async (payload) => {
+            posthog.capture('timezone component viewed', payload)
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -127,9 +127,9 @@ export const eventUsageLogic = kea<
             await breakpoint(500) // Debounce to avoid noisy events from changing filters multiple times
 
             // Reports `insight viewed` event
-            const { display, interval, date_from, date_to, shown_as } = filters
+            const { display, interval, date_from, date_to, shown_as, filter_test_accounts, formula } = filters
 
-            // DEPRECATED: Remove when releasing `remove-shownas`
+            // :TODO: DEPRECATED: Remove when releasing `remove-shownas`
             // Support for legacy `shown_as` property in a way that ensures standardized data reporting
             let { insight } = filters
             const SHOWN_AS_MAPPING: Record<string, 'TRENDS' | 'LIFECYCLE' | 'STICKINESS'> = {
@@ -148,7 +148,8 @@ export const eventUsageLogic = kea<
                 interval,
                 date_from,
                 date_to,
-                filters, // See https://github.com/PostHog/posthog/pull/2787#discussion_r556346868 for details
+                filter_test_accounts,
+                formula,
                 filters_count: filters.properties?.length || 0, // Only counts general filters (i.e. not per-event filters)
                 events_count: filters.events?.length || 0, // Number of event lines in insights graph; number of steps in funnel
                 actions_count: filters.actions?.length || 0, // Number of action lines in insights graph; number of steps in funnel
@@ -159,6 +160,7 @@ export const eventUsageLogic = kea<
             // Custom properties for each insight
             if (insight === 'TRENDS') {
                 properties.breakdown_type = filters.breakdown_type
+                properties.breakdown = filters.breakdown
             } else if (insight === 'SESSIONS') {
                 properties.session_distribution = filters.session
             } else if (insight === 'FUNNELS') {
@@ -174,6 +176,8 @@ export const eventUsageLogic = kea<
             } else if (insight === 'PATHS') {
                 properties.path_type = filters.path_type
                 properties.has_start_point = !!filters.start_point
+            } else if (insight === 'STICKINESS') {
+                properties.stickiness_days = filters.stickiness_days
             }
 
             posthog.capture('insight viewed', properties)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -80,6 +80,7 @@ export const eventUsageLogic = kea<
             project_timezone?: string,
             device_timezone?: string
         ) => ({ component, project_timezone, device_timezone }),
+        reportTestAccountFiltersUpdated: (filters: Record<string, any>[]) => ({ filters }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -308,6 +309,15 @@ export const eventUsageLogic = kea<
         },
         reportTimezoneComponentViewed: async (payload) => {
             posthog.capture('timezone component viewed', payload)
+        },
+        reportTestAccountFiltersUpdated: async ({ filters }) => {
+            const payload = {
+                filters_count: filters.length,
+                filters: filters.map((filter) => {
+                    return { key: filter.key, operator: filter.operator, value_length: filter.value.length }
+                }),
+            }
+            posthog.capture('test account filters updated', payload)
         },
     },
 })

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -10,20 +10,22 @@ export function TestAccountFiltersConfig(): JSX.Element {
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
     const { user } = useValues(userLogic)
 
+    const handleChange = (filters: FilterType[]): void => {
+        userUpdateRequest({
+            team: {
+                test_account_filters: filters,
+            },
+        })
+        reportTestAccountFiltersUpdated(filters)
+    }
+
     return (
         <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 8 }}>
                 <PropertyFilters
                     pageKey="testaccountfilters"
                     propertyFilters={user?.team?.test_account_filters}
-                    onChange={(filters: FilterType[]) => {
-                        userUpdateRequest({
-                            team: {
-                                test_account_filters: filters,
-                            },
-                        })
-                        reportTestAccountFiltersUpdated(filters)
-                    }}
+                    onChange={handleChange}
                 />
             </div>
         </div>

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -3,9 +3,11 @@ import { useActions, useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import { FilterType } from '~/types'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export function TestAccountFiltersConfig(): JSX.Element {
     const { userUpdateRequest } = useActions(userLogic)
+    const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
     const { user } = useValues(userLogic)
 
     return (
@@ -14,13 +16,14 @@ export function TestAccountFiltersConfig(): JSX.Element {
                 <PropertyFilters
                     pageKey="testaccountfilters"
                     propertyFilters={user?.team?.test_account_filters}
-                    onChange={(filters: FilterType[]) =>
+                    onChange={(filters: FilterType[]) => {
                         userUpdateRequest({
                             team: {
                                 test_account_filters: filters,
                             },
                         })
-                    }
+                        reportTestAccountFiltersUpdated(filters)
+                    }}
                 />
             </div>
         </div>

--- a/frontend/src/scenes/project/Settings/TimezoneConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TimezoneConfig.tsx
@@ -22,6 +22,7 @@ export function TimezoneConfig(): JSX.Element {
                 loading={currentTeamLoading}
                 value={currentTeam.timezone}
                 onChange={(val) => patchCurrentTeam({ timezone: val })}
+                data-attr="timezone-select"
             >
                 {Object.entries(preflight.available_timezones).map(([tz, offset]) => {
                     const display = `${tz.replace(/\//g, ' / ').replace(/_/g, ' ')} (UTC${


### PR DESCRIPTION
## Changes

This PR:
- Adds relevant information to `insight viewed` on whether the user is making use of formulas or filtering out test accounts.
- Opposite to [discussion](https://github.com/PostHog/posthog/pull/2787#discussion_r556346868), stops blindly sending all filters as an event property to avoid sending any information that could potentially be sensitive. Thoughts @macobo & @yakkomajuri ? The alternative I can think of is specifically redacting all filter values and sending the rest?
- Adds instrumentation around the timezone component.
- Small tweaks to timezone UX. Mainly we revert to showing timezones "GMT+X" instead of "UTC+X", as I believe more users will be familiar with GMT.
- Adds instrumentation to test/internal account filters to know when these are updated.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
