### PR TITLE
[Fix] Annotations list not refreshing after creating annotation

### DIFF
--- a/cypress/integration/annotations.js
+++ b/cypress/integration/annotations.js
@@ -11,6 +11,6 @@ describe('Annotations', () => {
         cy.get('[data-attr=create-annotation]').click()
         cy.get('[data-attr=create-annotation-input]').type('Test Annotation')
         cy.get('[data-attr=create-annotation-submit]').click()
-        cy.contains('Test Annotation').should('exist')
+        cy.get('[data-attr=annotations-table]').contains('Test Annotation').should('exist')
     })
 })

--- a/frontend/src/models/annotationsModel.js
+++ b/frontend/src/models/annotationsModel.js
@@ -14,7 +14,7 @@ export const annotationsModel = kea({
         }),
         deleteGlobalAnnotation: (id) => ({ id }),
     }),
-    loaders: () => ({
+    loaders: ({ values }) => ({
         globalAnnotations: {
             __default: [],
             loadGlobalAnnotations: async () => {
@@ -26,6 +26,16 @@ export const annotationsModel = kea({
                         })
                 )
                 return response.results
+            },
+            createGlobalAnnotation: async ({ dashboard_item, content, date_marker, created_at }) => {
+                const annotation = await api.create('api/annotation', {
+                    content,
+                    date_marker: dayjs.isDayjs(date_marker) ? date_marker : dayjs(date_marker),
+                    created_at,
+                    dashboard_item,
+                    scope: 'organization',
+                })
+                return [...(values.globalAnnotations || []), annotation]
             },
         },
     }),
@@ -49,16 +59,7 @@ export const annotationsModel = kea({
         ],
     }),
     listeners: ({ actions }) => ({
-        createGlobalAnnotation: async ({ dashboard_item, content, date_marker, created_at }) => {
-            await api.create('api/annotation', {
-                content,
-                date_marker: dayjs.isDayjs(date_marker) ? date_marker : dayjs(date_marker),
-                created_at,
-                dashboard_item,
-                scope: 'organization',
-            })
-        },
-        deleteGlobalAnnotation: async ({ id }) => {
+        deleteGlobalAnnotation: ({ id }) => {
             id >= 0 &&
                 deleteWithUndo({
                     endpoint: 'annotation',

--- a/frontend/src/models/annotationsModel.js
+++ b/frontend/src/models/annotationsModel.js
@@ -57,7 +57,6 @@ export const annotationsModel = kea({
                 dashboard_item,
                 scope: 'organization',
             })
-            actions.loadGlobalAnnotations()
         },
         deleteGlobalAnnotation: async ({ id }) => {
             id >= 0 &&

--- a/frontend/src/scenes/annotations/logic.js
+++ b/frontend/src/scenes/annotations/logic.js
@@ -65,7 +65,8 @@ export const annotationsTableLogic = kea({
             }
             actions.appendAnnotations(results)
         },
-        [annotationsModel.actions.createGlobalAnnotation]: () => {
+        [annotationsModel.actions.createGlobalAnnotation]: async ({}, breakpoint) => {
+            await breakpoint(200)
             actions.loadAnnotations({})
         },
     }),

--- a/frontend/src/scenes/annotations/logic.ts
+++ b/frontend/src/scenes/annotations/logic.ts
@@ -2,8 +2,10 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { toParams, deleteWithUndo } from 'lib/utils'
 import { annotationsModel } from '~/models'
+import { annotationsTableLogicType } from './logicType'
+import { AnnotationType } from '~/types'
 
-export const annotationsTableLogic = kea({
+export const annotationsTableLogic = kea<annotationsTableLogicType<AnnotationType>>({
     loaders: ({ actions }) => ({
         annotations: {
             __default: [],
@@ -38,26 +40,26 @@ export const annotationsTableLogic = kea({
         restoreAnnotation: (id) => ({ id }),
         loadAnnotationsNext: () => true,
         setNext: (next) => ({ next }),
-        appendAnnotations: (annotations) => ({ annotations }),
+        appendAnnotations: (annotations: AnnotationType[]) => ({ annotations }),
     }),
     listeners: ({ actions, values }) => ({
         updateAnnotation: async ({ id, content }) => {
             await api.update(`api/annotation/${id}`, { content })
-            actions.loadAnnotations({})
+            actions.loadAnnotations()
         },
         restoreAnnotation: async ({ id }) => {
             await api.update(`api/annotation/${id}`, { deleted: false })
-            actions.loadAnnotations({})
+            actions.loadAnnotations()
         },
         deleteAnnotation: ({ id }) => {
             deleteWithUndo({
                 endpoint: 'annotation',
                 object: { name: 'Annotation', id },
-                callback: () => actions.loadAnnotations({}),
+                callback: () => actions.loadAnnotations(),
             })
         },
         loadAnnotationsNext: async () => {
-            let results = []
+            let results: AnnotationType[] = []
             if (values.next) {
                 const response = await api.get(values.next)
                 actions.setNext(response.next)
@@ -65,9 +67,8 @@ export const annotationsTableLogic = kea({
             }
             actions.appendAnnotations(results)
         },
-        [annotationsModel.actions.createGlobalAnnotation]: async ({}, breakpoint) => {
-            await breakpoint(200)
-            actions.loadAnnotations({})
+        [annotationsModel.actionTypes.createGlobalAnnotationSuccess]: () => {
+            actions.loadAnnotations()
         },
     }),
     events: ({ actions }) => ({


### PR DESCRIPTION
## Problem

See #4277.

## Changes

- Fix cypress test that was asserting on existence of text in `<textarea>` and not annotations `<table>`.
- Refactor `createGlobalAnnotation` into its own loader to expose `createGlobalAnnotationSuccess` to `annotationLogic`
- Typescriptify `annotations/logic.js`

## Checklist

- [X] N/A All querysets/queries filter by Organization, by Team, and by User
- [X] N/A Django backend tests
- [X] N/A Jest frontend tests
- [X] N/A Cypress end-to-end tests
- [X] N/A Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious

## Testing

- Once the test was fixed, it correctly failed because the annotation didn't show up in the table (reproduces #4277). This PR fixed that test.
- `./bin/e2e-test-runner`

Before

https://user-images.githubusercontent.com/13460330/120408728-73803680-c304-11eb-8d50-8c1b058eac7c.mov

After

https://user-images.githubusercontent.com/13460330/120408559-200de880-c304-11eb-8eb4-577e07d79586.mov
