### PR TITLE
Fix stickiness caching issue

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -12,7 +12,7 @@ from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSession
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
 from ee.clickhouse.queries.util import get_earliest_timestamp
 from posthog.api.insight import InsightViewSet
-from posthog.constants import INSIGHT_FUNNELS, INSIGHT_PATHS, INSIGHT_SESSIONS, TRENDS_STICKINESS
+from posthog.constants import INSIGHT_FUNNELS, INSIGHT_PATHS, INSIGHT_SESSIONS, INSIGHT_STICKINESS, TRENDS_STICKINESS
 from posthog.decorators import cached_function
 from posthog.models import Event
 from posthog.models.filters import Filter
@@ -28,7 +28,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
         team = self.team
         filter = Filter(request=request)
 
-        if filter.shown_as == TRENDS_STICKINESS:
+        if filter.insight == INSIGHT_STICKINESS or filter.shown_as == TRENDS_STICKINESS:
             stickiness_filter = StickinessFilter(
                 request=request, team=team, get_earliest_timestamp=get_earliest_timestamp
             )

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -14,7 +14,14 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import format_next_url
 from posthog.celery import update_cache_item_task
-from posthog.constants import FROM_DASHBOARD, INSIGHT, INSIGHT_FUNNELS, INSIGHT_PATHS, TRENDS_STICKINESS
+from posthog.constants import (
+    FROM_DASHBOARD,
+    INSIGHT,
+    INSIGHT_FUNNELS,
+    INSIGHT_PATHS,
+    INSIGHT_STICKINESS,
+    TRENDS_STICKINESS,
+)
 from posthog.decorators import CacheType, cached_function
 from posthog.models import DashboardItem, Event, Filter, Team
 from posthog.models.filters import RetentionFilter
@@ -154,7 +161,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     def calculate_trends(self, request: request.Request) -> Dict[str, Any]:
         team = self.team
         filter = Filter(request=request)
-        if filter.shown_as == TRENDS_STICKINESS:
+        if filter.insight == INSIGHT_STICKINESS or filter.shown_as == TRENDS_STICKINESS:
             earliest_timestamp_func = lambda team_id: Event.objects.earliest_timestamp(team_id)
             stickiness_filter = StickinessFilter(
                 request=request, team=team, get_earliest_timestamp=earliest_timestamp_func

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 
+from posthog.constants import INSIGHT_STICKINESS
 from posthog.ee import is_clickhouse_enabled
 from posthog.models.dashboard_item import DashboardItem
 from posthog.models.event import Event

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -28,7 +28,7 @@ class CacheType(str, Enum):
 def cached_function():
     def parameterized_decorator(f: Callable):
         @wraps(f)
-        def wrapper(*args, **kwargs) -> Dict[str, Union[List, datetime, bool]]:
+        def wrapper(*args, **kwargs) -> Dict[str, Union[List, datetime, bool, str]]:
             # prepare caching params
             request: HttpRequest = args[1]
             team = cast(User, request.user).team

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -42,7 +42,7 @@ def cached_function():
             if not request.GET.get("refresh", False):
                 cached_result = get_safe_cache(cache_key)
                 if cached_result and cached_result.get("result"):
-                    return {**cached_result, "is_cached": True, "cache_key": cache_key}
+                    return {**cached_result, "is_cached": True}
             # call function being wrapped
             result = f(*args, **kwargs)
 
@@ -54,7 +54,7 @@ def cached_function():
                 if filter:
                     dashboard_items = DashboardItem.objects.filter(team_id=team.pk, filters_hash=cache_key)
                     dashboard_items.update(last_refresh=now())
-            return {**result, "cache_key": cache_key}
+            return result
 
         return wrapper
 

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -42,7 +42,7 @@ def cached_function():
             if not request.GET.get("refresh", False):
                 cached_result = get_safe_cache(cache_key)
                 if cached_result and cached_result.get("result"):
-                    return {**cached_result, "is_cached": True}
+                    return {**cached_result, "is_cached": True, "cache_key": cache_key}
             # call function being wrapped
             result = f(*args, **kwargs)
 
@@ -54,7 +54,7 @@ def cached_function():
                 if filter:
                     dashboard_items = DashboardItem.objects.filter(team_id=team.pk, filters_hash=cache_key)
                     dashboard_items.update(last_refresh=now())
-            return result
+            return {**result, "cache_key": cache_key}
 
         return wrapper
 

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -2,12 +2,22 @@ from typing import Any, Dict, List, Optional, Union
 
 from django.http import HttpRequest
 
-from posthog.constants import INSIGHT_PATHS, INSIGHT_RETENTION, INSIGHT_SESSIONS, INSIGHT_TRENDS
+from posthog.constants import INSIGHT_PATHS, INSIGHT_RETENTION, INSIGHT_SESSIONS, INSIGHT_STICKINESS, INSIGHT_TRENDS
+from posthog.ee import is_clickhouse_enabled
 from posthog.models.filters.path_filter import PathFilter
 
 
-def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None):
+def earliest_timestamp_func(team_id: int):
+    if is_clickhouse_enabled():
+        from ee.clickhouse.queries.util import get_earliest_timestamp
+
+        return get_earliest_timestamp(team_id)
     from posthog.models.event import Event
+
+    return Event.objects.earliest_timestamp(team_id)
+
+
+def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None):
     from posthog.models.filters.filter import Filter
     from posthog.models.filters.retention_filter import RetentionFilter
     from posthog.models.filters.sessions_filter import SessionsFilter
@@ -20,8 +30,7 @@ def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None):
         return RetentionFilter(data={**data, "insight": INSIGHT_RETENTION}, request=request)
     elif insight == INSIGHT_SESSIONS:
         return SessionsFilter(data={**data, "insight": INSIGHT_SESSIONS}, request=request)
-    elif insight == INSIGHT_TRENDS and data.get("shown_as") == "Stickiness":
-        earliest_timestamp_func = lambda team_id: Event.objects.earliest_timestamp(team_id)
+    elif insight == INSIGHT_STICKINESS or (insight == INSIGHT_TRENDS and data.get("shown_as") == "Stickiness"):
         return StickinessFilter(data=data, request=request, team=team, get_earliest_timestamp=earliest_timestamp_func)
     elif insight == INSIGHT_PATHS:
         return PathFilter(data={**data, "insight": INSIGHT_PATHS}, request=request)

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from posthog.constants import ENTITY_ID, ENTITY_TYPE
+from posthog.constants import ENTITY_ID, ENTITY_TYPE, INSIGHT_STICKINESS
 from posthog.decorators import CacheType
 from posthog.models import Dashboard, DashboardItem, Event, Filter
 from posthog.models.filters.retention_filter import RetentionFilter
@@ -151,4 +151,61 @@ class TestUpdateCache(APIBaseTest):
             filters=filter.to_dict(),
             team=self.team,
             last_refresh=now() - timedelta(days=30),
+        )
+
+    @patch("posthog.tasks.update_cache.group.apply_async")
+    @patch("posthog.celery.update_cache_item_task.s")
+    @freeze_time("2012-01-15")
+    def test_stickiness_regression(self, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock) -> None:
+        # We moved Stickiness from being a "shown_as" item to its own insight
+        # This move caused issues hence a regression test
+        filter_stickiness = StickinessFilter(
+            data={
+                "events": [{"id": "$pageview"}],
+                "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                "date_from": "2012-01-10",
+                "date_to": "2012-01-15",
+                "insight": INSIGHT_STICKINESS,
+                "shown_as": "Stickiness",
+            },
+            team=self.team,
+            get_earliest_timestamp=Event.objects.earliest_timestamp,
+        )
+        filter = Filter(
+            data={
+                "events": [{"id": "$pageview"}],
+                "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                "date_from": "2012-01-10",
+                "date_to": "2012-01-15",
+            }
+        )
+        shared_dashboard = Dashboard.objects.create(team=self.team, is_shared=True)
+
+        DashboardItem.objects.create(dashboard=shared_dashboard, filters=filter_stickiness.to_dict(), team=self.team)
+        DashboardItem.objects.create(dashboard=shared_dashboard, filters=filter.to_dict(), team=self.team)
+
+        item_stickiness_key = generate_cache_key(filter_stickiness.toJSON() + "_" + str(self.team.pk))
+        item_key = generate_cache_key(filter.toJSON() + "_" + str(self.team.pk))
+
+        update_cached_items()
+
+        for call_item in patch_update_cache_item.call_args_list:
+            update_cache_item(*call_item[0])
+
+        self.assertEqual(
+            get_safe_cache(item_stickiness_key)["result"][0]["labels"],
+            ["1 day", "2 days", "3 days", "4 days", "5 days", "6 days"],
+        )
+        self.assertEqual(
+            get_safe_cache(item_key)["result"][0]["labels"],
+            [
+                "Thu. 6 May",
+                "Fri. 7 May",
+                "Sat. 8 May",
+                "Sun. 9 May",
+                "Mon. 10 May",
+                "Tue. 11 May",
+                "Wed. 12 May",
+                "Thu. 13 May",
+            ],
         )

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -199,13 +199,11 @@ class TestUpdateCache(APIBaseTest):
         self.assertEqual(
             get_safe_cache(item_key)["result"][0]["labels"],
             [
-                "Thu. 6 May",
-                "Fri. 7 May",
-                "Sat. 8 May",
-                "Sun. 9 May",
-                "Mon. 10 May",
-                "Tue. 11 May",
-                "Wed. 12 May",
-                "Thu. 13 May",
+                "Tue. 10 January",
+                "Wed. 11 January",
+                "Thu. 12 January",
+                "Fri. 13 January",
+                "Sat. 14 January",
+                "Sun. 15 January",
             ],
         )

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -17,6 +17,7 @@ from posthog.constants import (
     INSIGHT_PATHS,
     INSIGHT_RETENTION,
     INSIGHT_SESSIONS,
+    INSIGHT_STICKINESS,
     INSIGHT_TRENDS,
     TRENDS_STICKINESS,
 )
@@ -80,7 +81,7 @@ def get_cache_type(filter: FilterType) -> CacheType:
         filter.insight == INSIGHT_TRENDS
         and isinstance(filter, StickinessFilter)
         and filter.shown_as == TRENDS_STICKINESS
-    ):
+    ) or filter.insight == INSIGHT_STICKINESS:
         return CacheType.STICKINESS
     else:
         return CacheType.TRENDS


### PR DESCRIPTION
## Changes

In a few places we were still expecting stickiness to be a Trends insight with shown_as. This caused the wrong filter to be created, which would create an incorrect cache key, leading to these weird issues. 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
