### PR TITLE
move create buttons above recent

### DIFF
--- a/frontend/src/scenes/onboarding/home/Home.scss
+++ b/frontend/src/scenes/onboarding/home/Home.scss
@@ -175,8 +175,5 @@
         @media only screen and (max-height: $lg) {
             max-height: 450px;
         }
-        @media only screen and (min-height: $xl) {
-            max-height: 750px;
-        }
     }
 }

--- a/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
+++ b/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { Avatar, Card, Divider, List, Space, Tooltip, Typography, Collapse, Skeleton } from 'antd'
+import { Avatar, Card, Divider, List, Tooltip, Typography, Collapse } from 'antd'
 
 const { Panel } = Collapse
 
@@ -166,14 +166,7 @@ function RecentInsightList(): JSX.Element {
 }
 
 export function DiscoverInsightsModule(): JSX.Element {
-    const {
-        insights,
-        insightsLoading,
-        teamInsights,
-        teamInsightsLoading,
-        savedInsights,
-        savedInsightsLoading,
-    } = useValues(insightHistoryLogic)
+    const { insights, teamInsights, savedInsights } = useValues(insightHistoryLogic)
     const { loadInsights, loadTeamInsights, loadSavedInsights } = useActions(insightHistoryLogic)
 
     useEffect(() => {
@@ -188,23 +181,9 @@ export function DiscoverInsightsModule(): JSX.Element {
                 Discover Insights
             </Title>
             <Divider />
-            <Skeleton
-                loading={
-                    insightsLoading &&
-                    insights.length === 0 &&
-                    teamInsightsLoading &&
-                    teamInsights.length === 0 &&
-                    savedInsightsLoading &&
-                    savedInsights.length === 0
-                }
-            >
-                <Space direction={'vertical'} className={'home-page'} size={'small'}>
-                    {(insights.length > 0 || teamInsights.length > 0 || savedInsights.length > 0) && (
-                        <RecentInsightList />
-                    )}
-                    <CreateAnalysisSection />
-                </Space>
-            </Skeleton>
+
+            <CreateAnalysisSection />
+            {(insights.length > 0 || teamInsights.length > 0 || savedInsights.length > 0) && <RecentInsightList />}
         </Card>
     )
 }

--- a/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
+++ b/frontend/src/scenes/onboarding/home/sections/DiscoverInsight.tsx
@@ -181,7 +181,6 @@ export function DiscoverInsightsModule(): JSX.Element {
                 Discover Insights
             </Title>
             <Divider />
-
             <CreateAnalysisSection />
             {(insights.length > 0 || teamInsights.length > 0 || savedInsights.length > 0) && <RecentInsightList />}
         </Card>


### PR DESCRIPTION
## Changes
- Move create analysis buttons back above recent section – they end up below the fold on some smaller screens. Has the added benefit of not needing a skeleton since the create buttons stay in the same spot.
## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
