### PR TITLE
Don't pin posthog/plugin-server version in dev CH docker-compose

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -75,7 +75,7 @@ services:
             - '8000:8000'
             - '8234:8234'
     plugins:
-        image: posthog/plugin-server:0.15.4
+        image: posthog/plugin-server:latest
         restart: on-failure
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'


### PR DESCRIPTION
## Changes

Tiny docker-compose change to always use latest image, since it's dev anyway.