### PR TITLE
Tally up counts of filters on events and actions

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -187,7 +187,7 @@ export const eventUsageLogic = kea<
                 }
             })
 
-            // The total # of filters applied on events
+            // The total # of filters applied on events and actions.
             properties.total_event_action_filters_count = totalEventActionFilters
 
             // Custom properties for each insight

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -175,6 +175,21 @@ export const eventUsageLogic = kea<
 
             properties.total_event_actions_count = (properties.events_count || 0) + (properties.actions_count || 0)
 
+            let totalEventActionFilters = 0
+            filters.events?.forEach((event) => {
+                if (event.properties?.length) {
+                    totalEventActionFilters += event.properties.length
+                }
+            })
+            filters.actions?.forEach((action) => {
+                if (action.properties?.length) {
+                    totalEventActionFilters += action.properties.length
+                }
+            })
+
+            // The total # of filters applied on events
+            properties.total_event_action_filters_count = totalEventActionFilters
+
             // Custom properties for each insight
             if (insight === 'TRENDS') {
                 properties.breakdown_type = filters.breakdown_type


### PR DESCRIPTION
## Changes
https://github.com/PostHog/posthog/issues/4213

Adds some more granularity to our insights viewed event. Specifically event/action filter counts, which are important for certain charts such as stickiness or sessions where we'd expect a fair amount of meaningful usage on the default event.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
