### PR TITLE
Allow all members to write projects

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -104,7 +104,6 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         ProjectMembershipNecessaryPermissions,
         PremiumMultiprojectPermissions,
         OrganizationMemberPermissions,
-        OrganizationAdminWritePermissions,
     ]
     lookup_field = "id"
     ordering = "-created_by"

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -121,7 +121,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         """
         Special permissions handling for create requests as the organization is inferred from the current user.
         """
-        if self.request.method == "POST":
+        if self.request.method == "POST" or self.request.method == "DELETE":
             organization = self.request.user.organization
 
             if not organization:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -73,7 +73,7 @@ class TestTeamAPI(APIBaseTest):
     def test_filter_permission(self):
 
         response = self.client.patch(
-            "/api/projects/%s/" % self.user.team.pk,
+            "/api/projects/%s/" % (self.user.team.pk if self.user.team else 0),
             {"test_account_filters": [{"key": "$current_url", "value": "test"}]},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -69,3 +69,15 @@ class TestTeamAPI(APIBaseTest):
 
         self.team.refresh_from_db()
         self.assertNotEqual(self.team.timezone, "America/I_Dont_Exist")
+
+    def test_filter_permission(self):
+
+        response = self.client.patch(
+            "/api/projects/%s/" % self.user.team.pk,
+            {"test_account_filters": [{"key": "$current_url", "value": "test"}]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_data = response.json()
+        self.assertEqual(response_data["name"], self.team.name)
+        self.assertEqual(response_data["test_account_filters"], [{"key": "$current_url", "value": "test"}])


### PR DESCRIPTION
## Changes

Had complaints from users who suddenly couldn't add test filters anymore. 
@paolodamico do you have more context on why you made this change? Did users ask for this? I find it quite annoying as all users are non-admin by default and I don't think these are shocking settings to be allowed to change. It's also confusing as there's no indication you're not allowed to change anything

I'd suggest either we merge this or make it really clear that as a member you're not allowed to change anything. Also as per our pricing model permissioning like this should be a paid feature.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
