### PR TITLE
Fix PersonHeader name rendering

### DIFF
--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -4,10 +4,11 @@ import { IconPerson } from 'lib/components/icons'
 import './PersonHeader.scss'
 
 export function PersonHeader({ person }: { person?: Partial<PersonType> | null }): JSX.Element {
-    const propertiesIdentifier = person?.properties
+    const propertyIdentifier = person?.properties
         ? person.properties.email || person.properties.name || person.properties.username
         : null
-    const customIdentifier = propertiesIdentifier ? JSON.stringify(propertiesIdentifier) : null
+    const customIdentifier =
+        typeof propertyIdentifier === 'object' ? JSON.stringify(propertyIdentifier) : propertyIdentifier
 
     const displayId = useMemo(() => {
         if (!person?.distinct_ids?.length) {


### PR DESCRIPTION
## Changes

This PR fixes a rendering issue we had in the `PersonHeader` component. See below.

**Before (notice the `"`)**
<img width="246" alt="" src="https://user-images.githubusercontent.com/5864173/117091058-fa92bc80-ad0e-11eb-8426-360dc4a6e502.png">

**After**
<img width="412" alt="" src="https://user-images.githubusercontent.com/5864173/117091056-f8c8f900-ad0e-11eb-8768-85c5d6e402da.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
