### PR TITLE
Remove MiniCssExtractPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
         "less": "^3.12.2",
         "less-loader": "^7.0.2",
         "lint-staged": "~10.2.13",
-        "mini-css-extract-plugin": "^1.6.0",
         "monaco-editor-webpack-plugin": "^2.0.0",
         "postcss-loader": "^3.0.0",
         "prettier": "^2.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* global require, module, process, __dirname */
 const path = require('path')
-const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
@@ -12,33 +11,25 @@ const webpackDevServerFrontendAddr = webpackDevServerHost === '0.0.0.0' ? '127.0
 
 function createEntry(entry) {
     const commonLoadersForSassAndLess = [
-        entry === 'toolbar'
-            ? {
-                  loader: 'style-loader',
-                  options: {
-                      insert: function insertAtTop(element) {
-                          // tunnel behind the shadow root
-                          if (window.__PHGTLB_ADD_STYLES__) {
-                              window.__PHGTLB_ADD_STYLES__(element)
-                          } else {
-                              if (!window.__PHGTLB_STYLES__) {
-                                  window.__PHGTLB_STYLES__ = []
+        {
+            loader: 'style-loader',
+            options:
+                entry === 'toolbar'
+                    ? {
+                          insert: function insertAtTop(element) {
+                              // tunnel behind the shadow root
+                              if (window.__PHGTLB_ADD_STYLES__) {
+                                  window.__PHGTLB_ADD_STYLES__(element)
+                              } else {
+                                  if (!window.__PHGTLB_STYLES__) {
+                                      window.__PHGTLB_STYLES__ = []
+                                  }
+                                  window.__PHGTLB_STYLES__.push(element)
                               }
-                              window.__PHGTLB_STYLES__.push(element)
-                          }
-                      },
-                  },
-              }
-            : entry === 'cypress'
-            ? {
-                  loader: 'style-loader',
-              }
-            : {
-                  // After all CSS loaders we use plugin to do his work.
-                  // It gets all transformed CSS and extracts it into separate
-                  // single bundled file
-                  loader: MiniCssExtractPlugin.loader,
-              },
+                          },
+                      }
+                    : undefined,
+        },
         {
             // This loader resolves url() and @imports inside CSS
             loader: 'css-loader',
@@ -206,12 +197,6 @@ function createEntry(entry) {
         ].concat(
             entry === 'main'
                 ? [
-                      // other bundles include the css in js via style-loader
-                      new MiniCssExtractPlugin({
-                          filename: '[name].css',
-                          chunkFilename: '[name].css',
-                          ignoreOrder: true,
-                      }),
                       // we need these only once per build
                       new HtmlWebpackPlugin({
                           alwaysWriteToDisk: true,
@@ -230,10 +215,6 @@ function createEntry(entry) {
                   ]
                 : entry === 'shared_dashboard'
                 ? [
-                      new MiniCssExtractPlugin({
-                          filename: '[name].css',
-                          ignoreOrder: true,
-                      }),
                       new HtmlWebpackPlugin({
                           alwaysWriteToDisk: true,
                           title: 'PostHog',


### PR DESCRIPTION
## Changes

- Removes CSS file generation with MiniCssExtractPlugin. The CSS will be bundled into the JS files. It'll remain code splitted, but loaded only after the JS parses. A slight slowdown, but probably not too bad. 🤞 
- Reasoning
   - There's something weird going on with CSS generation and caching. It feels like `main.css` is just not regenerating. 
   - In any case, to really fix it (I'd like to sleep), let's remove CSS files. For now. 
   - @samwinslow beat me to it with his approach in https://github.com/PostHog/posthog/pull/4541 , but I'd prefer to scope this down, as it's a PR that might get reverted.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
