### PR TITLE
SITE_URL config warning

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -68,11 +68,20 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
     },
     selectors: {
         systemStatus: [
-            () => [systemStatusLogic.selectors.systemStatus, systemStatusLogic.selectors.systemStatusLoading],
-            (statusMetrics, statusLoading) => {
+            () => [
+                systemStatusLogic.selectors.systemStatus,
+                systemStatusLogic.selectors.systemStatusLoading,
+                preflightLogic.selectors.siteUrlMisconfigured,
+            ],
+            (statusMetrics, statusLoading, siteUrlMisconfigured) => {
                 if (statusLoading) {
                     return true
                 }
+
+                if (siteUrlMisconfigured) {
+                    return false
+                }
+
                 const aliveMetrics = ['redis_alive', 'db_alive', 'plugin_sever_alive']
                 let aliveSignals = 0
                 for (const metric of statusMetrics) {

--- a/frontend/src/scenes/PreflightCheck/logic.ts
+++ b/frontend/src/scenes/PreflightCheck/logic.ts
@@ -34,16 +34,42 @@ export const preflightLogic = kea<preflightLogicType<PreflightStatus, PreflightM
     selectors: {
         socialAuthAvailable: [
             (s) => [s.preflight],
-            (preflight: PreflightStatus | null) =>
-                preflight && Object.values(preflight.available_social_auth_providers).filter((i) => i).length,
+            (preflight): boolean =>
+                Boolean(preflight && Object.values(preflight.available_social_auth_providers).filter((i) => i).length),
         ],
         realm: [
             (s) => [s.preflight],
-            (preflight: PreflightStatus | null): 'cloud' | 'hosted' | null => {
+            (preflight): 'cloud' | 'hosted' | null => {
                 if (!preflight) {
                     return null
                 }
                 return preflight.cloud ? 'cloud' : 'hosted'
+            },
+        ],
+        siteUrlMisconfigured: [
+            (s) => [s.preflight],
+            (preflight): boolean => {
+                return Boolean(preflight && (!preflight.site_url || preflight.site_url != window.location.origin))
+            },
+        ],
+        configOptions: [
+            (s) => [s.preflight],
+            (preflight): Record<string, string>[] => {
+                // Returns the preflight config options to display in the /instance/status page
+
+                const RELEVANT_CONFIGS = [
+                    {
+                        key: 'site_url',
+                        label: 'Site URL',
+                    },
+                    { key: 'email_service_available', label: 'Email service available' },
+                ]
+
+                if (!preflight) {
+                    return []
+                }
+                // @ts-ignore
+                return RELEVANT_CONFIGS.map((config) => ({ metric: config.label, value: preflight[config.key] }))
             },
         ],
     },

--- a/frontend/src/scenes/instance/SystemStatus/index.scss
+++ b/frontend/src/scenes/instance/SystemStatus/index.scss
@@ -1,4 +1,5 @@
 .system-status-scene {
+    margin-bottom: 64px;
     .metric-column {
         @media (min-width: 750px) {
             width: 33%;

--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -6,9 +6,21 @@ import { systemStatusLogic } from './systemStatusLogic'
 import { useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SystemStatusSubrows } from '~/types'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
+
+function RenderValue(value: any): JSX.Element | string {
+    if (typeof value === 'boolean') {
+        return <Tag color={value ? 'success' : 'error'}>{value ? 'Yes' : 'No'}</Tag>
+    }
+    if (value === null || value === undefined || value === '') {
+        return <Tag>Unknown</Tag>
+    }
+    return value.toString()
+}
 
 export function SystemStatus(): JSX.Element {
     const { systemStatus, systemStatusLoading, error } = useValues(systemStatusLogic)
+    const { configOptions, preflight, preflightLoading, siteUrlMisconfigured } = useValues(preflightLogic)
 
     const columns = [
         {
@@ -19,15 +31,7 @@ export function SystemStatus(): JSX.Element {
         {
             title: 'Value',
             dataIndex: 'value',
-            render: function RenderValue(value: any) {
-                if (typeof value === 'boolean') {
-                    return <Tag color={value ? 'success' : 'error'}>{value ? 'Yes' : 'No'}</Tag>
-                }
-                if (value === null || value === undefined) {
-                    return <Tag>Unknown</Tag>
-                }
-                return value.toString()
-            },
+            render: RenderValue,
         },
     ]
 
@@ -39,11 +43,34 @@ export function SystemStatus(): JSX.Element {
             />
             {error && (
                 <Alert
-                    message={error || <span>Something went wrong. Please try again or contact us.</span>}
+                    message="Something went wrong"
+                    description={error || <span>An unknown error occurred. Please try again or contact us.</span>}
                     type="error"
+                    showIcon
+                />
+            )}
+            {siteUrlMisconfigured && (
+                <Alert
+                    message="Misconfiguration detected"
+                    description={
+                        <>
+                            Your <code>SITE_URL</code> environment variable seems misconfigured. Your{' '}
+                            <code>SITE_URL</code> is set to <b>{RenderValue(preflight?.site_url)}</b> but you're
+                            currently browsing this page from{' '}
+                            <b>
+                                <code>{window.location.origin}</code>
+                            </b>
+                            . In order for PostHog to work properly, please set this to the origin where your instance
+                            is hosted.
+                        </>
+                    }
+                    showIcon
+                    type="warning"
+                    style={{ marginBottom: 32 }}
                 />
             )}
             <Card>
+                <h3 className="l3">Key metrics</h3>
                 <Table
                     className="system-status-table"
                     size="small"
@@ -59,6 +86,18 @@ export function SystemStatus(): JSX.Element {
                         rowExpandable: (row) => !!row.subrows && row.subrows.rows.length > 0,
                         expandRowByClick: true,
                     }}
+                />
+            </Card>
+            <Card style={{ marginTop: 32 }}>
+                <h3 className="l3">Configuration options</h3>
+                <Table
+                    className="system-config-table"
+                    size="small"
+                    rowKey="metric"
+                    pagination={{ pageSize: 99999, hideOnSinglePage: true }}
+                    dataSource={configOptions}
+                    columns={columns}
+                    loading={preflightLoading}
                 />
             </Card>
         </div>

--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -7,6 +7,7 @@ import { useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SystemStatusSubrows } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { IconExternalLink } from 'lib/components/icons'
 
 function RenderValue(value: any): JSX.Element | string {
     if (typeof value === 'boolean') {
@@ -61,7 +62,14 @@ export function SystemStatus(): JSX.Element {
                                 <code>{window.location.origin}</code>
                             </b>
                             . In order for PostHog to work properly, please set this to the origin where your instance
-                            is hosted.
+                            is hosted.{' '}
+                            <a
+                                target="_blank"
+                                rel="noopener"
+                                href="https://posthog.com/docs/configuring-posthog/environment-variables?utm_medium=in-product&utm_campaign=system-status-site-url-misconfig"
+                            >
+                                Learn more <IconExternalLink />
+                            </a>
                         </>
                     }
                     showIcon

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -633,7 +633,8 @@ export interface PreflightStatus {
     email_service_available?: boolean
     is_debug?: boolean
     is_event_property_usage_enabled?: boolean
-    licensed_users_available: number | null
+    licensed_users_available?: number | null
+    site_url?: string
 }
 
 export enum DashboardMode { // Default mode is null

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -63,6 +63,7 @@ class TestPreflight(APIBaseTest):
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
                     "licensed_users_available": None,
+                    "site_url": "http://localhost:8000",
                 },
             )
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
@@ -94,7 +95,7 @@ class TestPreflight(APIBaseTest):
     @pytest.mark.ee
     def test_cloud_preflight_request(self):
 
-        with self.settings(MULTI_TENANCY=True, PRIMARY_DB=RDBMS.CLICKHOUSE):
+        with self.settings(MULTI_TENANCY=True, PRIMARY_DB=RDBMS.CLICKHOUSE, SITE_URL="https://app.posthog.com"):
             response = self.client.get("/_preflight/")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response = response.json()
@@ -120,6 +121,7 @@ class TestPreflight(APIBaseTest):
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
                     "licensed_users_available": None,
+                    "site_url": "https://app.posthog.com",
                 },
             )
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
@@ -159,6 +161,7 @@ class TestPreflight(APIBaseTest):
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
                     "licensed_users_available": None,
+                    "site_url": "http://localhost:8000",
                 },
             )
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -211,6 +211,7 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
             "is_debug": settings.DEBUG,
             "is_event_property_usage_enabled": settings.ASYNC_EVENT_PROPERTY_USAGE,
             "licensed_users_available": get_licensed_users_available(),
+            "site_url": settings.SITE_URL,
         }
 
     return JsonResponse(response)


### PR DESCRIPTION
## Changes

- Show some configuration values in the `/instance/status` page.

<img width="1308" alt="" src="https://user-images.githubusercontent.com/5864173/116628992-2411a980-a905-11eb-88d6-d37b40554ce3.png">

- Show a misconfiguration warning when `SITE_URL` is not set correctly (closes #2951).
<img width="1355" alt="" src="https://user-images.githubusercontent.com/5864173/116628983-1f4cf580-a905-11eb-8911-fc58b78aca20.png">


## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [ ] Cypress end-to-end tests
- [x] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
