### PR TITLE
First and last seen event

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -103,10 +103,16 @@ class EventViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         if self.action == "list" or self.action == "sessions" or self.action == "actions":
             queryset = self._filter_request(self.request, queryset)
-
         order_by_param = self.request.GET.get("orderBy")
         order_by = ["-timestamp"] if not order_by_param else list(json.loads(order_by_param))
-        return queryset.order_by(*order_by)
+        queryset = queryset.order_by(*order_by)
+        if self.request.GET.get("first_seen"):
+            first = queryset.last() if order_by[0] == "-timestamp" else queryset.first()
+            return queryset.filter(id=first.id)
+        if self.request.GET.get("last_seen"):
+            last = queryset.first() if order_by[0] == "-timestamp" else queryset.last()
+            return queryset.filter(id=last.id)
+        return queryset
 
     def _filter_request(self, request: request.Request, queryset: EventManager) -> QuerySet:
         for key, value in request.GET.items():

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -422,6 +422,20 @@ def factory_test_event_api(event_factory, person_factory, _):
             response = self.client.get(f"/api/event/im_a_string_not_an_integer",)
             self.assertIn(response.status_code, [status.HTTP_404_NOT_FOUND, status.HTTP_400_BAD_REQUEST])
 
+        def test_first_last_seen_event(self):
+            for idx in range(0, 10):
+                event_factory(
+                    team=self.team,
+                    event="some event",
+                    distinct_id=idx,
+                    timestamp=timezone.now() - relativedelta(months=11) + relativedelta(days=idx, seconds=idx),
+                )
+            first_seen_response = self.client.get(f"/api/event/?first_seen=true").json()
+            self.assertEqual(first_seen_response["results"][0]["distinct_id"], "0")
+
+            last_seen_response = self.client.get(f"/api/event/?last_seen=true").json()
+            self.assertEqual(last_seen_response["results"][0]["distinct_id"], "9")
+
     return TestEvents
 
 


### PR DESCRIPTION
## Changes

Return the first/last seen event with `last_seen=true` or `first_seen=true` for #4267 

url example: `?properties=%7B%7D&event=watched_movie&orderBy=%5B"timestamp"%5D&last_seen=true`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
