### PR TITLE
Wrap feature flag key name in CopyToClipboardInline

### DIFF
--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -11,6 +11,7 @@ import { createdAtColumn, createdByColumn } from 'lib/components/Table'
 import { FeatureFlagGroupType, FeatureFlagType } from '~/types'
 import { router } from 'kea-router'
 import { LinkButton } from 'lib/components/LinkButton'
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 
 export function FeatureFlags(): JSX.Element {
     const { featureFlags, featureFlagsLoading } = useValues(featureFlagsLogic)
@@ -27,14 +28,18 @@ export function FeatureFlags(): JSX.Element {
             sorter: (a: FeatureFlagType, b: FeatureFlagType) => ('' + a.key).localeCompare(b.key),
             render: function Render(_: string, featureFlag: FeatureFlagType) {
                 return (
-                    <>
-                        {!featureFlag.active && (
-                            <Tooltip title="This feature flag is disabled.">
-                                <DisconnectOutlined style={{ marginRight: 4 }} />
-                            </Tooltip>
-                        )}
-                        {featureFlag.key}
-                    </>
+                    <div onClick={(e) => e.stopPropagation()}>
+                        <CopyToClipboardInline iconPosition="start" explicitValue={featureFlag.key}>
+                            <>
+                                {!featureFlag.active && (
+                                    <Tooltip title="This feature flag is disabled.">
+                                        <DisconnectOutlined style={{ marginRight: 4 }} />
+                                    </Tooltip>
+                                )}
+                                {featureFlag.key}
+                            </>
+                        </CopyToClipboardInline>
+                    </div>
                 )
             },
         },


### PR DESCRIPTION
## Changes

Enables quickly copying a feature flag key name to clipboard.

<img width="769" alt="Screen Shot 2021-05-12 at 3 39 38 PM" src="https://user-images.githubusercontent.com/4645779/118034696-48737a00-b338-11eb-836f-d13a3fe4987c.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
