### PR TITLE
Start frontend with docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,11 +38,11 @@ services:
             - redis:redis
         ports:
             - '8000:8000'
-    #frontend:
-    #<<: *backend
-    #command: ./bin/docker-frontend
-    #ports:
-    #- '8234:8234'
+    frontend:
+        <<: *backend
+        command: ./bin/docker-frontend
+        ports:
+            - '8234:8234'
     worker:
         <<: *backend
         command: ./bin/docker-worker


### PR DESCRIPTION
Start the frontend with docker for local dev

## Changes

- Starting the frontend was commented out for performance but it's confusing our users so I've reverted that change.

## Solutions

- You can easily turn off frontend by specifying the services you want to start at the command line