### PR TITLE
Use env var for pubsub plugins reload channel

### DIFF
--- a/posthog/plugins/reload.py
+++ b/posthog/plugins/reload.py
@@ -1,5 +1,6 @@
 from posthog.redis import get_client
+from posthog.settings import PLUGINS_RELOAD_PUBSUB_CHANNEL
 
 
 def reload_plugins_on_workers():
-    get_client().publish("reload-plugins", "reload!")
+    get_client().publish(PLUGINS_RELOAD_PUBSUB_CHANNEL, "reload!")


### PR DESCRIPTION
## Changes

We had the env var for this but the channel name was still hardcoded

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
