### PR TITLE
Don't preinstall GeoIP plugin when DISABLE_MMDB is truthy

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -74,9 +74,10 @@ if DEBUG:
 else:
     JS_URL = os.getenv("JS_URL", "")
 
+DISABLE_MMDB = get_from_env("DISABLE", True, type_cast=strtobool)  # plugin server setting disabling built-in GeoIP
 PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
     "PLUGINS_PREINSTALLED_URLS", "https://github.com/PostHog/posthog-plugin-geoip"
-).split(",") if not TEST else []
+).split(",") if not DISABLE_MMDB and not TEST else []
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -74,7 +74,7 @@ if DEBUG:
 else:
     JS_URL = os.getenv("JS_URL", "")
 
-DISABLE_MMDB = get_from_env("DISABLE", True, type_cast=strtobool)  # plugin server setting disabling built-in GeoIP
+DISABLE_MMDB = get_from_env("DISABLE_MMDB", False, type_cast=strtobool)  # plugin server setting disabling GeoIP feature
 PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
     "PLUGINS_PREINSTALLED_URLS", "https://github.com/PostHog/posthog-plugin-geoip"
 ).split(",") if not DISABLE_MMDB and not TEST else []

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -74,10 +74,10 @@ if DEBUG:
 else:
     JS_URL = os.getenv("JS_URL", "")
 
-DISABLE_MMDB = get_from_env("DISABLE_MMDB", False, type_cast=strtobool)  # plugin server setting disabling GeoIP feature
+DISABLE_MMDB = get_from_env("DISABLE_MMDB", TEST, type_cast=strtobool)  # plugin server setting disabling GeoIP feature
 PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
     "PLUGINS_PREINSTALLED_URLS", "https://github.com/PostHog/posthog-plugin-geoip"
-).split(",") if not DISABLE_MMDB and not TEST else []
+).split(",") if not DISABLE_MMDB else []
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
 


### PR DESCRIPTION
## Changes

This resolves https://github.com/PostHog/plugin-server/issues/391 by skipping GeoIP plugin preinstallation if the built-in GeoIP feature of the plugin server is disabled (e.g. for quicker ingestion launch in development).