### PR TITLE
Disable prepared statements to support pgbouncer for graphile on plugin server

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -61,6 +61,10 @@
                     "value": "graphile"
                 },
                 {
+                    "name": "JOB_QUEUE_GRAPHILE_PREPARED_STATEMENTS",
+                    "value": "True"
+                },
+                {
                     "name": "CRASH_IF_NO_PERSISTENT_JOB_QUEUE",
                     "value": "0"
                 }


### PR DESCRIPTION
## Changes

We are constrained right now on connections going to Aurora Postgres. We've stood up a pgbouncer service just for graphile. Next steps:

- [x] Stand up PGBouncer for Graphile talking to Aurora Postgres
- [ ] Disable prepared statements for Graphile going to Aurora Postgres (this diff)
- [ ] Update connection string to point to PGBouncer for Graphile
- [ ] Re-deploy plugin server

Plugin server already has this setting exposed. Nicely done @mariusandra .
https://github.com/PostHog/plugin-server/blob/baa8345a3f2475ed0cb0b59d4c9ab6429ef6b4cf/src/config/config.ts#L112

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
