### PR TITLE
Persist event and property definitions

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { Layout } from 'antd'
 import { ToastContainer, Slide } from 'react-toastify'
 
@@ -15,6 +15,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { preflightLogic } from './PreflightCheck/logic'
 import { BackTo } from 'lib/components/BackTo'
 import { Papercups } from 'lib/components/Papercups'
+import { eventDefinitionsLogic } from 'scenes/events/eventDefinitionsLogic'
+import { propertyDefinitionsLogic } from 'scenes/events/propertyDefinitionsLogic'
 
 function Toast(): JSX.Element {
     return <ToastContainer autoClose={8000} transition={Slide} position="top-right" />
@@ -27,6 +29,9 @@ export function App(): JSX.Element | null {
     const { location } = useValues(router)
     const { replace } = useActions(router)
     const { featureFlags } = useValues(featureFlagLogic)
+
+    useMountedLogic(eventDefinitionsLogic)
+    useMountedLogic(propertyDefinitionsLogic)
 
     useEffect(() => {
         if (scene === Scene.Signup && preflight && !preflight.cloud && preflight.initiated) {


### PR DESCRIPTION
## Changes

- Simpler version of https://github.com/PostHog/posthog/pull/4571
- Makes event and property definitions load no matter where you are in the app, and then keep them in memory for the entire duration of the app.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
