### PR TITLE
Fix authenticated invite when org-less

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -57,16 +57,16 @@ export function App(): JSX.Element | null {
                     }
                     return
                 }
-            }
 
-            // If ingestion tutorial not completed, redirect to it
-            if (
-                !user.team?.completed_snippet_onboarding &&
-                !location.pathname.startsWith('/ingestion') &&
-                !location.pathname.startsWith('/personalization')
-            ) {
-                replace('/ingestion')
-                return
+                // If ingestion tutorial not completed, redirect to it
+                if (
+                    !user.team?.completed_snippet_onboarding &&
+                    !location.pathname.startsWith('/ingestion') &&
+                    !location.pathname.startsWith('/personalization')
+                ) {
+                    replace('/ingestion')
+                    return
+                }
             }
         }
     }, [scene, user])

--- a/frontend/src/scenes/authentication/InviteSignup.scss
+++ b/frontend/src/scenes/authentication/InviteSignup.scss
@@ -54,7 +54,6 @@
         .whoami-mock {
             display: flex;
             align-items: center;
-            padding-left: $default_spacing;
             height: 100%;
             width: 100%;
 
@@ -65,8 +64,7 @@
                     border: 1px $text_light dashed;
                     border-radius: $radius;
                     background-color: rgba(white, 0.3);
-                    padding-left: 4px;
-                    padding-right: 4px;
+                    padding: 4px;
                 }
                 .whoami,
                 span {

--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -5,7 +5,7 @@ import { SceneLoading } from 'lib/utils'
 import './InviteSignup.scss'
 import { StarryBackground } from 'lib/components/StarryBackground'
 import { userLogic } from 'scenes/userLogic'
-import { Button, Row, Col, Input } from 'antd'
+import { Button, Row, Col, Input, Space } from 'antd'
 import { ArrowLeftOutlined, ArrowRightOutlined, ArrowDownOutlined } from '@ant-design/icons'
 import { router } from 'kea-router'
 import { PrevalidatedInvite } from '~/types'
@@ -131,27 +131,27 @@ function AuthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite }): 
 
     return (
         <div className="authenticated-invite">
-            <div className="inner">
-                <div>
+            <Space className="inner" direction="vertical" align="center">
+                <Row>
                     <h1 className="page-title">You have been invited to join {invite.organization_name}</h1>
-                </div>
-                <div>
-                    You will accept the invite under your <b>existing PostHog account</b> ({user?.email})
-                </div>
-                <Row className="mt text-muted">
-                    <Col span={24} md={12} style={{ textAlign: 'left' }}>
-                        You can change organizations at any time by clicking on the dropdown at the top right corner of
-                        the navigation bar.
-                    </Col>
-                    <Col md={12} span={0}>
-                        {user && (
-                            <div className="whoami-mock">
-                                <div className="whoami-inner-container">
-                                    <WhoAmI user={user} />
-                                </div>
+                </Row>
+                <Row>
+                    <span>
+                        You will accept the invite under your <b>existing PostHog account</b> ({user?.email})
+                    </span>
+                </Row>
+                {user && (
+                    <Row>
+                        <div className="whoami-mock">
+                            <div className="whoami-inner-container">
+                                <WhoAmI user={user} />
                             </div>
-                        )}
-                    </Col>
+                        </div>
+                    </Row>
+                )}
+                <Row>
+                    You can change organizations at any time by clicking on the dropdown at the top right corner of the
+                    navigation bar.
                 </Row>
                 <div>
                     {!acceptedInvite ? (
@@ -176,7 +176,7 @@ function AuthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite }): 
                         </Button>
                     )}
                 </div>
-            </div>
+            </Space>
         </div>
     )
 }


### PR DESCRIPTION
## Changes

`useEffect` fix to allow for using invites when not being in any org, plus some styling cleanup.

![fixed-invite](https://user-images.githubusercontent.com/4550621/116681770-b2da0100-a9ad-11eb-84bc-e996fbc664b6.png)
