### PR TITLE
Widen cohort dropdown

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilter.js
@@ -106,41 +106,43 @@ function CohortPaneContents({ onComplete, setThisFilter, value, displayOperatorA
     const { cohorts } = useValues(cohortsModel)
 
     return (
-        <>
-            <SelectGradientOverflow
-                style={{ width: '100%' }}
-                showSearch
-                optionFilterProp="children"
-                labelInValue
-                placeholder="Cohort name"
-                value={
-                    displayOperatorAndValue
-                        ? { value: '' }
-                        : {
-                              value: value,
-                              label: cohorts?.find((cohort) => cohort.id === value)?.name || value,
-                          }
-                }
-                onChange={(_, newFilter) => {
-                    onComplete()
-                    setThisFilter('id', newFilter.value, undefined, newFilter.type)
-                }}
-                data-attr="cohort-filter-select"
-                selectProps={selectProps}
-            >
-                {cohorts.map((item, index) => (
-                    <Select.Option
-                        className="ph-no-capture"
-                        key={'cohort-filter-' + index}
-                        value={item.id}
-                        type="cohort"
-                        data-attr={'cohort-filter-' + index}
-                    >
-                        {item.name}
-                    </Select.Option>
-                ))}
-            </SelectGradientOverflow>
-        </>
+        <Row gutter={8} className="full-width" wrap={false}>
+            <Col flex={1} style={{ minWidth: '11rem' }}>
+                <SelectGradientOverflow
+                    style={{ width: '100%' }}
+                    showSearch
+                    optionFilterProp="children"
+                    labelInValue
+                    placeholder="Cohort name"
+                    value={
+                        displayOperatorAndValue
+                            ? { value: '' }
+                            : {
+                                  value: value,
+                                  label: cohorts?.find((cohort) => cohort.id === value)?.name || value,
+                              }
+                    }
+                    onChange={(_, newFilter) => {
+                        onComplete()
+                        setThisFilter('id', newFilter.value, undefined, newFilter.type)
+                    }}
+                    data-attr="cohort-filter-select"
+                    selectProps={selectProps}
+                >
+                    {cohorts.map((item, index) => (
+                        <Select.Option
+                            className="ph-no-capture"
+                            key={'cohort-filter-' + index}
+                            value={item.id}
+                            type="cohort"
+                            data-attr={'cohort-filter-' + index}
+                        >
+                            {item.name}
+                        </Select.Option>
+                    ))}
+                </SelectGradientOverflow>
+            </Col>
+        </Row>
     )
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- matches the propertypanel styling with the cohortpanel styling
Before
<img width="375" alt="Screen Shot 2021-04-27 at 2 05 53 PM" src="https://user-images.githubusercontent.com/13127476/116290698-bda05600-a761-11eb-89ec-42ca794eef6a.png">
After
<img width="340" alt="Screen Shot 2021-04-27 at 2 02 01 PM" src="https://user-images.githubusercontent.com/13127476/116290616-a95c5900-a761-11eb-87ae-0f634f88de52.png">

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
