### PR TITLE
Defer event fields on team model to make grabbing fields a bit more lazy

### DIFF
--- a/ee/bin/docker-ch-test
+++ b/ee/bin/docker-ch-test
@@ -8,4 +8,5 @@ mkdir -p frontend/dist
 touch frontend/dist/index.html
 touch frontend/dist/layout.html
 touch frontend/dist/shared_dashboard.html
+pytest posthog
 pytest ee

--- a/ee/bin/docker-ch-test
+++ b/ee/bin/docker-ch-test
@@ -8,5 +8,4 @@ mkdir -p frontend/dist
 touch frontend/dist/index.html
 touch frontend/dist/layout.html
 touch frontend/dist/shared_dashboard.html
-pytest posthog
 pytest ee

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -17,6 +17,14 @@ TEAM_CACHE: Dict[str, "Team"] = {}
 
 TIMEZONES = [(tz, tz) for tz in pytz.common_timezones]
 
+DEFERRED_FIELDS = (
+    "event_names",
+    "event_names_with_usage",
+    "event_properties",
+    "event_properties_with_usage",
+    "event_properties_numerical",
+)
+
 
 class TeamManager(models.Manager):
     def set_test_account_filters(self, organization: Optional[Any]) -> List:
@@ -59,7 +67,7 @@ class TeamManager(models.Manager):
         if not token:
             return None
         try:
-            return Team.objects.get(api_token=token)
+            return Team.objects.get(api_token=token).defer(*DEFERRED_FIELDS)
         except Team.DoesNotExist:
             return None
 

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -67,7 +67,7 @@ class TeamManager(models.Manager):
         if not token:
             return None
         try:
-            return Team.objects.get(api_token=token).defer(*DEFERRED_FIELDS)
+            return Team.objects.defer(*DEFERRED_FIELDS).get(api_token=token)
         except Team.DoesNotExist:
             return None
 


### PR DESCRIPTION
## Changes

Currently every event that we consume we grab the entire team payload. This defers consuming the larger columns in the team table until they are required.

https://docs.djangoproject.com/en/3.2/ref/models/querysets/#django.db.models.query.QuerySet.defer

