### PR TITLE
Move history import to globals

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -11,6 +11,7 @@ style files without adding already imported styles. */
 @import './lib/components/PropertiesTable.scss';
 @import './lib/components/SelectBox.scss';
 @import './lib/components/SelectGradientOverflow.scss';
+@import './scenes/insights/InsightHistoryPanel/InsightHistoryPanel.scss';
 
 @font-face {
     font-family: 'GoshaSans-Bold';

--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -5,7 +5,7 @@ import { useValues, useActions } from 'kea'
 import { insightHistoryLogic } from './insightHistoryLogic'
 import { DashboardItemType } from '~/types'
 import { DashboardItem, DisplayedType, displayMap } from 'scenes/dashboard/DashboardItem'
-import './InsightHistoryPanel.scss'
+// import './InsightHistoryPanel.scss' //https://github.com/PostHog/posthog/issues/4524
 import dayjs from 'dayjs'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
 import { router } from 'kea-router'


### PR DESCRIPTION
## Changes

Implementing solution from https://github.com/PostHog/posthog/pull/4530 to fix Insight History css not showing on Home or from the Insights --> History view

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
