### PR TITLE
Fix commandpallet test

### DIFF
--- a/cypress/integration/commandPalette.js
+++ b/cypress/integration/commandPalette.js
@@ -5,6 +5,7 @@ describe('Command Palette', () => {
     })
 
     it('Shows on Ctrl + K press', () => {
+        cy.wait(1000)
         cy.get('body').type('{ctrl}k')
         cy.get('[data-attr=command-palette-input]').should('exist')
 

--- a/cypress/integration/commandPalette.js
+++ b/cypress/integration/commandPalette.js
@@ -5,7 +5,7 @@ describe('Command Palette', () => {
     })
 
     it('Shows on Ctrl + K press', () => {
-        cy.wait(1000)
+        cy.get('[data-attr=layout-content]').contains('Insights')
         cy.get('body').type('{ctrl}k')
         cy.get('[data-attr=command-palette-input]').should('exist')
 


### PR DESCRIPTION
## Changes

I think this works. Just waits until the page has loaded before sending the key combo

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
