### PR TITLE
Measure metrics from insights in instance metrics

### DIFF
--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -35,7 +35,7 @@ jobs:
                       **/node_modules/cypress
                       **/node_modules/cypress-terminal-report
                       **/node_modules/@cypress
-                  key: ${{ runner.os }}-cypress-6.7.0
+                  key: ${{ runner.os }}-cypress-6.7.0-v1
             - name: Install cypress
               if: steps.cypress-cache.outputs.cache-hit != 'true'
               run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,7 +83,7 @@ jobs:
                       **/node_modules/cypress
                       **/node_modules/cypress-terminal-report
                       **/node_modules/@cypress
-                  key: ${{ runner.os }}-cypress-6.7.0
+                  key: ${{ runner.os }}-cypress-6.7.0-v1
             - name: Install cypress
               if: steps.cypress-cache.outputs.cache-hit != 'true'
               run: |

--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -8,5 +8,5 @@ interface InternalMetricsPayload {
 }
 
 export function captureInternalMetric(payload: InternalMetricsPayload): Promise<void> {
-    return api.create('api/instance_status', payload)
+    return api.create('api/instance_status/capture', payload)
 }

--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -1,0 +1,12 @@
+import api from 'lib/api'
+
+interface InternalMetricsPayload {
+    method: 'incr' | 'timing'
+    metric: string
+    value: number
+    tags: Record<string, any>
+}
+
+export function captureInternalMetric(payload: InternalMetricsPayload): Promise<void> {
+    return api.create('api/instance_status', payload)
+}

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
-import { autocorrectInterval, objectsEqual, toParams } from 'lib/utils'
+import { autocorrectInterval, objectsEqual, toParams, uuid } from 'lib/utils'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
 import { funnelsModel } from '../../models/funnelsModel'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
@@ -82,7 +82,8 @@ export const funnelLogic = kea({
 
                 let result
 
-                insightLogic.actions.startQuery()
+                const queryId = uuid()
+                insightLogic.actions.startQuery(queryId)
 
                 const eventCount = params.events?.length
                 const actionCount = params.actions?.length
@@ -92,12 +93,12 @@ export const funnelLogic = kea({
                     result = await pollFunnel(params)
                     eventUsageLogic.actions.reportFunnelCalculated(eventCount, actionCount, interval, true)
                 } catch (e) {
-                    insightLogic.actions.endQuery(ViewType.FUNNELS, false, e)
+                    insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, false, e)
                     eventUsageLogic.actions.reportFunnelCalculated(eventCount, actionCount, interval, false, e.message)
                     return []
                 }
                 breakpoint()
-                insightLogic.actions.endQuery(ViewType.FUNNELS, result.last_refresh)
+                insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, result.last_refresh)
                 actions.setSteps(result.result)
                 return result.result
             },

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -166,7 +166,10 @@ export const insightLogic = kea<insightLogicType<ViewType, FilterType>>({
                 setTimeout(() => {
                     if (values && view == values.activeView) {
                         actions.setShowTimeoutMessage(true)
-                        // :TODO: Add instrumentation
+                        posthog.capture('insight timeout message shown', {
+                            insight: values.activeView,
+                            scene: sceneLogic.values.scene,
+                        })
                     }
                 }, SHOW_TIMEOUT_MESSAGE_AFTER)
             )
@@ -189,9 +192,6 @@ export const insightLogic = kea<insightLogicType<ViewType, FilterType>>({
                 }
 
                 posthog.capture('insight loaded', payload)
-                if (values.maybeShowTimeoutMessage) {
-                    posthog.capture('insight timeout message shown', payload)
-                }
                 if (values.maybeShowErrorMessage) {
                     posthog.capture('insight error message shown', payload)
                 }

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { toParams, objectsEqual } from 'lib/utils'
+import { toParams, objectsEqual, uuid } from 'lib/utils'
 import api from 'lib/api'
 import { router } from 'kea-router'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
@@ -72,15 +72,16 @@ export const pathsLogic = kea<pathsLogicType<PathResult, PropertyFilter, FilterT
                 }
                 const params = toParams({ ...filter, ...(refresh ? { refresh: true } : {}) })
                 let paths
-                insightLogic.actions.startQuery()
+                const queryId = uuid()
+                insightLogic.actions.startQuery(queryId)
                 try {
                     paths = await api.get(`api/insight/path${params ? `/?${params}` : ''}`)
                 } catch (e) {
-                    insightLogic.actions.endQuery(ViewType.PATHS, null, e)
+                    insightLogic.actions.endQuery(queryId, ViewType.PATHS, null, e)
                     return { paths: [], filter, error: true }
                 }
                 breakpoint()
-                insightLogic.actions.endQuery(ViewType.PATHS, paths.last_refresh)
+                insightLogic.actions.endQuery(queryId, ViewType.PATHS, paths.last_refresh)
                 return { paths: paths.result, filter }
             },
         },

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { toParams, objectsEqual } from 'lib/utils'
+import { toParams, objectsEqual, uuid } from 'lib/utils'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
 import { retentionTableLogicType } from './retentionTableLogicType'
@@ -68,17 +68,18 @@ export const retentionTableLogic = kea<
                 if (!refresh && (props.cachedResults || props.preventLoading) && values.filters === props.filters) {
                     return props.cachedResults
                 }
-                insightLogic.actions.startQuery()
+                const queryId = uuid()
+                insightLogic.actions.startQuery(queryId)
                 let res
                 const urlParams = toParams({ ...values.filters, ...(refresh ? { refresh: true } : {}) })
                 try {
                     res = await api.get(`api/insight/retention/?${urlParams}`)
                 } catch (e) {
-                    insightLogic.actions.endQuery(ViewType.RETENTION, null, e)
+                    insightLogic.actions.endQuery(queryId, ViewType.RETENTION, null, e)
                     return []
                 }
                 breakpoint()
-                insightLogic.actions.endQuery(ViewType.RETENTION, res.last_refresh)
+                insightLogic.actions.endQuery(queryId, ViewType.RETENTION, res.last_refresh)
                 return res.result
             },
         },

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 
 import api from 'lib/api'
-import { autocorrectInterval, errorToast, objectsEqual, toParams as toAPIParams } from 'lib/utils'
+import { autocorrectInterval, errorToast, objectsEqual, toParams as toAPIParams, uuid } from 'lib/utils'
 import { actionsModel } from '~/models/actionsModel'
 import { router } from 'kea-router'
 import {
@@ -162,7 +162,8 @@ export const trendsLogic = kea<
                 if (props.cachedResults && !refresh && values.filters === props.filters) {
                     return { result: props.cachedResults } as TrendResponse
                 }
-                insightLogic.actions.startQuery()
+                const queryId = uuid()
+                insightLogic.actions.startQuery(queryId)
                 let response
                 try {
                     if (values.filters?.insight === ViewType.SESSIONS || values.filters?.session) {
@@ -181,11 +182,11 @@ export const trendsLogic = kea<
                 } catch (e) {
                     console.error(e)
                     breakpoint()
-                    insightLogic.actions.endQuery(values.filters.insight || ViewType.TRENDS, null, e)
+                    insightLogic.actions.endQuery(queryId, values.filters.insight || ViewType.TRENDS, null, e)
                     return []
                 }
                 breakpoint()
-                insightLogic.actions.endQuery(values.filters.insight || ViewType.TRENDS, response.last_refresh)
+                insightLogic.actions.endQuery(queryId, values.filters.insight || ViewType.TRENDS, response.last_refresh)
 
                 return response
             },

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -141,6 +141,9 @@ class InstanceStatusViewSet(viewsets.ViewSet):
 
         return Response({"results": {"overview": metrics, "internal_metrics": get_internal_metrics_dashboards()}})
 
+    def create(self, request: Request) -> Response:
+        __import__("IPython").embed()  # FIXME
+
     @action(methods=["GET"], detail=False)
     def queries(self, request: Request) -> Response:
         queries = {"postgres_running": self.get_postgres_running_queries()}

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Union
 from django.db import connection
 from rest_framework import viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -142,7 +142,8 @@ class InstanceStatusViewSet(viewsets.ViewSet):
         return Response({"results": {"overview": metrics, "internal_metrics": get_internal_metrics_dashboards()}})
 
     # Used to capture internal metrics shown on dashboards
-    def create(self, request: Request) -> Response:
+    @action(methods=["POST"], detail=False, permission_classes=[AllowAny])
+    def capture(self, request: Request) -> Response:
         from posthog.internal_metrics import incr, timing
 
         method: Any = timing if request.data["method"] == "timing" else incr

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from django.db import connection
 from rest_framework import viewsets
@@ -145,7 +145,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
     def create(self, request: Request) -> Response:
         from posthog.internal_metrics import incr, timing
 
-        method = timing if request.data["method"] == "timing" else incr
+        method: Any = timing if request.data["method"] == "timing" else incr
         method(request.data["metric"], request.data["value"], request.data.get("tags", None))
         return Response({"status": 1})
 

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -8,7 +8,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.ee import is_clickhouse_enabled
-from posthog.internal_metrics import incr, timing
 from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import Element, Event, SessionRecordingEvent
 from posthog.permissions import SingleTenancyOrAdmin
@@ -144,6 +143,8 @@ class InstanceStatusViewSet(viewsets.ViewSet):
 
     # Used to capture internal metrics shown on dashboards
     def create(self, request: Request) -> Response:
+        from posthog.internal_metrics import incr, timing
+
         method = timing if request.data["method"] == "timing" else incr
         method(request.data["metric"], request.data["value"], request.data.get("tags", None))
         return Response({"status": 1})

--- a/posthog/api/test/test_instance_status.py
+++ b/posthog/api/test/test_instance_status.py
@@ -15,10 +15,10 @@ class TestInstanceStatus(APIBaseTest):
     @patch("posthog.internal_metrics.timing")
     @patch("posthog.internal_metrics.incr")
     def test_create_internal_metrics_route(self, incr_mock, timing_mock):
-        self.client.post("/api/instance_status", {"method": "incr", "metric": "foo", "value": 1})
+        self.client.post("/api/instance_status/capture", {"method": "incr", "metric": "foo", "value": 1})
         incr_mock.assert_called_with("foo", 1, None)
 
         self.client.post(
-            "/api/instance_status", {"method": "timing", "metric": "bar", "value": 15.2, "tags": {"team_id": 1}}
+            "/api/instance_status/capture", {"method": "timing", "metric": "bar", "value": 15.2, "tags": {"team_id": 1}}
         )
         timing_mock.assert_called_with("bar", 15.2, {"team_id": 1})

--- a/posthog/api/test/test_instance_status.py
+++ b/posthog/api/test/test_instance_status.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from rest_framework import status
+
+from posthog.internal_metrics import timing
+from posthog.test.base import APIBaseTest
+
+
+class TestInstanceStatus(APIBaseTest):
+    def test_instance_status_routes(self):
+        self.assertEqual(self.client.get("/api/instance_status").status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.get("/api/instance_status/queries").status_code, status.HTTP_200_OK)
+
+    @patch("posthog.internal_metrics.timing")
+    @patch("posthog.internal_metrics.incr")
+    def test_create_internal_metrics_route(self, incr_mock, timing_mock):
+        self.client.post("/api/instance_status", {"method": "incr", "metric": "foo", "value": 1})
+        self.client.post(
+            "/api/instance_status", {"method": "timing", "metric": "bar", "value": 15.2, "tags": {"team_id": 1}}
+        )
+
+        incr_mock.assert_called_with("foo", 1, None)
+        timing_mock.assert_called_with("bar", 15.2, {"team_id": 1})

--- a/posthog/api/test/test_instance_status.py
+++ b/posthog/api/test/test_instance_status.py
@@ -1,12 +1,13 @@
 from unittest.mock import patch
 
+import pytest
 from rest_framework import status
 
-from posthog.internal_metrics import timing
 from posthog.test.base import APIBaseTest
 
 
 class TestInstanceStatus(APIBaseTest):
+    @pytest.mark.skip_on_multitenancy
     def test_instance_status_routes(self):
         self.assertEqual(self.client.get("/api/instance_status").status_code, status.HTTP_200_OK)
         self.assertEqual(self.client.get("/api/instance_status/queries").status_code, status.HTTP_200_OK)
@@ -15,9 +16,9 @@ class TestInstanceStatus(APIBaseTest):
     @patch("posthog.internal_metrics.incr")
     def test_create_internal_metrics_route(self, incr_mock, timing_mock):
         self.client.post("/api/instance_status", {"method": "incr", "metric": "foo", "value": 1})
+        incr_mock.assert_called_with("foo", 1, None)
+
         self.client.post(
             "/api/instance_status", {"method": "timing", "metric": "bar", "value": 15.2, "tags": {"team_id": 1}}
         )
-
-        incr_mock.assert_called_with("foo", 1, None)
         timing_mock.assert_called_with("bar", 15.2, {"team_id": 1})

--- a/posthog/internal_metrics/team.py
+++ b/posthog/internal_metrics/team.py
@@ -14,6 +14,90 @@ CLICKHOUSE_DASHBOARD = {
     "name": "Clickhouse internal dashboard",
     "items": [
         {
+            "name": "Number of insights loaded vs failed",
+            "filters": {
+                "events": [
+                    {
+                        "id": "$$insight_load_time",
+                        "name": "insights loaded",
+                        "type": "events",
+                        "order": 0,
+                        "properties": [{"key": "success", "type": "event", "value": ["true"], "operator": "exact"}],
+                    },
+                    {
+                        "id": "$$insight_load_time",
+                        "name": "insights loaded",
+                        "type": "events",
+                        "order": 1,
+                        "properties": [{"key": "success", "type": "event", "value": ["false"], "operator": "exact"}],
+                    },
+                ],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "hour",
+                "date_from": "-24h",
+                "properties": [],
+            },
+        },
+        {
+            "name": "Insight load time",
+            "filters": {
+                "events": [
+                    {
+                        "id": "$$insight_load_time",
+                        "math": "avg",
+                        "name": "Load time (avg)",
+                        "type": "events",
+                        "order": 0,
+                        "properties": [],
+                        "math_property": "value",
+                    },
+                    {
+                        "id": "$$insight_load_time",
+                        "math": "p90",
+                        "name": "Load time (p90)",
+                        "type": "events",
+                        "order": 1,
+                        "properties": [],
+                        "math_property": "value",
+                    },
+                    {
+                        "id": "$$insight_load_time",
+                        "math": "p95",
+                        "name": "Load time (p95)",
+                        "type": "events",
+                        "order": 2,
+                        "properties": [],
+                        "math_property": "value",
+                    },
+                ],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "hour",
+                "date_from": "-24h",
+                "properties": [],
+            },
+        },
+        {
+            "name": "Number of insights with timeout message",
+            "filters": {
+                "events": [
+                    {
+                        "id": "$$insight_timeout",
+                        "name": "insight timeout",
+                        "type": "events",
+                        "order": 0,
+                        "properties": [],
+                    },
+                ],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "hour",
+                "date_from": "-24h",
+                "properties": [],
+            },
+        },
+        {
             "name": "Clickhouse total queries",
             "filters": {
                 "events": [


### PR DESCRIPTION
## Changes

This PR exposes metrics on insights loading on /instance/status. Specifically:
1. How many requests succeed vs fail
2. Timing (avg, p90, p95) of those requests
3. How many times do we show the timeout message

It also affects metrics we capture within posthog:
- Previously "timeout message shown" metric was *incorrect*: it contained failures when any exception was thrown (e.g. bug rather than timeout). 
- Also metrics on insight timeouts would not reach us if user navigated away from the page before query "completed".
- We now capture number of insights loaded + timing info + view the request was made from. This is useful to debug whether "failing" queries are caused by a thundering herd effect within dashboards + making it possible to graph experience over time.

How this works:
1. We expose more information on the request in `posthog.capture` calls
2. We expose a new endpoint POST `/api/instance/status` which allows sending limited metrics from frontend about the _instance_ health.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
