### PR TITLE
Rework ResizableTable column rendering

### DIFF
--- a/frontend/src/lib/components/ResizableTable/VirtualTableHeader.tsx
+++ b/frontend/src/lib/components/ResizableTable/VirtualTableHeader.tsx
@@ -73,7 +73,7 @@ function VirtualTableHeader<RecordType>({
     return (
         <div className="resizable-virtual-table-header">
             <div className="left-spacer" style={{ width: ANTD_EXPAND_BUTTON_WIDTH }} />
-            {columns.map(({ /*ellipsis, key,*/ title, width }, index) => (
+            {columns.map(({ title, width }, index) => (
                 <ResizableTitle
                     key={index}
                     initialWidth={width ?? minColumnWidth}

--- a/frontend/src/lib/components/ResizableTable/VirtualTableHeader.tsx
+++ b/frontend/src/lib/components/ResizableTable/VirtualTableHeader.tsx
@@ -61,7 +61,7 @@ function ResizableTitle({
     )
 }
 
-export default function VirtualTableHeader<RecordType>({
+function VirtualTableHeader<RecordType>({
     columns,
     handleResize,
     layoutEffect,
@@ -88,3 +88,5 @@ export default function VirtualTableHeader<RecordType>({
         </div>
     )
 }
+
+export default React.memo(VirtualTableHeader) as typeof VirtualTableHeader

--- a/frontend/src/lib/components/ResizableTable/VirtualTableHeader.tsx
+++ b/frontend/src/lib/components/ResizableTable/VirtualTableHeader.tsx
@@ -1,0 +1,90 @@
+import React, { useLayoutEffect, useState } from 'react'
+import { InternalColumnType, ResizeHandler, ANTD_EXPAND_BUTTON_WIDTH } from './index'
+import { ResizableBox } from 'react-resizable'
+interface ResizableTitleProps {
+    children: React.ReactChild
+    onResize: ResizeHandler
+    initialWidth: number
+    height: number
+    minConstraints: [number, number]
+    maxConstraints: [number, number]
+}
+
+interface VirtualTableHeaderProps<RecordType> {
+    columns: InternalColumnType<RecordType>[]
+    handleResize: (index: number) => ResizeHandler
+    layoutEffect?: CallableFunction
+    minColumnWidth: number
+}
+
+function ResizableTitle({
+    children,
+    onResize,
+    initialWidth,
+    height,
+    minConstraints,
+    maxConstraints,
+}: ResizableTitleProps): JSX.Element {
+    const innerContent = (
+        <div className="inner-wrapper">
+            <div className="inner-text">{children}</div>
+        </div>
+    )
+    const [width, setWidth] = useState(initialWidth)
+    const [isDragging, setIsDragging] = useState(false)
+    const handleResize: ResizeHandler = (event, data): void => {
+        setWidth(data.size.width)
+        onResize(event, data)
+    }
+    return (
+        <div className="react-resizable-wrapper">
+            <ResizableBox
+                width={width}
+                height={height}
+                minConstraints={minConstraints}
+                maxConstraints={maxConstraints}
+                axis="x"
+                handle={<span className="resizable-handle" data-drag-active={isDragging} />}
+                onResize={handleResize}
+                onResizeStart={(e) => {
+                    e.preventDefault()
+                    setIsDragging(true)
+                }}
+                onResizeStop={() => {
+                    setIsDragging(false)
+                }}
+                draggableOpts={{ enableUserSelectHack: true }}
+            >
+                {innerContent}
+            </ResizableBox>
+        </div>
+    )
+}
+
+export default function VirtualTableHeader<RecordType>({
+    columns,
+    handleResize,
+    layoutEffect,
+    minColumnWidth,
+}: VirtualTableHeaderProps<RecordType>): JSX.Element {
+    const maxColumnWidth = minColumnWidth * 12
+    const height = 60
+    useLayoutEffect(() => (typeof layoutEffect === 'function' ? layoutEffect() : undefined))
+    return (
+        <div className="resizable-virtual-table-header">
+            <div className="left-spacer" style={{ width: ANTD_EXPAND_BUTTON_WIDTH }} />
+            {columns.map(({ /*ellipsis, key,*/ title, width }, index) => (
+                <ResizableTitle
+                    key={index}
+                    initialWidth={width ?? minColumnWidth}
+                    height={height}
+                    onResize={handleResize(index)}
+                    minConstraints={[minColumnWidth, height]}
+                    maxConstraints={[maxColumnWidth, height]}
+                >
+                    {title}
+                </ResizableTitle>
+            ))}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/ResizableTable/index.scss
+++ b/frontend/src/lib/components/ResizableTable/index.scss
@@ -4,40 +4,86 @@
     max-width: 100%;
     overflow-x: auto;
     position: relative;
+
     .table-gradient-overlay {
         overflow-y: hidden;
+
         &.scrollable-right::after {
+            z-index: 99;
             @extend .mixin-gradient-overlay-right;
             right: 0;
             width: 150px;
         }
     }
 }
+
+.ant-table table {
+    border-collapse: collapse;
+    table-layout: fixed;
+
+    td {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        word-break: keep-all;
+    }
+}
+
+.resizable-virtual-table-header {
+    display: flex;
+
+    .react-resizable-wrapper {
+        background: rgb(250, 250, 250);
+        border-bottom: 1px solid #f0f0f0;
+
+        &:last-child {
+            .resizable-handle {
+                display: none;
+            }
+        }
+    }
+
+    .left-spacer {
+        background: rgb(250, 250, 250);
+        border-right: 1px solid #f0f0f0;
+        border-bottom: 1px solid #f0f0f0;
+        flex-grow: 0;
+        flex-shrink: 0;
+    }
+}
+
 .react-resizable {
-    .th-inner-wrapper {
+    position: relative;
+
+    .inner-wrapper {
+        height: 100%;
+        display: flex;
+        align-items: center;
+    }
+    .inner-text {
         max-height: 8rem;
         overflow: hidden;
+        padding: 8px;
+        font-weight: 500;
     }
+
     .resizable-handle {
         position: absolute;
         right: 0;
-        bottom: 0;
+        top: 0;
         z-index: 1;
         width: 10px;
         height: 100%;
         cursor: col-resize;
-        border-right: 1px solid lightgray;
+        border-right: 1px solid #f0f0f0;
         transition: 0.2s border-color ease;
+
         &:hover {
             border-color: $blue_300;
         }
+
         &[data-drag-active='true'] {
             border-color: $primary;
-        }
-    }
-    &:last-child {
-        .resizable-handle {
-            display: none;
         }
     }
 }

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Table, TableProps } from 'antd'
 import { ColumnType } from 'antd/lib/table'
 import { ResizableProps } from 'react-resizable'
@@ -155,6 +155,23 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
         entries.forEach(({ contentRect: { width } }) => handleWrapperResize(width))
     })
 
+    useEffect(() => {
+        // Update render prop when parent columns change
+        console.log('Effect running.')
+        setColumns((cols) => {
+            const lastIndex = cols.length
+            const nextColumns = cols.map((column, index) =>
+                index === lastIndex
+                    ? column
+                    : {
+                          ...column,
+                          render: initialColumns[index].render,
+                      }
+            )
+            return nextColumns
+        })
+    }, [initialColumns])
+
     useLayoutEffect(() => {
         // Calculate relative column widths (px) once the wrapper is mounted.
         if (scrollWrapperRef.current) {
@@ -169,7 +186,6 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
                         ? column
                         : {
                               ...column,
-                              render: initialColumns[index].render,
                               width: Math.max(columnSpanWidth * column.span, minColumnWidth),
                           }
                 )
@@ -179,7 +195,7 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             updateScrollGradient()
             setHeaderShouldRender(true)
         }
-    }, [initialColumns])
+    }, [])
 
     return (
         <div ref={scrollWrapperRef} className="resizable-table-scroll-container" onScroll={updateScrollGradient}>

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -157,7 +157,6 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
 
     useEffect(() => {
         // Update render prop when parent columns change
-        console.log('Effect running.')
         setColumns((cols) => {
             const lastIndex = cols.length
             const nextColumns = cols.map((column, index) =>

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -1,11 +1,13 @@
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import { Table, TableProps } from 'antd'
-import { Resizable } from 'react-resizable'
-import { getActiveBreakpoint, getFullwidthColumnSize, getMaxColumnWidth, getMinColumnWidth } from './responsiveUtils'
+import { ResizableProps } from 'react-resizable'
+import { getActiveBreakpoint, getFullwidthColumnSize, getMinColumnWidth } from './responsiveUtils'
 
 import './index.scss'
+import { ColumnType } from 'antd/lib/table'
+import VirtualTableHeader from './VirtualTableHeader'
 
-export interface ResizableColumnType<RecordType> {
+export interface ResizableColumnType<RecordType> extends ColumnType<RecordType> {
     title: string | JSX.Element
     key?: string
     render: (record: RecordType, ...rest: any) => JSX.Element
@@ -13,42 +15,16 @@ export interface ResizableColumnType<RecordType> {
     span: number
 }
 
-function ResizableTitle(props: any): JSX.Element {
-    const { children, onResize, width, minConstraints, maxConstraints, ...restProps } = props
-    if (!width) {
-        return <th {...restProps} />
-    }
-    const [isDragging, setIsDragging] = useState(false)
-    return (
-        <Resizable
-            width={width}
-            height={0}
-            minConstraints={minConstraints}
-            maxConstraints={maxConstraints}
-            axis="x"
-            handle={<span className="resizable-handle" data-drag-active={isDragging} />}
-            onResize={onResize}
-            onResizeStart={(e) => {
-                e.preventDefault()
-                setIsDragging(true)
-            }}
-            onResizeStop={() => setIsDragging(false)}
-            draggableOpts={{ enableUserSelectHack: false }}
-        >
-            <th {...restProps}>
-                <div className="th-inner-wrapper">{children}</div>
-            </th>
-        </Resizable>
-    )
+export interface InternalColumnType<RecordType> extends ResizableColumnType<RecordType> {
+    width?: number
 }
+
+export type ResizeHandler = Exclude<ResizableProps['onResize'], undefined>
+
+export const ANTD_EXPAND_BUTTON_WIDTH = 48
 
 interface ResizableTableProps<RecordType> extends TableProps<RecordType> {
     columns: ResizableColumnType<RecordType>[]
-}
-
-interface InternalColumnType<RecordType> extends ResizableColumnType<RecordType> {
-    onHeaderCell: (props: any) => React.HTMLAttributes<HTMLElement>
-    width: number
 }
 
 // Type matches antd.Table
@@ -58,13 +34,18 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
     ...props
 }: ResizableTableProps<RecordType>): JSX.Element {
     const breakpoint = getActiveBreakpoint()
-    const minWidth = getMinColumnWidth(breakpoint)
-    const maxWidth = getMaxColumnWidth(breakpoint)
+    const minColumnWidth = getMinColumnWidth(breakpoint)
+    const [columns, setColumns] = useState(() => {
+        const lastIndex = initialColumns.length
+        return initialColumns.map((col, index) => ({
+            ...col,
+            width: index === lastIndex ? undefined : minColumnWidth,
+        })) as InternalColumnType<RecordType>[]
+    })
+    const [headerShouldRender, setHeaderShouldRender] = useState(false)
     const scrollWrapperRef = useRef<HTMLDivElement>(null)
     const overlayRef = useRef<HTMLDivElement>(null)
-    function getTotalWidth(columns: InternalColumnType<RecordType>[]): number {
-        return columns.reduce((total, current) => total + current.width, 0)
-    }
+    const timeout: any = useRef()
     function setScrollableRight(value: boolean): void {
         if (value) {
             return overlayRef?.current?.classList.add('scrollable-right')
@@ -81,67 +62,77 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             }
         }
     }
-    const handleResize = (index: number) => (_: unknown, { size: { width } }: { size: { width: number } }) => {
-        setColumns((columns: InternalColumnType<RecordType>[]) => {
-            const nextColumns = [...columns]
-            nextColumns[index] = {
-                ...nextColumns[index],
-                width,
+    function updateColumnWidth(index: number, width: number): void {
+        const col = scrollWrapperRef.current?.querySelector(
+            // nth-child is 1-indexed. first column is fixed. last column width must be uncontrolled.
+            `.ant-table-content colgroup col:nth-child(${index + 2}):not(:last-child)`
+        )
+        col?.setAttribute('style', `width: ${width}px;`)
+    }
+    function updateTableWidth(): void {
+        // <table> elements have super strange auto-sizing: (https://css-tricks.com/fixing-tables-long-strings/)
+        // We control the width of the <table> based on the width of the virtual header.
+        const header = scrollWrapperRef.current?.querySelector('.resizable-virtual-table-header')
+        if (header?.childNodes) {
+            const children = Array.from(header?.childNodes) as HTMLElement[]
+            const headerWidth = children.reduce((total, { offsetWidth }) => total + (offsetWidth ?? 0), 0)
+            if (headerWidth) {
+                const table = scrollWrapperRef.current?.querySelector('.ant-table table')
+                table?.setAttribute('style', `width: ${headerWidth}px;`)
             }
-            return nextColumns
+        }
+    }
+    const handleResize = (index: number): ResizeHandler => (_, { size: { width } }) => {
+        if (timeout.current) {
+            cancelAnimationFrame(timeout.current)
+        }
+        timeout.current = requestAnimationFrame(function () {
+            updateColumnWidth(index, width)
+            updateTableWidth()
         })
         updateScrollGradient()
     }
-    const [columns, setColumns] = useState(() => {
-        const defaultColumnWidth = getFullwidthColumnSize()
-        return initialColumns.map(
-            (column, index) =>
-                ({
-                    ...column,
-                    width: defaultColumnWidth,
-                    onHeaderCell: ({ width }: { width: number }) => ({
-                        onResize: handleResize(index),
-                        minConstraints: [minWidth, 0],
-                        maxConstraints: [maxWidth, 0],
-                        width,
-                        style: {
-                            maxWidth,
-                            minWidth,
-                        },
-                    }),
-                } as InternalColumnType<RecordType>)
-        )
-    })
     useLayoutEffect(() => {
         // Calculate relative column widths (px) once the wrapper is mounted.
         if (scrollWrapperRef.current) {
             const wrapperWidth = scrollWrapperRef.current.clientWidth
-            const columnWidth = getFullwidthColumnSize(wrapperWidth)
+            const gridBasis = columns.reduce((total, { span }) => total + span, 0)
+            const columnSpanWidth = getFullwidthColumnSize(wrapperWidth, gridBasis)
             setColumns((cols) => {
-                const nextColumns = cols.map((column, index) => ({
-                    ...column,
-                    width: Math.max(minWidth, columnWidth * column.span),
-                    render: initialColumns[index].render,
-                }))
-                if (getTotalWidth(nextColumns) > wrapperWidth) {
-                    setScrollableRight(true)
-                }
+                const lastIndex = cols.length
+                const nextColumns = cols.map((column, index) => {
+                    if (index === lastIndex) {
+                        return column
+                    }
+                    return {
+                        ...column,
+                        render: initialColumns[index].render,
+                        width: Math.max(columnSpanWidth * column.span, minColumnWidth),
+                    }
+                })
                 return nextColumns
             })
+            updateScrollGradient()
+            setHeaderShouldRender(true)
         }
     }, [initialColumns])
 
     return (
         <div ref={scrollWrapperRef} className="resizable-table-scroll-container" onScroll={updateScrollGradient}>
             <div ref={overlayRef} className="table-gradient-overlay">
+                {headerShouldRender && (
+                    <VirtualTableHeader
+                        columns={columns}
+                        handleResize={handleResize}
+                        layoutEffect={updateTableWidth}
+                        minColumnWidth={minColumnWidth}
+                    />
+                )}
                 <Table
                     columns={columns}
                     components={{
                         ...components,
-                        header: {
-                            ...components?.header,
-                            cell: ResizableTitle,
-                        },
+                        header: { cell: () => null }, // Nix that header row
                     }}
                     tableLayout="fixed"
                     {...props}

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -42,16 +42,19 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             width: index === lastIndex ? undefined : minColumnWidth,
         })) as InternalColumnType<RecordType>[]
     })
+    const [headerColumns, setHeaderColumns] = useState(columns)
     const [headerShouldRender, setHeaderShouldRender] = useState(false)
     const scrollWrapperRef = useRef<HTMLDivElement>(null)
     const overlayRef = useRef<HTMLDivElement>(null)
     const timeout: any = useRef()
+
     function setScrollableRight(value: boolean): void {
         if (value) {
             return overlayRef?.current?.classList.add('scrollable-right')
         }
         return overlayRef?.current?.classList.remove('scrollable-right')
     }
+
     function updateScrollGradient(): void {
         if (overlayRef.current) {
             const overlay = overlayRef.current
@@ -62,6 +65,7 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             }
         }
     }
+
     function updateColumnWidth(index: number, width: number): void {
         const col = scrollWrapperRef.current?.querySelector(
             // nth-child is 1-indexed. first column is fixed. last column width must be uncontrolled.
@@ -69,6 +73,13 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
         )
         col?.setAttribute('style', `width: ${width}px;`)
     }
+
+    function unsetLastColumnStyle(): void {
+        // last column width must be uncontrolled.
+        const col = scrollWrapperRef.current?.querySelector('.ant-table-content colgroup col:last-child')
+        col?.removeAttribute('style')
+    }
+
     function updateTableWidth(): void {
         // <table> elements have super strange auto-sizing: (https://css-tricks.com/fixing-tables-long-strings/)
         // We control the width of the <table> based on the width of the virtual header.
@@ -81,8 +92,10 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
                 table?.setAttribute('style', `width: ${headerWidth}px;`)
             }
         }
+        unsetLastColumnStyle()
     }
-    const handleResize = (index: number): ResizeHandler => (_, { size: { width } }) => {
+
+    const handleColumnResize = (index: number): ResizeHandler => (_, { size: { width } }) => {
         if (timeout.current) {
             cancelAnimationFrame(timeout.current)
         }
@@ -92,24 +105,62 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
         })
         updateScrollGradient()
     }
+
+    function handleWrapperResize(newWidth: number): void {
+        if (timeout.current) {
+            cancelAnimationFrame(timeout.current)
+        }
+        timeout.current = requestAnimationFrame(function () {
+            const table = scrollWrapperRef.current?.querySelector('.ant-table table')
+            const oldWidth = table?.clientWidth
+            if (!oldWidth || oldWidth === newWidth) {
+                return
+            }
+            setHeaderShouldRender(false)
+            setHeaderColumns((cols) => {
+                const lastIndex = initialColumns.length
+                const nextColumns = cols.map((column, index) =>
+                    index === lastIndex
+                        ? column
+                        : {
+                              ...column,
+                              width: Math.max(((column.width ?? 0) / oldWidth) * newWidth, minColumnWidth),
+                          }
+                )
+                nextColumns.slice(0, lastIndex).forEach((col, index) => {
+                    updateColumnWidth(index, col.width ?? minColumnWidth)
+                })
+                updateTableWidth()
+                return nextColumns
+            })
+            setHeaderShouldRender(true)
+            updateTableWidth()
+        })
+    }
+
+    const resizeObserver = new ResizeObserver((entries) => {
+        entries.forEach(({ contentRect: { width } }) => handleWrapperResize(width))
+    })
+
     useLayoutEffect(() => {
         // Calculate relative column widths (px) once the wrapper is mounted.
         if (scrollWrapperRef.current) {
+            resizeObserver.observe(scrollWrapperRef.current)
             const wrapperWidth = scrollWrapperRef.current.clientWidth
             const gridBasis = columns.reduce((total, { span }) => total + span, 0)
             const columnSpanWidth = getFullwidthColumnSize(wrapperWidth, gridBasis)
             setColumns((cols) => {
                 const lastIndex = cols.length
-                const nextColumns = cols.map((column, index) => {
-                    if (index === lastIndex) {
-                        return column
-                    }
-                    return {
-                        ...column,
-                        render: initialColumns[index].render,
-                        width: Math.max(columnSpanWidth * column.span, minColumnWidth),
-                    }
-                })
+                const nextColumns = cols.map((column, index) =>
+                    index === lastIndex
+                        ? column
+                        : {
+                              ...column,
+                              render: initialColumns[index].render,
+                              width: Math.max(columnSpanWidth * column.span, minColumnWidth),
+                          }
+                )
+                setHeaderColumns(nextColumns)
                 return nextColumns
             })
             updateScrollGradient()
@@ -122,8 +173,8 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             <div ref={overlayRef} className="table-gradient-overlay">
                 {headerShouldRender && (
                     <VirtualTableHeader
-                        columns={columns}
-                        handleResize={handleResize}
+                        columns={headerColumns}
+                        handleResize={handleColumnResize}
                         layoutEffect={updateTableWidth}
                         minColumnWidth={minColumnWidth}
                     />

--- a/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
+++ b/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
@@ -10,13 +10,13 @@ export function getFullwidthColumnSize(wrapperWidth: number = 1200, gridBasis = 
     return Math.floor(innerWidth / gridBasis)
 }
 
-function getPixelValue(cssStatement: string): number {
-    return parseInt(cssStatement.replace(/\D/g, ''), 10)
+export function parsePixelValue(cssStatement: string): number {
+    return parseFloat(cssStatement.replace(/[^\d.]/g, ''))
 }
 
 export function getActiveBreakpoint(): number {
     const { innerWidth: width } = window
-    const breakpoints = Object.values(responsiveMap).map((cssStatement) => getPixelValue(cssStatement))
+    const breakpoints = Object.values(responsiveMap).map((cssStatement) => parsePixelValue(cssStatement))
     let breakpoint = breakpoints[0]
     breakpoints.forEach((value) => {
         if (width > breakpoint) {

--- a/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
+++ b/frontend/src/lib/components/ResizableTable/responsiveUtils.ts
@@ -1,17 +1,13 @@
 import { responsiveMap } from 'antd/lib/_util/responsiveObserve'
-
-const gridBasis = 24
+import { ANTD_EXPAND_BUTTON_WIDTH } from './index'
 
 export function getMinColumnWidth(breakpoint: number): number {
-    return breakpoint < 768 ? 40 : 50
+    return breakpoint < 576 ? 150 : 50
 }
 
-export function getMaxColumnWidth(breakpoint: number): number {
-    return breakpoint < 768 ? 500 : 750
-}
-
-export function getFullwidthColumnSize(wrapperWidth: number = 1200): number {
-    return Math.floor(wrapperWidth / gridBasis)
+export function getFullwidthColumnSize(wrapperWidth: number = 1200, gridBasis = 24): number {
+    const innerWidth = wrapperWidth - ANTD_EXPAND_BUTTON_WIDTH
+    return Math.floor(innerWidth / gridBasis)
 }
 
 function getPixelValue(cssStatement: string): number {

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -16,6 +16,7 @@
 }
 
 .sessions-with-filters {
+    flex-grow: 1;
     margin-top: 30px;
     min-width: 0;
     overflow: hidden;

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -99,28 +99,28 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
             render: function RenderDuration(session: SessionType) {
                 return <span>{session.event_count}</span>
             },
-            span: 1.5,
+            span: 2,
         },
         {
             title: 'Session duration',
             render: function RenderDuration(session: SessionType) {
                 return <span>{humanFriendlyDuration(session.length)}</span>
             },
-            span: 1.5,
+            span: 2,
         },
         {
             title: 'Start Time',
             render: function RenderStartTime(session: SessionType) {
                 return <span>{humanFriendlyDetailedTime(session.start_time)}</span>
             },
-            span: 2.5,
+            span: 3,
         },
         {
             title: 'End Time',
             render: function RenderEndTime(session: SessionType) {
                 return <span>{humanFriendlyDetailedTime(session.end_time)}</span>
             },
-            span: 2.5,
+            span: 3,
         },
         {
             title: 'Start Point',
@@ -129,7 +129,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 return <span>{url ? stripHTTP(url) : 'N/A'}</span>
             },
             ellipsis: true,
-            span: 3,
+            span: 4,
         },
         {
             title: 'End Point',
@@ -140,7 +140,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 return <span>{url ? stripHTTP(url) : 'N/A'}</span>
             },
             ellipsis: true,
-            span: 3,
+            span: 4,
         },
         {
             title: (

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "react-toastify": "^5.5.0",
         "redux": "^4.0.5",
         "reselect": "^4.0.0",
+        "resize-observer-polyfill": "^1.5.1",
         "rrweb": "^0.9.14",
         "sass": "^1.26.2",
         "zxcvbn": "^4.4.2"


### PR DESCRIPTION
## Changes

Fixes #4001, although needs further testing.

`ResizableTable` now renders the antd table separate from the header, which is a custom component called `VirtualTableHeader`. The previous approach used resizable components within the actual table, which forced the whole table to re-render on resize.

The header now controls the size of the columns via imperative manipulation of `style.width` on the `<colgroup>` rendered by antd. This avoids re-rendering the antd table because its props do not change.

### What still needs to be done:

Resize the whole table when its wrapper resizes.

Currently, the column sizes are set on first render, and will not grow if the user expands the window. We should probably keep track of which columns were user-resized and which were auto-sized and recalculate sizes for the auto-sized columns.

https://user-images.githubusercontent.com/4645779/115152025-73222980-a03d-11eb-871d-9c0401052fd0.mp4

This also means the table won't grow if it is mounted too soon after other animations take place on the page, for example, the sidebar-hiding animation:

https://user-images.githubusercontent.com/4645779/115152017-6d2c4880-a03d-11eb-9a15-14d6eaded126.mp4



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
