### PR TITLE
Change event target criteria for outside click (PropertyFilter)

### DIFF
--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -96,7 +96,7 @@ export function SelectGradientOverflow({
     }, [autoFocus, defaultOpen])
 
     const outsideClickListener = (event: any): void => {
-        if (!containerRef.current?.contains(event.target) && isOpen) {
+        if (!containerRef.current?.contains(event.target) && !dropdownRef.current?.contains(event.target) && isOpen) {
             selectRef.current?.blur()
         }
     }


### PR DESCRIPTION
## Changes

Fixes the following issue discovered in release 1.25 testing:

> Property filter scrollbar is useless. When you scroll and then try to click on a row item, the dropdown closes because it becomes out of focus.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
