### PR TITLE
Improvements to querying experience

### DIFF
--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -12,6 +12,7 @@ import { ProjectOutlined, LaptopOutlined, GlobalOutlined, SettingOutlined } from
 import { Link } from '../Link'
 import { humanTzOffset, shortTimeZone } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { TooltipPlacement } from 'antd/lib/tooltip'
 
 const BASE_OUTPUT_FORMAT = 'ddd, MMM D, YYYY HH:mm'
 
@@ -100,7 +101,13 @@ export function TZLabel({ time, showSeconds }: { time: string | dayjs.Dayjs; sho
 }
 
 /** Return an explainer component for analytics visualization pages. */
-export function TZIndicator({ style }: { style?: React.CSSProperties }): JSX.Element {
+export function TZIndicator({
+    style,
+    placement,
+}: {
+    style?: React.CSSProperties
+    placement?: TooltipPlacement
+}): JSX.Element {
     const { user } = useValues(userLogic)
     /* We use the team in userLogic because the attribute that we need `timezone` is available in that response,
      which will be loaded much sooner than `currentTeam`. */
@@ -118,7 +125,7 @@ export function TZIndicator({ style }: { style?: React.CSSProperties }): JSX.Ele
         <div className="tz-label-popover">
             <TZConversionHeader />
             <p style={{ maxWidth: 320 }}>
-                All graphs are calculated and presented in UTC (GTM timezone).
+                All graphs are calculated and presented in UTC (GMT timezone).
                 <br />
                 Conversion to your local timezones are shown below.
             </p>
@@ -149,7 +156,7 @@ export function TZIndicator({ style }: { style?: React.CSSProperties }): JSX.Ele
     )
 
     return (
-        <Popover content={PopoverContent} onVisibleChange={handleVisibleChange}>
+        <Popover content={PopoverContent} onVisibleChange={handleVisibleChange} placement={placement}>
             <span className="tz-indicator" style={style}>
                 <GlobalOutlined /> UTC
             </span>

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
@@ -24,6 +24,7 @@ export interface ActionFilterProps {
     sortable?: boolean // Whether actions/events can be sorted (used mainly for funnel step reordering)
     showLetters?: boolean // Whether to show a letter indicator identifying each graph
     showOr?: boolean // Whether to show the "OR" label after each filter
+    customRowPrefix?: string | JSX.Element // Custom prefix element to show in each ActionFilterRow
     horizontalUI?: boolean
 }
 
@@ -40,6 +41,7 @@ export function ActionFilter({
     showLetters = false,
     showOr = false,
     horizontalUI = false,
+    customRowPrefix,
 }: ActionFilterProps): JSX.Element {
     const logic = entityFilterLogic({ setFilters, filters, typeKey })
 
@@ -77,10 +79,10 @@ export function ActionFilter({
                                 logic={logic as any}
                                 filter={filter as ActionFilterType}
                                 index={index}
-                                filterIndex={index}
                                 hideMathSelector={hideMathSelector}
                                 hidePropertySelector={hidePropertySelector}
                                 filterCount={localFilters.length}
+                                customRowPrefix={customRowPrefix}
                             />
                         ))}
                     </SortableContainer>
@@ -98,6 +100,7 @@ export function ActionFilter({
                             showOr={showOr}
                             horizontalUI={horizontalUI}
                             filterCount={localFilters.length}
+                            customRowPrefix={customRowPrefix}
                         />
                     ))
                 )

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
@@ -25,6 +25,7 @@ export interface ActionFilterProps {
     showLetters?: boolean // Whether to show a letter indicator identifying each graph
     showOr?: boolean // Whether to show the "OR" label after each filter
     customRowPrefix?: string | JSX.Element // Custom prefix element to show in each ActionFilterRow
+    customActions?: JSX.Element // Custom actions to be added next to the add series button
     horizontalUI?: boolean
 }
 
@@ -42,6 +43,7 @@ export function ActionFilter({
     showOr = false,
     horizontalUI = false,
     customRowPrefix,
+    customActions,
 }: ActionFilterProps): JSX.Element {
     const logic = entityFilterLogic({ setFilters, filters, typeKey })
 
@@ -105,19 +107,23 @@ export function ActionFilter({
                     ))
                 )
             ) : null}
-            {!singleFilter && (
-                <div className="mt">
-                    <Button
-                        type={featureFlags[FEATURE_FLAGS.QUERY_UX_V2] ? 'dashed' : 'primary'}
-                        onClick={() => addFilter()}
-                        style={{ marginTop: '0.5rem' }}
-                        data-attr="add-action-event-button"
-                        icon={<PlusCircleOutlined />}
-                        disabled={disabled}
-                        className={`add-action-event-button${featureFlags[FEATURE_FLAGS.QUERY_UX_V2] ? ' new-ui' : ''}`}
-                    >
-                        {buttonCopy || 'Action or event'}
-                    </Button>
+            {(!singleFilter || customActions) && (
+                <div className="mt" style={{ display: 'flex', alignItems: 'center' }}>
+                    {!singleFilter && (
+                        <Button
+                            type={featureFlags[FEATURE_FLAGS.QUERY_UX_V2] ? 'dashed' : 'primary'}
+                            onClick={() => addFilter()}
+                            data-attr="add-action-event-button"
+                            icon={<PlusCircleOutlined />}
+                            disabled={disabled}
+                            className={`add-action-event-button${
+                                featureFlags[FEATURE_FLAGS.QUERY_UX_V2] ? ' new-ui' : ''
+                            }`}
+                        >
+                            {buttonCopy || 'Action or event'}
+                        </Button>
+                    )}
+                    {customActions}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
@@ -28,17 +28,18 @@ const determineFilterLabel = (visible: boolean, filter: Partial<ActionFilter>): 
     return 'Add filters'
 }
 
-interface ActionFilterRowProps {
+export interface ActionFilterRowProps {
     logic: typeof entityFilterLogic
     filter: ActionFilter
     index: number
     hideMathSelector?: boolean
-    hidePropertySelector?: boolean
+    hidePropertySelector?: boolean // DEPRECATED: Out of use in the new horizontal UI
     singleFilter?: boolean
     showOr?: boolean
     letter?: string | null
     horizontalUI?: boolean
     filterCount: number
+    customRowPrefix?: string | JSX.Element // Custom prefix element to show in each row
 }
 
 export function ActionFilterRow({
@@ -52,6 +53,7 @@ export function ActionFilterRow({
     letter,
     horizontalUI = false,
     filterCount,
+    customRowPrefix,
 }: ActionFilterRowProps): JSX.Element {
     const node = useRef<HTMLElement>(null)
     const { selectedFilter, entities, entityFilterVisible } = useValues(logic)
@@ -139,6 +141,7 @@ export function ActionFilterRow({
                         <span>{letter}</span>
                     </Col>
                 )}
+                {customRowPrefix && <Col>{customRowPrefix}</Col>}
                 {horizontalUI && !hideMathSelector && (
                     <>
                         <Col>Showing</Col>

--- a/frontend/src/scenes/insights/ActionFilter/Sortable.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/Sortable.tsx
@@ -5,9 +5,7 @@ import {
     SortableHandle as sortableHandle,
 } from 'react-sortable-hoc'
 import { EllipsisOutlined } from '@ant-design/icons'
-import { entityFilterLogic } from './entityFilterLogic'
-import { ActionFilter } from '~/types'
-import { ActionFilterRow } from './ActionFilterRow'
+import { ActionFilterRow, ActionFilterRowProps } from './ActionFilterRow'
 
 const DragHandle = sortableHandle(() => (
     <span className="action-filter-drag-handle">
@@ -15,39 +13,12 @@ const DragHandle = sortableHandle(() => (
     </span>
 ))
 
-interface SortableActionFilterRowProps {
-    logic: typeof entityFilterLogic
-    filter: ActionFilter
-    filterIndex: number
-    hideMathSelector?: boolean
-    hidePropertySelector?: boolean
-    filterCount: number
-}
-
-export const SortableActionFilterRow = sortableElement(
-    ({
-        logic,
-        filter,
-        filterIndex,
-        hideMathSelector,
-        hidePropertySelector,
-        filterCount,
-    }: SortableActionFilterRowProps) => (
-        <div className="draggable-action-filter">
-            {filterCount > 1 && <DragHandle />}
-            <ActionFilterRow
-                logic={logic}
-                filter={filter}
-                // sortableElement requires, yet eats the index prop, so passing via filterIndex here
-                index={filterIndex}
-                key={filterIndex}
-                hideMathSelector={hideMathSelector}
-                hidePropertySelector={hidePropertySelector}
-                filterCount={filterCount}
-            />
-        </div>
-    )
-)
+export const SortableActionFilterRow = sortableElement(({ filterCount, ...props }: ActionFilterRowProps) => (
+    <div className="draggable-action-filter">
+        {filterCount > 1 && <DragHandle />}
+        <ActionFilterRow filterCount={filterCount} {...props} />
+    </div>
+))
 
 export const SortableContainer = sortableContainer(({ children }: { children: React.ReactNode }) => {
     return <div>{children}</div>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -18,7 +18,7 @@ interface FunnelTabProps extends BaseTabProps {
     newUI: boolean
 }
 
-export function FunnelTab({ annotationsToCreate, newUI }: FunnelTabProps): JSX.Element {
+export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
     useMountedLogic(funnelCommandLogic)
     const { isStepsEmpty, filters, stepsWithCount } = useValues(funnelLogic())
     const { loadResults, clearFunnel, setFilters, saveFunnelInsight } = useActions(funnelLogic())
@@ -36,7 +36,7 @@ export function FunnelTab({ annotationsToCreate, newUI }: FunnelTabProps): JSX.E
         <div data-attr="funnel-tab">
             {newUI && (
                 <Row>
-                    <InsightTitle annotations={annotationsToCreate} filters={filters} />
+                    <InsightTitle />
                 </Row>
             )}
             <form

--- a/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
@@ -1,23 +1,27 @@
 import { Button, Popconfirm } from 'antd'
 import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 import React from 'react'
-import { FilterType } from '~/types'
+import { FilterType, InsightType } from '~/types'
 import { SaveOutlined, ClearOutlined } from '@ant-design/icons'
+import { useActions } from 'kea'
+import { router } from 'kea-router'
 
 interface Props {
     filters: FilterType
     annotations: any[] // TODO: Type properly
-    onReset: () => void
+    insight?: InsightType
+    onReset?: () => void
 }
 
-export function InsightActionBar({ filters, annotations, onReset }: Props): JSX.Element {
+export function InsightActionBar({ filters, annotations, insight, onReset }: Props): JSX.Element {
+    const { push } = useActions(router)
     return (
         <div className="insights-tab-actions">
             <Popconfirm
                 title="Are you sure? This will clear all filters and any progress will be lost."
                 onConfirm={() => {
                     window.scrollTo({ top: 0 })
-                    onReset()
+                    onReset ? onReset() : push(`/insights?insight=${insight}`)
                 }}
             >
                 <Button type="link" icon={<ClearOutlined />} className="btn-reset">

--- a/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
@@ -1,0 +1,42 @@
+import { Button, Popconfirm } from 'antd'
+import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
+import React from 'react'
+import { FilterType } from '~/types'
+import { SaveOutlined, ClearOutlined } from '@ant-design/icons'
+
+interface Props {
+    filters: FilterType
+    annotations: any[] // TODO: Type properly
+    onReset: () => void
+}
+
+export function InsightActionBar({ filters, annotations, onReset }: Props): JSX.Element {
+    return (
+        <div className="insights-tab-actions">
+            <Popconfirm
+                title="Are you sure? This will clear all filters and any progress will be lost."
+                onConfirm={() => {
+                    window.scrollTo({ top: 0 })
+                    onReset()
+                }}
+            >
+                <Button type="link" icon={<ClearOutlined />} className="btn-reset">
+                    Reset all
+                </Button>
+            </Popconfirm>
+            <SaveToDashboard
+                displayComponent={
+                    <Button icon={<SaveOutlined />} className="btn-save">
+                        Save to dashboard
+                    </Button>
+                }
+                item={{
+                    entity: {
+                        filters,
+                        annotations,
+                    },
+                }}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -143,7 +143,7 @@ function HorizontalDefaultInsightDisplayConfig({
     return (
         <div className="display-config-inner">
             <span className="hide-lte-md">
-                <TZIndicator style={{ float: 'left' }} />
+                <TZIndicator style={{ float: 'left', fontSize: '0.75rem', marginRight: 16 }} placement="topRight" />
             </span>
             <div style={{ width: '100%', textAlign: 'right' }}>
                 {showComparePrevious[activeView] && <CompareFilter />}

--- a/frontend/src/scenes/insights/InsightTabs/InsightTitle.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightTitle.tsx
@@ -1,16 +1,8 @@
-import { Button } from 'antd'
-import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 import React, { useState } from 'react'
-import { SaveOutlined, DashboardOutlined } from '@ant-design/icons'
-import { FilterType } from '~/types'
+import { DashboardOutlined } from '@ant-design/icons'
 import { router } from 'kea-router'
 
-export interface InsightTitleProps {
-    filters: FilterType
-    annotations: any[] // TODO: Type properly
-}
-
-export function InsightTitle({ annotations, filters }: InsightTitleProps): JSX.Element {
+export function InsightTitle(): JSX.Element {
     const [{ fromItemName, fromDashboard }] = useState(router.values.hashParams)
     return (
         <>
@@ -21,16 +13,7 @@ export function InsightTitle({ annotations, filters }: InsightTitleProps): JSX.E
                         title="Insight saved on dashboard"
                     />
                 )}
-                {fromItemName || 'Unsaved query'}{' '}
-                <SaveToDashboard
-                    displayComponent={<Button type="link" size="small" icon={<SaveOutlined />} />}
-                    item={{
-                        entity: {
-                            filters,
-                            annotations,
-                        },
-                    }}
-                />
+                {fromItemName || 'Unsaved query'}
             </h3>
         </>
     )

--- a/frontend/src/scenes/insights/InsightTabs/PathTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTabHorizontal.tsx
@@ -16,6 +16,7 @@ import { eventDefinitionsLogic } from 'scenes/events/eventDefinitionsLogic'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { BaseTabProps } from '../Insights'
 import { InsightTitle } from './InsightTitle'
+import { InsightActionBar } from './InsightActionBar'
 
 export function PathTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX.Element {
     const { customEventNames } = useValues(eventDefinitionsLogic)
@@ -29,7 +30,7 @@ export function PathTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX.El
         <Row gutter={16}>
             <Col md={16} xs={24}>
                 <Row>
-                    <InsightTitle annotations={annotationsToCreate} filters={filter} />
+                    <InsightTitle />
                 </Row>
                 <Row gutter={8} align="middle" className="mt">
                     <Col>Showing paths from</Col>
@@ -70,6 +71,7 @@ export function PathTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX.El
                         />
                     </Col>
                 </Row>
+                <InsightActionBar filters={filter} annotations={annotationsToCreate} insight="PATHS" />
             </Col>
             <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                 <h4 className="secondary">Global Filters</h4>

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTabHorizontal.tsx
@@ -5,7 +5,12 @@ import { ActionFilterDropdown } from '../ActionFilter/ActionFilterRow/ActionFilt
 import { entityFilterLogic } from '../ActionFilter/entityFilterLogic'
 
 import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
-import { retentionTableLogic, dateOptions, retentionOptionDescriptions } from 'scenes/retention/retentionTableLogic'
+import {
+    retentionTableLogic,
+    dateOptions,
+    retentionOptionDescriptions,
+    defaultFilters,
+} from 'scenes/retention/retentionTableLogic'
 import { Button, Select, Tooltip, Row, Col, Skeleton } from 'antd'
 
 import { FilterType, RetentionType } from '~/types'
@@ -17,6 +22,7 @@ import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { IconExternalLink } from 'lib/components/icons'
 import { BaseTabProps } from '../Insights'
 import { InsightTitle } from './InsightTitle'
+import { InsightActionBar } from './InsightActionBar'
 
 export function RetentionTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX.Element {
     const node = useRef<HTMLElement>(null)
@@ -82,7 +88,7 @@ export function RetentionTabHorizontal({ annotationsToCreate }: BaseTabProps): J
             <Row gutter={16}>
                 <Col md={16} xs={24}>
                     <Row>
-                        <InsightTitle annotations={annotationsToCreate} filters={filters} />
+                        <InsightTitle />
                     </Row>
                     <Row gutter={8} align="middle">
                         <Col>
@@ -174,6 +180,12 @@ export function RetentionTabHorizontal({ annotationsToCreate }: BaseTabProps): J
                             </p>
                         </Col>
                     </Row>
+                    <InsightActionBar
+                        filters={filters}
+                        annotations={annotationsToCreate}
+                        insight="RETENTION"
+                        onReset={() => setFilters(defaultFilters({}))}
+                    />
                 </Col>
                 <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                     <h4 className="secondary">Global Filters</h4>

--- a/frontend/src/scenes/insights/InsightTabs/SessionTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/SessionTabHorizontal.tsx
@@ -11,6 +11,7 @@ import { TestAccountFilter } from '../TestAccountFilter'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { BaseTabProps } from '../Insights'
 import { InsightTitle } from './InsightTitle'
+import { InsightActionBar } from './InsightActionBar'
 
 export function SessionTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX.Element {
     const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view: ViewType.SESSIONS }))
@@ -23,7 +24,7 @@ export function SessionTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX
         <Row gutter={16}>
             <Col md={16} xs={24}>
                 <Row>
-                    <InsightTitle annotations={annotationsToCreate} filters={filters} />
+                    <InsightTitle />
                 </Row>
                 <Row gutter={8} align="middle" className="mb">
                     <Col>Showing</Col>
@@ -42,6 +43,7 @@ export function SessionTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX
                     showOr={true}
                     horizontalUI
                 />
+                <InsightActionBar filters={filters} annotations={annotationsToCreate} insight="SESSIONS" />
             </Col>
             <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                 <h4 className="secondary">Global Filters</h4>

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -55,7 +55,14 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
                             buttonCopy="Add graph series"
                             showLetters={isUsingFormulas}
                             singleFilter={filters.insight === ViewType.LIFECYCLE}
-                            hidePropertySelector={filters.insight === ViewType.LIFECYCLE}
+                            hideMathSelector={filters.insight === ViewType.LIFECYCLE}
+                            customRowPrefix={
+                                filters.insight === ViewType.LIFECYCLE ? (
+                                    <>
+                                        Showing <b>Unique users</b> who did
+                                    </>
+                                ) : undefined
+                            }
                         />
                     )}
                 </Col>

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -18,14 +18,12 @@ import { TrendTabProps } from './TrendTab'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { InsightTitle } from '../InsightTitle'
 import { InsightActionBar } from '../InsightActionBar'
-import { router } from 'kea-router'
 
 export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps): JSX.Element {
     const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
     const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
-    const { push } = useActions(router)
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
     const { toggleLifecycle } = useActions(trendsLogic)
     const lifecycles = [
@@ -68,11 +66,7 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
                             }
                         />
                     )}
-                    <InsightActionBar
-                        filters={filters}
-                        annotations={annotationsToCreate}
-                        onReset={() => push(`/insights?insight=${filters.insight}`)}
-                    />
+                    <InsightActionBar filters={filters} annotations={annotationsToCreate} insight={filters.insight} />
                 </Col>
                 <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                     {filters.insight === ViewType.LIFECYCLE && (

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -17,12 +17,15 @@ import './TrendTab.scss'
 import { TrendTabProps } from './TrendTab'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { InsightTitle } from '../InsightTitle'
+import { InsightActionBar } from '../InsightActionBar'
+import { router } from 'kea-router'
 
 export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps): JSX.Element {
     const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
     const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
+    const { push } = useActions(router)
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
     const { toggleLifecycle } = useActions(trendsLogic)
     const lifecycles = [
@@ -43,7 +46,7 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
         <>
             <Row gutter={16}>
                 <Col md={16} xs={24}>
-                    <InsightTitle annotations={annotationsToCreate} filters={filters} />
+                    <InsightTitle />
                     {filtersLoading ? (
                         <Skeleton active />
                     ) : (
@@ -65,6 +68,11 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
                             }
                         />
                     )}
+                    <InsightActionBar
+                        filters={filters}
+                        annotations={annotationsToCreate}
+                        onReset={() => push(`/insights?insight=${filters.insight}`)}
+                    />
                 </Col>
                 <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                     {filters.insight === ViewType.LIFECYCLE && (

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -79,6 +79,24 @@
         }
     }
 
+    .insights-tab-actions {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        text-align: right;
+        .btn-reset {
+            color: rgba($danger, 0.8);
+        }
+        .btn-save {
+            border-color: $primary;
+            color: $primary;
+            &:hover {
+                border-color: darken($primary, 30%);
+                color: darken($primary, 30%);
+            }
+        }
+    }
+
     .retention-date-picker {
         background-color: transparent;
         border: 0;

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -293,7 +293,7 @@ export function Insights(): JSX.Element {
                                 className="insights-graph-container"
                             >
                                 <div>
-                                    {lastRefresh && (
+                                    {lastRefresh && dayjs().subtract(3, 'minutes') > dayjs(lastRefresh) && (
                                         <small style={{ position: 'absolute', marginTop: -21, right: 24 }}>
                                             Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
                                             <Button

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -341,7 +341,7 @@ export function Insights(): JSX.Element {
                                 !showTimeoutMessage &&
                                 activeView === ViewType.FUNNELS &&
                                 allFilters.display === FUNNEL_VIZ && (
-                                    <Card>
+                                    <Card style={{ marginTop: 16 }}>
                                         <FunnelPeople />
                                     </Card>
                                 )}
@@ -349,7 +349,7 @@ export function Insights(): JSX.Element {
                                 allFilters.display === ACTIONS_LINE_GRAPH_LINEAR ||
                                 allFilters.display === ACTIONS_LINE_GRAPH_CUMULATIVE) &&
                                 (activeView === ViewType.TRENDS || activeView === ViewType.SESSIONS) && (
-                                    <Card>
+                                    <Card style={{ marginTop: 16 }}>
                                         <BindLogic
                                             logic={trendsLogic}
                                             props={{ dashboardItemId: null, view: activeView }}

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -31,7 +31,7 @@ export const retentionOptionDescriptions = {
 }
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
-function defaultFilters(filters: Record<string, any>): Record<string, any> {
+export function defaultFilters(filters: Record<string, any>): Record<string, any> {
     return {
         target_entity: filters.target_entity || {
             id: '$pageview',


### PR DESCRIPTION
## Changes

This PR implements improvements to the querying experience based on feedback from usability tests.
1. Reduces prominence of timezone indicator. "Feels like this is something I should care about / spend time figuring out, when most of the time I won't need it".
2. Removes the math property selector from lifecycle. Lifecycle only works with Unique users.
3. Only shows last refreshed label if insight was refreshed more than 3 minutes ago. It's the same case as (1), one less thing to care about. Also, we realized that users instinctively click it if it's there.
4. Adds an action bar to each insight where a user can:
    - Save to dashboard. This is now clear, as users couldn't find the previous save button.
    - Reset all filters. Repeatedly requested/expected. 

<img width="1300" alt="" src="https://user-images.githubusercontent.com/5864173/118228353-e3567c00-b43e-11eb-9a9c-93e091105746.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
