### PR TITLE
Less dancing in dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -322,24 +322,24 @@
 
     @keyframes keyframes1 {
         0% {
-            transform: rotate(-0.5deg);
+            transform: rotate(-0.2deg);
             animation-timing-function: ease-in;
         }
 
         50% {
-            transform: rotate(0.75deg);
+            transform: rotate(0.2deg);
             animation-timing-function: ease-out;
         }
     }
 
     @keyframes keyframes2 {
         0% {
-            transform: rotate(0.5deg);
+            transform: rotate(0.2deg);
             animation-timing-function: ease-in;
         }
 
         50% {
-            transform: rotate(-0.75deg);
+            transform: rotate(-0.2deg);
             animation-timing-function: ease-out;
         }
     }

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -5,7 +5,7 @@ import { useActions, useValues } from 'kea'
 import { Responsive, WidthProvider } from 'react-grid-layout'
 
 import { DashboardItem } from 'scenes/dashboard/DashboardItem'
-import { triggerResize, triggerResizeAfterADelay } from 'lib/utils'
+import { isMobile, triggerResize, triggerResizeAfterADelay } from 'lib/utils'
 import { DashboardItemType, DashboardMode } from '~/types'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -27,7 +27,9 @@ export function DashboardItems({ inSharedMode }: { inSharedMode: boolean }): JSX
     // can not click links when dragging and 250ms after
     const isDragging = useRef(false)
     const dragEndTimeout = useRef<number | null>(null)
-    const className = 'layout' + (dashboardMode === DashboardMode.Edit ? ' dragging-items wobbly' : '')
+    const className =
+        'layout' +
+        (dashboardMode === DashboardMode.Edit ? (isMobile() ? ' dragging-items wobbly' : ' dragging-items') : '')
 
     return (
         <ReactGridLayout


### PR DESCRIPTION
## Changes

- Closes #3671.
- The dashboard wobbling is now only shown when the user is on a mobile device (see motivation on related issue).
- Reduces the noise in the wobbly effect in the dashboard edit mode. 
![image](https://user-images.githubusercontent.com/5864173/114108364-ce0e9080-9887-11eb-9d82-cb8767170516.gif)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
