### PR TITLE
SelectBox: fix 'cannot read length of undefined'

### DIFF
--- a/frontend/src/lib/components/SelectBox.tsx
+++ b/frontend/src/lib/components/SelectBox.tsx
@@ -140,9 +140,9 @@ export function SelectUnit({
     const [flattenedData, setFlattenedData] = useState<SelectedItem[]>([])
     const [groupTypes, setGroupTypes] = useState<string[]>([])
 
-    let lenghtOfData = 0
+    let lengthOfData = 0
     Object.values(items).forEach((entry) => {
-        lenghtOfData += entry.dataSource.length
+        lengthOfData += entry?.dataSource?.length || 0
     })
 
     useEffect(() => {
@@ -162,7 +162,7 @@ export function SelectUnit({
         setGroupTypes(_groupTypes)
         setData(formattedData)
         setHiddenData(_hiddenData)
-    }, [lenghtOfData])
+    }, [lengthOfData])
 
     useEffect(() => {
         const _flattenedData: SelectedItem[] = []


### PR DESCRIPTION
## Changes

Adding a filter may cause the insights UI to completely break; there's an undefined value where the type suggests it shouldn't be undefined. For now, this may fix it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
