### PR TITLE
Lifecycle Toggles: Add tooltips and refactor color imports

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -39,6 +39,11 @@ style files without adding already imported styles. */
     --lime: #bfef45;
     --apricot: #ffd8b1;
     --brown: #9a6324;
+    // Lifecycle series (color-blind accessible)
+    --lifecycle-new: #66c2a5;
+    --lifecycle-returning: #4575b4;
+    --lifecycle-resurrecting: #8da0cb;
+    --lifecycle-dormant: #fdae61;
 }
 
 // Text styles

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -39,11 +39,11 @@ style files without adding already imported styles. */
     --lime: #bfef45;
     --apricot: #ffd8b1;
     --brown: #9a6324;
-    // Lifecycle series (color-blind accessible)
-    --lifecycle-new: #66c2a5;
-    --lifecycle-returning: #4575b4;
-    --lifecycle-resurrecting: #8da0cb;
-    --lifecycle-dormant: #fdae61;
+    // Lifecycle series
+    --lifecycle-new: #99c5ff;
+    --lifecycle-returning: #71b96b;
+    --lifecycle-resurrecting: #c277cf;
+    --lifecycle-dormant: #f86234;
 }
 
 // Text styles

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -104,18 +104,16 @@ export function getChartColors(backgroundColor: string): string[] {
 }
 
 export function getBarColorFromStatus(status: string): string {
-    if (status === 'new') {
-        return cssHSL(161, 43, 58)
-    }
-    if (status === 'returning') {
-        return cssHSL(195, 58, 79)
-    }
-    if (status === 'resurrecting') {
-        return cssHSL(222, 37, 67)
-    }
-    if (status === 'dormant') {
-        return cssHSL(17, 96, 69)
-    } else {
-        return 'black'
+    switch (status) {
+        case 'new':
+            return cssHSL(161, 43, 58)
+        case 'returning':
+            return cssHSL(195, 58, 79)
+        case 'resurrecting':
+            return cssHSL(222, 37, 67)
+        case 'dormant':
+            return cssHSL(17, 96, 69)
+        default:
+            return 'black'
     }
 }

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -111,7 +111,7 @@ export function getBarColorFromStatus(status: string): string {
         return cssHSL(195, 58, 79)
     }
     if (status === 'resurrecting') {
-        return cssHSL(214, 45, 49)
+        return cssHSL(222, 37, 67)
     }
     if (status === 'dormant') {
         return cssHSL(17, 96, 69)

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -105,16 +105,16 @@ export function getChartColors(backgroundColor: string): string[] {
 
 export function getBarColorFromStatus(status: string): string {
     if (status === 'new') {
-        return cssHSL(214, 100, 80)
+        return cssHSL(7, 85, 56)
     }
     if (status === 'returning') {
-        return cssHSL(115, 35, 57)
+        return cssHSL(319, 57, 24)
     }
     if (status === 'resurrecting') {
-        return cssHSL(291, 48, 64)
+        return cssHSL(192, 41, 57)
     }
     if (status === 'dormant') {
-        return cssHSL(14, 94, 59)
+        return cssHSL(162, 77, 20)
     } else {
         return 'black'
     }

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -106,13 +106,13 @@ export function getChartColors(backgroundColor: string): string[] {
 export function getBarColorFromStatus(status: string): string {
     switch (status) {
         case 'new':
-            return cssHSL(161, 43, 58)
+            return '#66c2a5'
         case 'returning':
-            return cssHSL(195, 58, 79)
+            return '#4575B4'
         case 'resurrecting':
-            return cssHSL(222, 37, 67)
+            return '#8da0cb'
         case 'dormant':
-            return cssHSL(17, 96, 69)
+            return '#fdae61'
         default:
             return 'black'
     }

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -105,16 +105,16 @@ export function getChartColors(backgroundColor: string): string[] {
 
 export function getBarColorFromStatus(status: string): string {
     if (status === 'new') {
-        return cssHSL(7, 85, 56)
+        return cssHSL(161, 43, 58)
     }
     if (status === 'returning') {
-        return cssHSL(319, 57, 24)
+        return cssHSL(195, 58, 79)
     }
     if (status === 'resurrecting') {
-        return cssHSL(192, 41, 57)
+        return cssHSL(214, 45, 49)
     }
     if (status === 'dormant') {
-        return cssHSL(162, 77, 20)
+        return cssHSL(17, 96, 69)
     } else {
         return 'black'
     }

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -106,13 +106,10 @@ export function getChartColors(backgroundColor: string): string[] {
 export function getBarColorFromStatus(status: string): string {
     switch (status) {
         case 'new':
-            return '#66c2a5'
         case 'returning':
-            return '#4575B4'
         case 'resurrecting':
-            return '#8da0cb'
         case 'dormant':
-            return '#fdae61'
+            return getColorVar(`lifecycle-${status}`)
         default:
             return 'black'
     }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -5,5 +5,6 @@
         display: flex;
         justify-content: space-between;
         padding-bottom: 4px;
+        align-items: center;
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -7,4 +7,19 @@
         padding-bottom: 4px;
         align-items: center;
     }
+    .new {
+        background-color: #ee442f;
+    }
+
+    .returning {
+        background-color: #601a4a;
+    }
+
+    .resurrecting {
+        background-color: #63acbe;
+    }
+
+    .dormant {
+        background-color: #0b5a43;
+    }
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -7,19 +7,20 @@
         padding-bottom: 4px;
         align-items: center;
     }
+
     .new {
-        background-color: #ee442f;
+        background-color: #66c2a5;
     }
 
     .returning {
-        background-color: #601a4a;
+        background-color: #4575b4;
     }
 
     .resurrecting {
-        background-color: #63acbe;
+        background-color: #abd9e9;
     }
 
     .dormant {
-        background-color: #0b5a43;
+        background-color: #fdae61;
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -13,7 +13,7 @@
     }
 
     .returning {
-        background-color: #abd9e9;
+        background-color: #4575b4;
     }
 
     .resurrecting {

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -13,11 +13,11 @@
     }
 
     .returning {
-        background-color: #4575b4;
+        background-color: #abd9e9;
     }
 
     .resurrecting {
-        background-color: #abd9e9;
+        background-color: #8da0cb;
     }
 
     .dormant {

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -9,18 +9,18 @@
     }
 
     .new {
-        background-color: #66c2a5;
+        background-color: var(--lifecycle-new);
     }
 
     .returning {
-        background-color: #4575b4;
+        background-color: var(--lifecycle-returning);
     }
 
     .resurrecting {
-        background-color: #8da0cb;
+        background-color: var(--lifecycle-resurrecting);
     }
 
     .dormant {
-        background-color: #fdae61;
+        background-color: var(--lifecycle-dormant);
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -28,10 +28,10 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
     const { toggleLifecycle } = useActions(trendsLogic)
     const lifecycles = [
-        { name: 'new', tooltip: 'Users that are new' },
-        { name: 'resurrecting', tooltip: 'Users who were once active but became dormant, and are now active again' },
-        { name: 'returning', tooltip: 'Users who consistently use the product' },
-        { name: 'dormant', tooltip: 'Users who are inactive' },
+        { name: 'new', tooltip: 'Users that are new.' },
+        { name: 'resurrecting', tooltip: 'Users who were once active but became dormant, and are now active again.' },
+        { name: 'returning', tooltip: 'Users who consistently use the product.' },
+        { name: 'dormant', tooltip: 'Users who are inactive.' },
     ]
 
     return (

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -27,7 +27,12 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
     const { toggleLifecycle } = useActions(trendsLogic)
-    const lifecycleNames = ['new', 'resurrecting', 'returning', 'dormant']
+    const lifecycles = [
+        { name: 'new', tooltip: 'Users that are new' },
+        { name: 'resurrecting', tooltip: 'Users who were once active but became dormant, and are now active again' },
+        { name: 'returning', tooltip: 'Users who consistently use the product' },
+        { name: 'dormant', tooltip: 'Users who are inactive' },
+    ]
 
     return (
         <>
@@ -61,10 +66,19 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         <Skeleton active />
                     ) : (
                         <div className="toggles">
-                            {lifecycleNames.map((cycle, idx) => (
+                            {lifecycles.map((lifecycle, idx) => (
                                 <div key={idx}>
-                                    {cycle}{' '}
-                                    <Switch size="small" defaultChecked onChange={() => toggleLifecycle(cycle)} />
+                                    {lifecycle.name}{' '}
+                                    <div>
+                                        <Switch
+                                            size="small"
+                                            defaultChecked
+                                            onChange={() => toggleLifecycle(lifecycle.name)}
+                                        />
+                                        <Tooltip title={lifecycle.tooltip}>
+                                            <InfoCircleOutlined className="info-indicator" />
+                                        </Tooltip>
+                                    </div>
                                 </div>
                             ))}
                         </div>

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -72,6 +72,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                                     <div>
                                         <Switch
                                             size="small"
+                                            className={lifecycle.name}
                                             defaultChecked
                                             onChange={() => toggleLifecycle(lifecycle.name)}
                                         />


### PR DESCRIPTION
## Changes
Addresses #4041 

Updates to the lifecycle toggles:
- Add tooltips (feel free to correct any tooltip definitions, I just used google)
- Update chart colors to be more colorblind accessible! (interesting? fact: 1 in 12 men and 1 in 200 women are colorblind)

<img width="1302" alt="Screen Shot 2021-04-28 at 6 06 26 PM" src="https://user-images.githubusercontent.com/25164963/116480305-1699e800-a84f-11eb-8e9d-c2844971a3c5.png">

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [x] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
