### PR TITLE
Remove ENABLE_PERSISTENT_CONSOLE from prod task def

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -63,10 +63,6 @@
                 {
                     "name": "CRASH_IF_NO_PERSISTENT_JOB_QUEUE",
                     "value": "0"
-                },
-                {
-                    "name": "ENABLE_PERSISTENT_CONSOLE",
-                    "value": "1"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Not needed anymore since plugin sever 0.20 removed use of this.
