### PR TITLE
Add monitoring for table mutations which can degrade performance

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -82,6 +82,7 @@ def setup_periodic_tasks(sender, **kwargs):
         sender.add_periodic_task(120, clickhouse_lag.s(), name="clickhouse table lag")
         sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
         sender.add_periodic_task(120, clickhouse_part_count.s(), name="clickhouse table parts count")
+        sender.add_periodic_task(120, clickhouse_mutation_count.s(), name="clickhouse table mutations count")
     else:
         sender.add_periodic_task(
             ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
@@ -170,6 +171,27 @@ def clickhouse_part_count():
         for (table, parts) in rows:
             g = statsd.Gauge("%s_posthog_celery" % (settings.STATSD_PREFIX,))
             g.send("clickhouse_{table}_table_parts_count".format(table=table), parts)
+    else:
+        pass
+
+
+@app.task(ignore_result=True)
+def clickhouse_mutation_count():
+    if is_ee_enabled() and settings.EE_AVAILABLE:
+        from ee.clickhouse.client import sync_execute
+
+        QUERY = """
+            SELECT
+                table,
+                count(1) AS freq
+            FROM system.mutations
+            GROUP BY table
+            ORDER BY freq DESC 
+        """
+        rows = sync_execute(QUERY)
+        for (table, muts) in rows:
+            g = statsd.Gauge("%s_posthog_celery" % (settings.STATSD_PREFIX,))
+            g.send("clickhouse_{table}_table_mutations_count".format(table=table), muts)
     else:
         pass
 


### PR DESCRIPTION
## Changes

We had an outage this morning caused by Clickhouse slowing down. Upon investigation the root cause was determined to be `person_distinct_id` table having too many queued mutations.

Having this in grafana will allow us to page if mutations get too far behind.

