### PR TITLE
Allow dashboard description editing

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -37,6 +37,14 @@ $dashboard-title-size: 32px;
         .ant-card-body {
             padding: $default_spacing / 2 $default_spacing;
         }
+
+        div:hover {
+            cursor: text;
+        }
+
+        .add-description {
+            color: #9c9797;
+        }
     }
 
     .empty-state {

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -45,6 +45,8 @@ $dashboard-title-size: 32px;
         .edit-box {
             display: flex;
             justify-content: space-between;
+            align-items: center;
+            column-gap: 8px;
         }
 
         .add-description {

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -46,7 +46,7 @@ $dashboard-title-size: 32px;
             display: flex;
             justify-content: space-between;
             align-items: center;
-            column-gap: 8px;
+            column-gap: $default_spacing / 2;
         }
 
         .add-description {

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -42,6 +42,11 @@ $dashboard-title-size: 32px;
             cursor: text;
         }
 
+        .edit-box {
+            display: flex;
+            justify-content: space-between;
+        }
+
         .add-description {
             color: #9c9797;
         }

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -264,17 +264,17 @@ export function DashboardHeader(): JSX.Element {
                                 allowClear
                             />
                         ) : (
-                            dashboard.description || (
-                                <Button
-                                    type="link"
-                                    onClick={() =>
-                                        setDashboardMode(DashboardMode.Edit, DashboardEventSource.AddDescription)
-                                    }
-                                    style={{ width: '100%', textAlign: 'left' }}
-                                >
-                                    Add a description...
-                                </Button>
-                            )
+                            <div
+                                onDoubleClick={() =>
+                                    setDashboardMode(DashboardMode.Edit, DashboardEventSource.AddDescription)
+                                }
+                            >
+                                {dashboard.description ? (
+                                    <span>{dashboard.description}</span>
+                                ) : (
+                                    <span className="add-description">Add a description...</span>
+                                )}
+                            </div>
                         )}
                     </Card>
                 </>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -245,7 +245,7 @@ export function DashboardHeader(): JSX.Element {
                             tagsAvailable={dashboardTags.filter((tag) => !dashboard.tags.includes(tag))}
                         />
                     </div>
-                    <Card className="dashboard-description">
+                    <Card className="dashboard-description" bordered={!(dashboardMode === DashboardMode.Edit)}>
                         {dashboardMode === DashboardMode.Edit ? (
                             <Input.TextArea
                                 placeholder="Add a description to your dashboard that helps others understand it better."

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -265,7 +265,8 @@ export function DashboardHeader(): JSX.Element {
                             />
                         ) : (
                             <div
-                                onDoubleClick={() =>
+                                className="edit-box"
+                                onClick={() =>
                                     setDashboardMode(DashboardMode.Edit, DashboardEventSource.AddDescription)
                                 }
                             >
@@ -274,6 +275,7 @@ export function DashboardHeader(): JSX.Element {
                                 ) : (
                                     <span className="add-description">Add a description...</span>
                                 )}
+                                <EditOutlined />
                             </div>
                         )}
                     </Card>


### PR DESCRIPTION
## Changes
Closes https://github.com/PostHog/posthog/issues/2075

- double click to edit

https://user-images.githubusercontent.com/25164963/115575215-57629180-a290-11eb-8279-ff0fbbc70c8b.mov

- empty description state 

<img width="1032" alt="Screen Shot 2021-04-21 at 10 25 16 AM" src="https://user-images.githubusercontent.com/25164963/115574878-06529d80-a290-11eb-9479-d271dc641338.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
