### PR TITLE
Separate realm for hosted clickhouse users

### DIFF
--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -13,7 +13,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.plugin import PluginConfig
 from posthog.models.utils import namedtuplefetchall
-from posthog.utils import get_machine_id, get_previous_week
+from posthog.utils import get_instance_realm, get_machine_id, get_previous_week
 from posthog.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -24,6 +24,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
     report: Dict[str, Any] = {
         "posthog_version": VERSION,
         "deployment": os.getenv("DEPLOYMENT", "unknown"),
+        "realm": get_instance_realm(),
         "period": {"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
         "site_url": os.getenv("SITE_URL", "unknown"),
     }

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -503,9 +503,14 @@ def queryset_to_named_query(qs: QuerySet, prepend: str = "") -> Tuple[str, dict]
 
 def get_instance_realm() -> str:
     """
-    Returns the realm for the current instance. `cloud` or `hosted`.
+    Returns the realm for the current instance. `cloud` or `hosted` or `hosted-clickhouse`.
     """
-    return "cloud" if getattr(settings, "MULTI_TENANCY", False) else "hosted"
+    if settings.MULTI_TENANCY:
+        return "cloud"
+    elif os.getenv("HELM_INSTALL_INFO", False):
+        return "hosted-clickhouse"
+    else:
+        return "hosted"
 
 
 def get_available_social_auth_providers() -> Dict[str, bool]:


### PR DESCRIPTION
This includes clients like netdata etc who are deploying clickhouse

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
