### PR TITLE
Pin prod docker-compose to Postgres 13 and Redis 6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
             POSTGRES_USER: posthog
-        image: postgres:alpine
+        image: postgres:13-alpine
         volumes:
             - postgres-data:/var/lib/postgresql/data
     redis:
         container_name: posthog_redis
-        image: redis:alpine
+        image: redis:6-alpine
     web:
         container_name: posthog_web
         depends_on:


### PR DESCRIPTION
## Changes

`docker-compose.yml` change, resolves #3676. Using latest major versions which would be downloaded here now anyway, but which without pinning would be Postgres 14 or Redis 7 in the future, likely with breaking changes.