### PR TITLE
Fix toolbar modal URLs

### DIFF
--- a/frontend/src/lib/components/AppEditorLink/appUrlsLogic.ts
+++ b/frontend/src/lib/components/AppEditorLink/appUrlsLogic.ts
@@ -10,6 +10,9 @@ import { teamLogic } from 'scenes/teamLogic'
 const defaultValue = 'https://'
 
 export const appUrlsLogic = kea<appUrlsLogicType<TrendResult>>({
+    connect: {
+        values: [teamLogic, ['currentTeam']],
+    },
     actions: () => ({
         setAppUrls: (appUrls: string[]) => ({ appUrls }),
         addUrl: (value: string) => ({ value }),
@@ -56,8 +59,13 @@ export const appUrlsLogic = kea<appUrlsLogicType<TrendResult>>({
             },
         },
     }),
-    events: ({ actions }) => ({
-        afterMount: actions.loadSuggestions,
+    events: ({ actions, values }) => ({
+        afterMount: () => {
+            actions.loadSuggestions()
+            if (values.currentTeam) {
+                actions.setAppUrls(values.currentTeam.app_urls)
+            }
+        },
     }),
     reducers: () => ({
         appUrls: [


### PR DESCRIPTION
## Changes

Reported by a bunch of users.

This was a confusing one - users reported toolbar URLs would not persist, but I just couldn't reproduce it! Turns out we were relying on a signal from `teamLogic` to set these URLs, but that assumed `appUrlsLogic` would have been mounted beforehand.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
