### PR TITLE
Clarify project settings filter wording

### DIFF
--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -155,17 +155,16 @@ export function ProjectSettings(): JSX.Element {
                 <TimezoneConfig />
                 <Divider />
                 <h2 className="subtitle" id="internal-users-filtering">
-                    Filtering out internal and test users
+                    Filter Out Events
                 </h2>
                 <p>
-                    Increase the quality of your analytics results by filtering out internal users such as test accounts
-                    and team members from queries. This way only <b>real user data</b> will be taken into account.
+                    Increase the quality of your analytics results by filtering out events from team members, test
+                    accounts, and development environments. The events will still be captured and logged but will be
+                    excluded from queries, graphs, and other analyses.
                 </p>
                 <p>
-                    <i>
-                        For best effectiveness, make sure to properly define <b>non-internal</b> users with the filters
-                        below.
-                    </i>
+                    For example, <code>email ∌ example.com</code> to exclude all events from users on your team and{' '}
+                    <code>Host ≠ localhost:8000</code> to exclude all events from local development environments.
                 </p>
                 <TestAccountFiltersConfig />
                 <Divider />


### PR DESCRIPTION
## Changes

Clarifies the wording around filtering out events so they are not included in queries. Default values are added upon project creation but if those are deleted it's not 100% clear how filtering should work so examples have been added to the textual description.

Renamed heading to clarify and fixed capitalization to be consistent with other headings.

Also, clarifies that events will still be captured and logged but that those events won't be used within queries.

<img width="1552" alt="Screen Shot 2021-04-01 at 14 01 05" src="https://user-images.githubusercontent.com/328367/113297617-bb79e180-92f2-11eb-96b2-631f7b76dba4.png">

Notes: 

- I've run `yarn jest` to run the front-end tests but I couldn't see how to run the Cypress tests so have left that unchecked in the Checklist below.

## Checklist

- ~[ ] All querysets/queries filter by Organization, by Team, and by User~
- ~[ ] Django backend tests~
- [X] Jest frontend tests
- [ ] Cypress end-to-end tests
