### PR TITLE
Make Postgres ASYNC_EVENT_ACTION_MAPPING the way

### DIFF
--- a/cypress/fixtures/_preflight.json
+++ b/cypress/fixtures/_preflight.json
@@ -455,6 +455,5 @@
     "posthog_version": "1.23.1",
     "email_service_available": false,
     "is_debug": 1,
-    "is_event_property_usage_enabled": false,
-    "is_async_event_action_mapping_enabled": true
+    "is_event_property_usage_enabled": false
 }

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -183,7 +183,7 @@ export function ActionEdit({ action: loadedAction, actionId, apiURL, onSave, tem
                                 {slackEnabled ? 'Configure' : 'Enable'} this integration in Setup.
                             </Link>
                         </p>
-                        {preflight?.is_async_event_action_mapping_enabled && <AsyncActionMappingNotice />}
+                        {!preflight?.ee_enabled && <AsyncActionMappingNotice />}
                         {action.post_to_slack && (
                             <>
                                 <Input

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -37,7 +37,7 @@ export function WebhookIntegration(): JSX.Element {
                 <a href="https://posthog.com/docs/integrations/microsoft-teams">for Microsoft Teams</a>. Discord is also
                 supported.
             </p>
-            {preflight?.is_async_event_action_mapping_enabled && <AsyncActionMappingNotice />}
+            {!preflight?.ee_enabled && <AsyncActionMappingNotice />}
 
             <Input
                 value={webhook}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -618,7 +618,6 @@ export interface PreflightStatus {
     email_service_available?: boolean
     is_debug?: boolean
     is_event_property_usage_enabled?: boolean
-    is_async_event_action_mapping_enabled?: boolean
     licensed_users_available: number | null
 }
 

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -62,7 +62,6 @@ class TestPreflight(APIBaseTest):
                     "email_service_available": False,
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
-                    "is_async_event_action_mapping_enabled": True,
                     "licensed_users_available": None,
                 },
             )
@@ -120,7 +119,6 @@ class TestPreflight(APIBaseTest):
                     "email_service_available": False,
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
-                    "is_async_event_action_mapping_enabled": True,
                     "licensed_users_available": None,
                 },
             )
@@ -160,7 +158,6 @@ class TestPreflight(APIBaseTest):
                     "email_service_available": True,
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
-                    "is_async_event_action_mapping_enabled": True,
                     "licensed_users_available": None,
                 },
             )

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -291,7 +291,6 @@ def user(request):
             "is_staff": user.is_staff,
             "is_impersonated": is_impersonated_session(request),
             "is_event_property_usage_enabled": getattr(settings, "ASYNC_EVENT_PROPERTY_USAGE", False),
-            "is_async_event_action_mapping_enabled": getattr(settings, "ASYNC_EVENT_ACTION_MAPPING", False),
         }
     )
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -79,15 +79,15 @@ def setup_periodic_tasks(sender, **kwargs):
         sender.add_periodic_task(120, clickhouse_lag.s(), name="clickhouse table lag")
         sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
         sender.add_periodic_task(120, clickhouse_part_count.s(), name="clickhouse table parts count")
+    else:
+        sender.add_periodic_task(
+            ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
+            calculate_event_action_mappings.s(),
+            name="calculate event action mappings",
+            expires=ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
+        )
 
     sender.add_periodic_task(120, calculate_cohort.s(), name="recalculate cohorts")
-
-    sender.add_periodic_task(
-        ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
-        calculate_event_action_mappings.s(),
-        name="calculate event action mappings",
-        expires=ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
-    )
 
     if settings.ASYNC_EVENT_PROPERTY_USAGE:
         sender.add_periodic_task(

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -82,13 +82,12 @@ def setup_periodic_tasks(sender, **kwargs):
 
     sender.add_periodic_task(120, calculate_cohort.s(), name="recalculate cohorts")
 
-    if settings.ASYNC_EVENT_ACTION_MAPPING:
-        sender.add_periodic_task(
-            ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
-            calculate_event_action_mappings.s(),
-            name="calculate event action mappings",
-            expires=ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
-        )
+    sender.add_periodic_task(
+        ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
+        calculate_event_action_mappings.s(),
+        name="calculate event action mappings",
+        expires=ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
+    )
 
     if settings.ASYNC_EVENT_PROPERTY_USAGE:
         sender.add_periodic_task(

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -177,10 +177,6 @@ EE_AVAILABLE = False
 
 PLUGIN_SERVER_INGESTION = get_from_env("PLUGIN_SERVER_INGESTION", not TEST, type_cast=strtobool)
 
-# True if ingesting with the plugin server into Postgres, as it's then not possible to calculate the mapping on the fly
-ASYNC_EVENT_ACTION_MAPPING = PRIMARY_DB == RDBMS.POSTGRES and get_from_env(
-    "ASYNC_EVENT_ACTION_MAPPING", True, type_cast=strtobool
-)
 ACTION_EVENT_MAPPING_INTERVAL_SECONDS = get_from_env("ACTION_EVENT_MAPPING_INTERVAL_SECONDS", 300, type_cast=int)
 
 ASYNC_EVENT_PROPERTY_USAGE = get_from_env("ASYNC_EVENT_PROPERTY_USAGE", False, type_cast=strtobool)

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -209,7 +209,6 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
             "email_service_available": is_email_available(with_absolute_urls=True),
             "is_debug": settings.DEBUG,
             "is_event_property_usage_enabled": settings.ASYNC_EVENT_PROPERTY_USAGE,
-            "is_async_event_action_mapping_enabled": settings.ASYNC_EVENT_ACTION_MAPPING,
             "licensed_users_available": get_licensed_users_available(),
         }
 


### PR DESCRIPTION
## Changes

Since we're now using plugin server ingestion only, the old sync per-event approach to action matching can't be used. This removes code that was deprecated and will not be used anymore.

## Checklist

- [x] Django backend tests
