### PR TITLE
Migrate clickhouse alongside postgres in production

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -216,7 +216,7 @@
                 }
             ],
             "entryPoint": ["sh", "-c"],
-            "command": ["./bin/docker-migrate"],
+            "command": ["./bin/docker-migrate && python manage.py migrate_clickhouse"],
             "linuxParameters": {
                 "initProcessEnabled": true
             }


### PR DESCRIPTION
Latest migrations have been applied.

Only thing we need to keep in sync is CLICKHOUSE_MIGRATION_HOSTS env
variable going forward - managed via secrets manager.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
