### PR TITLE
Fix feature flag display with 0% rollout

### DIFF
--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -159,7 +159,7 @@ function GroupFilters({ group }: { group: FeatureFlagGroupType }): JSX.Element |
         )
     } else if (group.properties && group.properties.length > 0) {
         return <PropertyFiltersDisplay filters={group.properties} style={{ margin: 0 }} />
-    } else if (group.rollout_percentage) {
+    } else if (group.rollout_percentage !== null && group.rollout_percentage !== undefined) {
         return `${group.rollout_percentage}% of all users`
     } else {
         return '100% of all users'


### PR DESCRIPTION
## Changes
Fixes a bug reported by a user in which if you set up a match group to match 0% of users, we would show it in the feature flag table as 100% of users.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
