### PR TITLE
Fix ResizableTable always on scollbar

### DIFF
--- a/frontend/src/lib/components/ResizableTable/index.scss
+++ b/frontend/src/lib/components/ResizableTable/index.scss
@@ -2,7 +2,7 @@
 
 .resizable-table-scroll-container {
     max-width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
     position: relative;
     .table-gradient-overlay {
         overflow-y: hidden;


### PR DESCRIPTION
## Changes

Tiny CSS change to hide scrollbar on ResizableTable when there's no overflow (which can easily be missed on macOS, as it likes to hide scrollbars often). Fortunately @macobo rejects Apple tyranny, so we have at least one person to notice crap caused by macOS's quirks. Closes #3967.
