### PR TITLE
Clarify "Filter Out ..." settings copy

### DIFF
--- a/frontend/src/scenes/insights/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/TestAccountFilter.tsx
@@ -24,7 +24,7 @@ export function TestAccountFilter({
                     : "You don't have internal users filtering set up. Click the gear icon to configure it."
             }
         >
-            <Row style={{ alignItems: 'center' }}>
+            <Row style={{ alignItems: 'center', flexWrap: 'nowrap' }}>
                 <Switch
                     disabled={!hasFilters}
                     checked={hasFilters ? filters.filter_test_accounts : false}

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -160,7 +160,7 @@ export function ProjectSettings(): JSX.Element {
                 <p>
                     Increase the quality of your analytics results by filtering out events from internal sources, such
                     as team members, test accounts, or development environments. The data be saved nonetheless, however
-                    you'll be able to exclude it from queries with the "Filter out internal and test users " setting
+                    you'll be able to exclude it from queries with the "Filter out internal and test users" setting
                     during analysis.
                 </p>
                 <p>

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -155,16 +155,18 @@ export function ProjectSettings(): JSX.Element {
                 <TimezoneConfig />
                 <Divider />
                 <h2 className="subtitle" id="internal-users-filtering">
-                    Filter Out Events
+                    Filter Out Internal and Test Users
                 </h2>
                 <p>
-                    Increase the quality of your analytics results by filtering out events from team members, test
-                    accounts, and development environments. The events will still be captured and logged but will be
-                    excluded from queries, graphs, and other analyses.
+                    Increase the quality of your analytics results by filtering out events from internal sources, such
+                    as team members, test accounts, or development environments. The data be saved nonetheless, however
+                    you'll be able to exclude it from queries with the "Filter out internal and test users " setting
+                    during analysis.
                 </p>
                 <p>
-                    For example, <code>email ∌ example.com</code> to exclude all events from users on your team and{' '}
-                    <code>Host ≠ localhost:8000</code> to exclude all events from local development environments.
+                    Example filters to use below: <i>email ∌ yourcompany.com</i> to exclude all events from your
+                    company's employees, or <i>Host ∌ localhost</i> to exclude all events from local development
+                    environments.
                 </p>
                 <TestAccountFiltersConfig />
                 <Divider />


### PR DESCRIPTION
## Changes

Further clarified information on the filtering out option. #3839 made this copy partly better, but also partly less clear (e.g. that this happens only when the relevant setting is enabled in Insights).

Before
<img width="962" alt="Screen Shot 2021-04-01 at 19 32 47" src="https://user-images.githubusercontent.com/4550621/113332953-2858a000-9322-11eb-9326-9422f364db0c.png">

After
<img width="960" alt="Screen Shot 2021-04-01 at 19 31 56" src="https://user-images.githubusercontent.com/4550621/113332959-2a226380-9322-11eb-9bf7-91712260151e.png">
