### PR TITLE
Compact mode for new insights page

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -122,6 +122,7 @@ export const eventUsageLogic = kea<
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
         reportInsightsTabReset: true,
+        reportInsightsControlsCollapseToggle: (collapsed: boolean) => ({ collapsed }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -425,6 +426,9 @@ export const eventUsageLogic = kea<
         },
         reportInsightsTabReset: async () => {
             posthog.capture('insights tab reset')
+        },
+        reportInsightsControlsCollapseToggle: async ({ collapsed }) => {
+            posthog.capture('insight controls collapse toggled', { collapsed })
         },
     },
 })

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -28,6 +28,28 @@
 
     .insight-controls {
         overflow: visible;
+        position: relative;
+
+        .collapse-control {
+            position: absolute;
+            right: $default_spacing / 2;
+            top: $default_spacing / 2;
+            cursor: pointer;
+            z-index: $z_raised;
+        }
+
+        &.collapsed {
+            cursor: pointer;
+            border-color: $primary !important;
+            .tabs-inner {
+                display: none;
+            }
+
+            .collapse-control {
+                top: 50%;
+                transform: translateY(-50%);
+            }
+        }
     }
 
     .insights-graph-container {

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -234,20 +234,25 @@ export function Insights(): JSX.Element {
                                 onClick={() => controlsCollapsed && toggleControlsCollapsed()}
                             >
                                 {horizontalUI && (
-                                    <div
-                                        className="collapse-control"
-                                        onClick={() => !controlsCollapsed && toggleControlsCollapsed()}
-                                    >
-                                        {controlsCollapsed ? <DownOutlined /> : <UpOutlined />}
-                                    </div>
-                                )}
-                                {controlsCollapsed && (
-                                    <div>
-                                        <h3 className="l3">Query definition</h3>
-                                        <span className="text-small text-muted">
-                                            Click here to view and change the query events, filters and other settings.
-                                        </span>
-                                    </div>
+                                    <>
+                                        <div
+                                            role="button"
+                                            title={controlsCollapsed ? 'Expand panel' : 'Collapse panel'}
+                                            className="collapse-control"
+                                            onClick={() => !controlsCollapsed && toggleControlsCollapsed()}
+                                        >
+                                            {controlsCollapsed ? <DownOutlined /> : <UpOutlined />}
+                                        </div>
+                                        {controlsCollapsed && (
+                                            <div>
+                                                <h3 className="l3">Query definition</h3>
+                                                <span className="text-small text-muted">
+                                                    Click here to view and change the query events, filters and other
+                                                    settings.
+                                                </span>
+                                            </div>
+                                        )}
+                                    </>
                                 )}
                                 <div className="tabs-inner">
                                     {/* These are insight specific filters. They each have insight specific logics */}

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -20,7 +20,7 @@ import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic, logicFromInsight, ViewType } from './insightLogic'
 import { InsightHistoryPanel } from './InsightHistoryPanel'
 import { SavedFunnels } from './SavedCard'
-import { ReloadOutlined } from '@ant-design/icons'
+import { ReloadOutlined, DownOutlined, UpOutlined } from '@ant-design/icons'
 import { insightCommandLogic } from './insightCommandLogic'
 
 import './Insights.scss'
@@ -54,10 +54,16 @@ export function Insights(): JSX.Element {
     const [{ fromItem }] = useState(router.values.hashParams)
     const { clearAnnotationsToCreate } = useActions(annotationsLogic({ pageKey: fromItem }))
     const { annotationsToCreate } = useValues(annotationsLogic({ pageKey: fromItem }))
-    const { lastRefresh, isLoading, activeView, allFilters, showTimeoutMessage, showErrorMessage } = useValues(
-        insightLogic
-    )
-    const { setActiveView } = useActions(insightLogic)
+    const {
+        lastRefresh,
+        isLoading,
+        activeView,
+        allFilters,
+        showTimeoutMessage,
+        showErrorMessage,
+        controlsCollapsed,
+    } = useValues(insightLogic)
+    const { setActiveView, toggleControlsCollapsed } = useActions(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
 
@@ -223,12 +229,23 @@ export function Insights(): JSX.Element {
                 ) : (
                     <>
                         <Col xs={24} xl={horizontalUI ? 24 : 7}>
-                            <Card className="insight-controls">
-                                <div>
-                                    {/*
-                                These are insight specific filters.
-                                They each have insight specific logics
-                                */}
+                            <Card
+                                className={`insight-controls${controlsCollapsed ? ' collapsed' : ''}`}
+                                onClick={(e) => controlsCollapsed && e.stopPropagation() && toggleControlsCollapsed()}
+                            >
+                                <div className="collapse-control" onClick={() => toggleControlsCollapsed()}>
+                                    {controlsCollapsed ? <DownOutlined /> : <UpOutlined />}
+                                </div>
+                                {controlsCollapsed && (
+                                    <div>
+                                        <h3 className="l3">Query definition</h3>
+                                        <span className="text-small text-muted">
+                                            Click here to view and change the query events, filters and other settings.
+                                        </span>
+                                    </div>
+                                )}
+                                <div className="tabs-inner">
+                                    {/* These are insight specific filters. They each have insight specific logics */}
                                     {
                                         {
                                             [`${ViewType.TRENDS}`]: (

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -231,11 +231,16 @@ export function Insights(): JSX.Element {
                         <Col xs={24} xl={horizontalUI ? 24 : 7}>
                             <Card
                                 className={`insight-controls${controlsCollapsed ? ' collapsed' : ''}`}
-                                onClick={(e) => controlsCollapsed && e.stopPropagation() && toggleControlsCollapsed()}
+                                onClick={() => controlsCollapsed && toggleControlsCollapsed()}
                             >
-                                <div className="collapse-control" onClick={() => toggleControlsCollapsed()}>
-                                    {controlsCollapsed ? <DownOutlined /> : <UpOutlined />}
-                                </div>
+                                {horizontalUI && (
+                                    <div
+                                        className="collapse-control"
+                                        onClick={() => !controlsCollapsed && toggleControlsCollapsed()}
+                                    >
+                                        {controlsCollapsed ? <DownOutlined /> : <UpOutlined />}
+                                    </div>
+                                )}
                                 {controlsCollapsed && (
                                     <div>
                                         <h3 className="l3">Query definition</h3>

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -62,6 +62,8 @@ export const insightLogic = kea<insightLogicType>({
         setTimeout: (timeout) => ({ timeout }),
         setLastRefresh: (lastRefresh: string | null) => ({ lastRefresh }),
         setNotFirstLoad: () => {},
+        setControlsCollapsed: (controlsCollapsed: boolean) => ({ controlsCollapsed }),
+        toggleControlsCollapsed: true,
     }),
 
     reducers: {
@@ -133,6 +135,13 @@ export const insightLogic = kea<insightLogicType>({
             true,
             {
                 setNotFirstLoad: () => false,
+            },
+        ],
+        controlsCollapsed: [
+            false,
+            {
+                setControlsCollapsed: (_, { controlsCollapsed }) => controlsCollapsed,
+                toggleControlsCollapsed: (state) => !state,
             },
         ],
     },

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -62,7 +62,6 @@ export const insightLogic = kea<insightLogicType>({
         setTimeout: (timeout) => ({ timeout }),
         setLastRefresh: (lastRefresh: string | null) => ({ lastRefresh }),
         setNotFirstLoad: () => {},
-        setControlsCollapsed: (controlsCollapsed: boolean) => ({ controlsCollapsed }),
         toggleControlsCollapsed: true,
     }),
 
@@ -140,7 +139,6 @@ export const insightLogic = kea<insightLogicType>({
         controlsCollapsed: [
             false,
             {
-                setControlsCollapsed: (_, { controlsCollapsed }) => controlsCollapsed,
                 toggleControlsCollapsed: (state) => !state,
             },
         ],
@@ -184,6 +182,9 @@ export const insightLogic = kea<insightLogicType>({
             actions.setShowTimeoutMessage(false)
             actions.setShowErrorMessage(false)
             clearTimeout(values.timeout || undefined)
+        },
+        toggleControlsCollapsed: async () => {
+            eventUsageLogic.actions.reportInsightsControlsCollapseToggle(values.controlsCollapsed)
         },
     }),
     actionToUrl: ({ actions, values }) => ({

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -8,7 +8,6 @@ import {
     ACTIONS_PIE_CHART,
     ACTIONS_BAR_CHART,
     ACTIONS_BAR_CHART_VALUE,
-    FEATURE_FLAGS,
 } from 'lib/constants'
 
 import { ActionsPie, ActionsTable, ActionsLineGraph, ActionsBarValueGraph } from './viz'
@@ -16,13 +15,13 @@ import { SaveCohortModal } from './SaveCohortModal'
 import { trendsLogic } from './trendsLogic'
 import { ViewType } from 'scenes/insights/insightLogic'
 import { Button } from 'antd'
-import { featureFlagLogic } from '../../lib/logic/featureFlagLogic'
 
 interface Props {
     view: ViewType
 }
 
 export function TrendInsight({ view }: Props): JSX.Element {
+    const [cohortModalVisible, setCohortModalVisible] = useState(false)
     const {
         filters: _filters,
         showingPeople,
@@ -33,18 +32,12 @@ export function TrendInsight({ view }: Props): JSX.Element {
     const { saveCohortWithFilters, refreshCohort, loadMoreBreakdownValues } = useActions(
         trendsLogic({ dashboardItemId: null, view, filters: null })
     )
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const [cohortModalVisible, setCohortModalVisible] = useState(false)
-
     return (
         <>
             {(_filters.actions || _filters.events || _filters.session) && (
                 <div
                     style={{
-                        minHeight: featureFlags[FEATURE_FLAGS.QUERY_UX_V2]
-                            ? 'calc(100vh - 40rem)'
-                            : 'calc(90vh - 16rem)',
+                        minHeight: 'calc(90vh - 16rem)',
                         position: 'relative',
                     }}
                 >

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -120,6 +120,7 @@ $z_pinned_dashboards_popup: 962;
 $z_mobile_nav_overlay: 931;
 $z_top_navigation: 800;
 $z_content_overlay: 488;
+$z_raised: 5;
 $z_city_background_content: 1;
 $z_city_background_image: 0;
 


### PR DESCRIPTION
Reverts PostHog/posthog#4433 (see conversation in PR for context on motivation).

As an alternative approach, this PR adds support for collapsing the insight controls to take more advantage of the screen space.

<img width="1418" alt="" src="https://user-images.githubusercontent.com/5864173/119198046-b87bb180-ba56-11eb-8e76-11648938f477.png">
