### PR TITLE
Consider all licenses when computing max users

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -70,7 +70,7 @@ def get_max_users() -> Optional[int]:
     Returns the maximum number of users allowed.
     Examines all available valid licenses and returns the max users available.
     """
-    licenses = License.objects.all()
+    licenses = License.objects.filter(valid_until__gte=timezone.now())
     if len(licenses) > 0:
         return max([l.max_users for l in licenses])
     else:

--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -93,5 +93,3 @@ def get_licensed_users_available() -> Optional[int]:
 
         users_left = max_users - get_user_model().objects.count() - OrganizationInvite.objects.count()
         return max(users_left, 0)
-
-    return None

--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional, cast
 
 import requests
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
@@ -72,6 +73,9 @@ def get_max_users() -> Optional[int]:
     Returns the maximum number of users allowed.
     Examines all available valid licenses and returns the max users available.
     """
+    if settings.MULTI_TENANCY:
+        return None
+
     user_limits = [l.max_users for l in License.objects.filter(valid_until__gte=timezone.now())]
     if None in user_limits:
         return None

--- a/ee/models/test/test_license.py
+++ b/ee/models/test/test_license.py
@@ -26,6 +26,7 @@ def create_license(mocker: MockerFixture):
     return _inner
 
 
+@pytest.mark.skip_on_multitenancy
 def test_default_get_licensed_users_available(db):
     assert get_licensed_users_available() == 3
 

--- a/ee/models/test/test_license.py
+++ b/ee/models/test/test_license.py
@@ -1,0 +1,54 @@
+import datetime
+from unittest.mock import Mock
+
+import pytest
+from django.utils import timezone
+from pytest_mock.plugin import MockerFixture
+
+from ee.models.license import License, get_licensed_users_available
+from posthog.models import User
+
+
+@pytest.fixture
+def create_license(mocker: MockerFixture):
+    def _inner(key, max_users):
+        mock = Mock()
+        mock.ok = True
+        mock.json.return_value = {
+            "plan": key,
+            "valid_until": (timezone.now() + datetime.timedelta(days=10)).isoformat().replace("+00:00", "Z"),
+            "max_users": max_users,
+        }
+
+        mocker.patch("ee.models.license.requests.post", return_value=mock)
+        License.objects.create(key=key)
+
+    return _inner
+
+
+def test_default_get_licensed_users_available(db):
+    assert get_licensed_users_available() == 3
+
+
+def test_uses_max_value_from_license(db, create_license):
+    create_license("foo", max_users=2)
+    create_license("bar", max_users=4)
+
+    assert get_licensed_users_available() == 4
+
+    create_license("unlimited", max_users=None)
+
+    assert get_licensed_users_available() is None
+
+
+def test_get_users_available_when_users_exist(db, create_license):
+    create_license("bar", max_users=4)
+
+    User.objects.create(email="test@posthog.com")
+    User.objects.create(email="test2@posthog.com")
+
+    assert get_licensed_users_available() == 2
+
+    create_license("unlimited", max_users=None)
+
+    assert get_licensed_users_available() is None

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -37,7 +37,7 @@ class TestPreflight(APIBaseTest):
         )
 
     def test_preflight_request(self):
-        with self.settings(MULTI_TENANCY=False):
+        with self.settings(MULTI_TENANCY=False, PRIMARY_DB=RDBMS.POSTGRES):
             response = self.client.get("/_preflight/")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response = response.json()
@@ -62,7 +62,7 @@ class TestPreflight(APIBaseTest):
                     "email_service_available": False,
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
-                    "licensed_users_available": 2,
+                    "licensed_users_available": None,
                     "site_url": "http://localhost:8000",
                 },
             )
@@ -167,6 +167,7 @@ class TestPreflight(APIBaseTest):
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
 
     @pytest.mark.ee
+    @pytest.mark.skip_on_multitenancy
     def test_ee_preflight_with_users_limit(self):
 
         from ee.models.license import License, LicenseManager

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -62,7 +62,7 @@ class TestPreflight(APIBaseTest):
                     "email_service_available": False,
                     "is_debug": False,
                     "is_event_property_usage_enabled": False,
-                    "licensed_users_available": None,
+                    "licensed_users_available": 2,
                     "site_url": "http://localhost:8000",
                 },
             )


### PR DESCRIPTION
## Changes

We need to bump the max users on a client and this is keeping the new license from taking effect.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
