### PR TITLE
Upgrade rrweb fork

### DIFF
--- a/frontend/src/scenes/sessions/SessionsPlayer.scss
+++ b/frontend/src/scenes/sessions/SessionsPlayer.scss
@@ -1,3 +1,3 @@
-@import 'node_modules/rrweb/dist/rrweb.min';
+@import 'node_modules/@posthog/rrweb/dist/rrweb.min';
 @import 'node_modules/rc-tooltip/assets/bootstrap';
 @import 'node_modules/@posthog/react-rrweb-player/dist/index';

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "md5": "^2.3.0",
         "posthog-js": "1.10.0",
         "posthog-js-lite": "^0.0.3",
+        "posthog-rrweb": "0.9.15-beta",
         "prop-types": "^15.7.2",
         "query-selector-shadow-dom": "0.8.0",
         "rc-trigger": "^5.2.5",
@@ -85,7 +86,6 @@
         "redux": "^4.0.5",
         "reselect": "^4.0.0",
         "resize-observer-polyfill": "^1.5.1",
-        "rrweb": "^0.9.14",
         "sass": "^1.26.2",
         "use-debounce": "^6.0.1",
         "zxcvbn": "^4.4.2"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "node": ">=14"
     },
     "scripts": {
-        "copy-scripts": "cp node_modules/posthog-js/dist/array.js* frontend/dist/; cp node_modules/rrweb/dist/rrweb.min.js frontend/dist/recorder.js",
+        "copy-scripts": "cp node_modules/posthog-js/dist/array.js* frontend/dist/; cp node_modules/@posthog/rrweb/dist/rrweb.min.js frontend/dist/recorder.js",
         "test": "jest",
         "start": "concurrently -n WEBPACK,TYPEGEN -c blue,green \"yarn run start-http\" \"yarn run typegen:watch\"",
         "start-http": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve",
@@ -40,7 +40,8 @@
         "@babel/runtime": "^7.10.4",
         "@papercups-io/chat-widget": "^1.1.5",
         "@posthog/plugin-scaffold": "0.2.12",
-        "@posthog/react-rrweb-player": "^1.1.1",
+        "@posthog/react-rrweb-player": "1.1.3-beta",
+        "@posthog/rrweb": "^0.9.15-beta",
         "@posthog/simmerjs": "0.7.4",
         "@sentry/browser": "^6.0.4",
         "@types/md5": "^2.3.0",
@@ -66,7 +67,6 @@
         "md5": "^2.3.0",
         "posthog-js": "1.10.0",
         "posthog-js-lite": "^0.0.3",
-        "posthog-rrweb": "0.9.15-beta",
         "prop-types": "^15.7.2",
         "query-selector-shadow-dom": "0.8.0",
         "rc-trigger": "^5.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,18 +1601,29 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.2.12.tgz#3fc54881030ad6a51549e04f1d725644a1d1e0d5"
   integrity sha512-MhTK21NvIokMCo4MdJ4iEwjRj/vMG73ucRQtpBmBqZNd1wvy9C7HMFyHmR0uxz1RsT3SCPWuuj1HDvoJsb+QQw==
 
-"@posthog/react-rrweb-player@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@posthog/react-rrweb-player/-/react-rrweb-player-1.1.1.tgz#4020ad1413efef0d574fb4043303f0a6154989b0"
-  integrity sha512-z3OXhisr1UJKOYnOc8ebZ7dBvR33y4R6u4fK8negKfv0T5DE3nrg264D0FDwsN7Lke+ZLo2k8so1pD4SQQ6tYA==
+"@posthog/react-rrweb-player@1.1.3-beta":
+  version "1.1.3-beta"
+  resolved "https://registry.yarnpkg.com/@posthog/react-rrweb-player/-/react-rrweb-player-1.1.3-beta.tgz#1b729776d65575bb5b336c4e9f0be9544f4b4e6b"
+  integrity sha512-6RAxeQzcSCbJHIu7bXHEpZpbvwi1axuyHDyNXHxaDRQkg6CycUKrsPhyHVZMNMy3r+r0cHefTIFthyOhCgX4XA==
   dependencies:
+    "@posthog/rrweb" "0.9.15-beta"
     rc-slider "^9.6.2"
     rc-tooltip "^5.0.1"
     react-transition-group "^4.4.1"
-    rrweb "^0.9.14"
     screenfull "^5.0.2"
     use-debounce "^5.2.1"
     use-local-storage-state "^6.0.0"
+
+"@posthog/rrweb@0.9.15-beta", "@posthog/rrweb@^0.9.15-beta":
+  version "0.9.15-beta"
+  resolved "https://registry.yarnpkg.com/@posthog/rrweb/-/rrweb-0.9.15-beta.tgz#6049277a09820eb8ba1ee271b3bfa82555ea3ca3"
+  integrity sha512-+a4Gi9AwR5Ithrn0YxtSv5xGUV4Zgibjewjii4dSvfi/Yno4xXM2bMNuNYvzbxJulxyf6HxNq67PHB5Ds5kAdQ==
+  dependencies:
+    "@types/css-font-loading-module" "0.0.4"
+    "@xstate/fsm" "^1.4.0"
+    fflate "^0.4.4"
+    mitt "^1.1.3"
+    rrweb-snapshot "^1.1.2"
 
 "@posthog/simmerjs@0.7.4":
   version "0.7.4"
@@ -9252,17 +9263,6 @@ posthog-js@1.10.0:
   dependencies:
     fflate "^0.4.1"
 
-posthog-rrweb@0.9.15-beta:
-  version "0.9.15-beta"
-  resolved "https://registry.yarnpkg.com/posthog-rrweb/-/posthog-rrweb-0.9.15-beta.tgz#ea5778849f256e23af1d642218c2d4bfae1d0557"
-  integrity sha512-xRMsQ99X9gZeWk7Ac8xtAHMjk8DYye80ymQINC2VUa0XX8IecyR+Td0b+mC6IdweHTvC4aOPyb0cMd8RydTepw==
-  dependencies:
-    "@types/css-font-loading-module" "0.0.4"
-    "@xstate/fsm" "^1.4.0"
-    fflate "^0.4.4"
-    mitt "^1.1.3"
-    rrweb-snapshot "^1.1.2"
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -10424,26 +10424,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rrweb-snapshot@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.0.6.tgz#2b1143d2e8b5bba54c54bd63e485cfc253763b8e"
-  integrity sha512-ctwaNjFnomNFe446gOcMusSzIxLUnF0kq6ev0iuKa1W1lhiVcBoRdfpE8zDDRKee2MxHxt0rq2T5DMKSIAD6fQ==
-
 rrweb-snapshot@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.3.tgz#a2b35dd481281e70a8f25972c77ea03930ae338a"
   integrity sha512-FAMn6bonk1XCeoe87F9DxVpgeeSFCYoziLlzRI56S7Jb+t4lxX7LIN/VOqS3ZbVdGTiQLP4cosDtYU8pu6bnHg==
-
-rrweb@^0.9.14:
-  version "0.9.14"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-0.9.14.tgz#09bec604fc44c74801e4fe910606e5a6cde008ec"
-  integrity sha512-nm2rrVNoyWFPrbGQmcvTTlA7XjbbgPIgO7qsW0Zyr5iOURIFJDGPHFmOVLRyLpWiriVtEoXh6a+x+D1sj+qwWg==
-  dependencies:
-    "@types/css-font-loading-module" "0.0.4"
-    "@xstate/fsm" "^1.4.0"
-    fflate "^0.4.4"
-    mitt "^1.1.3"
-    rrweb-snapshot "^1.0.3"
 
 rsvp@^4.8.4:
   version "4.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9252,6 +9252,17 @@ posthog-js@1.10.0:
   dependencies:
     fflate "^0.4.1"
 
+posthog-rrweb@0.9.15-beta:
+  version "0.9.15-beta"
+  resolved "https://registry.yarnpkg.com/posthog-rrweb/-/posthog-rrweb-0.9.15-beta.tgz#ea5778849f256e23af1d642218c2d4bfae1d0557"
+  integrity sha512-xRMsQ99X9gZeWk7Ac8xtAHMjk8DYye80ymQINC2VUa0XX8IecyR+Td0b+mC6IdweHTvC4aOPyb0cMd8RydTepw==
+  dependencies:
+    "@types/css-font-loading-module" "0.0.4"
+    "@xstate/fsm" "^1.4.0"
+    fflate "^0.4.4"
+    mitt "^1.1.3"
+    rrweb-snapshot "^1.1.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -10417,6 +10428,11 @@ rrweb-snapshot@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.0.6.tgz#2b1143d2e8b5bba54c54bd63e485cfc253763b8e"
   integrity sha512-ctwaNjFnomNFe446gOcMusSzIxLUnF0kq6ev0iuKa1W1lhiVcBoRdfpE8zDDRKee2MxHxt0rq2T5DMKSIAD6fQ==
+
+rrweb-snapshot@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.3.tgz#a2b35dd481281e70a8f25972c77ea03930ae338a"
+  integrity sha512-FAMn6bonk1XCeoe87F9DxVpgeeSFCYoziLlzRI56S7Jb+t4lxX7LIN/VOqS3ZbVdGTiQLP4cosDtYU8pu6bnHg==
 
 rrweb@^0.9.14:
   version "0.9.14"


### PR DESCRIPTION
## Changes

Pulling from git didn't work so I published our own version of rrweb.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
