### PR TITLE
Fix feature flags insight link

### DIFF
--- a/cypress/integration/featureFlags.js
+++ b/cypress/integration/featureFlags.js
@@ -33,6 +33,11 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-submit]').click()
         cy.get('.Toastify__toast-body').click() // clicking the toast gets you back to the list
         cy.get('[data-attr=feature-flag-table]').should('contain', 'beta-feature-updated')
+
+        cy.get('[data-attr=usage]').click()
+        cy.location().should((loc) => {
+            expect(loc.pathname.toString()).to.contain('/insight')
+        })
     })
 
     it('Delete feature flag', () => {

--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -82,6 +82,7 @@ export function FeatureFlags(): JSX.Element {
                             BackTo
                         }
                         data-attr="usage"
+                        onClick={(e) => e.stopPropagation()}
                     >
                         Insights <ExportOutlined />
                     </Link>


### PR DESCRIPTION
## Changes

The click was hi-jacked by the click on the row itself so you couldn't actually open the link 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
