### PR TITLE
Add back graphile/aurora job queue

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -58,7 +58,11 @@
                 },
                 {
                     "name": "JOB_QUEUES",
-                    "value": ""
+                    "value": "graphile"
+                },
+                {
+                    "name": "CRASH_IF_NO_PERSISTENT_JOB_QUEUE",
+                    "value": "0"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

- Re-enables the queue. We should get better errors now.
- Explicitly set the `CRASH_IF_NO_PERSISTENT_JOB_QUEUE` env to "please do not crash"

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
