### PR TITLE
Add localhost:3000 into excluded urls

### DIFF
--- a/posthog/migrations/0132_team_test_account_filters.py
+++ b/posthog/migrations/0132_team_test_account_filters.py
@@ -40,7 +40,7 @@ def forward(apps, schema_editor):
             {
                 "key": "$host",
                 "operator": "is_not",
-                "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000", "localhost:3000"],
+                "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000"],
             },
         ]
         if team.organization:

--- a/posthog/migrations/0132_team_test_account_filters.py
+++ b/posthog/migrations/0132_team_test_account_filters.py
@@ -40,7 +40,7 @@ def forward(apps, schema_editor):
             {
                 "key": "$host",
                 "operator": "is_not",
-                "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000"],
+                "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000", "localhost:3000"],
             },
         ]
         if team.organization:

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -24,7 +24,7 @@ class TeamManager(models.Manager):
             {
                 "key": "$host",
                 "operator": "is_not",
-                "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000"],
+                "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000", "localhost:3000"],
             },
         ]
         if organization:

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -20,7 +20,7 @@ class TestTeam(BaseTest):
                 {
                     "key": "$host",
                     "operator": "is_not",
-                    "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000"],
+                    "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000", "localhost:3000"],
                 },
             ],
         )
@@ -36,7 +36,7 @@ class TestTeam(BaseTest):
                 {
                     "key": "$host",
                     "operator": "is_not",
-                    "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000"],
+                    "value": ["localhost:8000", "localhost:5000", "127.0.0.1:8000", "127.0.0.1:3000", "localhost:3000"],
                 },
             ],
         )


### PR DESCRIPTION
## Changes
Related issue: #3800 

- Fix the `create_team_with_test_account_filters` test code.
- Add host `localhost:3000` into initial value.
## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
