### PR TITLE
update conditional - only show skeleton if both groups are loading

### DIFF
--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -125,7 +125,7 @@ export const InsightHistoryPanel: React.FC<InsightHistoryPanelProps> = ({ displa
     const { reportInsightHistoryItemClicked } = useActions(eventUsageLogic)
 
     const [activeTab, setActiveTab] = useState(
-        insights?.length < 3 && teamInsights?.length > insights?.length
+        !insightsLoading && insights?.length < 3 && teamInsights?.length > insights?.length
             ? InsightHistoryType.TEAM
             : InsightHistoryType.RECENT
     )

--- a/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
+++ b/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
@@ -181,9 +181,7 @@ export function DiscoverInsightsModule(): JSX.Element {
             </Title>
             <Divider />
             <Skeleton
-                loading={
-                    (insightsLoading && insights.length === 0) || (teamInsightsLoading && teamInsights.length === 0)
-                }
+                loading={insightsLoading && insights.length === 0 && teamInsightsLoading && teamInsights.length === 0}
             >
                 <Space direction={'vertical'} className={'home-page'} size={'small'}>
                     {(insights.length > 0 || teamInsights.length > 0) && <RecentInsightList />}


### PR DESCRIPTION
## Changes

Update home to show results if dashboard _or_ recent items are available

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
