### PR TITLE
Add running & slow queries to instance status dashboards

### DIFF
--- a/ee/clickhouse/system_status.py
+++ b/ee/clickhouse/system_status.py
@@ -91,13 +91,6 @@ def query_with_columns(query, args=None, columns_to_remove=[]) -> List[Dict]:
     metrics, types = sync_execute(query, args, with_column_types=True)
     type_names = [key for key, _type in types]
 
-    import pprint
-
-    pprint.pprint(metrics)
-    import pprint
-
-    pprint.pprint(type_names)
-
     rows = [dict(zip(type_names, row)) for row in metrics]
     for row in rows:
         for key in columns_to_remove:

--- a/ee/clickhouse/system_status.py
+++ b/ee/clickhouse/system_status.py
@@ -5,7 +5,8 @@ from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
 
-SLOW_THRESHOLD = 10000
+SLOW_THRESHOLD_MS = 10000
+SLOW_AFTER = relativedelta(hours=6)
 
 SystemStatusRow = Dict
 
@@ -77,12 +78,12 @@ def get_clickhouse_slow_log() -> List[Dict]:
         f"""
             SELECT query_duration_ms as duration, query, *
             FROM system.query_log
-            WHERE query_duration_ms > {SLOW_THRESHOLD}
+            WHERE query_duration_ms > {SLOW_THRESHOLD_MS}
               AND event_time > %(after)s
             ORDER BY duration DESC
             LIMIT 200
         """,
-        {"after": timezone.now() - relativedelta(hours=6)},
+        {"after": timezone.now() - SLOW_AFTER},
         columns_to_remove=[
             "address",
             "initial_address",

--- a/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
@@ -48,6 +48,14 @@ export function InternalMetricsTab(): JSX.Element {
                     </div>
                     <QueryTable queries={postgresQueries} loading={queriesLoading} />
                 </Collapse.Panel>
+                <Collapse.Panel header="Clickhouse - currently running queries" key="2">
+                    <div className="mb float-right">
+                        <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
+                            <ReloadOutlined /> Reload Queries
+                        </Button>
+                    </div>
+                    <QueryTable queries={queries?.clickhouse_running} loading={queriesLoading} />
+                </Collapse.Panel>
             </Collapse>
         </Card>
     )
@@ -87,8 +95,9 @@ function QueryTable(props: {
             loading={props.loading}
             pagination={{ pageSize: 30, hideOnSinglePage: true }}
             size="small"
-            emptyText="No queries found"
             bordered
+            style={{ overflowX: 'auto', overflowY: 'auto' }}
+            locale={{ emptyText: 'No queries found' }}
         />
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
@@ -48,22 +48,26 @@ export function InternalMetricsTab(): JSX.Element {
                     </div>
                     <QueryTable queries={postgresQueries} loading={queriesLoading} />
                 </Collapse.Panel>
-                <Collapse.Panel header="Clickhouse - currently running queries" key="2">
-                    <div className="mb float-right">
-                        <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
-                            <ReloadOutlined /> Reload Queries
-                        </Button>
-                    </div>
-                    <QueryTable queries={queries?.clickhouse_running} loading={queriesLoading} />
-                </Collapse.Panel>
-                <Collapse.Panel header="Clickhouse - slow query log (past 6 hours)" key="3">
-                    <div className="mb float-right">
-                        <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
-                            <ReloadOutlined /> Reload Queries
-                        </Button>
-                    </div>
-                    <QueryTable queries={queries?.clickhouse_slow_log} loading={queriesLoading} />
-                </Collapse.Panel>
+                {queries?.clickhouse_running != undefined ? (
+                    <Collapse.Panel header="Clickhouse - currently running queries" key="2">
+                        <div className="mb float-right">
+                            <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
+                                <ReloadOutlined /> Reload Queries
+                            </Button>
+                        </div>
+                        <QueryTable queries={queries?.clickhouse_running} loading={queriesLoading} />
+                    </Collapse.Panel>
+                ) : null}
+                {queries?.clickhouse_slow_log != undefined ? (
+                    <Collapse.Panel header="Clickhouse - slow query log (past 6 hours)" key="3">
+                        <div className="mb float-right">
+                            <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
+                                <ReloadOutlined /> Reload Queries
+                            </Button>
+                        </div>
+                        <QueryTable queries={queries?.clickhouse_slow_log} loading={queriesLoading} />
+                    </Collapse.Panel>
+                ) : null}
             </Collapse>
         </Card>
     )

--- a/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
@@ -56,6 +56,14 @@ export function InternalMetricsTab(): JSX.Element {
                     </div>
                     <QueryTable queries={queries?.clickhouse_running} loading={queriesLoading} />
                 </Collapse.Panel>
+                <Collapse.Panel header="Clickhouse - slow query log (past 6 hours)" key="3">
+                    <div className="mb float-right">
+                        <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
+                            <ReloadOutlined /> Reload Queries
+                        </Button>
+                    </div>
+                    <QueryTable queries={queries?.clickhouse_slow_log} loading={queriesLoading} />
+                </Collapse.Panel>
             </Collapse>
         </Card>
     )

--- a/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
@@ -1,15 +1,94 @@
-import React from 'react'
-import { Card } from 'antd'
-import { useValues } from 'kea'
+import React, { useMemo, useState } from 'react'
+import { Button, Card, Checkbox, Collapse, Table } from 'antd'
+import { ReloadOutlined } from '@ant-design/icons'
+import { useActions, useValues } from 'kea'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
+import { QuerySummary } from '~/types'
+import { ColumnsType } from 'antd/lib/table'
 
 export function InternalMetricsTab(): JSX.Element {
-    const { systemStatus } = useValues(systemStatusLogic)
+    const { openSections, systemStatus, queries, queriesLoading } = useValues(systemStatusLogic)
+    const { setOpenSections, loadQueries } = useActions(systemStatusLogic)
+
+    const [showIdle, setShowIdle] = useState(false)
+    const postgresQueries = useMemo(
+        () => queries?.postgres_running?.filter(({ state }) => showIdle || state !== 'idle'),
+        [showIdle, queries]
+    )
 
     const dashboard = systemStatus?.internal_metrics.clickhouse
 
+    const reloadQueries = (e: React.MouseEvent): void => {
+        e.stopPropagation()
+        loadQueries()
+    }
+
     return (
-        <Card>{dashboard ? <Dashboard id={dashboard.id.toString()} shareToken={dashboard.share_token} /> : null}</Card>
+        <Card>
+            <Collapse activeKey={openSections} onChange={(keys) => setOpenSections(keys as string[])}>
+                {dashboard ? (
+                    <Collapse.Panel header="Dashboards" key="0">
+                        <Dashboard id={dashboard.id.toString()} shareToken={dashboard.share_token} />
+                    </Collapse.Panel>
+                ) : null}
+                <Collapse.Panel header="PostgreSQL - currently running queries" key="1">
+                    <div className="mb float-right">
+                        <Checkbox
+                            checked={showIdle}
+                            onChange={(e) => {
+                                setShowIdle(e.target.checked)
+                            }}
+                        >
+                            Show idle queries
+                        </Checkbox>
+                        <Button style={{ marginLeft: 8 }} onClick={reloadQueries}>
+                            <ReloadOutlined /> Reload Queries
+                        </Button>
+                    </div>
+                    <QueryTable queries={postgresQueries} loading={queriesLoading} />
+                </Collapse.Panel>
+            </Collapse>
+        </Card>
+    )
+}
+
+function QueryTable(props: {
+    queries?: QuerySummary[]
+    loading: boolean
+    columnExtra?: Record<string, any>
+}): JSX.Element {
+    const columns: ColumnsType<QuerySummary> = [
+        {
+            title: 'duration',
+            dataIndex: 'duration',
+            key: 'duration',
+            sorter: (a, b) => +a.duration - +b.duration,
+        },
+        {
+            title: 'query',
+            dataIndex: 'query',
+            key: 'query',
+        },
+    ]
+
+    if (props.queries && props.queries.length > 0) {
+        Object.keys(props.queries[0]).forEach((column) => {
+            if (column !== 'duration' && column !== 'query') {
+                columns.push({ title: column, dataIndex: column, key: column })
+            }
+        })
+    }
+
+    return (
+        <Table
+            dataSource={props.queries || []}
+            columns={columns}
+            loading={props.loading}
+            pagination={{ pageSize: 30, hideOnSinglePage: true }}
+            size="small"
+            emptyText="No queries found"
+            bordered
+        />
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -47,7 +47,7 @@ export const systemStatusLogic = kea<
             },
         ],
         openSections: [
-            ['0', '1'] as string[],
+            ['0'] as string[],
             { persist: true },
             {
                 setOpenSections: (_, { sections }) => sections,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -564,6 +564,12 @@ export interface SystemStatus {
     }
 }
 
+export type QuerySummary = { duration: string } & Record<string, string>
+
+export interface SystemStatusQueriesResult {
+    postgres_running: QuerySummary[]
+}
+
 export type PersonalizationData = Record<string, string | string[] | null>
 
 interface EnabledSetupState {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -568,6 +568,7 @@ export type QuerySummary = { duration: string } & Record<string, string>
 
 export interface SystemStatusQueriesResult {
     postgres_running: QuerySummary[]
+    clickhouse_running?: QuerySummary[]
 }
 
 export type PersonalizationData = Record<string, string | string[] | null>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -569,6 +569,7 @@ export type QuerySummary = { duration: string } & Record<string, string>
 export interface SystemStatusQueriesResult {
     postgres_running: QuerySummary[]
     clickhouse_running?: QuerySummary[]
+    clickhouse_slow_log?: QuerySummary[]
 }
 
 export type PersonalizationData = Record<string, string | string[] | null>

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -145,6 +145,11 @@ class InstanceStatusViewSet(viewsets.ViewSet):
     def queries(self, request: Request) -> Response:
         queries = {"postgres_running": self.get_postgres_running_queries()}
 
+        if is_clickhouse_enabled():
+            from ee.clickhouse.system_status import get_clickhouse_running_queries
+
+            queries["clickhouse_running"] = get_clickhouse_running_queries()
+
         return Response({"results": queries})
 
     def get_postgres_running_queries(self):
@@ -157,7 +162,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
             FROM pg_stat_activity
             WHERE query NOT LIKE '%pg_stat_activity%'
               AND query != ''
-              AND now() - query_start > INTERVAL '10 seconds'
+              AND now() - query_start > INTERVAL '3 seconds'
             ORDER BY state, duration DESC
         """
         )

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -146,9 +146,10 @@ class InstanceStatusViewSet(viewsets.ViewSet):
         queries = {"postgres_running": self.get_postgres_running_queries()}
 
         if is_clickhouse_enabled():
-            from ee.clickhouse.system_status import get_clickhouse_running_queries
+            from ee.clickhouse.system_status import get_clickhouse_running_queries, get_clickhouse_slow_log
 
             queries["clickhouse_running"] = get_clickhouse_running_queries()
+            queries["clickhouse_slow_log"] = get_clickhouse_slow_log()
 
         return Response({"results": queries})
 


### PR DESCRIPTION
Depends on https://github.com/PostHog/posthog/pull/4416

- Allow getting table schema from clickhouse
- Show PostgreSQL queries in system status page
- Show table with currently running queries
- Show slow queries from the past 6 hours
- Make collapsible sections optional

Dashboards are open by default, rest are collapsed.

![image](https://user-images.githubusercontent.com/148820/119008798-2793d000-b99b-11eb-9511-56c3fbb7fb5b.png)

![image](https://user-images.githubusercontent.com/148820/119008760-1f3b9500-b99b-11eb-899f-2e7ac609c857.png)

![image](https://user-images.githubusercontent.com/148820/119008715-15199680-b99b-11eb-97fb-2f64c1de8053.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
