### PR TITLE
Fix math selector width

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow.tsx
@@ -241,6 +241,7 @@ function MathSelector({
             value={math || 'total'}
             onChange={(value) => onMathSelect(index, value)}
             data-attr={`math-selector-${index}`}
+            dropdownMatchSelectWidth={false}
         >
             <Select.OptGroup key="event aggregates" label="Event aggregation">
                 {math_entries.map(([key, { name, description, onProperty }]) => {


### PR DESCRIPTION
## Changes

*Please describe.*  

Fixes #4045.

Before (cc @corywatilo):
![image](https://user-images.githubusercontent.com/4645779/116453421-dde91700-a82c-11eb-94cb-8d9b13410481.png)

After:
<img width="341" alt="Screen Shot 2021-04-28 at 2 20 55 PM" src="https://user-images.githubusercontent.com/4645779/116453504-f9542200-a82c-11eb-9a20-27c24e59ae59.png">

Useful to know that this fix was as simple as setting `dropdownMatchSelectWidth` false on the antd Select

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
