### PR TITLE
Dashboards: allow changing date ranges on /instance/status dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -18,11 +18,12 @@ import { EmptyDashboardComponent } from './EmptyDashboardComponent'
 interface Props {
     id: string
     shareToken?: string
+    internal?: boolean
 }
 
-export function Dashboard({ id, shareToken }: Props): JSX.Element {
+export function Dashboard({ id, shareToken, internal }: Props): JSX.Element {
     return (
-        <BindLogic logic={dashboardLogic} props={{ id: parseInt(id), shareToken }}>
+        <BindLogic logic={dashboardLogic} props={{ id: parseInt(id), shareToken, internal }}>
             <DashboardView />
         </BindLogic>
     )
@@ -34,7 +35,7 @@ function DashboardView(): JSX.Element {
     const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
 
     useKeyboardHotkeys(
-        dashboardMode === DashboardMode.Public
+        dashboardMode === DashboardMode.Public || dashboardMode === DashboardMode.Internal
             ? {}
             : {
                   e: {
@@ -102,7 +103,7 @@ function DashboardView(): JSX.Element {
 
     return (
         <div className="dashboard">
-            {dashboardMode !== DashboardMode.Public && <DashboardHeader />}
+            {dashboardMode !== DashboardMode.Public && dashboardMode !== DashboardMode.Internal && <DashboardHeader />}
             {items && items.length ? (
                 <div>
                     <div className="dashboard-items-actions">

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -143,7 +143,7 @@ function DashboardView(): JSX.Element {
                             </div>
                         )}
                     </div>
-                    <DashboardItems inSharedMode={dashboardMode === DashboardMode.Public} />
+                    <DashboardItems />
                 </div>
             ) : (
                 <EmptyDashboardComponent />

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -13,7 +13,7 @@ import { DashboardEventSource } from '../../lib/utils/eventUsageLogic'
 
 const ReactGridLayout = WidthProvider(Responsive)
 
-export function DashboardItems({ inSharedMode }: { inSharedMode: boolean }): JSX.Element {
+export function DashboardItems(): JSX.Element {
     const { dashboard, items, layouts, layoutForItem, breakpoints, cols, dashboardMode } = useValues(dashboardLogic)
     const { loadDashboardItems, updateLayouts, updateContainerWidth, updateItemColor, setDashboardMode } = useActions(
         dashboardLogic
@@ -99,7 +99,7 @@ export function DashboardItems({ inSharedMode }: { inSharedMode: boolean }): JSX
                         }
                         updateItemColor={updateItemColor}
                         isDraggingRef={isDragging}
-                        inSharedMode={inSharedMode}
+                        dashboardMode={dashboardMode}
                         isOnEditMode={dashboardMode === DashboardMode.Edit}
                         setEditMode={() => setDashboardMode(DashboardMode.Edit, DashboardEventSource.LongPress)}
                         index={index}

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -264,7 +264,10 @@ export const dashboardLogic = kea({
         afterMount: () => {
             actions.loadDashboardItems()
             if (props.shareToken) {
-                actions.setDashboardMode(DashboardMode.Public, DashboardEventSource.Browser)
+                actions.setDashboardMode(
+                    props.internal ? DashboardMode.Internal : DashboardMode.Public,
+                    DashboardEventSource.Browser
+                )
                 dashboardsModel.actions.loadSharedDashboard(props.shareToken)
             }
         },

--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -66,6 +66,7 @@ function InsightPane({
                                 loadTeamInsights()
                             }}
                             saveDashboardItem={updateInsight}
+                            dashboardMode={null}
                             onClick={() => {
                                 if (reportOnClick) {
                                     reportOnClick()

--- a/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
@@ -29,7 +29,7 @@ export function InternalMetricsTab(): JSX.Element {
             <Collapse activeKey={openSections} onChange={(keys) => setOpenSections(keys as string[])}>
                 {dashboard ? (
                     <Collapse.Panel header="Dashboards" key="0">
-                        <Dashboard id={dashboard.id.toString()} shareToken={dashboard.share_token} />
+                        <Dashboard id={dashboard.id.toString()} shareToken={dashboard.share_token} internal />
                     </Collapse.Panel>
                 ) : null}
                 <Collapse.Panel header="PostgreSQL - currently running queries" key="1">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -682,6 +682,7 @@ export enum DashboardMode { // Default mode is null
     Fullscreen = 'fullscreen', // When the dashboard is on full screen (presentation) mode
     Sharing = 'sharing', // When the sharing configuration is opened
     Public = 'public', // When viewing the dashboard publicly via a shareToken
+    Internal = 'internal', // When embedded into another page (e.g. /instance/status)
 }
 
 export enum DashboardItemMode {

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -109,9 +109,11 @@ class PublicTokenAuthentication(authentication.BaseAuthentication):
             Dashboard = apps.get_model(app_label="posthog", model_name="Dashboard")
             dashboard = Dashboard.objects.filter(
                 share_token=request.GET.get("share_token"), pk=request.parser_context["kwargs"].get("pk"),
-            )
-            if not dashboard.exists():
+            ).first()
+            if dashboard is None:
                 raise AuthenticationFailed(detail="Dashboard doesn't exist")
+            if dashboard.team.organization.for_internal_metrics:
+                return None
             return (AnonymousUser(), None)
         return None
 

--- a/posthog/internal_metrics/team.py
+++ b/posthog/internal_metrics/team.py
@@ -236,6 +236,7 @@ CLICKHOUSE_DASHBOARD = {
             },
         },
     ],
+    "filters": {"interval": "hour", "date_from": "-24h",},
 }
 
 
@@ -288,7 +289,11 @@ def get_or_create_dashboard(team_id: int, definition: Dict) -> Dashboard:
     if dashboard is None:
         Dashboard.objects.filter(team_id=team_id, name=definition["name"]).delete()
         dashboard = Dashboard.objects.create(
-            name=definition["name"], description=description, team_id=team_id, share_token=secrets.token_urlsafe(22)
+            name=definition["name"],
+            filters=definition["filters"],
+            description=description,
+            team_id=team_id,
+            share_token=secrets.token_urlsafe(22),
         )
 
         for index, item in enumerate(definition["items"]):


### PR DESCRIPTION
- Show more things when embedding dashboard for internal purposes
- Show refresh button for /instance/status dashboard
- Allow logged in users to change date range in /instance/status dashboard

![image](https://user-images.githubusercontent.com/148820/119631312-710b7180-be18-11eb-98ed-0d68a07e6ec8.png)

Related ticket: https://github.com/PostHog/vpc/issues/45

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
