### PR TITLE
Make sure the proper math is applied when calculating top elements for breakdown

### DIFF
--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -90,11 +90,11 @@ class ClickhouseTrendsBreakdown:
             )
         elif filter.breakdown_type == "person":
             _params, breakdown_filter, _breakdown_filter_params, breakdown_value = self._breakdown_person_params(
-                filter, team_id
+                "count(*)" if entity.math == "dau" else aggregate_operation, filter, team_id
             )
         else:
             _params, breakdown_filter, _breakdown_filter_params, breakdown_value = self._breakdown_prop_params(
-                filter, team_id
+                "count(*)" if entity.math == "dau" else aggregate_operation, filter, team_id
             )
 
         if len(_params["values"]) == 0:
@@ -148,7 +148,7 @@ class ClickhouseTrendsBreakdown:
 
         return params, breakdown_filter, breakdown_filter_params, "value"
 
-    def _breakdown_person_params(self, filter: Filter, team_id: int):
+    def _breakdown_person_params(self, aggregate_operation: str, filter: Filter, team_id: int):
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
         prop_filters, prop_filter_params = parse_prop_clauses(
             filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts
@@ -159,6 +159,7 @@ class ClickhouseTrendsBreakdown:
             parsed_date_to=parsed_date_to,
             latest_person_sql=GET_LATEST_PERSON_SQL.format(query=""),
             prop_filters=prop_filters,
+            aggregate_operation=aggregate_operation,
         )
         top_elements_array = self._get_top_elements(elements_query, filter, team_id, params=prop_filter_params)
         params = {
@@ -171,13 +172,16 @@ class ClickhouseTrendsBreakdown:
 
         return params, breakdown_filter, breakdown_filter_params, "value"
 
-    def _breakdown_prop_params(self, filter: Filter, team_id: int):
+    def _breakdown_prop_params(self, aggregate_operation: str, filter: Filter, team_id: int):
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
         prop_filters, prop_filter_params = parse_prop_clauses(
             filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts
         )
         elements_query = TOP_ELEMENTS_ARRAY_OF_KEY_SQL.format(
-            parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to, prop_filters=prop_filters
+            parsed_date_from=parsed_date_from,
+            parsed_date_to=parsed_date_to,
+            prop_filters=prop_filters,
+            aggregate_operation=aggregate_operation,
         )
         top_elements_array = self._get_top_elements(elements_query, filter, team_id, params=prop_filter_params)
         params = {

--- a/ee/clickhouse/sql/trends/top_elements.py
+++ b/ee/clickhouse/sql/trends/top_elements.py
@@ -2,7 +2,7 @@ TOP_ELEMENTS_ARRAY_OF_KEY_SQL = """
 SELECT groupArray(value) FROM (
     SELECT
         JSONExtractRaw(properties, %(key)s) as value,
-        count(*) as count
+        {aggregate_operation} as count
     FROM events e
     WHERE
         team_id = %(team_id)s {parsed_date_from} {parsed_date_to} {prop_filters}

--- a/ee/clickhouse/sql/trends/top_person_props.py
+++ b/ee/clickhouse/sql/trends/top_person_props.py
@@ -1,6 +1,6 @@
 TOP_PERSON_PROPS_ARRAY_OF_KEY_SQL = """
 SELECT groupArray(value) FROM (
-    SELECT value, count(*) as count
+    SELECT value, {aggregate_operation} as count
     FROM
     events e 
     INNER JOIN (SELECT person_id, distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s) as pid ON e.distinct_id = pid.distinct_id

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -434,7 +434,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(
                         data={
                             "display": TRENDS_TABLE,
-                            "interval": "week",
+                            "interval": "day",
                             "breakdown": "$some_property",
                             "events": [{"id": "sign up", "math": "median", "math_property": "$math_prop"}],
                         }
@@ -447,7 +447,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(
                         data={
                             "display": TRENDS_TABLE,
-                            "interval": "day",
+                            "interval": "week",
                             "breakdown": "$some_property",
                             "events": [{"id": "sign up", "math": "median", "math_property": "$math_prop"}],
                         }
@@ -457,6 +457,48 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
 
             self.assertEqual(daily_response[0]["aggregated_value"], 2.0)
             self.assertEqual(daily_response[0]["aggregated_value"], weekly_response[0]["aggregated_value"])
+
+        def test_trends_breakdown_with_math_func(self):
+
+            with freeze_time("2020-01-01 00:06:34"):
+                for i in range(20):
+                    person = person_factory(team_id=self.team.pk, distinct_ids=[f"person{i}"])
+                    event_factory(
+                        team=self.team,
+                        event="sign up",
+                        distinct_id=f"person{i}",
+                        properties={"$some_property": f"value_{i}", "$math_prop": 1},
+                    )
+                    event_factory(
+                        team=self.team,
+                        event="sign up",
+                        distinct_id=f"person{i}",
+                        properties={"$some_property": f"value_{i}", "$math_prop": 1},
+                    )
+
+                person = person_factory(team_id=self.team.pk, distinct_ids=[f"person21"])
+                event_factory(
+                    team=self.team,
+                    event="sign up",
+                    distinct_id=f"person21",
+                    properties={"$some_property": "value_21", "$math_prop": 25},
+                )
+
+            with freeze_time("2020-01-04T13:00:01Z"):
+                daily_response = trends().run(
+                    Filter(
+                        data={
+                            "display": TRENDS_TABLE,
+                            "interval": "day",
+                            "breakdown": "$some_property",
+                            "events": [{"id": "sign up", "math": "p90", "math_property": "$math_prop"}],
+                        }
+                    ),
+                    self.team,
+                )
+
+            breakdown_vals = [val["breakdown_value"] for val in daily_response]
+            self.assertTrue("value_21" in breakdown_vals)
 
         def test_trends_compare(self):
             self._create_events()


### PR DESCRIPTION
## Changes

*Please describe.*  
- the clickhouse implementation of breakdowns runs a query to get top elements that will be queried in the breakdown query but the query previously was not accounting for math_funs
- implements math into the query and adds tests
- fixes[ this issue](https://github.com/PostHog/ops/issues/217)
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
