### PR TITLE
Upgrade to Django 3.1.12, urllib & requests

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,6 @@
 # pip-compile requirements-dev.in
 
-Django==3.1.8 # freeze version to the same as in production
+Django==3.1.12 # freeze version to the same as in production
 djangorestframework==3.12.2 # freeze version to the same as in production
 
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -162,7 +162,7 @@ typing-extensions==3.7.4.2
     #   mypy
 uritemplate==3.0.1
     # via coreapi
-urllib3==1.26.4
+urllib3==1.26.5
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,7 +33,7 @@ django-stubs==1.8.0
     # via
     #   -r requirements-dev.in
     #   djangorestframework-stubs
-django==3.1.8
+django==3.1.12
     # via
     #   -r requirements-dev.in
     #   django-stubs

--- a/requirements.in
+++ b/requirements.in
@@ -43,7 +43,7 @@ statshog==1.0.6
 python3-openid==3.1.0
 pytz==2021.1
 redis==3.4.1
-requests==2.22.0
+requests==2.25.1
 requests-oauthlib==1.3.0
 sentry-sdk==0.19.2
 semantic_version==2.8.5

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ clickhouse-driver==0.2.0
 clickhouse-pool==0.4.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
-Django==3.1.8
+Django==3.1.12
 django-axes==5.9.0
 django-cors-headers==3.5.0
 django-deprecate-fields==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
     # via -r requirements.in
 django-statsd==2.5.2
     # via -r requirements.in
-django==3.1.8
+django==3.1.12
     # via
     #   -r requirements.in
     #   django-axes

--- a/requirements.txt
+++ b/requirements.txt
@@ -177,7 +177,7 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements.in
     #   social-auth-core
-requests==2.22.0
+requests==2.25.1
     # via
     #   -r requirements.in
     #   django-rest-hooks
@@ -217,7 +217,7 @@ tzlocal==2.1
     # via clickhouse-driver
 unicodecsv==0.14.1
     # via djangorestframework-csv
-urllib3==1.25.8
+urllib3==1.26.5
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
## Changes

Upgrades to Django 3.1.12 to cover vulnerabilities that have been addressed since 3.1.8

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
