### PR TITLE
Make sure event prop breakdowns return correct people

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -133,13 +133,11 @@ def _process_content_sql(team: Team, entity: Entity, filter: Filter):
         cohort = Cohort.objects.get(pk=filter.breakdown_value)
         person_filter, person_filter_params = format_filter_query(cohort)
         person_filter = "AND distinct_id IN ({})".format(person_filter)
-    elif (
-        filter.breakdown_type == "person"
-        and isinstance(filter.breakdown, str)
-        and isinstance(filter.breakdown_value, str)
-    ):
-        person_prop = Property(**{"key": filter.breakdown, "value": filter.breakdown_value, "type": "person"})
-        filter.properties.append(person_prop)
+    elif filter.breakdown_type and isinstance(filter.breakdown, str) and isinstance(filter.breakdown_value, str):
+        breakdown_prop = Property(
+            **{"key": filter.breakdown, "value": filter.breakdown_value, "type": filter.breakdown_type}
+        )
+        filter.properties.append(breakdown_prop)
 
     prop_filters, prop_filter_params = parse_prop_clauses(
         filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -353,10 +353,17 @@ def _filter_person_prop_breakdown(events: QuerySet, filter: Filter) -> QuerySet:
     return events
 
 
+def _filter_event_prop_breakdown(events: QuerySet, filter: Filter) -> QuerySet:
+    if filter.breakdown_type == "event":
+        events = events.filter(**{"properties__{}".format(filter.breakdown): filter.breakdown_value,})
+    return events
+
+
 def calculate_people(team: Team, events: QuerySet, filter: Filter, use_offset: bool = True) -> QuerySet:
     events = events.values("person_id").distinct()
     events = _filter_cohort_breakdown(events, filter)
     events = _filter_person_prop_breakdown(events, filter)
+    events = _filter_event_prop_breakdown(events, filter)
 
     people = Person.objects.filter(
         team=team,

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -495,7 +495,8 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
             ).json()
 
             self.assertEqual(len(people["results"][0]["people"]), 2)
-            self.assertEqual(people["results"][0]["people"][0]["id"], person1.pk)
+            ordered_people = sorted([p["id"] for p in people["results"][0]["people"]])
+            self.assertEqual(ordered_people, sorted([person1.pk, person2.pk]))
 
     return TestActionPeople
 

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -493,7 +493,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                     "breakdown": "event_prop",
                 },
             ).json()
-            print(people)
+
             self.assertEqual(len(people["results"][0]["people"]), 2)
             self.assertEqual(people["results"][0]["people"][0]["id"], person1.pk)
 

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -348,35 +348,67 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
         def _create_multiple_people(self):
             person1 = person_factory(team_id=self.team.pk, distinct_ids=["person1"], properties={"name": "person1"})
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person1", timestamp="2020-01-01T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person1",
+                timestamp="2020-01-01T12:00:00Z",
+                properties={"event_prop": "prop1"},
             )
 
             person2 = person_factory(team_id=self.team.pk, distinct_ids=["person2"], properties={"name": "person2"})
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person2", timestamp="2020-01-01T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person2",
+                timestamp="2020-01-01T12:00:00Z",
+                properties={"event_prop": "prop1"},
             )
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person2", timestamp="2020-01-02T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person2",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={"event_prop": "prop1"},
             )
             # same day
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person2", timestamp="2020-01-02T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person2",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={"event_prop": "prop1"},
             )
 
             person3 = person_factory(team_id=self.team.pk, distinct_ids=["person3"], properties={"name": "person3"})
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person3", timestamp="2020-01-01T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person3",
+                timestamp="2020-01-01T12:00:00Z",
+                properties={"event_prop": "prop2"},
             )
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person3", timestamp="2020-01-02T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person3",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={"event_prop": "prop2"},
             )
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person3", timestamp="2020-01-03T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person3",
+                timestamp="2020-01-03T12:00:00Z",
+                properties={"event_prop": "prop2"},
             )
 
             person4 = person_factory(team_id=self.team.pk, distinct_ids=["person4"], properties={"name": "person4"})
             event_factory(
-                team=self.team, event="watched movie", distinct_id="person4", timestamp="2020-01-05T12:00:00Z",
+                team=self.team,
+                event="watched movie",
+                distinct_id="person4",
+                timestamp="2020-01-05T12:00:00Z",
+                properties={"event_prop": "prop3"},
             )
             return (person1, person2, person3, person4)
 
@@ -444,6 +476,26 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
             ).json()
             self.assertEqual(len(people["results"][0]["people"]), 1)
             self.assertEqual(people["results"][0]["people"][0]["id"], person3.pk)
+
+        def test_breakdown_by_event_property_people_endpoint(self):
+            person1, person2, person3, person4 = self._create_multiple_people()
+            action = action_factory(name="watched movie", team=self.team)
+
+            people = self.client.get(
+                "/api/action/people/",
+                data={
+                    "date_from": "2020-01-01",
+                    "date_to": "2020-01-07",
+                    ENTITY_TYPE: "events",
+                    ENTITY_ID: "watched movie",
+                    "breakdown_type": "event",
+                    "breakdown_value": "prop1",
+                    "breakdown": "event_prop",
+                },
+            ).json()
+            print(people)
+            self.assertEqual(len(people["results"][0]["people"]), 2)
+            self.assertEqual(people["results"][0]["people"][0]["id"], person1.pk)
 
     return TestActionPeople
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- was missing logic for adding event prop to breakdown people query
- modify the current logic to ensure we add the event breakdown prop and add a test
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
