### PR TITLE
Fix action error with gt

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -41,7 +41,7 @@ def format_action_filter(
             prop_query, prop_params = parse_prop_clauses(
                 Filter(data={"properties": step.properties}).properties,
                 team_id=action.team.pk if filter_by_team else None,
-                prepend="action_props_{}".format(action.pk),
+                prepend="action_props_{}_{}".format(action.pk, step.pk),
             )
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -90,6 +90,7 @@ def prop_filter_json_extract(
     denormalized = "properties_{}".format(prop.key.lower())
     operator = prop.operator
     params: Dict[str, Any] = {}
+
     if operator == "is_not":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): box_value(prop.value)}
         return (

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -153,3 +153,24 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         full_query = "SELECT uuid FROM events WHERE {}".format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)
+
+    def test_double(self):
+        # Tests a regression where the second step properties would override those of the first step, causing issues
+        _create_event(
+            event="insight viewed", team=self.team, distinct_id="whatever", properties={"filters_count": 2},
+        )
+
+        action1 = Action.objects.create(team=self.team, name="action1")
+        step1 = ActionStep.objects.create(
+            event="insight viewed",
+            action=action1,
+            properties=[{"key": "insight", "type": "event", "value": ["RETENTION"], "operator": "exact"}],
+        )
+        step2 = ActionStep.objects.create(
+            event="insight viewed",
+            action=action1,
+            properties=[{"key": "filters_count", "type": "event", "value": "1", "operator": "gt"}],
+        )
+
+        events = query_action(action1)
+        self.assertEqual(len(events), 1)

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -173,4 +173,4 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         )
 
         events = query_action(action1)
-        self.assertEqual(len(events), 1)
+        self.assertEqual(len(events), 1)  # type: ignore


### PR DESCRIPTION
Closes #4195

## Changes

The test case probably explains this best, but the issue was the values in the query would be overridden by other steps in the action as the prepend only looked at the action ID, not the action ID + step ID.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
