### PR TITLE
Handle empty distinct_id in capture endpoint

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -241,7 +241,10 @@ def get_event(request):
             return cors_response(
                 request,
                 generate_exception_response(
-                    "Distinct ID field `distinct_id` must have a non-empty value.", code="required", attr="distinct_id"
+                    "capture",
+                    "Distinct ID field `distinct_id` must have a non-empty value.",
+                    code="required",
+                    attr="distinct_id",
                 ),
             )
         if not event.get("event"):
@@ -268,7 +271,7 @@ def get_event(request):
                 ip=ip,
                 site_url=request.build_absolute_uri("/")[:-1],
                 data=event,
-                team_id=team.id,
+                team_id=team.pk,
                 now=now,
                 sent_at=sent_at,
                 event_uuid=event_uuid,
@@ -279,7 +282,7 @@ def get_event(request):
             celery_app.send_task(
                 name=task_name,
                 queue=celery_queue,
-                args=[distinct_id, ip, request.build_absolute_uri("/")[:-1], event, team.id, now.isoformat(), sent_at,],
+                args=[distinct_id, ip, request.build_absolute_uri("/")[:-1], event, team.pk, now.isoformat(), sent_at,],
             )
     timer.stop()
     return cors_response(request, JsonResponse({"status": 1}))

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -112,13 +112,17 @@ def _get_project_id(data, request) -> Optional[int]:
 
 
 def _get_distinct_id(data: Dict[str, Any]) -> str:
+    raw_value: Any = ""
     try:
-        return str(data["$distinct_id"])[0:200]
+        raw_value = data["$distinct_id"]
     except KeyError:
         try:
-            return str(data["properties"]["distinct_id"])[0:200]
+            raw_value = data["properties"]["distinct_id"]
         except KeyError:
-            return str(data["distinct_id"])[0:200]
+            raw_value = data["distinct_id"]
+    if not raw_value:
+        raise ValueError()
+    return str(raw_value)[0:200]
 
 
 def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], team: Team, distinct_id: str):
@@ -221,7 +225,7 @@ def get_event(request):
                     "You need to set user distinct ID field `distinct_id`.", code="required", attr="distinct_id"
                 ),
             )
-        if not distinct_id:
+        except ValueError:
             return cors_response(
                 request,
                 generate_exception_response(

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -221,6 +221,13 @@ def get_event(request):
                     "You need to set user distinct ID field `distinct_id`.", code="required", attr="distinct_id"
                 ),
             )
+        if not distinct_id:
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "Distinct ID field `distinct_id` must have a non-empty value.", code="required", attr="distinct_id"
+                ),
+            )
         if not event.get("event"):
             return cors_response(
                 request,

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -642,17 +642,37 @@ class TestCapture(BaseTest):
             ),
         )
 
-    @patch("posthog.api.capture.celery_app.send_task")
-    def test_nan(self, patch_process_event_with_plugins):
-        self.client.post(
+    def test_nan(self):
+        response = self.client.post(
             "/track/",
             data={
                 "data": json.dumps([{"event": "beep", "properties": {"distinct_id": float("nan")}}]),
                 "api_key": self.team.api_token,
             },
         )
-        arguments = self._to_arguments(patch_process_event_with_plugins)
-        self.assertEqual(arguments["data"]["properties"]["distinct_id"], None)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            self.validation_error_response(
+                "Distinct ID field `distinct_id` must have a non-empty value.", code="required", attr="distinct_id"
+            ),
+        )
+
+    def test_distinct_id_set_but_null(self):
+        response = self.client.post(
+            "/e/",
+            data={"api_key": self.team.api_token, "type": "capture", "event": "user signed up", "distinct_id": None},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            self.validation_error_response(
+                "Distinct ID field `distinct_id` must have a non-empty value.", code="required", attr="distinct_id"
+            ),
+        )
 
     @patch("posthog.api.capture.celery_app.send_task")
     def test_add_feature_flags_if_missing(self, patch_process_event_with_plugins) -> None:

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -123,7 +123,7 @@ class Team(UUIDClassicModel):
     event_properties_with_usage: models.JSONField = models.JSONField(default=list)
     event_properties_numerical: models.JSONField = models.JSONField(default=list)
 
-    objects = TeamManager()
+    objects: TeamManager = TeamManager()
 
     def __str__(self):
         if self.name:


### PR DESCRIPTION
## Changes

Immediate improvement related to https://github.com/PostHog/plugin-server/issues/339. There still may or may not be an underlying client library issue, but in any case it's better to catch this early and loudly rather than swallowing in a late stage of ingestion.