### PR TITLE
Update autocapture label to be more descriptive

### DIFF
--- a/frontend/src/scenes/ingestion/panels/FrameworkGrid.tsx
+++ b/frontend/src/scenes/ingestion/panels/FrameworkGrid.tsx
@@ -24,7 +24,7 @@ const getDisplayName = (frameworks: Record<string, string>, item: Framework | st
     if (item?.toString() === 'PURE_JS') {
         return 'JAVASCRIPT SDK'
     } else if (item?.toString() === 'AUTOCAPTURE') {
-        return 'Auto Capture (JS Snippet)'
+        return 'Auto Capture (HTML Tag)'
     } else if (item?.toString() === 'NODEJS') {
         return 'NODE JS'
     } else {


### PR DESCRIPTION
## Changes
Changing the description of autocapture from 'JS Snippet' to 'HTML Tag' – that's a more accurate representation of what it is, and is familiar to how GA talks about their tags, so less technical folks should get it too (i.e. the wordpress, blog usecase). 

See this [slack thread](https://posthogusers.slack.com/archives/C0189CTRDF1/p1617790789047000) for the inspo.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
