### PR TITLE
Handle invalid JSON passed through properties.

### DIFF
--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -293,3 +293,8 @@ class TestDashboard(APIBaseTest):
         # Expecting this to only have one day as per the dashboard filter
         response = self.client.get("/api/dashboard/%s/" % dashboard.pk).json()
         self.assertEqual(len(response["items"][0]["result"][0]["days"]), 2)  # type: ignore
+
+    def test_invalid_properties(self):
+        response = self.client.get("/api/insight/trend/?properties=%s" % ("inavlid_json")).json()
+
+        self.assertEqual(response["result"], [])

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -295,6 +295,11 @@ class TestDashboard(APIBaseTest):
         self.assertEqual(len(response["items"][0]["result"][0]["days"]), 2)  # type: ignore
 
     def test_invalid_properties(self):
-        response = self.client.get("/api/insight/trend/?properties=%s" % ("inavlid_json")).json()
+        properties = "invalid_json"
 
-        self.assertEqual(response["result"], [])
+        response = self.client.get(f"/api/insight/trend/?properties={properties}")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(
+            response.json(), self.validation_error_response("Properties are unparsable!", "invalid_input")
+        )

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -61,10 +61,18 @@ class Filter(
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         if request:
+
+            properties = {}
+            if request.GET.get(PROPERTIES):
+                try:
+                    properties = json.loads(request.GET[PROPERTIES])
+                except json.decoder.JSONDecodeError:
+                    properties = {}
+
             data = {
                 **request.GET.dict(),
                 **(data if data else {}),
-                **({PROPERTIES: json.loads(request.GET[PROPERTIES])} if request.GET.get(PROPERTIES) else {}),
+                **({PROPERTIES: properties}),
             }
         elif not data:
             raise ValueError("You need to define either a data dict or a request")

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, Optional
 
 from django.http import HttpRequest
+from rest_framework.exceptions import ValidationError
 
 from posthog.constants import PROPERTIES
 from posthog.models.filters.base_filter import BaseFilter
@@ -61,14 +62,12 @@ class Filter(
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         if request:
-
             properties = {}
             if request.GET.get(PROPERTIES):
                 try:
                     properties = json.loads(request.GET[PROPERTIES])
                 except json.decoder.JSONDecodeError:
-                    properties = {}
-
+                    raise ValidationError("Properties are unparsable!")
             data = {
                 **request.GET.dict(),
                 **(data if data else {}),


### PR DESCRIPTION
## Changes

Fixes #4630 by using empty properties in case an invalid one is sent. I guess a better approach would be to throw validation error instead. I will be happy to know about the correct approach for this.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
