### PR TITLE
Don't catch all exceptions for migrating clickhouse

### DIFF
--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -8,14 +8,11 @@ class Command(BaseCommand):
     help = "Migrate clickhouse"
 
     def handle(self, *args, **options):
-        try:
-            Database(
-                CLICKHOUSE_DATABASE,
-                db_url=CLICKHOUSE_HTTP_URL,
-                username=CLICKHOUSE_USER,
-                password=CLICKHOUSE_PASSWORD,
-                verify_ssl_cert=False,
-            ).migrate("ee.clickhouse.migrations")
-            print("migration successful")
-        except Exception as e:
-            print(e)
+        Database(
+            CLICKHOUSE_DATABASE,
+            db_url=CLICKHOUSE_HTTP_URL,
+            username=CLICKHOUSE_USER,
+            password=CLICKHOUSE_PASSWORD,
+            verify_ssl_cert=False,
+        ).migrate("ee.clickhouse.migrations")
+        print("migration successful")


### PR DESCRIPTION
This is making it hard to wait until clickhouse has been set up for VPC
deployments.

It was introduced in
https://github.com/PostHog/posthog/pull/2034/files#diff-ea7b79cfe0fd591ead9add4372dab5f31aa4f6155f304bc0d63ef667c9e8ac95L16
for an unknown reason (debug code?)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
