### PR TITLE
Add params for setting max connections for clickhouse connection pool

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -20,6 +20,8 @@ from posthog.internal_metrics import timing
 from posthog.settings import (
     CLICKHOUSE_ASYNC,
     CLICKHOUSE_CA,
+    CLICKHOUSE_CONN_POOL_MAX,
+    CLICKHOUSE_CONN_POOL_MIN,
     CLICKHOUSE_DATABASE,
     CLICKHOUSE_HOST,
     CLICKHOUSE_PASSWORD,
@@ -68,8 +70,8 @@ else:
             password=CLICKHOUSE_PASSWORD,
             ca_certs=CLICKHOUSE_CA,
             verify=CLICKHOUSE_VERIFY,
-            connections_min=20,
-            connections_max=1000,
+            connections_min=CLICKHOUSE_CONN_POOL_MIN,
+            connections_max=CLICKHOUSE_CONN_POOL_MAX,
         )
 
         @async_to_sync
@@ -98,8 +100,8 @@ else:
             password=CLICKHOUSE_PASSWORD,
             ca_certs=CLICKHOUSE_CA,
             verify=CLICKHOUSE_VERIFY,
-            connections_min=20,
-            connections_max=1000,
+            connections_min=CLICKHOUSE_CONN_POOL_MIN,
+            connections_max=CLICKHOUSE_CONN_POOL_MAX,
         )
 
         def async_execute(query, args=None, settings=None):

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -154,6 +154,9 @@ CLICKHOUSE_REPLICATION = get_from_env("CLICKHOUSE_REPLICATION", False, type_cast
 CLICKHOUSE_ENABLE_STORAGE_POLICY = get_from_env("CLICKHOUSE_ENABLE_STORAGE_POLICY", False, type_cast=strtobool)
 CLICKHOUSE_ASYNC = get_from_env("CLICKHOUSE_ASYNC", False, type_cast=strtobool)
 
+CLICKHOUSE_CONN_POOL_MIN = os.getenv("CLICKHOUSE_CONN_POOL_MIN", 20)
+CLICKHOUSE_CONN_POOL_MAX = os.getenv("CLICKHOUSE_CONN_POOL_MAX", 1000)
+
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"
 if CLICKHOUSE_SECURE:


### PR DESCRIPTION
## Changes

This is to add a lever to see if we can reduce the number of errors coming from vpc deploys due to ch pool running out of connections.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
