### PR TITLE
fix stateful renders in ResizableTable

### DIFF
--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -87,6 +87,7 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             nextColumns[index] = {
                 ...nextColumns[index],
                 width,
+                render: initialColumns[index].render,
             }
             return nextColumns
         })
@@ -118,9 +119,10 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             const wrapperWidth = scrollWrapperRef.current.clientWidth
             const columnWidth = getFullwidthColumnSize(wrapperWidth)
             setColumns((cols) => {
-                const nextColumns = cols.map((column) => ({
+                const nextColumns = cols.map((column, index) => ({
                     ...column,
                     width: Math.max(minWidth, columnWidth * column.span),
+                    render: initialColumns[index].render,
                 }))
                 if (getTotalWidth(nextColumns) > wrapperWidth) {
                     setScrollableRight(true)
@@ -128,7 +130,8 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
                 return nextColumns
             })
         }
-    }, [])
+    }, [initialColumns])
+
     return (
         <div ref={scrollWrapperRef} className="resizable-table-scroll-container" onScroll={updateScrollGradient}>
             <div ref={overlayRef} className="table-gradient-overlay">

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -87,7 +87,6 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             nextColumns[index] = {
                 ...nextColumns[index],
                 width,
-                render: initialColumns[index].render,
             }
             return nextColumns
         })


### PR DESCRIPTION
## Changes

**EDIT:** Did some quick testing now, seems like I broke some stuff too. I could revisit later or @samwinslow, given you have more context here, you could take over this PR.

ResizableTable broke stateful renders for columns, causing stuff like the `You have 0 new events` bug.

This is because our `render` functions for columns sometimes use state, and since we were never updating `columns` when the state changed, the values would always reflect the initial state of the parent component. 

Thought this would be a simple thing but had to go into a bit of a rabbit hole to find it. Doesn't look like the best approach but putting this up because PRs over issues.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
