### PR TITLE
Fix events failure & typescript migration

### DIFF
--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -2,13 +2,14 @@ import React, { useLayoutEffect, useRef, useState } from 'react'
 import { Table, TableProps } from 'antd'
 import { Resizable } from 'react-resizable'
 import { getActiveBreakpoint, getFullwidthColumnSize, getMaxColumnWidth, getMinColumnWidth } from './responsiveUtils'
+import { RenderedCell } from 'rc-table/lib/interface'
 
 import './index.scss'
 
 export interface ResizableColumnType<RecordType> {
     title: string | JSX.Element
     key?: string
-    render: (record: RecordType, ...rest: any) => JSX.Element
+    render: (record: RecordType, ...rest: any) => JSX.Element | RenderedCell<RecordType>
     ellipsis?: boolean
     span: number
 }

--- a/frontend/src/scenes/actions/EventName.js
+++ b/frontend/src/scenes/actions/EventName.js
@@ -4,7 +4,7 @@ import { useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 
-export function EventName({ value, onChange, isActionStep }) {
+export function EventName({ value, onChange, isActionStep = false }) {
     const { eventNamesGrouped } = useValues(teamLogic)
 
     return (

--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -43,7 +43,7 @@ export function ManageEvents(): JSX.Element {
             <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={setTab}>
                 <Tabs.TabPane tab="Events" key="live">
                     See all events that are being sent to this project in real time.
-                    <EventsTable fixedFilters={''} pageKey={undefined} />
+                    <EventsTable />
                 </Tabs.TabPane>
                 <Tabs.TabPane tab={<span data-attr="events-actions-tab">Actions</span>} key="actions">
                     <ActionsTable />

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -17,13 +17,25 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { ViewType } from 'scenes/insights/insightLogic'
-import { ResizableTable } from 'lib/components/ResizableTable'
+import { ResizableColumnType, ResizableTable } from 'lib/components/ResizableTable'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { EventFormattedType } from '~/types'
 
 dayjs.extend(LocalizedFormat)
 dayjs.extend(relativeTime)
 
-export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
+interface FixedFilters {
+    person_id?: string
+    distinct_ids?: string[]
+}
+
+interface EventsTable {
+    fixedFilters?: FixedFilters
+    filtersEnabled?: boolean
+    pageKey: string
+}
+
+export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: EventsTable): JSX.Element {
     const logic = eventsTableLogic({ fixedFilters, key: pageKey })
     const {
         properties,
@@ -38,13 +50,12 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
     const { fetchNextEvents, prependNewEvents, setEventFilter } = useActions(logic)
 
     const showLinkToPerson = !fixedFilters?.person_id
-    let columns = [
+    const columns: ResizableColumnType<EventFormattedType>[] = [
         {
             title: `Event${eventFilter ? ` (${eventFilter})` : ''}`,
             key: 'event',
-            rowKey: 'id',
             span: 4,
-            render: function renderEvent(item) {
+            render: function render(item) {
                 if (!item.event) {
                     return {
                         children: item.date_break
@@ -60,7 +71,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                         },
                     }
                 }
-                let { event } = item
+                const { event } = item
                 return <PropertyKeyInfo value={eventToName(event)} />
             },
         },
@@ -90,15 +101,16 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                 if (!event) {
                     return { props: { colSpan: 0 } }
                 }
-                let param = event.properties['$current_url'] ? '$current_url' : '$screen_name'
+                const param = event.properties['$current_url'] ? '$current_url' : '$screen_name'
                 if (filtersEnabled) {
                     return (
-                        <FilterPropertyLink
-                            className="ph-no-capture"
-                            property={param}
-                            value={event.properties[param]}
-                            filters={{ properties }}
-                        />
+                        <span className="ph-no-capture">
+                            <FilterPropertyLink
+                                property={param}
+                                value={event.properties[param]}
+                                filters={{ properties }}
+                            />
+                        </span>
                     )
                 }
                 return <Property value={event.properties[param]} />
@@ -200,7 +212,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
         },
     ]
 
-    function _personInsightLink() {
+    function _personInsightLink(): JSX.Element | null {
         if (fixedFilters && fixedFilters.distinct_ids?.length) {
             const params = {
                 insight: ViewType.TRENDS,
@@ -242,7 +254,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                 <div style={{ flex: 1 }}>
                     <EventName
                         value={eventFilter}
-                        onChange={(value) => {
+                        onChange={(value: string) => {
                             setEventFilter(value || '')
                         }}
                     />
@@ -282,7 +294,9 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                         ),
                     }}
                     pagination={{ pageSize: 99999, hideOnSinglePage: true }}
-                    rowKey={(row) => (row.event ? row.event.id + '-' + row.event.actionId : row.date_break)}
+                    rowKey={(row) =>
+                        row.event ? row.event.id + '-' + row.event.event : row.date_break?.toString() || ''
+                    }
                     rowClassName={(row) => {
                         if (row.event) {
                             return 'event-row ' + (row.event.event === '$exception' && 'event-row-is-exception')
@@ -293,12 +307,13 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }) {
                         if (row.new_events) {
                             return 'event-row-new'
                         }
+                        return ''
                     }}
                     expandable={{
                         expandedRowRender: function renderExpand({ event }) {
                             return <EventDetails event={event} />
                         },
-                        rowExpandable: ({ event }) => event,
+                        rowExpandable: ({ event }) => !!event,
                         expandRowByClick: true,
                     }}
                     onRow={(row) => ({

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -25,14 +25,14 @@ dayjs.extend(LocalizedFormat)
 dayjs.extend(relativeTime)
 
 interface FixedFilters {
-    person_id?: string
+    person_id?: string | number
     distinct_ids?: string[]
 }
 
 interface EventsTable {
     fixedFilters?: FixedFilters
     filtersEnabled?: boolean
-    pageKey: string
+    pageKey?: string
 }
 
 export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: EventsTable): JSX.Element {

--- a/frontend/src/scenes/events/eventsTableLogic.js
+++ b/frontend/src/scenes/events/eventsTableLogic.js
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { objectsEqual, toParams } from 'lib/utils'
+import { errorToast, objectsEqual, toParams } from 'lib/utils'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import dayjs from 'dayjs'
@@ -50,6 +50,7 @@ export const eventsTableLogic = kea({
         fetchEvents: (nextParams = null) => ({ nextParams }),
         fetchEventsSuccess: (events, hasNext = false, isNext = false) => ({ events, hasNext, isNext }),
         fetchNextEvents: true,
+        fetchOrPollFailure: (error) => ({ error }),
         flipSort: true,
         pollEvents: true,
         pollEventsSuccess: (events) => ({ events }),
@@ -82,6 +83,7 @@ export const eventsTableLogic = kea({
                 fetchEvents: (state, { nextParams }) => (nextParams ? state : state || null),
                 setDelayedLoading: () => true,
                 fetchEventsSuccess: () => false,
+                fetchOrPollFailure: () => false,
             },
         ],
         isLoadingNext: [
@@ -222,7 +224,15 @@ export const eventsTableLogic = kea({
                     orderBy: [values.orderBy],
                 })
 
-                const events = await api.get(`${props.apiUrl || 'api/event/'}?${urlParams}`)
+                let events = null
+
+                try {
+                    events = await api.get(`${props.apiUrl || 'api/event/'}?${urlParams}`)
+                } catch (error) {
+                    actions.fetchOrPollFailure(error)
+                    return
+                }
+
                 breakpoint()
                 actions.fetchEventsSuccess(events.results, events.next, !!nextParams)
 
@@ -248,7 +258,15 @@ export const eventsTableLogic = kea({
                 params.after = event.timestamp || event.event.timestamp
             }
 
-            const events = await api.get(`${props.apiUrl || 'api/event/'}?${toParams(params)}`)
+            let events = null
+
+            try {
+                events = await api.get(`${props.apiUrl || 'api/event/'}?${toParams(params)}`)
+            } catch (e) {
+                // We don't call fetchOrPollFailure because we don't to generate an error alert for this
+                return
+            }
+
             breakpoint()
 
             if (props.live) {
@@ -258,6 +276,14 @@ export const eventsTableLogic = kea({
             }
 
             actions.setPollTimeout(setTimeout(actions.pollEvents, POLL_TIMEOUT))
+        },
+        fetchOrPollFailure: ({ error }) => {
+            errorToast(
+                undefined,
+                'There was a problem fetching your events. Please refresh this page to try again.',
+                error.detail,
+                error.code
+            )
         },
     }),
 })

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 import { IconPerson } from 'lib/components/icons'
 import './PersonHeader.scss'
 
-export function PersonHeader({ person }: { person: Partial<PersonType> }): JSX.Element {
+export function PersonHeader({ person }: { person?: Partial<PersonType> | null }): JSX.Element {
     const customIdentifier = person?.properties
         ? person.properties.email || person.properties.name || person.properties.username
         : null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,7 @@ import {
 import { PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginInstallationType } from 'scenes/plugins/types'
 import { ViewType } from 'scenes/insights/insightLogic'
+import { Dayjs } from 'dayjs'
 
 export type AvailableFeatures =
     | 'zapier'
@@ -317,6 +318,12 @@ export interface EventType {
     properties: Record<string, any>
     timestamp: string
     person?: Partial<PersonType> | null
+}
+
+export interface EventFormattedType {
+    event: EventType
+    date_break?: Dayjs
+    new_events?: boolean
 }
 
 export interface SessionType {


### PR DESCRIPTION
## Changes

- This PR fixes a bug in /events where if fetching the events list failed, it caused the screen to load indefinitely without any errors, and cause an unhandled JS error.
- In addition, this PR transitions `EventsTable` component to Typescript.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
