### PR TITLE
Fix display of plugin error seconds

### DIFF
--- a/frontend/src/scenes/plugins/plugin/PluginError.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginError.tsx
@@ -11,7 +11,7 @@ export function PluginError({ error, reset }: { error: PluginErrorType; reset?: 
     }
     return (
         <Popover
-            title={<div style={{ textAlign: 'center' }}>{dayjs(error.time).format('YYYY-MM-DD - HH:mm:SS')}</div>}
+            title={<div style={{ textAlign: 'center' }}>{dayjs(error.time).format('YYYY-MM-DD - HH:mm:ss')}</div>}
             content={
                 <>
                     {reset ? (


### PR DESCRIPTION
## Changes

Before:
<img width="737" alt="Screenshot 2021-04-13 at 09 25 16" src="https://user-images.githubusercontent.com/53387/114513289-526f6380-9c3a-11eb-9e46-11f97d28aa28.png">

After:
<img width="749" alt="Screenshot 2021-04-13 at 09 25 36" src="https://user-images.githubusercontent.com/53387/114513309-5602ea80-9c3a-11eb-88c1-43bb6834070f.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
