### PR TITLE
Fix navigation to insights from dashboards

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -113,4 +113,12 @@ describe('Dashboard', () => {
         cy.get('[data-attr="dashboard-item-0-dropdown-move-0"]').click({ force: true })
         cy.get('[data-attr=success-toast]').should('exist')
     })
+
+    it('Opens dashboard item in insights', () => {
+        cy.get('[data-attr=dashboard-name]').contains('My App Dashboard').click()
+        cy.get('[data-attr=dashboard-item-0] .dashboard-item-title a').click()
+        cy.location('pathname').should('include', '/insights')
+        cy.get('[data-attr=math-selector-0]').contains('Active users').should('exist')
+        cy.get('[data-attr=trend-line-graph]').should('exist')
+    })
 })

--- a/cypress/integration/person.js
+++ b/cypress/integration/person.js
@@ -1,6 +1,6 @@
 describe('Person Visualization Check', () => {
     beforeEach(() => {
-        cy.get('[data-attr=menu-item-persons]').click()
+        cy.get('[data-attr=menu-item-persons]').click().click()
         cy.get('.ant-spin-spinning').should('not.exist') // Wait until initial table load to be able to use the search
         cy.get('[data-attr=persons-search]').type('deb').should('have.value', 'deb')
         cy.get('.ant-input-search-button').click()

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -519,7 +519,7 @@ export const trendsLogic = kea<
                     cleanSearchParams['compare'] = false
                 }
 
-                Object.assign(cleanSearchParams, getDefaultFilters(values.filters, values.eventNames))
+                Object.assign(cleanSearchParams, getDefaultFilters(cleanSearchParams, values.eventNames))
 
                 if (!objectsEqual(cleanSearchParams, values.filters)) {
                     actions.setFilters(cleanSearchParams, false)


### PR DESCRIPTION
## Changes

Fixes a minor bug introduced in #3866 in which navigation from dashboards to insights was broken (filters would get reset after navigating).
- Adds a test to catch this behavior in the future.

## Checklist

- [X] All querysets/queries filter by Organization, by Team, and by User. **Not applicable**
- [X] Django backend tests. **Not applicable**
- [X] Jest frontend tests
- [X] Cypress end-to-end tests
- [X] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious. **Not applicable**
