### PR TITLE
Bumped cffi so that pip will install deps for M1 chip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ certifi==2019.11.28
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.0
+cffi==1.14.5
     # via cryptography
 chardet==3.0.4
     # via requests


### PR DESCRIPTION
## Changes

Bumped `cffi` so that pip installs deps for M1 chip set.

Please see #2916 
