### PR TITLE
Fix 2K0

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -13,7 +13,7 @@ import {
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { isMobile, triggerResizeAfterADelay } from 'lib/utils'
+import { isMobile } from 'lib/utils'
 import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import lgLogo from 'public/posthog-logo-white.svg'
 import smLogo from 'public/icon-white.svg'
@@ -245,7 +245,6 @@ export function MainNavigation(): JSX.Element {
                 trigger={null}
                 onCollapse={(collapsed) => {
                     setMenuCollapsed(collapsed)
-                    triggerResizeAfterADelay()
                 }}
                 className="navigation-main"
             >

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -5,7 +5,7 @@ import { prompt } from 'lib/logic/prompt'
 import { router } from 'kea-router'
 import { toast } from 'react-toastify'
 import React from 'react'
-import { clearDOMTextSelection, toParams, triggerResizeAfterADelay } from 'lib/utils'
+import { clearDOMTextSelection, toParams } from 'lib/utils'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
 import { PATHS_VIZ, ACTIONS_LINE_GRAPH_LINEAR } from 'lib/constants'
 import { ViewType } from 'scenes/insights/insightLogic'
@@ -353,11 +353,6 @@ export const dashboardLogic = kea({
                     toast.dismiss(cache.draggingToastId)
                     cache.draggingToastId = null
                 }
-            }
-
-            // Full screen mode special handling
-            if (mode === DashboardMode.Fullscreen) {
-                triggerResizeAfterADelay()
             }
 
             eventUsageLogic.actions.reportDashboardModeToggled(mode, source)

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -359,7 +359,9 @@ export const dashboardLogic = kea({
         },
         addGraph: () => {
             router.actions.push(
-                `/insights?insight=TRENDS#backTo=${values.dashboard.name}&backToURL=/dashboard/${values.dashboard.id}`
+                `/insights?insight=TRENDS#backTo=${encodeURIComponent(values.dashboard.name)}&backToURL=/dashboard/${
+                    values.dashboard.id
+                }`
             )
         },
         saveNewTag: ({ tag }) => {


### PR DESCRIPTION
## Changes

This PR:
- Fixes bug 2K0, caused by dashboards having names with special characters (`%` in this case). Diagnosed with [session recording](https://app.posthog.com/person/H-KTGQ4qR4kWNqZx3OKqaWDiKfz1GoYM6ZBEB--g3bE?date=2021-03-26&sessionRecordingId=1786f4cce441622-0f660188924269-6518207c-13c680-1786f4cce4513cc&filters=%5B%7B%22type%22%3A%22event_type%22%2C%22key%22%3A%22id%22%2C%22value%22%3A%22%24exception%22%2C%22label%22%3A%22%24exception%22%7D%5D). @yakkomajuri FYI this was one bug that would've been almost impossible to figure out without capturing the dashboard name on session recording (just as a good discussion point).
- Removes unnecessary resize event triggers as neither the navbar nor the fullscreen modes require them to display dashboards correctly.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
