### PR TITLE
add user filter to lifecycle

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -73,6 +73,7 @@ services:
         command: ./ee/bin/docker-ch-dev-web
         ports:
             - '8000:8000'
+            - '8234:8234'
     plugins:
         image: posthog/plugin-server:latest
         restart: on-failure

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -73,7 +73,6 @@ services:
         command: ./ee/bin/docker-ch-dev-web
         ports:
             - '8000:8000'
-            - '8234:8234'
     plugins:
         image: posthog/plugin-server:latest
         restart: on-failure

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -78,6 +78,9 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
                 <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                     {filters.insight === ViewType.LIFECYCLE && (
                         <>
+                            <h4 className="secondary">Global Filters</h4>
+                            <TestAccountFilter filters={filters} onChange={setFilters} />
+                            <hr />
                             <h4 className="secondary">Lifecycle Toggles</h4>
                             {filtersLoading ? (
                                 <Skeleton active />
@@ -100,10 +103,6 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
                                     ))}
                                 </div>
                             )}
-
-                            <hr />
-                            <h4 className="secondary">Filters</h4>
-                            <TestAccountFilter filters={filters} onChange={setFilters} />
                         </>
                     )}
                     {filters.insight !== ViewType.LIFECYCLE && (

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTabHorizontal.tsx
@@ -100,6 +100,10 @@ export function TrendTabHorizontal({ view, annotationsToCreate }: TrendTabProps)
                                     ))}
                                 </div>
                             )}
+
+                            <hr />
+                            <h4 className="secondary">Filters</h4>
+                            <TestAccountFilter filters={filters} onChange={setFilters} />
                         </>
                     )}
                     {filters.insight !== ViewType.LIFECYCLE && (


### PR DESCRIPTION
## Changes

the filter not being there could cause unexpected behaviour if it was set in a different insight.

@paolodamico any idea why we don't have global filters for lifecycle?

After:
![image](https://user-images.githubusercontent.com/1727427/120369342-69b1ff80-c313-11eb-8166-1163614ec70b.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
