### PR TITLE
Use virtual list for property select

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -42,7 +42,6 @@ export function PropertySelect({ optionGroups, value, onChange, placeholder, aut
                 onChange(type, val.replace(/^(event_|person_|element_)/gi, ''))
             }}
             style={{ width: '100%' }}
-            virtual={false}
         >
             {optionGroups.map(
                 (group) =>


### PR DESCRIPTION
## Changes

I think this got added [a while ago](https://github.com/PostHog/posthog/commit/720c06f9e6cd598180133ed29f1d8873bc444c6b#diff-362e941677926eb428f4963335f4bf0e60a485ed7d80cda9d0ef6bfbcc95370aR25) because of e2e tests, but it makes the list very slow (esp with lots of keys). It's also the only place we don't use a virtual list so I think it should be safe.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
