### PR TITLE
Fix first_name cannot be blank (POSTHOG-2PW)

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -80,7 +80,7 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
     if user:
         return {"is_new": False}
     user_email = details["email"][0] if isinstance(details["email"], (list, tuple)) else details["email"]
-    user_name = details["fullname"]
+    user_name = details["fullname"] or ""
     strategy.session_set("user_name", user_name)
     strategy.session_set("backend", backend.name)
     from_invite = False

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -80,7 +80,7 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
     if user:
         return {"is_new": False}
     user_email = details["email"][0] if isinstance(details["email"], (list, tuple)) else details["email"]
-    user_name = details["fullname"] or ""
+    user_name = details["fullname"] or details["username"]
     strategy.session_set("user_name", user_name)
     strategy.session_set("backend", backend.name)
     from_invite = False


### PR DESCRIPTION
## Changes

Seems that there's a small chance we don't actually get `fullname` for users which throws an error and prevents them from being created. 

Happy to take another approach here but should be fine to have no first name?

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
