### PR TITLE
Avoid showing "dashboard not found" for loading dashboards

### DIFF
--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -118,7 +118,10 @@ export const dashboardsModel = kea({
                 return [...list.filter((d) => d.pinned), ...list.filter((d) => !d.pinned)]
             },
         ],
-        dashboardsLoading: [() => [selectors.rawDashboardsLoading], (rawDashboardsLoading) => rawDashboardsLoading],
+        dashboardsLoading: [
+            () => [selectors.rawDashboardsLoading, selectors.sharedDashboardsLoading],
+            (a, b) => a || b,
+        ],
         pinnedDashboards: [() => [selectors.dashboards], (dashboards) => dashboards.filter((d) => d.pinned)],
     }),
 

--- a/frontend/src/models/dashboardsModel.js
+++ b/frontend/src/models/dashboardsModel.js
@@ -120,7 +120,7 @@ export const dashboardsModel = kea({
         ],
         dashboardsLoading: [
             () => [selectors.rawDashboardsLoading, selectors.sharedDashboardsLoading],
-            (a, b) => a || b,
+            (dashesLoading, sharedLoading) => dashesLoading || sharedLoading,
         ],
         pinnedDashboards: [() => [selectors.dashboards], (dashboards) => dashboards.filter((d) => d.pinned)],
     }),

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -62,7 +62,7 @@ class TestUserAPI(APIBaseTest):
         )  # Ensure we're not returning the full `Team`
         self.assertNotIn("event_names", response_data["organization"]["teams"][0])
 
-        self.assertEqual(
+        self.assertCountEqual(
             response_data["organizations"],
             [
                 {"id": str(self.organization.id), "name": self.organization.name},


### PR DESCRIPTION
Follow-up to https://github.com/PostHog/posthog/pull/4429

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
