### PR TITLE
Docker support on the Apple M1 chip / arm64

### DIFF
--- a/bin/docker-backend
+++ b/bin/docker-backend
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+python manage.py migrate
+
+python manage.py runserver 0.0.0.0:8000

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' \
+    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' 'libpq-dev' \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
@@ -23,6 +23,11 @@ RUN apt-get update \
     && yarn --frozen-lockfile
 
 COPY requirements.txt .
+
+# RUN pip install --upgrade requests
+# RUN pip uninstall psycopg2 psycopg2-binary
+# RUN pip install psycopg2-binary
+
 RUN pip install -r requirements.txt --no-cache-dir
 
 COPY requirements-dev.txt .

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' 'libpq-dev' \
+    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' 'libpq-dev=11.*' \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
@@ -23,10 +23,6 @@ RUN apt-get update \
     && yarn --frozen-lockfile
 
 COPY requirements.txt .
-
-# RUN pip install --upgrade requests
-# RUN pip uninstall psycopg2 psycopg2-binary
-# RUN pip install psycopg2-binary
 
 RUN pip install -r requirements.txt --no-cache-dir
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,11 +15,11 @@ services:
         container_name: posthog_redis
         ports:
             - '6379:6379'
-    worker: &worker
+    backend: &backend
         build:
             context: .
             dockerfile: dev.Dockerfile
-        command: ./bin/docker-worker
+        command: ./bin/docker-backend
         volumes:
             - .:/code
         environment:
@@ -36,9 +36,18 @@ services:
         links:
             - db:db
             - redis:redis
-    web:
-        <<: *worker
-        command: ./bin/docker-dev-web
         ports:
             - '8000:8000'
-            - '8234:8234'
+    #frontend:
+    #<<: *backend
+    #command: ./bin/docker-frontend
+    #ports:
+    #- '8234:8234'
+    worker:
+        <<: *backend
+        command: ./bin/docker-worker
+        ports: []
+        depends_on:
+            - db
+            - redis
+            - backend


### PR DESCRIPTION
## Changes

#3990

Docker isn't working for arm64 for two reasons:
- Upgrade docker to 3.3.0+
- Missing library `libpq-dev` for `pg_config`

[See this article](https://authzed.com/blog/onboarding-with-an-m1/) for more information.

## Checklist

- [x] Add `libpq-dev` to dev.Dockerfile so that pg_config is able to build
- [x] Removed frontend from docker compose file. Running Webpack separately provides faster startup times and lower memory consumption in docker.