### PR TITLE
Avoid side-effects in api/capture import

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -25,8 +25,6 @@ if is_ee_enabled():
     from ee.kafka_client.client import KafkaProducer
     from ee.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION
 
-    producer = KafkaProducer()
-
     def log_event(
         distinct_id: str,
         ip: Optional[str],
@@ -51,7 +49,7 @@ if is_ee_enabled():
             "now": now.isoformat(),
             "sent_at": sent_at.isoformat() if sent_at else "",
         }
-        producer.produce(topic=topic, data=data)
+        KafkaProducer().produce(topic=topic, data=data)
 
 
 def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:


### PR DESCRIPTION
This could cause scripts to fail when kafka is not available even if not
used.

KafkaProducer class is already a singleton wrapper so this changes no
behavior

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
