### PR TITLE
Fix popover padding

### DIFF
--- a/frontend/src/lib/components/Annotations/AnnotationMarker.scss
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.scss
@@ -1,3 +1,0 @@
-.ant-popover-inner-content {
-    padding: 0;
-}

--- a/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
@@ -9,7 +9,6 @@ import dayjs from 'dayjs'
 import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import { dashboardColors } from 'lib/colors'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import './AnnotationMarker.scss'
 import { AnnotationScope, AnnotationType } from '~/types'
 
 const { TextArea } = Input


### PR DESCRIPTION
## Changes

Fix as part of break the release activity.

Fix margins in popovers.



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
