### PR TITLE
Remove deprecated person API actions `by_distinct_id` and `by_email`

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -142,36 +142,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         return self._filter_request(self.request, super().get_queryset())
 
     @action(methods=["GET"], detail=False)
-    def by_distinct_id(self, request, **kwargs):
-        """
-        DEPRECATED in favor of /api/person/?distinct_id={id}
-        """
-        warnings.warn(
-            "/api/person/by_distinct_id/ endpoint is deprecated; use /api/person/ instead.", DeprecationWarning,
-        )
-        result = self.get_by_distinct_id(request)
-        return response.Response(result)
-
-    def get_by_distinct_id(self, request):
-        person = self.get_queryset().get(persondistinctid__distinct_id=str(request.GET["distinct_id"]))
-        return PersonSerializer(person).data
-
-    @action(methods=["GET"], detail=False)
-    def by_email(self, request, **kwargs):
-        """
-        DEPRECATED in favor of /api/person/?email={email}
-        """
-        warnings.warn(
-            "/api/person/by_email/ endpoint is deprecated; use /api/person/ instead.", DeprecationWarning,
-        )
-        result = self.get_by_email(request)
-        return response.Response(result)
-
-    def get_by_email(self, request):
-        person = self.get_queryset().get(properties__email=str(request.GET["email"]))
-        return PersonSerializer(person).data
-
-    @action(methods=["GET"], detail=False)
     def properties(self, request: request.Request, **kwargs) -> response.Response:
         result = self.get_properties(request)
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -247,29 +247,6 @@ def factory_test_person(event_factory, person_factory, get_events, get_people):
             response = self.client.delete(f"/api/person/{person.pk}/")
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        def test_filters_by_endpoints_are_deprecated(self):
-            person_factory(
-                team=self.team, distinct_ids=["person_1"], properties={"email": "someone@gmail.com"},
-            )
-
-            # By Distinct ID
-            with self.assertWarns(DeprecationWarning) as warnings:
-                response = self.client.get("/api/person/by_distinct_id/?distinct_id=person_1")
-
-            self.assertEqual(response.status_code, status.HTTP_200_OK)  # works but it's deprecated
-            self.assertEqual(
-                str(warnings.warning), "/api/person/by_distinct_id/ endpoint is deprecated; use /api/person/ instead.",
-            )
-
-            # By Distinct ID
-            with self.assertWarns(DeprecationWarning) as warnings:
-                response = self.client.get("/api/person/by_email/?email=someone@gmail.com")
-
-            self.assertEqual(response.status_code, status.HTTP_200_OK)  # works but it's deprecated
-            self.assertEqual(
-                str(warnings.warning), "/api/person/by_email/ endpoint is deprecated; use /api/person/ instead.",
-            )
-
         def test_filter_id_or_uuid(self) -> None:
             person1 = person_factory(team=self.team, properties={"$browser": "whatever", "$os": "Mac OS X"})
             person2 = person_factory(team=self.team, properties={"random_prop": "asdf"})


### PR DESCRIPTION
## Changes

These two person API actions `by_distinct_id` and `by_email` have not been documented and they've been deprecated half a year ago, so should be good to remove.

## Checklist

- [x] Django backend tests