### PR TITLE
show dashboard items if there are no recent items

### DIFF
--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -124,7 +124,11 @@ export const InsightHistoryPanel: React.FC<InsightHistoryPanelProps> = ({ displa
     const { loadNextInsights, loadNextSavedInsights, loadNextTeamInsights } = useActions(insightHistoryLogic)
     const { reportInsightHistoryItemClicked } = useActions(eventUsageLogic)
 
-    const [activeTab, setActiveTab] = useState(InsightHistoryType.RECENT)
+    const [activeTab, setActiveTab] = useState(
+        insights.length === 0 && teamInsights.length > insights.length
+            ? InsightHistoryType.TEAM
+            : InsightHistoryType.RECENT
+    )
 
     return (
         <div data-attr="insight-history-panel" className="insight-history-panel">

--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -125,7 +125,7 @@ export const InsightHistoryPanel: React.FC<InsightHistoryPanelProps> = ({ displa
     const { reportInsightHistoryItemClicked } = useActions(eventUsageLogic)
 
     const [activeTab, setActiveTab] = useState(
-        insights.length === 0 && teamInsights.length > insights.length
+        insights?.length < 3 && teamInsights?.length > insights?.length
             ? InsightHistoryType.TEAM
             : InsightHistoryType.RECENT
     )

--- a/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
+++ b/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
@@ -166,11 +166,12 @@ function RecentInsightList(): JSX.Element {
 }
 
 export function DiscoverInsightsModule(): JSX.Element {
-    const { insights, insightsLoading } = useValues(insightHistoryLogic)
-    const { loadInsights } = useActions(insightHistoryLogic)
+    const { insights, insightsLoading, teamInsights, teamInsightsLoading } = useValues(insightHistoryLogic)
+    const { loadInsights, loadTeamInsights } = useActions(insightHistoryLogic)
 
     useEffect(() => {
         loadInsights()
+        loadTeamInsights()
     }, [])
 
     return (
@@ -179,9 +180,13 @@ export function DiscoverInsightsModule(): JSX.Element {
                 Discover Insights
             </Title>
             <Divider />
-            <Skeleton loading={insightsLoading && insights.length === 0}>
+            <Skeleton
+                loading={
+                    (insightsLoading && insights.length === 0) || (teamInsightsLoading && teamInsights.length === 0)
+                }
+            >
                 <Space direction={'vertical'} className={'home-page'} size={'small'}>
-                    {insights.length > 0 && <RecentInsightList />}
+                    {(insights.length > 0 || teamInsights.length > 0) && <RecentInsightList />}
                     <CreateAnalysisSection />
                 </Space>
             </Skeleton>


### PR DESCRIPTION
## Changes
Surface dashboard items first on project home if not enough recent items.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
