### PR TITLE
@ import all scss in lib/components

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -6,6 +6,12 @@ style files without adding already imported styles. */
 @import 'node_modules/react-toastify/dist/ReactToastify';
 @import './vars';
 
+// https://github.com/PostHog/posthog/issues/4524
+@import './lib/components/ActionComponents.scss';
+@import './lib/components/PropertiesTable.scss';
+@import './lib/components/SelectBox.scss';
+@import './lib/components/SelectGradientOverflow.scss';
+
 @font-face {
     font-family: 'GoshaSans-Bold';
     src: url('../public/GoshaSans-Bold.woff2') format('woff2'), url('../public/GoshaSans-Bold.woff') format('woff');

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -5,7 +5,7 @@ import { Dropdown, Input, Menu, Popconfirm, Table, Tooltip } from 'antd'
 import { NumberOutlined, BulbOutlined, StopOutlined, DeleteOutlined } from '@ant-design/icons'
 import { isURL } from 'lib/utils'
 import { IconExternalLink, IconText } from 'lib/components/icons'
-import './PropertiesTable.scss'
+// import './PropertiesTable.scss' //https://github.com/PostHog/posthog/issues/4524
 import stringWithWBR from 'lib/utils/stringWithWBR'
 
 type HandledType = 'string' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'

--- a/frontend/src/lib/components/SelectBox.tsx
+++ b/frontend/src/lib/components/SelectBox.tsx
@@ -5,7 +5,7 @@ import { List } from 'antd'
 import { DownOutlined, RightOutlined } from '@ant-design/icons'
 import { ActionType, CohortType } from '~/types'
 import { selectBoxLogic } from 'lib/logic/selectBoxLogic'
-import './SelectBox.scss' // https://github.com/PostHog/posthog/issues/4524
+// import './SelectBox.scss' // https://github.com/PostHog/posthog/issues/4524
 import { selectBoxLogicType } from 'lib/logic/selectBoxLogicType'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 

--- a/frontend/src/lib/components/SelectBox.tsx
+++ b/frontend/src/lib/components/SelectBox.tsx
@@ -5,7 +5,7 @@ import { List } from 'antd'
 import { DownOutlined, RightOutlined } from '@ant-design/icons'
 import { ActionType, CohortType } from '~/types'
 import { selectBoxLogic } from 'lib/logic/selectBoxLogic'
-import './SelectBox.scss'
+import './SelectBox.scss' // https://github.com/PostHog/posthog/issues/4524
 import { selectBoxLogicType } from 'lib/logic/selectBoxLogicType'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, RefObject, useEffect, useRef, useState } from 'react'
 import { Select, Tag, Tooltip } from 'antd'
 import { RefSelectProps, SelectProps } from 'antd/lib/select'
-import './SelectGradientOverflow.scss'
+// import './SelectGradientOverflow.scss' //https://github.com/PostHog/posthog/issues/4524
 import { CloseButton } from './CloseButton'
 
 interface DropdownGradientRendererProps {


### PR DESCRIPTION
## Changes

Contributes to #4524. Hotfix to ensure component-level SCSS files are loaded. A more stable fix is needed.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
