### PR TITLE
Add match group count to cohorts table

### DIFF
--- a/frontend/src/scenes/persons/Cohorts.tsx
+++ b/frontend/src/scenes/persons/Cohorts.tsx
@@ -75,6 +75,13 @@ export function Cohorts(): JSX.Element {
             },
             sorter: (a: CohortType, b: CohortType) => (a.count || 0) - (b.count || 0),
         },
+        {
+            title: 'Match groups',
+            render: function RenderCount(_: any, cohort: CohortType) {
+                return cohort.groups.length
+            },
+            sorter: (a: CohortType, b: CohortType) => (a.count || 0) - (b.count || 0),
+        },
         createdAtColumn(),
         createdByColumn(cohorts),
         {


### PR DESCRIPTION
## Changes

Not sure if this is seen as useful by everyone, but I've had quite a few instances where I have cohorts that are a collection of companies for example, and then the total number of users in the cohort doesn't actually tell me how many companies are in the cohort. We're talking cohorts with dozens of match groups here e.g. "Onboarded Users".

So this would be useful to me as a user of PostHog at least.

<img width="1440" alt="Screenshot 2021-03-29 at 11 04 48" src="https://user-images.githubusercontent.com/38760734/112828180-e6f49600-907e-11eb-9c01-c033de303a0c.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
