### PR TITLE
Add cloud job queue envs

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -58,7 +58,7 @@
                 },
                 {
                     "name": "JOB_QUEUES",
-                    "value": "graphile"
+                    "value": "graphile,s3"
                 },
                 {
                     "name": "CRASH_IF_NO_PERSISTENT_JOB_QUEUE",
@@ -117,6 +117,26 @@
                 {
                     "name": "JOB_QUEUE_GRAPHILE_URL",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_GRAPHILE_URL::"
+                },
+                {
+                    "name": "JOB_QUEUE_S3_AWS_ACCESS_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_S3_AWS_ACCESS_KEY::"
+                },
+                {
+                    "name": "JOB_QUEUE_S3_AWS_SECRET_ACCESS_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_S3_AWS_SECRET_ACCESS_KEY::"
+                },
+                {
+                    "name": "JOB_QUEUE_S3_AWS_REGION",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_S3_AWS_REGION::"
+                },
+                {
+                    "name": "JOB_QUEUE_S3_BUCKET_NAME",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_S3_BUCKET_NAME::"
+                },
+                {
+                    "name": "JOB_QUEUE_S3_PREFIX",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_S3_PREFIX::"
                 },
                 {
                     "name": "STATSD_HOST",


### PR DESCRIPTION
## Changes

- Enables the S3 job queue as a backup to postgres for PostHog cloud
- Still needs some manual testing before being ready for merge

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
