### PR TITLE
Update password change components

### DIFF
--- a/frontend/src/scenes/authentication/PasswordInput.tsx
+++ b/frontend/src/scenes/authentication/PasswordInput.tsx
@@ -7,22 +7,30 @@ const PasswordStrength = lazy(() => import('../../lib/components/PasswordStrengt
 interface PasswordInputProps extends FormItemProps {
     showStrengthIndicator?: boolean
     label?: string
+    style?: React.CSSProperties
+    validateMinLength?: boolean
 }
 
 export function PasswordInput({
     label = 'Password',
     showStrengthIndicator,
+    validateMinLength,
+    style,
     ...props
 }: PasswordInputProps): JSX.Element {
     return (
-        <>
+        <div style={style}>
             <Form.Item
                 name="password"
                 label={label}
                 rules={[
                     {
                         required: true,
-                        message: 'Please enter your password to continue',
+                        message: `Please enter your ${label.toLowerCase()} to continue`,
+                    },
+                    {
+                        min: validateMinLength ? 8 : undefined,
+                        message: `Your ${label.toLowerCase()} must be at least 8 characters long`,
                     },
                 ]}
                 style={showStrengthIndicator ? { marginBottom: 0 } : undefined}
@@ -39,6 +47,6 @@ export function PasswordInput({
                     )}
                 </Form.Item>
             )}
-        </>
+        </div>
     )
 }

--- a/frontend/src/scenes/authentication/PasswordInput.tsx
+++ b/frontend/src/scenes/authentication/PasswordInput.tsx
@@ -26,11 +26,11 @@ export function PasswordInput({
                 rules={[
                     {
                         required: true,
-                        message: `Please enter your ${label.toLowerCase()} to continue`,
+                        message: `Please enter your password to continue`,
                     },
                     {
                         min: validateMinLength ? 8 : undefined,
-                        message: `Your ${label.toLowerCase()} must be at least 8 characters long`,
+                        message: `Your password must be at least 8 characters long`,
                     },
                 ]}
                 style={showStrengthIndicator ? { marginBottom: 0 } : undefined}

--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -55,6 +55,7 @@ function FormStepOne(): JSX.Element {
                 showStrengthIndicator
                 validateStatus={signupResponse?.errorAttribute === 'password' ? 'error' : undefined}
                 help={signupResponse?.errorAttribute === 'password' ? signupResponse.errorDetail : undefined}
+                validateMinLength
             />
             <Form.Item>
                 <Button className="rocket-button" htmlType="submit" data-attr="signup-continue" block>

--- a/frontend/src/scenes/me/Settings/ChangePassword.tsx
+++ b/frontend/src/scenes/me/Settings/ChangePassword.tsx
@@ -1,83 +1,50 @@
-import React, { useState } from 'react'
-import { toast } from 'react-toastify'
-import api from 'lib/api'
-import { Input, Button } from 'antd'
+import React from 'react'
+import { Input, Button, Form } from 'antd'
 import { useActions, useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
-import Form from 'antd/lib/form/Form'
-import FormItem from 'antd/lib/form/FormItem'
-import { errorToast } from 'lib/utils'
+import { PasswordInput } from 'scenes/authentication/PasswordInput'
 
 export function ChangePassword(): JSX.Element {
-    const { user } = useValues(userLogic)
-    const { loadUser } = useActions(userLogic)
+    const { user, userLoading } = useValues(userLogic)
+    const { updateUser } = useActions(userLogic)
+    const [form] = Form.useForm()
 
-    const [currentPassword, setCurrentPassword] = useState('')
-    const [newPassword, setNewPassword] = useState('')
-
-    async function submit(): Promise<void> {
-        try {
-            await api.update('api/user/change_password', {
-                currentPassword,
-                newPassword,
-            })
-            loadUser()
-            toast.success('Password changed')
-        } catch (response) {
-            errorToast(undefined, 'There was a problem changing your password', response.error)
-        }
+    const updateCompleted = (): void => {
+        form.resetFields()
     }
 
     return (
-        <Form onFinish={submit} labelAlign="left" layout="vertical">
-            <FormItem
+        <Form
+            onFinish={(values) => updateUser({ user: values, successCallback: updateCompleted })}
+            labelAlign="left"
+            layout="vertical"
+            requiredMark={false}
+            form={form}
+        >
+            <Form.Item
                 label="Current Password"
                 rules={[
                     {
                         required: !user || user.has_password,
-                        message: 'Please input current password!',
+                        message: 'Please input your current password',
                     },
                 ]}
+                name="current_password"
             >
                 <Input.Password
-                    name="currentPassword"
-                    required
-                    onChange={(event) => {
-                        setCurrentPassword(event.target.value)
-                    }}
-                    value={currentPassword}
                     style={{ maxWidth: 400 }}
                     autoComplete="current-password"
-                    disabled={!!user && !user.has_password}
-                    placeholder={user && !user.has_password ? 'signed up with external login' : undefined}
+                    disabled={(!!user && !user.has_password) || userLoading}
+                    placeholder={user && !user.has_password ? 'signed up with external login' : '********'}
                     className="ph-ignore-input"
                 />
-            </FormItem>
-            <FormItem
-                label="New Password"
-                rules={[
-                    {
-                        required: true,
-                        message: 'Please input new password!',
-                    },
-                ]}
-            >
-                <Input.Password
-                    name="newPassword"
-                    required
-                    onChange={(event) => {
-                        setNewPassword(event.target.value)
-                    }}
-                    value={newPassword}
-                    style={{ maxWidth: 400 }}
-                    autoComplete="new-password"
-                />
-            </FormItem>
-            <FormItem>
-                <Button type="primary" htmlType="submit">
+            </Form.Item>
+            <PasswordInput label="New Password" showStrengthIndicator style={{ maxWidth: 400 }} validateMinLength />
+            <Form.Item>
+                <Button type="primary" htmlType="submit" loading={userLoading}>
                     Change Password
                 </Button>
-            </FormItem>
+            </Form.Item>
         </Form>
     )
 }

--- a/frontend/src/scenes/me/Settings/OptOutCapture.tsx
+++ b/frontend/src/scenes/me/Settings/OptOutCapture.tsx
@@ -19,7 +19,7 @@ export function OptOutCapture(): JSX.Element {
             </p>
             <Switch
                 data-attr="anonymize-data-collection"
-                onChange={(checked) => updateUser({ anonymize_data: checked })}
+                onChange={(checked) => updateUser({ user: { anonymize_data: checked } })}
                 defaultChecked={user?.anonymize_data}
                 loading={userLoading}
                 disabled={userLoading}

--- a/frontend/src/scenes/me/Settings/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/me/Settings/UpdateEmailPreferences.tsx
@@ -14,7 +14,7 @@ export function UpdateEmailPreferences(): JSX.Element {
                 id="email-preferences"
                 data-attr="email-preferences"
                 onChange={() => {
-                    updateUser({ email_opt_in: !user?.email_opt_in })
+                    updateUser({ user: { email_opt_in: !user?.email_opt_in } })
                 }}
                 defaultChecked={user?.email_opt_in}
                 loading={userLoading}

--- a/frontend/src/scenes/project/Settings/ToolbarSettings.tsx
+++ b/frontend/src/scenes/project/Settings/ToolbarSettings.tsx
@@ -15,7 +15,9 @@ export function ToolbarSettings(): JSX.Element {
                     <Switch
                         onChange={() => {
                             updateUser({
-                                toolbar_mode: user?.toolbar_mode === 'disabled' ? 'toolbar' : 'disabled',
+                                user: {
+                                    toolbar_mode: user?.toolbar_mode === 'disabled' ? 'toolbar' : 'disabled',
+                                },
                             })
                         }}
                         defaultChecked={user?.toolbar_mode !== 'disabled'}

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -2,11 +2,16 @@ import React from 'react'
 import { kea } from 'kea'
 import api from 'lib/api'
 import { userLogicType } from './userLogicType'
-import { UserType, UserUpdateType } from '~/types'
+import { UserType } from '~/types'
 import posthog from 'posthog-js'
 import { toast } from 'react-toastify'
 
-export const userLogic = kea<userLogicType<UserType, UserUpdateType>>({
+interface UpdateUserPayload {
+    user: Partial<UserType>
+    successCallback?: () => void
+}
+
+export const userLogic = kea<userLogicType<UserType, UpdateUserPayload>>({
     actions: () => ({
         loadUser: (resetOnFailure?: boolean) => ({ resetOnFailure }),
         updateCurrentTeam: (teamId: number, destination?: string) => ({ teamId, destination }),
@@ -43,7 +48,7 @@ export const userLogic = kea<userLogicType<UserType, UserUpdateType>>({
                 (user?.team?.is_demo && user?.organization?.teams && user.organization.teams.length == 1) || false,
         ],
     }),
-    loaders: ({ values }) => ({
+    loaders: ({ values, actions }) => ({
         user: [
             null as UserType | null,
             {
@@ -78,14 +83,22 @@ export const userLogic = kea<userLogicType<UserType, UserUpdateType>>({
                         return user
                     } catch (e) {
                         console.error(e)
+                        actions.loadUserFailure(e)
                     }
                     return null
                 },
-                updateUser: async (payload: Partial<UserType>) => {
+                updateUser: async ({ user, successCallback }: UpdateUserPayload) => {
                     if (!values.user) {
                         throw new Error('Current user has not been loaded yet, so it cannot be updated!')
                     }
-                    return await api.update('api/users/@me/', payload)
+                    try {
+                        const response = await api.update('api/users/@me/', user)
+                        successCallback && successCallback()
+                        return response
+                    } catch (e) {
+                        console.error(e)
+                        actions.updateUserFailure(e)
+                    }
                 },
             },
         ],

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -81,9 +81,9 @@ export const userLogic = kea<userLogicType<UserType, UpdateUserPayload>>({
                             }
                         }
                         return user
-                    } catch (e) {
-                        console.error(e)
-                        actions.loadUserFailure(e)
+                    } catch (error) {
+                        console.error(error)
+                        actions.loadUserFailure(error.message)
                     }
                     return null
                 },
@@ -95,9 +95,9 @@ export const userLogic = kea<userLogicType<UserType, UpdateUserPayload>>({
                         const response = await api.update('api/users/@me/', user)
                         successCallback && successCallback()
                         return response
-                    } catch (e) {
-                        console.error(e)
-                        actions.updateUserFailure(e)
+                    } catch (error) {
+                        console.error(error)
+                        actions.updateUserFailure(error.message)
                     }
                 },
             },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,11 +45,6 @@ export interface UserBasicType {
     email: string
 }
 
-export interface UserUpdateType {
-    user?: Omit<Partial<UserType>, 'team'>
-    team?: Partial<TeamType>
-}
-
 export interface PluginAccess {
     view: boolean
     install: boolean


### PR DESCRIPTION
## Changes

This PR updates the `ChangePassword.tsx` to use the main `userLogic` and the new `/users/@me/` endpoint
- Additionally, we also make use of the standardized `PasswordInput.tsx` component.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
