### PR TITLE
Include more clickhouse query metrics

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -186,6 +186,8 @@ def save_query(sql: str, params: Dict, execution_time: float) -> None:
     """
     Save query for debugging purposes
     """
+    if _request_information is None:
+        return
 
     try:
         key = "save_query_{}".format(_request_information["user_id"])

--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -4,12 +4,12 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import celery
 import pytz
-import statsd
 from dateutil.parser import isoparse
 from django.conf import settings
 from django.utils import timezone
 from rest_framework import serializers
 from sentry_sdk import capture_exception
+from statshog.defaults.django import statsd
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.element import chain_to_elements, elements_to_string
@@ -68,7 +68,7 @@ def create_event(
         and Hook.objects.filter(event="action_performed", team=team).exists()
     ):
         try:
-            statsd.Counter("%s_posthog_cloud_hooks_send_task" % (settings.STATSD_PREFIX,)).increment()
+            statsd.incr("posthog_cloud_hooks_send_task")
             celery.current_app.send_task(
                 "ee.tasks.webhooks_ee.post_event_to_webhook_ee",
                 (

--- a/ee/models/hook.py
+++ b/ee/models/hook.py
@@ -1,9 +1,8 @@
 from typing import Optional
 
-import statsd
-from django.conf import settings
 from django.db import models
 from rest_hooks.models import AbstractHook
+from statshog.defaults.django import statsd
 
 from ee.tasks.hooks import DeliverHook
 from posthog.models.team import Team
@@ -27,7 +26,7 @@ def find_and_fire_hook(
         # action_performed is a resource_id-filterable hook
         hooks = hooks.filter(models.Q(resource_id=instance.pk))
     for hook in hooks:
-        statsd.Counter("%s_posthog_cloud_hooks_rest_fired" % (settings.STATSD_PREFIX,)).increment()
+        statsd.incr("posthog_cloud_hooks_rest_fired")
         hook.deliver_hook(instance, payload_override)
 
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -146,7 +146,7 @@ def clickhouse_lag():
                 )
                 query = QUERY.format(table=table)
                 lag = sync_execute(query)[0][2]
-                statsd.gauge(f"posthog_celery_clickhouse_{table}_table_lag_seconds", lag)
+                statsd.gauge("posthog_celery_clickhouse__table_lag_seconds", lag, tags={"table": table})
             except:
                 pass
     else:
@@ -165,7 +165,7 @@ def clickhouse_row_count():
                 QUERY = """select count(1) freq from {table};"""
                 query = QUERY.format(table=table)
                 rows = sync_execute(query)[0][0]
-                statsd.gauge(f"posthog_celery_clickhouse_{table}_table_row_count", rows)
+                statsd.gauge(f"posthog_celery_clickhouse_table_row_count", rows, tags={"table": table})
             except:
                 pass
     else:
@@ -187,7 +187,7 @@ def clickhouse_part_count():
         """
         rows = sync_execute(QUERY)
         for (table, parts) in rows:
-            statsd.gauge(f"posthog_celery_clickhouse_{table}_table_parts_count", parts)
+            statsd.gauge(f"posthog_celery_clickhouse_table_parts_count", parts, tags={"table": table})
     else:
         pass
 
@@ -209,7 +209,7 @@ def clickhouse_mutation_count():
         """
         rows = sync_execute(QUERY)
         for (table, muts) in rows:
-            statsd.gauge(f"posthog_celery_clickhouse_{table}_table_mutations_count", muts)
+            statsd.gauge(f"posthog_celery_clickhouse_table_mutations_count", muts, tags={"table": table})
     else:
         pass
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -208,6 +208,9 @@ ALLOWED_HOSTS = get_list(os.getenv("ALLOWED_HOSTS", "*"))
 STATSD_HOST = os.getenv("STATSD_HOST")
 STATSD_PORT = os.getenv("STATSD_PORT", 8125)
 STATSD_PREFIX = os.getenv("STATSD_PREFIX", "")
+STATSD_TELEGRAF = True
+STATSD_CLIENT = "statshog"
+STATSD_SEPARATOR = "_"
 
 # django-axes settings to lockout after too many attempts
 AXES_ENABLED = get_from_env("AXES_ENABLED", True, type_cast=strtobool)

--- a/posthog/tasks/test/test_session_recording_retention.py
+++ b/posthog/tasks/test/test_session_recording_retention.py
@@ -29,7 +29,8 @@ class TestSessionRecording(BaseTest):
                 [
                     call(team_id=team.id, time_threshold=now() - timedelta(days=5)),
                     call(team_id=team3.id, time_threshold=now() - timedelta(days=6)),
-                ]
+                ],
+                any_order=True,
             )
 
     def test_deletes_from_django(self) -> None:

--- a/requirements.in
+++ b/requirements.in
@@ -39,7 +39,7 @@ posthoganalytics==1.1.3
 protobuf==3.13.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.1
-python-statsd==2.1.0
+statshog==1.0.6
 python3-openid==3.1.0
 pytz==2021.1
 redis==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,9 +155,7 @@ python-dateutil==2.8.1
     #   celery-redbeat
     #   posthoganalytics
 python-statsd==2.1.0
-    # via
-    #   -r requirements.in
-    #   django-statsd
+    # via django-statsd
 python3-openid==3.1.0
     # via
     #   -r requirements.in
@@ -209,6 +207,8 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sqlparse==0.3.0
     # via django
+statshog==1.0.6
+    # via -r requirements.in
 tenacity==6.1.0
     # via celery-redbeat
 toronado==0.0.11


### PR DESCRIPTION
- Use `statshog` over python-statsd
- Include custom tags for every query + add annotation to query
- Use tags in more queries over interpolation

Solves part of https://github.com/PostHog/product-internal/issues/34.

After this we can:
- Figure out from query logs where queries are coming from (speeding up debugging)
- Break down query speeds by user queries vs others (e.g. celery) --
  better represents overall speed, can be used for alerting/thresholds
- Figure out how fast queries are on average for various teams

Note some alerts/dashboards will need updating after this, will handle once merged!

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
