### PR TITLE
Fix events with spaces and only add URL for pageviews

### DIFF
--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -74,11 +74,8 @@ export function ManageEvents(): JSX.Element {
                     queries where made using this event.
                     <br />
                     <br />
-                    {user?.is_event_property_usage_enabled ? (
-                        <EventsVolumeTable />
-                    ) : (
-                        <UsageDisabledWarning tab="Events Stats" />
-                    )}
+                    <EventsVolumeTable />
+                    {!user?.is_event_property_usage_enabled && <UsageDisabledWarning tab="Events Stats" />}
                 </Tabs.TabPane>
                 <Tabs.TabPane tab="Properties Stats" key="properties">
                     See all property keys that have ever been sent to this team, including the volume and how often

--- a/frontend/src/scenes/events/createActionFromEvent.js
+++ b/frontend/src/scenes/events/createActionFromEvent.js
@@ -34,8 +34,12 @@ export async function createActionFromEvent(event, increment, recurse = createAc
         steps: [
             {
                 event: event.event,
-                url: event.properties.$current_url,
-                url_matching: 'exact',
+                ...(event.event === '$pageview'
+                    ? {
+                          url: event.properties.$current_url,
+                          url_matching: 'exact',
+                      }
+                    : {}),
                 ...(event.elements.length > 0 ? elementsToAction(event.elements) : {}),
             },
         ],

--- a/frontend/src/scenes/events/createActionFromEvent.js
+++ b/frontend/src/scenes/events/createActionFromEvent.js
@@ -34,7 +34,7 @@ export async function createActionFromEvent(event, increment, recurse = createAc
         steps: [
             {
                 event: event.event,
-                ...(event.event === '$pageview'
+                ...(event.event === '$pageview' || event.event === '$autocapture'
                     ? {
                           url: event.properties.$current_url,
                           url_matching: 'exact',

--- a/frontend/src/scenes/events/createActionFromEvent.test.js
+++ b/frontend/src/scenes/events/createActionFromEvent.test.js
@@ -40,7 +40,7 @@ describe('createActionFromEvent()', () => {
 
             expect(api.create).toHaveBeenCalledWith('api/action', {
                 name: 'some-event event',
-                steps: [{ event: 'some-event', url: 'http://foo.bar/some/path', url_matching: 'exact' }],
+                steps: [{ event: 'some-event' }],
             })
         })
 
@@ -59,7 +59,7 @@ describe('createActionFromEvent()', () => {
 
                 expect(api.create).toHaveBeenCalledWith('api/action', {
                     name: 'some-event event 4',
-                    steps: [{ event: 'some-event', url: 'http://foo.bar/some/path', url_matching: 'exact' }],
+                    steps: [{ event: 'some-event' }],
                 })
             })
         })


### PR DESCRIPTION
## Changes

Fixes two issues:
- User had events with trailing spaces. This works correctly in most of our system, but when saving an action we'd trim that trailing space.
- We would add the url for most actions, but we'd only show the URL if it was a $pageview, leading to confusing behaviour. Now we only add the url to actions with $pageview.

I thought about automatically trimming the spaces off of new events but that would cause a whole host of backwards compatibility issues

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
