### PR TITLE
added a close X button on the top right corner of the retension modal…

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -109,7 +109,7 @@ export function RetentionTable({
             {results && (
                 <Modal
                     visible={modalVisible}
-                    closable={false}
+                    closable={true}
                     onCancel={dismissModal}
                     footer={<Button onClick={dismissModal}>Close</Button>}
                     style={{
@@ -135,7 +135,7 @@ export function RetentionTable({
                                                         .map((data, index) => <th key={index}>{data.label}</th>)}
                                             </tr>
                                             <tr>
-                                                <td />
+                                                <td>user_id</td>
                                                 {results &&
                                                     results[selectedRow]?.values.map((data: any, index: number) => (
                                                         <td key={index}>


### PR DESCRIPTION
…, added a column header for the table therein

## Changes
Added a 'X' (close button) on the top right corner for Retention pop-up, also, added a column header (user_id) for the table. 
*Please describe.*  
*If this affects the frontend, include screenshots.* 
<img width="1678" alt="Screenshot 2021-05-13 at 8 01 00 PM" src="https://user-images.githubusercontent.com/11834249/118140488-04f73980-b426-11eb-8b2d-865b29ee8ce3.png">
 

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [x] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
