### PR TITLE
Add PersonAvatar to PersonHeader

### DIFF
--- a/frontend/src/scenes/persons/PersonAvatar.scss
+++ b/frontend/src/scenes/persons/PersonAvatar.scss
@@ -1,0 +1,5 @@
+.person-avatar {
+    margin: 2px;
+    max-width: 36px;
+    max-height: 36px;
+}

--- a/frontend/src/scenes/persons/PersonAvatar.tsx
+++ b/frontend/src/scenes/persons/PersonAvatar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { IconPerson } from 'lib/components/icons'
+import { PersonType } from '~/types'
 import './PersonAvatar.scss'
 
 export function PersonAvatar({ person }: { person?: Partial<PersonType> | null }): JSX.Element {

--- a/frontend/src/scenes/persons/PersonAvatar.tsx
+++ b/frontend/src/scenes/persons/PersonAvatar.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react'
+import { IconPerson } from 'lib/components/icons'
+import './PersonAvatar.scss'
+
+export function PersonAvatar({ person }: { person?: Partial<PersonType> | null }): JSX.Element {
+    const [hasError, setHasError] = useState(false)
+
+    const avatar = person?.properties ? person.properties.avatar : null
+
+    if (avatar && isValidUrl(avatar) && !hasError) {
+        return (
+            <img
+                className="person-avatar"
+                src={avatar}
+                onError={() => {
+                    setHasError(true)
+                }}
+            />
+        )
+    }
+
+    return <IconPerson />
+}
+
+const isValidUrl = (url: string): boolean => {
+    try {
+        new URL(url)
+        return true
+    } catch {
+        return false
+    }
+}

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -1,6 +1,6 @@
 import { PersonType } from '~/types'
 import React, { useMemo } from 'react'
-import { IconPerson } from 'lib/components/icons'
+import { PersonAvatar } from 'scenes/persons/PersonAvatar'
 import './PersonHeader.scss'
 
 export function PersonHeader({ person }: { person?: Partial<PersonType> | null }): JSX.Element {
@@ -21,7 +21,7 @@ export function PersonHeader({ person }: { person?: Partial<PersonType> | null }
             {person?.is_identified ? (
                 <div className="person-header identified">
                     <span>
-                        <IconPerson />
+                        <PersonAvatar person={person} />
                     </span>
                     {customIdentifier ? (
                         <span className="ph-no-capture text-ellipsis">{customIdentifier}</span>
@@ -31,7 +31,8 @@ export function PersonHeader({ person }: { person?: Partial<PersonType> | null }
                 </div>
             ) : (
                 <div className="person-header anonymous">
-                    <IconPerson /> Unidentified {customIdentifier || <>user {displayId}</>}
+                    <PersonAvatar person={person} />
+                    Unidentified {customIdentifier || <>user {displayId}</>}
                 </div>
             )}
         </>


### PR DESCRIPTION
## Changes

First stab at https://github.com/PostHog/posthog/issues/4088 

I cannot seem to get the avatar to load in the table view, only in the detail view. Maybe this is because all properties are not loaded in the table view?

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious

<img width="1429" alt="image" src="https://user-images.githubusercontent.com/721372/115938807-ba9b2200-a450-11eb-8322-5d91e8209ef7.png">

