### PR TITLE
Format label property key

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -238,7 +238,10 @@ export function formatLabel(label: string, action: ActionFilter): string {
     }
     if (action?.properties?.length) {
         label += ` (${action.properties
-            .map((property) => operatorMap[property.operator || 'exact'].split(' ')[0] + ' ' + property.value)
+            .map(
+                (property) =>
+                    `${property.key} ${operatorMap[property.operator || 'exact'].split(' ')[0]} ${property.value}`
+            )
             .join(', ')})`
     }
     return label


### PR DESCRIPTION
## Changes

Adds property key to filter presentation in tooltips.
<img width="361" alt="tooltip" src="https://user-images.githubusercontent.com/4550621/113430125-eb4fe480-93d9-11eb-949f-f1bec4c937d2.png">
Noticed we were missing this while refactoring #3063.

## Checklist

- [ ] Jest frontend tests
