### PR TITLE
3609 refresh dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -14,6 +14,9 @@ import { DashboardEventSource } from '../../lib/utils/eventUsageLogic'
 import { TZIndicator } from 'lib/components/TimezoneAware'
 import { Link } from 'lib/components/Link'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
+import { Button } from 'antd'
+import { ReloadOutlined } from '@ant-design/icons'
+import dayjs from 'dayjs'
 
 interface Props {
     id: string
@@ -29,10 +32,11 @@ export function Dashboard({ id, shareToken }: Props): JSX.Element {
 }
 
 function DashboardView(): JSX.Element {
-    const { dashboard, itemsLoading, items, filters: dashboardFilters, dashboardMode } = useValues(dashboardLogic)
+    const { dashboard, itemsLoading, items, lastRefreshed, filters: dashboardFilters, dashboardMode } = useValues(
+        dashboardLogic
+    )
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
-
+    const { setDashboardMode, addGraph, setDates, refreshAllDashboardItems } = useActions(dashboardLogic)
     useKeyboardHotkeys(
         dashboardMode === DashboardMode.Public
             ? {}
@@ -106,7 +110,7 @@ function DashboardView(): JSX.Element {
             {items && items.length ? (
                 <div>
                     <div className="dashboard-items-actions">
-                        {/* :TODO: Bring this back when addressing https://github.com/PostHog/posthog/issues/3609
+                        {/* :TODO: Bring this back when addressing https://github.com/PostHog/posthog/issues/3609 */}
                         <div className="left-item">
                             Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b>
                             {dashboardMode !== DashboardMode.Public && (
@@ -115,7 +119,7 @@ function DashboardView(): JSX.Element {
                                 </Button>
                             )}
                         </div>
-                         */}
+
                         {dashboardMode !== DashboardMode.Public && (
                             <div
                                 style={{

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -110,7 +110,6 @@ function DashboardView(): JSX.Element {
             {items && items.length ? (
                 <div>
                     <div className="dashboard-items-actions">
-                        {/* :TODO: Bring this back when addressing https://github.com/PostHog/posthog/issues/3609 */}
                         <div className="left-item">
                             Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b>
                             {dashboardMode !== DashboardMode.Public && (
@@ -119,7 +118,6 @@ function DashboardView(): JSX.Element {
                                 </Button>
                             )}
                         </div>
-
                         {dashboardMode !== DashboardMode.Public && (
                             <div
                                 style={{

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -317,7 +317,6 @@ export const dashboardLogic = kea({
         refreshAllDashboardItems: async (_, breakpoint) => {
             await breakpoint(100)
             dashboardItemsModel.actions.refreshAllDashboardItems({})
-            setTimeout(() => actions.loadDashboardItems(), 1000)
 
             eventUsageLogic.actions.reportDashboardRefreshed(values.lastRefreshed)
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -317,6 +317,7 @@ export const dashboardLogic = kea({
         refreshAllDashboardItems: async (_, breakpoint) => {
             await breakpoint(100)
             dashboardItemsModel.actions.refreshAllDashboardItems({})
+            setTimeout(() => actions.loadDashboardItems(), 1000)
 
             eventUsageLogic.actions.reportDashboardRefreshed(values.lastRefreshed)
         },

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -182,7 +182,7 @@ export const funnelLogic = kea({
         },
         setFilters: ({ refresh }) => {
             if (refresh) {
-                actions.loadResults()
+                actions.loadResults(true)
             }
             const cleanedParams = cleanFunnelParams(values.filters)
             insightLogic.actions.setAllFilters(cleanedParams)

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -183,11 +183,14 @@ export const pathsLogic = kea<pathsLogicType<PathResult, PropertyFilter, FilterT
             (propertiesLoaded): boolean => !propertiesLoaded,
         ],
     },
-    actionToUrl: ({ values }) => ({
+    actionToUrl: ({ props, values }) => ({
         setProperties: () => {
             return ['/insights', values.propertiesForUrl]
         },
         setFilter: () => {
+            if (props.dashboardItemId) {
+                return
+            }
             return ['/insights', values.propertiesForUrl]
         },
     }),

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -103,7 +103,7 @@ export const retentionTableLogic = kea<
     },
     actions: () => ({
         // TODO: This needs to be properly typed with `FilterType`. N.B. We're currently mixing snake_case and pascalCase attribute names.
-        setFilters: (filters: Record<string, any>) => ({ filters }),
+        setFilters: (filters: Record<string, any>, refresh = false) => ({ filters, refresh }),
         loadMorePeople: true,
         updatePeople: (people) => ({ people }),
         updateRetention: (retention: RetentionTablePayload[] | RetentionTrendPayload[]) => ({ retention }),
@@ -186,7 +186,10 @@ export const retentionTableLogic = kea<
         setProperties: () => {
             actions.loadResults()
         },
-        setFilters: () => {
+        setFilters: ({ refresh }) => {
+            if (refresh) {
+                actions.loadResults(true)
+            }
             actions.loadResults()
         },
         loadResults: () => {
@@ -208,7 +211,7 @@ export const retentionTableLogic = kea<
         },
         [dashboardItemsModel.actionTypes.refreshAllDashboardItems]: (filters: FilterType) => {
             if (props.dashboardItemId) {
-                actions.setFilters(filters)
+                actions.setFilters(filters, true)
             }
         },
     }),

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -480,9 +480,9 @@ export const trendsLogic = kea<
             }
             actions.setIndexedResults(indexedResults)
         },
-        [dashboardItemsModel.actionTypes.refreshAllDashboardItems]: (filters: Record<string, any>) => {
+        [dashboardItemsModel.actionTypes.refreshAllDashboardItems]: () => {
             if (props.dashboardItemId) {
-                actions.setFilters(filters, true)
+                actions.loadResults(true)
             }
         },
         loadMoreBreakdownValues: async () => {


### PR DESCRIPTION
## Changes

Items weren't refreshing properly because we weren't passing `true` to the refresh parameter when we loaded results in the item's corresponding logic file.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
