### PR TITLE
Improve clarity of main nav hotkeys

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -139,8 +139,16 @@ code.code {
     margin-bottom: $default_spacing * 0.5;
 }
 
+.mb-025 {
+    margin-bottom: $default_spacing * 0.25;
+}
+
 .mt-05 {
     margin-top: $default_spacing * 0.5;
+}
+
+.mt-025 {
+    margin-top: $default_spacing * 0.25;
 }
 
 .mr {
@@ -155,8 +163,16 @@ code.code {
     margin-right: $default_spacing * 0.5;
 }
 
+.mr-025 {
+    margin-right: $default_spacing * 0.25;
+}
+
 .ml-05 {
     margin-left: $default_spacing * 0.5;
+}
+
+.ml-025 {
+    margin-left: $default_spacing * 0.25;
 }
 
 .pa {

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -552,3 +552,12 @@ code.code {
     align-items: center;
     justify-content: center;
 }
+
+.hotkey-plus {
+    display: inline;
+    &::after {
+        content: '+';
+        margin-left: 6px;
+        font-size: 1rem;
+    }
+}

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -105,6 +105,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
                                 {hotkey && featureFlags['hotkeys-3740'] && (
                                     <>
                                         <span className="hotkey menu-tooltip-hotkey">G</span>
+                                        <span className="hotkey-plus" />
                                         <span className="hotkey menu-tooltip-hotkey">{hotkey.toUpperCase()}</span>
                                     </>
                                 )}

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -100,7 +100,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
                 title={
                     tooltip && !isMobile() ? (
                         <>
-                            <div className="mb-05">
+                            <div className="mb-025">
                                 <b>{title}</b>
                                 {hotkey && featureFlags['hotkeys-3740'] && (
                                     <>


### PR DESCRIPTION
## Changes

Styling adjustments. This adds a plus sign between hotkeys in combinations and slightly reduces margins inside tooltip.

Before
<img width="332" alt="Screen Shot 2021-04-01 at 20 09 29" src="https://user-images.githubusercontent.com/4550621/113336126-33adca80-9326-11eb-92a5-f17f6143e0fb.png">

After
<img width="333" alt="Screen Shot 2021-04-01 at 20 08 55" src="https://user-images.githubusercontent.com/4550621/113336048-17aa2900-9326-11eb-881c-904755f08ccc.png">

