### PR TITLE
Fix moving from person sessions to global sessions

### DIFF
--- a/frontend/src/scenes/sessions/Sessions.tsx
+++ b/frontend/src/scenes/sessions/Sessions.tsx
@@ -15,7 +15,7 @@ export function Sessions(): JSX.Element {
                 <Divider type="vertical" className="sessions-divider" />
             </div>
             <div className="sessions-with-filters">
-                <SessionsView />
+                <SessionsView key="global" />
             </div>
         </div>
     )

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -22,6 +22,7 @@ interface Params {
 export const sessionsTableLogic = kea<
     sessionsTableLogicType<Dayjs, SessionType, SessionRecordingId, PropertyFilter, SessionsPropertyFilter, EventType>
 >({
+    key: (props) => props.personIds || 'global',
     props: {} as {
         personIds?: string[]
     },


### PR DESCRIPTION
## Changes

Previously if you clicked on a person and looked at their sessions, and then navigated to the global sessions view the table would still be filtered on that 1 person.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
