### PR TITLE
Bump cryptography to 3.4.7 and add macosx_arm64 install script

### DIFF
--- a/bin/install-macosx_arm64
+++ b/bin/install-macosx_arm64
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install scripts for M1 Macs
+# See https://github.com/PostHog/posthog/issues/2916
+# NB: use cryptography==3.4.7
+
+# Set ld flags to use OpenSSL installed with brew
+export LDFLAGS="-L$(brew --prefix openssl)/lib"
+export CPPFLAGS="-I$(brew --prefix openssl)/include"
+
+# Use system OpenSSL instead of BoringSSL for GRPC
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
+
+pip cache purge
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ clickhouse-driver==0.2.0
     #   clickhouse-pool
 clickhouse-pool==0.4.3
     # via -r requirements.in
-cryptography==3.3.2
+cryptography==3.4.7
     # via
     #   kafka-helper
     #   social-auth-core


### PR DESCRIPTION
## Changes

I found that I was able to install PostHog locally on an M1 Mac by bumping `cryptography` to 3.4.7 and setting flags as mentioned in issue #2916. Per the cryptography [release log](https://cryptography.io/en/latest/changelog.html), it looks like 3.4.x removed support for python2. Correct me if I'm wrong but I believe we already don't support python2.

Again I am not a superuser of Python so I hope this doesn't break anything. But the install script in `bin` might provide a better developer experience for new hires/contributors working on Apple silicon.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
