### PR TITLE
Fix cached trends on dashboards not loading

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -161,7 +161,7 @@ export const trendsLogic = kea<
             __default: {} as TrendResponse,
             loadResults: async (refresh = false, breakpoint) => {
                 if (props.cachedResults && !refresh && values.filters === props.filters) {
-                    return props.cachedResults
+                    return { result: props.cachedResults } as TrendResponse
                 }
                 insightLogic.actions.startQuery()
                 let response
@@ -180,6 +180,7 @@ export const trendsLogic = kea<
                         )
                     }
                 } catch (e) {
+                    console.error(e)
                     breakpoint()
                     insightLogic.actions.endQuery(values.filters.insight || ViewType.TRENDS, null, e)
                     return []


### PR DESCRIPTION
## Changes

Fixes an issue (we accidentally missed it on #3782) in which cached trends would not load on dashboards. Originally reported on [Slack](https://posthog.slack.com/archives/C0113360FFV/p1617318009104400).

Additionally, we'll now log these errors in the console to at least get a Sentry report, and be able to troubleshoot faster.

<img width="800" alt="" src="https://user-images.githubusercontent.com/5864173/113368099-6f936080-9323-11eb-980e-54005fd43ade.png">

Worth considering for the future: adding tests for cached items. Maybe this is a job for component tests?

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
