### PR TITLE
Remove 'string, parsable as datetime'

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -1,24 +1,22 @@
 import React, { CSSProperties, useMemo, useState } from 'react'
 
-import dayjs from 'dayjs'
 import { keyMapping, PropertyKeyInfo } from './PropertyKeyInfo'
 import { Dropdown, Input, Menu, Popconfirm, Table, Tooltip } from 'antd'
-import { NumberOutlined, CalendarOutlined, BulbOutlined, StopOutlined, DeleteOutlined } from '@ant-design/icons'
+import { NumberOutlined, BulbOutlined, StopOutlined, DeleteOutlined } from '@ant-design/icons'
 import { isURL } from 'lib/utils'
 import { IconExternalLink, IconText } from 'lib/components/icons'
 import './PropertiesTable.scss'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 
-type HandledType = 'string' | 'string, parsable as datetime' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
+type HandledType = 'string' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
 type Type = HandledType | 'symbol' | 'object' | 'function'
 
 const keyMappingKeys = Object.keys(keyMapping.event)
 
 const iconStyle: CSSProperties = { display: 'inline-block', marginRight: '0.5rem', opacity: 0.75 }
 
-const typeToIcon: Record<HandledType | string, JSX.Element> = {
+const typeToIcon: Record<HandledType, JSX.Element> = {
     string: <IconText />,
-    'string, parsable as datetime': <CalendarOutlined />,
     number: <NumberOutlined />,
     bigint: <NumberOutlined />,
     boolean: <BulbOutlined />,
@@ -61,13 +59,7 @@ function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType
     const textBasedTypes = ['string', 'number', 'bigint'] // Values that are edited with a text box
     const boolNullTypes = ['boolean', 'null'] // Values that are edited with the boolNullSelect dropdown
 
-    let valueType: Type = typeof value
-    if (value === null) {
-        // typeof null returns 'object' ¯\_(ツ)_/¯
-        valueType = 'null'
-    } else if (valueType === 'string' && dayjs(value).isValid()) {
-        valueType = 'string, parsable as datetime'
-    }
+    const valueType: Type = value === null ? 'null' : typeof value // typeof null returns 'object' ¯\_(ツ)_/¯
 
     const boolNullSelect = (
         <Menu
@@ -107,13 +99,13 @@ function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType
 
     return (
         <div className="properties-table-value">
-            {typeToIcon[valueType] ? (
+            {typeToIcon[valueType as HandledType] ? (
                 <>
                     {!editing ? (
                         <>
                             <div style={iconStyle}>
                                 <Tooltip title={`Property of type ${valueType}.`}>
-                                    <span>{typeToIcon[valueType]}</span>
+                                    <span>{typeToIcon[valueType as HandledType]}</span>
                                 </Tooltip>
                             </div>
                             {canEdit && boolNullTypes.includes(valueType) ? (


### PR DESCRIPTION
## Changes

This removes `'string, parsable as datetime'` in `PropertiesTable`. That classification is just often more confusing than helpful due to the _very_ loose datetime parsing rules of Day.js - entirely non-datetime strings are presented as datetimes. Resolves #3937.