### PR TITLE
Quick hotfix of broken frontend

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -152,8 +152,8 @@ export const navigationLogic = kea<navigationLogicType<UserType, SystemStatus, W
             null as string | null,
             {
                 loadLatestVersion: async () => {
-                    const versions = await api.get('https://update.posthog.com/versions')
-                    return versions[0].version
+                    const versions = (await api.get('https://update.posthog.com/versions')) || []
+                    return versions[0]?.version || '1.25.0' // HACK: Super quick fix so the frontend doesn't fail terribly
                 },
             },
         ],

--- a/frontend/src/scenes/events/propertyDefinitionsLogic.ts
+++ b/frontend/src/scenes/events/propertyDefinitionsLogic.ts
@@ -30,7 +30,7 @@ export const propertyDefinitionsLogic = kea<
                     const propertyStorage = await api.get(url)
                     return {
                         count: propertyStorage.count,
-                        results: [...values.propertyStorage.results, ...propertyStorage.results],
+                        results: [...(values.propertyStorage.results || []), ...(propertyStorage.results || [])],
                         next: propertyStorage.next,
                     }
                 },


### PR DESCRIPTION
## Changes

Filters not loading and various parts of Kea state failing to initialize; see screenshot.

https://files.slack.com/files-pri/TSS5W8YQZ-F023D7WJSNL/screen_shot_2021-05-21_at_8.59.26_am.png

This is a very temporary fix.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
