### PR TITLE
Hotfix SCSS for trend graphs

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -12,6 +12,7 @@ style files without adding already imported styles. */
 @import './lib/components/SelectBox.scss';
 @import './lib/components/SelectGradientOverflow.scss';
 @import './scenes/insights/InsightHistoryPanel/InsightHistoryPanel.scss';
+@import './scenes/insights/LineGraph/LineGraph.scss';
 
 @font-face {
     font-family: 'GoshaSans-Bold';

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -14,6 +14,8 @@ style files without adding already imported styles. */
 @import './scenes/insights/InsightHistoryPanel/InsightHistoryPanel.scss';
 @import './scenes/insights/LineGraph/LineGraph.scss';
 @import './scenes/dashboard/DashboardItems.scss';
+@import './lib/components/ResizableTable/index.scss';
+@import './lib/components/ResizableTable/TableConfig.scss';
 
 @font-face {
     font-family: 'GoshaSans-Bold';

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -13,6 +13,7 @@ style files without adding already imported styles. */
 @import './lib/components/SelectGradientOverflow.scss';
 @import './scenes/insights/InsightHistoryPanel/InsightHistoryPanel.scss';
 @import './scenes/insights/LineGraph/LineGraph.scss';
+@import './scenes/dashboard/DashboardItems.scss';
 
 @font-face {
     font-family: 'GoshaSans-Bold';

--- a/frontend/src/lib/components/ResizableTable/TableConfig.tsx
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Col, Input, Row, Tooltip } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { DownloadOutlined, SettingOutlined, SaveOutlined, SearchOutlined, ClearOutlined } from '@ant-design/icons'
-import './TableConfig.scss'
+// import './TableConfig.scss' // https://github.com/PostHog/posthog/issues/4524
 import { useActions, useValues } from 'kea'
 import { tableConfigLogic } from './tableConfigLogic'
 import Modal from 'antd/lib/modal/Modal'

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -8,7 +8,7 @@ import { getActiveBreakpoint, getFullwidthColumnSize, getMinColumnWidth, parsePi
 import VirtualTableHeader from './VirtualTableHeader'
 import { TableConfig as _TableConfig } from './TableConfig'
 
-import './index.scss'
+// import './index.scss' // https://github.com/PostHog/posthog/issues/4524
 
 export const TableConfig = _TableConfig
 

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -1,4 +1,4 @@
-import './DashboardItems.scss'
+// import './DashboardItems.scss' //https://github.com/PostHog/posthog/issues/4524
 import { Link } from 'lib/components/Link'
 import { useActions, useValues } from 'kea'
 import { Dropdown, Menu, Tooltip, Alert, Button, Skeleton } from 'antd'

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify'
 import { Annotations, annotationsLogic, AnnotationMarker } from 'lib/components/Annotations'
 import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import dayjs from 'dayjs'
-import './LineGraph.scss'
+// import './LineGraph.scss' //https://github.com/PostHog/posthog/issues/4524
 
 //--Chart Style Options--//
 // Chart.defaults.global.defaultFontFamily = "'PT Sans', sans-serif"


### PR DESCRIPTION
## Changes

*Please describe.*  
Hotfix for LineGraph SCSS not being loaded correctly (results in all graph containers having the incorrect height; see photo). There seems to be no rhyme or reason to which SCSS files get randomly dropped from the production build.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
