### PR TITLE
Refactor SelectBox search logic & add instrumentation

### DIFF
--- a/frontend/src/lib/components/SelectBox.tsx
+++ b/frontend/src/lib/components/SelectBox.tsx
@@ -4,7 +4,7 @@ import { Col, Row, Input } from 'antd'
 import { List } from 'antd'
 import { DownOutlined, RightOutlined } from '@ant-design/icons'
 import { ActionType, CohortType } from '~/types'
-import { selectBoxLogic, searchItems } from 'lib/logic/selectBoxLogic'
+import { selectBoxLogic } from 'lib/logic/selectBoxLogic'
 import './SelectBox.scss'
 import { selectBoxLogicType } from 'lib/logic/selectBoxLogicType'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -37,17 +37,6 @@ export interface SelectedItem {
     cohort?: CohortType
 }
 
-const searchGroupItems = (items: SelectBoxItem[], search: string): SelectBoxItem[] => {
-    const newItems: SelectBoxItem[] = []
-    for (const item of items) {
-        newItems.push({
-            ...item,
-            dataSource: searchItems(item.dataSource, search),
-        })
-    }
-    return newItems
-}
-
 export function SelectBox({
     items,
     selectedItemKey,
@@ -65,7 +54,7 @@ export function SelectBox({
 }): JSX.Element {
     const dropdownRef = useRef<HTMLDivElement>(null)
     const dropdownLogic = selectBoxLogic({ updateFilter: onSelect, items })
-    const { selectedItem, selectedGroup, search } = useValues(dropdownLogic)
+    const { selectedItem, selectedGroup, data } = useValues(dropdownLogic)
     const { setSearch, setSelectedItem, onKeyDown } = useActions(dropdownLogic)
 
     const deselect = (e: MouseEvent): void => {
@@ -74,8 +63,6 @@ export function SelectBox({
         }
         onDismiss(e)
     }
-
-    const data = !search ? items : searchGroupItems(items, search)
 
     useEffect(() => {
         if (selectedItemKey) {
@@ -102,9 +89,7 @@ export function SelectBox({
                     <Input
                         placeholder={inputPlaceholder || 'Search events'}
                         autoFocus
-                        onChange={(e) => {
-                            setSearch(e.target.value)
-                        }}
+                        onChange={(e) => setSearch(e.target.value)}
                         onKeyDown={(e) => {
                             e.key === 'Tab' && onDismiss() // Close select box when input blurs via Tab
                         }}

--- a/frontend/src/lib/components/SelectBox.tsx
+++ b/frontend/src/lib/components/SelectBox.tsx
@@ -16,11 +16,13 @@ import { ListRowProps, ListRowRenderer } from 'react-virtualized'
 export interface SelectBoxItem {
     dataSource: SelectedItem[]
     renderInfo({ item }: { item: SelectedItem }): JSX.Element
+    key: string
     name: string
     header: (label: string) => JSX.Element
     type: string
     getValue: (item: SelectedItem) => string | number
     getLabel: (item: SelectedItem) => string
+    metadata?: Record<string, any> // Used to store additional data (e.g. search term)
 }
 
 export interface SelectedItem {

--- a/frontend/src/lib/logic/selectBoxLogic.ts
+++ b/frontend/src/lib/logic/selectBoxLogic.ts
@@ -2,6 +2,7 @@ import { kea } from 'kea'
 import { SelectBoxItem, SelectedItem } from 'lib/components/SelectBox'
 import { selectBoxLogicType } from './selectBoxLogicType'
 import Fuse from 'fuse.js'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 const scrollUpIntoView = (key: string): void => {
     const searchList = document.querySelector('.search-list')
@@ -92,6 +93,7 @@ export const selectBoxLogic = kea<selectBoxLogicType<SelectedItem, SelectBoxItem
                     newItems.push({
                         ...item,
                         dataSource: searchItems(item.dataSource, search),
+                        metadata: { search },
                     })
                 }
                 return newItems
@@ -135,6 +137,19 @@ export const selectBoxLogic = kea<selectBoxLogicType<SelectedItem, SelectBoxItem
             }
             e.stopPropagation()
             e.preventDefault()
+        },
+        setSearch: async ({ search }, breakpoint) => {
+            await breakpoint(700)
+            if (values.data[0].metadata?.search === search) {
+                const extraProps = {} as Record<string, number>
+                for (const item of values.data) {
+                    extraProps[`count_${item.key}`] = item.dataSource.length
+                    if (item.key === 'events') {
+                        extraProps.count_posthog_events = item.dataSource.filter((item) => item.name[0] === '$').length
+                    }
+                }
+                eventUsageLogic.actions.reportEventSearched(search, extraProps)
+            }
         },
     }),
 })

--- a/frontend/src/lib/logic/selectBoxLogic.ts
+++ b/frontend/src/lib/logic/selectBoxLogic.ts
@@ -81,6 +81,22 @@ export const selectBoxLogic = kea<selectBoxLogicType<SelectedItem, SelectBoxItem
                 )
             },
         ],
+        data: [
+            (s) => [s.search],
+            (search): SelectBoxItem[] => {
+                if (!search) {
+                    return props.items
+                }
+                const newItems: SelectBoxItem[] = []
+                for (const item of props.items) {
+                    newItems.push({
+                        ...item,
+                        dataSource: searchItems(item.dataSource, search),
+                    })
+                }
+                return newItems
+            },
+        ],
     }),
     listeners: ({ props, values, actions }) => ({
         clickSelectedItem: ({ item, group }: { item: SelectedItem; group: SelectBoxItem }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -95,9 +95,9 @@ export const eventUsageLogic = kea<
             extraProps?: Record<string, string | boolean | number | undefined>
         ) => ({ module, item, extraProps }),
         reportProjectHomeSeen: (teamHasData: boolean) => ({ teamHasData }),
-        reportEventSearched: (search_term: string, extra_props?: Record<string, number>) => ({
-            search_term,
-            extra_props,
+        reportEventSearched: (searchTerm: string, extraProps?: Record<string, number>) => ({
+            searchTerm,
+            extraProps,
         }),
     },
     listeners: {
@@ -355,13 +355,12 @@ export const eventUsageLogic = kea<
         reportProjectHomeSeen: async ({ teamHasData }) => {
             posthog.capture('project home seen', { team_has_data: teamHasData })
         },
-        reportEventSearched: async ({ search_term, extra_props }) => {
-            if (preflightLogic.values.realm !== 'cloud') {
-                // This event is only captured on PostHog Cloud
-                return
+        reportEventSearched: async ({ searchTerm, extraProps }) => {
+            // This event is only captured on PostHog Cloud
+            if (preflightLogic.values.realm === 'cloud') {
+                // Triggered when a search is executed for an action/event (mainly for use on insights)
+                posthog.capture('event searched', { searchTerm, ...extraProps })
             }
-            // Triggered when a search is executed for an action/event (mainly for use on insights)
-            posthog.capture('event searched', { search_term, ...extra_props })
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -93,6 +93,10 @@ export const eventUsageLogic = kea<
             extraProps?: Record<string, string | boolean | number | undefined>
         ) => ({ module, item, extraProps }),
         reportProjectHomeSeen: (teamHasData: boolean) => ({ teamHasData }),
+        reportEventSearched: (search_term: string, extra_props?: Record<string, number>) => ({
+            search_term,
+            extra_props,
+        }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -348,6 +352,10 @@ export const eventUsageLogic = kea<
         },
         reportProjectHomeSeen: async ({ teamHasData }) => {
             posthog.capture('project home seen', { team_has_data: teamHasData })
+        },
+        reportEventSearched: async ({ search_term, extra_props }) => {
+            // Triggered when a search is executed for an action/event (mainly for use on insights)
+            posthog.capture('event searched', { search_term, ...extra_props })
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -7,6 +7,7 @@ import { eventUsageLogicType } from './eventUsageLogicType'
 import { AnnotationType, FilterType, DashboardType, PersonType, DashboardMode, HotKeys, GlobalHotKeys } from '~/types'
 import { ViewType } from 'scenes/insights/insightLogic'
 import dayjs from 'dayjs'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
 
 const keyMappingKeys = Object.keys(keyMapping.event)
 
@@ -24,6 +25,7 @@ export enum DashboardEventSource {
 export const eventUsageLogic = kea<
     eventUsageLogicType<AnnotationType, FilterType, DashboardType, PersonType, DashboardMode, DashboardEventSource>
 >({
+    connect: [preflightLogic],
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
@@ -354,6 +356,10 @@ export const eventUsageLogic = kea<
             posthog.capture('project home seen', { team_has_data: teamHasData })
         },
         reportEventSearched: async ({ search_term, extra_props }) => {
+            if (preflightLogic.values.realm !== 'cloud') {
+                // This event is only captured on PostHog Cloud
+                return
+            }
             // Triggered when a search is executed for an action/event (mainly for use on insights)
             posthog.capture('event searched', { search_term, ...extra_props })
         },

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterDropdown.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterDropdown.tsx
@@ -65,6 +65,7 @@ export function ActionFilterDropdown({
             onSelect={callUpdateFilter}
             items={[
                 {
+                    key: 'suggested',
                     name: 'Suggested for you',
                     header: function suggestionHeader(label: string) {
                         return (
@@ -104,6 +105,7 @@ export function ActionFilterDropdown({
                     getLabel: (item: SelectedItem) => item.name || '',
                 },
                 {
+                    key: 'actions',
                     name: 'Actions',
                     header: function actionHeader(label: string) {
                         return (
@@ -125,6 +127,7 @@ export function ActionFilterDropdown({
                     getLabel: (item: SelectedItem) => item.action?.name || '',
                 },
                 {
+                    key: 'events',
                     name: 'Events',
                     header: function eventHeader(label: string) {
                         return (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -353,12 +353,6 @@ export interface SessionType {
     matching_events: Array<number | string>
 }
 
-export interface FormattedNumber {
-    // :TODO: DEPRECATED, formatting will now happen client-side
-    value: number
-    formatted: string
-}
-
 export interface BillingType {
     should_setup_billing: boolean
     is_billing_active: boolean


### PR DESCRIPTION
## Changes

- Refactors the search logic of the `SelectBox` to use a Kea selector. This results in **a lot less computations** as previously we would be searching on every render trigger (e.g. just by hovering differnt items; see below).

**Before**
![image](https://user-images.githubusercontent.com/5864173/118152089-2c6be900-b3c9-11eb-94d8-3665a2779e3d.gif)


**After**
![image](https://user-images.githubusercontent.com/5864173/118152112-32fa6080-b3c9-11eb-878d-1f3fb8c7baff.gif)

- Adds an `event searched` event to aid in identifying gaps in UX (see #4331 for details). 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
