### PR TITLE
Fix how we measure clickhouse query time

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -130,7 +130,7 @@ else:
                 raise e
             finally:
                 execution_time = time() - start_time
-                statsd.gauge("clickhouse_sync_execution_time", execution_time * 1000.0, tags=tags)
+                statsd.timing("clickhouse_sync_execution_time", execution_time * 1000.0, tags=tags)
                 if app_settings.SHELL_PLUS_PRINT_SQL:
                     print(format_sql(query, args))
                     print("Execution time: %.6fs" % (execution_time,))


### PR DESCRIPTION
Previously a gauge was used. From statsd definitions:

```
StatsD also supports gauges. A gauge will take on the arbitrary value assigned to it, and will maintain its value until it is next set.

gaugor:333|g
If the gauge is not updated at the next flush, it will send the previous value. You can opt to send no metric at all for this gauge, by setting config.deleteGauges
```

This is not appropriate for what we're trying to do (measure all
queries). This change fixes things.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
