### PR TITLE
Fix Cohort Select width

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -48,57 +48,54 @@ function PropertyPaneContents({
     }
 
     return (
-        <>
-            <Row gutter={8} className="full-width" wrap={false}>
-                <Col flex={1} style={{ minWidth: '11rem' }}>
-                    <PropertySelect
-                        value={
-                            type === 'cohort'
-                                ? null
-                                : {
-                                      value: propkey,
-                                      label:
-                                          keyMapping[type === 'element' ? 'element' : 'event'][propkey]?.label ||
-                                          propkey,
-                                  }
-                        }
-                        onChange={(newType, newValue) =>
-                            setThisFilter(
-                                newValue,
-                                undefined,
-                                newValue === '$active_feature_flags' ? 'icontains' : operator,
-                                newType
-                            )
-                        }
-                        optionGroups={optionGroups}
-                        autoOpenIfEmpty
-                        delayBeforeAutoOpen={delayBeforeAutoOpen}
-                        placeholder="Property key"
-                    />
-                </Col>
+        <Row gutter={8} className="full-width" wrap={false}>
+            <Col flex={1} style={{ minWidth: '11rem' }}>
+                <PropertySelect
+                    value={
+                        type === 'cohort'
+                            ? null
+                            : {
+                                  value: propkey,
+                                  label:
+                                      keyMapping[type === 'element' ? 'element' : 'event'][propkey]?.label || propkey,
+                              }
+                    }
+                    onChange={(newType, newValue) =>
+                        setThisFilter(
+                            newValue,
+                            undefined,
+                            newValue === '$active_feature_flags' ? 'icontains' : operator,
+                            newType
+                        )
+                    }
+                    optionGroups={optionGroups}
+                    autoOpenIfEmpty
+                    delayBeforeAutoOpen={delayBeforeAutoOpen}
+                    placeholder="Property key"
+                />
+            </Col>
 
-                {displayOperatorAndValue && (
-                    <OperatorValueSelect
-                        type={type}
-                        propkey={propkey}
-                        operator={operator}
-                        value={value}
-                        onChange={(newOperator, newValue) => {
-                            setThisFilter(propkey, newValue, newOperator, type)
-                            if (newOperator && newValue && !isOperatorMulti(newOperator)) {
-                                onComplete()
-                            }
-                        }}
-                        columnOptions={{
-                            flex: 1,
-                            style: {
-                                maxWidth: '50vw',
-                            },
-                        }}
-                    />
-                )}
-            </Row>
-        </>
+            {displayOperatorAndValue && (
+                <OperatorValueSelect
+                    type={type}
+                    propkey={propkey}
+                    operator={operator}
+                    value={value}
+                    onChange={(newOperator, newValue) => {
+                        setThisFilter(propkey, newValue, newOperator, type)
+                        if (newOperator && newValue && !isOperatorMulti(newOperator)) {
+                            onComplete()
+                        }
+                    }}
+                    columnOptions={{
+                        flex: 1,
+                        style: {
+                            maxWidth: '50vw',
+                        },
+                    }}
+                />
+            )}
+        </Row>
     )
 }
 
@@ -106,41 +103,39 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
     const { cohorts } = useValues(cohortsModel)
 
     return (
-        <>
-            <SelectGradientOverflow
-                style={{ width: '100%' }}
-                showSearch
-                optionFilterProp="children"
-                labelInValue
-                placeholder="Cohort name"
-                value={
-                    displayOperatorAndValue
-                        ? { value: '' }
-                        : {
-                              value: value,
-                              label: cohorts?.find((cohort) => cohort.id === value)?.name || value,
-                          }
-                }
-                onChange={(_, newFilter) => {
-                    onComplete()
-                    setThisFilter('id', newFilter.value, undefined, newFilter.type)
-                }}
-                data-attr="cohort-filter-select"
-                selectProps={selectProps}
-            >
-                {cohorts.map((item, index) => (
-                    <Select.Option
-                        className="ph-no-capture"
-                        key={'cohort-filter-' + index}
-                        value={item.id}
-                        type="cohort"
-                        data-attr={'cohort-filter-' + index}
-                    >
-                        {item.name}
-                    </Select.Option>
-                ))}
-            </SelectGradientOverflow>
-        </>
+        <SelectGradientOverflow
+            style={{ width: '100%' }}
+            showSearch
+            optionFilterProp="children"
+            labelInValue
+            placeholder="Cohort name"
+            value={
+                displayOperatorAndValue
+                    ? { value: '' }
+                    : {
+                          value: value,
+                          label: cohorts?.find((cohort) => cohort.id === value)?.name || value,
+                      }
+            }
+            onChange={(_, newFilter) => {
+                onComplete()
+                setThisFilter('id', newFilter.value, undefined, newFilter.type)
+            }}
+            data-attr="cohort-filter-select"
+            selectProps={selectProps}
+        >
+            {cohorts.map((item, index) => (
+                <Select.Option
+                    className="ph-no-capture"
+                    key={'cohort-filter-' + index}
+                    value={item.id}
+                    type="cohort"
+                    data-attr={'cohort-filter-' + index}
+                >
+                    {item.name}
+                </Select.Option>
+            ))}
+        </SelectGradientOverflow>
     )
 }
 

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -100,7 +100,7 @@ export function SelectGradientOverflow({
     }
     document.addEventListener('click', outsideClickListener)
     return (
-        <div ref={containerRef}>
+        <div ref={containerRef} style={{ width: '100%' }}>
             <Select
                 {...props}
                 ref={selectRef}


### PR DESCRIPTION
## Changes

We added a wrapping div in #3957 that didn't set width, so when the cohort `select` was setting `width: 100%`, it was actually referring to a div with a width of 42px.

This fixes that + removes some unnecesssary React fragments.

Closes #4045

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
