### PR TITLE
Add plugin server tests

### DIFF
--- a/.github/workflows/plugin-server-tests.yml
+++ b/.github/workflows/plugin-server-tests.yml
@@ -1,0 +1,80 @@
+name: Plugin Server Tests
+
+on:
+    - pull_request
+
+jobs:
+    tests-postgres-1:
+        name: Tests / Postgres + Redis (1)
+        runs-on: ubuntu-20.04
+
+        services:
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: test_posthog
+                ports: ['5432:5432']
+                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+            redis:
+                image: redis
+                ports:
+                    - '6379:6379'
+                options: >-
+                    --health-cmd "redis-cli ping"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+
+        env:
+            REDIS_URL: 'redis://localhost'
+
+        steps:
+            - name: Check out Django server for database setup
+              uses: actions/checkout@v2
+              with:
+                  path: 'posthog/'
+
+            - name: Check out plugin server
+              uses: actions/checkout@v2
+              with:
+                  repository: 'PostHog/plugin-server'
+                  path: 'plugin-server/'
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.8
+
+            - name: Set up Node 14
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ env.pythonLocation }}
+                  key: ${{ env.pythonLocation }}-v1-${{ hashFiles('posthog/requirements.txt') }}
+
+            - name: Install requirements.txt dependencies with pip
+              run: |
+                  pip install --upgrade pip
+                  pip install --upgrade --upgrade-strategy eager -r posthog/requirements.txt
+
+            - name: Set up databases
+              env:
+                  SECRET_KEY: 'abcdef' # unsafe - for testing only
+                  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/posthog'
+                  TEST: 'true'
+              run: python posthog/manage.py setup_test_environment
+
+            - name: Install package.json dependencies with Yarn
+              run: cd plugin-server && yarn && ls && pwd
+
+            - name: Test with Jest
+              env:
+                  # Below DB name has `test_` prepended, as that's how Django (ran above) creates the test DB
+                  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/test_posthog'
+                  REDIS_URL: 'redis://localhost'
+              run: ls && pwd && cd plugin-server && yarn test:postgres:1

--- a/.github/workflows/plugin-server-tests.yml
+++ b/.github/workflows/plugin-server-tests.yml
@@ -113,13 +113,13 @@ jobs:
             - name: Check out Django server for database setup
               uses: actions/checkout@v2
               with:
-                  repository: 'PostHog/posthog'
                   path: 'posthog/'
 
             - name: Check out plugin server
               uses: actions/checkout@v2
               with:
-                  path: 'plugin-server'
+                  repository: 'PostHog/plugin-server'
+                  path: 'plugin-server/'
 
             - name: Fix Kafka Hostname
               run: |

--- a/.github/workflows/plugin-server-tests.yml
+++ b/.github/workflows/plugin-server-tests.yml
@@ -78,3 +78,94 @@ jobs:
                   DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/test_posthog'
                   REDIS_URL: 'redis://localhost'
               run: ls && pwd && cd plugin-server && yarn test:postgres:1
+
+    tests-clickhouse-1:
+        name: Tests / ClickHouse + Kafka (1)
+        runs-on: ubuntu-20.04
+
+        services:
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: test_posthog
+                ports: ['5432:5432']
+                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+            redis:
+                image: redis
+                ports:
+                    - '6379:6379'
+                options: >-
+                    --health-cmd "redis-cli ping"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+
+        env:
+            REDIS_URL: 'redis://localhost'
+            CLICKHOUSE_HOST: 'localhost'
+            CLICKHOUSE_DATABASE: 'posthog_test'
+            KAFKA_ENABLED: 'true'
+            KAFKA_HOSTS: 'kafka:9092'
+
+        steps:
+            - name: Check out Django server for database setup
+              uses: actions/checkout@v2
+              with:
+                  repository: 'PostHog/posthog'
+                  path: 'posthog/'
+
+            - name: Check out plugin server
+              uses: actions/checkout@v2
+              with:
+                  path: 'plugin-server'
+
+            - name: Fix Kafka Hostname
+              run: |
+                  sudo bash -c 'echo "127.0.0.1 kafka zookeeper" >> /etc/hosts'
+                  ping -c 1 kafka
+                  ping -c 1 zookeeper
+
+            - name: Start Kafka, ClickHouse, Zookeeper
+              run: |
+                  cd posthog/ee
+                  docker-compose -f docker-compose.ch.yml up -d zookeeper kafka clickhouse
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.8
+
+            - name: Set up Node 14
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+
+            - uses: actions/cache@v2
+              with:
+                  path: ${{ env.pythonLocation }}
+                  key: ${{ env.pythonLocation }}-v1-${{ hashFiles('posthog/requirements.txt') }}
+
+            - name: Install requirements.txt dependencies with pip
+              run: |
+                  pip install --upgrade pip
+                  pip install --upgrade --upgrade-strategy eager -r posthog/requirements.txt
+
+            - name: Set up databases
+              env:
+                  SECRET_KEY: 'abcdef' # unsafe - for testing only
+                  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/posthog'
+                  PRIMARY_DB: 'clickhouse'
+                  TEST: 'true'
+              run: python posthog/manage.py setup_test_environment
+
+            - name: Install package.json dependencies with Yarn
+              run: cd plugin-server && yarn
+
+            - name: Test with Jest
+              env:
+                  # Below DB name has `test_` prepended, as that's how Django (ran above) creates the test DB
+                  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/test_posthog'
+                  REDIS_URL: 'redis://localhost'
+              run: cd plugin-server && yarn test:clickhouse:1

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -101,6 +101,7 @@ export function Insights(): JSX.Element {
 
     return (
         <div className={`insights-page${horizontalUI ? ' horizontal-ui' : ''}`}>
+            <PageHeader title="Insights" />
             {newUI && <PageHeader title="Insights" />}
             <Row justify="space-between" align="middle" className="top-bar">
                 <Tabs


### PR DESCRIPTION
## Changes

~~**WIP**.~~

Testing running a subset of plugin server tests here just to confirm things like migrations here won't break anything over there. Ofc won't run the entire test suite.

EDIT:

Let's get this in once plugin tests are de-flaked only. The idea is to run PSQL 1 and CH 1 just to get an idea of things. This is a bit arbitrary, so happy to dig into this deeper later and specify a specific test suite to run here. Probably we can ignore most plugin server stuff and focus on query testing to watch for schema changes.

Another approach is to write a bot to tell people with migrations in their PRs to make sure plugin-server will be fine with it.

EDIT 2: 

Context: https://github.com/PostHog/plugin-server/pull/383

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
