### PR TITLE
Don't use plugin-server restart loop in production

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -99,7 +99,7 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
                 }
             ],
-            "entryPoint": ["./bin/plugin-server"]
+            "entryPoint": ["./bin/plugin-server --no-restart-loop"]
         }
     ],
     "requiresCompatibilities": ["FARGATE"],


### PR DESCRIPTION
If plugin server is misconfigured this makes plugin server crash loudly
instead of seeming to be healthy.

Related issue: https://github.com/PostHog/vpc/issues/39
