### PR TITLE
Add warning to breakdown that we only show top 20 values

### DIFF
--- a/frontend/src/scenes/insights/BreakdownFilter.js
+++ b/frontend/src/scenes/insights/BreakdownFilter.js
@@ -108,6 +108,7 @@ function Content({ breakdown, breakdown_type, onChange }) {
                     breakdown={(!breakdown_type || breakdown_type == 'property') && breakdown}
                     onChange={onChange}
                 />
+                <i>Note: We'll only show the 20 values with the most volume.</i>
             </TabPane>
             <TabPane tab="Cohort" key="cohort">
                 <CohortFilter breakdown={breakdown_type == 'cohort' && breakdown} onChange={onChange} />

--- a/frontend/src/scenes/insights/BreakdownFilter.js
+++ b/frontend/src/scenes/insights/BreakdownFilter.js
@@ -108,7 +108,10 @@ function Content({ breakdown, breakdown_type, onChange }) {
                     breakdown={(!breakdown_type || breakdown_type == 'property') && breakdown}
                     onChange={onChange}
                 />
-                <i>Note: We'll only show the 20 values with the most volume.</i>
+                <span className="text-muted">
+                    Note: If there are more than 20 properties, <b>only the top 20</b> with the highest volume{' '}
+                    <b>will be shown</b>.
+                </span>
             </TabPane>
             <TabPane tab="Cohort" key="cohort">
                 <CohortFilter breakdown={breakdown_type == 'cohort' && breakdown} onChange={onChange} />


### PR DESCRIPTION
## Changes

People get confused about this sometimes. I know we have something in the works to be able to show more but this is helpful for now.

![image](https://user-images.githubusercontent.com/1727427/112823715-ead9e580-9089-11eb-803b-ffd45192f9db.png)



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
