### PR TITLE
Only call load when filters change

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -466,9 +466,11 @@ export const trendsLogic = kea<
                 )
             }
         },
-        setFilters: async () => {
+        setFilters: async ({ filters }) => {
             insightLogic.actions.setAllFilters(values.filters)
-            actions.loadResults()
+            if (!objectsEqual(filters, values.filters)) {
+                actions.loadResults()
+            }
         },
         loadResultsSuccess: () => {
             if (!props.dashboardItemId) {
@@ -512,7 +514,9 @@ export const trendsLogic = kea<
             actions.setBreakdownValuesLoading(false)
         },
         [eventDefinitionsLogic.actionTypes.loadEventDefinitionsSuccess]: async () => {
-            actions.setFilters(getDefaultFilters(values.filters, eventDefinitionsLogic.values.eventNames), true)
+            if (!values.filters?.events?.length && !values.filters?.actions?.length) {
+                actions.setFilters(getDefaultFilters(values.filters, eventDefinitionsLogic.values.eventNames), true)
+            }
         },
     }),
 

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -466,11 +466,9 @@ export const trendsLogic = kea<
                 )
             }
         },
-        setFilters: async ({ filters }) => {
+        setFilters: async () => {
             insightLogic.actions.setAllFilters(values.filters)
-            if (!objectsEqual(filters, values.filters)) {
-                actions.loadResults()
-            }
+            actions.loadResults()
         },
         loadResultsSuccess: () => {
             if (!props.dashboardItemId) {
@@ -514,8 +512,13 @@ export const trendsLogic = kea<
             actions.setBreakdownValuesLoading(false)
         },
         [eventDefinitionsLogic.actionTypes.loadEventDefinitionsSuccess]: async () => {
-            if (!values.filters?.events?.length && !values.filters?.actions?.length) {
-                actions.setFilters(getDefaultFilters(values.filters, eventDefinitionsLogic.values.eventNames), true)
+            const newFilter = getDefaultFilters(values.filters, eventDefinitionsLogic.values.eventNames)
+            const mergedFilter: Partial<FilterType> = {
+                ...values.filters,
+                ...newFilter,
+            }
+            if (!objectsEqual(values.filters, mergedFilter)) {
+                actions.setFilters(mergedFilter, true)
             }
         },
     }),


### PR DESCRIPTION
## Changes

*Please describe.*  
- If a team has more properties than the event_definitions route can return in one request, the successive requests that are required will cause trendsLogic to continuously refresh because `setFilters` always triggers a load
- this change ensures that we only trigger a reload when the filters actually change 
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
