### PR TITLE
Log to sentry when migrations are out of date

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -2,6 +2,7 @@ import os
 from functools import wraps
 from typing import Dict, List, Union
 
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required as base_login_required
@@ -55,6 +56,8 @@ def health(request):
     plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
     status = 503 if plan else 200
     if status == 503:
+        err = Exception("Migrations are not up to date. If this continues migrations have failed")
+        sentry_sdk.capture_exception(err)
         return HttpResponse("Migrations are not up to date", status=status, content_type="text/plain")
     if status == 200:
         return HttpResponse("ok", status=status, content_type="text/plain")


### PR DESCRIPTION
## Changes

Currently if migrations have failed we just will no longer deploy the most recent version of the app. This can cause issues when plugin-server is expecting a new feature to be available.

Fail loudly when migrations are not up to date 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
