### PR TITLE
Tweak sessions filter UI and use PropertyKeyInfo

### DIFF
--- a/frontend/src/lib/components/SelectBox.scss
+++ b/frontend/src/lib/components/SelectBox.scss
@@ -1,9 +1,8 @@
 .select-box {
     position: absolute;
     width: 620px;
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 9px 28px 8px rgba(0, 0, 0, 0.05);
     border-radius: 2px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
     height: 400px;
     background: #fff;
     z-index: 999;

--- a/frontend/src/lib/components/SelectDownIcon.tsx
+++ b/frontend/src/lib/components/SelectDownIcon.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DownOutlined } from '@ant-design/icons'
 
+// Downward arrow icon with styling that mimics that of the antd Select
 export const SelectDownIcon = (props: React.HTMLAttributes<HTMLSpanElement>): JSX.Element => {
     return (
         <span {...props}>

--- a/frontend/src/lib/components/SelectDownIcon.tsx
+++ b/frontend/src/lib/components/SelectDownIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { DownOutlined } from '@ant-design/icons'
+
+export const SelectDownIcon = (props: React.HTMLAttributes<HTMLSpanElement>): JSX.Element => {
+    return (
+        <span {...props}>
+            <DownOutlined
+                style={{
+                    paddingLeft: '0.6em',
+                    fontSize: '90%',
+                    opacity: 0.5,
+                }}
+            />
+        </span>
+    )
+}

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -181,14 +181,14 @@
     .sessions-filter-row-filters {
         display: flex;
         width: 100%;
-    }
 
-    .sessions-filter-row-filters > * {
-        flex: 1;
-    }
+        & > * {
+            flex: 1;
+        }
 
-    .sessions-filter-row-filters > *:not(:last-child) {
-        margin-right: 16px;
+        & > *:not(:last-child) {
+            margin-right: 16px;
+        }
     }
 }
 

--- a/frontend/src/scenes/sessions/filters/EditFiltersPanel.tsx
+++ b/frontend/src/scenes/sessions/filters/EditFiltersPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Card, Divider, Space } from 'antd'
 import { useActions, useValues } from 'kea'
-import { DownOutlined, SaveOutlined, SearchOutlined } from '@ant-design/icons'
+import { SaveOutlined, SearchOutlined } from '@ant-design/icons'
 import { CloseButton } from 'lib/components/CloseButton'
 import { Entity, EventTypePropertyFilter, PersonPropertyFilter, PropertyFilter, RecordingPropertyFilter } from '~/types'
 import { sessionsFiltersLogic } from 'scenes/sessions/filters/sessionsFiltersLogic'
@@ -12,9 +12,11 @@ import { SessionsFilterBox } from 'scenes/sessions/filters/SessionsFilterBox'
 import { AddFilterButton } from 'scenes/sessions/filters/AddFilterButton'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { LinkButton } from 'lib/components/LinkButton'
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { ACTION_TYPE, EVENT_TYPE } from 'lib/constants'
 import { ViewType } from 'scenes/insights/insightLogic'
 import { toParams } from 'lib/utils'
+import { SelectDownIcon } from 'lib/components/SelectDownIcon'
 
 interface Props {
     onSubmit: () => void
@@ -173,8 +175,8 @@ export function EditFiltersPanel({ onSubmit }: Props): JSX.Element | null {
                                         }}
                                         data-attr="edit-session-filter"
                                     >
-                                        <strong>{item.label}</strong>
-                                        <DownOutlined style={{ fontSize: 12, color: 'rgba(0,0,0,0.5)' }} />
+                                        <PropertyKeyInfo value={item.label || 'Property'} />
+                                        <SelectDownIcon className="text-muted" />
                                     </Button>
                                     <SessionsFilterBox selector={selector} />
                                 </div>

--- a/frontend/src/scenes/sessions/filters/EditFiltersPanel.tsx
+++ b/frontend/src/scenes/sessions/filters/EditFiltersPanel.tsx
@@ -175,7 +175,7 @@ export function EditFiltersPanel({ onSubmit }: Props): JSX.Element | null {
                                         }}
                                         data-attr="edit-session-filter"
                                     >
-                                        <PropertyKeyInfo value={item.label || 'Property'} />
+                                        <PropertyKeyInfo value={item.label ?? ''} />
                                         <SelectDownIcon className="text-muted" />
                                     </Button>
                                     <SessionsFilterBox selector={selector} />

--- a/frontend/src/scenes/sessions/filters/SearchAllBox.tsx
+++ b/frontend/src/scenes/sessions/filters/SearchAllBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { SearchOutlined } from '@ant-design/icons'
+import { DownOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
 import { useActions, useValues } from 'kea'
 import { sessionsFiltersLogic } from 'scenes/sessions/filters/sessionsFiltersLogic'
@@ -11,13 +11,20 @@ export function SearchAllBox(): JSX.Element {
     return (
         <div className="mb-05 full-width">
             <Button
-                className="full-width"
                 style={{ textAlign: 'left' }}
                 data-attr="sessions-filter-open"
                 onClick={() => (openFilter ? closeFilterSelect() : openFilterSelect('new'))}
             >
-                <SearchOutlined />
-                <span className="text-muted">Filter sessions by users, actions, events, ...</span>
+                <span className="text-muted">
+                    Filter by user, action, or event properties
+                    <DownOutlined
+                        style={{
+                            paddingLeft: '0.6em',
+                            fontSize: '90%',
+                            opacity: 0.5,
+                        }}
+                    />
+                </span>
             </Button>
         </div>
     )

--- a/frontend/src/scenes/sessions/filters/SearchAllBox.tsx
+++ b/frontend/src/scenes/sessions/filters/SearchAllBox.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { DownOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
 import { useActions, useValues } from 'kea'
 import { sessionsFiltersLogic } from 'scenes/sessions/filters/sessionsFiltersLogic'
+import { SelectDownIcon } from 'lib/components/SelectDownIcon'
 
 export function SearchAllBox(): JSX.Element {
     const { openFilter } = useValues(sessionsFiltersLogic)
@@ -17,13 +17,7 @@ export function SearchAllBox(): JSX.Element {
             >
                 <span className="text-muted">
                     Filter by user, action, or event properties
-                    <DownOutlined
-                        style={{
-                            paddingLeft: '0.6em',
-                            fontSize: '90%',
-                            opacity: 0.5,
-                        }}
-                    />
+                    <SelectDownIcon />
                 </span>
             </Button>
         </div>


### PR DESCRIPTION
## Changes

Fixes #3384 — though there is a lot more do be done with filter UX overall 😄 

Before:

<img width="1028" alt="Screen Shot 2021-04-28 at 4 49 57 PM" src="https://user-images.githubusercontent.com/4645779/116470906-0596aa00-a842-11eb-8b3e-f0af9eee6886.png">

After:

<img width="1031" alt="Screen Shot 2021-04-28 at 4 49 30 PM" src="https://user-images.githubusercontent.com/4645779/116470932-0f201200-a842-11eb-8ac7-a84271cb31c4.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
