### PR TITLE
Increase page size for async event/property fetching

### DIFF
--- a/frontend/src/scenes/events/eventDefinitionsLogic.ts
+++ b/frontend/src/scenes/events/eventDefinitionsLogic.ts
@@ -24,7 +24,7 @@ export const eventDefinitionsLogic = kea<
             {
                 loadEventDefinitions: async (initial?: boolean) => {
                     const url = initial
-                        ? 'api/projects/@current/event_definitions/?limit=500'
+                        ? 'api/projects/@current/event_definitions/?limit=5000'
                         : values.eventStorage.next
                     if (!url) {
                         throw new Error('Incorrect call to eventDefinitionsLogic.loadEventDefinitions')

--- a/frontend/src/scenes/events/propertyDefinitionsLogic.ts
+++ b/frontend/src/scenes/events/propertyDefinitionsLogic.ts
@@ -22,7 +22,7 @@ export const propertyDefinitionsLogic = kea<
             {
                 loadPropertyDefinitions: async (initial?: boolean) => {
                     const url = initial
-                        ? 'api/projects/@current/property_definitions/?limit=500'
+                        ? 'api/projects/@current/property_definitions/?limit=5000'
                         : values.propertyStorage.next
                     if (!url) {
                         throw new Error('Incorrect call to propertyDefinitionsLogic.loadPropertyDefinitions')


### PR DESCRIPTION
## Changes

- Increases page size by 10x to 5000 event names or property names per page, resulting in massive gains in loading with ~25k event names.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
