### PR TITLE
Send information whether a clickhouse query failed to statsd

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -124,6 +124,10 @@ else:
             try:
                 sql, tags = _annotate_tagged_query(query, args)
                 result = client.execute(sql, args, settings=settings)
+            except Exception as e:
+                tags["failed"] = True
+                tags["reason"] = str(e)
+                raise e
             finally:
                 execution_time = time() - start_time
                 statsd.gauge("clickhouse_sync_execution_time", execution_time * 1000.0, tags=tags)


### PR DESCRIPTION
## Changes

This is useful to know how many of our queries are failing in total - a spike could mean something is configured wrong. :)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
