### PR TITLE
Can't alter table and data within a transaction

### DIFF
--- a/posthog/migrations/0156_insight_short_id.py
+++ b/posthog/migrations/0156_insight_short_id.py
@@ -13,6 +13,9 @@ def create_short_ids(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    # This avoids: "cannot ALTER TABLE "posthog_dashboarditem" because it has pending trigger events"
+    # Basically, we can't alter a table and change its data inside one transaction
+    atomic = False
 
     dependencies = [
         ("posthog", "0155_organization_available_features"),


### PR DESCRIPTION
## Changes

- Makes migration 0156 work if you have dashboard items in the system.
- Avoids `django.db.utils.OperationalError: cannot ALTER TABLE "posthog_dashboarditem" because it has pending trigger events`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
