### PR TITLE
Adding shadows to cards in general for better  (Insights, 

### DIFF
--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -1,5 +1,9 @@
 @import '~/vars';
 
+.ant-card-bordered {
+    @extend .card_style;
+}
+
 .insights-page {
     .top-bar {
         .ant-tabs,
@@ -28,11 +32,14 @@
 
     .insight-controls {
         overflow: visible;
+        // @extend .card_style;
     }
 
     .insights-graph-container {
+        // @extend .card_style;
         .ant-card-head {
-            background-color: rgba(0, 0, 0, 0.03);
+            background-color: #f9f9f9;
+            border-bottom: 1px solid #e4e4e4;
         }
     }
 

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -73,6 +73,12 @@ $dusk_sky: linear-gradient(180deg, #20305a 0%, #373088 33.85%, #d05783 100%);
 $night_sky: linear-gradient(180deg, #200c39 0%, #373088 75%, #4a3587 100%);
 $space: linear-gradient(180deg, #0a092a 0%, #271955 100%);
 
+//card-shadows
+.card_style {
+    border-radius: 4px;
+    box-shadow: 0px 4px 10px #00000010;
+}
+
 // Fonts
 $gosha_sans: 'GoshaSans-Bold', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue';
 


### PR DESCRIPTION
## Changes

- adding shadows to all cards in general so they can distinguish themselves from the background better
- added a border-radius of 4px on all cards to give it a more friendly & smooth UI vs being rectangular in shape and looking/feeling functional (might make it 6px later but 4px seems good to begin with)
- adding border-bottom and updating background color for ant-head (head above the graphs) for better separation with the grey background

Here's a before / after screenshot - cards are now easily differentiated from the background.

<img width="3040" alt="Shadow change" src="https://user-images.githubusercontent.com/18334593/118409732-890d2380-b6a9-11eb-9d77-07db24fb0c07.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
