### PR TITLE
Update plugin server in ee/docker-compose.* to 0.15.4

### DIFF
--- a/ee/docker-compose.ch.test.yml
+++ b/ee/docker-compose.ch.test.yml
@@ -70,7 +70,7 @@ services:
             - redis:redis
             - kafka:kafka
     plugins:
-        image: posthog/plugin-server:0.11.3
+        image: posthog/plugin-server:0.15.4
         restart: on-failure
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -69,7 +69,7 @@ services:
             - redis:redis
             - kafka:kafka
     plugins:
-        image: posthog/plugin-server:0.11.3
+        image: posthog/plugin-server:0.15.4
         restart: on-failure
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'


### PR DESCRIPTION
## Changes

This should be autoupdated by the plugin server update workflow, but for some reason wasn't. It's just a development thing, so fixing here for now and will look into the update workflow later.