### PR TITLE
Measure erroring API requests on the client

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,5 +1,6 @@
 import { fromParamsGivenUrl, toParams } from 'lib/utils'
 import { Environments, ENVIRONMENT_LOCAL_STORAGE_KEY } from 'lib/constants'
+import posthog from 'posthog-js'
 
 export function getCookie(name) {
     var cookieValue = null
@@ -38,6 +39,7 @@ class Api {
         }
 
         if (!response.ok) {
+            posthog.capture('client_request_failure', { url, method: 'GET', status: response.status })
             const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }
@@ -57,6 +59,7 @@ class Api {
             body: isFormData ? data : JSON.stringify(data),
         })
         if (!response.ok) {
+            posthog.capture('client_request_failure', { url, method: 'PATCH', status: response.status })
             const jsonData = await getJSONOrThrow(response)
             if (Array.isArray(jsonData)) {
                 throw jsonData
@@ -79,6 +82,7 @@ class Api {
             body: isFormData ? data : JSON.stringify(data),
         })
         if (!response.ok) {
+            posthog.capture('client_request_failure', { url, method: 'POST', status: response.status })
             const jsonData = await getJSONOrThrow(response)
             if (Array.isArray(jsonData)) {
                 throw jsonData
@@ -99,6 +103,7 @@ class Api {
             },
         })
         if (!response.ok) {
+            posthog.capture('client_request_failure', { url, method: 'DELETE', status: response.status })
             const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }


### PR DESCRIPTION
Anecdotally I've seen a lot of these requests fail for no good reason
with a 502 error. I have a clue for how to fix this, but first measure!

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
