### PR TITLE
Dashboard insight setup

### DIFF
--- a/frontend/src/scenes/dashboard-insight/DashboardInsight.scss
+++ b/frontend/src/scenes/dashboard-insight/DashboardInsight.scss
@@ -8,7 +8,7 @@
         display: flex;
         justify-content: space-between;
         padding: $default_spacing;
-        background: white;
+        border: 1px solid $warning;
 
         .title-description {
             flex-direction: column;

--- a/frontend/src/scenes/dashboard-insight/DashboardInsight.scss
+++ b/frontend/src/scenes/dashboard-insight/DashboardInsight.scss
@@ -1,0 +1,48 @@
+@import '~/vars';
+
+.dashboard-insight-header {
+    padding-top: $default_spacing * 2;
+    padding-bottom: 12px;
+
+    .header-container {
+        display: flex;
+        justify-content: space-between;
+        padding: $default_spacing;
+        background: white;
+
+        .title-description {
+            flex-direction: column;
+            width: 100%;
+            .status-svg {
+                color: $warning;
+                font-size: 18px;
+                margin-right: 6px;
+            }
+        }
+    }
+
+    .dashboard-insight-description {
+        margin-top: 8px;
+        .ant-card-body {
+            padding: 0;
+        }
+        &:hover {
+            cursor: text;
+        }
+    }
+
+    .description-box {
+        display: flex;
+        width: 100%;
+        justify-content: space-between;
+        align-items: center;
+        padding: 5px;
+        border: 1px solid $bg_mid;
+    }
+
+    .edit-box {
+        textarea {
+            resize: none;
+        }
+    }
+}

--- a/frontend/src/scenes/dashboard-insight/DashboardInsight.tsx
+++ b/frontend/src/scenes/dashboard-insight/DashboardInsight.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { useValues } from 'kea'
+import { FunnelViz } from 'scenes/funnels/FunnelViz'
+import { dashboardInsightLogic } from './dashboardInsightLogic'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import './DashboardInsight.scss'
+import { DashboardInsightHeader } from './DashboardInsightHeader'
+
+export function DashboardInsight(): JSX.Element {
+    const { dashboardInsight } = useValues(dashboardInsightLogic)
+    const { dashboard } = useValues(dashboardLogic({ id: 5 }))
+    const Element = FunnelViz
+    const color = dashboardInsight?.color || 'white'
+
+    return(
+        dashboardInsight &&
+        <>
+            <DashboardInsightHeader dashboardInsight={dashboardInsight} dashboardName={dashboard?.name}/>
+
+            {/* <div className="dashboard-insight-chart"> */}
+                <Element
+                    dashboardItemId={dashboardInsight.id}
+                    filters={dashboardInsight.filters}
+                    color={color}
+                    theme={color === 'white' ? 'light' : 'dark'}
+                    inSharedMode={false}
+                />
+            {/* </div> */}
+        </>
+    )
+}

--- a/frontend/src/scenes/dashboard-insight/DashboardInsight.tsx
+++ b/frontend/src/scenes/dashboard-insight/DashboardInsight.tsx
@@ -5,19 +5,40 @@ import { dashboardInsightLogic } from './dashboardInsightLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import './DashboardInsight.scss'
 import { DashboardInsightHeader } from './DashboardInsightHeader'
+import { Paths } from 'scenes/paths/Paths'
+import { ActionsBarValueGraph, ActionsLineGraph, ActionsPie, ActionsTable } from 'scenes/trends/viz'
+import { RetentionContainer } from 'scenes/retention/RetentionContainer'
+import { ViewType } from 'scenes/insights/insightLogic'
 
 export function DashboardInsight(): JSX.Element {
     const { dashboardInsight } = useValues(dashboardInsightLogic)
     const { dashboard } = useValues(dashboardLogic({ id: 5 }))
-    const Element = FunnelViz
+
+    const mapping: Record<string, any> = {
+        FunnelViz: FunnelViz,
+        PathsViz: Paths,
+        ActionsLineGraph: ActionsLineGraph,
+        ActionsBarValue: ActionsBarValueGraph,
+        ActionsTable: ActionsTable,
+        ActionsPie: ActionsPie,
+    }
+
+    const displayElement = (display: string): any => {
+        return mapping[display]
+    }
+
+    let Element
+    if (dashboardInsight?.insight === ViewType.RETENTION) {
+        Element = RetentionContainer
+    } else {
+        Element = displayElement(dashboardInsight?.filters.display)
+    }
     const color = dashboardInsight?.color || 'white'
 
-    return(
-        dashboardInsight &&
-        <>
-            <DashboardInsightHeader dashboardInsight={dashboardInsight} dashboardName={dashboard?.name}/>
-
-            {/* <div className="dashboard-insight-chart"> */}
+    return (
+        dashboardInsight && (
+            <>
+                <DashboardInsightHeader dashboardInsight={dashboardInsight} dashboardName={dashboard?.name} />
                 <Element
                     dashboardItemId={dashboardInsight.id}
                     filters={dashboardInsight.filters}
@@ -25,7 +46,7 @@ export function DashboardInsight(): JSX.Element {
                     theme={color === 'white' ? 'light' : 'dark'}
                     inSharedMode={false}
                 />
-            {/* </div> */}
-        </>
+            </>
+        )
     )
 }

--- a/frontend/src/scenes/dashboard-insight/DashboardInsightHeader.tsx
+++ b/frontend/src/scenes/dashboard-insight/DashboardInsightHeader.tsx
@@ -1,27 +1,27 @@
-import { Button, Card, Input, PageHeader } from "antd"
-import { useValues, useActions } from "kea"
-import { IconDashboard } from "lib/components/icons"
-import { Link } from "lib/components/Link"
-import React, { useState } from "react"
-import { userLogic } from "scenes/userLogic"
-import { dashboardItemsModel } from "~/models/dashboardItemsModel"
-import { DashboardItemType } from "~/types"
+import { Button, Card, Input } from 'antd'
+import { useValues, useActions } from 'kea'
+import { IconDashboard } from 'lib/components/icons'
+import { Link } from 'lib/components/Link'
+import React, { useState } from 'react'
+import { userLogic } from 'scenes/userLogic'
+import { DashboardItemMode, DashboardItemType } from '~/types'
 import { ArrowLeftOutlined, EditOutlined } from '@ant-design/icons'
 import './DashboardInsight.scss'
+import { dashboardInsightLogic } from './dashboardInsightLogic'
+import { PageHeader } from 'lib/components/PageHeader'
 
 interface Props {
-    dashboardInsight: DashboardItemType,
+    dashboardInsight: DashboardItemType
     dashboardName: string
 }
 
 export function DashboardInsightHeader({ dashboardInsight, dashboardName }: Props): JSX.Element {
-    // const { dashboardItemMode } = useValues(dashboardItemsModel)
-    // const { setDashboardItemMode, updateDashboardItem } = useActions(dashboardItemsModel)
+    const { dashboardInsightMode } = useValues(dashboardInsightLogic)
+    const { setDashboardInsightMode, updateDashboardInsight } = useActions(dashboardInsightLogic)
     const [newDescription, setNewDescription] = useState(dashboardInsight.description) // Used to update the input immediately, debouncing API calls
     const { user } = useValues(userLogic)
     const isDashboardCollab = user?.organization?.available_features?.includes('dashboard_collaboration')
-    // const isDashboardItemEditMode = dashboardItemMode === DashboardItemMode.Edit
-    const isDashboardItemEditMode = true
+    const isDashboardItemEditMode = dashboardInsightMode === DashboardItemMode.Edit
 
     return (
         <div className="dashboard-insight-header">
@@ -62,7 +62,7 @@ export function DashboardInsightHeader({ dashboardInsight, dashboardName }: Prop
                                 ) : (
                                     <div
                                         className="description-box"
-                                        // onClick={() => setDashboardItemMode(DashboardItemMode.Edit)}
+                                        onClick={() => setDashboardInsightMode(DashboardItemMode.Edit)}
                                     >
                                         {dashboardInsight.description ? (
                                             <span>{dashboardInsight.description}</span>
@@ -77,20 +77,20 @@ export function DashboardInsightHeader({ dashboardInsight, dashboardName }: Prop
                             </Card>
                         )}
                     </div>
-                    {/* {isDashboardCollab && isDashboardItemEditMode && (
+                    {isDashboardCollab && isDashboardItemEditMode && (
                         <Button
                             style={{ marginLeft: 8, alignSelf: 'flex-end' }}
                             onClick={() =>
                                 newDescription !== dashboardInsight.description
-                                    ? updateDashboardItem(dashboardInsight.id, { description: newDescription })
-                                    : setDashboardItemMode(null)
+                                    ? updateDashboardInsight(dashboardInsight.id, { description: newDescription })
+                                    : setDashboardInsightMode(null)
                             }
                             type="primary"
                             data-attr="dashboard-insight-description-submit"
                         >
                             Finish
                         </Button>
-                    )} */}
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/dashboard-insight/DashboardInsightHeader.tsx
+++ b/frontend/src/scenes/dashboard-insight/DashboardInsightHeader.tsx
@@ -1,0 +1,98 @@
+import { Button, Card, Input, PageHeader } from "antd"
+import { useValues, useActions } from "kea"
+import { IconDashboard } from "lib/components/icons"
+import { Link } from "lib/components/Link"
+import React, { useState } from "react"
+import { userLogic } from "scenes/userLogic"
+import { dashboardItemsModel } from "~/models/dashboardItemsModel"
+import { DashboardItemType } from "~/types"
+import { ArrowLeftOutlined, EditOutlined } from '@ant-design/icons'
+import './DashboardInsight.scss'
+
+interface Props {
+    dashboardInsight: DashboardItemType,
+    dashboardName: string
+}
+
+export function DashboardInsightHeader({ dashboardInsight, dashboardName }: Props): JSX.Element {
+    // const { dashboardItemMode } = useValues(dashboardItemsModel)
+    // const { setDashboardItemMode, updateDashboardItem } = useActions(dashboardItemsModel)
+    const [newDescription, setNewDescription] = useState(dashboardInsight.description) // Used to update the input immediately, debouncing API calls
+    const { user } = useValues(userLogic)
+    const isDashboardCollab = user?.organization?.available_features?.includes('dashboard_collaboration')
+    // const isDashboardItemEditMode = dashboardItemMode === DashboardItemMode.Edit
+    const isDashboardItemEditMode = true
+
+    return (
+        <div className="dashboard-insight-header">
+            <Link to={`/dashboard/${dashboardInsight.dashboard}`}>
+                <ArrowLeftOutlined /> To {dashboardName} dashboard
+            </Link>
+
+            <div style={{ marginTop: -16 }}>
+                <PageHeader title={dashboardInsight.name} />
+
+                <div className="header-container text-default">
+                    <div className="title-description">
+                        <div className="status" style={{ display: 'flex' }}>
+                            <div className="status-svg">
+                                {isDashboardItemEditMode ? <EditOutlined /> : <IconDashboard />}
+                            </div>
+                            <span style={{ paddingLeft: 6 }}>
+                                {isDashboardItemEditMode ? 'Editing graph' : 'Viewing graph'}{' '}
+                                <b>{dashboardInsight.name}</b> from{' '}
+                                <Link to={`/dashboard/${dashboardInsight.dashboard}`}>{dashboardName}</Link> dashboard.
+                            </span>
+                        </div>
+
+                        {isDashboardCollab && (
+                            <Card className="dashboard-insight-description" bordered={false}>
+                                {isDashboardItemEditMode ? (
+                                    <div className="edit-box">
+                                        <Input.TextArea
+                                            placeholder="Add a description to your dashboard insight that helps others understand it better."
+                                            value={newDescription}
+                                            onChange={(e) => {
+                                                setNewDescription(e.target.value)
+                                            }}
+                                            autoSize
+                                            allowClear
+                                        />
+                                    </div>
+                                ) : (
+                                    <div
+                                        className="description-box"
+                                        // onClick={() => setDashboardItemMode(DashboardItemMode.Edit)}
+                                    >
+                                        {dashboardInsight.description ? (
+                                            <span>{dashboardInsight.description}</span>
+                                        ) : (
+                                            <span className="text-muted">
+                                                Add a description for this dashboard insight...
+                                            </span>
+                                        )}
+                                        <EditOutlined />
+                                    </div>
+                                )}
+                            </Card>
+                        )}
+                    </div>
+                    {/* {isDashboardCollab && isDashboardItemEditMode && (
+                        <Button
+                            style={{ marginLeft: 8, alignSelf: 'flex-end' }}
+                            onClick={() =>
+                                newDescription !== dashboardInsight.description
+                                    ? updateDashboardItem(dashboardInsight.id, { description: newDescription })
+                                    : setDashboardItemMode(null)
+                            }
+                            type="primary"
+                            data-attr="dashboard-insight-description-submit"
+                        >
+                            Finish
+                        </Button>
+                    )} */}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
+++ b/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
@@ -10,15 +10,6 @@ export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
     }),
 
     reducers: () => ({
-        dashboardInsightMode: [
-            null as DashboardItemMode | null,
-            {
-                setDashboardInsightMode: (_, { mode }) => mode,
-            },
-        ],
-    }),
-
-    loaders: () => ({
         dashboardInsight: [
             null as DashboardItemType | null,
             {
@@ -27,6 +18,12 @@ export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
                     return response
                 },
                 setDashboardInsight: (dashboardInsight: DashboardItemType) => dashboardInsight,
+            },
+        ],
+        dashboardInsightMode: [
+            null as DashboardItemMode | null,
+            {
+                setDashboardInsightMode: (_, { mode }) => mode,
             },
         ],
     }),

--- a/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
+++ b/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
@@ -43,7 +43,7 @@ export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
     }),
 
     urlToAction: ({ actions }) => ({
-        '/dashboard_insight(/:id)': async ({ id }) => {
+        '/dashboard_insight(/:id)': async ({ id }: { id: number }) => {
             actions.loadDashboardInsight(id)
         },
     }),

--- a/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
+++ b/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
@@ -1,24 +1,50 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { DashboardItemType } from '~/types'
+import { DashboardItemMode, DashboardItemType } from '~/types'
 import { dashboardInsightLogicType } from './dashboardInsightLogicType'
 
 export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
     actions: () => ({
-
+        updateDashboardInsight: (id: number, payload: Partial<DashboardItemType>) => ({ id, ...payload }),
+        setDashboardInsightMode: (mode: DashboardItemMode) => ({ mode }),
     }),
+
+    reducers: () => ({
+        dashboardInsightMode: [
+            null as DashboardItemMode | null,
+            {
+                setDashboardInsightMode: (_, { mode }) => mode,
+            },
+        ],
+    }),
+
     loaders: () => ({
-        dashboardInsight: {
-            loadDashboardInsight: async (id: number): Promise<DashboardItemType> => {
-                const response = await api.get(`api/dashboard_item/${id}`)
-                return response
+        dashboardInsight: [
+            null as DashboardItemType | null,
+            {
+                loadDashboardInsight: async (id: number): Promise<DashboardItemType> => {
+                    const response = await api.get(`api/dashboard_item/${id}`)
+                    return response
+                },
+                setDashboardInsight: (dashboardInsight: DashboardItemType) => dashboardInsight,
+            },
+        ],
+    }),
+
+    listeners: ({ actions }) => ({
+        updateDashboardInsight: async ({ id, ...payload }) => {
+            if (!Object.entries(payload).length) {
+                return
             }
-        }
+            const response = await api.update(`api/dashboard_item/${id}`, payload)
+            actions.setDashboardInsightMode(null)
+            actions.setDashboardInsight(response)
+        },
     }),
 
     urlToAction: ({ actions }) => ({
         '/dashboard_insight(/:id)': async ({ id }) => {
             actions.loadDashboardInsight(id)
         },
-    })
+    }),
 })

--- a/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
+++ b/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
@@ -1,0 +1,24 @@
+import { kea } from 'kea'
+import api from 'lib/api'
+import { DashboardItemType } from '~/types'
+import { dashboardInsightLogicType } from './dashboardInsightLogicType'
+
+export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
+    actions: () => ({
+
+    }),
+    loaders: () => ({
+        dashboardInsight: {
+            loadDashboardInsight: async (id: number): Promise<DashboardItemType> => {
+                const response = await api.get(`api/dashboard_item/${id}`)
+                return response
+            }
+        }
+    }),
+
+    urlToAction: ({ actions }) => ({
+        '/dashboard_insight(/:id)': async ({ id }) => {
+            actions.loadDashboardInsight(id)
+        },
+    })
+})

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -56,7 +56,8 @@ interface Params {
 export const scenes: Record<Scene, () => any> = {
     [Scene.Dashboards]: () => import(/* webpackChunkName: 'dashboards' */ './dashboard/Dashboards'),
     [Scene.Dashboard]: () => import(/* webpackChunkName: 'dashboard' */ './dashboard/Dashboard'),
-    [Scene.DashboardInsight]: () => import (/* webpackChunkName: 'dashboard' */ './dashboard-insight/DashboardInsight'),
+    [Scene.DashboardInsight]: () =>
+        import(/* webpackChunkName: 'dashboardInsight' */ './dashboard-insight/DashboardInsight'),
     [Scene.Insights]: () => import(/* webpackChunkName: 'insights' */ './insights/Insights'),
     [Scene.Cohorts]: () => import(/* webpackChunkName: 'cohorts' */ './persons/Cohorts'),
     [Scene.Events]: () => import(/* webpackChunkName: 'events' */ './events/Events'),

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -13,6 +13,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 export enum Scene {
     Dashboards = 'dashboards',
     Dashboard = 'dashboard',
+    DashboardInsight = 'dashboardInsight',
     Insights = 'insights',
     Cohorts = 'cohorts',
     Events = 'events',
@@ -55,6 +56,7 @@ interface Params {
 export const scenes: Record<Scene, () => any> = {
     [Scene.Dashboards]: () => import(/* webpackChunkName: 'dashboards' */ './dashboard/Dashboards'),
     [Scene.Dashboard]: () => import(/* webpackChunkName: 'dashboard' */ './dashboard/Dashboard'),
+    [Scene.DashboardInsight]: () => import (/* webpackChunkName: 'dashboard' */ './dashboard-insight/DashboardInsight'),
     [Scene.Insights]: () => import(/* webpackChunkName: 'insights' */ './insights/Insights'),
     [Scene.Cohorts]: () => import(/* webpackChunkName: 'cohorts' */ './persons/Cohorts'),
     [Scene.Events]: () => import(/* webpackChunkName: 'events' */ './events/Events'),
@@ -147,6 +149,7 @@ export const redirects: Record<string, string | ((params: Params) => any)> = {
 export const routes: Record<string, Scene> = {
     '/dashboard': Scene.Dashboards,
     '/dashboard/:id': Scene.Dashboard,
+    '/dashboard_insight/:id': Scene.DashboardInsight,
     '/action/:id': Scene.Action,
     '/action': Scene.Action,
     '/insights': Scene.Insights,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -665,6 +665,10 @@ export enum DashboardMode { // Default mode is null
     Public = 'public', // When viewing the dashboard publicly via a shareToken
 }
 
+export enum DashboardItemMode {
+    Edit = 'edit',
+}
+
 // Reserved hotkeys globally available
 export type GlobalHotKeys = 'g'
 


### PR DESCRIPTION
## Changes

 Round 2 of dashboard insight page setup 😄 for #3551 

1. Set up *separate* component and logic files for this page. The route is accessible only if you manually go to `/dashboard_insight/${id}`

2. Moved over the dashboard item description editing stuff I had worked on 

TODO for a separate, next PR 
- Address the actual filters handling !
- Address the look and size of the graphs
- Address more detailed description/title editing 
- Address somewhat duplicate code with the mapping like how the `DashboardItem` component renders its own charts
- Include a e2e test or two 😓 

**Overall Page View**
<img width="1082" alt="Screen Shot 2021-05-11 at 4 20 53 PM" src="https://user-images.githubusercontent.com/25164963/117879354-df76fe00-b274-11eb-8dca-160c62d327e9.png">

**Description editing** 
https://user-images.githubusercontent.com/25164963/117879267-c3735c80-b274-11eb-999f-c8fb2a42049a.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
