### PR TITLE
Update signup page free event count

### DIFF
--- a/frontend/src/scenes/authentication/SignupSideContent.tsx
+++ b/frontend/src/scenes/authentication/SignupSideContent.tsx
@@ -19,7 +19,7 @@ export function SignupSideContentCloud({ utm_tags }: { utm_tags: string }): JSX.
                 We manage hosting, scaling and upgrades.
                 <div className="signup-list">
                     <div>
-                        <CheckOutlined /> First 10k events free every month
+                        <CheckOutlined /> First 1M events free every month
                     </div>
                     <div>
                         <CheckOutlined /> Pay per use, cancel anytime


### PR DESCRIPTION
Seems like we have not yet updated the copy everywhere - user in slack was confused

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
