### PR TITLE
Custom events for tracking new filter UI interactions

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertySelect.tsx
@@ -4,6 +4,8 @@ import { Select } from 'antd'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { SelectOption } from '~/types'
+import { useActions } from 'kea'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface Props {
     optionGroups: Array<PropertyOptionGroup>
@@ -59,6 +61,7 @@ export function PropertySelect({
     dropdownMatchSelectWidth = true,
 }: Props): JSX.Element {
     const [search, setSearch] = useState(false as string | false)
+    const { reportPropertySelectOpened } = useActions(eventUsageLogic)
     return (
         <SelectGradientOverflow
             showSearch
@@ -81,6 +84,11 @@ export function PropertySelect({
             }}
             style={{ width: '100%' }}
             dropdownMatchSelectWidth={dropdownMatchSelectWidth}
+            onDropdownVisibleChange={(open) => {
+                if (open) {
+                    reportPropertySelectOpened()
+                }
+            }}
         >
             {optionGroups.map(
                 (group) =>

--- a/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
@@ -25,7 +25,7 @@ import { PropertyFilterInternalProps } from './PropertyFilter'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 
 import './UnifiedPropertyFilter.scss'
-import posthog from 'posthog-js'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 function FilterDropdown({ open, children }: { open: boolean; children: React.ReactNode }): JSX.Element | null {
     return open ? <div>{children}</div> : null
@@ -92,6 +92,7 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
 
     const { cohorts } = useValues(cohortsModel)
     const { setFilter } = useActions(logic)
+    const { reportPropertySelectOpened } = useActions(eventUsageLogic)
     const { key, value, operator, type } = filters[index]
     const [open, setOpen] = useState(false)
     const selectBoxToggleRef = useRef<HTMLElement>(null)
@@ -204,7 +205,7 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
     const onClick = (e: React.SyntheticEvent): void => {
         e.preventDefault()
         if (!open) {
-            posthog.capture('property select toggle opened')
+            reportPropertySelectOpened()
         }
         setOpen(!open)
     }

--- a/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
@@ -25,6 +25,7 @@ import { PropertyFilterInternalProps } from './PropertyFilter'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 
 import './UnifiedPropertyFilter.scss'
+import posthog from 'posthog-js'
 
 function FilterDropdown({ open, children }: { open: boolean; children: React.ReactNode }): JSX.Element | null {
     return open ? <div>{children}</div> : null
@@ -132,6 +133,7 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
             })),
             renderInfo: EventPropertiesInfo,
             type: 'event',
+            key: 'events',
             getValue: (item) => item.name || '',
             getLabel: (item) => item.name || '',
         },
@@ -170,6 +172,7 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
                 )
             },
             type: 'person',
+            key: 'persons',
             getValue: (item) => item.name || '',
             getLabel: (item) => item.name || '',
         },
@@ -192,6 +195,7 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
                 })),
             renderInfo: CohortPropertiesInfo,
             type: 'cohort',
+            key: 'cohorts',
             getValue: (item) => item.name || '',
             getLabel: (item) => item.name || '',
         },
@@ -199,6 +203,9 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
 
     const onClick = (e: React.SyntheticEvent): void => {
         e.preventDefault()
+        if (!open) {
+            posthog.capture('property select toggle opened')
+        }
         setOpen(!open)
     }
 
@@ -225,6 +232,7 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
                         style={{ display: 'flex', alignItems: 'center' }}
                         ref={selectBoxToggleRef}
                         icon={!key ? <PlusOutlined /> : null}
+                        data-attr={'property-select-toggle-' + index}
                     >
                         <span className="text-overflow" style={{ maxWidth: '100%' }}>
                             {key ? <PropertyKeyInfo value={key} /> : 'Add filter'}

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
@@ -7,7 +7,10 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { Input, Select, Modal, Radio } from 'antd'
 import { prompt } from 'lib/logic/prompt'
 import dayjs from 'dayjs'
-import posthog from 'posthog-js'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+
+const unmount = eventUsageLogic.mount()
+const { reportCreatedDashboardFromModal } = eventUsageLogic.actions
 
 const saveToDashboardModalLogic = kea({
     connect: {
@@ -50,7 +53,7 @@ const saveToDashboardModalLogic = kea({
         },
 
         [dashboardsModel.actions.addDashboardSuccess]: ({ dashboard }) => {
-            posthog.capture('created new dashboard from modal')
+            reportCreatedDashboardFromModal()
             actions.setDashboardId(dashboard.id)
         },
     }),
@@ -74,6 +77,7 @@ export function SaveToDashboardModal({
     const logic = saveToDashboardModalLogic({ fromDashboard })
     const { dashboards, dashboardId } = useValues(logic)
     const { addNewDashboard, setDashboardId } = useActions(logic)
+    const { reportSavedInsightToDashboard } = useActions(eventUsageLogic)
     const [name, setName] = useState(fromItemName || initialName || '')
     const [visible, setVisible] = useState(true)
     const [newItem, setNewItem] = useState(!fromItem)
@@ -102,7 +106,7 @@ export function SaveToDashboardModal({
         } else {
             await api.update(`api/insight/${fromItem}`, { filters })
         }
-        posthog.capture('saved insight to dashboard')
+        reportSavedInsightToDashboard()
         toast(
             <div data-attr="success-toast">
                 {newItem ? 'Panel added to dashboard.' : 'Panel updated!'}&nbsp;
@@ -171,3 +175,5 @@ export function SaveToDashboardModal({
         </Modal>
     )
 }
+
+unmount()

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
@@ -9,9 +9,6 @@ import { prompt } from 'lib/logic/prompt'
 import dayjs from 'dayjs'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
-const unmount = eventUsageLogic.mount()
-const { reportCreatedDashboardFromModal } = eventUsageLogic.actions
-
 const saveToDashboardModalLogic = kea({
     connect: {
         values: [dashboardsModel, ['dashboards', 'lastDashboardId']],
@@ -52,8 +49,8 @@ const saveToDashboardModalLogic = kea({
             })
         },
 
-        [dashboardsModel.actions.addDashboardSuccess]: ({ dashboard }) => {
-            reportCreatedDashboardFromModal()
+        [dashboardsModel.actions.addDashboardSuccess]: async ({ dashboard }) => {
+            eventUsageLogic.actions.reportCreatedDashboardFromModal()
             actions.setDashboardId(dashboard.id)
         },
     }),
@@ -175,5 +172,3 @@ export function SaveToDashboardModal({
         </Modal>
     )
 }
-
-unmount()

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.js
@@ -7,6 +7,7 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { Input, Select, Modal, Radio } from 'antd'
 import { prompt } from 'lib/logic/prompt'
 import dayjs from 'dayjs'
+import posthog from 'posthog-js'
 
 const saveToDashboardModalLogic = kea({
     connect: {
@@ -49,6 +50,7 @@ const saveToDashboardModalLogic = kea({
         },
 
         [dashboardsModel.actions.addDashboardSuccess]: ({ dashboard }) => {
+            posthog.capture('created new dashboard from modal')
             actions.setDashboardId(dashboard.id)
         },
     }),
@@ -100,6 +102,7 @@ export function SaveToDashboardModal({
         } else {
             await api.update(`api/insight/${fromItem}`, { filters })
         }
+        posthog.capture('saved insight to dashboard')
         toast(
             <div data-attr="success-toast">
                 {newItem ? 'Panel added to dashboard.' : 'Panel updated!'}&nbsp;

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -119,6 +119,7 @@ export const eventUsageLogic = kea<
         reportInsightFilterAdded: (newLength: number) => ({ newLength }),
         reportInsightFilterSet: (filters: Array<{ id: string | number | null; type?: EntityType }>) => ({ filters }),
         reportEntityFilterVisibilitySet: (index: number, visible: boolean) => ({ index, visible }),
+        reportPropertySelectOpened: true,
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -402,6 +403,9 @@ export const eventUsageLogic = kea<
         },
         reportEntityFilterVisibilitySet: ({ index, visible }) => {
             posthog.capture('entity filter visbility set', { index, visible })
+        },
+        reportPropertySelectOpened: () => {
+            posthog.capture('property select toggle opened')
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -109,12 +109,6 @@ export const eventUsageLogic = kea<
             extraProps,
         }),
         reportInsightFilterUpdated: (index: number, name: string | null, type?: EntityType) => ({ type, index, name }),
-        reportInsightFilterPropertyUpdated: (index?: number) => ({ index }),
-        reportInsightFilterMathUpdated: (index: number, mathProps: { math?: string; mathProperty?: string }) => ({
-            index,
-            math: mathProps.math,
-            mathProperty: mathProps.mathProperty,
-        }),
         reportInsightFilterRemoved: (index: number) => ({ index }),
         reportInsightFilterAdded: (newLength: number) => ({ newLength }),
         reportInsightFilterSet: (filters: Array<{ id: string | number | null; type?: EntityType }>) => ({ filters }),
@@ -388,12 +382,6 @@ export const eventUsageLogic = kea<
         },
         reportInsightFilterUpdated: async ({ type, index, name }) => {
             posthog.capture('filter updated', { type, index, name })
-        },
-        reportInsightFilterPropertyUpdated: async ({ index }) => {
-            posthog.capture('filter property updated', { index })
-        },
-        reportInsightFilterMathUpdated: async ({ index, math, mathProperty }) => {
-            posthog.capture('filter math updated', { math, mathProperty, index })
         },
         reportInsightFilterRemoved: async ({ index }) => {
             posthog.capture('local filter removed', { index })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -4,7 +4,16 @@ import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import posthog from 'posthog-js'
 import { userLogic } from 'scenes/userLogic'
 import { eventUsageLogicType } from './eventUsageLogicType'
-import { AnnotationType, FilterType, DashboardType, PersonType, DashboardMode, HotKeys, GlobalHotKeys } from '~/types'
+import {
+    AnnotationType,
+    FilterType,
+    DashboardType,
+    PersonType,
+    DashboardMode,
+    HotKeys,
+    GlobalHotKeys,
+    EntityType,
+} from '~/types'
 import { ViewType } from 'scenes/insights/insightLogic'
 import dayjs from 'dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
@@ -99,6 +108,17 @@ export const eventUsageLogic = kea<
             searchTerm,
             extraProps,
         }),
+        reportInsightFilterUpdated: (index: number, name: string | null, type?: EntityType) => ({ type, index, name }),
+        reportInsightFilterPropertyUpdated: (index?: number) => ({ index }),
+        reportInsightFilterMathUpdated: (index: number, mathProps: { math?: string; mathProperty?: string }) => ({
+            index,
+            math: mathProps.math,
+            mathProperty: mathProps.mathProperty,
+        }),
+        reportInsightFilterRemoved: (index: number) => ({ index }),
+        reportInsightFilterAdded: (newLength: number) => ({ newLength }),
+        reportInsightFilterSet: (filters: Array<{ id: string | number | null; type?: EntityType }>) => ({ filters }),
+        reportEntityFilterVisibilitySet: (index: number, visible: boolean) => ({ index, visible }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -361,6 +381,27 @@ export const eventUsageLogic = kea<
                 // Triggered when a search is executed for an action/event (mainly for use on insights)
                 posthog.capture('event searched', { searchTerm, ...extraProps })
             }
+        },
+        reportInsightFilterUpdated: ({ type, index, name }) => {
+            posthog.capture('filter updated', { type, index, name })
+        },
+        reportInsightFilterPropertyUpdated: ({ index }) => {
+            posthog.capture('filter property updated', { index })
+        },
+        reportInsightFilterMathUpdated: ({ index, math, mathProperty }) => {
+            posthog.capture('filter math updated', { math, mathProperty, index })
+        },
+        reportInsightFilterRemoved: ({ index }) => {
+            posthog.capture('local filter removed', { index })
+        },
+        reportInsightFilterAdded: ({ newLength }) => {
+            posthog.capture('filter added', { newLength })
+        },
+        reportInsightFilterSet: ({ filters }) => {
+            posthog.capture('filters set', { filters })
+        },
+        reportEntityFilterVisibilitySet: ({ index, visible }) => {
+            posthog.capture('entity filter visbility set', { index, visible })
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -120,6 +120,8 @@ export const eventUsageLogic = kea<
         reportInsightFilterSet: (filters: Array<{ id: string | number | null; type?: EntityType }>) => ({ filters }),
         reportEntityFilterVisibilitySet: (index: number, visible: boolean) => ({ index, visible }),
         reportPropertySelectOpened: true,
+        reportCreatedDashboardFromModal: true,
+        reportSavedInsightToDashboard: true,
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -406,6 +408,12 @@ export const eventUsageLogic = kea<
         },
         reportPropertySelectOpened: () => {
             posthog.capture('property select toggle opened')
+        },
+        reportCreatedDashboardFromModal: () => {
+            posthog.capture('created new dashboard from modal')
+        },
+        reportSavedInsightToDashboard: () => {
+            posthog.capture('saved insight to dashboard')
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -385,34 +385,34 @@ export const eventUsageLogic = kea<
                 posthog.capture('event searched', { searchTerm, ...extraProps })
             }
         },
-        reportInsightFilterUpdated: ({ type, index, name }) => {
+        reportInsightFilterUpdated: async ({ type, index, name }) => {
             posthog.capture('filter updated', { type, index, name })
         },
-        reportInsightFilterPropertyUpdated: ({ index }) => {
+        reportInsightFilterPropertyUpdated: async ({ index }) => {
             posthog.capture('filter property updated', { index })
         },
-        reportInsightFilterMathUpdated: ({ index, math, mathProperty }) => {
+        reportInsightFilterMathUpdated: async ({ index, math, mathProperty }) => {
             posthog.capture('filter math updated', { math, mathProperty, index })
         },
-        reportInsightFilterRemoved: ({ index }) => {
+        reportInsightFilterRemoved: async ({ index }) => {
             posthog.capture('local filter removed', { index })
         },
-        reportInsightFilterAdded: ({ newLength }) => {
+        reportInsightFilterAdded: async ({ newLength }) => {
             posthog.capture('filter added', { newLength })
         },
-        reportInsightFilterSet: ({ filters }) => {
+        reportInsightFilterSet: async ({ filters }) => {
             posthog.capture('filters set', { filters })
         },
-        reportEntityFilterVisibilitySet: ({ index, visible }) => {
+        reportEntityFilterVisibilitySet: async ({ index, visible }) => {
             posthog.capture('entity filter visbility set', { index, visible })
         },
-        reportPropertySelectOpened: () => {
+        reportPropertySelectOpened: async () => {
             posthog.capture('property select toggle opened')
         },
-        reportCreatedDashboardFromModal: () => {
+        reportCreatedDashboardFromModal: async () => {
             posthog.capture('created new dashboard from modal')
         },
-        reportSavedInsightToDashboard: () => {
+        reportSavedInsightToDashboard: async () => {
             posthog.capture('saved insight to dashboard')
         },
     },

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -122,6 +122,7 @@ export const eventUsageLogic = kea<
         reportPropertySelectOpened: true,
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
+        reportInsightsTabReset: true,
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -414,6 +415,9 @@ export const eventUsageLogic = kea<
         },
         reportSavedInsightToDashboard: async () => {
             posthog.capture('saved insight to dashboard')
+        },
+        reportInsightsTabReset: async () => {
+            posthog.capture('insights tab reset')
         },
     },
 })

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -18,6 +18,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 export type LocalFilter = EntityFilter & { order: number; properties?: PropertyFilter[] }
 export type BareEntity = Pick<Entity, 'id' | 'name'>
 
+const unmount = eventUsageLogic.mount()
+
 const {
     reportInsightFilterUpdated,
     reportInsightFilterPropertyUpdated,
@@ -199,3 +201,5 @@ export const entityFilterLogic = kea<
         },
     }),
 })
+
+unmount()

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -133,13 +133,11 @@ export const entityFilterLogic = kea<
             !props.singleMode && actions.selectFilter(null)
         },
         updateFilterProperty: async ({ properties, index }) => {
-            eventUsageLogic.actions.reportInsightFilterPropertyUpdated(index)
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, properties } : filter))
             )
         },
         updateFilterMath: async ({ math, math_property, index }) => {
-            eventUsageLogic.actions.reportInsightFilterMathUpdated(index, { math, mathProperty: math_property })
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, math, math_property } : filter))
             )

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -18,18 +18,6 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 export type LocalFilter = EntityFilter & { order: number; properties?: PropertyFilter[] }
 export type BareEntity = Pick<Entity, 'id' | 'name'>
 
-const unmount = eventUsageLogic.mount()
-
-const {
-    reportInsightFilterUpdated,
-    reportInsightFilterPropertyUpdated,
-    reportInsightFilterMathUpdated,
-    reportInsightFilterRemoved,
-    reportInsightFilterAdded,
-    reportInsightFilterSet,
-    reportEntityFilterVisibilitySet,
-} = eventUsageLogic.actions
-
 export function toLocalFilters(filters: FilterType): LocalFilter[] {
     return [
         ...(filters[EntityTypes.ACTIONS] || []),
@@ -137,33 +125,33 @@ export const entityFilterLogic = kea<
     },
 
     listeners: ({ actions, values, props }) => ({
-        updateFilter: ({ type, index, name, id }) => {
-            reportInsightFilterUpdated(index, name)
+        updateFilter: async ({ type, index, name, id }) => {
+            eventUsageLogic.actions.reportInsightFilterUpdated(index, name)
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, id, name, type } : filter))
             )
             !props.singleMode && actions.selectFilter(null)
         },
-        updateFilterProperty: ({ properties, index }) => {
-            reportInsightFilterPropertyUpdated(index)
+        updateFilterProperty: async ({ properties, index }) => {
+            eventUsageLogic.actions.reportInsightFilterPropertyUpdated(index)
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, properties } : filter))
             )
         },
-        updateFilterMath: ({ math, math_property, index }) => {
-            reportInsightFilterMathUpdated(index, { math, mathProperty: math_property })
+        updateFilterMath: async ({ math, math_property, index }) => {
+            eventUsageLogic.actions.reportInsightFilterMathUpdated(index, { math, mathProperty: math_property })
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, math, math_property } : filter))
             )
         },
-        removeLocalFilter: ({ index }) => {
-            reportInsightFilterRemoved(index)
+        removeLocalFilter: async ({ index }) => {
+            eventUsageLogic.actions.reportInsightFilterRemoved(index)
             actions.setFilters(values.localFilters.filter((_, i) => i !== index))
         },
-        addFilter: () => {
+        addFilter: async () => {
             const previousLength = values.localFilters.length
             const newLength = previousLength + 1
-            reportInsightFilterAdded(newLength)
+            eventUsageLogic.actions.reportInsightFilterAdded(newLength)
             if (values.localFilters.length > 0) {
                 const lastFilter: LocalFilter = values.localFilters[previousLength - 1]
                 const order = lastFilter.order + 1
@@ -180,15 +168,15 @@ export const entityFilterLogic = kea<
                 ])
             }
         },
-        setFilters: ({ filters }) => {
+        setFilters: async ({ filters }) => {
             const sanitizedFilters = filters?.map(({ id, type }) => ({ id, type }))
-            reportInsightFilterSet(sanitizedFilters)
+            eventUsageLogic.actions.reportInsightFilterSet(sanitizedFilters)
             if (typeof props.setFilters === 'function') {
                 props.setFilters(toFilters(filters))
             }
         },
-        setEntityFilterVisibility: ({ index, value }) => {
-            reportEntityFilterVisibilitySet(index, value)
+        setEntityFilterVisibility: async ({ index, value }) => {
+            eventUsageLogic.actions.reportEntityFilterVisibilitySet(index, value)
         },
     }),
     events: ({ actions, props, values }) => ({
@@ -201,5 +189,3 @@ export const entityFilterLogic = kea<
         },
     }),
 })
-
-unmount()

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -13,6 +13,7 @@ import {
 import { entityFilterLogicType } from './entityFilterLogicType'
 import { ActionFilterProps } from './ActionFilter'
 import { eventDefinitionsLogic } from 'scenes/events/eventDefinitionsLogic'
+import posthog from 'posthog-js'
 
 export type LocalFilter = EntityFilter & { order: number; properties?: PropertyFilter[] }
 export type BareEntity = Pick<Entity, 'id' | 'name'>
@@ -125,25 +126,30 @@ export const entityFilterLogic = kea<
 
     listeners: ({ actions, values, props }) => ({
         updateFilter: ({ type, index, name, id }) => {
+            posthog.capture('filter updated', { type, index, name, id })
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, id, name, type } : filter))
             )
             !props.singleMode && actions.selectFilter(null)
         },
         updateFilterProperty: ({ properties, index }) => {
+            posthog.capture('filter property updated', { index })
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, properties } : filter))
             )
         },
         updateFilterMath: ({ math, math_property, index }) => {
+            posthog.capture('filter math updated', { math, math_property, index })
             actions.setFilters(
                 values.localFilters.map((filter, i) => (i === index ? { ...filter, math, math_property } : filter))
             )
         },
         removeLocalFilter: ({ index }) => {
+            posthog.capture('local filter removed', { index, previousLength: values.localFilters.length })
             actions.setFilters(values.localFilters.filter((_, i) => i !== index))
         },
         addFilter: () => {
+            posthog.capture('filter added', { previousLength: values.localFilters.length })
             if (values.localFilters.length > 0) {
                 const lastFilter: LocalFilter = values.localFilters[values.localFilters.length - 1]
                 const order = lastFilter.order + 1
@@ -161,9 +167,13 @@ export const entityFilterLogic = kea<
             }
         },
         setFilters: ({ filters }) => {
+            posthog.capture('filters set', { filters: filters?.map(({ id, type }) => ({ id, type })) })
             if (typeof props.setFilters === 'function') {
                 props.setFilters(toFilters(filters))
             }
+        },
+        setEntityFilterVisibility: ({ index, value }) => {
+            posthog.capture('entity filter visbility set', { index, visible: value })
         },
     }),
     events: ({ actions, props, values }) => ({

--- a/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
@@ -5,7 +5,7 @@ import { FilterType, InsightType } from '~/types'
 import { SaveOutlined, ClearOutlined } from '@ant-design/icons'
 import { useActions } from 'kea'
 import { router } from 'kea-router'
-import posthog from 'posthog-js'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface Props {
     filters: FilterType
@@ -16,6 +16,7 @@ interface Props {
 
 export function InsightActionBar({ filters, annotations, insight, onReset }: Props): JSX.Element {
     const { push } = useActions(router)
+    const { reportInsightsTabReset } = useActions(eventUsageLogic)
     return (
         <div className="insights-tab-actions">
             <Popconfirm
@@ -23,7 +24,7 @@ export function InsightActionBar({ filters, annotations, insight, onReset }: Pro
                 onConfirm={() => {
                     window.scrollTo({ top: 0 })
                     onReset ? onReset() : push(`/insights?insight=${insight}`)
-                    posthog.capture('insights tab reset')
+                    reportInsightsTabReset()
                 }}
             >
                 <Button type="link" icon={<ClearOutlined />} className="btn-reset">

--- a/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
@@ -5,6 +5,7 @@ import { FilterType, InsightType } from '~/types'
 import { SaveOutlined, ClearOutlined } from '@ant-design/icons'
 import { useActions } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 interface Props {
     filters: FilterType
@@ -22,6 +23,7 @@ export function InsightActionBar({ filters, annotations, insight, onReset }: Pro
                 onConfirm={() => {
                     window.scrollTo({ top: 0 })
                     onReset ? onReset() : push(`/insights?insight=${insight}`)
+                    posthog.capture('insights tab reset')
                 }}
             >
                 <Button type="link" icon={<ClearOutlined />} className="btn-reset">


### PR DESCRIPTION
## Changes

In order to measure usage of the new filter UI, send some custom events.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
