### PR TITLE
Only send internal metrics from FE is CAPTURE_INTERNAL_METRICS is enabled

### DIFF
--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -5,6 +5,7 @@ declare global {
         JS_POSTHOG_API_KEY?: str
         JS_POSTHOG_HOST?: str
         JS_POSTHOG_SELF_CAPTURE?: boolean
+        JS_CAPTURE_INTERNAL_METRICS?: boolean
         posthog?: posthog
     }
 }

--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -7,6 +7,8 @@ interface InternalMetricsPayload {
     tags: Record<string, any>
 }
 
-export function captureInternalMetric(payload: InternalMetricsPayload): Promise<void> {
-    return api.create('api/instance_status/capture', payload)
+export async function captureInternalMetric(payload: InternalMetricsPayload): Promise<void> {
+    if (window.JS_CAPTURE_INTERNAL_METRICS) {
+        await api.create('api/instance_status/capture', payload)
+    }
 }

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -17,6 +17,7 @@
     window.JS_POSTHOG_API_KEY = {{js_posthog_api_key | safe}};
     window.JS_POSTHOG_HOST = {{js_posthog_host | safe}};
     window.JS_POSTHOG_SELF_CAPTURE = {{self_capture | yesno:"true,false" }};
+    window.JS_CAPTURE_INTERNAL_METRICS = {{js_capture_internal_metrics | yesno:"true,false"}}
     </script>
 {% endif %}
 {% if sentry_dsn %}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -212,6 +212,8 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
         context["js_posthog_api_key"] = "'sTMFPsFhdP1Ssg'"
         context["js_posthog_host"] = "'https://app.posthog.com'"
 
+    context["js_capture_internal_metrics"] = settings.CAPTURE_INTERNAL_METRICS
+
     html = template.render(context, request=request)
     return HttpResponse(html)
 


### PR DESCRIPTION
Housekeeping, users who won't see the metrics won't have noise in their network console

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
