### PR TITLE
Fix POSTHOG-DW

### DIFF
--- a/frontend/src/scenes/events/EventsTable.js
+++ b/frontend/src/scenes/events/EventsTable.js
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import dayjs from 'dayjs'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { EventDetails } from 'scenes/events/EventDetails'
-import { ExportOutlined, ClearOutlined } from '@ant-design/icons'
+import { ExportOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
 import { Button, Row, Spin, Table, Tooltip, Col } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
@@ -166,16 +166,9 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                     <EventName
                         value={eventFilter}
                         onChange={(value) => {
-                            setEventFilter(value)
+                            setEventFilter(value || '')
                         }}
                     />
-                    <Button
-                        disabled={eventFilter === ''}
-                        onClick={() => setEventFilter('')}
-                        style={{ display: 'inline-block', marginLeft: 5 }}
-                    >
-                        <ClearOutlined />
-                    </Button>
                 </Col>
                 <Col span={pageKey === 'events' ? 2 : 4}>
                     <Tooltip title="Up to 100,000 latest events.">


### PR DESCRIPTION
## Changes

Fixes error in which clearing the event filter select caused an exception in Kea reducer.
- Additionally, we remove the additional clear button in favor of the default behavior of clearing within the select.

<img width="236" alt="" src="https://user-images.githubusercontent.com/5864173/112896722-95a2d180-9093-11eb-962a-7dfebc866520.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
