### PR TITLE
Make `.text-muted` half opacity black instead of solid light gray

### DIFF
--- a/frontend/src/scenes/sessions/filters/EditFiltersPanel.tsx
+++ b/frontend/src/scenes/sessions/filters/EditFiltersPanel.tsx
@@ -97,7 +97,7 @@ export function EditFiltersPanel({ onSubmit }: Props): JSX.Element | null {
                                         data-attr="edit-session-filter"
                                     >
                                         <strong>{item.label}</strong>
-                                        <DownOutlined style={{ fontSize: 12, color: '#bfbfbf' }} />
+                                        <DownOutlined style={{ fontSize: 12, color: 'rgba(0,0,0,0.5)' }} />
                                     </Button>
                                     <SessionsFilterBox selector={selector} />
                                 </div>

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -16,7 +16,7 @@ $brand_yellow: #f9bd2b;
 // Text colors
 $text_default: #2d2d2d;
 $text_light: rgba(255, 255, 255, 0.88);
-$text_muted: #bfbfbf;
+$text_muted: rgba(0, 0, 0, 0.5);
 $text_muted_alt: #35416b;
 
 // Background colors


### PR DESCRIPTION
## Changes

As @corywatilo noted, `.text-muted` may be _too_ muted, especially for off-white backgrounds. This makes that class's text color half opacity black instead of solid light gray, which should make things better. Resolves #3799.

| Before | After |
| --- | --- |
| <img width="666" alt="Screen Shot 2021-04-01 at 17 43 55" src="https://user-images.githubusercontent.com/4550621/113321869-4f0fda00-9314-11eb-9bf0-ed00120e5318.png"> | <img width="644" alt="Screen Shot 2021-04-01 at 17 44 20" src="https://user-images.githubusercontent.com/4550621/113321878-51723400-9314-11eb-817c-01ab13abbffa.png"> |
| <img width="698" alt="Screen Shot 2021-04-01 at 17 43 27" src="https://user-images.githubusercontent.com/4550621/113321876-50d99d80-9314-11eb-81b9-162a07e82378.png"> | <img width="700" alt="Screen Shot 2021-04-01 at 17 44 43" src="https://user-images.githubusercontent.com/4550621/113321882-520aca80-9314-11eb-8a67-c1f920ae20c1.png"> |
