### PR TITLE
Closes #4218 fix loading overlay blocking chart interactions

### DIFF
--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -1,4 +1,5 @@
 /* DEPRECATED in favor of global.scss */
+@import '~/vars';
 
 .layout-container {
     max-width: 100vw;
@@ -23,7 +24,7 @@
     text-align: center;
     min-height: 6rem;
     opacity: 0.7;
-    z-index: 9999;
+    z-index: $z_content_overlay;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Changes

Initially the z-index for the overlay (9999) was higher than the filter popover (ant-popover with z-index 1030), so the the overlay covered (with 0.7 opacity) the filter making it unusable.

Before (note the filter box is greyed out on the right side):
<img width="945" alt="Screenshot 2021-05-06 at 20 58 11" src="https://user-images.githubusercontent.com/890921/117351276-60dc2400-ae62-11eb-8b99-c5a137ae9791.png">
After:
<img width="937" alt="Screenshot 2021-05-06 at 20 42 51" src="https://user-images.githubusercontent.com/890921/117350959-ffb45080-ae61-11eb-967d-56ccf241f6a9.png">

Questions/concerns:
1.  Not sure if we want the `loading-overlay` to always have that z-index, in addition to dashboarditems it's also referenced in `frontend/src/lib/utils.tsx`
2. I see the `style.scss` file has a comment about it being deprecated,  should I be changing it?
3. How can I run the Jest frontend tests (I saw info for the Cypress ones here: https://posthog.com/docs/contributing#frontend though I'm still working on getting them to run)?

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
