### PR TITLE
only explicitly set color if label is present on breakdown by

### DIFF
--- a/frontend/src/scenes/insights/BreakdownFilter/BreakdownFilter.js
+++ b/frontend/src/scenes/insights/BreakdownFilter/BreakdownFilter.js
@@ -162,7 +162,7 @@ export function BreakdownFilter({ filters, onChange }) {
                     type={breakdown ? 'primary' : 'default'}
                     disabled={insight === ViewType.STICKINESS || insight === ViewType.LIFECYCLE}
                     data-attr="add-breakdown-button"
-                    style={{ color: '#fff' }}
+                    style={label ? { color: '#fff' } : {}}
                 >
                     <PropertyKeyInfo value={label || 'Add breakdown'} />
                 </Button>


### PR DESCRIPTION
## Changes

*Please describe.*  
- follow-up to #4401, breakdown by filter button had blank label because it was white label on white background
*If this affects the frontend, include screenshots.*  
![Screen Shot 2021-05-20 at 3 05 01 PM](https://user-images.githubusercontent.com/13127476/119034790-c3faaa00-b97c-11eb-8a74-ea52199b1ebf.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
