### PR TITLE
Autofocus filter dropdown

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -72,7 +72,7 @@ function PropertyPaneContents({
                         }
                         optionGroups={optionGroups}
                         autoOpenIfEmpty
-                        delayBeforeAutoOpen={selectProps.delayBeforeAutoOpen}
+                        delayBeforeAutoOpen={selectProps?.delayBeforeAutoOpen}
                         placeholder="Property key"
                     />
                 </Col>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -21,6 +21,7 @@ function PropertyPaneContents({
     operator,
     type,
     displayOperatorAndValue,
+    selectProps,
 }) {
     const optionGroups = [
         {
@@ -71,6 +72,7 @@ function PropertyPaneContents({
                         }
                         optionGroups={optionGroups}
                         autoOpenIfEmpty
+                        delayBeforeAutoOpen={selectProps.delayBeforeAutoOpen}
                         placeholder="Property key"
                     />
                 </Col>
@@ -100,7 +102,7 @@ function PropertyPaneContents({
     )
 }
 
-function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorAndValue }) {
+function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorAndValue, selectProps }) {
     const { cohorts } = useValues(cohortsModel)
 
     return (
@@ -124,6 +126,7 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
                     setThisFilter('id', newFilter.value, undefined, newFilter.type)
                 }}
                 data-attr="cohort-filter-select"
+                selectProps={selectProps}
             >
                 {cohorts.map((item, index) => (
                     <Select.Option
@@ -141,7 +144,7 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
     )
 }
 
-export function PropertyFilter({ index, onComplete, logic }) {
+export function PropertyFilter({ index, onComplete, logic, selectProps }) {
     const { eventProperties, personProperties, filters } = useValues(logic)
     const { setFilter } = useActions(logic)
     let { key, value, operator, type } = filters[index]
@@ -175,6 +178,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     operator={operator}
                     type={type}
                     displayOperatorAndValue={displayOperatorAndValue}
+                    selectProps={selectProps}
                 />
             </TabPane>
             <TabPane tab="Cohort" key="cohort" style={{ display: 'flex' }}>
@@ -183,6 +187,7 @@ export function PropertyFilter({ index, onComplete, logic }) {
                     setThisFilter={setThisFilter}
                     value={value}
                     displayOperatorAndValue={displayOperatorAndValue}
+                    selectProps={selectProps}
                 />
                 {type === 'cohort' && value ? (
                     <Link to={`/cohorts/${value}`} target="_blank">

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -21,7 +21,7 @@ function PropertyPaneContents({
     operator,
     type,
     displayOperatorAndValue,
-    selectProps,
+    selectProps: { delayBeforeAutoOpen = 0 },
 }) {
     const optionGroups = [
         {
@@ -72,7 +72,7 @@ function PropertyPaneContents({
                         }
                         optionGroups={optionGroups}
                         autoOpenIfEmpty
-                        delayBeforeAutoOpen={selectProps?.delayBeforeAutoOpen}
+                        delayBeforeAutoOpen={delayBeforeAutoOpen}
                         placeholder="Property key"
                     />
                 </Col>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -41,10 +41,21 @@ const FilterRow = React.memo(function FilterRow({
             <Popover
                 trigger="click"
                 onVisibleChange={handleVisibleChange}
+                destroyTooltipOnHide={true}
                 defaultVisible={false}
                 visible={open}
                 placement={popoverPlacement || 'bottomLeft'}
-                content={<PropertyFilter key={index} index={index} onComplete={() => setOpen(false)} logic={logic} />}
+                content={
+                    <PropertyFilter
+                        key={index}
+                        index={index}
+                        onComplete={() => setOpen(false)}
+                        logic={logic}
+                        selectProps={{
+                            delayBeforeAutoOpen: 150,
+                        }}
+                    />
+                }
             >
                 {key ? (
                     <PropertyFilterButton onClick={() => setOpen(!open)} item={item} />

--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -12,6 +12,7 @@ interface Props {
     onChange: (type: PropertyOptionGroup['type'], value: string) => void
     placeholder: string
     autoOpenIfEmpty?: boolean
+    delayBeforeAutoOpen?: number | false
 }
 
 interface PropertyOptionGroup {
@@ -32,12 +33,14 @@ export function PropertySelect({
     onChange,
     placeholder,
     autoOpenIfEmpty,
+    delayBeforeAutoOpen,
 }: Props): JSX.Element {
     return (
         <SelectGradientOverflow
             showSearch
             autoFocus={autoOpenIfEmpty && !propertyOption?.value}
             defaultOpen={autoOpenIfEmpty && !propertyOption?.value}
+            delayBeforeAutoOpen={delayBeforeAutoOpen}
             placeholder={placeholder}
             data-attr="property-filter-dropdown"
             labelInValue

--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -26,16 +26,22 @@ interface SelectionOptionType {
     type: 'event' | 'person' | 'element'
 }
 
-export function PropertySelect({ optionGroups, value, onChange, placeholder, autoOpenIfEmpty }: Props): JSX.Element {
+export function PropertySelect({
+    optionGroups,
+    value: propertyOption,
+    onChange,
+    placeholder,
+    autoOpenIfEmpty,
+}: Props): JSX.Element {
     return (
         <SelectGradientOverflow
             showSearch
-            autoFocus={autoOpenIfEmpty && !value}
-            defaultOpen={autoOpenIfEmpty && !value}
+            autoFocus={autoOpenIfEmpty && !propertyOption?.value}
+            defaultOpen={autoOpenIfEmpty && !propertyOption?.value}
             placeholder={placeholder}
             data-attr="property-filter-dropdown"
             labelInValue
-            value={value || undefined}
+            value={propertyOption || undefined}
             filterOption={(input, option) => option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
             onChange={(_: null, selection) => {
                 const { value: val, type } = selection as SelectionOptionType

--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -8,7 +8,7 @@ type PropertyOption = EventProperty
 
 interface Props {
     optionGroups: Array<PropertyOptionGroup>
-    value: PropertyOption | null
+    value: Partial<PropertyOption> | null
     onChange: (type: PropertyOptionGroup['type'], value: string) => void
     placeholder: string
     autoOpenIfEmpty?: boolean

--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -12,7 +12,7 @@ interface Props {
     onChange: (type: PropertyOptionGroup['type'], value: string) => void
     placeholder: string
     autoOpenIfEmpty?: boolean
-    delayBeforeAutoOpen?: number | false
+    delayBeforeAutoOpen?: number
 }
 
 interface PropertyOptionGroup {

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -5,6 +5,7 @@ import { isMobile, isOperatorFlag, isOperatorMulti, isOperatorRegex, isValidRege
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 
 export function PropertyValue({
+    // TODO: Convert to TS.
     propertyKey,
     type,
     endpoint,

--- a/frontend/src/lib/components/PropertyFilters/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyValue.js
@@ -5,7 +5,6 @@ import { isMobile, isOperatorFlag, isOperatorMulti, isOperatorRegex, isValidRege
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 
 export function PropertyValue({
-    // TODO: Convert to TS.
     propertyKey,
     type,
     endpoint,

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -96,15 +96,12 @@ export function SelectGradientOverflow({
         }
     }
     document.addEventListener('click', outsideClickListener)
-
     return (
         <div ref={containerRef}>
             <Select
                 {...props}
                 ref={selectRef}
                 open={isOpen}
-                onClick={() => setOpen(!isOpen)}
-                onSelect={() => setOpen(false)}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 onPopupScroll={() => {

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -52,9 +52,8 @@ export function SelectGradientOverflow({
     const containerRef: React.RefObject<HTMLDivElement> = useRef(null)
     const dropdownRef = useRef<HTMLDivElement>(null)
     const [isOpen, setOpen] = useState(false)
-    const [enableAutoFocus, setEnableAutoFocus] = useState(true)
 
-    function updateScrollGradient(): void {
+    const updateScrollGradient = (): void => {
         const dropdown = dropdownRef.current
         if (!dropdown) {
             return
@@ -75,17 +74,24 @@ export function SelectGradientOverflow({
         }
     }
 
+    const onFocus = (): void => {
+        setTimeout(() => setOpen(true), delayBeforeAutoOpen || 0)
+    }
+
+    const onBlur = (): void => {
+        if (isOpen) {
+            setOpen(false)
+        }
+    }
+
     useEffect(() => {
-        if (autoFocus && enableAutoFocus) {
+        if (autoFocus || defaultOpen) {
             selectRef.current?.focus()
-            setTimeout(() => setOpen(true), delayBeforeAutoOpen || 0)
         }
     }, [autoFocus])
 
     const outsideClickListener = (event: any): void => {
         if (!containerRef.current?.contains(event.target) && isOpen) {
-            setEnableAutoFocus(false)
-            setOpen(false)
             selectRef.current?.blur()
         }
     }
@@ -99,11 +105,12 @@ export function SelectGradientOverflow({
                 open={isOpen}
                 onClick={() => setOpen(!isOpen)}
                 onSelect={() => setOpen(false)}
+                onFocus={onFocus}
+                onBlur={onBlur}
                 onPopupScroll={() => {
                     updateScrollGradient()
                 }}
                 tagRender={CustomTag}
-                defaultOpen={defaultOpen}
                 dropdownRender={(menu) => (
                     <DropdownGradientRenderer
                         menu={menu}

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -88,7 +88,7 @@ export function SelectGradientOverflow({
         if (autoFocus || defaultOpen) {
             selectRef.current?.focus()
         }
-    }, [autoFocus])
+    }, [autoFocus, defaultOpen])
 
     const outsideClickListener = (event: any): void => {
         if (!containerRef.current?.contains(event.target) && isOpen) {

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -40,14 +40,17 @@ function CustomTag({ label, onClose, value }: CustomTagProps): JSX.Element {
 /**
  * Ant Design Select extended with a gradient overlay to indicate a scrollable list.
  */
+
+type SelectGradientOverflowProps = SelectProps<any> & {
+    delayBeforeAutoOpen?: number
+}
+
 export function SelectGradientOverflow({
     autoFocus = false,
     defaultOpen = false,
-    delayBeforeAutoOpen = false,
+    delayBeforeAutoOpen,
     ...props
-}: SelectProps<any> & {
-    delayBeforeAutoOpen?: number | false
-}): JSX.Element {
+}: SelectGradientOverflowProps): JSX.Element {
     const selectRef: React.RefObject<RefSelectProps> | null = useRef(null)
     const containerRef: React.RefObject<HTMLDivElement> = useRef(null)
     const dropdownRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Changes

Fixes #3936. Autofocus logic changed slightly because the value given to `PropertySelect` might actually be an object with undefined values, rather than `null`, and therefore not falsy.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
