### PR TITLE
Reorder EventsTable selector and filter; copy change

### DIFF
--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -22,7 +22,8 @@ export function EventName({ value, onChange, isActionStep = false }: EventNameIn
                 onChange={onChange}
                 filterOption={(input, option) => option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
                 disabled={isActionStep && eventNamesGrouped[0].options.length === 0}
-                value={value}
+                value={value || undefined}
+                placeholder="All events"
                 data-attr="event-name-box"
             >
                 {eventNamesGrouped.map((typeGroup) => {

--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -42,7 +42,7 @@ export function ManageEvents(): JSX.Element {
             <PageHeader title="Events" />
             <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={setTab}>
                 <Tabs.TabPane tab="Events" key="live">
-                    See events that are being sent to this project in real time.
+                    See events being sent to this project in near real time.
                     <EventsTable />
                 </Tabs.TabPane>
                 <Tabs.TabPane tab={<span data-attr="events-actions-tab">Actions</span>} key="actions">

--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -42,7 +42,7 @@ export function ManageEvents(): JSX.Element {
             <PageHeader title="Events" />
             <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={setTab}>
                 <Tabs.TabPane tab="Events" key="live">
-                    See all events that are being sent to this project in real time.
+                    See events that are being sent to this project in real time.
                     <EventsTable />
                 </Tabs.TabPane>
                 <Tabs.TabPane tab={<span data-attr="events-actions-tab">Actions</span>} key="actions">

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -214,8 +214,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
 
     return (
         <div className="events" data-attr="events-table">
-            {filtersEnabled ? <PropertyFilters pageKey={'EventsTable'} /> : null}
-            <Row>
+            <Row style={{ paddingTop: '0.5rem' }}>
                 <Col span={pageKey === 'events' ? 22 : 20}>
                     <EventName
                         value={eventFilter}
@@ -223,6 +222,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
                             setEventFilter(value || '')
                         }}
                     />
+                    {filtersEnabled ? <PropertyFilters pageKey={'EventsTable'} /> : null}
                 </Col>
                 <Col span={pageKey === 'events' ? 2 : 4} className="text-right">
                     <Tooltip title="Up to 100,000 latest events.">


### PR DESCRIPTION
## Changes

Before: Kind of confusing that filters appears above the Events selector when it is conceptually more narrow.

<img width="622" alt="Screen Shot 2021-04-28 at 2 47 32 PM" src="https://user-images.githubusercontent.com/4645779/116456825-b1cf9500-a830-11eb-9fea-e9084bf0914d.png">

After - empty state

<img width="612" alt="Screen Shot 2021-04-28 at 2 43 43 PM" src="https://user-images.githubusercontent.com/4645779/116457205-1be83a00-a831-11eb-81fa-b067ff1cf26a.png">

After - with filter applied

<img width="654" alt="Screen Shot 2021-04-28 at 2 44 12 PM" src="https://user-images.githubusercontent.com/4645779/116457258-286c9280-a831-11eb-82db-cd600ac8433a.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
