### PR TITLE
Add `--plan` and `--fake` flags to migrate_clickhouse

### DIFF
--- a/ee/clickhouse/README.md
+++ b/ee/clickhouse/README.md
@@ -8,6 +8,10 @@ Clickhouse Support works by swapping in separate queries and classes in the syst
 
 The `django_clickhouse` orm is used to manage migrations and models. The ORM is used to mimic the django model and migration structure in the main folder.
 
+Certain migrations (e.g. changing table engines) can be quite expensive and tricky, especially for deployments outside of cloud. To skip these steps during deployment setup, check for the `CLICKHOUSE_INITIAL_MIGRATIONS` environment variable.
+
+If you need help in making them happen, ask for help from team deployments.
+
 ### Queries
 
 Queries parallel the queries folder in the main folder however, clickhouse queries are written in SQL and do not utilize the ORM.

--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -1,18 +1,66 @@
+import datetime
+
 from django.core.management.base import BaseCommand
 from infi.clickhouse_orm import Database  # type: ignore
+from infi.clickhouse_orm.migrations import MigrationHistory  # type: ignore
+from infi.clickhouse_orm.utils import import_submodules  # type: ignore
 
 from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_HTTP_URL, CLICKHOUSE_PASSWORD, CLICKHOUSE_USER
+
+MIGRATIONS_PACKAGE_NAME = "ee.clickhouse.migrations"
 
 
 class Command(BaseCommand):
     help = "Migrate clickhouse"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--upto", default=99_999, type=int, help="Database state will be brought to the state after that migration."
+        )
+        parser.add_argument("--fake", action="store_true", help="Mark migrations as run without actually running them.")
+        parser.add_argument(
+            "--plan", action="store_true", help="Shows a list of the migration actions that will be performed."
+        )
+
     def handle(self, *args, **options):
-        Database(
+        database = Database(
             CLICKHOUSE_DATABASE,
             db_url=CLICKHOUSE_HTTP_URL,
             username=CLICKHOUSE_USER,
             password=CLICKHOUSE_PASSWORD,
             verify_ssl_cert=False,
-        ).migrate("ee.clickhouse.migrations")
-        print("migration successful")
+        )
+
+        if options["plan"]:
+            print("List of clickhouse migrations to be applied:")
+            for migration_name in self.get_migrations(database, options["upto"]):
+                print(f"Migration would get applied: {migration_name}")
+            else:
+                print("Clickhouse migrations up to date!")
+        elif options["fake"]:
+            for migration_name in self.get_migrations(database, options["upto"]):
+                print(f"Faked migration: {migration_name}")
+                database.insert(
+                    [
+                        MigrationHistory(
+                            package_name=MIGRATIONS_PACKAGE_NAME,
+                            module_name=migration_name,
+                            applied=datetime.date.today(),
+                        )
+                    ]
+                )
+            print("Migrations done")
+        else:
+            database.migrate(MIGRATIONS_PACKAGE_NAME, options["upto"])
+            print("Migration successful")
+
+    def get_migrations(self, database, upto):
+        applied_migrations = database._get_applied_migrations(MIGRATIONS_PACKAGE_NAME)
+        modules = import_submodules(MIGRATIONS_PACKAGE_NAME)
+        unapplied_migrations = set(modules.keys()) - applied_migrations
+
+        for migration_name in sorted(unapplied_migrations):
+            yield migration_name
+
+            if int(migration_name[:4]) >= upto:
+                break


### PR DESCRIPTION
This can be used to bring a production environment up to date.

Related issue: #4090

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
