### PR TITLE
Fix POSTHOG-2P8 bug - error handling unauthorized requests

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -75,6 +75,8 @@ def _get_project_id(data, request) -> Optional[int]:
         return int(request.POST["project_id"])
     if request.POST.get("project_id"):
         return int(request.POST["project_id"])
+    if isinstance(data, list):
+        data = data[0]  # Mixpanel Swift SDK
     if data.get("project_id"):
         return int(data["project_id"])
     return None

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -158,8 +158,20 @@ class TestCapture(BaseTest):
                 "distinct_id": "94b03e599131fd5026b",
                 "ip": "127.0.0.1",
                 "site_url": "http://testserver",
-                "data": data,
-                "team_id": self.team.pk,
+                "data": {
+                    "event": "$pageleave",
+                    "api_key": "zwtVwatmw2dB6NlKnp7OKR1IVBeJr1-Tf8CwWh5rCWI",
+                    "project_id": 1,
+                    "properties": {
+                        "$os": "Linux",
+                        "$browser": "Chrome",
+                        "$device_type": "Desktop",
+                        "distinct_id": "94b03e599131fd5026b",
+                        "token": "fake token",
+                    },
+                    "timestamp": "2021-04-20T19:11:33.841Z",
+                },
+                "team_id": 1,
             },
         )
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -160,7 +160,7 @@ class TestCapture(BaseTest):
                 "site_url": "http://testserver",
                 "data": {
                     "event": "$pageleave",
-                    "api_key": "zwtVwatmw2dB6NlKnp7OKR1IVBeJr1-Tf8CwWh5rCWI",
+                    "api_key": key.value,
                     "project_id": 1,
                     "properties": {
                         "$os": "Linux",


### PR DESCRIPTION
## Changes

Fixes bug https://sentry.io/organizations/posthog/issues/2352148355/ caused by sending a batch request with an incorrect ingestion key.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
