### PR TITLE
Fuzzy search for properties

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertySelect.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import Fuse from 'fuse.js'
 import { Select } from 'antd'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
@@ -27,6 +28,28 @@ interface SelectionOptionType {
     type: 'event' | 'person' | 'element'
 }
 
+const fuseCache: Record<string, any> = {}
+
+export const searchItems = (
+    sources: Array<{ value: string }>,
+    search: string | false,
+    groupType: 'event' | 'person' | 'element'
+): Array<{ value: string }> => {
+    if (!search) {
+        return sources
+    }
+
+    if (!fuseCache[groupType]) {
+        fuseCache[groupType] = new Fuse(sources, {
+            keys: ['value'],
+            threshold: 0.3,
+        })
+    }
+    return fuseCache[groupType].search(search).map((result: Record<string, { item: string }>) => {
+        return result.item
+    })
+}
+
 export function PropertySelect({
     optionGroups,
     value: propertyOption,
@@ -35,6 +58,7 @@ export function PropertySelect({
     autoOpenIfEmpty,
     delayBeforeAutoOpen,
 }: Props): JSX.Element {
+    const [search, setSearch] = useState(false as string | false)
     return (
         <SelectGradientOverflow
             showSearch
@@ -45,7 +69,12 @@ export function PropertySelect({
             data-attr="property-filter-dropdown"
             labelInValue
             value={propertyOption || undefined}
-            filterOption={(input, option) => option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
+            onSearch={(value) => {
+                setSearch(value)
+            }}
+            filterOption={() => {
+                return true // set to avoid ant.d doing its own filtering
+            }}
             onChange={(_: null, selection) => {
                 const { value: val, type } = selection as SelectionOptionType
                 onChange(type, val.replace(/^(event_|person_|element_)/gi, ''))
@@ -56,7 +85,7 @@ export function PropertySelect({
                 (group) =>
                     group.options?.length > 0 && (
                         <Select.OptGroup key={group.type} label={group.label}>
-                            {group.options.map((option, index) => (
+                            {searchItems(group.options, search, group.type).map((option, index) => (
                                 <Select.Option
                                     key={`${group.type}_${option.value}`}
                                     value={`${group.type}_${option.value}`}


### PR DESCRIPTION
## Changes

Add fuzzy search to the properties dropdown for ease of use. A specific thing I ran against was typing `utm campaign` which didn't work as the actual key is `$utm_campaign`. Tested up to 10k props and it's fast.



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
