### PR TITLE
Add support for comparing floats

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -157,7 +157,7 @@ def prop_filter_json_extract(
     elif operator == "gt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND toInt64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) > %(v{prepend}_{idx})s".format(
+            "AND toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) > %(v{prepend}_{idx})s".format(
                 idx=idx,
                 prepend=prepend,
                 left=denormalized
@@ -171,7 +171,7 @@ def prop_filter_json_extract(
     elif operator == "lt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
-            "AND toInt64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) < %(v{prepend}_{idx})s".format(
+            "AND toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) < %(v{prepend}_{idx})s".format(
                 idx=idx,
                 prepend=prepend,
                 left=denormalized

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -204,6 +204,32 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         filter = Filter(data={"properties": [{"key": "test_prop", "value": 3, "operator": "lt"}],})
         self.assertEqual(len(self._run_query(filter)), 3)
 
+    def test_prop_decimals(self):
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": 1.4},
+        )
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": 1.3},
+        )
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": 2},
+        )
+        _create_event(
+            event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": 2.5},
+        )
+
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": 1.5}],})
+        self.assertEqual(len(self._run_query(filter)), 0)
+
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": 1.2, "operator": "gt"}],})
+        self.assertEqual(len(self._run_query(filter)), 4)
+
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": "1.2", "operator": "gt"}],})
+        self.assertEqual(len(self._run_query(filter)), 4)
+
+        filter = Filter(data={"properties": [{"key": "test_prop", "value": 2.3, "operator": "lt"}],})
+        self.assertEqual(len(self._run_query(filter)), 3)
+
 
 class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
     CLASS_DATA_LEVEL_SETUP = False


### PR DESCRIPTION
## Changes

*Please describe.*  
- clickhouse property comparisons was converting arguments to ints rather than floats
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
