### PR TITLE
Use alternative way of color corresponding lifecycle toggles

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -1,26 +1,27 @@
 .toggles {
     text-transform: uppercase;
     div {
-        font-size: 12px;
+        font-size: 13px;
         display: flex;
         justify-content: space-between;
         padding-bottom: 4px;
         align-items: center;
+        font-weight: 700;
     }
 
     .new {
-        background-color: var(--lifecycle-new);
+        color: var(--lifecycle-new);
     }
 
     .returning {
-        background-color: var(--lifecycle-returning);
+        color: var(--lifecycle-returning);
     }
 
     .resurrecting {
-        background-color: var(--lifecycle-resurrecting);
+        color: var(--lifecycle-resurrecting);
     }
 
     .dormant {
-        background-color: var(--lifecycle-dormant);
+        color: var(--lifecycle-dormant);
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.scss
@@ -1,27 +1,38 @@
 .toggles {
     text-transform: uppercase;
     div {
-        font-size: 13px;
+        font-size: 12px;
         display: flex;
         justify-content: space-between;
         padding-bottom: 4px;
         align-items: center;
-        font-weight: 700;
     }
 
     .new {
-        color: var(--lifecycle-new);
+        .ant-checkbox-checked .ant-checkbox-inner {
+            border-color: var(--lifecycle-new);
+            background-color: var(--lifecycle-new);
+        }
     }
 
     .returning {
-        color: var(--lifecycle-returning);
+        .ant-checkbox-checked .ant-checkbox-inner {
+            border-color: var(--lifecycle-returning);
+            background-color: var(--lifecycle-returning);
+        }
     }
 
     .resurrecting {
-        color: var(--lifecycle-resurrecting);
+        .ant-checkbox-checked .ant-checkbox-inner {
+            border-color: var(--lifecycle-resurrecting);
+            background-color: var(--lifecycle-resurrecting);
+        }
     }
 
     .dormant {
-        color: var(--lifecycle-dormant);
+        .ant-checkbox-checked .ant-checkbox-inner {
+            border-color: var(--lifecycle-dormant);
+            background-color: var(--lifecycle-dormant);
+        }
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useValues, useActions } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { ActionFilter } from '../../ActionFilter/ActionFilter'
-import { Tooltip, Row, Skeleton, Switch } from 'antd'
+import { Tooltip, Row, Skeleton, Checkbox } from 'antd'
 import { BreakdownFilter } from '../../BreakdownFilter'
 import { CloseButton } from 'lib/components/CloseButton'
 import { InfoCircleOutlined } from '@ant-design/icons'
@@ -61,12 +61,12 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     ) : (
                         <div className="toggles">
                             {lifecycles.map((lifecycle, idx) => (
-                                <div key={idx} className={lifecycle.name}>
+                                <div key={idx}>
                                     {lifecycle.name}{' '}
                                     <div>
-                                        <Switch
-                                            size="small"
+                                        <Checkbox
                                             defaultChecked
+                                            className={lifecycle.name}
                                             onChange={() => toggleLifecycle(lifecycle.name)}
                                         />
                                         <Tooltip title={lifecycle.tooltip}>

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -61,12 +61,11 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     ) : (
                         <div className="toggles">
                             {lifecycles.map((lifecycle, idx) => (
-                                <div key={idx}>
+                                <div key={idx} className={lifecycle.name}>
                                     {lifecycle.name}{' '}
                                     <div>
                                         <Switch
                                             size="small"
-                                            className={lifecycle.name}
                                             defaultChecked
                                             onChange={() => toggleLifecycle(lifecycle.name)}
                                         />


### PR DESCRIPTION
## Changes

I think this is a better way of color corresponding the lifecycle toggles and we won't have to maintain an extra layer of state in order to toggle the switch colors ON and OFF correctly.

<img width="754" alt="Screen Shot 2021-05-04 at 4 37 37 PM" src="https://user-images.githubusercontent.com/25164963/117066823-391c7d00-acf7-11eb-8ca4-b529b460f572.png">


## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [x] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
