### PR TITLE
Remove deprecated social auth handling

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -195,34 +195,6 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     context["self_capture"] = False
     context["opt_out_capture"] = os.getenv("OPT_OUT_CAPTURE", False)
 
-    # TODO: BEGINS DEPRECATED CODE
-    # Code deprecated in favor of posthog.api.authentication.AuthenticationSerializer
-    # Remove after migrating login to React
-    if settings.SOCIAL_AUTH_GITHUB_KEY and settings.SOCIAL_AUTH_GITHUB_SECRET:
-        context["github_auth"] = True
-    if settings.SOCIAL_AUTH_GITLAB_KEY and settings.SOCIAL_AUTH_GITLAB_SECRET:
-        context["gitlab_auth"] = True
-    if getattr(settings, "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY", None) and getattr(
-        settings, "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET", None
-    ):
-        if settings.MULTI_TENANCY:
-            context["google_auth"] = True
-        else:
-            google_login_paid_for = False
-            try:
-                from ee.models.license import License
-            except ImportError:
-                pass
-            else:
-                license = License.objects.first_valid()
-                if license is not None and "google_login" in license.available_features:
-                    google_login_paid_for = True
-            if google_login_paid_for:
-                context["google_auth"] = True
-            else:
-                print_warning(["You have Google login set up, but not the required premium PostHog plan!"])
-    # ENDS DEPRECATED CODE
-
     if os.environ.get("SENTRY_DSN"):
         context["sentry_dsn"] = os.environ["SENTRY_DSN"]
 


### PR DESCRIPTION
## Changes

This says `Remove after migrating login to React`, which I think is the case now, though not absolutely sure about the state of play here.
