### PR TITLE
Use default axes on line graphs

### DIFF
--- a/frontend/src/scenes/insights/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph.js
@@ -291,8 +291,6 @@ export function LineGraph({
                         gridLines: { color: axisLineColor, zeroLineColor: axisColor },
                         ticks: percentage
                             ? {
-                                  min: 0,
-                                  max: 100, // Your absolute max value
                                   callback: function (value) {
                                       return value.toFixed(0) + '%' // convert it to percentage
                                   },


### PR DESCRIPTION
## Changes
Addresses https://github.com/PostHog/posthog/issues/3882

We had a min and max value set which [overrode ChartJS's logic](https://www.chartjs.org/docs/latest/axes/cartesian/#axis-range-settings) (cmd+f 'min' 'max') to determine axis sizes for percentage charts. This let's chartJS decide the axis based on the values.

Uses chartjs' defaults to build the axis on line graphs.
<img width="1653" alt="Screen Shot 2021-04-09 at 2 52 26 PM" src="https://user-images.githubusercontent.com/5965891/114248301-33c45080-994c-11eb-96c5-22995b860159.png">
<img width="1658" alt="Screen Shot 2021-04-09 at 2 58 44 PM" src="https://user-images.githubusercontent.com/5965891/114248303-358e1400-994c-11eb-9ab1-6fc3acc5d814.png">
<img width="1641" alt="Screen Shot 2021-04-09 at 2 59 03 PM" src="https://user-images.githubusercontent.com/5965891/114248304-3626aa80-994c-11eb-8b14-238c041c709c.png">




## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
