### PR TITLE
Add reload all dashboard items, fix reloading internal dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -114,7 +114,7 @@ $dashboard-title-size: 32px;
     justify-content: space-between;
 
     margin-top: -1rem;
-    margin-bottom: $default_spacing / 2;
+    margin-bottom: $default_spacing;
 
     width: 100%;
 

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import dayjs from 'dayjs'
 import { SceneLoading } from 'lib/utils'
 import { BindLogic, useActions, useValues } from 'kea'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -31,7 +32,9 @@ export function Dashboard({ id, shareToken, internal }: Props): JSX.Element {
 }
 
 function DashboardView(): JSX.Element {
-    const { dashboard, itemsLoading, items, filters: dashboardFilters, dashboardMode } = useValues(dashboardLogic)
+    const { dashboard, itemsLoading, items, filters: dashboardFilters, dashboardMode, lastRefreshed } = useValues(
+        dashboardLogic
+    )
     const { dashboardsLoading } = useValues(dashboardsModel)
     const { setDashboardMode, addGraph, setDates, loadDashboardItems } = useActions(dashboardLogic)
 
@@ -91,7 +94,7 @@ function DashboardView(): JSX.Element {
                 <div>
                     <div className="dashboard-items-actions">
                         <div className="left-item">
-                            {/* Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b> */}
+                            Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b>
                             {dashboardMode !== DashboardMode.Public && (
                                 <Button
                                     type="link"

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { DashboardHeader } from 'scenes/dashboard/DashboardHeader'
 import { DashboardItems } from 'scenes/dashboard/DashboardItems'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { CalendarOutlined } from '@ant-design/icons'
+import { CalendarOutlined, ReloadOutlined } from '@ant-design/icons'
 import './Dashboard.scss'
 import { useKeyboardHotkeys } from '../../lib/hooks/useKeyboardHotkeys'
 import { DashboardMode } from '../../types'
@@ -14,6 +14,7 @@ import { DashboardEventSource } from '../../lib/utils/eventUsageLogic'
 import { TZIndicator } from 'lib/components/TimezoneAware'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
 import { NotFound } from 'lib/components/NotFound'
+import { Button } from 'antd'
 
 interface Props {
     id: string
@@ -32,7 +33,7 @@ export function Dashboard({ id, shareToken, internal }: Props): JSX.Element {
 function DashboardView(): JSX.Element {
     const { dashboard, itemsLoading, items, filters: dashboardFilters, dashboardMode } = useValues(dashboardLogic)
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
+    const { setDashboardMode, addGraph, setDates, loadDashboardItems } = useActions(dashboardLogic)
 
     useKeyboardHotkeys(
         dashboardMode === DashboardMode.Public || dashboardMode === DashboardMode.Internal
@@ -89,16 +90,19 @@ function DashboardView(): JSX.Element {
             {items && items.length ? (
                 <div>
                     <div className="dashboard-items-actions">
-                        {/* :TODO: Bring this back when addressing https://github.com/PostHog/posthog/issues/3609
                         <div className="left-item">
-                            Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b>
+                            {/* Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b> */}
                             {dashboardMode !== DashboardMode.Public && (
-                                <Button type="link" icon={<ReloadOutlined />} onClick={refreshAllDashboardItems}>
+                                <Button
+                                    type="link"
+                                    icon={<ReloadOutlined />}
+                                    onClick={() => loadDashboardItems({ refresh: true })}
+                                >
                                     Refresh
                                 </Button>
                             )}
                         </div>
-                         */}
+
                         {dashboardMode !== DashboardMode.Public && (
                             <div
                                 style={{

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -112,7 +112,6 @@ function DashboardView(): JSX.Element {
                                     display: 'flex',
                                     alignItems: 'center',
                                     justifyContent: 'flex-end',
-                                    width: '100%',
                                 }}
                             >
                                 <TZIndicator style={{ marginRight: 8, fontWeight: 'bold' }} />

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -24,7 +24,6 @@ import {
     DeliveredProcedureOutlined,
     BarChartOutlined,
     SaveOutlined,
-    ReloadOutlined,
 } from '@ant-design/icons'
 import { dashboardColorNames, dashboardColors } from 'lib/colors'
 import { useLongPress } from 'lib/hooks/useLongPress'
@@ -229,7 +228,6 @@ export function DashboardItem({
         preventLoading,
     }
 
-    const { loadResults } = useActions(logicFromInsight(item.filters.insight, logicProps))
     const { results, resultsLoading } = useValues(logicFromInsight(item.filters.insight, logicProps))
     const previousLoading = usePrevious(resultsLoading)
 
@@ -310,20 +308,6 @@ export function DashboardItem({
                                         />
                                     </Tooltip>
                                 ))}
-                            {/* :TODO: Remove individual refresh when addressing https://github.com/PostHog/posthog/issues/3609  */}
-                            <Tooltip
-                                title={
-                                    <i>
-                                        Last updated:{' '}
-                                        {item.last_refresh ? dayjs(item.last_refresh).fromNow() : 'recently'}
-                                    </i>
-                                }
-                            >
-                                <ReloadOutlined
-                                    style={{ cursor: 'pointer', marginTop: -3 }}
-                                    onClick={() => loadResults(true)}
-                                />
-                            </Tooltip>
                             {dashboardMode !== DashboardMode.Internal && (
                                 <Dropdown
                                     placement="bottomRight"

--- a/frontend/src/scenes/dashboard/dashboardLogic.js
+++ b/frontend/src/scenes/dashboard/dashboardLogic.js
@@ -40,10 +40,10 @@ export const dashboardLogic = kea({
         allItems: [
             {},
             {
-                loadDashboardItems: async () => {
+                loadDashboardItems: async ({ refresh = undefined } = {}) => {
                     try {
                         const dashboard = await api.get(
-                            `api/dashboard/${props.id}/?${toParams({ share_token: props.shareToken })}`
+                            `api/dashboard/${props.id}/?${toParams({ share_token: props.shareToken, refresh })}`
                         )
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
                         eventUsageLogic.actions.reportDashboardViewed(dashboard, !!props.shareToken)
@@ -262,7 +262,7 @@ export const dashboardLogic = kea({
     }),
     events: ({ actions, cache, props }) => ({
         afterMount: () => {
-            actions.loadDashboardItems()
+            actions.loadDashboardItems({ refresh: props.internal })
             if (props.shareToken) {
                 actions.setDashboardMode(
                     props.internal ? DashboardMode.Internal : DashboardMode.Public,

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -20,6 +20,7 @@ from posthog.auth import PersonalAPIKeyAuthentication, PublicTokenAuthentication
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, DashboardItem, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions
+from posthog.tasks.update_cache import update_dashboard_items_cache
 from posthog.utils import get_safe_cache, render_template, str_to_bool
 
 
@@ -95,6 +96,10 @@ class DashboardSerializer(serializers.ModelSerializer):
     def get_items(self, dashboard: Dashboard):
         if self.context["view"].action == "list":
             return None
+
+        if self.context["request"].GET.get("refresh"):
+            update_dashboard_items_cache(dashboard)
+
         items = dashboard.items.filter(deleted=False).order_by("order").all()
         self.context.update({"dashboard": dashboard})
         return DashboardItemSerializer(items, many=True, context=self.context).data

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -165,6 +165,29 @@ class TestDashboard(APIBaseTest):
         self.assertEqual(response["items"][0]["result"], None)
         self.assertEqual(response["items"][0]["last_refresh"], None)
 
+    def test_refresh_cache(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="dashboard")
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
+
+        with freeze_time("2020-01-04T13:00:01Z"):
+            # Pretend we cached something a while ago, but we won't have anything in the redis cache
+            item = DashboardItem.objects.create(
+                dashboard=dashboard, filters=Filter(data=filter_dict).to_dict(), team=self.team, last_refresh=now()
+            )
+
+        with freeze_time("2020-01-20T13:00:01Z"):
+            response = self.client.get("/api/dashboard/%s?refresh=true" % dashboard.pk).json()
+
+            self.assertIsNotNone(response["items"][0]["result"])
+            self.assertIsNotNone(response["items"][0]["last_refresh"])
+            self.assertEqual(response["items"][0]["result"][0]["count"], 0)
+
+            item = DashboardItem.objects.get(pk=item.pk)
+            self.assertAlmostEqual(item.last_refresh, now(), delta=timezone.timedelta(seconds=5))
+
     def test_dashboard_endpoints(self):
         # create
         response = self.client.post("/api/dashboard/", {"name": "Default", "pinned": "true"},)

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -2,7 +2,7 @@ import importlib
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from celery import group
 from dateutil.relativedelta import relativedelta
@@ -115,7 +115,9 @@ def update_cached_items() -> None:
     taskset.apply_async()
 
 
-def dashboard_item_update_task_params(item: DashboardItem, dashboard: Optional[Dashboard] = None):
+def dashboard_item_update_task_params(
+    item: DashboardItem, dashboard: Optional[Dashboard] = None
+) -> Tuple[str, CacheType, Dict]:
     filter = get_filter(data=item.dashboard_filters(dashboard), team=item.team)
     cache_key = generate_cache_key("{}_{}".format(filter.toJSON(), item.team_id))
 


### PR DESCRIPTION
Closes #3609 and closes #4587.

Dashboard items now have no more individual refresh items, instead there's one button to refresh the whole dashboard.

How it works: On a refresh we call API endpoint with refresh parameter, which makes it update the cache before returning results. This bypasses the need to fetch data from /api/insight and other endpoints which are not embedding-aware

![image](https://user-images.githubusercontent.com/148820/120801515-ededc800-c549-11eb-80f2-91e2d0c06a6d.png)
![image](https://user-images.githubusercontent.com/148820/120801538-f5ad6c80-c549-11eb-8fbf-3b5eea433ba4.png)


## Commits

- Re-add refresh button, respect refresh in API
- Show \"last refresh time\" in dashboard.
- Remove individual refresh buttons according to TODO
- Add tests
