### PR TITLE
Add NewRelic to cloud deployment

### DIFF
--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -2,4 +2,5 @@
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
+# Warning: Changing the command below affects posthog-cloud. Please check ./bin/pull_main for details
 celery -A posthog beat -S redbeat.RedBeatScheduler

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -75,6 +75,7 @@ FLAGS=()
 echo
 echo "celery -A posthog worker ${FLAGS[*]}"
 echo
+# Warning: Changing the command below affects posthog-cloud. Please check ./bin/pull_main for details
 celery -A posthog worker ${FLAGS[*]}
 
 # Stop the beat!

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -227,10 +227,14 @@
                 {
                     "name": "STRIPE_WEBHOOK_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
+                },
+                {
+                    "name": "NEW_RELIC_LICENSE_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:NEW_RELIC_LICENSE_KEY::"
                 }
             ],
             "entryPoint": ["sh", "-c"],
-            "command": ["./bin/docker-server"]
+            "command": ["./bin/docker-server-newrelic"]
         }
     ],
     "requiresCompatibilities": ["FARGATE"],

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -221,6 +221,10 @@
                 {
                     "name": "STRIPE_WEBHOOK_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
+                },
+                {
+                    "name": "NEW_RELIC_LICENSE_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:NEW_RELIC_LICENSE_KEY::"
                 }
             ],
             "entryPoint": ["sh", "-c"],


### PR DESCRIPTION
## Changes

This PR adds NewRelic's Python APM to our cloud deployment on the worker & the web server. This will help us better diagnose the performance of our application.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
