### PR TITLE
Move instance/status api code under viewSet

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -19,7 +19,7 @@ export const systemStatusLogic = kea<systemStatusLogicType<SystemStatus, SystemS
                     if (preflightLogic.values.preflight?.cloud && !userLogic.values.user?.is_staff) {
                         return null
                     }
-                    return (await api.get('_system_status')).results
+                    return (await api.get('/api/instance/status')).results
                 },
             },
         ],

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -19,7 +19,7 @@ export const systemStatusLogic = kea<systemStatusLogicType<SystemStatus, SystemS
                     if (preflightLogic.values.preflight?.cloud && !userLogic.values.user?.is_staff) {
                         return null
                     }
-                    return (await api.get('/api/instance/status')).results
+                    return (await api.get('api/instance_status')).results
                 },
             },
         ],

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -14,6 +14,7 @@ from . import (
     event_definition,
     feature_flag,
     insight,
+    instance_status,
     organization,
     organization_invite,
     organization_member,
@@ -82,6 +83,7 @@ projects_router.register(
 # General endpoints (shared across EE & FOSS)
 router.register(r"login", authentication.LoginViewSet)
 router.register(r"users", user.UserViewSet)
+router.register(r"instance_status", instance_status.InstanceStatusViewSet, "instance_status")
 
 if is_clickhouse_enabled():
     try:

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from posthog.ee import is_clickhouse_enabled
 from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import Element, Event, SessionRecordingEvent
-from posthog.permissions import IsMultiTenancyAdmin
+from posthog.permissions import SingleTenancyOrAdmin
 from posthog.utils import (
     get_plugin_server_job_queues,
     get_plugin_server_version,
@@ -29,7 +29,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
     Show info about instance for this user
     """
 
-    permission_classes = [IsAuthenticated, IsMultiTenancyAdmin]
+    permission_classes = [IsAuthenticated, SingleTenancyOrAdmin]
 
     def list(self, request: Request) -> Response:
         redis_alive = is_redis_alive()

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -1,0 +1,140 @@
+from typing import Dict, List, Union
+
+from django.db import connection
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.ee import is_clickhouse_enabled
+from posthog.internal_metrics.team import get_internal_metrics_dashboards
+from posthog.models import Element, Event, SessionRecordingEvent
+from posthog.permissions import IsMultiTenancyAdmin
+from posthog.utils import (
+    get_plugin_server_job_queues,
+    get_plugin_server_version,
+    get_redis_info,
+    get_redis_queue_depth,
+    get_table_approx_count,
+    get_table_size,
+    is_plugin_server_alive,
+    is_postgres_alive,
+    is_redis_alive,
+)
+from posthog.version import VERSION
+
+
+class InstanceStatusViewSet(viewsets.ViewSet):
+    """
+    Show info about instance for this user
+    """
+
+    permission_classes = [IsAuthenticated, IsMultiTenancyAdmin]
+
+    def list(self, request: Request) -> Response:
+        redis_alive = is_redis_alive()
+        postgres_alive = is_postgres_alive()
+
+        metrics: List[Dict[str, Union[str, bool, int, float]]] = []
+
+        metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
+
+        metrics.append(
+            {
+                "key": "analytics_database",
+                "metric": "Analytics database in use",
+                "value": "ClickHouse" if is_clickhouse_enabled() else "Postgres",
+            }
+        )
+
+        metrics.append(
+            {"key": "plugin_sever_alive", "metric": "Plugin server alive", "value": is_plugin_server_alive()}
+        )
+        metrics.append(
+            {
+                "key": "plugin_sever_version",
+                "metric": "Plugin server version",
+                "value": get_plugin_server_version() or "unknown",
+            }
+        )
+
+        plugin_server_queues = get_plugin_server_job_queues()
+        metrics.append(
+            {
+                "key": "plugin_sever_job_queues",
+                "metric": "Job queues enabled in plugin server",
+                "value": ", ".join([q.capitalize() for q in plugin_server_queues])
+                if plugin_server_queues
+                else "unknown",
+            }
+        )
+
+        metrics.append({"key": "db_alive", "metric": "Postgres database alive", "value": postgres_alive})
+        if postgres_alive:
+            postgres_version = connection.cursor().connection.server_version
+            metrics.append(
+                {
+                    "key": "pg_version",
+                    "metric": "Postgres version",
+                    "value": f"{postgres_version // 10000}.{(postgres_version // 100) % 100}.{postgres_version % 100}",
+                }
+            )
+
+            if not is_clickhouse_enabled():
+                event_table_count = get_table_approx_count(Event._meta.db_table)
+                event_table_size = get_table_size(Event._meta.db_table)
+
+                element_table_count = get_table_approx_count(Element._meta.db_table)
+                element_table_size = get_table_size(Element._meta.db_table)
+
+                session_recording_event_table_count = get_table_approx_count(SessionRecordingEvent._meta.db_table)
+                session_recording_event_table_size = get_table_size(SessionRecordingEvent._meta.db_table)
+
+                metrics.append(
+                    {
+                        "metric": "Postgres elements table size",
+                        "value": f"{element_table_count} rows (~{element_table_size})",
+                    }
+                )
+                metrics.append(
+                    {"metric": "Postgres events table size", "value": f"{event_table_count} rows (~{event_table_size})"}
+                )
+                metrics.append(
+                    {
+                        "metric": "Postgres session recording table size",
+                        "value": f"{session_recording_event_table_count} rows (~{session_recording_event_table_size})",
+                    }
+                )
+        if is_clickhouse_enabled():
+            from ee.clickhouse.system_status import system_status
+
+            metrics.extend(list(system_status()))
+
+        metrics.append({"key": "redis_alive", "metric": "Redis alive", "value": redis_alive})
+        if redis_alive:
+            import redis
+
+            try:
+                redis_info = get_redis_info()
+                redis_queue_depth = get_redis_queue_depth()
+                metrics.append({"metric": "Redis version", "value": f"{redis_info.get('redis_version')}"})
+                metrics.append({"metric": "Redis current queue depth", "value": f"{redis_queue_depth}"})
+                metrics.append(
+                    {"metric": "Redis connected client count", "value": f"{redis_info.get('connected_clients')}"}
+                )
+                metrics.append({"metric": "Redis memory used", "value": f"{redis_info.get('used_memory_human', '?')}B"})
+                metrics.append(
+                    {"metric": "Redis memory peak", "value": f"{redis_info.get('used_memory_peak_human', '?')}B"}
+                )
+                metrics.append(
+                    {
+                        "metric": "Redis total memory available",
+                        "value": f"{redis_info.get('total_system_memory_human', '?')}B",
+                    }
+                )
+            except redis.exceptions.ConnectionError as e:
+                metrics.append(
+                    {"metric": "Redis metrics", "value": f"Redis connected but then failed to return metrics: {e}"}
+                )
+
+        return Response({"results": {"overview": metrics, "internal_metrics": get_internal_metrics_dashboards()}})

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -54,7 +54,7 @@ class UninitiatedOrCloudOnly(BasePermission):
         return settings.MULTI_TENANCY or not User.objects.exists()
 
 
-class IsMultiTenancyAdmin(BasePermission):
+class SingleTenancyOrAdmin(BasePermission):
     """
     Allows access to only staff users on cloud.
     """

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -54,6 +54,17 @@ class UninitiatedOrCloudOnly(BasePermission):
         return settings.MULTI_TENANCY or not User.objects.exists()
 
 
+class IsMultiTenancyAdmin(BasePermission):
+    """
+    Allows access to only staff users on cloud.
+    """
+
+    message = "You are not an admin."
+
+    def has_permission(self, request, view):
+        return not settings.MULTI_TENANCY or request.user.is_staff
+
+
 class ProjectMembershipNecessaryPermissions(BasePermission):
     """Require organization and project membership to access endpoint."""
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -34,7 +34,7 @@ from posthog.event_usage import report_user_signed_up
 from .api.organization import OrganizationSignupSerializer
 from .models import OrganizationInvite, Team, User
 from .utils import render_template
-from .views import health, login_required, preflight_check, robots_txt, stats, system_status
+from .views import health, login_required, preflight_check, robots_txt, stats
 
 
 def home(request, *args, **kwargs):
@@ -200,7 +200,6 @@ urlpatterns = [
     opt_slash_path("_health", health),
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
-    opt_slash_path("_system_status", system_status),
     # admin
     path("admin/", admin.site.urls),
     path("admin/", include("loginas.urls")),

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -1,41 +1,30 @@
 import os
 from functools import wraps
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required as base_login_required
-from django.db import DEFAULT_DB_ALIAS, connection, connections
+from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
-from rest_framework.exceptions import AuthenticationFailed
 
 from posthog.ee import is_clickhouse_enabled
 from posthog.email import is_email_available
-from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import User
 from posthog.utils import (
-    get_plugin_server_job_queues,
-    get_redis_info,
-    get_redis_queue_depth,
-    get_table_approx_count,
-    get_table_size,
+    get_available_social_auth_providers,
+    get_available_timezones_with_offsets,
+    get_celery_heartbeat,
     is_celery_alive,
     is_plugin_server_alive,
     is_postgres_alive,
     is_redis_alive,
 )
 from posthog.version import VERSION
-
-from .utils import (
-    get_available_social_auth_providers,
-    get_available_timezones_with_offsets,
-    get_celery_heartbeat,
-    get_plugin_server_version,
-)
 
 ROBOTS_TXT_CONTENT = "User-agent: *\nDisallow: /"
 
@@ -85,120 +74,6 @@ def stats(request):
 
 def robots_txt(request):
     return HttpResponse(ROBOTS_TXT_CONTENT, content_type="text/plain")
-
-
-@never_cache
-@login_required
-def system_status(request):
-    is_multitenancy: bool = getattr(settings, "MULTI_TENANCY", False)
-
-    if is_multitenancy and not request.user.is_staff:
-        raise AuthenticationFailed(detail="You're not authorized.")
-
-    from .models import Element, Event, SessionRecordingEvent
-
-    redis_alive = is_redis_alive()
-    postgres_alive = is_postgres_alive()
-
-    metrics: List[Dict[str, Union[str, bool, int, float]]] = []
-
-    metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
-
-    metrics.append(
-        {
-            "key": "analytics_database",
-            "metric": "Analytics database in use",
-            "value": "ClickHouse" if is_clickhouse_enabled() else "Postgres",
-        }
-    )
-
-    metrics.append({"key": "plugin_sever_alive", "metric": "Plugin server alive", "value": is_plugin_server_alive()})
-    metrics.append(
-        {
-            "key": "plugin_sever_version",
-            "metric": "Plugin server version",
-            "value": get_plugin_server_version() or "unknown",
-        }
-    )
-
-    plugin_server_queues = get_plugin_server_job_queues()
-    metrics.append(
-        {
-            "key": "plugin_sever_job_queues",
-            "metric": "Job queues enabled in plugin server",
-            "value": ", ".join([q.capitalize() for q in plugin_server_queues]) if plugin_server_queues else "unknown",
-        }
-    )
-
-    metrics.append({"key": "db_alive", "metric": "Postgres database alive", "value": postgres_alive})
-    if postgres_alive:
-        postgres_version = connection.cursor().connection.server_version
-        metrics.append(
-            {
-                "key": "pg_version",
-                "metric": "Postgres version",
-                "value": f"{postgres_version // 10000}.{(postgres_version // 100) % 100}.{postgres_version % 100}",
-            }
-        )
-
-        if not is_clickhouse_enabled():
-            event_table_count = get_table_approx_count(Event._meta.db_table)
-            event_table_size = get_table_size(Event._meta.db_table)
-
-            element_table_count = get_table_approx_count(Element._meta.db_table)
-            element_table_size = get_table_size(Element._meta.db_table)
-
-            session_recording_event_table_count = get_table_approx_count(SessionRecordingEvent._meta.db_table)
-            session_recording_event_table_size = get_table_size(SessionRecordingEvent._meta.db_table)
-
-            metrics.append(
-                {
-                    "metric": "Postgres elements table size",
-                    "value": f"{element_table_count} rows (~{element_table_size})",
-                }
-            )
-            metrics.append(
-                {"metric": "Postgres events table size", "value": f"{event_table_count} rows (~{event_table_size})"}
-            )
-            metrics.append(
-                {
-                    "metric": "Postgres session recording table size",
-                    "value": f"{session_recording_event_table_count} rows (~{session_recording_event_table_size})",
-                }
-            )
-    if is_clickhouse_enabled():
-        from ee.clickhouse.system_status import system_status
-
-        metrics.extend(list(system_status()))
-
-    metrics.append({"key": "redis_alive", "metric": "Redis alive", "value": redis_alive})
-    if redis_alive:
-        import redis
-
-        try:
-            redis_info = get_redis_info()
-            redis_queue_depth = get_redis_queue_depth()
-            metrics.append({"metric": "Redis version", "value": f"{redis_info.get('redis_version')}"})
-            metrics.append({"metric": "Redis current queue depth", "value": f"{redis_queue_depth}"})
-            metrics.append(
-                {"metric": "Redis connected client count", "value": f"{redis_info.get('connected_clients')}"}
-            )
-            metrics.append({"metric": "Redis memory used", "value": f"{redis_info.get('used_memory_human', '?')}B"})
-            metrics.append(
-                {"metric": "Redis memory peak", "value": f"{redis_info.get('used_memory_peak_human', '?')}B"}
-            )
-            metrics.append(
-                {
-                    "metric": "Redis total memory available",
-                    "value": f"{redis_info.get('total_system_memory_human', '?')}B",
-                }
-            )
-        except redis.exceptions.ConnectionError as e:
-            metrics.append(
-                {"metric": "Redis metrics", "value": f"Redis connected but then failed to return metrics: {e}"}
-            )
-
-    return JsonResponse({"results": {"overview": metrics, "internal_metrics": get_internal_metrics_dashboards()}})
 
 
 @never_cache


### PR DESCRIPTION
I will be adding other endpoints, which should live under it rather than
separately

Sorry @tiina303 for the merge conflicts this causes

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
