### PR TITLE
Env for async event property usage calculation interval

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -32,6 +32,9 @@ app.conf.broker_pool_limit = 0
 # How frequently do we want to calculate action -> event relationships if async is enabled
 ACTION_EVENT_MAPPING_INTERVAL_SECONDS = settings.ACTION_EVENT_MAPPING_INTERVAL_SECONDS
 
+# How frequently do we want to calculate event property stats if async is enabled
+EVENT_PROPERTY_USAGE_INTERVAL_SECONDS = settings.EVENT_PROPERTY_USAGE_INTERVAL_SECONDS
+
 if settings.STATSD_HOST is not None:
     statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
 
@@ -83,7 +86,11 @@ def setup_periodic_tasks(sender, **kwargs):
         )
 
     if settings.ASYNC_EVENT_PROPERTY_USAGE:
-        sender.add_periodic_task(60 * 60, calculate_event_property_usage.s(), name="calculate event property usage")
+        sender.add_periodic_task(
+            EVENT_PROPERTY_USAGE_INTERVAL_SECONDS,
+            calculate_event_property_usage.s(),
+            name="calculate event property usage",
+        )
 
 
 @app.task(ignore_result=True)

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -177,9 +177,12 @@ PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", not TEST, type
 ASYNC_EVENT_ACTION_MAPPING = PRIMARY_DB == RDBMS.POSTGRES and get_from_env(
     "ASYNC_EVENT_ACTION_MAPPING", True, type_cast=strtobool
 )
+ACTION_EVENT_MAPPING_INTERVAL_SECONDS = get_from_env("ACTION_EVENT_MAPPING_INTERVAL_SECONDS", 300, type_cast=int)
 
 ASYNC_EVENT_PROPERTY_USAGE = get_from_env("ASYNC_EVENT_PROPERTY_USAGE", False, type_cast=strtobool)
-ACTION_EVENT_MAPPING_INTERVAL_SECONDS = get_from_env("ACTION_EVENT_MAPPING_INTERVAL_SECONDS", 300, type_cast=int)
+EVENT_PROPERTY_USAGE_INTERVAL_SECONDS = get_from_env(
+    "ASYNC_EVENT_PROPERTY_USAGE_INTERVAL_SECONDS", 60 * 60, type_cast=int
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/


### PR DESCRIPTION
## Changes

- Adds `EVENT_PROPERTY_USAGE_INTERVAL_SECONDS` = 1h
- Should help a customer
- I followed the same naming convention as for `ASYNC_EVENT_ACTION_MAPPING`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
