### PR TITLE
use aria label as event title when text is not available

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -466,6 +466,8 @@ export function eventToName(event: EventType): string {
         }
         if (event.elements[0].text) {
             name += ' with text "' + event.elements[0].text + '"'
+        } else if (event.elements[0].attributes['attr__aria-label']) {
+            name += ' with aria label "' + event.elements[0].attributes['attr__aria-label'] + '"'
         }
     }
     return name


### PR DESCRIPTION
## Changes

When a clicked element has no text but does have an aria label, display the latter as the title of the autocaptured event.

![screenshot](https://user-images.githubusercontent.com/19322/119058230-d9e08d00-b9c5-11eb-8608-133b80c8bd59.png)

Fixes https://github.com/PostHog/posthog/issues/791

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
