### PR TITLE
Change distinct_ids array to just one for insight link

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -26,7 +26,7 @@ dayjs.extend(relativeTime)
 
 interface FixedFilters {
     person_id?: string | number
-    distinct_ids?: string[]
+    distinct_id?: string
 }
 
 interface EventsTable {
@@ -213,7 +213,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
     ]
 
     function _personInsightLink(): JSX.Element | null {
-        if (fixedFilters && fixedFilters.distinct_ids?.length) {
+        if (fixedFilters && fixedFilters.distinct_id) {
             const params = {
                 insight: ViewType.TRENDS,
                 interval: 'day',
@@ -229,7 +229,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
                 properties: [
                     {
                         key: 'distinct_id',
-                        value: fixedFilters.distinct_ids[0],
+                        value: fixedFilters.distinct_id,
                         operator: 'exact',
                         type: 'event',
                     },

--- a/frontend/src/scenes/persons/Person.cy-spec.js
+++ b/frontend/src/scenes/persons/Person.cy-spec.js
@@ -27,7 +27,7 @@ describe('<Person /> ', () => {
         cy.wait('@api_event').map(helpers.getSearchParameters).should('eql', {
             orderBy: '["-timestamp"]',
             person_id: '1',
-            distinct_ids: '["01779064-53be-000c-683f-23b1a8c8eb4c"]',
+            distinct_id: '01779064-53be-000c-683f-23b1a8c8eb4c',
             properties: '{}',
         })
 

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -63,7 +63,10 @@ export function Person(): JSX.Element {
                             {activeTab === 'events' ? (
                                 <EventsTable
                                     pageKey={person.distinct_ids.join('__')} // force refresh if distinct_ids change
-                                    fixedFilters={{ person_id: person.id, distinct_ids: person.distinct_ids }}
+                                    fixedFilters={{
+                                        person_id: person.id,
+                                        distinct_id: person.distinct_ids ? person.distinct_ids[0] : undefined,
+                                    }}
                                 />
                             ) : (
                                 <SessionsView


### PR DESCRIPTION
## Changes

*Please describe.*  
- only need to use a single distinct_id so only pass one
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
