### PR TITLE
Refactor insights endpoint to use new router logic

### DIFF
--- a/ee/clickhouse/test/test_middleware.py
+++ b/ee/clickhouse/test/test_middleware.py
@@ -6,7 +6,7 @@ class TestQueryMiddleware(APILicensedTest):
     def test_query(self):
         self.user.is_staff = True
         self.user.save()
-        response = self.client.get('/api/insight/trend/?events=[{"id": "$pageview"}]')
+        response = self.client.get('/api/projects/@current/insight/trend/?events=[{"id": "$pageview"}]')
         self.assertEqual(response.status_code, 200)
         response = self.client.get("/api/debug_ch_queries/").json()
         self.assertIn("SELECT", response[0]["query"])  # type: ignore
@@ -14,7 +14,7 @@ class TestQueryMiddleware(APILicensedTest):
         #  Test saving queries if we're impersonating a user
         user2 = User.objects.create_and_join(organization=self.organization, email="test", password="bla")
         self.client.post("/admin/login/user/{}/".format(user2.pk))
-        self.client.get('/api/insight/trend/?events=[{"id": "$pageleave"}]')
+        self.client.get('/api/projects/@current/insight/trend/?events=[{"id": "$pageleave"}]')
 
         response = self.client.get("/api/debug_ch_queries/").json()
         self.assertIn("SELECT", response[0]["query"])  # type: ignore

--- a/frontend/src/lib/components/AppEditorLink/appUrlsLogic.ts
+++ b/frontend/src/lib/components/AppEditorLink/appUrlsLogic.ts
@@ -30,7 +30,8 @@ export const appUrlsLogic = kea<appUrlsLogicType<TrendResult>>({
                     breakdown: '$current_url',
                     date_from: dayjs().subtract(3, 'days').toISOString(),
                 }
-                const result = (await api.get('api/insight/trend/?' + toParams(params))).result as TrendResult[]
+                const result = (await api.get('api/projects/@current/insight/trend/?' + toParams(params)))
+                    .result as TrendResult[]
                 if (result && result[0]?.count === 0) {
                     return []
                 }

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
@@ -81,7 +81,7 @@ export function SaveToDashboardModal({
     async function save(event) {
         event.preventDefault()
         if (newItem) {
-            const response = await api.create('api/insight', {
+            const response = await api.create('api/projects/@current/insight', {
                 filters,
                 name,
                 dashboard: dashboardId,
@@ -98,7 +98,7 @@ export function SaveToDashboardModal({
                 }
             }
         } else {
-            await api.update(`api/insight/${fromItem}`, { filters })
+            await api.update(`api/projects/@current/insight/${fromItem}`, { filters })
         }
         toast(
             <div data-attr="success-toast">

--- a/frontend/src/models/dashboardItemsModel.tsx
+++ b/frontend/src/models/dashboardItemsModel.tsx
@@ -28,7 +28,7 @@ export const dashboardItemsModel = kea<dashboardItemsModelType<DashboardItemType
                 value: item.name,
                 error: 'You must enter name',
                 success: async (name: string) => {
-                    item = await api.update(`api/insight/${item.id}`, { name })
+                    item = await api.update(`api/projects/@current/insight/${item.id}`, { name })
                     toast('Succesfully renamed item')
                     actions.renameDashboardItemSuccess(item)
                 },
@@ -46,12 +46,12 @@ export const dashboardItemsModel = kea<dashboardItemsModelType<DashboardItemType
 
             const { id: _discard, ...rest } = item // eslint-disable-line
             const newItem = dashboardId ? { ...rest, dashboard: dashboardId, layouts } : { ...rest, layouts }
-            const addedItem = await api.create('api/insight', newItem)
+            const addedItem = await api.create('api/projects/@current/insight', newItem)
 
             const dashboard = dashboardId ? dashboardsModel.values.rawDashboards[dashboardId] : null
 
             if (move) {
-                const deletedItem = await api.update(`api/insight/${item.id}`, {
+                const deletedItem = await api.update(`api/projects/@current/insight/${item.id}`, {
                     deleted: true,
                 })
                 dashboardsModel.actions.updateDashboardItem(deletedItem)
@@ -68,8 +68,8 @@ export const dashboardItemsModel = kea<dashboardItemsModelType<DashboardItemType
                             onClick={async () => {
                                 toast.dismiss(toastId)
                                 const [restoredItem, removedItem] = await Promise.all([
-                                    api.update(`api/insight/${item.id}`, { deleted: false }),
-                                    api.update(`api/insight/${addedItem.id}`, {
+                                    api.update(`api/projects/@current/insight/${item.id}`, { deleted: false }),
+                                    api.update(`api/projects/@current/insight/${addedItem.id}`, {
                                         deleted: true,
                                     }),
                                 ])

--- a/frontend/src/models/funnelsModel.ts
+++ b/frontend/src/models/funnelsModel.ts
@@ -24,7 +24,7 @@ export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>
             __default: [] as SavedFunnel[],
             loadFunnels: async () => {
                 const response = await api.get(
-                    'api/insight/?' +
+                    'api/projects/@current/insight/?' +
                         toParams({
                             order: '-created_at',
                             saved: true,
@@ -37,7 +37,7 @@ export const funnelsModel = kea<funnelsModelType<SavedFunnel, DashboardItemType>
                 return results
             },
             deleteFunnel: async (funnelId: number) => {
-                await api.delete(`api/insight/${funnelId}`)
+                await api.delete(`api/projects/@current/insight/${funnelId}`)
                 return values.funnels.filter((funnel) => funnel.id !== funnelId)
             },
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -305,7 +305,7 @@ export const dashboardLogic = kea({
             })
         },
         updateItemColor: ({ id, color }) => {
-            api.update(`api/insight/${id}`, { color })
+            api.update(`api/projects/@current/insight/${id}`, { color })
         },
         refreshAllDashboardItems: async (_, breakpoint) => {
             await breakpoint(100)

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -15,12 +15,12 @@ function wait(ms = 1000) {
 const SECONDS_TO_POLL = 3 * 60
 
 async function pollFunnel(params = {}) {
-    let result = await api.get('api/insight/funnel/?' + toParams(params))
+    let result = await api.get('api/projects/@current/insight/funnel/?' + toParams(params))
     let start = window.performance.now()
     while (result.result.loading && (window.performance.now() - start) / 1000 < SECONDS_TO_POLL) {
         await wait()
         const { refresh: _, ...restParams } = params // eslint-disable-line
-        result = await api.get('api/insight/funnel/?' + toParams(restParams))
+        result = await api.get('api/projects/@current/insight/funnel/?' + toParams(restParams))
     }
     // if endpoint is still loading after 3 minutes just return default
     if (result.loading) {
@@ -189,7 +189,7 @@ export const funnelLogic = kea({
             insightLogic.actions.setLastRefresh(false)
         },
         saveFunnelInsight: async ({ name }) => {
-            await api.create('api/insight', {
+            await api.create('api/projects/@current/insight', {
                 filters: values.filters,
                 name,
                 saved: true,

--- a/frontend/src/scenes/insights/InsightHistoryPanel/insightHistoryLogic.ts
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/insightHistoryLogic.ts
@@ -36,7 +36,7 @@ export const insightHistoryLogic = kea<insightHistoryLogicType<DashboardItemType
             __default: [] as DashboardItemType[],
             loadInsights: async () => {
                 const response = await api.get(
-                    'api/insight/?' +
+                    'api/projects/@current/insight/?' +
                         toParams({
                             order: '-created_at',
                             limit: 20,
@@ -51,7 +51,7 @@ export const insightHistoryLogic = kea<insightHistoryLogicType<DashboardItemType
             __default: [] as DashboardItemType[],
             loadSavedInsights: async () => {
                 const response = await api.get(
-                    'api/insight/?' +
+                    'api/projects/@current/insight/?' +
                         toParams({
                             order: '-created_at',
                             saved: true,
@@ -67,7 +67,7 @@ export const insightHistoryLogic = kea<insightHistoryLogicType<DashboardItemType
             __default: [] as DashboardItemType[],
             loadTeamInsights: async () => {
                 const response = await api.get(
-                    'api/insight/?' +
+                    'api/projects/@current/insight/?' +
                         toParams({
                             order: '-created_at',
                             saved: true,
@@ -155,12 +155,12 @@ export const insightHistoryLogic = kea<insightHistoryLogicType<DashboardItemType
     },
     listeners: ({ actions, values }) => ({
         createInsight: async ({ filters }) => {
-            await api.create('api/insight', {
+            await api.create('api/projects/@current/insight', {
                 filters,
             })
         },
         updateInsight: async ({ insight }) => {
-            await api.update(`api/insight/${insight.id}`, insight)
+            await api.update(`api/projects/@current/insight/${insight.id}`, insight)
             toast('Saved Insight')
             actions.updateInsightSuccess(insight)
         },

--- a/frontend/src/scenes/insights/Trends.cy-spec.js
+++ b/frontend/src/scenes/insights/Trends.cy-spec.js
@@ -23,7 +23,9 @@ describe('<Insights /> trends', () => {
         cy.intercept('/api/action/', { fixture: 'api/action/actions' })
         cy.intercept('/api/cohort/', { fixture: 'api/cohort/cohorts' })
         cy.intercept('/api/person/properties/', { fixture: 'api/person/properties' })
-        cy.interceptLazy('/api/insight/', () => ({ fixture: 'api/insight/trends' })).as('api_insight')
+        cy.interceptLazy('/api/projects/@current/insight/', () => ({
+            fixture: 'api/insight/trends',
+        })).as('api_insight')
 
         helpers.mockPosthog()
     })
@@ -75,7 +77,9 @@ describe('<Insights /> trends', () => {
     it('can render bar graphs', () => {
         mountAndCheckAPI()
 
-        cy.overrideInterceptLazy('/api/insight/', () => ({ fixture: 'api/insight/trends/breakdown' }))
+        cy.overrideInterceptLazy('/api/projects/@current/insight/', () => ({
+            fixture: 'api/projects/@current/insight/trends/breakdown',
+        }))
 
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=prop-breakdown-select]').click().type('Browser').type('{enter}')

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -74,7 +74,7 @@ export const pathsLogic = kea<pathsLogicType<PathResult, PropertyFilter, FilterT
                 let paths
                 insightLogic.actions.startQuery()
                 try {
-                    paths = await api.get(`api/insight/path${params ? `/?${params}` : ''}`)
+                    paths = await api.get(`api/projects/@current/insight/path${params ? `/?${params}` : ''}`)
                 } catch (e) {
                     insightLogic.actions.endQuery(ViewType.PATHS, null, e)
                     return { paths: [], filter, error: true }

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -72,7 +72,7 @@ export const retentionTableLogic = kea<
                 let res
                 const urlParams = toParams({ ...values.filters, ...(refresh ? { refresh: true } : {}) })
                 try {
-                    res = await api.get(`api/insight/retention/?${urlParams}`)
+                    res = await api.get(`api/projects/@current/insight/retention/?${urlParams}`)
                 } catch (e) {
                     insightLogic.actions.endQuery(ViewType.RETENTION, null, e)
                     return []

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -167,13 +167,13 @@ export const trendsLogic = kea<
                 try {
                     if (values.filters?.insight === ViewType.SESSIONS || values.filters?.session) {
                         response = await api.get(
-                            'api/insight/session/?' +
+                            'api/projects/@current/insight/session/?' +
                                 (refresh ? 'refresh=true&' : '') +
                                 toAPIParams(filterClientSideParams(values.filters))
                         )
                     } else {
                         response = await api.get(
-                            'api/insight/trend/?' +
+                            'api/projects/@current/insight/trend/?' +
                                 (refresh ? 'refresh=true&' : '') +
                                 toAPIParams(filterClientSideParams(values.filters))
                         )

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -99,16 +99,17 @@ if is_clickhouse_enabled():
         # legacy endpoints (to be removed eventually)
         router.register(r"action", LegacyClickhouseActionsViewSet, basename="action")
         router.register(r"event", ClickhouseEventsViewSet, basename="event")
-        router.register(r"insight", ClickhouseInsightsViewSet, basename="insight")
         router.register(r"person", ClickhousePersonViewSet, basename="person")
         router.register(r"paths", ClickhousePathsViewSet, basename="paths")
         router.register(r"element", ClickhouseElementViewSet, basename="element")
         router.register(r"cohort", ClickhouseCohortViewSet, basename="cohort")
         # nested endpoints
         projects_router.register(r"actions", ClickhouseActionsViewSet, "project_actions", ["team_id"])
+        projects_router.register(
+            r"insight", ClickhouseInsightsViewSet, "project_insights", ["team_id"],
+        )
 else:
     # legacy endpoints (to be removed eventually)
-    router.register(r"insight", insight.InsightViewSet)
     router.register(r"action", action.LegacyActionViewSet)
     router.register(r"person", person.PersonViewSet)
     router.register(r"event", event.EventViewSet)
@@ -117,3 +118,4 @@ else:
     router.register(r"cohort", cohort.CohortViewSet)
     # nested endpoints
     projects_router.register(r"actions", action.ActionViewSet, "project_actions", ["team_id"])
+    projects_router.register(r"insight", insight.InsightViewSet, "project_insights", ["team_id"])

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -88,8 +88,6 @@ class InsightSerializer(serializers.ModelSerializer):
 
 
 class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = DashboardItem.objects.all()
     serializer_class = InsightSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions]

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -130,7 +130,7 @@ class TestDashboard(APIBaseTest):
 
         # cache results
         response = self.client.get(
-            "/api/insight/trend/?events=%s&properties=%s"
+            "/api/projects/@current/insight/trend/?events=%s&properties=%s"
             % (json.dumps(filter_dict["events"]), json.dumps(filter_dict["properties"]))
         )
         self.assertEqual(response.status_code, 200)
@@ -273,7 +273,7 @@ class TestDashboard(APIBaseTest):
             dashboard=dashboard, filters=filter.to_dict(), team=self.team,
         )
         self.client.get(
-            "/api/insight/trend/?events=%s&properties=%s&date_from=-7d"
+            "/api/projects/@current/insight/trend/?events=%s&properties=%s&date_from=-7d"
             % (json.dumps(filter_dict["events"]), json.dumps(filter_dict["properties"]))
         )
         patch_response = self.client.patch(
@@ -283,7 +283,7 @@ class TestDashboard(APIBaseTest):
 
         # cache results
         response = self.client.get(
-            "/api/insight/trend/?events=%s&properties=%s&date_from=-24h"
+            "/api/projects/@current/insight/trend/?events=%s&properties=%s&date_from=-24h"
             % (json.dumps(filter_dict["events"]), json.dumps(filter_dict["properties"]))
         )
         self.assertEqual(response.status_code, 200)

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -33,7 +33,7 @@ def insight_test_factory(event_factory, person_factory):
             # create without user
             DashboardItem.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team)
 
-            response = self.client.get("/api/insight/", data={"user": "true"}).json()
+            response = self.client.get("/api/projects/@current/insight/", data={"user": "true"}).json()
 
             self.assertEqual(len(response["results"]), 1)
 
@@ -55,14 +55,16 @@ def insight_test_factory(event_factory, person_factory):
             # create without user
             DashboardItem.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team)
 
-            response = self.client.get("/api/insight/", data={"saved": "true", "user": "true",},).json()
+            response = self.client.get(
+                "/api/projects/@current/insight/", data={"saved": "true", "user": "true",},
+            ).json()
 
             self.assertEqual(len(response["results"]), 1)
 
         def test_create_insight_items(self):
             # Make sure the endpoint works with and without the trailing slash
             self.client.post(
-                "/api/insight",
+                "/api/projects/@current/insight",
                 data={
                     "filters": {
                         "events": [{"id": "$pageview"}],
@@ -86,7 +88,7 @@ def insight_test_factory(event_factory, person_factory):
 
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = self.client.get(
-                    "/api/insight/trend/?events={}".format(json.dumps([{"id": "$pageview"}]))
+                    "/api/projects/@current/insight/trend/?events={}".format(json.dumps([{"id": "$pageview"}]))
                 ).json()
 
             self.assertEqual(response["result"][0]["count"], 2)
@@ -102,7 +104,7 @@ def insight_test_factory(event_factory, person_factory):
 
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 response = self.client.get(
-                    "/api/insight/trend/",
+                    "/api/projects/@current/insight/trend/",
                     data={
                         "events": json.dumps([{"id": "$pageview"}]),
                         "breakdown": "$some_property",
@@ -121,7 +123,7 @@ def insight_test_factory(event_factory, person_factory):
                 properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
             )
 
-            response = self.client.get("/api/insight/path",).json()
+            response = self.client.get("/api/projects/@current/insight/path",).json()
             self.assertEqual(len(response["result"]), 1)
 
         # TODO: remove this check
@@ -131,7 +133,7 @@ def insight_test_factory(event_factory, person_factory):
             def test_insight_funnels_basic(self):
                 event_factory(team=self.team, event="user signed up", distinct_id="1")
                 response = self.client.get(
-                    "/api/insight/funnel/?events={}".format(
+                    "/api/projects/@current/insight/funnel/?events={}".format(
                         json.dumps([{"id": "user signed up", "type": "events", "order": 0},])
                     )
                 ).json()
@@ -153,7 +155,7 @@ def insight_test_factory(event_factory, person_factory):
                     distinct_id="person1",
                     timestamp=timezone.now() - timedelta(days=10),
                 )
-                response = self.client.get("/api/insight/retention/",).json()
+                response = self.client.get("/api/projects/@current/insight/retention/",).json()
 
                 self.assertEqual(len(response["result"]), 11)
 

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -91,25 +91,25 @@ def paths_test_factory(paths, event_factory, person_factory):
             with freeze_time("2012-01-15T03:21:34.000Z"):
                 date_from = now() - relativedelta(days=7)
                 response = self.client.get(
-                    "/api/insight/path/?insight=PATHS&date_from=" + date_from.strftime("%Y-%m-%d")
+                    "/api/projects/@current/insight/path/?insight=PATHS&date_from=" + date_from.strftime("%Y-%m-%d")
                 ).json()
                 self.assertEqual(len(response["result"]), 4)
 
                 date_to = now()
                 response = self.client.get(
-                    "/api/insight/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
+                    "/api/projects/@current/insight/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
                 ).json()
                 self.assertEqual(len(response["result"]), 4)
 
                 date_from = now() + relativedelta(days=7)
                 response = self.client.get(
-                    "/api/insight/path/?insight=PATHS&date_from=" + date_from.strftime("%Y-%m-%d")
+                    "/api/projects/@current/insight/path/?insight=PATHS&date_from=" + date_from.strftime("%Y-%m-%d")
                 ).json()
                 self.assertEqual(len(response["result"]), 0)
 
                 date_to = now() - relativedelta(days=7)
                 response = self.client.get(
-                    "/api/insight/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
+                    "/api/projects/@current/insight/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
                 ).json()
                 self.assertEqual(len(response["result"]), 0)
 
@@ -431,7 +431,7 @@ def paths_test_factory(paths, event_factory, person_factory):
                 properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team,
             )
 
-            response = self.client.get("/api/insight/path/?type=%24pageview&start=%2Fpricing").json()
+            response = self.client.get("/api/projects/@current/insight/path/?type=%24pageview&start=%2Fpricing").json()
 
             response = paths().run(
                 team=self.team, filter=PathFilter(data={"path_type": "$pageview", "start_point": "/pricing"}),


### PR DESCRIPTION
## Changes

Needed for some new dashboarding schenanigans.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
