### PR TITLE
Fix dashboard insight loader

### DIFF
--- a/cypress/integration/commandPalette.js
+++ b/cypress/integration/commandPalette.js
@@ -5,6 +5,7 @@ describe('Command Palette', () => {
     })
 
     it('Shows on Ctrl + K press', () => {
+        cy.get('[data-attr=layout-content]').contains('Insights')
         cy.get('body').type('{ctrl}k')
         cy.get('[data-attr=command-palette-input]').should('exist')
 

--- a/cypress/integration/commandPalette.js
+++ b/cypress/integration/commandPalette.js
@@ -5,7 +5,6 @@ describe('Command Palette', () => {
     })
 
     it('Shows on Ctrl + K press', () => {
-        cy.get('[data-attr=layout-content]').contains('Insights')
         cy.get('body').type('{ctrl}k')
         cy.get('[data-attr=command-palette-input]').should('exist')
 

--- a/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
+++ b/frontend/src/scenes/dashboard-insight/dashboardInsightLogic.ts
@@ -9,7 +9,7 @@ export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
         setDashboardInsightMode: (mode: DashboardItemMode) => ({ mode }),
     }),
 
-    reducers: () => ({
+    loaders: () => ({
         dashboardInsight: [
             null as DashboardItemType | null,
             {
@@ -20,6 +20,9 @@ export const dashboardInsightLogic = kea<dashboardInsightLogicType>({
                 setDashboardInsight: (dashboardInsight: DashboardItemType) => dashboardInsight,
             },
         ],
+    }),
+
+    reducers: () => ({
         dashboardInsightMode: [
             null as DashboardItemMode | null,
             {


### PR DESCRIPTION
## Changes

It was broken because the action for it didn't exist

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
