### PR TITLE
Fix persons search

### DIFF
--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useValues, useActions } from 'kea'
 import { PersonsTable } from './PersonsTable'
 import { Button, Row, Radio } from 'antd'
@@ -16,12 +16,19 @@ export function Persons({ cohort }: { cohort: CohortType }): JSX.Element {
     const { loadPersons, setListFilters } = useActions(personsLogic)
     const { persons, listFilters, personsLoading } = useValues(personsLogic)
 
+    useEffect(() => {
+        if (cohort) {
+            setListFilters({ cohort: cohort.id })
+            loadPersons()
+        }
+    }, [])
+
     return (
         <div className="persons-list">
             {!cohort && <PageHeader title="Persons" />}
             <Row style={{ gap: '0.75rem' }} className="mb">
                 <div style={{ flexGrow: 1, maxWidth: 600 }}>
-                    <PersonsSearch cohort={cohort} />
+                    <PersonsSearch />
                     <div className="text-muted text-small">
                         You can also filter persons that have a certain property set (e.g. <code>has:email</code> or{' '}
                         <code>has:name</code>)

--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { useValues, useActions } from 'kea'
 import { PersonsTable } from './PersonsTable'
-import { Button, Input, Row, Radio } from 'antd'
+import { Button, Row, Radio } from 'antd'
 import { ExportOutlined, PlusOutlined } from '@ant-design/icons'
 import { PageHeader } from 'lib/components/PageHeader'
 import { personsLogic } from './personsLogic'
@@ -10,45 +10,18 @@ import { CohortType } from '~/types'
 import { LinkButton } from 'lib/components/LinkButton'
 import { ClockCircleFilled } from '@ant-design/icons'
 import { toParams } from 'lib/utils'
+import { PersonsSearch } from './PersonsSearch'
 
 export function Persons({ cohort }: { cohort: CohortType }): JSX.Element {
     const { loadPersons, setListFilters } = useActions(personsLogic)
-    const { persons, listFilters, personsLoading, exampleEmail } = useValues(personsLogic)
-    const [searchTerm, setSearchTerm] = useState('') // Not on Kea because it's a component-specific store & to avoid changing the URL on every keystroke
-
-    useEffect(() => {
-        setSearchTerm(listFilters.search)
-        if (cohort) {
-            setListFilters({ cohort: cohort.id })
-            loadPersons()
-        }
-    }, [])
+    const { persons, listFilters, personsLoading } = useValues(personsLogic)
 
     return (
         <div className="persons-list">
             {!cohort && <PageHeader title="Persons" />}
             <Row style={{ gap: '0.75rem' }} className="mb">
                 <div style={{ flexGrow: 1, maxWidth: 600 }}>
-                    <Input.Search
-                        data-attr="persons-search"
-                        placeholder={`search person by email, name or ID (e.g. ${exampleEmail})`}
-                        autoFocus
-                        value={searchTerm}
-                        onChange={(e) => {
-                            setSearchTerm(e.target.value)
-                            if (!e.target.value) {
-                                setListFilters({ search: undefined })
-                                loadPersons()
-                            }
-                        }}
-                        enterButton
-                        allowClear
-                        onSearch={() => {
-                            setListFilters({ search: searchTerm || undefined })
-                            loadPersons()
-                        }}
-                        style={{ width: '100%' }}
-                    />
+                    <PersonsSearch cohort={cohort} />
                     <div className="text-muted text-small">
                         You can also filter persons that have a certain property set (e.g. <code>has:email</code> or{' '}
                         <code>has:name</code>)

--- a/frontend/src/scenes/persons/PersonsSearch.tsx
+++ b/frontend/src/scenes/persons/PersonsSearch.tsx
@@ -2,19 +2,14 @@ import React, { useState, useEffect } from 'react'
 import { Input } from 'antd'
 import { useValues, useActions } from 'kea'
 import { personsLogic } from './personsLogic'
-import { CohortType } from '~/types'
 
-export const PersonsSearch = ({ cohort }: { cohort: CohortType }): JSX.Element => {
+export const PersonsSearch = (): JSX.Element => {
     const { loadPersons, setListFilters } = useActions(personsLogic)
     const { exampleEmail, listFilters } = useValues(personsLogic)
     const [searchTerm, setSearchTerm] = useState('')
 
     useEffect(() => {
         setSearchTerm(listFilters.search)
-        if (cohort) {
-            setListFilters({ cohort: cohort.id })
-            loadPersons()
-        }
     }, [])
 
     return (

--- a/frontend/src/scenes/persons/PersonsSearch.tsx
+++ b/frontend/src/scenes/persons/PersonsSearch.tsx
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react'
+import { Input } from 'antd'
+import { useValues, useActions } from 'kea'
+import { personsLogic } from './personsLogic'
+import { CohortType } from '~/types'
+
+export const PersonsSearch = ({ cohort }: { cohort: CohortType }): JSX.Element => {
+    const { loadPersons, setListFilters } = useActions(personsLogic)
+    const { exampleEmail, listFilters } = useValues(personsLogic)
+    const [searchTerm, setSearchTerm] = useState('')
+
+    useEffect(() => {
+        setSearchTerm(listFilters.search)
+        if (cohort) {
+            setListFilters({ cohort: cohort.id })
+            loadPersons()
+        }
+    }, [])
+
+    return (
+        <Input.Search
+            data-attr="persons-search"
+            placeholder={`search person by email, name or ID (e.g. ${exampleEmail})`}
+            autoFocus
+            value={searchTerm}
+            onChange={(e) => {
+                setSearchTerm(e.target.value)
+                if (!e.target.value) {
+                    setListFilters({ search: undefined })
+                    loadPersons()
+                }
+            }}
+            enterButton
+            allowClear
+            onSearch={() => {
+                setListFilters({ search: searchTerm || undefined })
+                loadPersons()
+            }}
+            style={{ width: '100%' }}
+        />
+    )
+}


### PR DESCRIPTION
## Changes

We should really keep input components separate from larger components - Every state change on the input will cause a re-render of the entire component, which leads to significant lags between keypress and UI response.

This PR extracts the search bar away from `Persons.tsx` to a separate component.

### Before

Watch until the end - I'm typing the whole time, but all the characters only appear after a long while.

https://user-images.githubusercontent.com/38760734/114551549-1a284f00-9c53-11eb-9555-1a942e733af2.mov

### After 


https://user-images.githubusercontent.com/38760734/114551560-1eed0300-9c53-11eb-936c-0ce735ccc911.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
