### PR TITLE
Handle deleted team when trying to sync event prop definitions

### DIFF
--- a/posthog/tasks/sync_event_and_properties_definitions.py
+++ b/posthog/tasks/sync_event_and_properties_definitions.py
@@ -20,6 +20,10 @@ def sync_event_and_properties_definitions(team_uuid: str) -> None:
 
     team: Team = Team.objects.only("uuid", *DEFERRED_FIELDS).get(uuid=team_uuid)
 
+    # The team may have gotten deleted before the task could run
+    if not team:
+        return
+
     # Transform data for quick usability
     transformed_event_usage = {
         event_usage_record["event"]: event_usage_record for event_usage_record in team.event_names_with_usage

--- a/posthog/tasks/sync_event_and_properties_definitions.py
+++ b/posthog/tasks/sync_event_and_properties_definitions.py
@@ -1,5 +1,5 @@
 # TODO: #4070 Fully temporary until these properties are migrated away from `Team` model
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from django.db import models
 from django.dispatch.dispatcher import receiver
@@ -19,13 +19,16 @@ def team_saved(sender: Any, instance: Team, **kwargs: Dict) -> None:
 @app.task(ignore_result=True)
 def sync_event_and_properties_definitions(team_uuid: str) -> None:
 
-    team: Team = None
+    team: Optional[Team] = None
 
     # It is possible that the team was deleted before the task could run
     try:
-        team: Team = Team.objects.only("uuid", *DEFERRED_FIELDS).get(uuid=team_uuid)
+        team = Team.objects.only("uuid", *DEFERRED_FIELDS).get(uuid=team_uuid)
     except Team.DoesNotExist as e:
         capture_exception(e)
+
+    if team is None:
+        return
 
     # Transform data for quick usability
     transformed_event_usage = {


### PR DESCRIPTION
## Changes

https://sentry.io/organizations/posthog/issues/2355997539/?project=1899813&query=is%3Aunresolved

The reason I can see for this happening is that the team is deleted by the time the task actually gets to run.

~~EDIT: Just saw that this actually won't suppress the error - will update~~

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
