### PR TITLE
Set max_threads for clickhouse explicitly (hotfix)

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -126,6 +126,8 @@ else:
     def sync_execute(query, args=None, settings=None):
         with ch_pool.get_client() as client:
             start_time = time()
+            settings = settings or {}
+            settings["max_threads"] = 48  # :TODO: Nuke this, update configuration
             try:
                 result = client.execute(query, args, settings=settings)
             finally:


### PR DESCRIPTION
We're seeing queries try to spawn 15k threads due to an invalid
max_threads setting in clickhouse. Since no-one awake has ssh access
this is a temporary hotfix to make things work.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
