### PR TITLE
Remove persons to insights link

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -5,7 +5,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { EventDetails } from 'scenes/events/EventDetails'
 import { ExportOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
-import { Button, Spin, Tooltip } from 'antd'
+import { Button, Spin, Tooltip, Col, Row } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { EventName } from 'scenes/actions/EventName'
@@ -212,55 +212,19 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
         },
     ]
 
-    function _personInsightLink(): JSX.Element | null {
-        if (fixedFilters && fixedFilters.distinct_ids?.length) {
-            const params = {
-                insight: ViewType.TRENDS,
-                interval: 'day',
-                display: 'ActionsLineGraph',
-                events: [
-                    {
-                        id: '$pageview',
-                        name: '$pageview',
-                        type: 'events',
-                        order: 0,
-                    },
-                ],
-                properties: [
-                    {
-                        key: 'distinct_id',
-                        value: fixedFilters.distinct_ids[0],
-                        operator: 'exact',
-                        type: 'event',
-                    },
-                ],
-            }
-            const encodedParams = toParams(params)
-            const personInsightLink = `/insights?${encodedParams}#backTo=person&backToURL=${window.location.pathname}`
-            return (
-                <Link to={personInsightLink} style={{ marginRight: 10 }}>
-                    View Insights
-                </Link>
-            )
-        }
-
-        return null
-    }
-
     return (
         <div className="events" data-attr="events-table">
             {filtersEnabled ? <PropertyFilters pageKey={'EventsTable'} /> : null}
-            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start' }}>
-                <div style={{ flex: 1 }}>
+            <Row>
+                <Col span={pageKey === 'events' ? 22 : 20}>
                     <EventName
                         value={eventFilter}
                         onChange={(value: string) => {
                             setEventFilter(value || '')
                         }}
                     />
-                </div>
-                <div>
-                    {_personInsightLink()}
+                </Col>
+                <Col span={pageKey === 'events' ? 2 : 4} className="text-right">
                     <Tooltip title="Up to 100,000 latest events.">
                         <Button
                             type="default"
@@ -276,8 +240,8 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
                             Export
                         </Button>
                     </Tooltip>
-                </div>
-            </div>
+                </Col>
+            </Row>
             <div>
                 <ResizableTable
                     dataSource={eventsFormatted}

--- a/frontend/src/scenes/persons/Person.cy-spec.js
+++ b/frontend/src/scenes/persons/Person.cy-spec.js
@@ -27,7 +27,6 @@ describe('<Person /> ', () => {
         cy.wait('@api_event').map(helpers.getSearchParameters).should('eql', {
             orderBy: '["-timestamp"]',
             person_id: '1',
-            distinct_ids: '["01779064-53be-000c-683f-23b1a8c8eb4c"]',
             properties: '{}',
         })
 

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -63,7 +63,7 @@ export function Person(): JSX.Element {
                             {activeTab === 'events' ? (
                                 <EventsTable
                                     pageKey={person.distinct_ids.join('__')} // force refresh if distinct_ids change
-                                    fixedFilters={{ person_id: person.id, distinct_ids: person.distinct_ids }}
+                                    fixedFilters={{ person_id: person.id }}
                                 />
                             ) : (
                                 <SessionsView


### PR DESCRIPTION
## Changes

*Please describe.*  
- this needs to be removed until we add a filter by person_id ability for insight filtering
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
