### PR TITLE
Add migration that migrates the table again without sharding

### DIFF
--- a/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
+++ b/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
@@ -1,0 +1,7 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.cohort import CREATE_COHORTPEOPLE_TABLE_SQL, DROP_COHORTPEOPLE_TABLE_SQL
+from posthog.settings import CLICKHOUSE_REPLICATION
+
+# run create table again with proper configuration
+operations = [migrations.RunSQL(DROP_COHORTPEOPLE_TABLE_SQL), migrations.RunSQL(CREATE_COHORTPEOPLE_TABLE_SQL)]

--- a/ee/clickhouse/sql/clickhouse.py
+++ b/ee/clickhouse/sql/clickhouse.py
@@ -16,7 +16,7 @@ MERGE_TABLE_ENGINE = (
 )
 
 COLLAPSING_TABLE_ENGINE = (
-    "ReplicatedCollapsingMergeTree('/clickhouse/tables/{{shard}}/posthog.{table}', '{{replica}}', {ver})"
+    "ReplicatedCollapsingMergeTree('/clickhouse/tables/noshard/posthog.{table}', '{{replica}}-{{shard}}', {ver})"
     if CLICKHOUSE_REPLICATION
     else "CollapsingMergeTree({ver})"
 )

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -15,7 +15,7 @@ CREATE TABLE cohortpeople
 Order By (team_id, cohort_id, person_id)
 {storage_policy}
 """.format(
-    engine=table_engine("cohortpeople", "sign", COLLAPSING_MERGE_TREE), storage_policy=STORAGE_POLICY
+    engine=table_engine("cohortpeople", "sign", COLLAPSING_MERGE_TREE), storage_policy=""
 )
 
 DROP_COHORTPEOPLE_TABLE_SQL = """


### PR DESCRIPTION
## Changes

*Please describe.*  
- follow up of #4477 to migrate without sharding
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
