### PR TITLE
Fix sessions indefinite loading users bug

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -100,8 +100,8 @@ function parsePeopleParams(peopleParams: PeopleParamType, filters: Partial<Filte
     const { action, date_from, date_to, breakdown_value, ...restParams } = peopleParams
     const params = filterClientSideParams({
         ...filters,
-        entity_id: action.id,
-        entity_type: action.type,
+        entity_id: action.id || filters?.events?.[0].id,
+        entity_type: action.type || filters?.events?.[0].type,
         entity_math: action.math || undefined,
         breakdown_value,
     })

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -100,8 +100,8 @@ function parsePeopleParams(peopleParams: PeopleParamType, filters: Partial<Filte
     const { action, date_from, date_to, breakdown_value, ...restParams } = peopleParams
     const params = filterClientSideParams({
         ...filters,
-        entity_id: action.id || filters?.events?.[0].id,
-        entity_type: action.type || filters?.events?.[0].type,
+        entity_id: action.id || filters?.events?.[0]?.id || filters?.actions?.[0]?.id,
+        entity_type: action.type || filters?.events?.[0]?.type || filters?.actions?.[0]?.type,
         entity_math: action.math || undefined,
         breakdown_value,
     })


### PR DESCRIPTION
## Changes

Closes #3985 

Going to **insights -> sessions -> graph data point** would load indefinitely
The API call was expecting entity values which weren't being set properly in the trends logic

https://user-images.githubusercontent.com/25164963/115620384-1637a500-a2c3-11eb-9dda-2aa645deb77d.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
