### PR TITLE
Update constants.tsx to rename "Active users" to "Unique users"

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -74,7 +74,7 @@ export const MATHS: Record<string, any> = {
         type: EVENT_MATH_TYPE,
     },
     dau: {
-        name: 'Unique events',
+        name: 'Unique instance of event',
         description: (
             <>
                 Users active in the time interval.

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -74,7 +74,7 @@ export const MATHS: Record<string, any> = {
         type: EVENT_MATH_TYPE,
     },
     dau: {
-        name: 'Unique instance of event',
+        name: 'Unique users',
         description: (
             <>
                 Users active in the time interval.

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -74,7 +74,7 @@ export const MATHS: Record<string, any> = {
         type: EVENT_MATH_TYPE,
     },
     dau: {
-        name: 'Active users',
+        name: 'Unique events',
         description: (
             <>
                 Users active in the time interval.


### PR DESCRIPTION
Rename dropdown option to be more clear

## Changes

The event aggregation dropdown includes an option titled *Active users*

In the constants file, this parameter has the following description:

> If a user performs an event 3 times in a given day/week/month, it counts only as 1.

Imo a clearer option for this option would be *Unique users*

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests