### PR TITLE
change created_at to _timestamp

### DIFF
--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -205,32 +205,6 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 0)
 
-    def test_cohort_updated_props(self):
-        # The way clickhouse works is that updates aren't instant, so two people with the same ID are in the database
-        # Make sure we get the last one.
-        person1 = _create_person(
-            distinct_ids=["some_other_id_2"],
-            team_id=self.team.pk,
-            properties={"$some_prop": "updated"},
-            timestamp=datetime(2020, 1, 1, 12, 0, 1),
-        )
-        _create_person(
-            uuid=person1.uuid,
-            distinct_ids=["some_other_id"],
-            team_id=self.team.pk,
-            properties={"$some_prop": "something"},
-            timestamp=datetime(2020, 1, 1, 12, 0, 4),
-        )
-
-        cohort1 = Cohort.objects.create(
-            team=self.team, groups=[{"properties": {"$some_prop": "updated"}}], name="cohort1",
-        )
-
-        final_query, params = format_filter_query(cohort1)
-
-        result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 0)
-
     def test_cohort_get_person_ids_by_cohort_id(self):
         user1 = _create_person(distinct_ids=["user1"], team_id=self.team.pk, properties={"$some_prop": "something"})
         user2 = _create_person(distinct_ids=["user2"], team_id=self.team.pk, properties={"$some_prop": "another"})

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -59,8 +59,8 @@ FROM kafka_{table_name}
 
 GET_LATEST_PERSON_SQL = """
 SELECT * FROM person JOIN (
-    SELECT id, max(created_at) as created_at FROM person WHERE team_id = %(team_id)s GROUP BY id
-) as person_max ON person.id = person_max.id AND person.created_at = person_max.created_at
+    SELECT id, max(_timestamp) as _timestamp FROM person WHERE team_id = %(team_id)s GROUP BY id
+) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp
 WHERE team_id = %(team_id)s
 {query}
 """


### PR DESCRIPTION
## Changes

*Please describe.*  
- currently using `created_at` to find latest person row but duplicates are requiring `_timestamp` to properly filter them out
- removing test because it's testing irrelevant version of code (relying on `created_at` when you really need `_timestamp`)

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
