### PR TITLE
Fix apt-get install error when building docker images

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /code
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u1 git=1:2.20.1-2+deb10u3 build-essential=12.6 \
+    && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 git=1:2.20.1-2+deb10u3 build-essential=12.6 \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=14.16.0-1nodesource1 \
     && rm -rf /var/lib/apt/lists/* \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -8,7 +8,7 @@ COPY . /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u1 git=1:2.20.1-2+deb10u3 build-essential=12.6 \
+    && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 git=1:2.20.1-2+deb10u3 build-essential=12.6 \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=14.16.0-1nodesource1 \
     && npm install -g yarn@1 \


### PR DESCRIPTION
The error was:

```
The following packages have unmet dependencies:
  curl : Depends: libcurl4 (= 7.64.0-4+deb10u1) but 7.64.0-4+deb10u2 is to be installed
```

## Changes

After opening https://github.com/PostHog/posthog/pull/3832 I noticed a CI check failing, which this change fixes.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
