### PR TITLE
Add PostHog version to system status

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -23,6 +23,7 @@ from posthog.utils import (
     is_postgres_alive,
     is_redis_alive,
 )
+from posthog.version import VERSION
 
 from .utils import (
     get_available_social_auth_providers,
@@ -78,6 +79,8 @@ def system_status(request):
 
     metrics: List[Dict[str, Union[str, bool, int, float]]] = []
 
+    metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
+
     metrics.append(
         {
             "key": "analytics_database",
@@ -91,6 +94,15 @@ def system_status(request):
             "key": "ingestion_server",
             "metric": "Event ingestion via",
             "value": "Plugin Server" if settings.PLUGIN_SERVER_INGESTION else "Django",
+        }
+    )
+
+    metrics.append({"key": "plugin_sever_alive", "metric": "Plugin server alive", "value": is_plugin_server_alive()})
+    metrics.append(
+        {
+            "key": "plugin_sever_version",
+            "metric": "Plugin server version",
+            "value": get_plugin_server_version() or "unknown",
         }
     )
 
@@ -154,15 +166,6 @@ def system_status(request):
             metrics.append(
                 {"metric": "Redis metrics", "value": f"Redis connected but then failed to return metrics: {e}"}
             )
-
-    metrics.append({"key": "plugin_sever_alive", "metric": "Plugin server alive", "value": is_plugin_server_alive()})
-    metrics.append(
-        {
-            "key": "plugin_sever_version",
-            "metric": "Plugin server version",
-            "value": get_plugin_server_version() or "unknown",
-        }
-    )
 
     return JsonResponse({"results": metrics})
 


### PR DESCRIPTION
## Changes

- Making screenshot debugging easier, one commit at a time
- Adds the posthog version to the top of the list
- Moves the plugin server info a bit higher up

![image](https://user-images.githubusercontent.com/53387/113260991-3204e800-92cf-11eb-9404-349923624225.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
