### PR TITLE
Fixes lifecycle & stickiness selecting action/events

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -20,6 +20,8 @@ export enum ViewType {
     PATHS = 'PATHS',
 }
 
+export const TRENDS_BASED_INSIGHTS = ['TRENDS', 'STICKINESS', 'LIFECYCLE'] // Insights that are based on the same `Trends` components
+
 /*
 InsightLogic maintains state for changing between insight features
 This includes handling the urls and view state

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -234,7 +234,6 @@ export const trendsLogic = kea<
             >,
             {
                 setFilters: (state, { filters, mergeFilters }) => {
-                    console.log(state, filters, mergeFilters)
                     const newState = state?.insight && TRENDS_BASED_INSIGHTS.includes(state.insight) ? state : {}
                     return cleanFilters({
                         ...(mergeFilters ? newState : {}),

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -14,7 +14,7 @@ import {
     ACTION_TYPE,
     ShownAsValue,
 } from 'lib/constants'
-import { ViewType, insightLogic, defaultFilterTestAccounts } from '../insights/insightLogic'
+import { ViewType, insightLogic, defaultFilterTestAccounts, TRENDS_BASED_INSIGHTS } from '../insights/insightLogic'
 import { insightHistoryLogic } from '../insights/InsightHistoryPanel/insightHistoryLogic'
 import { SESSIONS_WITH_RECORDINGS_FILTER } from 'scenes/sessions/filters/constants'
 import { ActionFilter, ActionType, FilterType, PersonType, PropertyFilter, TrendResult, EntityTypes } from '~/types'
@@ -234,7 +234,8 @@ export const trendsLogic = kea<
             >,
             {
                 setFilters: (state, { filters, mergeFilters }) => {
-                    const newState = state?.insight === ViewType.TRENDS ? state : {}
+                    console.log(state, filters, mergeFilters)
+                    const newState = state?.insight && TRENDS_BASED_INSIGHTS.includes(state.insight) ? state : {}
                     return cleanFilters({
                         ...(mergeFilters ? newState : {}),
                         ...filters,


### PR DESCRIPTION
## Changes

In a recent PR we changed some behavior on how we recognize filters for trends-based insights. This caused a bug where if you changed the event/action of a stickiness or lifecycle chart you would be taken to the trends tab. More context [in this thread](https://posthog.slack.com/archives/C01G8S5T08Z/p1620346724063100)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
