### PR TITLE
Hide login link from signup if instance is not initiated

### DIFF
--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -209,12 +209,15 @@ export function Signup(): JSX.Element {
                         <h2 className="subtitle" style={{ justifyContent: 'center' }}>
                             Get started
                         </h2>
-                        <div className="text-center" style={{ marginBottom: 32 }}>
-                            Already have an account?{' '}
-                            <Link to="/login" data-attr="signup-login-link">
-                                Sign in
-                            </Link>
-                        </div>
+                        {(preflight?.cloud || preflight?.initiated) && ( // For now, if you're not on cloud, you wouldn't see
+                            // this page, but future-proofing this (with `preflight.initiated`) in case this changes.
+                            <div className="text-center" style={{ marginBottom: 32 }}>
+                                Already have an account?{' '}
+                                <Link to="/login" data-attr="signup-login-link">
+                                    Sign in
+                                </Link>
+                            </div>
+                        )}
                         {!signupResponseLoading &&
                             signupResponse?.errorCode &&
                             !['email', 'password'].includes(signupResponse?.errorAttribute || '') && (


### PR DESCRIPTION
## Changes

On self-hosted, if your instance is not initiated (i.e. you haven't created any user), we hide the "Already have an account? Log in" prompt from the signup page to avoid confusion.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
