### PR TITLE
Make new Sessions filter UI responsive

### DIFF
--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -58,8 +58,8 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
     ...props
 }: ResizableTableProps<RecordType>): JSX.Element {
     const breakpoint = getActiveBreakpoint()
-    const minConstraints = [getMinColumnWidth(breakpoint), 0]
-    const maxConstraints = [getMaxColumnWidth(breakpoint), 0]
+    const minWidth = getMinColumnWidth(breakpoint)
+    const maxWidth = getMaxColumnWidth(breakpoint)
     const scrollWrapperRef = useRef<HTMLDivElement>(null)
     const overlayRef = useRef<HTMLDivElement>(null)
     function getTotalWidth(columns: InternalColumnType<RecordType>[]): number {
@@ -93,7 +93,7 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
         updateScrollGradient()
     }
     const [columns, setColumns] = useState(() => {
-        const defaultColumnWidth = getFullwidthColumnSize({ useMinWidth: false })
+        const defaultColumnWidth = getFullwidthColumnSize()
         return initialColumns.map(
             (column, index) =>
                 ({
@@ -101,9 +101,13 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
                     width: defaultColumnWidth,
                     onHeaderCell: ({ width }: { width: number }) => ({
                         onResize: handleResize(index),
-                        minConstraints,
-                        maxConstraints,
+                        minConstraints: [minWidth, 0],
+                        maxConstraints: [maxWidth, 0],
                         width,
+                        style: {
+                            maxWidth,
+                            minWidth,
+                        },
                     }),
                 } as InternalColumnType<RecordType>)
         )
@@ -112,14 +116,11 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
         // Calculate relative column widths (px) once the wrapper is mounted.
         if (scrollWrapperRef.current) {
             const wrapperWidth = scrollWrapperRef.current.clientWidth
-            const columnWidth = getFullwidthColumnSize({
-                wrapperWidth,
-                breakpoint,
-            })
+            const columnWidth = getFullwidthColumnSize(wrapperWidth)
             setColumns((cols) => {
                 const nextColumns = cols.map((column) => ({
                     ...column,
-                    width: columnWidth * column.span,
+                    width: Math.max(minWidth, columnWidth * column.span),
                 }))
                 if (getTotalWidth(nextColumns) > wrapperWidth) {
                     setScrollableRight(true)

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -93,7 +93,7 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
         updateScrollGradient()
     }
     const [columns, setColumns] = useState(() => {
-        const defaultColumnWidth = getFullwidthColumnSize({})
+        const defaultColumnWidth = getFullwidthColumnSize({ useMinWidth: false })
         return initialColumns.map(
             (column, index) =>
                 ({

--- a/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
+++ b/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
@@ -10,21 +10,8 @@ export function getMaxColumnWidth(breakpoint: number): number {
     return breakpoint < 768 ? 500 : 750
 }
 
-export function getFullwidthColumnSize({
-    wrapperWidth = 1200,
-    breakpoint = 1600,
-    useMinWidth = true,
-}: {
-    wrapperWidth?: number
-    breakpoint?: number
-    useMinWidth?: boolean
-}): number {
-    const columnWidth = Math.floor(wrapperWidth / gridBasis)
-    if (!useMinWidth) {
-        return columnWidth
-    }
-    const minWidth = getMinColumnWidth(breakpoint)
-    return Math.max(columnWidth, minWidth)
+export function getFullwidthColumnSize(wrapperWidth: number = 1200): number {
+    return Math.floor(wrapperWidth / gridBasis)
 }
 
 function getPixelValue(cssStatement: string): number {

--- a/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
+++ b/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
@@ -13,12 +13,17 @@ export function getMaxColumnWidth(breakpoint: number): number {
 export function getFullwidthColumnSize({
     wrapperWidth = 1200,
     breakpoint = 1600,
+    useMinWidth = true,
 }: {
     wrapperWidth?: number
     breakpoint?: number
+    useMinWidth?: boolean
 }): number {
-    const minWidth = getMinColumnWidth(breakpoint)
     const columnWidth = Math.floor(wrapperWidth / gridBasis)
+    if (!useMinWidth) {
+        return columnWidth
+    }
+    const minWidth = getMinColumnWidth(breakpoint)
     return Math.max(columnWidth, minWidth)
 }
 

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -1,8 +1,24 @@
 @import '~/vars';
 
+.sessions-wrapper {
+    display: flex;
+    flex-direction: row;
+}
+
+.sessions-sidebar {
+    display: flex;
+    flex-direction: row;
+    position: sticky;
+    top: $top_nav_height;
+    overflow: auto;
+    min-width: 260px;
+    height: 100%;
+}
+
 .sessions-with-filters {
     margin-top: 30px;
-    margin-left: 299px;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .sessions-divider {
@@ -14,7 +30,6 @@
 
 .sessions-filters-menu {
     border-right: unset;
-    width: 260px;
 
     .ant-menu-item-group-title {
         text-transform: uppercase;
@@ -178,4 +193,20 @@
 
 .sessions-event-highlighted {
     background-color: #fdedc9;
+}
+
+@media (max-width: $md) {
+    .sessions-wrapper {
+        display: block;
+    }
+
+    .sessions-sidebar {
+        display: block;
+        position: unset;
+        height: unset;
+    }
+
+    .sessions-divider {
+        display: none;
+    }
 }

--- a/frontend/src/scenes/sessions/Sessions.tsx
+++ b/frontend/src/scenes/sessions/Sessions.tsx
@@ -10,16 +10,8 @@ export function Sessions(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     if (featureFlags['filter_by_session_props']) {
         return (
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
-                <div
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        position: 'fixed',
-                        overflow: 'auto',
-                        height: '100%',
-                    }}
-                >
+            <div className="sessions-wrapper">
+                <div className="sessions-sidebar">
                     <div>
                         <PageHeader title="Sessions" />
                         <SavedFiltersMenu />

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -116,14 +116,14 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
             render: function RenderStartTime(session: SessionType) {
                 return <span>{humanFriendlyDetailedTime(session.start_time)}</span>
             },
-            span: 3,
+            span: 2.5,
         },
         {
             title: 'End Time',
             render: function RenderEndTime(session: SessionType) {
                 return <span>{humanFriendlyDetailedTime(session.end_time)}</span>
             },
-            span: 3,
+            span: 2.5,
         },
         {
             title: 'Start Point',


### PR DESCRIPTION
## Changes

BEFORE: No responsive repositioning of sidebar in Sessions. Weird overlap on scroll.

https://user-images.githubusercontent.com/4645779/114793941-77a6c380-9d59-11eb-9869-5dfacfa614ce.mp4

AFTER: Sidebar has `position: sticky`. Table stays in container.

https://user-images.githubusercontent.com/4645779/114798223-de7caa80-9d62-11eb-9850-f47b1a9a7903.mp4


AFTER: medium breakpoint

<img width="718" alt="Screen Shot 2021-04-14 at 8 45 38 PM" src="https://user-images.githubusercontent.com/4645779/114798185-cad14400-9d62-11eb-974f-8802b53f1833.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
