### PR TITLE
backup mvp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cypress/screenshots/
 docker-compose.prod.yml
 .python-version
 *.isorted
+ee/s3data/

--- a/ee/api/backup.py
+++ b/ee/api/backup.py
@@ -1,4 +1,3 @@
-# TODO: move to ee/
 import json
 from typing import Dict, List, Tuple
 
@@ -10,18 +9,16 @@ URL_BASE = "http://clickhouse:7171/backup"
 
 
 def get_backup_info() -> Dict:
-    # TODO fill with actual data
     return {"is_enabled": is_enabled(), "existing_backups": get_existing_backup_names()}
 
 
 def is_enabled() -> bool:
-    return is_clickhouse_enabled()  # TODO more specofic backup related setup
+    return is_clickhouse_enabled()
 
 
 def get_existing_backup_names() -> List[str]:
     if not is_enabled():
         return []
-    # TODO: error handling etc
     url = f"{URL_BASE}/list"
     response = requests.get(url)
     items = response.text.split("\n")[:-1]  # to ignore the '' last one from linebreak
@@ -32,7 +29,6 @@ def get_existing_backup_names() -> List[str]:
 def get_status() -> List[str]:
     if not is_enabled():
         return []
-    # TODO: make a refresh button
     url = f"{URL_BASE}/status"
     response = requests.get(url)
     items = response.text.split("\n")[:-1]  # to ignore the '' last one from linebreak

--- a/ee/clickhouse-backup-config.yml
+++ b/ee/clickhouse-backup-config.yml
@@ -1,0 +1,76 @@
+general:
+    remote_storage: s3
+    max_file_size: 1099511627776
+    disable_progress_bar: false
+    backups_to_keep_local: 0
+    backups_to_keep_remote: 0
+    log_level: info
+    allow_empty_backups: false
+clickhouse:
+    username: default
+    password: ''
+    host: localhost
+    port: 9000
+    disk_mapping: {}
+    skip_tables:
+        - system.*
+    timeout: 5m
+    freeze_by_part: false
+    secure: false
+    skip_verify: false
+    sync_replicated_tables: true
+s3:
+    access_key: 'AKIAIOSFODNN7EXAMPLE'
+    secret_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+    bucket: 'posthog-ch-backups-test'
+    endpoint: 'http://s3:9090'
+    acl: private
+    force_path_style: true
+    path: 'backup'
+    disable_ssl: true
+    compression_level: 1
+    compression_format: tar
+gcs:
+    credentials_file: ''
+    credentials_json: ''
+    bucket: ''
+    path: ''
+    compression_level: 1
+    compression_format: tar
+cos:
+    url: ''
+    timeout: 2m
+    secret_id: ''
+    secret_key: ''
+    path: ''
+    compression_format: tar
+    compression_level: 1
+api:
+    listen: 0.0.0.0:7171
+    enable_metrics: true
+    enable_pprof: false
+    username: ''
+    password: ''
+    secure: false
+    certificate_file: ''
+    private_key_file: ''
+    create_integration_tables: false
+ftp:
+    address: ''
+    timeout: 2m
+    username: ''
+    password: ''
+    tls: false
+    path: ''
+    compression_format: tar
+    compression_level: 1
+azblob:
+    endpoint_suffix: core.windows.net
+    account_name: ''
+    account_key: ''
+    sas: ''
+    container: ''
+    path: ''
+    compression_level: 1
+    compression_format: tar
+    sse_key: ''

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -26,17 +26,32 @@ services:
             - ./idl:/idl
             - ../docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ../docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
+            - ../../clickhouse-backup/clickhouse-backup:/usr/bin/clickhouse-backup
+            - ../../clickhouse-backup/config.yml:/etc/clickhouse-backup/config.yml
     zookeeper:
         image: wurstmeister/zookeeper
     kafka:
         image: wurstmeister/kafka
         depends_on:
             - zookeeper
+            - s3
         ports:
             - '9092:9092'
         environment:
             KAFKA_ADVERTISED_HOST_NAME: kafka
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            REMOTE_STORAGE: 's3'
+            LOG_LEVEL: 'debug'
+            S3_ENDPOINT: 'http://s3:9090'
+            S3_ACCESS_KEY: 'AKIAIOSFODNN7EXAMPLE'
+            S3_SECRET_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+            S3_BUCKET: 'posthog-ch-backups-test'
+            S3_COMPRESSION_LEVEL: '1'
+            S3_COMPRESSION_FORMAT: 'tar'
+            S3_ACL: 'private'
+            S3_FORCE_PATH_STYLE: 'true'
+            S3_PATH: 'backup'
+            S3_DISABLE_SSL: 'true'
     worker: &worker
         build:
             context: ../
@@ -102,7 +117,9 @@ services:
             API_LISTEN: '0.0.0.0:7171'
             REMOTE_STORAGE: 's3'
             LOG_LEVEL: 'debug'
+            BACKUPS_TO_KEEP_LOCAL: '5'
             CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_FREEZE_BY_PART: 'true'
             S3_ENDPOINT: 'http://s3:9090'
             S3_ACCESS_KEY: 'AKIAIOSFODNN7EXAMPLE'
             S3_SECRET_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -103,7 +103,7 @@ services:
             REMOTE_STORAGE: 's3'
             LOG_LEVEL: 'debug'
             CLICKHOUSE_HOST: 'clickhouse'
-            S3_ENDPOINT: 'http://minio:9090'
+            S3_ENDPOINT: 'http://s3:9090'
             S3_ACCESS_KEY: 'AKIAIOSFODNN7EXAMPLE'
             S3_SECRET_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
             S3_BUCKET: 'posthog-ch-backups-test'
@@ -115,8 +115,8 @@ services:
             S3_DISABLE_SSL: 'true'
         depends_on:
             - clickhouse
-            - minio
-    minio:
+            - s3
+    s3:
         image: minio/minio
         command: server --address :9090 /data
         ports:

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -58,7 +58,6 @@ services:
             PGHOST: db
             PGUSER: posthog
             PGPASSWORD: posthog
-            CAPTURE_INTERNAL_METRICS: 'true'
         depends_on:
             - db
             - redis
@@ -84,7 +83,6 @@ services:
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
             CLICKHOUSE_HOST: 'clickhouse'
-            CAPTURE_INTERNAL_METRICS: 'true'
         depends_on:
             - db
             - redis

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -93,3 +93,36 @@ services:
             - redis:redis
             - clickhouse:clickhouse
             - kafka:kafka
+    chbk:
+        image: alexakulov/clickhouse-backup
+        command: server
+        ports:
+            - '7171:7171'
+        environment:
+            API_LISTEN: '0.0.0.0:7171'
+            REMOTE_STORAGE: 's3'
+            LOG_LEVEL: 'debug'
+            CLICKHOUSE_HOST: 'clickhouse'
+            S3_ENDPOINT: 'http://minio:9090'
+            S3_ACCESS_KEY: 'AKIAIOSFODNN7EXAMPLE'
+            S3_SECRET_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+            S3_BUCKET: 'posthog-ch-backups-test'
+            S3_COMPRESSION_LEVEL: '1'
+            S3_COMPRESSION_FORMAT: 'tar'
+            S3_ACL: 'private'
+            S3_FORCE_PATH_STYLE: 'true'
+            S3_PATH: 'backup'
+            S3_DISABLE_SSL: 'true'
+        depends_on:
+            - clickhouse
+            - minio
+    minio:
+        image: minio/minio
+        command: server --address :9090 /data
+        ports:
+            - '9090:9090'
+        volumes:
+            - ./s3data:/data
+        environment:
+            MINIO_ROOT_USER: 'AKIAIOSFODNN7EXAMPLE'
+            MINIO_ROOT_PASSWORD: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -58,6 +58,7 @@ services:
             PGHOST: db
             PGUSER: posthog
             PGPASSWORD: posthog
+            CAPTURE_INTERNAL_METRICS: 'true'
         depends_on:
             - db
             - redis
@@ -83,6 +84,7 @@ services:
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
             CLICKHOUSE_HOST: 'clickhouse'
+            CAPTURE_INTERNAL_METRICS: 'true'
         depends_on:
             - db
             - redis

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -28,7 +28,7 @@ services:
             - ../docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ../docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ../../clickhouse-backup/clickhouse-backup:/usr/bin/clickhouse-backup
-            - ../../clickhouse-backup/config.yml:/etc/clickhouse-backup/config.yml
+            - ./clickhouse-backup-config.yml:/etc/clickhouse-backup/config.yml
     zookeeper:
         image: wurstmeister/zookeeper
     kafka:

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -22,6 +22,7 @@ services:
             - '9000:9000'
             - '9440:9440'
             - '9009:9009'
+            - '7171:7171'
         volumes:
             - ./idl:/idl
             - ../docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
@@ -40,18 +41,6 @@ services:
         environment:
             KAFKA_ADVERTISED_HOST_NAME: kafka
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-            REMOTE_STORAGE: 's3'
-            LOG_LEVEL: 'debug'
-            S3_ENDPOINT: 'http://s3:9090'
-            S3_ACCESS_KEY: 'AKIAIOSFODNN7EXAMPLE'
-            S3_SECRET_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-            S3_BUCKET: 'posthog-ch-backups-test'
-            S3_COMPRESSION_LEVEL: '1'
-            S3_COMPRESSION_FORMAT: 'tar'
-            S3_ACL: 'private'
-            S3_FORCE_PATH_STYLE: 'true'
-            S3_PATH: 'backup'
-            S3_DISABLE_SSL: 'true'
     worker: &worker
         build:
             context: ../
@@ -108,31 +97,6 @@ services:
             - redis:redis
             - clickhouse:clickhouse
             - kafka:kafka
-    chbk:
-        image: alexakulov/clickhouse-backup
-        command: server
-        ports:
-            - '7171:7171'
-        environment:
-            API_LISTEN: '0.0.0.0:7171'
-            REMOTE_STORAGE: 's3'
-            LOG_LEVEL: 'debug'
-            BACKUPS_TO_KEEP_LOCAL: '5'
-            CLICKHOUSE_HOST: 'clickhouse'
-            CLICKHOUSE_FREEZE_BY_PART: 'true'
-            S3_ENDPOINT: 'http://s3:9090'
-            S3_ACCESS_KEY: 'AKIAIOSFODNN7EXAMPLE'
-            S3_SECRET_KEY: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-            S3_BUCKET: 'posthog-ch-backups-test'
-            S3_COMPRESSION_LEVEL: '1'
-            S3_COMPRESSION_FORMAT: 'tar'
-            S3_ACL: 'private'
-            S3_FORCE_PATH_STYLE: 'true'
-            S3_PATH: 'backup'
-            S3_DISABLE_SSL: 'true'
-        depends_on:
-            - clickhouse
-            - s3
     s3:
         image: minio/minio
         command: server --address :9090 /data

--- a/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { Button, Card, Input, Select, Tooltip } from 'antd'
+import { useActions, useValues } from 'kea'
+import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
+import Paragraph from 'antd/lib/typography/Paragraph'
+
+export function BackupTab(): JSX.Element {
+    const { systemStatus } = useValues(systemStatusLogic)
+    const { createBackup, restoreFromBackup } = useActions(systemStatusLogic)
+    const [ restoreCandidate, setRestoreCandidate] = useState('')
+    const [ backupSuffix, setBackupSuffix] = useState('')
+    const defaultSuffix = "ui"
+
+    return (
+        <>
+            <Card>
+                {console.log("In backup tab")}
+                {systemStatus?.backup.is_enabled ? (
+                    <>
+                        <Tooltip title={`Only alphanumeric-_ are accepted. Default suffix is \"${defaultSuffix}\"`}
+                        >
+                            <Input 
+                                style={{ width: 400 }}
+                                addonBefore="YYYY-MM-DD-HH-mm-" 
+                                placeholder="Optional custom suffix" 
+                                onChange={(value) => setBackupSuffix(value.target.value.replace(/[^\w\-]/g, ''))}
+                            />
+                        </Tooltip>
+                        &nbsp;&nbsp;
+                        <Button
+                            type="primary"
+                            onClick={() => createBackup(`${new Date().toISOString().replace(/[:T]/g, '-').substr(0,17)}${backupSuffix?backupSuffix:defaultSuffix}`)}
+                        >
+                            Create Backup
+                        </Button>
+                        <br/> 
+                        <h2 style={{ color: 'var(--danger)' }}>
+                            Danger Zone
+                        </h2>
+                        <Paragraph type="danger">
+                            This is owerwrites all data in Clickhouse. Please be certain.
+                            <br/>
+                        </Paragraph>
+                        <Select 
+                            showSearch
+                            style={{ width: 400 }}
+                            placeholder="Search to Select"
+                            filterOption={(input, option) =>
+                                  option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+                            }
+                            onChange={(value) => setRestoreCandidate(value)}
+                        >
+                            {systemStatus?.backup.existing_bk_names.map((name) => (
+                                <Select.Option key={name} value={name}>{name}</Select.Option>
+                            ))}
+                        </Select>
+                        &nbsp;&nbsp;
+                        <Button danger
+                            // we probably want to restrict it to some group of users explicitly here too similar to https://github.com/PostHog/posthog/blob/2b4290959108dd6401449e9a7c1251e2dbcb980e/frontend/src/scenes/organization/Settings/index.tsx#L61 
+                            // Probably want it to throw up a confirmation dialog box
+                            onClick={() => restoreFromBackup(restoreCandidate)}
+                        >
+                            Restore From Backup
+                        </Button>
+
+                    </>
+                ) : (
+                  <b> Backups are currently not enabled, read how to enable backups TODO link. </b>
+                )}
+
+                {/* 1. if not existing then link to a help page, else
+                  2. Show a button for a manual backup now (with an option to name it something)
+                  3. dropdown to restore from a backup (admin only action, i.e. we shouldn't have that right for the posthog cloud maybe?)
+                  4. settings for regular backups (mainly frequency)  <- that should maybe also be in the config file ???
+                  */}
+            </Card>
+        </>
+    )
+}

--- a/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
@@ -2,78 +2,71 @@ import React, { useState } from 'react'
 import { Button, Card, Input, Select, Tooltip } from 'antd'
 import { useActions, useValues } from 'kea'
 import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
-import Paragraph from 'antd/lib/typography/Paragraph'
 
 export function BackupTab(): JSX.Element {
     const { systemStatus } = useValues(systemStatusLogic)
     const { createBackup, restoreFromBackup } = useActions(systemStatusLogic)
-    const [ restoreCandidate, setRestoreCandidate] = useState('')
-    const [ backupSuffix, setBackupSuffix] = useState('')
-    const defaultSuffix = "ui"
+    const [restoreCandidate, setRestoreCandidate] = useState('')
+    const [backupSuffix, setBackupSuffix] = useState('')
+    const defaultSuffix = 'ui'
 
     return (
-        <>
-            <Card>
-                {console.log("In backup tab")}
-                {systemStatus?.backup.is_enabled ? (
-                    <>
-                        <Tooltip title={`Only alphanumeric-_ are accepted. Default suffix is \"${defaultSuffix}\"`}
-                        >
-                            <Input 
-                                style={{ width: 400 }}
-                                addonBefore="YYYY-MM-DD-HH-mm-" 
-                                placeholder="Optional custom suffix" 
-                                onChange={(value) => setBackupSuffix(value.target.value.replace(/[^\w\-]/g, ''))}
-                            />
-                        </Tooltip>
-                        &nbsp;&nbsp;
-                        <Button
-                            type="primary"
-                            onClick={() => createBackup(`${new Date().toISOString().replace(/[:T]/g, '-').substr(0,17)}${backupSuffix?backupSuffix:defaultSuffix}`)}
-                        >
-                            Create Backup
-                        </Button>
-                        <br/> 
-                        <h2 style={{ color: 'var(--danger)' }}>
-                            Danger Zone
-                        </h2>
-                        <Paragraph type="danger">
-                            This is owerwrites all data in Clickhouse. Please be certain.
-                            <br/>
-                        </Paragraph>
-                        <Select 
-                            showSearch
+        <Card>
+            {systemStatus?.backup.is_enabled ? (
+                <>
+                    <Tooltip title={`Only alphanumeric-_ are accepted. Default suffix is \"${defaultSuffix}\"`}>
+                        <Input
                             style={{ width: 400 }}
-                            placeholder="Search to Select"
-                            filterOption={(input, option) =>
-                                  option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
-                            }
-                            onChange={(value) => setRestoreCandidate(value)}
-                        >
-                            {systemStatus?.backup.existing_bk_names.map((name) => (
-                                <Select.Option key={name} value={name}>{name}</Select.Option>
-                            ))}
-                        </Select>
-                        &nbsp;&nbsp;
-                        <Button danger
-                            // we probably want to restrict it to some group of users explicitly here too similar to https://github.com/PostHog/posthog/blob/2b4290959108dd6401449e9a7c1251e2dbcb980e/frontend/src/scenes/organization/Settings/index.tsx#L61 
-                            // Probably want it to throw up a confirmation dialog box
-                            onClick={() => restoreFromBackup(restoreCandidate)}
-                        >
-                            Restore From Backup
-                        </Button>
-
-                    </>
-                ) : (
-                  <b> Backups are currently not enabled, read how to enable backups TODO link. </b>
-                )}
-
-                {/* 1. if not existing then link to a help page, else
-                  2. Show a button for a manual backup now (with an option to name it something)
-                  3. dropdown to restore from a backup (admin only action, i.e. we shouldn't have that right for the posthog cloud maybe?)
-                  4. settings for regular backups (mainly frequency)  <- that should maybe also be in the config file ???
-                  */}
-            </Card>
-        </>
+                            addonBefore="YYYY-MM-DD-HH-mm-"
+                            placeholder="Optional custom suffix"
+                            onChange={(value) => setBackupSuffix(value.target.value.replace(/[^\w\-]/g, ''))}
+                        />
+                    </Tooltip>
+                    &nbsp;&nbsp;
+                    <Button
+                        // TODO: provide some info about where the errors went
+                        type="primary"
+                        onClick={() =>
+                            createBackup(
+                                `${new Date().toISOString().replace(/[:T]/g, '-').substr(0, 17)}${
+                                    backupSuffix ? backupSuffix : defaultSuffix
+                                }`
+                            )
+                        }
+                    >
+                        Create Backup
+                    </Button>
+                    <br />
+                    <br />
+                    <Select
+                        showSearch
+                        style={{ width: 360 }}
+                        placeholder="Search to Select"
+                        filterOption={(input, option) =>
+                            option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+                        }
+                        onChange={(value) => setRestoreCandidate(value)}
+                    >
+                        {systemStatus?.backup.existing_backups.map((name) => (
+                            <Select.Option key={name} value={name}>
+                                {name}
+                            </Select.Option>
+                        ))}
+                    </Select>
+                    &nbsp;&nbsp;
+                    <Button
+                        type="primary"
+                        // TODO: what happens if some tables exist?
+                        // TODO: restoring specific tables, maybe?
+                        // TODO: provide some info about where the errors went
+                        onClick={() => restoreFromBackup(restoreCandidate)}
+                    >
+                        Restore From Backup
+                    </Button>
+                </>
+            ) : (
+                <b> Backups are currently not enabled, read how to enable backups TODO link. </b>
+            )}
+        </Card>
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
@@ -1,14 +1,19 @@
 import React, { useState } from 'react'
-import { Button, Card, Input, Select, Tooltip } from 'antd'
+import { Button, Card, Input, Select, Table, Tooltip } from 'antd'
 import { useActions, useValues } from 'kea'
 import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
+import { ReloadOutlined } from '@ant-design/icons'
 
 export function BackupTab(): JSX.Element {
-    const { systemStatus } = useValues(systemStatusLogic)
-    const { createBackup, restoreFromBackup } = useActions(systemStatusLogic)
+    const { systemStatus, backupStatus, backupStatusLoading } = useValues(systemStatusLogic)
+    const { createBackup, restoreFromBackup, loadBackupStatus } = useActions(systemStatusLogic)
     const [restoreCandidate, setRestoreCandidate] = useState('')
     const [backupSuffix, setBackupSuffix] = useState('')
     const defaultSuffix = 'ui'
+    const reloadStatus = (e: React.MouseEvent): void => {
+        e.stopPropagation()
+        loadBackupStatus()
+    }
 
     return (
         <Card>
@@ -63,6 +68,26 @@ export function BackupTab(): JSX.Element {
                     >
                         Restore From Backup
                     </Button>
+                    <br />
+                    <br />
+                    <Button style={{ marginLeft: 8 }} onClick={reloadStatus}>
+                        <ReloadOutlined /> Reload Queries
+                    </Button>
+                    <Table
+                        dataSource={backupStatus || []}
+                        columns={[
+                            { title: 'command', dataIndex: 'command' },
+                            { title: 'status', dataIndex: 'status' },
+                            { title: 'start', dataIndex: 'start' },
+                            { title: 'finish', dataIndex: 'finish' },
+                            { title: 'error', dataIndex: 'error' },
+                        ]}
+                        loading={backupStatusLoading}
+                        size="small"
+                        bordered
+                        style={{ overflowX: 'auto', overflowY: 'auto' }}
+                        locale={{ emptyText: 'No backup status found' }}
+                    />
                 </>
             ) : (
                 <b> Backups are currently not enabled, read how to enable backups TODO link. </b>

--- a/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/BackupTab.tsx
@@ -29,7 +29,6 @@ export function BackupTab(): JSX.Element {
                     </Tooltip>
                     &nbsp;&nbsp;
                     <Button
-                        // TODO: provide some info about where the errors went
                         type="primary"
                         onClick={() =>
                             createBackup(
@@ -59,13 +58,7 @@ export function BackupTab(): JSX.Element {
                         ))}
                     </Select>
                     &nbsp;&nbsp;
-                    <Button
-                        type="primary"
-                        // TODO: what happens if some tables exist?
-                        // TODO: restoring specific tables, maybe?
-                        // TODO: provide some info about where the errors went
-                        onClick={() => restoreFromBackup(restoreCandidate)}
-                    >
+                    <Button type="primary" onClick={() => restoreFromBackup(restoreCandidate)}>
                         Restore From Backup
                     </Button>
                     <br />

--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -9,6 +9,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { IconExternalLink } from 'lib/components/icons'
 import { OverviewTab } from 'scenes/instance/SystemStatus/OverviewTab'
 import { InternalMetricsTab } from 'scenes/instance/SystemStatus/InternalMetricsTab'
+import { BackupTab } from 'scenes/instance/SystemStatus/BackupTab'
 
 export function SystemStatus(): JSX.Element {
     const { tab, error, systemStatus } = useValues(systemStatusLogic)
@@ -60,18 +61,19 @@ export function SystemStatus(): JSX.Element {
                 />
             )}
 
-            {systemStatus?.internal_metrics.clickhouse ? (
-                <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={(key) => setTab(key as TabName)}>
-                    <Tabs.TabPane tab="Overview" key="overview">
-                        <OverviewTab />
-                    </Tabs.TabPane>
+            <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={(key) => setTab(key as TabName)}>
+                <Tabs.TabPane tab="Overview" key="overview">
+                    <OverviewTab />
+                </Tabs.TabPane>
+                {systemStatus?.internal_metrics.clickhouse ? (
                     <Tabs.TabPane tab="Internal metrics" key="internal_metrics">
                         <InternalMetricsTab />
                     </Tabs.TabPane>
-                </Tabs>
-            ) : (
-                <OverviewTab />
-            )}
+                ) : null}
+                <Tabs.TabPane tab="Backup" key="backup">
+                    <BackupTab />
+                </Tabs.TabPane>
+            </Tabs>
         </div>
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -13,6 +13,8 @@ export const systemStatusLogic = kea<
     actions: {
         setTab: (tab: TabName) => ({ tab }),
         setOpenSections: (sections: string[]) => ({ sections }),
+        createBackup: (name: string) => ({ name }),
+        restoreFromBackup: (name: string) => ({ name }),
     },
     loaders: {
         systemStatus: [
@@ -67,6 +69,12 @@ export const systemStatusLogic = kea<
             if (tab === 'internal_metrics') {
                 actions.loadQueries()
             }
+        },
+        createBackup: async ({ name }) => {
+            console.log(`In createBackup listener with ${name}`)
+        },
+        restoreFromBackup: async ({ name }) => {
+            console.log(`In restore listener with ${name}`)
         },
     }),
 

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -2,13 +2,19 @@ import api from 'lib/api'
 import { kea } from 'kea'
 import { systemStatusLogicType } from './systemStatusLogicType'
 import { userLogic } from 'scenes/userLogic'
-import { SystemStatus, SystemStatusRow, SystemStatusQueriesResult } from '~/types'
+import { SystemStatus, SystemStatusRow, SystemStatusQueriesResult, SystemStatusBackupStatusRow } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 
 export type TabName = 'overview' | 'internal_metrics'
 
 export const systemStatusLogic = kea<
-    systemStatusLogicType<SystemStatus, SystemStatusRow, SystemStatusQueriesResult, TabName>
+    systemStatusLogicType<
+        SystemStatus,
+        SystemStatusRow,
+        SystemStatusQueriesResult,
+        SystemStatusBackupStatusRow,
+        TabName
+    >
 >({
     actions: {
         setTab: (tab: TabName) => ({ tab }),
@@ -32,6 +38,12 @@ export const systemStatusLogic = kea<
             null as SystemStatusQueriesResult | null,
             {
                 loadQueries: async () => (await api.get('api/instance_status/queries')).results,
+            },
+        ],
+        backupStatus: [
+            [] as SystemStatusBackupStatusRow[],
+            {
+                loadBackupStatus: async () => (await api.get('api/instance_status/backup_status')).results,
             },
         ],
     },
@@ -69,12 +81,18 @@ export const systemStatusLogic = kea<
             if (tab === 'internal_metrics') {
                 actions.loadQueries()
             }
+            if (tab === 'backup') {
+                actions.loadBackupStatus()
+            }
         },
         createBackup: async ({ name }) => {
             console.log(`In createBackup listener with ${name}`)
+            //await api.create('http://clickhouse:7171/backup/create?name=${name}')
+            await api.create('api/instance_status/create_backup')
         },
         restoreFromBackup: async ({ name }) => {
             console.log(`In restore listener with ${name}`)
+            await api.create('api/instance_status/restore_from_backup')
         },
     }),
 

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -88,11 +88,12 @@ export const systemStatusLogic = kea<
         createBackup: async ({ name }) => {
             console.log(`In createBackup listener with ${name}`)
             //await api.create('http://clickhouse:7171/backup/create?name=${name}')
-            await api.create('api/instance_status/create_backup')
+            await api.create('api/instance_status/create_backup', { name: name })
+            //await api.create('api/instance_status/create_backup')
         },
         restoreFromBackup: async ({ name }) => {
             console.log(`In restore listener with ${name}`)
-            await api.create('api/instance_status/restore_from_backup')
+            await api.create('api/instance_status/restore_from_backup', { name: name })
         },
     }),
 

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -87,9 +87,7 @@ export const systemStatusLogic = kea<
         },
         createBackup: async ({ name }) => {
             console.log(`In createBackup listener with ${name}`)
-            //await api.create('http://clickhouse:7171/backup/create?name=${name}')
             await api.create('api/instance_status/create_backup', { name: name })
-            //await api.create('api/instance_status/create_backup')
         },
         restoreFromBackup: async ({ name }) => {
             console.log(`In restore listener with ${name}`)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -564,7 +564,7 @@ export interface SystemStatus {
     }
     backup: {
         is_enabled: boolean
-        existing_bk_names: string[]
+        existing_backups: string[]
     }
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -562,6 +562,10 @@ export interface SystemStatus {
             share_token: string
         }
     }
+    backup: {
+        is_enabled: boolean
+        existing_bk_names: string[]
+    }
 }
 
 export type QuerySummary = { duration: string } & Record<string, string>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -576,6 +576,14 @@ export interface SystemStatusQueriesResult {
     clickhouse_slow_log?: QuerySummary[]
 }
 
+export interface SystemStatusBackupStatusRow {
+    command: string
+    status: string
+    start?: string
+    finish?: string
+    error?: string
+}
+
 export type PersonalizationData = Record<string, string | string[] | null>
 
 interface EnabledSetupState {

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.backup import get_backup_info
 from posthog.ee import is_clickhouse_enabled
 from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import Element, Event, SessionRecordingEvent
@@ -139,7 +140,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
                     {"metric": "Redis metrics", "value": f"Redis connected but then failed to return metrics: {e}"}
                 )
 
-        return Response({"results": {"overview": metrics, "internal_metrics": get_internal_metrics_dashboards()}})
+        return Response({"results": {"overview": metrics, "internal_metrics": get_internal_metrics_dashboards(), 'backup': get_backup_info()}})
 
     @action(methods=["GET"], detail=False)
     def queries(self, request: Request) -> Response:

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -1,9 +1,9 @@
 from typing import Dict, List, Union
 
 from django.db import connection
-from posthog.backup import create_backup, get_backup_info
-from posthog.backup import get_status as get_backup_status
-from posthog.backup import restore_from_backup
+from ee.api.backup import create_backup, get_backup_info
+from ee.api.backup import get_status as get_backup_status
+from ee.api.backup import restore_from_backup
 from posthog.ee import is_clickhouse_enabled
 from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import Element, Event, SessionRecordingEvent

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -147,14 +147,12 @@ class InstanceStatusViewSet(viewsets.ViewSet):
 
     @action(methods=["POST"], detail=False)
     def create_backup(self, request: Request) -> Response:
-        print(request)
-        code, data = create_backup("my-test-backup-name")
+        code, data = create_backup(request.data["name"])
         return Response(data, status=status.HTTP_201_CREATED)  # todo we only ack actually
 
     @action(methods=["POST"], detail=False)
     def restore_from_backup(self, request: Request) -> Response:
-        print(request)
-        code, data = restore_from_backup("my-test-backup-name")
+        code, data = restore_from_backup(request.data["name"])
         return Response(data, status=status.HTTP_201_CREATED)  # todo we only ack actually
 
     @action(methods=["GET"], detail=False)

--- a/posthog/backup.py
+++ b/posthog/backup.py
@@ -1,3 +1,4 @@
+# TODO: move to ee/
 from typing import Dict, List
 
 from posthog.ee import is_clickhouse_enabled

--- a/posthog/backup.py
+++ b/posthog/backup.py
@@ -1,15 +1,16 @@
-from functools import lru_cache
 from typing import Dict, List
+
 from posthog.ee import is_clickhouse_enabled
 
-# TODO: make sure the cache here is the right thing
-@lru_cache(maxsize=1)
+
 def get_backup_info() -> Dict:
     # TODO fill with actual data
-    return {"is_enabled": is_enabled(), "existing_bk_names": get_existing_backup_names()}
+    return {"is_enabled": is_enabled(), "existing_backups": get_existing_backup_names()}
+
 
 def is_enabled() -> bool:
     return is_clickhouse_enabled()  # TODO more specofic backup related setup
+
 
 def get_existing_backup_names() -> List[str]:
     return ["bk1", "bk2", "bk333"]

--- a/posthog/backup.py
+++ b/posthog/backup.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+from typing import Dict, List
+from posthog.ee import is_clickhouse_enabled
+
+# TODO: make sure the cache here is the right thing
+@lru_cache(maxsize=1)
+def get_backup_info() -> Dict:
+    # TODO fill with actual data
+    return {"is_enabled": is_enabled(), "existing_bk_names": get_existing_backup_names()}
+
+def is_enabled() -> bool:
+    return is_clickhouse_enabled()  # TODO more specofic backup related setup
+
+def get_existing_backup_names() -> List[str]:
+    return ["bk1", "bk2", "bk333"]

--- a/posthog/backup.py
+++ b/posthog/backup.py
@@ -1,7 +1,12 @@
 # TODO: move to ee/
-from typing import Dict, List
+import json
+from typing import Dict, List, Tuple
+
+import requests
 
 from posthog.ee import is_clickhouse_enabled
+
+URL_BASE = "http://clickhouse:7171/backup"
 
 
 def get_backup_info() -> Dict:
@@ -14,4 +19,37 @@ def is_enabled() -> bool:
 
 
 def get_existing_backup_names() -> List[str]:
-    return ["bk1", "bk2", "bk333"]
+    if not is_enabled():
+        return []
+    # TODO: error handling etc
+    url = f"{URL_BASE}/list"
+    response = requests.get(url)
+    items = response.text.split("\n")[:-1]  # to ignore the '' last one from linebreak
+    names = [json.loads(i)["name"] for i in items]
+    return names
+
+
+def get_status() -> List[str]:
+    if not is_enabled():
+        return []
+    # TODO: make a refresh button
+    url = f"{URL_BASE}/status"
+    response = requests.get(url)
+    items = response.text.split("\n")[:-1]  # to ignore the '' last one from linebreak
+    res = [json.loads(i) for i in reversed(items)]
+    print(res)
+    return res
+
+
+def create_backup(name: str) -> Tuple[int, str]:
+    url = f"{URL_BASE}/create?name={name}"
+    response = requests.post(url)
+    print(f"Created backup with {name}")
+    return int(response.status_code), str(response.json()) if response.ok else ""  # only if response is good
+
+
+def restore_from_backup(name: str) -> Tuple[int, str]:
+    url = f"{URL_BASE}/restore/{name}"
+    response = requests.post(url)
+    print(f"Restored from backup with {name}")
+    return int(response.status_code), str(response.json()) if response.ok else ""  # only if response is good


### PR DESCRIPTION
## Changes

<img width="790" alt="Screenshot 2021-05-26 at 07 32 19" src="https://user-images.githubusercontent.com/890921/119607660-fe3ccf00-bdf4-11eb-956a-7650149854ed.png">

Note that the dropdown for choosing a backup doesn't refresh automatically only on page refresh.

How to use this MVP:
1) get the clickhouse-backup binary it should be in this location `../clickhouse-backup/clickhouse-backup` (see `ee/docker-compose.ch.yml`). The binary can be downloaded from https://github.com/AlexAkulov/clickhouse-backup/releases/tag/v1.0.0-beta1 (note that version v1.0.0-beta1 was used for testing)
2) start everything `docker-compose -f ee/docker-compose.ch.yml up`
3) start clickhouse-backup in the clickhouse container `docker-compose -f ee/docker-compose.ch.yml exec clickhouse sh -c "clickhouse-backup server"` 

For restoring the tables cannot exist and that is the plan in the future too, there will be documentation with instructions to delete the tables, e.g. one could run `clickhouse-client -q 'DROP DATABASE posthog' && clickhouse-client -q 'CREATE DATABASE posthog'`.

Next up:
- [ ] limit access to the backup tab
- [ ] docker-compose file to contain everything and no need to have clickhouse-backup binary locally and running `docker exec`
- [ ] upload/download from remote if needed
- [ ] k8s (sidecar)
- [ ] documentation about how to set it up/use it
- [ ] backing up/restoring specific tables
- [ ] better error handling + tests for `backup.py`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
