### PR TITLE
Use cohortpeople table for queries

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
+from dateutil import parser
 from django.conf import settings
 from django.utils import timezone
 
@@ -23,7 +24,7 @@ from ee.clickhouse.sql.person import (
 from posthog.models import Action, Cohort, Filter, Team
 
 # temporary marker to denote when cohortpeople table started being populated
-TEMP_PRECALCULATED_MARKER = datetime.strptime("2021-06-07T15:00:00+00:00", "%Y-%m-%dT%H:%M:%S+00:00")
+TEMP_PRECALCULATED_MARKER = parser.parse("2021-06-07T15:00:00+00:00")
 
 
 def format_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -94,7 +94,12 @@ def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
 
 
 def determine_precalculated_or_live_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
-    if cohort.last_calculation > TEMP_PRECALCULATED_MARKER and not settings.DEBUG and not settings.TEST:
+    if (
+        cohort.last_calculation
+        and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
+        and not settings.DEBUG
+        and not settings.TEST
+    ):
         return (
             f"""
         person_id IN ({GET_PERSON_ID_BY_COHORT_ID})

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -2,12 +2,14 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
+from django.conf import settings
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.sql.cohort import (
     CALCULATE_COHORT_PEOPLE_SQL,
+    GET_PERSON_ID_BY_COHORT_ID,
     INSERT_PEOPLE_MATCHING_COHORT_ID_SQL,
     REMOVE_PEOPLE_NOT_MATCHING_COHORT_ID_SQL,
 )
@@ -19,6 +21,9 @@ from ee.clickhouse.sql.person import (
     PERSON_STATIC_COHORT_TABLE,
 )
 from posthog.models import Action, Cohort, Filter, Team
+
+# temporary marker to denote when cohortpeople table started being populated
+TEMP_PRECALCULATED_MARKER = datetime.strptime("2021-06-07T15:00:00+00:00", "%Y-%m-%dT%H:%M:%S+00:00")
 
 
 def format_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
@@ -81,11 +86,24 @@ def parse_action_timestamps(days: int) -> Tuple[str, Dict[str, str]]:
 
 
 def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
-    person_query, params = format_person_query(cohort)
+    person_query, params = determine_precalculated_or_live_person_query(cohort)
     person_id_query = CALCULATE_COHORT_PEOPLE_SQL.format(
         query=person_query, latest_distinct_id_sql=GET_LATEST_PERSON_DISTINCT_ID_SQL
     )
     return person_id_query, params
+
+
+def determine_precalculated_or_live_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
+    if cohort.last_calculation > TEMP_PRECALCULATED_MARKER and not settings.DEBUG and not settings.TEST:
+        return (
+            f"""
+        person_id IN ({GET_PERSON_ID_BY_COHORT_ID})
+        """,
+            {"team_id": cohort.team_id, "cohort_id": cohort.pk},
+        )
+    else:
+        person_query, params = format_person_query(cohort)
+        return person_query, params
 
 
 def get_person_ids_by_cohort_id(team: Team, cohort_id: int):

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -49,3 +49,7 @@ INSERT INTO cohortpeople
     AND person.is_deleted = 0
     AND id IN ({cohort_filter})
 """
+
+GET_PERSON_ID_BY_COHORT_ID = """
+SELECT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s GROUP BY person_id, cohort_id, team_id HAVING sum(sign) > 0
+"""


### PR DESCRIPTION
## Changes

*Please describe.*  
- adds temporary logic to decide whether to use precaculated table or the existing cohort building solution
- temporary because the cohortpeople table isn't fully up to date yet but this can give us gradual query performance improvement
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
