### PR TITLE
Default set debug=1 to bin/start

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -3,7 +3,7 @@ set -e
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-DEBUG=1
+export DEBUG=1
 
 ./bin/start-worker &
 ./bin/start-backend &

--- a/bin/start
+++ b/bin/start
@@ -3,6 +3,8 @@ set -e
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
+DEBUG=1
+
 ./bin/start-worker &
 ./bin/start-backend &
 ./bin/start-frontend &


### PR DESCRIPTION
## Changes

Buddy ran into this while running ./bin/start. No reason not to set this.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
