### PR TITLE
Skip CI for posthog-contributions-bot

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -6,6 +6,8 @@ env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     REDIS_URL: 'redis://localhost'
 
+if: ${{ github.actor != 'posthog-contributions-bot' }}
+
 jobs:
     backend-code-quality:
         name: Code quality checks

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -6,12 +6,11 @@ env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     REDIS_URL: 'redis://localhost'
 
-if: ${{ github.actor != 'posthog-contributions-bot' }}
-
 jobs:
     backend-code-quality:
         name: Code quality checks
         runs-on: ubuntu-latest
+        if: ${{ github.actor != 'posthog-contributions-bot' }}
 
         services:
             postgres:
@@ -68,6 +67,8 @@ jobs:
     django:
         name: Django tests – Py ${{ matrix.python-version }}
         runs-on: ubuntu-latest
+        if: ${{ github.actor != 'posthog-contributions-bot' }}
+
         strategy:
             fail-fast: false
             matrix:
@@ -144,6 +145,7 @@ jobs:
     cloud:
         name: Django tests – Cloud
         runs-on: ubuntu-latest
+        if: ${{ github.actor != 'posthog-contributions-bot' }}
 
         services:
             postgres:
@@ -270,6 +272,7 @@ jobs:
     foss:
         name: Django tests – FOSS
         runs-on: ubuntu-latest
+        if: ${{ github.actor != 'posthog-contributions-bot' }}
 
         services:
             postgres:

--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -3,12 +3,12 @@ name: Cypress Component
 on:
     - pull_request
 
-if: ${{ github.actor != 'posthog-contributions-bot' }}
-
 jobs:
     cypress-component:
         name: Cypress component tests
         runs-on: ubuntu-18.04
+        if: ${{ github.actor != 'posthog-contributions-bot' }}
+
         steps:
             - name: Checkout
               uses: actions/checkout@v1

--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -3,6 +3,8 @@ name: Cypress Component
 on:
     - pull_request
 
+if: ${{ github.actor != 'posthog-contributions-bot' }}
+
 jobs:
     cypress-component:
         name: Cypress component tests

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -6,6 +6,8 @@ on:
             - master
             - main
 
+if: ${{ github.actor != 'posthog-contributions-bot' }}
+
 jobs:
     build-push:
         name: Build Docker images and push them

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -6,8 +6,6 @@ on:
             - master
             - main
 
-if: ${{ github.actor != 'posthog-contributions-bot' }}
-
 jobs:
     build-push:
         name: Build Docker images and push them

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,12 +3,12 @@ name: E2E
 on:
     - pull_request
 
-if: ${{ github.actor != 'posthog-contributions-bot' }}
-
 jobs:
     cypress:
         name: Cypress E2E tests
         runs-on: ubuntu-18.04
+        if: ${{ github.actor != 'posthog-contributions-bot' }}
+
         strategy:
             # when one test fails, DO NOT cancel the other
             # containers, because this will kill Cypress processes

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,8 @@ name: E2E
 on:
     - pull_request
 
+if: ${{ github.actor != 'posthog-contributions-bot' }}
+
 jobs:
     cypress:
         name: Cypress E2E tests


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

The bot would normally add "[skip ci]" to the commit but given that we have a required check that just never gets reported back and the status never goes green.

The bot only changes the README and .all-contributorsrc, and would still require someone to merge.

A bit of a waste to run all of our actions on such changes, especially since there'll be a lot of them.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
