### PR TITLE
Fixes project settings not loading

### DIFF
--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -8,7 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 export function TestAccountFiltersConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
     const handleChange = (filters: FilterType[]): void => {
         updateCurrentTeam({ test_account_filters: filters })
@@ -18,11 +18,13 @@ export function TestAccountFiltersConfig(): JSX.Element {
     return (
         <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 8 }}>
-                <PropertyFilters
-                    pageKey="testaccountfilters"
-                    propertyFilters={currentTeam?.test_account_filters}
-                    onChange={handleChange}
-                />
+                {!currentTeamLoading && (
+                    <PropertyFilters
+                        pageKey="testaccountfilters"
+                        propertyFilters={currentTeam?.test_account_filters}
+                        onChange={handleChange}
+                    />
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -61,6 +61,12 @@ const logic = kea<logicType>({
         handleTestError: ({ error }) => {
             errorToast('Error validating your webhook', 'Your webhook returned the following error response:', error)
         },
+        [teamLogic.actionTypes.loadCurrentTeamSuccess]: () => {
+            const webhook = teamLogic.values.currentTeam?.slack_incoming_webhook
+            if (webhook) {
+                actions.setEditedWebhook(webhook)
+            }
+        },
     }),
 })
 


### PR DESCRIPTION
## Changes

Fixes two bugs discovered in the _Break the release_ session.
- Webhook will not get loaded after a refresh if the first page being loaded is the /project/settings page.
- Same for test account filters.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
