### PR TITLE
Fix non-sting custom identifier

### DIFF
--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -4,9 +4,10 @@ import { IconPerson } from 'lib/components/icons'
 import './PersonHeader.scss'
 
 export function PersonHeader({ person }: { person?: Partial<PersonType> | null }): JSX.Element {
-    const customIdentifier = person?.properties
+    const propertiesIdentifier = person?.properties
         ? person.properties.email || person.properties.name || person.properties.username
         : null
+    const customIdentifier = propertiesIdentifier ? JSON.stringify(propertiesIdentifier) : null
 
     const displayId = useMemo(() => {
         if (!person?.distinct_ids?.length) {


### PR DESCRIPTION
## Changes

A user reported that their persons page was not loading. Turns out they had a user with email, distinct id, and name set to `{}`, and we didn't like that.

This fixes it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
