### PR TITLE
Maybe fix dashboard loading

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -530,7 +530,7 @@ export const trendsLogic = kea<
 
     urlToAction: ({ actions, values, props }) => ({
         '/insights(/dashboard_item)(/:dashboardItemId)': async (
-            { dashboardItemId },
+            { dashboardItemId }: { dashboardItemId: number },
             searchParams: Partial<FilterType>
         ) => {
             if (props.dashboardItemId) {


### PR DESCRIPTION
## Changes

I'm not sure this will fix the actual issue but it avoids hitting dashboard_item a bunch of times at least

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
