### PR TITLE
Cut off long props/events in table

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Popover } from 'antd'
+import { Popover, Typography } from 'antd'
 import { KeyMapping } from '~/types'
 
 export interface KeyMappingInterface {
@@ -443,7 +443,11 @@ export function PropertyKeyInfo({ value, type = 'event' }: PropertyKeyInfoInterf
     if (value in keyMapping[type]) {
         data = keyMapping[type][value]
     } else {
-        return <>{value}</>
+        return (
+            <Typography.Text ellipsis={true} style={{ maxWidth: 400 }} title={value}>
+                {value}
+            </Typography.Text>
+        )
     }
 
     return (


### PR DESCRIPTION
## Changes

If someone had a really long event name or property key it would take up the entire screen so you couldn't see any of the volume. Now it'll ellipsis it + show the full title when you hover over

![image](https://user-images.githubusercontent.com/1727427/116698897-39e6a380-a9c5-11eb-85c2-8178618c083d.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
