### PR TITLE
Fix Broken Link to Integrations

### DIFF
--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -46,7 +46,7 @@ export function EventName({ value, onChange, isActionStep = false }: EventNameIn
 
                     <small>
                         {eventNamesGrouped[0].options.length === 0 && "You haven't sent any custom events."}{' '}
-                        <a href="https://posthog.com/docs/integrations" target="_blank" rel="noopener noreferrer">
+                        <a href="https://posthog.com/docs/libraries" target="_blank" rel="noopener noreferrer">
                             See documentation
                         </a>{' '}
                         on how to send custom events in lots of languages.


### PR DESCRIPTION
I noted that we redirect `docs/integrations/*` to `docs/libraries/*`, but found this specific one to be broken. Not sure if I should be fixing it like this, or by adding to a redirect rule.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
