### PR TITLE
Coerce possibly undefined values in insights filters to `[]`

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
@@ -124,12 +124,13 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
                     </>
                 )
             },
-            dataSource: eventProperties.map(({ value: eventValue, label, is_numerical }) => ({
-                name: label || '',
-                key: `event_${eventValue}`,
-                eventValue,
-                is_numerical,
-            })),
+            dataSource:
+                eventProperties.map(({ value: eventValue, label, is_numerical }) => ({
+                    name: label || '',
+                    key: `event_${eventValue}`,
+                    eventValue,
+                    is_numerical,
+                })) || [],
             renderInfo: EventPropertiesInfo,
             type: 'event',
             key: 'events',
@@ -145,10 +146,11 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
                     </>
                 )
             },
-            dataSource: personProperties.map(({ name }) => ({
-                name,
-                key: `person_${name}`,
-            })),
+            dataSource:
+                personProperties.map(({ name }) => ({
+                    name,
+                    key: `person_${name}`,
+                })) || [],
             renderInfo: function personPropertiesRenderInfo({ item }) {
                 return (
                     <>
@@ -182,14 +184,15 @@ export function UnifiedPropertyFilter({ index, onComplete, logic }: PropertyFilt
                     </>
                 )
             },
-            dataSource: cohorts
-                ?.filter(({ deleted }) => !deleted)
-                .map((cohort) => ({
-                    name: cohort.name || '',
-                    key: `cohort_${cohort.id}`,
-                    value: cohort.name,
-                    cohort,
-                })),
+            dataSource:
+                cohorts
+                    ?.filter(({ deleted }) => !deleted)
+                    ?.map((cohort) => ({
+                        name: cohort.name || '',
+                        key: `cohort_${cohort.id}`,
+                        value: cohort.name,
+                        cohort,
+                    })) || [],
             renderInfo: CohortPropertiesInfo,
             type: 'cohort',
             key: 'cohorts',


### PR DESCRIPTION
## Changes

May close #4626 (cannot reproduce locally, though).

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
