### PR TITLE
Remove graphile queue so new plugin server could run

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -58,7 +58,7 @@
                 },
                 {
                     "name": "JOB_QUEUES",
-                    "value": "graphile"
+                    "value": ""
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

- Disables the postgres job queue which seems to have connection issues.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
