### PR TITLE
Add bin script to start Cypress component tests

### DIFF
--- a/bin/component-test-runner
+++ b/bin/component-test-runner
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py setup_dev &
+yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
+
+# Only start webpack if not already running
+nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
+
+CYPRESS_BASE_URL=http://localhost:8080 npx cypress open
+
+yarn remove cypress cypress-terminal-report @cypress/react @cypress/webpack-preprocessor

--- a/bin/component-test-runner
+++ b/bin/component-test-runner
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py setup_dev &
 yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
 
 # Only start webpack if not already running


### PR DESCRIPTION
## Changes

Add a new script to start Cypress component (not E2E) tests with `npx cypress open`. If this already exists feel free to point me toward it and close this PR!

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
