### PR TITLE
Display current billing usage for metered plans

### DIFF
--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -7,7 +7,7 @@ import { userLogic } from 'scenes/userLogic'
 import { Badge } from 'lib/components/Badge'
 import { ChangelogModal } from '~/layout/ChangelogModal'
 import { router } from 'kea-router'
-import { Button, Dropdown } from 'antd'
+import { Button, Card, Dropdown } from 'antd'
 import {
     ProjectOutlined,
     DownOutlined,
@@ -31,6 +31,7 @@ import { UserType } from '~/types'
 import { CreateInviteModalWithButton } from 'scenes/organization/Settings/CreateInviteModal'
 import MD5 from 'crypto-js/md5'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { billingLogic } from 'scenes/billing/billingLogic'
 
 export interface ProfilePictureProps {
     name?: string
@@ -78,6 +79,7 @@ export function TopNavigation(): JSX.Element {
     )
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
+    const { billing } = useValues(billingLogic)
     const { logout, updateCurrentTeam, updateCurrentOrganization } = useActions(userLogic)
     const { showUpgradeModal } = useActions(sceneLogic)
     const { sceneConfig } = useValues(sceneLogic)
@@ -96,6 +98,19 @@ export function TopNavigation(): JSX.Element {
                 </div>
             </div>
             <div className="text-center mt" style={{ paddingRight: 16, paddingLeft: 16 }}>
+                {billing?.plan?.is_metered_billing && (billing?.current_bill_amount ?? false) && (
+                    <Link to="/organization/billing" data-attr="top-menu-billing-usage">
+                        <Card
+                            bodyStyle={{ padding: 4, fontWeight: 'bold' }}
+                            style={{ marginBottom: 16, cursor: 'pointer' }}
+                        >
+                            <span className="text-small text-muted">
+                                <b>Current usage</b>
+                            </span>
+                            <div style={{ fontSize: '1.05rem' }}>${billing?.current_bill_amount?.toLocaleString()}</div>
+                        </Card>
+                    </Link>
+                )}
                 <div>
                     {preflight?.email_service_available ? (
                         <Button

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -114,7 +114,7 @@ export function TopNavigation(): JSX.Element {
                                 ) : (
                                     <>
                                         Unavailable{' '}
-                                        <Tooltip title="We can't show your current bill amount. If you keep seeing this message contact us.">
+                                        <Tooltip title="We can't show your current bill amount right now. If you keep seeing this message, contact us.">
                                             <InfoCircleOutlined />
                                         </Tooltip>
                                     </>

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -114,7 +114,7 @@ export function TopNavigation(): JSX.Element {
                                 ) : (
                                     <>
                                         Unavailable{' '}
-                                        <Tooltip title="We can't show your current bill amount right now. If you keep seeing this message, contact us.">
+                                        <Tooltip title="We can't show your current bill amount right now. Please check back in a few minutes. If you keep seeing this message, contact us.">
                                             <InfoCircleOutlined />
                                         </Tooltip>
                                     </>

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -7,7 +7,7 @@ import { userLogic } from 'scenes/userLogic'
 import { Badge } from 'lib/components/Badge'
 import { ChangelogModal } from '~/layout/ChangelogModal'
 import { router } from 'kea-router'
-import { Button, Card, Dropdown } from 'antd'
+import { Button, Card, Dropdown, Tooltip } from 'antd'
 import {
     ProjectOutlined,
     DownOutlined,
@@ -17,6 +17,7 @@ import {
     SearchOutlined,
     SettingOutlined,
     UserAddOutlined,
+    InfoCircleOutlined,
 } from '@ant-design/icons'
 import { guardPremiumFeature } from 'scenes/UpgradeModal'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -98,7 +99,7 @@ export function TopNavigation(): JSX.Element {
                 </div>
             </div>
             <div className="text-center mt" style={{ paddingRight: 16, paddingLeft: 16 }}>
-                {billing?.plan?.is_metered_billing && (billing?.current_bill_amount ?? false) && (
+                {preflight?.cloud && billing?.should_display_current_bill && (
                     <Link to="/organization/billing" data-attr="top-menu-billing-usage">
                         <Card
                             bodyStyle={{ padding: 4, fontWeight: 'bold' }}
@@ -107,7 +108,18 @@ export function TopNavigation(): JSX.Element {
                             <span className="text-small text-muted">
                                 <b>Current usage</b>
                             </span>
-                            <div style={{ fontSize: '1.05rem' }}>${billing?.current_bill_amount?.toLocaleString()}</div>
+                            <div style={{ fontSize: '1.05rem' }}>
+                                {billing?.current_bill_amount !== undefined && billing?.current_bill_amount !== null ? (
+                                    `$${billing?.current_bill_amount?.toLocaleString()}`
+                                ) : (
+                                    <>
+                                        Unavailable{' '}
+                                        <Tooltip title="We can't show your current bill amount. If you keep seeing this message contact us.">
+                                            <InfoCircleOutlined />
+                                        </Tooltip>
+                                    </>
+                                )}
+                            </div>
                         </Card>
                     </Link>
                 )}

--- a/frontend/src/scenes/billing/Billing.scss
+++ b/frontend/src/scenes/billing/Billing.scss
@@ -26,4 +26,11 @@
             margin-top: $default_spacing;
         }
     }
+
+    .bill-amount {
+        margin-top: $default_spacing / 2;
+        font-size: 1.2rem;
+        font-weight: bold;
+        text-align: center;
+    }
 }

--- a/frontend/src/scenes/billing/CurrentUsage.tsx
+++ b/frontend/src/scenes/billing/CurrentUsage.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { compactNumber } from 'lib/utils'
 import React from 'react'
 import { billingLogic } from './billingLogic'
+import { InfoCircleOutlined } from '@ant-design/icons'
 
 export function CurrentUsage(): JSX.Element | null {
     const { eventAllocation, percentage, strokeColor, billing } = useValues(billingLogic)
@@ -16,13 +17,38 @@ export function CurrentUsage(): JSX.Element | null {
         <>
             <div className="space-top" />
             <Card title="Current monthly usage">
+                {billing.should_display_current_bill && (
+                    <>
+                        <h3 className="l3">Current bill amount</h3>
+                        This is the amount (in dollars) of the bill for the currently ongoing period. The final amount
+                        will be billed a few days after the end of the month.{' '}
+                        <b>
+                            Please note this number is computed daily, so events ingested in the last 24 hours may not
+                            be reflected yet.
+                        </b>{' '}
+                        Keep in mind if you're trying to compare number of events and bill amount.
+                        <div className="bill-amount">
+                            {billing?.current_bill_amount !== undefined && billing?.current_bill_amount !== null ? (
+                                `$${billing?.current_bill_amount?.toLocaleString()}`
+                            ) : (
+                                <>
+                                    Unavailable{' '}
+                                    <Tooltip title="We can't show your current bill amount right now. If you keep seeing this message, contact us.">
+                                        <InfoCircleOutlined />
+                                    </Tooltip>
+                                </>
+                            )}
+                        </div>
+                    </>
+                )}
+                <h3 className="l3 mt">Current event usage</h3>
                 {billing.current_usage !== null ? (
                     <>
                         Your organization has used{' '}
                         <Tooltip title={`${billing.current_usage.toLocaleString()} events`}>
                             <b>{compactNumber(billing.current_usage)}</b>
                         </Tooltip>{' '}
-                        events this month.{' '}
+                        events this month (calculated roughly every hour).{' '}
                         {eventAllocation && (
                             <>
                                 You can use up to <b>{compactNumber(eventAllocation)}</b> events per month.
@@ -48,8 +74,8 @@ export function CurrentUsage(): JSX.Element | null {
                     </>
                 ) : (
                     <div>
-                        Currently we do not have information about your usage. Please check back again in a few minutes
-                        or{' '}
+                        Currently we do not have information about the number of billed events. Please check back again
+                        in a few minutes or{' '}
                         <a href="https://posthog.com/support/" target="_blank">
                             contact us
                         </a>{' '}

--- a/frontend/src/scenes/billing/CurrentUsage.tsx
+++ b/frontend/src/scenes/billing/CurrentUsage.tsx
@@ -3,7 +3,6 @@ import { useValues } from 'kea'
 import { compactNumber } from 'lib/utils'
 import React from 'react'
 import { billingLogic } from './billingLogic'
-import { InfoCircleOutlined } from '@ant-design/icons'
 
 export function CurrentUsage(): JSX.Element | null {
     const { eventAllocation, percentage, strokeColor, billing } = useValues(billingLogic)
@@ -20,25 +19,26 @@ export function CurrentUsage(): JSX.Element | null {
                 {billing.should_display_current_bill && (
                     <>
                         <h3 className="l3">Current bill amount</h3>
-                        This is the amount (in dollars) of the bill for the currently ongoing period. The final amount
-                        will be billed a few days after the end of the month.{' '}
-                        <b>
-                            Please note this number is computed daily, so events ingested in the last 24 hours may not
-                            be reflected yet.
-                        </b>{' '}
-                        Keep in mind if you're trying to compare number of events and bill amount.
-                        <div className="bill-amount">
-                            {billing?.current_bill_amount !== undefined && billing?.current_bill_amount !== null ? (
-                                `$${billing?.current_bill_amount?.toLocaleString()}`
-                            ) : (
-                                <>
-                                    Unavailable{' '}
-                                    <Tooltip title="We can't show your current bill amount right now. If you keep seeing this message, contact us.">
-                                        <InfoCircleOutlined />
-                                    </Tooltip>
-                                </>
-                            )}
-                        </div>
+                        {billing?.current_bill_amount !== undefined && billing?.current_bill_amount !== null ? (
+                            <>
+                                This is the amount (in dollars) of the bill for the currently ongoing period. The final
+                                amount will be billed a few days after the end of the month. Please note this number is
+                                reported on a daily basis,{' '}
+                                <b>so events ingested in the last 24 hours may not be reflected yet.</b>
+                                <div className="bill-amount">
+                                    {`$${billing?.current_bill_amount?.toLocaleString()}`}
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                We can't show your current bill amount right now. Please check back again in a few
+                                minutes or{' '}
+                                <a href="https://posthog.com/support/" target="_blank">
+                                    contact us
+                                </a>{' '}
+                                if this message does not disappear.
+                            </>
+                        )}
                     </>
                 )}
                 <h3 className="l3 mt">Current event usage</h3>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -341,6 +341,7 @@ export interface BillingType {
     event_allocation: number | null
     current_usage: number | null
     subscription_url: string
+    current_bill_amount: number | null
 }
 
 export interface PlanInterface {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -342,6 +342,7 @@ export interface BillingType {
     current_usage: number | null
     subscription_url: string
     current_bill_amount: number | null
+    should_display_current_bill: boolean
 }
 
 export interface PlanInterface {


### PR DESCRIPTION
## Changes

- This PR builds up on https://github.com/PostHog/posthog-cloud/pull/102 to display the current bill usage for users in metered plans.

**Display in top navigation bar**
<img width="223" alt="" src="https://user-images.githubusercontent.com/5864173/114632366-6f745880-9c73-11eb-890d-a2dff4f8ff5c.png">

**Display in top navigation when number is not available**
<img width="216" alt="" src="https://user-images.githubusercontent.com/5864173/114632395-7bf8b100-9c73-11eb-83ad-ae3e4a954a07.png">

**Display in billing page**
<img width="1354" alt="" src="https://user-images.githubusercontent.com/5864173/114632448-929f0800-9c73-11eb-9664-b47bcbc8c8dd.png">


**Display in billing page when number is not available**
<img width="1350" alt="" src="https://user-images.githubusercontent.com/5864173/114632453-95016200-9c73-11eb-9cb6-0b234616790d.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
