### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,4 @@ import-order-style = pycharm
 max-line-length = 127
 max-complexity = 10
 
+select=E9,F63,F7,F82,W605

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -44,10 +44,10 @@ class ClickhouseElementViewSet(ElementViewSet):
             return response.Response([])
 
         if key == "tag_name":
-            select_regex = "^([-_a-zA-Z0-9]*?)[\.|:]"
+            select_regex = r"^([-_a-zA-Z0-9]*?)[\.|:]"
             filter_regex = select_regex
             if value:
-                filter_regex = "^([-_a-zA-Z0-9]*?{}[-_a-zA-Z0-9]*?)[\.|:]".format(value)
+                filter_regex = r"^([-_a-zA-Z0-9]*?{}[-_a-zA-Z0-9]*?)[\.|:]".format(value)
         else:
             if value:
                 filter_regex = '[:|"]{}=".*?{}.*?"'.format(key, value)

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
         "*.{js,ts,tsx,json,yml,css,scss}": "prettier --write",
         "*.{js,ts,tsx}": "eslint --fix",
         "*.{py,pyi}": [
-            "flake8 --select=E9,F63,F7,F82",
+            "flake8 --select=E9,F63,F7,F82,W605",
             "black",
             "isort"
         ]

--- a/posthog/migrations/0132_team_test_account_filters.py
+++ b/posthog/migrations/0132_team_test_account_filters.py
@@ -48,7 +48,7 @@ def forward(apps, schema_editor):
             generic_emails = GenericEmails()
             example_emails = [email.email for email in example_emails if not generic_emails.is_generic(email.email)]
             if len(example_emails) > 0:
-                example_email = re.search("@[\w.]+", example_emails[0])
+                example_email = re.search(r"@[\w.]+", example_emails[0])
                 if example_email:
                     filters += [
                         {"key": "email", "operator": "not_icontains", "value": example_email.group(), "type": "person"},

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -128,11 +128,11 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
                 distinct_id="test",
                 properties={"$current_url": "https://whatever.com"},
             )
-            filter = Filter(data={"properties": {"$current_url__regex": "\.com$"}})
+            filter = Filter(data={"properties": {"$current_url__regex": r"\.com$"}})
             events = filter_events(filter, self.team)
             self.assertEqual(events[0]["id"], event2.pk)
 
-            filter = Filter(data={"properties": {"$current_url__not_regex": "\.eee$"}})
+            filter = Filter(data={"properties": {"$current_url__not_regex": r"\.eee$"}})
             events = filter_events(filter, self.team, order_by="timestamp")
             self.assertEqual(events[0]["id"], event1.pk)
             self.assertEqual(events[1]["id"], event2.pk)

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -44,7 +44,7 @@ class TeamManager(models.Manager):
             generic_emails = GenericEmails()
             example_emails = [email.email for email in example_emails if not generic_emails.is_generic(email.email)]
             if len(example_emails) > 0:
-                example_email = re.search("@[\w.]+", example_emails[0])
+                example_email = re.search(r"@[\w.]+", example_emails[0])
                 if example_email:
                     return [
                         {"key": "email", "operator": "not_icontains", "value": example_email.group(), "type": "person"},


### PR DESCRIPTION
## Changes

Fix deprecation warnings due to invalid escape sequences in Python 3.8. Fixes #4632 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
