### PR TITLE
New querying horizontal UI - continuation

### DIFF
--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -3,7 +3,7 @@ import { useValues, useActions } from 'kea'
 import { Checkbox } from 'antd'
 import { compareFilterLogic } from './compareFilterLogic'
 
-export function CompareFilter() {
+export function CompareFilter(): JSX.Element {
     const { compare, disabled } = useValues(compareFilterLogic)
     const { setCompare } = useActions(compareFilterLogic)
     return (
@@ -15,7 +15,7 @@ export function CompareFilter() {
             style={{ marginLeft: 8, marginRight: 6 }}
             disabled={disabled}
         >
-            Compare Previous
+            Compare previous
         </Checkbox>
     )
 }

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -2,11 +2,13 @@ import { kea } from 'kea'
 import { router } from 'kea-router'
 import { objectsEqual } from 'lib/utils'
 import { ViewType } from 'scenes/insights/insightLogic'
+import { InsightType } from '~/types'
+import { compareFilterLogicType } from './compareFilterLogicType'
 
-export const compareFilterLogic = kea({
+export const compareFilterLogic = kea<compareFilterLogicType<InsightType>>({
     actions: () => ({
-        setCompare: (compare) => ({ compare }),
-        setDisabled: (disabled) => ({ disabled }),
+        setCompare: (compare: boolean) => ({ compare }),
+        setDisabled: (disabled: boolean) => ({ disabled }),
         toggleCompare: true,
     }),
     reducers: () => ({
@@ -39,8 +41,11 @@ export const compareFilterLogic = kea({
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights': (_, { compare, insight, date_from }) => {
-            if (compare != null) {
+        '/insights': (
+            _: any,
+            { compare, insight, date_from }: { compare?: boolean; insight?: InsightType; date_from?: string }
+        ) => {
+            if (compare !== undefined) {
                 actions.setCompare(compare)
             }
             if (insight === ViewType.LIFECYCLE || date_from === 'all') {

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -5,7 +5,7 @@ import { useValues, useActions } from 'kea'
 import { ViewType } from 'scenes/insights/insightLogic'
 import { disableHourFor, disableMinuteFor } from 'lib/utils'
 
-let intervalMapping = {
+const intervalMapping = {
     minute: 'Minute',
     hour: 'Hourly',
     day: 'Daily',
@@ -13,8 +13,13 @@ let intervalMapping = {
     month: 'Monthly',
 }
 
-export function IntervalFilter({ view, disabled = false }) {
-    const { interval } = useValues(intervalFilterLogic)
+interface InvertalFilterProps {
+    view: ViewType
+    disabled?: boolean
+}
+
+export function IntervalFilter({ view, disabled }: InvertalFilterProps): JSX.Element {
+    const interval: 'minute' | 'hour' | 'day' | 'week' | 'month' = useValues(intervalFilterLogic).interval
     const { setIntervalFilter, setDateFrom } = useActions(intervalFilterLogic)
     return (
         <Select
@@ -44,8 +49,8 @@ export function IntervalFilter({ view, disabled = false }) {
                         break
                 }
 
-                const minute_disabled = key === 'minute' && disableMinuteFor[newDateFrom]
-                const hour_disabled = key === 'hour' && disableHourFor[newDateFrom]
+                const minute_disabled = key === 'minute' && newDateFrom && disableMinuteFor[newDateFrom]
+                const hour_disabled = key === 'hour' && newDateFrom && disableHourFor[newDateFrom]
                 if (minute_disabled || hour_disabled) {
                     return false
                 }
@@ -58,17 +63,15 @@ export function IntervalFilter({ view, disabled = false }) {
             }}
             data-attr="interval-filter"
         >
-            {Object.entries(intervalMapping).map(([key, value]) => {
-                return (
-                    <Select.Option
-                        key={key}
-                        value={key}
-                        disabled={(key === 'minute' || key === 'hour') && view === ViewType.SESSIONS}
-                    >
-                        {value}
-                    </Select.Option>
-                )
-            })}
+            {Object.entries(intervalMapping).map(([key, value]) => (
+                <Select.Option
+                    key={key}
+                    value={key}
+                    disabled={(key === 'minute' || key === 'hour') && view === ViewType.SESSIONS}
+                >
+                    {value}
+                </Select.Option>
+            ))}
         </Select>
     )
 }

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -6,6 +6,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface Props {
     item: DashboardItemAttributes
+    displayComponent?: JSX.Element // Show custom component instead of default `Add to dashboard` button
 }
 
 interface DashboardItemAttributes {
@@ -22,8 +23,7 @@ interface FunnelPayload {
     name: string
 }
 
-export function SaveToDashboard(props: Props): JSX.Element {
-    const { item } = props
+export function SaveToDashboard({ item, displayComponent }: Props): JSX.Element {
     const [openModal, setOpenModal] = useState<boolean>(false)
     const { dashboardItem } = useValues(insightLogic)
 
@@ -42,7 +42,7 @@ export function SaveToDashboard(props: Props): JSX.Element {
         <span className="save-to-dashboard">
             {openModal && (
                 <SaveToDashboardModal
-                    closeModal={(): void => setOpenModal(false)}
+                    closeModal={() => setOpenModal(false)}
                     name={_name}
                     filters={_filters}
                     fromItem={dashboardItem?.id}
@@ -51,9 +51,13 @@ export function SaveToDashboard(props: Props): JSX.Element {
                     annotations={_annotations}
                 />
             )}
-            <Button onClick={(): void => setOpenModal(true)} type="primary" data-attr="save-to-dashboard-button">
-                {dashboardItem?.id ? 'Update Dashboard' : 'Add to dashboard'}
-            </Button>
+            {displayComponent ? (
+                <span onClick={() => setOpenModal(true)}>{displayComponent}</span>
+            ) : (
+                <Button onClick={() => setOpenModal(true)} type="primary" data-attr="save-to-dashboard-button">
+                    {dashboardItem?.id ? 'Update Dashboard' : 'Add to dashboard'}
+                </Button>
+            )}
         </span>
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -10,6 +10,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import React from 'react'
 import { DisplayType, FilterType } from '~/types'
 import { ViewType } from '../insightLogic'
+import { CalendarOutlined } from '@ant-design/icons'
 
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
@@ -157,7 +158,18 @@ function HorizontalDefaultInsightDisplayConfig({
 
                 {showIntervalFilter(activeView, allFilters) && <IntervalFilter view={activeView} />}
                 {showDateFilter[activeView] && (
-                    <DateFilter defaultValue="Last 7 days" disabled={dateFilterDisabled} bordered={false} />
+                    <>
+                        <DateFilter
+                            defaultValue="Last 7 days"
+                            disabled={dateFilterDisabled}
+                            bordered={false}
+                            makeLabel={(key) => (
+                                <>
+                                    <CalendarOutlined /> {key}
+                                </>
+                            )}
+                        />
+                    </>
                 )}
             </div>
         </div>

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -1,0 +1,165 @@
+import { useValues } from 'kea'
+import { ChartFilter } from 'lib/components/ChartFilter'
+import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { IntervalFilter } from 'lib/components/IntervalFilter'
+import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
+import { TZIndicator } from 'lib/components/TimezoneAware'
+import { ACTIONS_BAR_CHART_VALUE, ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_PIE_CHART, ACTIONS_TABLE } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import React from 'react'
+import { DisplayType, FilterType } from '~/types'
+import { ViewType } from '../insightLogic'
+
+interface InsightDisplayConfigProps {
+    clearAnnotationsToCreate: () => void
+    allFilters: FilterType
+    activeView: ViewType
+    annotationsToCreate: any[] // TODO: Annotate properly
+}
+
+export function InsightDisplayConfig({
+    horizontalUI,
+    ...props
+}: InsightDisplayConfigProps & { horizontalUI: boolean }): JSX.Element {
+    return horizontalUI ? (
+        <HorizontalDefaultInsightDisplayConfig {...props} />
+    ) : (
+        <DefaultInsightDisplayConfig {...props} />
+    )
+}
+
+const showIntervalFilter = function (activeView: ViewType, filter: FilterType): boolean {
+    switch (activeView) {
+        case ViewType.FUNNELS:
+            return filter.display === ACTIONS_LINE_GRAPH_LINEAR
+        case ViewType.RETENTION:
+        case ViewType.PATHS:
+            return false
+        case ViewType.TRENDS:
+        case ViewType.STICKINESS:
+        case ViewType.LIFECYCLE:
+        case ViewType.SESSIONS:
+        default:
+            return ![ACTIONS_PIE_CHART, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE].includes(filter.display || '') // sometimes insights aren't set for trends
+    }
+}
+
+const showChartFilter = function (activeView: ViewType, featureFlags: Record<string, boolean>): boolean {
+    switch (activeView) {
+        case ViewType.TRENDS:
+        case ViewType.STICKINESS:
+        case ViewType.SESSIONS:
+        case ViewType.RETENTION:
+            return true
+        case ViewType.FUNNELS:
+            return featureFlags['funnel-trends-1269']
+        case ViewType.LIFECYCLE:
+        case ViewType.PATHS:
+            return false
+        default:
+            return true // sometimes insights aren't set for trends
+    }
+}
+
+const showDateFilter = {
+    [`${ViewType.TRENDS}`]: true,
+    [`${ViewType.STICKINESS}`]: true,
+    [`${ViewType.LIFECYCLE}`]: true,
+    [`${ViewType.SESSIONS}`]: true,
+    [`${ViewType.FUNNELS}`]: true,
+    [`${ViewType.RETENTION}`]: false,
+    [`${ViewType.PATHS}`]: true,
+}
+
+const showComparePrevious = {
+    [`${ViewType.TRENDS}`]: true,
+    [`${ViewType.STICKINESS}`]: true,
+    [`${ViewType.LIFECYCLE}`]: false,
+    [`${ViewType.SESSIONS}`]: true,
+    [`${ViewType.FUNNELS}`]: false,
+    [`${ViewType.RETENTION}`]: false,
+    [`${ViewType.PATHS}`]: false,
+}
+
+const isFunnelEmpty = (filters: FilterType): boolean => {
+    return (!filters.actions && !filters.events) || (filters.actions?.length === 0 && filters.events?.length === 0)
+}
+
+function DefaultInsightDisplayConfig({
+    allFilters,
+    activeView,
+    clearAnnotationsToCreate,
+    annotationsToCreate,
+}: InsightDisplayConfigProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
+
+    return (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+            <TZIndicator style={{ float: 'left' }} />
+            <div style={{ width: '100%', textAlign: 'right' }}>
+                {showIntervalFilter(activeView, allFilters) && <IntervalFilter view={activeView} />}
+                {showChartFilter(activeView, featureFlags) && (
+                    <ChartFilter
+                        onChange={(display: DisplayType) => {
+                            if (display === ACTIONS_TABLE || display === ACTIONS_PIE_CHART) {
+                                clearAnnotationsToCreate()
+                            }
+                        }}
+                        filters={allFilters}
+                        disabled={allFilters.insight === ViewType.LIFECYCLE}
+                    />
+                )}
+
+                {showDateFilter[activeView] && (
+                    <DateFilter defaultValue="Last 7 days" disabled={dateFilterDisabled} bordered={false} />
+                )}
+
+                {showComparePrevious[activeView] && <CompareFilter />}
+                <SaveToDashboard
+                    item={{
+                        entity: {
+                            filters: allFilters,
+                            annotations: annotationsToCreate,
+                        },
+                    }}
+                />
+            </div>
+        </div>
+    )
+}
+
+function HorizontalDefaultInsightDisplayConfig({
+    allFilters,
+    activeView,
+    clearAnnotationsToCreate,
+}: InsightDisplayConfigProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
+
+    return (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+            <TZIndicator style={{ float: 'left' }} />
+            <div style={{ width: '100%', textAlign: 'right' }}>
+                {showComparePrevious[activeView] && <CompareFilter />}
+                {showChartFilter(activeView, featureFlags) && (
+                    <ChartFilter
+                        onChange={(display: DisplayType) => {
+                            if (display === ACTIONS_TABLE || display === ACTIONS_PIE_CHART) {
+                                clearAnnotationsToCreate()
+                            }
+                        }}
+                        filters={allFilters}
+                        disabled={allFilters.insight === ViewType.LIFECYCLE}
+                    />
+                )}
+
+                {showIntervalFilter(activeView, allFilters) && <IntervalFilter view={activeView} />}
+                {showDateFilter[activeView] && (
+                    <DateFilter defaultValue="Last 7 days" disabled={dateFilterDisabled} bordered={false} />
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -18,6 +18,7 @@ import { TrendTabHorizontal } from './TrendTabHorizontal'
 
 interface TrendTabProps {
     view: string
+    annotationsToCreate: any[] // TODO: Type properly
 }
 
 export function TrendTab(props: TrendTabProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -16,7 +16,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './TrendTab.scss'
 import { TrendTabHorizontal } from './TrendTabHorizontal'
 
-interface TrendTabProps {
+export interface TrendTabProps {
     view: string
     annotationsToCreate: any[] // TODO: Type properly
 }

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -14,12 +14,18 @@ import { Formula } from './Formula'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './TrendTab.scss'
+import { TrendTabHorizontal } from './TrendTabHorizontal'
 
 interface TrendTabProps {
     view: string
 }
 
-export function TrendTab({ view }: TrendTabProps): JSX.Element {
+export function TrendTab(props: TrendTabProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    return featureFlags['4050-query-ui-optB'] ? <TrendTabHorizontal {...props} /> : <DefaultTrendTab {...props} />
+}
+
+function DefaultTrendTab({ view }: TrendTabProps): JSX.Element {
     const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
     const { featureFlags } = useValues(featureFlagLogic)
@@ -42,7 +48,6 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                 <Skeleton active />
             ) : (
                 <ActionFilter
-                    horizontalUI={featureFlags['4050-query-ui-optB']}
                     filters={filters}
                     setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
                     typeKey={'trends_' + view}

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -15,10 +15,7 @@ import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './TrendTab.scss'
 import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
-
-interface TrendTabProps {
-    view: string
-}
+import { TrendTabProps } from './TrendTab'
 
 export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps): JSX.Element {
     const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -14,12 +14,13 @@ import { Formula } from './Formula'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './TrendTab.scss'
+import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 
 interface TrendTabProps {
     view: string
 }
 
-export function TrendTabHorizontal({ view }: TrendTabProps): JSX.Element {
+export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps): JSX.Element {
     const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
     const { featureFlags } = useValues(featureFlagLogic)
@@ -38,7 +39,16 @@ export function TrendTabHorizontal({ view }: TrendTabProps): JSX.Element {
             <Row gutter={16}>
                 <Col md={16}>
                     <h3 className="l3" style={{ display: 'flex', alignItems: 'center' }}>
-                        Unsaved query <Button type="link" size="small" icon={<SaveOutlined />} />
+                        Unsaved query{' '}
+                        <SaveToDashboard
+                            displayComponent={<Button type="link" size="small" icon={<SaveOutlined />} />}
+                            item={{
+                                entity: {
+                                    filters: filters,
+                                    annotations: annotationsToCreate,
+                                },
+                            }}
+                        />
                     </h3>
                     {filtersLoading ? (
                         <Skeleton active />

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -58,7 +58,6 @@ export function TrendTabHorizontal({ view }: TrendTabProps): JSX.Element {
                 <Col md={8}>
                     {filters.insight === ViewType.LIFECYCLE && (
                         <>
-                            <hr />
                             <h4 className="secondary">Lifecycle Toggles</h4>
                             {filtersLoading ? (
                                 <Skeleton active />

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react'
+import { useValues, useActions } from 'kea'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { ActionFilter } from '../../ActionFilter/ActionFilter'
+import { Tooltip, Row, Skeleton, Checkbox, Col, Button } from 'antd'
+import { BreakdownFilter } from '../../BreakdownFilter'
+import { CloseButton } from 'lib/components/CloseButton'
+import { InfoCircleOutlined, SaveOutlined } from '@ant-design/icons'
+import { trendsLogic } from '../../../trends/trendsLogic'
+import { ViewType } from '../../insightLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FilterType } from '~/types'
+import { Formula } from './Formula'
+import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import './TrendTab.scss'
+
+interface TrendTabProps {
+    view: string
+}
+
+export function TrendTabHorizontal({ view }: TrendTabProps): JSX.Element {
+    const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))
+    const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { preflight } = useValues(preflightLogic)
+    const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
+    const { toggleLifecycle } = useActions(trendsLogic)
+    const lifecycles = [
+        { name: 'new', tooltip: 'Users that are new.' },
+        { name: 'resurrecting', tooltip: 'Users who were once active but became dormant, and are now active again.' },
+        { name: 'returning', tooltip: 'Users who consistently use the product.' },
+        { name: 'dormant', tooltip: 'Users who are inactive.' },
+    ]
+
+    return (
+        <>
+            <Row gutter={16}>
+                <Col md={16}>
+                    <h3 className="l3" style={{ display: 'flex', alignItems: 'center' }}>
+                        Unsaved query <Button type="link" size="small" icon={<SaveOutlined />} />
+                    </h3>
+                    {filtersLoading ? (
+                        <Skeleton active />
+                    ) : (
+                        <ActionFilter
+                            horizontalUI
+                            filters={filters}
+                            setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
+                            typeKey={'trends_' + view}
+                            buttonCopy="Add graph series"
+                            showLetters={isUsingFormulas}
+                            singleFilter={filters.insight === ViewType.LIFECYCLE}
+                            hidePropertySelector={filters.insight === ViewType.LIFECYCLE}
+                        />
+                    )}
+                </Col>
+                <Col md={8}>
+                    {filters.insight === ViewType.LIFECYCLE && (
+                        <>
+                            <hr />
+                            <h4 className="secondary">Lifecycle Toggles</h4>
+                            {filtersLoading ? (
+                                <Skeleton active />
+                            ) : (
+                                <div className="toggles">
+                                    {lifecycles.map((lifecycle, idx) => (
+                                        <div key={idx}>
+                                            {lifecycle.name}{' '}
+                                            <div>
+                                                <Checkbox
+                                                    defaultChecked
+                                                    className={lifecycle.name}
+                                                    onChange={() => toggleLifecycle(lifecycle.name)}
+                                                />
+                                                <Tooltip title={lifecycle.tooltip}>
+                                                    <InfoCircleOutlined className="info-indicator" />
+                                                </Tooltip>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    )}
+                    <h4 className="secondary">Global Filters</h4>
+                    {filtersLoading ? (
+                        <Skeleton active paragraph={{ rows: 2 }} />
+                    ) : (
+                        <>
+                            <PropertyFilters pageKey="trends-filters" />
+                            <TestAccountFilter filters={filters} onChange={setFilters} />
+                            {(!filters.insight || filters.insight === ViewType.TRENDS) &&
+                                featureFlags['3275-formulas'] &&
+                                preflight?.ee_enabled && (
+                                    <>
+                                        <hr />
+                                        <h4 className="secondary">Formula</h4>
+                                        <Formula
+                                            filters={filters}
+                                            onFocus={(hasFocus, localFormula) =>
+                                                setIsUsingFormulas(hasFocus ? true : localFormula ? true : false)
+                                            }
+                                            onChange={(formula: string): void => {
+                                                setIsUsingFormulas(formula ? true : false)
+                                                setFilters({ formula })
+                                            }}
+                                        />
+                                    </>
+                                )}
+                        </>
+                    )}
+                    {filters.insight !== ViewType.LIFECYCLE && filters.insight !== ViewType.STICKINESS && (
+                        <>
+                            <hr />
+                            <h4 className="secondary">
+                                Breakdown by
+                                <Tooltip
+                                    placement="right"
+                                    title="Use breakdown to see the aggregation (total volume, active users, etc.) for each value of that property. For example, breaking down by Current URL with total volume will give you the event volume for each URL your users have visited."
+                                >
+                                    <InfoCircleOutlined className="info-indicator" />
+                                </Tooltip>
+                            </h4>
+                            {filtersLoading ? (
+                                <Skeleton paragraph={{ rows: 0 }} active />
+                            ) : (
+                                <Row align="middle">
+                                    <BreakdownFilter
+                                        filters={filters}
+                                        onChange={(breakdown: string, breakdown_type: string): void =>
+                                            setFilters({ breakdown, breakdown_type })
+                                        }
+                                    />
+                                    {filters.breakdown && (
+                                        <CloseButton
+                                            onClick={(): void => setFilters({ breakdown: false, breakdown_type: null })}
+                                            style={{ marginTop: 1, marginLeft: 5 }}
+                                        />
+                                    )}
+                                </Row>
+                            )}
+                        </>
+                    )}
+                </Col>
+            </Row>
+        </>
+    )
+}

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -9,12 +9,6 @@
         .ant-btn-loading-icon {
             display: none;
         }
-
-        &.horizontal-ui {
-            .ant-tabs-tab {
-                padding: 0; // More compact tabs to save vertical space
-            }
-        }
     }
     hr {
         margin: 1rem 0;
@@ -32,12 +26,43 @@
         }
     }
 
-    .horizontal-ui-card {
-        .ant-card-body {
-            padding: $default_spacing * 0.6 $default_spacing;
+    .insight-controls {
+        overflow: visible;
+    }
+
+    .insights-graph-container {
+        .ant-card-head {
+            background-color: rgba(0, 0, 0, 0.03);
         }
-        margin-bottom: $default_spacing / 2;
-        border: 1px solid $border_light;
+    }
+
+    &.horizontal-ui {
+        .top-bar {
+            .ant-tabs-tab {
+                padding: 0; // More compact tabs to save vertical space
+            }
+        }
+
+        .insight-controls {
+            margin-bottom: $default_spacing / 2;
+            border: 1px solid $border_light;
+            .ant-card-body {
+                padding: $default_spacing * 0.6 $default_spacing;
+            }
+        }
+
+        .insights-graph-container {
+            .ant-card-head {
+                min-height: unset;
+                @extend .mixin-elevated;
+                background-color: rgba(0, 0, 0, 0.02);
+                border: 1px solid $border_light;
+
+                .ant-card-head-title {
+                    padding: $default_spacing / 2 0;
+                }
+            }
+        }
     }
 }
 

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -9,6 +9,12 @@
         .ant-btn-loading-icon {
             display: none;
         }
+
+        &.horizontal-ui {
+            .ant-tabs-tab {
+                padding: 0; // More compact tabs to save vertical space
+            }
+        }
     }
     hr {
         margin: 1rem 0;
@@ -24,6 +30,14 @@
         .hotkey {
             background-color: rgba($primary, 0.2) !important;
         }
+    }
+
+    .horizontal-ui-card {
+        .ant-card-body {
+            padding: $default_spacing * 0.6 $default_spacing;
+        }
+        margin-bottom: $default_spacing / 2;
+        border: 1px solid $border_light;
     }
 }
 

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -47,7 +47,7 @@
             margin-bottom: $default_spacing / 2;
             border: 1px solid $border_light;
             .ant-card-body {
-                padding: $default_spacing * 0.6 $default_spacing;
+                padding: $default_spacing * 0.8 $default_spacing;
             }
         }
 

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -57,6 +57,7 @@
                 @extend .mixin-elevated;
                 background-color: rgba(0, 0, 0, 0.02);
                 border: 1px solid $border_light;
+                padding-right: $default_spacing / 4;
 
                 .ant-card-head-title {
                     padding: $default_spacing / 2 0;

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -2,24 +2,13 @@ import React, { useState } from 'react'
 import { useActions, useMountedLogic, useValues, BindLogic } from 'kea'
 
 import { isMobile, Loading } from 'lib/utils'
-import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { DateFilter } from './DateFilter'
-import { IntervalFilter } from 'lib/components/IntervalFilter/IntervalFilter'
 
 import { PageHeader } from 'lib/components/PageHeader'
 
-import { ChartFilter } from 'lib/components/ChartFilter'
 import { Tabs, Row, Col, Card, Button, Tooltip } from 'antd'
-import {
-    ACTIONS_LINE_GRAPH_LINEAR,
-    ACTIONS_LINE_GRAPH_CUMULATIVE,
-    ACTIONS_TABLE,
-    ACTIONS_PIE_CHART,
-    ACTIONS_BAR_CHART_VALUE,
-    FUNNEL_VIZ,
-} from 'lib/constants'
+import { ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_LINE_GRAPH_CUMULATIVE, FUNNEL_VIZ } from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'
 import { router } from 'kea-router'
 
@@ -31,7 +20,6 @@ import { RetentionTab, SessionTab, TrendTab, PathTab, FunnelTab } from './Insigh
 import { FunnelViz } from 'scenes/funnels/FunnelViz'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic, logicFromInsight, ViewType } from './insightLogic'
-import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { InsightHistoryPanel } from './InsightHistoryPanel'
 import { SavedFunnels } from './SavedCard'
 import { ReloadOutlined } from '@ant-design/icons'
@@ -44,67 +32,14 @@ import { People } from 'scenes/funnels/People'
 import { TrendLegend } from './TrendLegend'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { TZIndicator } from 'lib/components/TimezoneAware'
-import { DashboardItemType, DisplayType, FilterType, HotKeys } from '~/types'
+import { DashboardItemType, HotKeys } from '~/types'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DashboardItemHeader } from 'scenes/dashboard/DashboardItemHeader'
+import { InsightDisplayConfig } from './InsightTabs/InsightDisplayConfig'
 
 dayjs.extend(relativeTime)
 const { TabPane } = Tabs
-
-const showIntervalFilter = function (activeView: ViewType, filter: FilterType): boolean {
-    switch (activeView) {
-        case ViewType.FUNNELS:
-            return filter.display === ACTIONS_LINE_GRAPH_LINEAR
-        case ViewType.RETENTION:
-        case ViewType.PATHS:
-            return false
-        case ViewType.TRENDS:
-        case ViewType.STICKINESS:
-        case ViewType.LIFECYCLE:
-        case ViewType.SESSIONS:
-        default:
-            return ![ACTIONS_PIE_CHART, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE].includes(filter.display || '') // sometimes insights aren't set for trends
-    }
-}
-
-const showChartFilter = function (activeView: ViewType, featureFlags: Record<string, boolean>): boolean {
-    switch (activeView) {
-        case ViewType.TRENDS:
-        case ViewType.STICKINESS:
-        case ViewType.SESSIONS:
-        case ViewType.RETENTION:
-            return true
-        case ViewType.FUNNELS:
-            return featureFlags['funnel-trends-1269']
-        case ViewType.LIFECYCLE:
-        case ViewType.PATHS:
-            return false
-        default:
-            return true // sometimes insights aren't set for trends
-    }
-}
-
-const showDateFilter = {
-    [`${ViewType.TRENDS}`]: true,
-    [`${ViewType.STICKINESS}`]: true,
-    [`${ViewType.LIFECYCLE}`]: true,
-    [`${ViewType.SESSIONS}`]: true,
-    [`${ViewType.FUNNELS}`]: true,
-    [`${ViewType.RETENTION}`]: false,
-    [`${ViewType.PATHS}`]: true,
-}
-
-const showComparePrevious = {
-    [`${ViewType.TRENDS}`]: true,
-    [`${ViewType.STICKINESS}`]: true,
-    [`${ViewType.LIFECYCLE}`]: false,
-    [`${ViewType.SESSIONS}`]: true,
-    [`${ViewType.FUNNELS}`]: false,
-    [`${ViewType.RETENTION}`]: false,
-    [`${ViewType.PATHS}`]: false,
-}
 
 function InsightHotkey({ hotkey }: { hotkey: HotKeys }): JSX.Element {
     /* Temporary element to only show hotkeys when feature flag is active */
@@ -131,7 +66,8 @@ export function Insights(): JSX.Element {
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
 
     const { loadResults } = useActions(logicFromInsight(activeView, { dashboardItemId: null, filters: allFilters }))
-    const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
+
+    const horizontalUI = featureFlags['4050-query-ui-optB']
 
     const handleHotkeyNavigation = (view: ViewType, hotkey: HotKeys): void => {
         setActiveView(view)
@@ -167,7 +103,7 @@ export function Insights(): JSX.Element {
     )
 
     return (
-        <div className="insights-page">
+        <div className={`insights-page${horizontalUI ? ' horizontal-ui' : ''}`}>
             <Header dashboardItem={dashboardItem} />
             {!dashboardItem && (
                 <Row justify="space-between" align="middle" className="top-bar">
@@ -176,7 +112,7 @@ export function Insights(): JSX.Element {
                         style={{
                             overflow: 'visible',
                         }}
-                        className={`top-bar${featureFlags['4050-query-ui-optB'] ? ' horizontal-ui' : ''}`}
+                        className="top-bar"
                         onChange={(key) => setActiveView(key)}
                         animated={false}
                         tabBarExtraContent={{
@@ -291,11 +227,8 @@ export function Insights(): JSX.Element {
                     </Col>
                 ) : (
                     <>
-                        <Col xs={24} xl={featureFlags['4050-query-ui-optB'] ? 24 : 7}>
-                            <Card
-                                className={featureFlags['4050-query-ui-optB'] ? 'horizontal-ui-card' : ''}
-                                style={{ overflow: 'visible' }}
-                            >
+                        <Col xs={24} xl={horizontalUI ? 24 : 7}>
+                            <Card className="insight-controls">
                                 <div>
                                     {/*
                                 These are insight specific filters.
@@ -323,58 +256,23 @@ export function Insights(): JSX.Element {
                                 </Card>
                             )}
                         </Col>
-                        <Col xs={24} xl={featureFlags['4050-query-ui-optB'] ? 24 : 17}>
-                            {' '}
+                        <Col xs={24} xl={horizontalUI ? 24 : 17}>
                             {/* TODO: extract to own file. Props: activeView, allFilters, showDateFilter, dateFilterDisabled, annotationsToCreate; lastRefresh, showErrorMessage, showTimeoutMessage, isLoading; ... */}
-                            {/*
-                        These are filters that are reused between insight features.
-                        They each have generic logic that updates the url
-                        */}
+                            {/* These are filters that are reused between insight features. They
+                                each have generic logic that updates the url
+                            */}
                             <Card
                                 title={
-                                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                                        <TZIndicator style={{ float: 'left' }} />
-                                        <div style={{ width: '100%', textAlign: 'right' }}>
-                                            {showIntervalFilter(activeView, allFilters) && (
-                                                <IntervalFilter view={activeView} />
-                                            )}
-                                            {showChartFilter(activeView, featureFlags) && (
-                                                <ChartFilter
-                                                    onChange={(display: DisplayType) => {
-                                                        if (
-                                                            display === ACTIONS_TABLE ||
-                                                            display === ACTIONS_PIE_CHART
-                                                        ) {
-                                                            clearAnnotationsToCreate()
-                                                        }
-                                                    }}
-                                                    filters={allFilters}
-                                                    disabled={allFilters.insight === ViewType.LIFECYCLE}
-                                                />
-                                            )}
-
-                                            {showDateFilter[activeView] && (
-                                                <DateFilter
-                                                    defaultValue="Last 7 days"
-                                                    disabled={dateFilterDisabled}
-                                                    bordered={false}
-                                                />
-                                            )}
-
-                                            {showComparePrevious[activeView] && <CompareFilter />}
-                                            <SaveToDashboard
-                                                item={{
-                                                    entity: {
-                                                        filters: allFilters,
-                                                        annotations: annotationsToCreate,
-                                                    },
-                                                }}
-                                            />
-                                        </div>
-                                    </div>
+                                    <InsightDisplayConfig
+                                        activeView={activeView}
+                                        allFilters={allFilters}
+                                        annotationsToCreate={annotationsToCreate}
+                                        clearAnnotationsToCreate={clearAnnotationsToCreate}
+                                        horizontalUI={horizontalUI}
+                                    />
                                 }
-                                headStyle={{ backgroundColor: 'rgba(0,0,0,.03)' }}
                                 data-attr="insights-graph"
+                                className="insights-graph-container"
                             >
                                 <div>
                                     {lastRefresh && (
@@ -448,10 +346,6 @@ export function Insights(): JSX.Element {
             </Row>
         </div>
     )
-}
-
-const isFunnelEmpty = (filters: FilterType): boolean => {
-    return (!filters.actions && !filters.events) || (filters.actions?.length === 0 && filters.events?.length === 0)
 }
 
 function FunnelInsight(): JSX.Element {

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -172,12 +172,11 @@ export function Insights(): JSX.Element {
             {!dashboardItem && (
                 <Row justify="space-between" align="middle" className="top-bar">
                     <Tabs
-                        size="large"
                         activeKey={activeView}
                         style={{
                             overflow: 'visible',
                         }}
-                        className="top-bar"
+                        className={`top-bar${featureFlags['4050-query-ui-optB'] ? ' horizontal-ui' : ''}`}
                         onChange={(key) => setActiveView(key)}
                         animated={false}
                         tabBarExtraContent={{
@@ -293,7 +292,10 @@ export function Insights(): JSX.Element {
                 ) : (
                     <>
                         <Col xs={24} xl={featureFlags['4050-query-ui-optB'] ? 24 : 7}>
-                            <Card className="" style={{ overflow: 'visible' }}>
+                            <Card
+                                className={featureFlags['4050-query-ui-optB'] ? 'horizontal-ui-card' : ''}
+                                style={{ overflow: 'visible' }}
+                            >
                                 <div>
                                     {/*
                                 These are insight specific filters.

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -236,9 +236,24 @@ export function Insights(): JSX.Element {
                                 */}
                                     {
                                         {
-                                            [`${ViewType.TRENDS}`]: <TrendTab view={ViewType.TRENDS} />,
-                                            [`${ViewType.STICKINESS}`]: <TrendTab view={ViewType.STICKINESS} />,
-                                            [`${ViewType.LIFECYCLE}`]: <TrendTab view={ViewType.LIFECYCLE} />,
+                                            [`${ViewType.TRENDS}`]: (
+                                                <TrendTab
+                                                    view={ViewType.TRENDS}
+                                                    annotationsToCreate={annotationsToCreate}
+                                                />
+                                            ),
+                                            [`${ViewType.STICKINESS}`]: (
+                                                <TrendTab
+                                                    view={ViewType.STICKINESS}
+                                                    annotationsToCreate={annotationsToCreate}
+                                                />
+                                            ),
+                                            [`${ViewType.LIFECYCLE}`]: (
+                                                <TrendTab
+                                                    view={ViewType.LIFECYCLE}
+                                                    annotationsToCreate={annotationsToCreate}
+                                                />
+                                            ),
                                             [`${ViewType.SESSIONS}`]: <SessionTab />,
                                             [`${ViewType.FUNNELS}`]: <FunnelTab />,
                                             [`${ViewType.RETENTION}`]: <RetentionTab />,


### PR DESCRIPTION
## Changes

This PR continues work towards #4050 (issue still WIP, but working through bite-sized PRs). This PR handles most UI layout changes.

<img width="1436" alt="" src="https://user-images.githubusercontent.com/5864173/117359851-d6e58880-ae6c-11eb-8598-369bb72f394e.png">

In addition:
- This PR converts to TS some related insights components.
- Abstracts the card header of the insights container (where you set the interval, date range, ...) into it's own component `InsightDisplayConfig.tsx` to be able to return different components in the new UI.
- To simplify changes and future maintenance if we either keep this new UI or not, `TrendTabHorizontal.tsx` is introduced as a high-level component to encompass most changes to the layout.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
