### PR TITLE
Experiment - Don't send people to Home by default

### DIFF
--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -8,7 +8,6 @@ import { sceneLogicType } from './sceneLogicType'
 import { eventUsageLogic } from '../lib/utils/eventUsageLogic'
 import { preflightLogic } from './PreflightCheck/logic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export enum Scene {
     Dashboards = 'dashboards',
@@ -247,9 +246,6 @@ export const sceneLogic = kea<sceneLogicType>({
     },
     urlToAction: ({ actions }) => {
         featureFlagLogic.mount() // Otherwise logic is not loaded before this
-        if (featureFlagLogic && featureFlagLogic.values.featureFlags[FEATURE_FLAGS.PROJECT_HOME]) {
-            redirects['/'] = '/home'
-        }
 
         const mapping: Record<string, (params: Params) => any> = {}
 


### PR DESCRIPTION
## Changes
Project Home has been a good experiment and has driven positive results in terms of activation and retention, however there are lots of improvements to make – and a more holistic version of a "project homepage" that takes into account clearer application navigation overall and improvements across the board. A lot of the things our current project home page does deliberant will hopefully be translated into our product itself – i.e. we'll teach you about insights on the insights page itself, not on a home page.

There's a big [list](https://github.com/PostHog/posthog/issues/4479#issuecomment-848396150) of next steps to make this a better experience. 

While we're thinking about the next experience, I'd like to float the idea of not defaulting anyone to "home".

The goal of this change is basically - let's not send anyone to Project Home as a default. Let's assume that by default, confused users will navigate away from insights and go to more friendly areas (i.e. home).

One problem with this – it's _weird_ to have something called "home" but not send users there as a default – so I'm open to some edits here but the goal really is to learn, how many people _choose_ to navigate to home. Right now it shows positive impact but are we _drawing_ people to it? This will help us form an opinion on the right page to send activated users to. I suspect today they prefer to end up straight in Insights.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
