### PR TITLE
Refactor funnel filters & fix flexbox sizing

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilterButton.tsx
@@ -9,13 +9,22 @@ import { keyMapping } from '../PropertyKeyInfo'
 export interface Props {
     item: PropertyFilter
     onClick?: () => void
+    style?: React.CSSProperties
 }
 
-const PropertyFilterButton: React.FunctionComponent<Props> = ({ item, onClick }: Props) => {
+const PropertyFilterButton: React.FunctionComponent<Props> = ({ item, onClick, style }: Props) => {
     const { cohorts } = useValues(cohortsModel)
 
     return (
-        <Button type="primary" shape="round" style={{ maxWidth: '75%' }} onClick={onClick}>
+        <Button
+            type="primary"
+            shape="round"
+            style={{
+                maxWidth: '75%',
+                ...style,
+            }}
+            onClick={onClick}
+        >
             <span className="ph-no-capture" style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                 {formatPropertyLabel(item, cohorts, keyMapping)}
             </span>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -9,6 +9,7 @@ import PropertyFilterButton from './PropertyFilterButton'
 import '../../../scenes/actions/Actions.scss'
 
 const FilterRow = React.memo(function FilterRow({
+    buttonStyle,
     item,
     index,
     filters,
@@ -47,7 +48,7 @@ const FilterRow = React.memo(function FilterRow({
                 content={<PropertyFilter key={index} index={index} onComplete={() => setOpen(false)} logic={logic} />}
             >
                 {key ? (
-                    <PropertyFilterButton onClick={() => setOpen(!open)} item={item} />
+                    <PropertyFilterButton onClick={() => setOpen(!open)} item={item} style={buttonStyle || {}} />
                 ) : (
                     <Button type="default" shape="round" data-attr={'new-prop-filter-' + pageKey}>
                         Add filter
@@ -73,6 +74,7 @@ const FilterRow = React.memo(function FilterRow({
 })
 
 export function PropertyFilters({
+    buttonStyle,
     endpoint = null,
     propertyFilters = null,
     onChange = null,
@@ -89,6 +91,7 @@ export function PropertyFilters({
                 filters.map((item, index) => {
                     return (
                         <FilterRow
+                            buttonStyle={buttonStyle}
                             key={index}
                             logic={logic}
                             item={item}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.js
@@ -74,7 +74,7 @@ const FilterRow = React.memo(function FilterRow({
 })
 
 export function PropertyFilters({
-    buttonStyle,
+    buttonStyle = {},
     endpoint = null,
     propertyFilters = null,
     onChange = null,

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -1,17 +1,15 @@
 import React, { useRef } from 'react'
 import { useActions, useValues } from 'kea'
-import { Button, Tooltip, Col, Row, Select } from 'antd'
+import { Button, Col, Row } from 'antd'
 import { EntityTypes } from '../../trends/trendsLogic'
 import { ActionFilterDropdown } from './ActionFilterDropdown'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { PROPERTY_MATH_TYPE, EVENT_MATH_TYPE, MATHS } from 'lib/constants'
+import { MATHS } from 'lib/constants'
 import { DownOutlined, DeleteOutlined } from '@ant-design/icons'
-import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import './ActionFilterRow.scss'
 import { teamLogic } from 'scenes/teamLogic'
-
-const EVENT_MATH_ENTRIES = Object.entries(MATHS).filter(([, item]) => item.type == EVENT_MATH_TYPE)
-const PROPERTY_MATH_ENTRIES = Object.entries(MATHS).filter(([, item]) => item.type == PROPERTY_MATH_TYPE)
+import { MathSelector } from './MathSelector'
+import { MathPropertySelector } from './MathPropertySelector'
 
 const determineFilterLabel = (visible, filter) => {
     if (visible) {
@@ -95,7 +93,7 @@ export function ActionFilterRow({
         value = entity.id || filter.id
     }
     return (
-        <div>
+        <div className="action-filter-row">
             {showOr && (
                 <Row align="center">
                     {index > 0 && (
@@ -193,122 +191,5 @@ export function ActionFilterRow({
                 </div>
             )}
         </div>
-    )
-}
-
-function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAvailable, style }) {
-    const numericalNotice = `This can only be used on properties that have at least one number type occurence in your events.${
-        areEventPropertiesNumericalAvailable ? '' : ' None have been found yet!'
-    }`
-
-    return (
-        <Select
-            style={{ width: 150, ...style }}
-            value={math || 'total'}
-            onChange={(value) => onMathSelect(index, value)}
-            data-attr={`math-selector-${index}`}
-        >
-            <Select.OptGroup key="event aggregates" label="Event aggregation">
-                {EVENT_MATH_ENTRIES.map(([key, { name, description, onProperty }]) => {
-                    const disabled = onProperty && !areEventPropertiesNumericalAvailable
-                    return (
-                        <Select.Option key={key} value={key} data-attr={`math-${key}-${index}`} disabled={disabled}>
-                            <Tooltip
-                                title={
-                                    onProperty ? (
-                                        <>
-                                            {description}
-                                            <br />
-                                            {numericalNotice}
-                                        </>
-                                    ) : (
-                                        description
-                                    )
-                                }
-                                placement="right"
-                            >
-                                <div
-                                    style={{
-                                        height: '100%',
-                                        width: '100%',
-                                        paddingRight: 8,
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                    }}
-                                >
-                                    {name}
-                                </div>
-                            </Tooltip>
-                        </Select.Option>
-                    )
-                })}
-            </Select.OptGroup>
-            <Select.OptGroup key="property aggregates" label="Property aggregation">
-                {PROPERTY_MATH_ENTRIES.map(([key, { name, description, onProperty }]) => {
-                    const disabled = onProperty && !areEventPropertiesNumericalAvailable
-                    return (
-                        <Select.Option key={key} value={key} data-attr={`math-${key}-${index}`} disabled={disabled}>
-                            <Tooltip
-                                title={
-                                    onProperty ? (
-                                        <>
-                                            {description}
-                                            <br />
-                                            {numericalNotice}
-                                        </>
-                                    ) : (
-                                        description
-                                    )
-                                }
-                                placement="right"
-                            >
-                                <div style={{ height: '100%', width: '100%' }}>{name}</div>
-                            </Tooltip>
-                        </Select.Option>
-                    )
-                })}
-            </Select.OptGroup>
-        </Select>
-    )
-}
-
-function MathPropertySelector(props) {
-    const applicableProperties = props.properties
-        .filter(({ value }) => (value[0] !== '$' || value === '$time') && value !== 'distinct_id' && value !== 'token')
-        .sort((a, b) => (a.value + '').localeCompare(b.value))
-
-    return (
-        <SelectGradientOverflow
-            showSearch
-            style={{ width: 150 }}
-            onChange={(_, payload) => props.onMathPropertySelect(props.index, payload && payload.value)}
-            className="property-select"
-            value={props.mathProperty}
-            data-attr="math-property-select"
-            dropdownMatchSelectWidth={350}
-            placeholder={'Select property'}
-        >
-            {applicableProperties.map(({ value, label }) => (
-                <Select.Option
-                    key={`math-property-${value}-${props.index}`}
-                    value={value}
-                    data-attr={`math-property-${value}-${props.index}`}
-                >
-                    <Tooltip
-                        title={
-                            <>
-                                Calculate {MATHS[props.math].name.toLowerCase()} from property <code>{label}</code>.
-                                Note that only {props.name} occurences where <code>{label}</code> is set and a number
-                                will be taken into account.
-                            </>
-                        }
-                        placement="right"
-                        overlayStyle={{ zIndex: 9999999999 }}
-                    >
-                        {label}
-                    </Tooltip>
-                </Select.Option>
-            ))}
-        </SelectGradientOverflow>
     )
 }

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -183,7 +183,7 @@ export function ActionFilterRow({
                 <div className="ml">
                     <PropertyFilters
                         buttonStyle={{
-                            maxWidth: 'calc(100% - 24px)',
+                            maxWidth: 'calc(100% - 24px)', // 24px is padding on .ant-card-body
                         }}
                         pageKey={`${index}-${value}-filter`}
                         properties={eventProperties}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.js
@@ -182,6 +182,9 @@ export function ActionFilterRow({
             {visible && (
                 <div className="ml">
                     <PropertyFilters
+                        buttonStyle={{
+                            maxWidth: 'calc(100% - 24px)',
+                        }}
                         pageKey={`${index}-${value}-filter`}
                         properties={eventProperties}
                         propertyFilters={filter.properties}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.scss
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.scss
@@ -1,5 +1,10 @@
 @import '~/vars';
 
+.action-filter-row {
+    flex-grow: 1;
+    overflow: hidden;
+}
+
 .property-select {
     cursor: pointer;
     margin-top: 6px;

--- a/frontend/src/scenes/insights/ActionFilter/MathPropertySelector.js
+++ b/frontend/src/scenes/insights/ActionFilter/MathPropertySelector.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Tooltip, Select } from 'antd'
+import { MATHS } from 'lib/constants'
+import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
+
+export function MathPropertySelector(props) {
+    const applicableProperties = props.properties
+        .filter(({ value }) => (value[0] !== '$' || value === '$time') && value !== 'distinct_id' && value !== 'token')
+        .sort((a, b) => (a.value + '').localeCompare(b.value))
+
+    return (
+        <SelectGradientOverflow
+            showSearch
+            style={{ width: 150 }}
+            onChange={(_, payload) => props.onMathPropertySelect(props.index, payload && payload.value)}
+            className="property-select"
+            value={props.mathProperty}
+            data-attr="math-property-select"
+            dropdownMatchSelectWidth={350}
+            placeholder={'Select property'}
+        >
+            {applicableProperties.map(({ value, label }) => (
+                <Select.Option
+                    key={`math-property-${value}-${props.index}`}
+                    value={value}
+                    data-attr={`math-property-${value}-${props.index}`}
+                >
+                    <Tooltip
+                        title={
+                            <>
+                                Calculate {MATHS[props.math].name.toLowerCase()} from property <code>{label}</code>.
+                                Note that only {props.name} occurences where <code>{label}</code> is set and a number
+                                will be taken into account.
+                            </>
+                        }
+                        placement="right"
+                        overlayStyle={{ zIndex: 9999999999 }}
+                    >
+                        {label}
+                    </Tooltip>
+                </Select.Option>
+            ))}
+        </SelectGradientOverflow>
+    )
+}

--- a/frontend/src/scenes/insights/ActionFilter/MathSelector.js
+++ b/frontend/src/scenes/insights/ActionFilter/MathSelector.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import { Tooltip, Select } from 'antd'
+import { PROPERTY_MATH_TYPE, EVENT_MATH_TYPE, MATHS } from 'lib/constants'
+
+const EVENT_MATH_ENTRIES = Object.entries(MATHS).filter(([, item]) => item.type == EVENT_MATH_TYPE)
+const PROPERTY_MATH_ENTRIES = Object.entries(MATHS).filter(([, item]) => item.type == PROPERTY_MATH_TYPE)
+
+export function MathSelector({ math, index, onMathSelect, areEventPropertiesNumericalAvailable, style }) {
+    const numericalNotice = `This can only be used on properties that have at least one number type occurence in your events.${
+        areEventPropertiesNumericalAvailable ? '' : ' None have been found yet!'
+    }`
+
+    return (
+        <Select
+            style={{ width: 150, ...style }}
+            value={math || 'total'}
+            onChange={(value) => onMathSelect(index, value)}
+            data-attr={`math-selector-${index}`}
+        >
+            <Select.OptGroup key="event aggregates" label="Event aggregation">
+                {EVENT_MATH_ENTRIES.map(([key, { name, description, onProperty }]) => {
+                    const disabled = onProperty && !areEventPropertiesNumericalAvailable
+                    return (
+                        <Select.Option key={key} value={key} data-attr={`math-${key}-${index}`} disabled={disabled}>
+                            <Tooltip
+                                title={
+                                    onProperty ? (
+                                        <>
+                                            {description}
+                                            <br />
+                                            {numericalNotice}
+                                        </>
+                                    ) : (
+                                        description
+                                    )
+                                }
+                                placement="right"
+                            >
+                                <div
+                                    style={{
+                                        height: '100%',
+                                        width: '100%',
+                                        paddingRight: 8,
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                    }}
+                                >
+                                    {name}
+                                </div>
+                            </Tooltip>
+                        </Select.Option>
+                    )
+                })}
+            </Select.OptGroup>
+            <Select.OptGroup key="property aggregates" label="Property aggregation">
+                {PROPERTY_MATH_ENTRIES.map(([key, { name, description, onProperty }]) => {
+                    const disabled = onProperty && !areEventPropertiesNumericalAvailable
+                    return (
+                        <Select.Option key={key} value={key} data-attr={`math-${key}-${index}`} disabled={disabled}>
+                            <Tooltip
+                                title={
+                                    onProperty ? (
+                                        <>
+                                            {description}
+                                            <br />
+                                            {numericalNotice}
+                                        </>
+                                    ) : (
+                                        description
+                                    )
+                                }
+                                placement="right"
+                            >
+                                <div style={{ height: '100%', width: '100%' }}>{name}</div>
+                            </Tooltip>
+                        </Select.Option>
+                    )
+                })}
+            </Select.OptGroup>
+        </Select>
+    )
+}


### PR DESCRIPTION
## Changes

This is actually quite a simple PR, but it looks bigger than it is because some files moved around.

- Moved components required by `ActionFilterRow` into their own files for readability.
- Created the ability to override the styling of `Button`s within `PropertyFilters` via props.
- Resized property filter buttons on Funnels sidebar to take advantage of extra screen space when available.

BEFORE
<img width="407" alt="Screen Shot 2021-04-12 at 5 04 17 PM" src="https://user-images.githubusercontent.com/4645779/114471663-fddad280-9bbe-11eb-8eba-cb1344bd7b83.png">

BEFORE - Medium breakpoint
<img width="686" alt="Screen Shot 2021-04-12 at 5 00 56 PM" src="https://user-images.githubusercontent.com/4645779/114471686-07fcd100-9bbf-11eb-9ed3-8b58c14754b7.png">

AFTER - Medium breakpoint
<img width="522" alt="Screen Shot 2021-04-12 at 6 39 01 PM" src="https://user-images.githubusercontent.com/4645779/114471730-164aed00-9bbf-11eb-9944-fa25695209b2.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
