### PR TITLE
Fix breakdown color and selecting numbers

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -464,6 +464,7 @@ export function PropertyKeyInfo({
     type = 'event',
     disablePopover = false,
 }: PropertyKeyInfoInterface): JSX.Element {
+    value = `${value}` // convert to string
     let data = null
     if (value in keyMapping[type]) {
         data = { ...keyMapping[type][value] }
@@ -475,7 +476,7 @@ export function PropertyKeyInfo({
         }
     } else {
         return (
-            <Typography.Text ellipsis={true} style={{ maxWidth: 400 }} title={value}>
+            <Typography.Text ellipsis={true} style={{ color: 'inherit', maxWidth: 400 }} title={value}>
                 {value}
             </Typography.Text>
         )

--- a/frontend/src/scenes/insights/BreakdownFilter/BreakdownFilter.js
+++ b/frontend/src/scenes/insights/BreakdownFilter/BreakdownFilter.js
@@ -162,6 +162,7 @@ export function BreakdownFilter({ filters, onChange }) {
                     type={breakdown ? 'primary' : 'default'}
                     disabled={insight === ViewType.STICKINESS || insight === ViewType.LIFECYCLE}
                     data-attr="add-breakdown-button"
+                    style={{ color: '#fff' }}
                 >
                     <PropertyKeyInfo value={label || 'Add breakdown'} />
                 </Button>


### PR DESCRIPTION
## Changes

before
![image](https://user-images.githubusercontent.com/1727427/118826976-3bb4d000-b8bc-11eb-9180-ec3134be0038.png)

after
![image](https://user-images.githubusercontent.com/1727427/118826993-3f485700-b8bc-11eb-9128-619a9359437c.png)

Also, selecting a number as the key caused the page to blank out, which is now fixed.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
