### PR TITLE
Hide main navigation scrollbar

### DIFF
--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -36,6 +36,11 @@
         overflow-y: auto;
         padding-bottom: 32px;
         scroll-behavior: smooth;
+        -ms-overflow-style: none; /* IE and Edge */
+        scrollbar-width: none; /* Firefox */
+        &::-webkit-scrollbar {
+            display: none;
+        }
     }
 
     .nav-logo {


### PR DESCRIPTION
## Changes

Fixes #3606.

- Force the navigation scrollbar not to display with some browser-specific targeting.
- It is not enough to set `overflow-y: auto`, because the scrollbar will still show so long as the content box is larger than the client box.
- Note that this does decrease accessibility for the sake of aesthetics; but the orange "scroll down" button assists with that.

Before: see original issue
After:
<img width="460" alt="Screen Shot 2021-04-14 at 9 37 17 PM" src="https://user-images.githubusercontent.com/4645779/114801610-091e3180-9d6a-11eb-8556-4639c89ea002.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious

## Tested on:

- [x] Chromium (Linux)
- [x] Firefox (Linux)
- [x] Chrome (OSX)
- [x] Safari (OSX)
- [ ] (Windows)
