### PR TITLE
Add plugin server job queues to sys status

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -472,6 +472,14 @@ def get_plugin_server_version() -> Optional[str]:
     return None
 
 
+def get_plugin_server_job_queues() -> Optional[str]:
+    cache_key_value = get_client().get("@posthog-plugin-server/enabled-job-queues")
+    if cache_key_value:
+        qs = cache_key_value.decode("utf-8").replace('"', "")
+        return ", ".join([q.capitalize() for q in qs.split(",")])
+    return None
+
+
 def get_redis_info() -> Mapping[str, Any]:
     return get_client().info()
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -472,11 +472,11 @@ def get_plugin_server_version() -> Optional[str]:
     return None
 
 
-def get_plugin_server_job_queues() -> Optional[str]:
+def get_plugin_server_job_queues() -> Optional[List[str]]:
     cache_key_value = get_client().get("@posthog-plugin-server/enabled-job-queues")
     if cache_key_value:
         qs = cache_key_value.decode("utf-8").replace('"', "")
-        return ", ".join([q.capitalize() for q in qs.split(",")])
+        return qs.split(",")
     return None
 
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -120,11 +120,12 @@ def system_status(request):
         }
     )
 
+    plugin_server_queues = get_plugin_server_job_queues()
     metrics.append(
         {
             "key": "plugin_sever_job_queues",
             "metric": "Job queues enabled in plugin server",
-            "value": get_plugin_server_job_queues() or "unknown",
+            "value": ", ".join([q.capitalize() for q in plugin_server_queues]) if plugin_server_queues else "unknown",
         }
     )
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -17,6 +17,7 @@ from posthog.ee import is_ee_enabled
 from posthog.email import is_email_available
 from posthog.models import User
 from posthog.utils import (
+    get_plugin_server_job_queues,
     get_redis_info,
     get_redis_queue_depth,
     get_table_approx_count,
@@ -116,6 +117,14 @@ def system_status(request):
             "key": "plugin_sever_version",
             "metric": "Plugin server version",
             "value": get_plugin_server_version() or "unknown",
+        }
+    )
+
+    metrics.append(
+        {
+            "key": "plugin_sever_job_queues",
+            "metric": "Job queues enabled in plugin server",
+            "value": get_plugin_server_job_queues() or "unknown",
         }
     )
 


### PR DESCRIPTION
## Changes

List job queues that are enabled in the plugin server in system status


:warning: https://github.com/PostHog/plugin-server/pull/377 must be merged first!

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
