### PR TITLE
set platform when footer chosen

### DIFF
--- a/frontend/src/scenes/ingestion/panels/FrameworkGrid.tsx
+++ b/frontend/src/scenes/ingestion/panels/FrameworkGrid.tsx
@@ -132,6 +132,7 @@ export function FrameworkGrid(): JSX.Element {
                     style={{ marginLeft: 5 }}
                     className="button-border clickable"
                     onClick={() => {
+                        setPlatform(frameworkToPlatform(API))
                         setFramework(API)
                     }}
                 >


### PR DESCRIPTION
## Changes

Fixes a bug where there's no back navigation if you choose the footer API option on the new ingestion grid.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
