### PR TITLE
Increments StatsD counter with tags in generate_exception_response

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -136,12 +136,13 @@ def get_event(request):
     except RequestParsingError as error:
         capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
         return cors_response(
-            request, generate_exception_response(f"Malformed request data: {error}", code="invalid_payload"),
+            request, generate_exception_response("capture", f"Malformed request data: {error}", code="invalid_payload"),
         )
     if not data:
         return cors_response(
             request,
             generate_exception_response(
+                "capture",
                 "No data found. Make sure to use a POST request when sending the payload in the body of the request.",
                 code="no_data",
             ),
@@ -155,6 +156,7 @@ def get_event(request):
         return cors_response(
             request,
             generate_exception_response(
+                "capture",
                 "API key not provided. You can find your project API key in PostHog project settings.",
                 type="authentication_error",
                 code="missing_api_key",
@@ -175,6 +177,7 @@ def get_event(request):
             return cors_response(
                 request,
                 generate_exception_response(
+                    "capture",
                     "Project API key invalid. You can find your project API key in PostHog project settings.",
                     type="authentication_error",
                     code="invalid_api_key",
@@ -186,6 +189,7 @@ def get_event(request):
             return cors_response(
                 request,
                 generate_exception_response(
+                    "capture",
                     "Invalid Personal API key.",
                     type="authentication_error",
                     code="invalid_personal_api_key",
@@ -209,7 +213,9 @@ def get_event(request):
     try:
         events = preprocess_session_recording_events(events)
     except ValueError as e:
-        return cors_response(request, generate_exception_response(f"Invalid payload: {e}", code="invalid_payload"))
+        return cors_response(
+            request, generate_exception_response("capture", f"Invalid payload: {e}", code="invalid_payload")
+        )
 
     for event in events:
         try:
@@ -218,14 +224,17 @@ def get_event(request):
             return cors_response(
                 request,
                 generate_exception_response(
-                    "You need to set user distinct ID field `distinct_id`.", code="required", attr="distinct_id"
+                    "capture",
+                    "You need to set user distinct ID field `distinct_id`.",
+                    code="required",
+                    attr="distinct_id",
                 ),
             )
         if not event.get("event"):
             return cors_response(
                 request,
                 generate_exception_response(
-                    "You need to set user event name, field `event`.", code="required", attr="event"
+                    "capture", "You need to set user event name, field `event`.", code="required", attr="event"
                 ),
             )
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -171,7 +171,10 @@ def get_event(request):
             project_id = _get_project_id(data, request)
         except ValueError:
             return cors_response(
-                request, generate_exception_response("Invalid Project ID.", code="invalid_project", attr="project_id"),
+                request,
+                generate_exception_response(
+                    "capture", "Invalid Project ID.", code="invalid_project", attr="project_id"
+                ),
             )
         if not project_id:
             return cors_response(

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -84,7 +84,8 @@ def get_decide(request: HttpRequest):
         except RequestParsingError as error:
             capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
             return cors_response(
-                request, generate_exception_response(f"Malformed request data: {error}", code="malformed_data"),
+                request,
+                generate_exception_response("decide", f"Malformed request data: {error}", code="malformed_data"),
             )
         token = _get_token(data, request)
         team = Team.objects.get_team_from_token(token)
@@ -95,6 +96,7 @@ def get_decide(request: HttpRequest):
                 return cors_response(
                     request,
                     generate_exception_response(
+                        "decide",
                         "Project API key invalid. You can find your project API key in PostHog project settings.",
                         code="invalid_api_key",
                         type="authentication_error",
@@ -107,6 +109,7 @@ def get_decide(request: HttpRequest):
                 return cors_response(
                     request,
                     generate_exception_response(
+                        "decide",
                         "Invalid Personal API key.",
                         code="invalid_personal_key",
                         type="authentication_error",

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -31,5 +31,5 @@ def generate_exception_response(
     """
     Generates a friendly JSON error response in line with drf-exceptions-hog for endpoints not under DRF.
     """
-    statsd.incr(f"posthog_cloud_raw_endpoint_exception", tags={"endpoint": endpoint, "code": code, "detail": detail})
+    statsd.incr(f"posthog_cloud_raw_endpoint_exception", tags={"endpoint": endpoint, "code": code, "type": type})
     return JsonResponse({"type": type, "code": code, "detail": detail, "attr": attr}, status=status_code,)

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -4,6 +4,7 @@ from django.http.response import JsonResponse
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from sentry_sdk import capture_exception
+from statshog.defaults.django import statsd
 
 
 class RequestParsingError(Exception):
@@ -20,6 +21,7 @@ def exception_reporting(exception: Exception, *args, **kwargs) -> None:
 
 
 def generate_exception_response(
+    endpoint: str,
     detail: str,
     code: str = "invalid",
     type: str = "validation_error",
@@ -29,4 +31,5 @@ def generate_exception_response(
     """
     Generates a friendly JSON error response in line with drf-exceptions-hog for endpoints not under DRF.
     """
+    statsd.incr(f"posthog_cloud_raw_endpoint_exception", tags={"endpoint": endpoint, "code": code, "detail": detail})
     return JsonResponse({"type": type, "code": code, "detail": detail, "attr": attr}, status=status_code,)


### PR DESCRIPTION
## Changes

Would be useful to get some graphs of 400s in capture/decide endpoints (e.g. how often is distinct_id missing). Does extensive use of tags make sense here?
