### PR TITLE
NPS adjustment & release

### DIFF
--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -32,8 +32,7 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
         ],
         userIsOldEnough: [
             () => [userLogic.selectors.user],
-            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-45, 'day')),
-            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-0, 'day')),
+            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-15, 'day')),
         ],
         npsPromptEnabled: [
             (s) => [s.featureFlagEnabled, s.userIsOldEnough],

--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -33,6 +33,7 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
         userIsOldEnough: [
             () => [userLogic.selectors.user],
             (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-45, 'day')),
+            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-0, 'day')),
         ],
         npsPromptEnabled: [
             (s) => [s.featureFlagEnabled, s.userIsOldEnough],
@@ -79,6 +80,9 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
             posthog.people.set({ nps_2106: true })
             localStorage.setItem(NPS_LOCALSTORAGE_KEY, 'true')
             cache.timeout = window.setTimeout(() => actions.hide(), NPS_HIDE_TIMEOUT)
+        },
+        show: () => {
+            posthog.capture('nps modal shown')
         },
     }),
     events: ({ actions, values, cache }) => ({


### PR DESCRIPTION
## Changes

- Changes NPS requirement to having joined for 15 days instead of 45.
- Adds event when NPS modal is shown to make conversion tracking easier.

Will release the experiment when this is merged.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
