### PR TITLE
Add GitHub style deletion confirmation UI for organizations

### DIFF
--- a/frontend/src/scenes/organization/Settings/DangerZone.tsx
+++ b/frontend/src/scenes/organization/Settings/DangerZone.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { DeleteOutlined } from '@ant-design/icons'
-import { Button, Modal } from 'antd'
+import { Button, Input, Modal } from 'antd'
 import { organizationLogic } from 'scenes/organizationLogic'
 import Paragraph from 'antd/lib/typography/Paragraph'
 import { RestrictedComponentProps } from '../../../lib/components/RestrictedArea'
@@ -16,6 +16,7 @@ export function DeleteOrganizationModal({
     const { currentOrganization, organizationBeingDeleted } = useValues(organizationLogic)
     const { deleteOrganization } = useActions(organizationLogic)
 
+    const [deletionEnabled, setDeletionEnabled] = useState(false)
     const isDeletionInProgress = !!currentOrganization && organizationBeingDeleted?.id === currentOrganization.id
 
     return (
@@ -28,6 +29,7 @@ export function DeleteOrganizationModal({
                 // @ts-expect-error - data-attr works just fine despite not being in ButtonProps
                 'data-attr': 'delete-organization-ok',
                 loading: isDeletionInProgress,
+                disabled: !deletionEnabled,
             }}
             onCancel={() => setIsVisible(false)}
             cancelButtonProps={{
@@ -35,8 +37,19 @@ export function DeleteOrganizationModal({
             }}
             visible={isVisible}
         >
-            Organization deletion <b>cannot be undone</b>. You will lose all data, <b>including all events</b>, related
-            to all projects within this organization.
+            <p>
+                Organization deletion <b>cannot be undone</b>. You will lose all data, <b>including all events</b>,
+                related to all projects within this organization.
+            </p>
+            Please type <strong>{currentOrganization ? currentOrganization.name : 'I confirm'}</strong> to confirm.
+            <Input
+                type="text"
+                onChange={(e) => {
+                    const { value } = e.target
+                    setDeletionEnabled(value === (currentOrganization ? currentOrganization.name : 'I confirm'))
+                }}
+                style={{ marginTop: '1rem' }}
+            />
         </Modal>
     )
 }

--- a/frontend/src/scenes/organization/Settings/DangerZone.tsx
+++ b/frontend/src/scenes/organization/Settings/DangerZone.tsx
@@ -16,7 +16,7 @@ export function DeleteOrganizationModal({
     const { currentOrganization, organizationBeingDeleted } = useValues(organizationLogic)
     const { deleteOrganization } = useActions(organizationLogic)
 
-    const [deletionEnabled, setDeletionEnabled] = useState(false)
+    const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false)
     const isDeletionInProgress = !!currentOrganization && organizationBeingDeleted?.id === currentOrganization.id
 
     return (
@@ -29,7 +29,7 @@ export function DeleteOrganizationModal({
                 // @ts-expect-error - data-attr works just fine despite not being in ButtonProps
                 'data-attr': 'delete-organization-ok',
                 loading: isDeletionInProgress,
-                disabled: !deletionEnabled,
+                disabled: !isDeletionConfirmed,
             }}
             onCancel={() => setIsVisible(false)}
             cancelButtonProps={{
@@ -41,14 +41,19 @@ export function DeleteOrganizationModal({
                 Organization deletion <b>cannot be undone</b>. You will lose all data, <b>including all events</b>,
                 related to all projects within this organization.
             </p>
-            Please type <strong>{currentOrganization ? currentOrganization.name : 'I confirm'}</strong> to confirm.
+            <p>
+                Please type{' '}
+                <strong>{currentOrganization ? currentOrganization.name : "this organization's name"}</strong> to
+                confirm.
+            </p>
             <Input
                 type="text"
                 onChange={(e) => {
-                    const { value } = e.target
-                    setDeletionEnabled(value === (currentOrganization ? currentOrganization.name : 'I confirm'))
+                    if (currentOrganization) {
+                        const { value } = e.target
+                        setIsDeletionConfirmed(value.toLowerCase() === currentOrganization.name.toLowerCase())
+                    }
                 }}
-                style={{ marginTop: '1rem' }}
             />
         </Modal>
     )


### PR DESCRIPTION
## Changes

As a user, when deleting an organization, the process should be safe (more than just clicking). This PR adds a GitHub style "Please type FooBar to confirm.".

This is my first PR to PostHog, feedback welcome 😄 

Heals #4456

![PosthogDeleteUI](https://user-images.githubusercontent.com/11272509/119410473-ce9ca280-bce0-11eb-86d4-8cb1f5f3d353.gif)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
