### PR TITLE
Fix shared dashboard rendering with multiline descriptions

### DIFF
--- a/frontend/src/shared_dashboard.ejs
+++ b/frontend/src/shared_dashboard.ejs
@@ -5,9 +5,9 @@
       window.__SHARED_DASHBOARD__ = {
         id: {{dashboard.id}},
         share_token: '{{dashboard.share_token}}',
-        name: '{{dashboard.name}}',
-        description: '{{dashboard.description}}',
-        team_name: '{{team_name}}'
+        name: `{{dashboard.name}}`,
+        description: `{{dashboard.description}}`,
+        team_name: `{{team_name}}`
       }
     </script>
     {% include "head.html" %}


### PR DESCRIPTION
## Changes

Dashboards which had multi-line descriptions were not rendering properly when shared.

Reported by a [user](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1617719908063200)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
