### PR TITLE
Change funnels API from GET to POST

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -63,7 +63,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
     @cached_function()
     def calculate_funnel(self, request: Request) -> Dict[str, Any]:
         team = self.team
-        filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS})
+        filter = Filter(request=request, data={**request.data, "insight": INSIGHT_FUNNELS})
         return {"result": ClickhouseFunnel(team=team, filter=filter).run()}
 
     @cached_function()

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -18,11 +18,9 @@ async function pollFunnel(params = {}) {
     const { refresh, ...bodyParams } = params // eslint-disable-line
     let result = await api.create('api/insight/funnel/?' + (refresh ? 'refresh=true' : ''), bodyParams)
     let start = window.performance.now()
-    console.log('first result', result)
     while (result.result.loading && (window.performance.now() - start) / 1000 < SECONDS_TO_POLL) {
         await wait()
         result = await api.create('api/insight/funnel', bodyParams)
-        console.log('next result', result)
     }
     // if endpoint is still loading after 3 minutes just return default
     if (result.loading) {
@@ -93,7 +91,6 @@ export const funnelLogic = kea({
 
                 try {
                     result = await pollFunnel(params)
-                    console.log('RESULT', result)
                     eventUsageLogic.actions.reportFunnelCalculated(eventCount, actionCount, interval, true)
                 } catch (e) {
                     insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, false, e)
@@ -188,7 +185,6 @@ export const funnelLogic = kea({
             if (refresh) {
                 actions.loadResults()
             }
-            console.log('refresh', refresh)
             const cleanedParams = cleanFunnelParams(values.filters)
             insightLogic.actions.setAllFilters(cleanedParams)
             insightLogic.actions.setLastRefresh(false)

--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
-import { autocorrectInterval, objectsEqual, toParams, uuid } from 'lib/utils'
+import { autocorrectInterval, objectsEqual, uuid } from 'lib/utils'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
 import { funnelsModel } from '../../models/funnelsModel'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
@@ -15,12 +15,14 @@ function wait(ms = 1000) {
 const SECONDS_TO_POLL = 3 * 60
 
 async function pollFunnel(params = {}) {
-    let result = await api.get('api/insight/funnel/?' + toParams(params))
+    const { refresh, ...bodyParams } = params // eslint-disable-line
+    let result = await api.create('api/insight/funnel/?' + (refresh ? 'refresh=true' : ''), bodyParams)
     let start = window.performance.now()
+    console.log('first result', result)
     while (result.result.loading && (window.performance.now() - start) / 1000 < SECONDS_TO_POLL) {
         await wait()
-        const { refresh: _, ...restParams } = params // eslint-disable-line
-        result = await api.get('api/insight/funnel/?' + toParams(restParams))
+        result = await api.create('api/insight/funnel', bodyParams)
+        console.log('next result', result)
     }
     // if endpoint is still loading after 3 minutes just return default
     if (result.loading) {
@@ -91,6 +93,7 @@ export const funnelLogic = kea({
 
                 try {
                     result = await pollFunnel(params)
+                    console.log('RESULT', result)
                     eventUsageLogic.actions.reportFunnelCalculated(eventCount, actionCount, interval, true)
                 } catch (e) {
                     insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, false, e)
@@ -185,6 +188,7 @@ export const funnelLogic = kea({
             if (refresh) {
                 actions.loadResults()
             }
+            console.log('refresh', refresh)
             const cleanedParams = cleanFunnelParams(values.filters)
             insightLogic.actions.setAllFilters(cleanedParams)
             insightLogic.actions.setLastRefresh(false)

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -39,7 +39,7 @@ from posthog.models.team import Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions
 from posthog.queries import base, retention, stickiness, trends
 from posthog.tasks.calculate_action import calculate_action
-from posthog.utils import generate_cache_key, get_safe_cache
+from posthog.utils import generate_cache_key, get_safe_cache, should_refresh
 
 from .person import PersonSerializer, paginated_result
 
@@ -246,7 +246,7 @@ class ActionViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False)
     def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         team = self.team
-        refresh = request.GET.get("refresh", None)
+        refresh = should_refresh(request)
         dashboard_id = request.GET.get("from_dashboard", None)
 
         filter = Filter(request=request)

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -182,10 +182,8 @@ def insight_test_factory(event_factory, person_factory):
             @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
             def test_insight_funnels_basic(self):
                 event_factory(team=self.team, event="user signed up", distinct_id="1")
-                response = self.client.get(
-                    "/api/insight/funnel/?events={}".format(
-                        json.dumps([{"id": "user signed up", "type": "events", "order": 0},])
-                    )
+                response = self.client.post(
+                    "/api/insight/funnel/", {"events": [{"id": "user signed up", "type": "events", "order": 0}]}
                 ).json()
                 self.assertEqual(response["result"]["loading"], True)
 

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -42,5 +42,5 @@ def get_filter(team, data: dict = {}, request: Optional[Request] = None):
     elif insight == INSIGHT_PATHS:
         return PathFilter(data={**data, "insight": INSIGHT_PATHS}, request=request)
     elif insight == INSIGHT_FUNNELS:
-        return Filter(data={**request.data, "insight": INSIGHT_FUNNELS}, request=request)
+        return Filter(data={**(request.data if request else {}), "insight": INSIGHT_FUNNELS}, request=request)
     return Filter(data=data, request=request)

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -1,8 +1,15 @@
 from typing import Any, Dict, List, Optional, Union
 
-from django.http import HttpRequest
+from rest_framework.request import Request
 
-from posthog.constants import INSIGHT_PATHS, INSIGHT_RETENTION, INSIGHT_SESSIONS, INSIGHT_STICKINESS, INSIGHT_TRENDS
+from posthog.constants import (
+    INSIGHT_FUNNELS,
+    INSIGHT_PATHS,
+    INSIGHT_RETENTION,
+    INSIGHT_SESSIONS,
+    INSIGHT_STICKINESS,
+    INSIGHT_TRENDS,
+)
 from posthog.ee import is_clickhouse_enabled
 from posthog.models.filters.path_filter import PathFilter
 
@@ -17,7 +24,7 @@ def earliest_timestamp_func(team_id: int):
     return Event.objects.earliest_timestamp(team_id)
 
 
-def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None):
+def get_filter(team, data: dict = {}, request: Optional[Request] = None):
     from posthog.models.filters.filter import Filter
     from posthog.models.filters.retention_filter import RetentionFilter
     from posthog.models.filters.sessions_filter import SessionsFilter
@@ -25,7 +32,7 @@ def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None):
 
     insight = data.get("insight")
     if not insight and request:
-        insight = request.GET.get("insight")
+        insight = request.GET.get("insight") or request.data.get("insight")
     if insight == INSIGHT_RETENTION:
         return RetentionFilter(data={**data, "insight": INSIGHT_RETENTION}, request=request)
     elif insight == INSIGHT_SESSIONS:
@@ -34,4 +41,6 @@ def get_filter(team, data: dict = {}, request: Optional[HttpRequest] = None):
         return StickinessFilter(data=data, request=request, team=team, get_earliest_timestamp=earliest_timestamp_func)
     elif insight == INSIGHT_PATHS:
         return PathFilter(data={**data, "insight": INSIGHT_PATHS}, request=request)
+    elif insight == INSIGHT_FUNNELS:
+        return Filter(data={**request.data, "insight": INSIGHT_FUNNELS}, request=request)
     return Filter(data=data, request=request)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -33,6 +33,7 @@ from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
 from django.utils import timezone
+from rest_framework.request import Request
 from sentry_sdk import push_scope
 
 from posthog.exceptions import RequestParsingError
@@ -661,3 +662,8 @@ def get_available_timezones_with_offsets() -> Dict[str, float]:
         offset_hours = int(offset.total_seconds()) / 3600
         result[tz] = offset_hours
     return result
+
+
+def should_refresh(request: Request) -> bool:
+    key = "refresh"
+    return (request.query_params.get(key, "") or request.GET.get(key, "")).lower() == "true"


### PR DESCRIPTION
## Problem

See #4554.

See discussion on PR #4561.

User created a long funnel (17 steps) which resulted in a request to `api/insight/funnel` that had a path longer than `4094` bytes. Gunicorn sets the default `limit_request_line` to `4094` to protect against DDOS attacks [[docs]](https://docs.gunicorn.org/en/stable/settings.html#limit-request-line), a bad request from the gunicorn layer was being propagated to the user. 

## Changes

- Change `api/insight/funnel` from GET to POST endpoint
- Refactor out util function to check for refresh flag

## Checklist

- [] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [ ] Jest frontend tests
- [X] Cypress end-to-end tests
- [] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious

## Testing

- Spot testing by checking network request of Insights>Funnels page.