### PR TITLE
speed up autoplay, scroll more slides

### DIFF
--- a/frontend/src/scenes/onboarding/home/sections/PostHogLessons.tsx
+++ b/frontend/src/scenes/onboarding/home/sections/PostHogLessons.tsx
@@ -84,13 +84,13 @@ function Tutorials(): JSX.Element {
     const settings = {
         dots: true,
         slidesToShow: 4,
-        slidesToScroll: 2,
+        slidesToScroll: 3,
         arrows: true,
         nextArrow: <CarouselArrow direction="next" />,
         prevArrow: <CarouselArrow direction="prev" />,
         autoplay: true,
         vertical: false,
-        autoplaySpeed: 7500,
+        autoplaySpeed: 5500,
         centerMode: true,
         centerPadding: '10px',
         responsive: [


### PR DESCRIPTION
## Changes
Right now only the first shown articles are being interacted with, to see if it's a content vs exposure thing:
- Reducing the autoplay delay
- Increasing the number of slides scrolled

Potential next step: randomize the list we show, but that won't be very performant.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
