### PR TITLE
Allow math filter on $time property

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -257,8 +257,9 @@ function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAv
 }
 
 function MathPropertySelector(props) {
+    console.log(props.properties)
     const applicableProperties = props.properties
-        .filter(({ value }) => value[0] !== '$' && value !== 'distinct_id' && value !== 'token')
+        .filter(({ value }) => (value[0] !== '$' || value === '$time') && value !== 'distinct_id' && value !== 'token')
         .sort((a, b) => (a.value + '').localeCompare(b.value))
 
     return (

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -257,7 +257,6 @@ function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAv
 }
 
 function MathPropertySelector(props) {
-    console.log(props.properties)
     const applicableProperties = props.properties
         .filter(({ value }) => (value[0] !== '$' || value === '$time') && value !== 'distinct_id' && value !== 'token')
         .sort((a, b) => (a.value + '').localeCompare(b.value))


### PR DESCRIPTION
## Changes

Allows using the math filters on the `$time` property. This enables a workaround for a use case reported by a customer in which they want to see a list of users and their last log in time.

Definitely a workaround because the datetimes are not parsed and hard to read. Definitely considering a better solution for this.

<img width="900" alt="" src="https://user-images.githubusercontent.com/5864173/113063060-8aba7080-9169-11eb-88d8-a014ef5f20cd.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
