### PR TITLE
Update wording for `runEvery` functions in PluginEditor

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -12,7 +12,7 @@ function processEvent(event, { config }) {
         event.properties['hello'] = \`Hello \${config.name || 'world'}\`
     }
     
-    // Return the event to injest, return nothing to discard  
+    // Return the event to ingest, return nothing to discard  
     return event
 }
 
@@ -21,7 +21,7 @@ function processEvent(event, { config }) {
 // 
 // }
 
-// /* Ran once per hour across all worker instance */
+// /* Runs once every full hour */
 // function runEveryHour(meta) {
 //     const weather = await (await fetch('https://weather.example.api/?city=New+York')).json()
 //     posthog.capture('weather', { degrees: weather.deg, fahrenheit: weather.us })

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -21,7 +21,7 @@ function processEvent(event, { config }) {
 // 
 // }
 
-// /* Ran once per hour on each worker instance */
+// /* Ran once per hour across all worker instance */
 // function runEveryHour(meta) {
 //     const weather = await (await fetch('https://weather.example.api/?city=New+York')).json()
 //     posthog.capture('weather', { degrees: weather.deg, fahrenheit: weather.us })


### PR DESCRIPTION
There's a distributed lock across plugin servers that ensures only one server gets the task ( https://github.com/PostHog/plugin-server/blob/master/src/main/services/schedule.ts#L43 ), and piscina enqueues the task only once, which ensures only one worker in a server gets it (https://github.com/PostHog/plugin-server/blob/master/src/main/services/schedule.ts#L94-L103)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
