### PR TITLE
Fix dev.Dockerfile (following #4007)

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -44,9 +44,9 @@ COPY plugins/yarn.lock plugins/
 COPY . .
 
 # generate Django's static files
-RUN DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
+RUN DATABASE_URL='postgres:///' REDIS_URL='redis:///' mkdir frontend/dist && python manage.py collectstatic --noinput
 
 # install frontend dependencies
-RUN mkdir frontend/dist && yarn install && yarn install --cwd plugins && yarn cache clean
+RUN yarn install && yarn install --cwd plugins && yarn cache clean
 
 CMD ["./bin/docker-dev"]


### PR DESCRIPTION
## Changes

Fixes the development Dockerfile (command that needs to run sooner) following #4007.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
