### PR TITLE
Add stickiness test account filter for clickhouse and test

### DIFF
--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -35,7 +35,9 @@ class ClickhouseStickiness(Stickiness):
     def stickiness(self, entity: Entity, filter: StickinessFilter, team_id: int) -> Dict[str, Any]:
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team_id)
+        prop_filters, prop_filter_params = parse_prop_clauses(
+            filter.properties, team_id, filter_test_accounts=filter.filter_test_accounts
+        )
         trunc_func = get_trunc_func_ch(filter.interval)
 
         params: Dict = {"team_id": team_id}


### PR DESCRIPTION
## Changes

*Please describe.*  
- clickhouse stickness didn't have test account filtering
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
