### PR TITLE
Warn before running all tests

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -7,6 +7,21 @@ then
     exit
 fi
 
+
+if [ $# -eq 0 ]; then
+    echo "Are you sure you want to run all backend tests? You can run specific tests by doing:"
+    echo " "
+    echo "bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user"
+    echo " "
+    read -r -p "Run all tests? [y/N] " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
+    then
+        echo "OK!"
+    else
+        exit
+    fi
+fi
+
 export REDIS_URL='redis:///'
 export TEST=1
 psql posthog -c "drop database if exists test_posthog"


### PR DESCRIPTION
## Changes

Some confusion on errors that popped up when running _all_ tests locally. Added a warning and suggestion for what to do instead

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
