### PR TITLE
Resolves #3801 - Test users filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/OperatorValueSelect.tsx
@@ -72,6 +72,11 @@ export function OperatorValueSelect({
     )
 }
 
+type CustomOptionsType = {
+    value: PropertyOperator
+    label: string
+}
+
 export function OperatorSelect({ operator, operators, onChange }: OperatorSelectProps): JSX.Element {
     return (
         <Select
@@ -84,7 +89,7 @@ export function OperatorSelect({ operator, operators, onChange }: OperatorSelect
             }}
             placeholder="Property key"
             onChange={(_value, op) => {
-                const newOperator = op as { value: PropertyOperator } & Record<string, any>
+                const newOperator = op as typeof op & CustomOptionsType
                 onChange(newOperator.value)
             }}
         >

--- a/frontend/src/lib/components/PropertyFilters/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/OperatorValueSelect.tsx
@@ -83,13 +83,14 @@ export function OperatorSelect({ operator, operators, onChange }: OperatorSelect
                 label: operatorMap[operator || 'exact'],
             }}
             placeholder="Property key"
-            onChange={(_, newOperator) => {
-                onChange(newOperator.value as PropertyOperator)
+            onChange={(_value, op) => {
+                const newOperator = op as { value: PropertyOperator } & Record<string, any>
+                onChange(newOperator.value)
             }}
         >
-            {operators.map((operator) => (
-                <Select.Option key={operator} value={operator || 'exact'}>
-                    {operatorMap[operator || 'exact']}
+            {operators.map((op) => (
+                <Select.Option key={op} value={op || 'exact'}>
+                    {operatorMap[op || 'exact']}
                 </Select.Option>
             ))}
         </Select>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -46,7 +46,7 @@ function PropertyPaneContents({
     return (
         <>
             <Row gutter={8} className="full-width" wrap={false}>
-                <Col span={8}>
+                <Col flex={1} style={{ minWidth: '15vw' }}>
                     <PropertySelect
                         value={
                             type === 'cohort'
@@ -85,7 +85,10 @@ function PropertyPaneContents({
                             }
                         }}
                         columnOptions={{
-                            span: 8,
+                            flex: 1,
+                            style: {
+                                maxWidth: '33.3vw',
+                            },
                         }}
                     />
                 )}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -46,7 +46,7 @@ function PropertyPaneContents({
     return (
         <>
             <Row gutter={8} className="full-width" wrap={false}>
-                <Col flex={'1'}>
+                <Col span={8}>
                     <PropertySelect
                         value={
                             type === 'cohort'
@@ -84,7 +84,9 @@ function PropertyPaneContents({
                                 onComplete()
                             }
                         }}
-                        columnOptions={{ flex: '1' }}
+                        columnOptions={{
+                            span: 8,
+                        }}
                     />
                 )}
             </Row>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -58,11 +58,11 @@ function PropertyPaneContents({
                                           propkey,
                                   }
                         }
-                        onChange={(type, value) =>
+                        onChange={(type, _value) =>
                             setThisFilter(
-                                value,
+                                _value,
                                 undefined,
-                                value === '$active_feature_flags' ? 'icontains' : operator,
+                                _value === '$active_feature_flags' ? 'icontains' : operator,
                                 type
                             )
                         }

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -46,7 +46,7 @@ function PropertyPaneContents({
     return (
         <>
             <Row gutter={8} className="full-width" wrap={false}>
-                <Col flex={1} style={{ minWidth: '15vw' }}>
+                <Col flex={1} style={{ minWidth: '11rem' }}>
                     <PropertySelect
                         value={
                             type === 'cohort'
@@ -87,7 +87,7 @@ function PropertyPaneContents({
                         columnOptions={{
                             flex: 1,
                             style: {
-                                maxWidth: '33.3vw',
+                                maxWidth: '50vw',
                             },
                         }}
                     />

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -39,7 +39,10 @@ function PropertyPaneContents({
         optionGroups.push({
             type: 'element',
             label: 'Elements',
-            options: ['tag_name', 'text', 'href', 'selector'].map((value) => ({ value, label: value })),
+            options: ['tag_name', 'text', 'href', 'selector'].map((option) => ({
+                value: option,
+                label: option,
+            })),
         })
     }
 
@@ -58,12 +61,12 @@ function PropertyPaneContents({
                                           propkey,
                                   }
                         }
-                        onChange={(type, _value) =>
+                        onChange={(newType, newValue) =>
                             setThisFilter(
-                                _value,
+                                newValue,
                                 undefined,
-                                _value === '$active_feature_flags' ? 'icontains' : operator,
-                                type
+                                newValue === '$active_feature_flags' ? 'icontains' : operator,
+                                newType
                             )
                         }
                         optionGroups={optionGroups}
@@ -144,9 +147,10 @@ export function PropertyFilter({ index, onComplete, logic }) {
     let { key, value, operator, type } = filters[index]
     const [activeKey, setActiveKey] = useState(type === 'cohort' ? 'cohort' : 'property')
 
-    const setThisFilter = useCallback((key, value, operator, type) => setFilter(index, key, value, operator, type), [
-        index,
-    ])
+    const setThisFilter = useCallback(
+        (newKey, newValue, newOperator, newType) => setFilter(index, newKey, newValue, newOperator, newType),
+        [index]
+    )
 
     const displayOperatorAndValue = key && type !== 'cohort'
 

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -29,7 +29,14 @@ const FilterRow = React.memo(function FilterRow({
     }
 
     return (
-        <Row align="middle" className="mt-05 mb-05" data-attr={'property-filter-' + index}>
+        <Row
+            align="middle"
+            className="mt-05 mb-05"
+            data-attr={'property-filter-' + index}
+            style={{
+                maxWidth: '90vw',
+            }}
+        >
             <Popover
                 trigger="click"
                 onVisibleChange={handleVisibleChange}

--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -38,8 +38,8 @@ export function PropertySelect({ optionGroups, value, onChange, placeholder, aut
             value={value || undefined}
             filterOption={(input, option) => option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
             onChange={(_: null, selection) => {
-                const { value, type } = selection as SelectionOptionType
-                onChange(type, value.replace(/^(event_|person_|element_)/gi, ''))
+                const { value: val, type } = selection as SelectionOptionType
+                onChange(type, val.replace(/^(event_|person_|element_)/gi, ''))
             }}
             style={{ width: '100%' }}
             virtual={false}

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -46,6 +46,11 @@ export function PropertyValue({
         }
     }
 
+    function setValue(newValue) {
+        onSet(newValue)
+        setInput('')
+    }
+
     useEffect(() => {
         loadPropertyValues('')
     }, [propertyKey])
@@ -66,9 +71,9 @@ export function PropertyValue({
                 style={{ width: '100%', ...style }}
                 onChange={(value, payload) => {
                     if (isOperatorMulti(operator) && payload.length > 0) {
-                        onSet(value)
+                        setValue(value)
                     } else {
-                        onSet(payload?.value ?? null)
+                        setValue(payload?.value ?? null)
                     }
                 }}
                 value={value || placeholder}

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -64,11 +64,11 @@ export function PropertyValue({
                 showSearch
                 autoFocus={!value && !isMobile()}
                 style={{ width: '100%', ...style }}
-                onChange={(_, payload) => {
+                onChange={(value, payload) => {
                     if (isOperatorMulti(operator) && payload.length > 0) {
-                        onSet(payload.map(({ value: val }) => val))
+                        onSet(value)
                     } else {
-                        onSet((payload && payload.value) || null)
+                        onSet(payload?.value ?? null)
                     }
                 }}
                 value={value || placeholder}

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -69,9 +69,9 @@ export function PropertyValue({
                 showSearch
                 autoFocus={!value && !isMobile()}
                 style={{ width: '100%', ...style }}
-                onChange={(value, payload) => {
+                onChange={(val, payload) => {
                     if (isOperatorMulti(operator) && payload.length > 0) {
-                        setValue(value)
+                        setValue(val)
                     } else {
                         setValue(payload?.value ?? null)
                     }

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -106,6 +106,7 @@ export function PropertyValue({
                         value={id || name}
                         data-attr={'prop-val-' + index}
                         className="ph-no-capture"
+                        title={name}
                     >
                         {name === true && 'true'}
                         {name === false && 'false'}

--- a/frontend/src/lib/components/SelectGradientOverflow.scss
+++ b/frontend/src/lib/components/SelectGradientOverflow.scss
@@ -11,3 +11,35 @@
         @extend .mixin-gradient-overlay;
     }
 }
+
+.ant-select-selection-overflow-item {
+    .ant-tag {
+        margin: 1px 4px 1px 0;
+        display: flex;
+        align-items: center;
+        flex-basis: auto;
+        flex-grow: 0;
+        flex-shrink: 0;
+        overflow: hidden;
+        padding: 0 4px 0 8px;
+        font-size: inherit;
+        line-height: inherit;
+        background: #f5f5f5;
+        border: 1px solid #f0f0f0;
+        user-select: none;
+        .label {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .btn-close {
+            font-size: 10px;
+            margin-left: 4px;
+            .anticon-close {
+                color: rgba(0, 0, 0, 0.45);
+                & :hover {
+                    color: rgba(0, 0, 0, 0.75);
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, RefObject, useEffect, useRef } from 'react'
 import { Select } from 'antd'
 import { SelectProps } from 'antd/lib/select'
 import './SelectGradientOverflow.scss'
+import { CloseButton } from './CloseButton'
 
 interface DropdownGradientRendererProps {
     updateScrollGradient: () => void
@@ -18,6 +19,27 @@ function DropdownGradientRenderer({
         updateScrollGradient()
     })
     return <div ref={innerRef}>{menu}</div>
+}
+
+/**
+ * Ant Design does not export the component used in multi-select lists,
+ * so we're recreating it with a title property for better UX
+ */
+type CustomTagProps = Parameters<Exclude<SelectProps<any>['tagRender'], undefined>>[0]
+
+function CustomTag({ label, onClose, value }: CustomTagProps): JSX.Element {
+    return (
+        <div className="ant-select-selection-overflow-item">
+            <span className="ant-select-selection-item">
+                <span className="ant-select-selection-item-content" title={value.toString()}>
+                    {label}
+                </span>
+                <span className="ant-select-selection-item-remove" unselectable="on" aria-hidden="true">
+                    <CloseButton onClick={onClose} style={{ cursor: 'pointer', float: 'none', color: 'inherit' }} />
+                </span>
+            </span>
+        </div>
+    )
 }
 
 /**
@@ -53,6 +75,7 @@ export function SelectGradientOverflow(props: SelectProps<any>): JSX.Element {
             onPopupScroll={() => {
                 updateScrollGradient()
             }}
+            tagRender={CustomTag}
             dropdownRender={(menu) => (
                 <DropdownGradientRenderer
                     menu={menu}

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, RefObject, useEffect, useRef } from 'react'
-import { Select } from 'antd'
+import { Select, Tag, Tooltip } from 'antd'
 import { SelectProps } from 'antd/lib/select'
 import './SelectGradientOverflow.scss'
 import { CloseButton } from './CloseButton'
@@ -22,23 +22,18 @@ function DropdownGradientRenderer({
 }
 
 /**
- * Ant Design does not export the component used in multi-select lists,
- * so we're recreating it with a title property for better UX
+ * Ant Design Tag with custom styling in .scss to match default style
  */
 type CustomTagProps = Parameters<Exclude<SelectProps<any>['tagRender'], undefined>>[0]
 
 function CustomTag({ label, onClose, value }: CustomTagProps): JSX.Element {
     return (
-        <div className="ant-select-selection-overflow-item">
-            <span className="ant-select-selection-item">
-                <span className="ant-select-selection-item-content" title={value.toString()}>
-                    {label}
-                </span>
-                <span className="ant-select-selection-item-remove" unselectable="on" aria-hidden="true">
-                    <CloseButton onClick={onClose} style={{ cursor: 'pointer', float: 'none', color: 'inherit' }} />
-                </span>
-            </span>
-        </div>
+        <Tooltip title={value.toString()}>
+            <Tag>
+                <span className="label">{label}</span>
+                <CloseButton onClick={onClose} />
+            </Tag>
+        </Tooltip>
     )
 }
 


### PR DESCRIPTION
## Changes

- Fixes disappearing filters in "Filter out test users" section of project settings
- Flex-sized columns in the property pane are now fixed width
- Closes #3801

As shown here, the fixed-width columns obscure some data. This might not be ideal, even though it looks less "jumpy" than before.

<img width="889" alt="Screen Shot 2021-04-01 at 6 23 18 PM" src="https://user-images.githubusercontent.com/4645779/113360321-85028d80-9317-11eb-9a98-e9c32c23cba7.png">

First PR in this repository! Please feel free to point out anything about code style, naming of branches/commits, etc. that can ease my transition into the team.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
