### PR TITLE
Release session filters

### DIFF
--- a/frontend/src/scenes/sessions/Sessions.cy-spec.js
+++ b/frontend/src/scenes/sessions/Sessions.cy-spec.js
@@ -18,7 +18,6 @@ describe('<Sessions />', () => {
         helpers.setLocation('/sessions')
     })
 
-    given('featureFlags', () => ['filter_by_session_props'])
     given('sessions', () => () => ({ fixture: 'api/event/sessions/demo_sessions' }))
 
     const iterateResponses = (responses) => {

--- a/frontend/src/scenes/sessions/Sessions.tsx
+++ b/frontend/src/scenes/sessions/Sessions.tsx
@@ -3,32 +3,20 @@ import { SessionsView } from './SessionsView'
 import { SavedFiltersMenu } from 'scenes/sessions/filters/SavedFiltersMenu'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Divider } from 'antd'
-import { useValues } from 'kea'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export function Sessions(): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    if (featureFlags['filter_by_session_props']) {
-        return (
-            <div className="sessions-wrapper">
-                <div className="sessions-sidebar">
-                    <div>
-                        <PageHeader title="Sessions" />
-                        <SavedFiltersMenu />
-                    </div>
-                    <Divider type="vertical" className="sessions-divider" />
+    return (
+        <div className="sessions-wrapper">
+            <div className="sessions-sidebar">
+                <div>
+                    <PageHeader title="Sessions" />
+                    <SavedFiltersMenu />
                 </div>
-                <div className="sessions-with-filters">
-                    <SessionsView />
-                </div>
+                <Divider type="vertical" className="sessions-divider" />
             </div>
-        )
-    } else {
-        return (
-            <>
-                <PageHeader title="Sessions" />
+            <div className="sessions-with-filters">
                 <SessionsView />
-            </>
-        )
-    }
+            </div>
+        </div>
+    )
 }

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -16,10 +16,8 @@ import {
     PlaySquareOutlined,
 } from '@ant-design/icons'
 import { SessionsPlayerButton, sessionPlayerUrl } from './SessionsPlayerButton'
-import { PropertyFilters } from 'lib/components/PropertyFilters'
 import { SessionsPlay } from './SessionsPlay'
 import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LinkButton } from 'lib/components/LinkButton'
 import { SessionsFilterBox } from 'scenes/sessions/filters/SessionsFilterBox'
 import { EditFiltersPanel } from 'scenes/sessions/filters/EditFiltersPanel'
@@ -67,7 +65,6 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
     const { fetchNextSessions, previousDay, nextDay, setFilters, applyFilters } = useActions(logic)
     const { currentTeam } = useValues(teamLogic)
     const { shareFeedbackCommand } = useActions(commandPaletteLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const enableSessionRecordingCTA = (
         <>
@@ -193,18 +190,10 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 <Button onClick={nextDay} icon={<CaretRightOutlined />} data-attr="sessions-next-date" />
             </Space>
 
-            {featureFlags['filter_by_session_props'] && (
-                <>
-                    <SearchAllBox />
-                    <SessionsFilterBox selector="new" />
-                </>
-            )}
+            <SearchAllBox />
+            <SessionsFilterBox selector="new" />
 
-            {featureFlags['filter_by_session_props'] ? (
-                <EditFiltersPanel onSubmit={applyFilters} />
-            ) : (
-                <PropertyFilters pageKey={'sessions-' + (personIds && JSON.stringify(personIds))} endpoint="sessions" />
-            )}
+            <EditFiltersPanel onSubmit={applyFilters} />
 
             <div className="text-right mb mt">
                 <Tooltip title={playAllCTA}>

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -49,20 +49,15 @@ export function PersonModal({ visible, view, onSaveCohort }: Props): JSX.Element
                                 </Button>
                             )}
                     </div>
-                    {featureFlags['filter_by_session_props_link'] ? (
-                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
-                            <Link
-                                to={peopleModalURL.sessions}
-                                style={{ marginLeft: 8 }}
-                                data-attr="persons-modal-sessions"
-                            >
-                                <ClockCircleOutlined /> View related sessions <ArrowRightOutlined />
-                            </Link>
-                            <Link to={peopleModalURL.recordings} type="primary" data-attr="persons-modal-recordings">
-                                View related recordings <ArrowRightOutlined />
-                            </Link>
-                        </div>
-                    ) : null}
+
+                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+                        <Link to={peopleModalURL.sessions} style={{ marginLeft: 8 }} data-attr="persons-modal-sessions">
+                            <ClockCircleOutlined /> View related sessions <ArrowRightOutlined />
+                        </Link>
+                        <Link to={peopleModalURL.recordings} type="primary" data-attr="persons-modal-recordings">
+                            View related recordings <ArrowRightOutlined />
+                        </Link>
+                    </div>
                 </div>
             ) : (
                 <p>Loading users...</p>


### PR DESCRIPTION
## Changes

Releases feature flags `filter_by_session_props` & `filter_by_session_props_link`, removing any previously conditional code. For context, these feature flags are already fully released to 100% of users.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
