### PR TITLE
Match session setting to insight param

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -20,7 +20,7 @@ export enum ViewType {
     PATHS = 'PATHS',
 }
 
-export const TRENDS_BASED_INSIGHTS = ['TRENDS', 'STICKINESS', 'LIFECYCLE'] // Insights that are based on the same `Trends` components
+export const TRENDS_BASED_INSIGHTS = ['TRENDS', 'SESSIONS', 'STICKINESS', 'LIFECYCLE'] // Insights that are based on the same `Trends` components
 
 /*
 InsightLogic maintains state for changing between insight features

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -56,7 +56,7 @@ interface PeopleParamType {
 
 function cleanFilters(filters: Partial<FilterType>): Record<string, any> {
     return {
-        insight: filters.session ? ViewType.SESSIONS : filters.insight || ViewType.TRENDS,
+        insight: ViewType.TRENDS,
         ...filters,
         interval: autocorrectInterval(filters),
         display:
@@ -67,7 +67,6 @@ function cleanFilters(filters: Partial<FilterType>): Record<string, any> {
         events: Array.isArray(filters.events) ? filters.events : undefined,
         properties: filters.properties || [],
         ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
-        ...(filters.session ? { session: filters.session } : {}),
     }
 }
 

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -56,7 +56,7 @@ interface PeopleParamType {
 
 function cleanFilters(filters: Partial<FilterType>): Record<string, any> {
     return {
-        insight: ViewType.TRENDS,
+        insight: filters.session ? ViewType.SESSIONS : filters.insight,
         ...filters,
         interval: autocorrectInterval(filters),
         display:

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -56,7 +56,7 @@ interface PeopleParamType {
 
 function cleanFilters(filters: Partial<FilterType>): Record<string, any> {
     return {
-        insight: filters.session ? ViewType.SESSIONS : filters.insight,
+        insight: filters.session ? ViewType.SESSIONS : filters.insight || ViewType.TRENDS,
         ...filters,
         interval: autocorrectInterval(filters),
         display:
@@ -67,6 +67,7 @@ function cleanFilters(filters: Partial<FilterType>): Record<string, any> {
         events: Array.isArray(filters.events) ? filters.events : undefined,
         properties: filters.properties || [],
         ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
+        ...(filters.session ? { session: filters.session } : {}),
     }
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- `insight` was defaulting to `TRENDS` when session filter was updated which caused a session graph to show up under trends insight
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
