### PR TITLE
Give plugin server ECS task 16 GB instead of 8 GB

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -104,5 +104,5 @@
     ],
     "requiresCompatibilities": ["FARGATE"],
     "cpu": "4096",
-    "memory": "8192"
+    "memory": "16384"
 }


### PR DESCRIPTION
## Changes

Should resolve a production issue with out-of-memory crashes.
