### PR TITLE
Reduce visual weight for dashboard placeholders

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -58,7 +58,7 @@ export function Dashboards(): JSX.Element {
             dataIndex: 'description',
             key: 'description',
             render: function Render(description: string) {
-                return <>{description || <span style={{ color: 'var(--muted)' }}>Dashboard has no description</span>}</>
+                return <>{description || <span style={{ color: 'var(--muted)' }}>-</span>}</>
             },
         },
         {
@@ -69,7 +69,7 @@ export function Dashboards(): JSX.Element {
                 return tags.length ? (
                     <ObjectTags tags={tags} staticOnly />
                 ) : (
-                    <span style={{ color: 'var(--muted)' }}>Dashboard has no tags</span>
+                    <span style={{ color: 'var(--muted)' }}>-</span>
                 )
             },
             filters: dashboardTags.map((tag) => {


### PR DESCRIPTION
## Changes
Use less text to display empty descriptions / tags.

Reduces visual weight on dashboard pages with missing info– [discussion.](https://posthog.slack.com/archives/C01RJ7T212S/p1617672803017800)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
