### PR TITLE
update column width md screens

### DIFF
--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -56,7 +56,7 @@ function InsightPane({
             {loading && <Loading />}
             {data &&
                 data.map((insight: DashboardItemType, index: number) => (
-                    <Col xs={24} sm={data.length > 1 ? 8 : 12} key={insight.id} style={{ height: 270 }}>
+                    <Col xs={24} sm={12} md={data.length > 1 ? 8 : 12} key={insight.id} style={{ height: 270 }}>
                         <DashboardItem
                             item={{ ...insight, color: null }}
                             key={insight.id + '_user'}

--- a/frontend/src/scenes/onboarding/home/Home.scss
+++ b/frontend/src/scenes/onboarding/home/Home.scss
@@ -167,7 +167,7 @@
             max-width: 900px;
         }
         @media only screen and (max-width: $md) {
-            max-width: 650px;
+            max-width: 600px;
         }
         @media only screen and (max-width: $sm) {
             max-width: 315px;

--- a/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
+++ b/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
@@ -166,12 +166,20 @@ function RecentInsightList(): JSX.Element {
 }
 
 export function DiscoverInsightsModule(): JSX.Element {
-    const { insights, insightsLoading, teamInsights, teamInsightsLoading } = useValues(insightHistoryLogic)
-    const { loadInsights, loadTeamInsights } = useActions(insightHistoryLogic)
+    const {
+        insights,
+        insightsLoading,
+        teamInsights,
+        teamInsightsLoading,
+        savedInsights,
+        savedInsightsLoading,
+    } = useValues(insightHistoryLogic)
+    const { loadInsights, loadTeamInsights, loadSavedInsights } = useActions(insightHistoryLogic)
 
     useEffect(() => {
         loadInsights()
         loadTeamInsights()
+        loadSavedInsights()
     }, [])
 
     return (
@@ -181,10 +189,19 @@ export function DiscoverInsightsModule(): JSX.Element {
             </Title>
             <Divider />
             <Skeleton
-                loading={insightsLoading && insights.length === 0 && teamInsightsLoading && teamInsights.length === 0}
+                loading={
+                    insightsLoading &&
+                    insights.length === 0 &&
+                    teamInsightsLoading &&
+                    teamInsights.length === 0 &&
+                    savedInsightsLoading &&
+                    savedInsights.length === 0
+                }
             >
                 <Space direction={'vertical'} className={'home-page'} size={'small'}>
-                    {(insights.length > 0 || teamInsights.length > 0) && <RecentInsightList />}
+                    {(insights.length > 0 || teamInsights.length > 0 || savedInsights.length > 0) && (
+                        <RecentInsightList />
+                    )}
                     <CreateAnalysisSection />
                 </Space>
             </Skeleton>


### PR DESCRIPTION
## Changes

- allow saved items to trigger recent analyses showing up
- more granular col width for md screens

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
