### PR TITLE
WIP: Fix issues with MiniCssExtractPlugin and SCSS loading

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -4,5 +4,10 @@ set -e
 # pass first argument to WEBPACK_HOT_RELOAD_HOST
 [ $# -ge 1 ] && export WEBPACK_HOT_RELOAD_HOST=$1
 
-yarn install
-yarn start
+if [ $PROD_BUILD_LOCAL_DEBUG == 1 ]; then
+    yarn install --production=false
+    NODE_ENV=production yarn start
+else
+    yarn install
+    yarn start
+fi

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,33 +26,25 @@ function getPublicOutputPath() {
 
 function createEntry(entry) {
     const commonLoadersForSassAndLess = [
-        entry === 'toolbar'
-            ? {
-                  loader: 'style-loader',
-                  options: {
-                      insert: function insertAtTop(element) {
-                          // tunnel behind the shadow root
-                          if (window.__PHGTLB_ADD_STYLES__) {
-                              window.__PHGTLB_ADD_STYLES__(element)
-                          } else {
-                              if (!window.__PHGTLB_STYLES__) {
-                                  window.__PHGTLB_STYLES__ = []
+        {
+            loader: 'style-loader',
+            options:
+                entry === 'toolbar'
+                    ? {
+                          insert: function insertAtTop(element) {
+                              // tunnel behind the shadow root
+                              if (window.__PHGTLB_ADD_STYLES__) {
+                                  window.__PHGTLB_ADD_STYLES__(element)
+                              } else {
+                                  if (!window.__PHGTLB_STYLES__) {
+                                      window.__PHGTLB_STYLES__ = []
+                                  }
+                                  window.__PHGTLB_STYLES__.push(element)
                               }
-                              window.__PHGTLB_STYLES__.push(element)
-                          }
-                      },
-                  },
-              }
-            : entry === 'cypress'
-            ? {
-                  loader: 'style-loader',
-              }
-            : {
-                  // After all CSS loaders we use plugin to do his work.
-                  // It gets all transformed CSS and extracts it into separate
-                  // single bundled file
-                  loader: MiniCssExtractPlugin.loader,
-              },
+                          },
+                      }
+                    : undefined,
+        },
         {
             // This loader resolves url() and @imports inside CSS
             loader: 'css-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,22 @@ const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 const AntdDayjsWebpackPlugin = require('antd-dayjs-webpack-plugin')
 
+if (process.env.NODE_ENV === 'production' && process.env.PROD_BUILD_LOCAL_DEBUG) {
+    console.log('PROD_BUILD_LOCAL_DEBUG: Building for production, but using dev output folder.')
+}
+
 const webpackDevServerHost = process.env.WEBPACK_HOT_RELOAD_HOST || '127.0.0.1'
 const webpackDevServerFrontendAddr = webpackDevServerHost === '0.0.0.0' ? '127.0.0.1' : webpackDevServerHost
+
+function getPublicOutputPath() {
+    if (process.env.JS_URL) {
+        return `${process.env.JS_URL}${process.env.JS_URL.endsWith('/') ? '' : '/'}static/`
+    } else if (process.env.NODE_ENV === 'production' && !process.env.PROD_BUILD_LOCAL_DEBUG) {
+        return '/static/'
+    } else {
+        return `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerFrontendAddr}:8234/static/`
+    }
+}
 
 function createEntry(entry) {
     const commonLoadersForSassAndLess = [
@@ -70,11 +84,7 @@ function createEntry(entry) {
             path: path.resolve(__dirname, 'frontend', 'dist'),
             filename: '[name].js',
             chunkFilename: '[name].[contenthash].js',
-            publicPath: process.env.JS_URL
-                ? `${process.env.JS_URL}${process.env.JS_URL.endsWith('/') ? '' : '/'}static/`
-                : process.env.NODE_ENV === 'production'
-                ? '/static/'
-                : `http${process.env.LOCAL_HTTPS ? 's' : ''}://${webpackDevServerFrontendAddr}:8234/static/`,
+            publicPath: getPublicOutputPath(),
         },
         resolve: {
             extensions: ['.js', '.ts', '.tsx'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,7 +195,7 @@ function createEntry(entry) {
                       hot: true,
                       host: webpackDevServerHost,
                       port: 8234,
-                      stats: 'minimal',
+                      stats: process.env.PROD_BUILD_LOCAL_DEBUG ? 'verbose' : 'minimal',
                       disableHostCheck: !!process.env.LOCAL_HTTPS,
                       public: process.env.JS_URL
                           ? new URL(process.env.JS_URL).host


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.* 

Added debug flags for ./bin/start to reproduce the env in which SCSS is not properly loaded.

In webpack config, disable the mini-css loader but retain the plugin... this fixes the issue but may have unknown implications for tree-shaking or bundle size.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
