### PR TITLE
Allow webhook removal

### DIFF
--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -8,7 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 export function TestAccountFiltersConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
-    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
+    const { currentTeam } = useValues(teamLogic)
 
     const handleChange = (filters: FilterType[]): void => {
         updateCurrentTeam({ test_account_filters: filters })
@@ -18,7 +18,7 @@ export function TestAccountFiltersConfig(): JSX.Element {
     return (
         <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 8 }}>
-                {!currentTeamLoading && (
+                {currentTeam && (
                     <PropertyFilters
                         pageKey="testaccountfilters"
                         propertyFilters={currentTeam?.test_account_filters}

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
-import { Input, Button } from 'antd'
+import { Input, Button, Col, Row } from 'antd'
 import { teamLogic } from 'scenes/teamLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { webhookIntegrationLogic } from './webhookIntegrationLogic'
@@ -16,7 +16,7 @@ export function AsyncActionMappingNotice(): JSX.Element {
 
 export function WebhookIntegration(): JSX.Element {
     const [webhook, setWebhook] = useState('')
-    const { testWebhook } = useActions(webhookIntegrationLogic)
+    const { testWebhook, removeWebhook } = useActions(webhookIntegrationLogic)
     const { loading } = useValues(webhookIntegrationLogic)
     const { preflight } = useValues(preflightLogic)
     const { currentTeam } = useValues(teamLogic)
@@ -49,16 +49,35 @@ export function WebhookIntegration(): JSX.Element {
                 disabled={loading}
                 onPressEnter={() => testWebhook(webhook)}
             />
-            <Button
-                type="primary"
-                onClick={(e) => {
-                    e.preventDefault()
-                    testWebhook(webhook)
-                }}
-                loading={loading}
-            >
-                {webhook ? 'Test & Save' : 'Save'}
-            </Button>
+            <Row>
+                <Col>
+                    <Button
+                        type="primary"
+                        disabled={!webhook}
+                        onClick={(e) => {
+                            e.preventDefault()
+                            testWebhook(webhook)
+                        }}
+                        loading={loading}
+                    >
+                        {webhook ? 'Test & Save' : 'Save'}
+                    </Button>
+                </Col>
+                <Col style={{ marginLeft: 10 }}>
+                    <Button
+                        type="default"
+                        danger
+                        onClick={(e) => {
+                            e.preventDefault()
+                            removeWebhook()
+                            setWebhook('')
+                        }}
+                        disabled={!currentTeam?.slack_incoming_webhook}
+                    >
+                        Remove Webhook
+                    </Button>
+                </Col>
+            </Row>
         </div>
     )
 }

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -45,7 +45,7 @@ export function WebhookIntegration(): JSX.Element {
                 onChange={(e) => setWebhook(e.target.value)}
                 style={{ maxWidth: '40rem', marginBottom: '1rem', display: 'block' }}
                 type="url"
-                placeholder={'integration disabled – type a URL to enable'}
+                placeholder={currentTeam?.slack_incoming_webhook ? '' : 'Integration disabled – type a URL to enable'}
                 disabled={loading}
                 onPressEnter={() => testWebhook(webhook)}
             />

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -45,7 +45,9 @@ export function WebhookIntegration(): JSX.Element {
                 onChange={(e) => setWebhook(e.target.value)}
                 style={{ maxWidth: '40rem', marginBottom: '1rem', display: 'block' }}
                 type="url"
-                placeholder={currentTeam?.slack_incoming_webhook ? '' : 'Integration disabled – type a URL to enable'}
+                placeholder={
+                    currentTeam?.slack_incoming_webhook ? '' : 'integration disabled – enter URL, then Test & Save'
+                }
                 disabled={loading}
                 onPressEnter={() => testWebhook(webhook)}
             />
@@ -60,7 +62,7 @@ export function WebhookIntegration(): JSX.Element {
                         }}
                         loading={loading}
                     >
-                        {webhook ? 'Test & Save' : 'Save'}
+                        Test & Save
                     </Button>
                 </Col>
                 <Col style={{ marginLeft: 10 }}>
@@ -74,7 +76,7 @@ export function WebhookIntegration(): JSX.Element {
                         }}
                         disabled={!currentTeam?.slack_incoming_webhook}
                     >
-                        Remove Webhook
+                        Clear & Disable
                     </Button>
                 </Col>
             </Row>

--- a/frontend/src/scenes/project/Settings/webhookIntegrationLogic.ts
+++ b/frontend/src/scenes/project/Settings/webhookIntegrationLogic.ts
@@ -35,6 +35,15 @@ export const webhookIntegrationLogic = kea<webhookIntegrationLogicType>({
                 },
             },
         ],
+        removedWebhook: [
+            null,
+            {
+                removeWebhook: () => {
+                    teamLogic.actions.updateCurrentTeam({ slack_incoming_webhook: '' })
+                    return null
+                },
+            },
+        ],
     }),
     listeners: () => ({
         testWebhookSuccess: async ({ testedWebhook }) => {


### PR DESCRIPTION
## Changes

Removing a webhook hasn't been working, this PR fixes that. 

Ideally we'd have a toggle to keep the URL and disable/enable the integration but that's a feature rather than a bug fix.

### What it looks like


https://user-images.githubusercontent.com/38760734/116291721-71b2d880-a784-11eb-8f4f-b880558515bb.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
