### PR TITLE
Fix lifecycle graph count bug

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -26,9 +26,8 @@ export function ActionsLineGraph({
     const { loadPeople } = useActions(logic)
 
     const [{ fromItem }] = useState(router.values.hashParams)
-
     return indexedResults && !resultsLoading ? (
-        indexedResults.reduce((total, item) => total + item.count, 0) !== 0 ? (
+        indexedResults.filter((result) => result.count !== 0).length > 0 ? (
             <LineGraph
                 data-attr="trend-line-graph"
                 type={


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog/issues/4035

Before: 

Lifecycles graph were not rendering anything 

<img width="855" alt="Screen Shot 2021-04-19 at 2 58 00 PM" src="https://user-images.githubusercontent.com/25164963/115288624-a5a45300-a11f-11eb-9eca-69d0f17fc4b3.png">

because we were totaling the count of each lifecycle option instead of checking if they were all empty

ex: [62, -62, 0, 0] should return a graph because there are values for two out of the four lifecycle toggles

<img width="1080" alt="Screen Shot 2021-04-19 at 2 55 16 PM" src="https://user-images.githubusercontent.com/25164963/115288280-434b5280-a11f-11eb-811b-a133133eb41a.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
