### PR TITLE
New env: UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -35,6 +35,9 @@ ACTION_EVENT_MAPPING_INTERVAL_SECONDS = settings.ACTION_EVENT_MAPPING_INTERVAL_S
 # How frequently do we want to calculate event property stats if async is enabled
 EVENT_PROPERTY_USAGE_INTERVAL_SECONDS = settings.EVENT_PROPERTY_USAGE_INTERVAL_SECONDS
 
+# How frequently do we want to check if dashboard items need to be recalculated
+UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS = settings.UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS
+
 if settings.STATSD_HOST is not None:
     statsd.Connection.set_defaults(host=settings.STATSD_HOST, port=settings.STATSD_PORT)
 
@@ -68,7 +71,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 
-    sender.add_periodic_task(90, check_cached_items.s(), name="check dashboard items")
+    sender.add_periodic_task(
+        UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS, check_cached_items.s(), name="check dashboard items"
+    )
 
     if is_ee_enabled():
         sender.add_periodic_task(120, clickhouse_lag.s(), name="clickhouse table lag")

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -184,6 +184,10 @@ EVENT_PROPERTY_USAGE_INTERVAL_SECONDS = get_from_env(
     "ASYNC_EVENT_PROPERTY_USAGE_INTERVAL_SECONDS", 60 * 60, type_cast=int
 )
 
+UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS = get_from_env(
+    "UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS", 90, type_cast=int
+)
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 


### PR DESCRIPTION
## Changes

- Adds new env `UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS`
- This is currently set to 90 seconds (no change)
- The script that it controls re-runs queries for all dashboard items
- This is way too frequent with you have a lot of dashboard items and not enough muscle in your database. The same items that take over 90 seconds to queue will get queued over and over again.
- This results in a race condition where the worker exceeds all clickhouse pool connections and too much load on the database
- With the env, we can at least control it to a degree

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
