### PR TITLE
Fix dashboards list after visiting /instance/status

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -308,7 +308,7 @@ export function objectsEqual(obj1: any, obj2: any): boolean {
     return JSON.stringify(obj1) === JSON.stringify(obj2)
 }
 
-export function idToKey(array: Record<string, any>[], keyField: string = 'id'): any {
+export function idToKey(array: Record<string, any>[], keyField: string = 'id'): Record<string, any> {
     const object: Record<string, any> = {}
     for (const element of array) {
         object[element[keyField]] = element

--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -20,15 +20,13 @@ export const dashboardsModel = kea({
         rawDashboards: [
             {},
             {
-                loadDashboards: async (shareToken = undefined, breakpoint) => {
-                    await breakpoint(50)
-                    try {
-                        const { results } = await api.get(`api/dashboard?${toParams({ share_token: shareToken })}`)
-                        return idToKey(results)
-                    } catch {
-                        return {}
-                    }
-                },
+                loadDashboards: (_, breakpoint) => loadDashboard(undefined, breakpoint),
+            },
+        ],
+        sharedDashboards: [
+            null,
+            {
+                loadSharedDashboard: (shareToken, breakpoint) => loadDashboard(shareToken, breakpoint),
             },
         ],
         // We're not using this loader as a reducer per se, but just calling it `dashboard`
@@ -180,3 +178,13 @@ export const dashboardsModel = kea({
         '/dashboard/:id': ({ id }) => actions.setLastDashboardId(parseInt(id)),
     }),
 })
+
+async function loadDashboard(shareToken, breakpoint) {
+    await breakpoint(50)
+    try {
+        const { results } = await api.get(`api/dashboard?${toParams({ share_token: shareToken })}`)
+        return idToKey(results)
+    } catch {
+        return {}
+    }
+}

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -148,8 +148,11 @@ export const dashboardLogic = kea({
             },
         ],
         dashboard: [
-            () => [dashboardsModel.selectors.dashboards],
-            (dashboards) => {
+            () => [dashboardsModel.selectors.sharedDashboards, dashboardsModel.selectors.dashboards],
+            (sharedDashboards, dashboards) => {
+                if (sharedDashboards && !!sharedDashboards[props.id]) {
+                    return sharedDashboards[props.id]
+                }
                 return dashboards.find((d) => d.id === props.id)
             },
         ],
@@ -258,7 +261,7 @@ export const dashboardLogic = kea({
             actions.loadDashboardItems()
             if (props.shareToken) {
                 actions.setDashboardMode(DashboardMode.Public, DashboardEventSource.Browser)
-                dashboardsModel.actions.loadDashboards(props.shareToken)
+                dashboardsModel.actions.loadSharedDashboard(props.shareToken)
             }
         },
         beforeUnmount: () => {


### PR DESCRIPTION
After https://github.com/PostHog/posthog/pull/4366, we embed a shared
dashboard into instance status page. A bug that arose from it was that
after visiting the page, dashboards list would only contain one
(incorrect) dashboard.

This fixes that by managing shared dashboards separately from list of
dashboards.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
