### PR TITLE
Notify Sentry of production releases

### DIFF
--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -120,8 +120,13 @@ jobs:
                   task-definition: ${{ steps.task-def-plugins.outputs.task-definition }}
                   service: posthog-production-plugins
                   cluster: posthog-production-cluster
-
-            - name: Notify Sentry of a production release
+    sentry:
+        name: Notify Sentry of a production release
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Checkout master
+              uses: actions/checkout@v2
+            - name: Notify Sentry
               uses: getsentry/action-release@v1
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -120,3 +120,12 @@ jobs:
                   task-definition: ${{ steps.task-def-plugins.outputs.task-definition }}
                   service: posthog-production-plugins
                   cluster: posthog-production-cluster
+
+            - name: Notify Sentry of a production release
+              uses: getsentry/action-release@v1
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: posthog
+                  SENTRY_PROJECT: posthog
+              with:
+                  environment: production


### PR DESCRIPTION
## Changes

This will notify Sentry of releases to production to help identify faster commits that caused a bug.

**Before**
<img width="843" alt="" src="https://user-images.githubusercontent.com/5864173/114890334-c5561700-9dbf-11eb-8e5e-2cb4092119b8.png">


**After**
<img width="843" alt="" src="https://user-images.githubusercontent.com/5864173/114904032-43b8b600-9dcc-11eb-8fd6-6e4ca470b0f4.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
