### PR TITLE
Make docker apt version pinning less strict

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=7.* git=1:2.* build-essential=12.6 \
+    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs=14.* postgresql-client-12=12.* \
+    && apt-get install -y --no-install-recommends 'nodejs=14.*' 'postgresql-client-12=12.*' \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g yarn@1 \
     && yarn config set network-timeout 300000 \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 git=1:2.20.1-2+deb10u3 build-essential=12.6 \
+    && apt-get install -y --no-install-recommends curl=7.* git=1:2.* build-essential=12.6 \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs=14.16.0-1nodesource1 postgresql-client-12=12.6-1.pgdg100+1 \
+    && apt-get install -y --no-install-recommends nodejs=14.* postgresql-client-12=12.* \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g yarn@1 \
     && yarn config set network-timeout 300000 \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -8,9 +8,9 @@ COPY . /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=7.* git=1:2.* build-essential=12.6 \
+    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=14.* \
+    && apt-get install -y --no-install-recommends 'nodejs=14.*' \
     && npm install -g yarn@1 \
     && yarn config set network-timeout 300000 \
     && yarn --frozen-lockfile \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -8,9 +8,9 @@ COPY . /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 git=1:2.20.1-2+deb10u3 build-essential=12.6 \
+    && apt-get install -y --no-install-recommends curl=7.* git=1:2.* build-essential=12.6 \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs=14.16.0-1nodesource1 \
+    && apt-get install -y --no-install-recommends nodejs=14.* \
     && npm install -g yarn@1 \
     && yarn config set network-timeout 300000 \
     && yarn --frozen-lockfile \


### PR DESCRIPTION
## Changes

Fixes the following error that I got today when running `COMPOSE_FILE=docker-compose.dev.yml docker-compose up -d`:
```
#6 20.65 Warning: apt-key output should not be parsed (stdout is not a terminal)
#6 21.16 OK
#6 21.27 Hit:1 http://deb.debian.org/debian buster InRelease
#6 21.27 Hit:2 http://security.debian.org/debian-security buster/updates InRelease
#6 21.27 Hit:3 http://deb.debian.org/debian buster-updates InRelease
#6 21.35 Hit:4 https://deb.nodesource.com/node_14.x buster InRelease
#6 21.71 Get:5 http://apt.postgresql.org/pub/repos/apt buster-pgdg InRelease [104 kB]
#6 22.27 Get:6 http://apt.postgresql.org/pub/repos/apt buster-pgdg/main amd64 Packages [219 kB]
#6 22.46 Fetched 322 kB in 1s (266 kB/s)
#6 22.46 Reading package lists...
#6 23.10 Reading package lists...
#6 23.67 Building dependency tree...
#6 23.81 Reading state information...
#6 23.89 E: Version '14.16.0-1nodesource1' for 'nodejs' was not found
------
executor failed running [/bin/bash -o pipefail -c apt-get update     && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 git=1:2.20.1-2+deb10u3 build-essential=12.6     && curl -sL https://deb.nodesource.com/setup_14.x | bash -     && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list     && apt-get update     && apt-get install -y --no-install-recommends nodejs=14.16.0-1nodesource1 postgresql-client-12=12.6-1.pgdg100+1     && rm -rf /var/lib/apt/lists/*     && npm install -g yarn@1     && yarn config set network-timeout 300000     && yarn --frozen-lockfile]: exit code: 100
```

Version pinning was introduced in https://github.com/PostHog/posthog/pull/3663 to solve https://github.com/hadolint/hadolint/wiki/DL3008 .

The goal of this change is to avoid the docker build process from breaking when a newer version is available. This `xxx.*` approach is used as example (like: `s3cmd=1.1.*`) on https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get which 
DL3008 links to.

No errors/warnings reported by hadolint with this change:
```
$ docker run -it --rm -v $PWD:/app -w /app hadolint/hadolint hadolint *.Dockerfile -f json
[]
```

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
