### PR TITLE
Avoid double-stacked <hr /> lines in trends

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -53,9 +53,9 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                 />
             )}
 
-            <hr />
             {filters.insight === ViewType.LIFECYCLE && (
                 <>
+                    <hr />
                     <h4 className="secondary">Lifecycle Toggles</h4>
                     {filtersLoading ? (
                         <Skeleton active />


### PR DESCRIPTION
Broken by https://github.com/PostHog/posthog/pull/3961

Screenshot of the broken UI:
![image](https://user-images.githubusercontent.com/148820/115014110-9375ab00-9eba-11eb-8042-e18bf035dc2e.png)
