### PR TITLE
Add requirement to check CSS responsiveness

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,4 @@
 - [ ] Jest frontend tests
 - [ ] Cypress end-to-end tests
 - [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
+- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)


### PR DESCRIPTION
## Rationale

We are NOT targeting PostHog for mobile users right now, but when working on new features, let's just take the extra five minutes to check that our interface is *usable* on a 320px screen and decent at 360px. This doesn't mean beautiful or joy-sparkingly-good, just decent. Usually all is fine, but sometimes you might need to add a few media queries or break apart a table, or whatever.

It's so much more effort (combined over everyone involved) to later come back and fix such issues via future PRs. Let's just do things right from the get go. 

## Changes

- Adds one line: "Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)" to the requirements we must tick when making a PR to this repo.
- Please suggest alternative wording if applicable.

## Extra context

This is the easiest way to change your screen resolution:

![2021-06-04 13 29 04](https://user-images.githubusercontent.com/53387/120794742-e8d44d00-c538-11eb-84dc-7d9058afb3f8.gif)

ProTip(TM): always keep your "inspect" view on the right side of the screen. You're welcome.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
