### PR TITLE
Remove IS_DOCKER env var

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,6 @@ services:
             - '8000:8000'
             - '8234:8234'
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
             SECRET_KEY: '<randomly generated secret key>'
@@ -45,7 +44,6 @@ services:
         volumes:
             - .:/code
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
             SECRET_KEY: '<randomly generated secret key>'

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -20,7 +20,6 @@ services:
         ports:
             - '8000:8000'
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             REDIS_URL: 'redis://redis:6379/'
             SECRET_KEY: '<randomly generated secret key>'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
             - redis
         environment:
             DATABASE_URL: postgres://posthog:posthog@db:5432/posthog
-            IS_DOCKER: 'true'
             REDIS_URL: redis://redis:6379/
             SECRET_KEY: <randomly generated secret key>
         image: posthog/posthog:latest

--- a/ee/docker-compose.ch.test.yml
+++ b/ee/docker-compose.ch.test.yml
@@ -24,7 +24,6 @@ services:
             - '8000:8000'
             - '8234:8234'
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog'
@@ -53,7 +52,6 @@ services:
         volumes:
             - ..:/code
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog'

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -24,7 +24,6 @@ services:
             - '8000:8000'
             - '8234:8234'
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog'
@@ -52,7 +51,6 @@ services:
         volumes:
             - ..:/code
         environment:
-            IS_DOCKER: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog'

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -65,10 +65,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "IS_DOCKER",
-                    "value": "True"
-                },
-                {
                     "name": "KAFKA_BASE64_KEYS",
                     "value": "True"
                 },

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -71,10 +71,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "IS_DOCKER",
-                    "value": "True"
-                },
-                {
                     "name": "KAFKA_BASE64_KEYS",
                     "value": "True"
                 },

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -65,10 +65,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "IS_DOCKER",
-                    "value": "True"
-                },
-                {
                     "name": "KAFKA_BASE64_KEYS",
                     "value": "True"
                 },


### PR DESCRIPTION
## Changes

It appears that the `IS_DOCKER` env var has never been actually used since being added in a9e412c49db84dc50c5a7e101edf70aec282544b, it just got rolled over all the time, so ended up being defined in a bunch of places and read nowhere. This PR removes it altogether. Resolves #3836. Closes #3840.