### PR TITLE
Solve race conditions around internal metrics

### DIFF
--- a/posthog/internal_metrics/team.py
+++ b/posthog/internal_metrics/team.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import Dict, Optional
 
 from django.conf import settings
+from django.db import transaction
 from sentry_sdk.api import capture_exception
 
 from posthog.models.dashboard import Dashboard
@@ -333,17 +334,18 @@ def get_internal_metrics_team_id() -> Optional[int]:
         return None
 
     try:
-        team = Team.objects.filter(organization__for_internal_metrics=True).first()
+        with transaction.atomic():
+            team = Team.objects.filter(organization__for_internal_metrics=True).first()
 
-        if team is None:
-            organization = Organization.objects.create(name=NAME, for_internal_metrics=True)
-            team = Team.objects.create(
-                name=NAME,
-                organization=organization,
-                ingested_event=True,
-                completed_snippet_onboarding=True,
-                is_demo=True,
-            )
+            if team is None:
+                organization = Organization.objects.create(name=NAME, for_internal_metrics=True)
+                team = Team.objects.create(
+                    name=NAME,
+                    organization=organization,
+                    ingested_event=True,
+                    completed_snippet_onboarding=True,
+                    is_demo=True,
+                )
 
         return team.pk
     except:
@@ -353,7 +355,6 @@ def get_internal_metrics_team_id() -> Optional[int]:
         return None
 
 
-@lru_cache(maxsize=1)
 def get_internal_metrics_dashboards() -> Dict:
     team_id = get_internal_metrics_team_id()
 


### PR DESCRIPTION
The app can behave oddly around boot, resulting in:
1. Seemingly missing dashboards for internal metrics
2. Organization but no team for internal metrics

This PR aims to solve both by:
1. Removing caching for dashboards (rare case)
2. Handling race in org creation with an explicit transaction

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
