### PR TITLE
Add 5min staleness restart check to plugin server

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -51,6 +51,10 @@
                 {
                     "name": "NODE_OPTIONS",
                     "value": "--max-old-space-size=4096"
+                },
+                {
+                    "name": "STALENESS_RESTART_SECONDS",
+                    "value": "300"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

- This won't restart it yet (not implemented), but will trigger an alert to sentry if no event has been ingested in 5min per plugin server task.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
