### PR TITLE
Rename free clickhouse plan

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -48,7 +48,7 @@ class License(models.Model):
     max_users: models.IntegerField = models.IntegerField(default=None, null=True)  # None = no restriction
 
     ENTERPRISE_PLAN = "enterprise"
-    BASE_CLICKHOUSE_PLAN = "base_clickhouse"
+    FREE_CLICKHOUSE_PLAN = "free_clickhouse"
     ENTERPRISE_FEATURES = [
         "zapier",
         "organizations_projects",
@@ -57,7 +57,7 @@ class License(models.Model):
     ]  # Base premium features
     PLANS = {
         ENTERPRISE_PLAN: ENTERPRISE_FEATURES + ["clickhouse"],
-        BASE_CLICKHOUSE_PLAN: ["clickhouse"],
+        FREE_CLICKHOUSE_PLAN: ["clickhouse"],
     }
 
     @property

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -172,7 +172,7 @@ class TestPreflight(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123", plan="base_clickhouse", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
+            key="key_123", plan="free_clickhouse", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
         )
 
         OrganizationInvite.objects.create(organization=self.organization, target_email="invite@posthog.com")


### PR DESCRIPTION
This was named this way in license server, typo?

Caused warning to be shown even if user had entered a license

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
