### PR TITLE
Reply to inviting user on invite emails

### DIFF
--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -86,6 +86,10 @@ class TestOrganizationInvitesAPI(APIBaseTest):
             },
         )
 
+        # Assert invite email is sent
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].reply_to, [self.user.email])  # Reply-To is set to the inviting user
+
     def test_can_create_invites_for_the_same_email_multiple_times(self):
         email = "x@posthog.com"
         count = OrganizationInvite.objects.count()

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -45,7 +45,7 @@ def _send_email(
     headers: Dict,
     txt_body: str = "",
     html_body: str = "",
-    reply_to: str = "",
+    reply_to: Optional[str] = None,
 ) -> None:
     """
     Sends built email message asynchronously.
@@ -110,7 +110,7 @@ class EmailMessage:
         template_name: str,
         template_context: Optional[Dict] = None,
         headers: Optional[Dict] = None,
-        reply_to: str = "",
+        reply_to: Optional[str] = None,
     ):
         if not is_email_available():
             raise exceptions.ImproperlyConfigured("Email is not enabled in this instance.",)

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -67,13 +67,14 @@ def _send_email(
                 continue
 
             records.append(record)
+            reply_to = reply_to or settings.EMAIL_REPLY_TO
 
             email_message = mail.EmailMultiAlternatives(
                 subject=subject,
                 body=txt_body,
                 to=[dest["recipient"]],
                 headers=headers,
-                reply_to=[reply_to or settings.EMAIL_REPLY_TO],
+                reply_to=[reply_to] if reply_to else None,
             )
 
             email_message.attach_alternative(html_body, "text/html")

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -97,7 +97,12 @@ def _send_email(
 
 class EmailMessage:
     def __init__(
-        self, campaign_key: str, subject: str, template_name: str, template_context: Optional[Dict] = None,
+        self,
+        campaign_key: str,
+        subject: str,
+        template_name: str,
+        template_context: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
     ):
         if not is_email_available():
             raise exceptions.ImproperlyConfigured("Email is not enabled in this instance.",)
@@ -107,7 +112,7 @@ class EmailMessage:
         template = get_template(f"email/{template_name}.html")
         self.html_body = inline_css(template.render(template_context))
         self.txt_body = ""
-        self.headers: Dict = {}
+        self.headers = headers if headers else {}
         self.to: List[Dict[str, str]] = []
 
     def add_recipient(self, email: str, name: Optional[str] = None) -> None:

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -507,7 +507,7 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = get_from_env("EMAIL_USE_TLS", False, type_cast=strtobool)
 EMAIL_USE_SSL = get_from_env("EMAIL_USE_SSL", False, type_cast=strtobool)
 DEFAULT_FROM_EMAIL = os.getenv("EMAIL_DEFAULT_FROM", os.getenv("DEFAULT_FROM_EMAIL", "root@localhost"))
-EMAIL_REPLY_TO = os.getenv("EMAIL_REPLY_TO", "")
+EMAIL_REPLY_TO = os.getenv("EMAIL_REPLY_TO", None)
 
 MULTI_TENANCY = False  # overriden by posthog-cloud
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -507,7 +507,7 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = get_from_env("EMAIL_USE_TLS", False, type_cast=strtobool)
 EMAIL_USE_SSL = get_from_env("EMAIL_USE_SSL", False, type_cast=strtobool)
 DEFAULT_FROM_EMAIL = os.getenv("EMAIL_DEFAULT_FROM", os.getenv("DEFAULT_FROM_EMAIL", "root@localhost"))
-EMAIL_REPLY_TO = os.getenv("EMAIL_REPLY_TO")
+EMAIL_REPLY_TO = os.getenv("EMAIL_REPLY_TO", "")
 
 MULTI_TENANCY = False  # overriden by posthog-cloud
 

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -121,7 +121,7 @@ def send_invite(invite_id: str) -> None:
         subject=f"{invite.created_by.first_name} invited you to join {invite.organization.name} on PostHog",
         template_name="invite",
         template_context={"invite": invite},
-        headers={"Reply-To": invite.created_by.email} if invite.created_by and invite.created_by.email else None,
+        reply_to=invite.created_by.email if invite.created_by and invite.created_by.email else "",
     )
     message.add_recipient(email=invite.target_email)
     message.send()

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -121,6 +121,7 @@ def send_invite(invite_id: str) -> None:
         subject=f"{invite.created_by.first_name} invited you to join {invite.organization.name} on PostHog",
         template_name="invite",
         template_context={"invite": invite},
+        headers={"Reply-To": invite.created_by.email} if invite.created_by and invite.created_by.email else None,
     )
     message.add_recipient(email=invite.target_email)
     message.send()


### PR DESCRIPTION
## Changes

Sets the reply to email address to that of the inviting user when receiving a invite to join PostHog. That way the invitee can contact the person who's sending them the invite directly. Prompted by a customer support request.

## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [X] Jest frontend tests. **Not applicable.**
- [X] Cypress end-to-end tests. **Not applicable.**
