### PR TITLE
Fix property popover arrow placement on cohorts page

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -16,6 +16,7 @@ const FilterRow = React.memo(function FilterRow({
     pageKey,
     showConditionBadge,
     totalCount,
+    popoverPlacement,
 }) {
     const { remove } = useActions(logic)
     let [open, setOpen] = useState(false)
@@ -35,7 +36,7 @@ const FilterRow = React.memo(function FilterRow({
                 onVisibleChange={handleVisibleChange}
                 defaultVisible={false}
                 visible={open}
-                placement="bottomLeft"
+                placement={popoverPlacement || 'bottomLeft'}
                 content={<PropertyFilter key={index} index={index} onComplete={() => setOpen(false)} logic={logic} />}
             >
                 {key ? (
@@ -70,6 +71,7 @@ export function PropertyFilters({
     onChange = null,
     pageKey,
     showConditionBadge = false,
+    popoverPlacement = null,
 }) {
     const logic = propertyFilterLogic({ propertyFilters, endpoint, onChange, pageKey })
     const { filters } = useValues(logic)
@@ -88,6 +90,7 @@ export function PropertyFilters({
                             filters={filters}
                             pageKey={pageKey}
                             showConditionBadge={showConditionBadge}
+                            popoverPlacement={popoverPlacement}
                         />
                     )
                 })}

--- a/frontend/src/scenes/persons/CohortGroup.tsx
+++ b/frontend/src/scenes/persons/CohortGroup.tsx
@@ -86,6 +86,7 @@ export function CohortGroup({
                             }}
                             propertyFilters={group.properties || {}}
                             style={{ margin: '1rem 0 0' }}
+                            popoverPlacement="bottomRight"
                         />
                     )}
                     {selected == 'action' && (


### PR DESCRIPTION
## Changes

Before:

<img width="1855" alt="Screen Shot 2021-04-07 at 13 53 04" src="https://user-images.githubusercontent.com/611271/113862710-11460200-97a9-11eb-813a-b5d39b4586c8.png">

After:

<img width="1855" alt="Screen Shot 2021-04-07 at 13 53 57" src="https://user-images.githubusercontent.com/611271/113862732-1a36d380-97a9-11eb-875d-d4363a590a06.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
