### PR TITLE
No login flash

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect } from 'react'
-import { kea, useActions, useMountedLogic, useValues } from 'kea'
+import React from 'react'
+import { kea, useMountedLogic, useValues } from 'kea'
 import { Layout } from 'antd'
 import { ToastContainer, Slide } from 'react-toastify'
 
 import { MainNavigation, TopNavigation, DemoWarnings } from '~/layout/navigation'
 import { BillingAlerts } from 'lib/components/BillingAlerts'
 import { userLogic } from 'scenes/userLogic'
-import { sceneLogic, Scene } from 'scenes/sceneLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneLoading } from 'lib/utils'
-import { router } from 'kea-router'
 import { CommandPalette } from 'lib/components/CommandPalette'
 import { UpgradeModal } from './UpgradeModal'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -84,54 +83,8 @@ function Models(): null {
 function AppScene(): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { scene, params, loadedScenes, sceneConfig } = useValues(sceneLogic)
-    const { preflight } = useValues(preflightLogic)
-    const { location } = useValues(router)
-    const { replace } = useActions(router)
     const { featureFlags } = useValues(featureFlagLogic)
     const { showingDelayedSpinner } = useValues(appLogic)
-
-    useEffect(() => {
-        if (scene === Scene.Signup && preflight && !preflight.cloud && preflight.initiated) {
-            // If user is on an initiated self-hosted instance, redirect away from signup
-            replace('/login')
-            return
-        }
-    }, [scene, preflight])
-
-    useEffect(() => {
-        if (user) {
-            // If user is already logged in, redirect away from unauthenticated-only routes like signup
-            if (sceneConfig.onlyUnauthenticated) {
-                replace('/')
-                return
-            }
-
-            // Redirect to org/project creation if there's no org/project respectively, unless using invite
-            if (scene !== Scene.InviteSignup) {
-                if (!user.organization) {
-                    if (location.pathname !== '/organization/create') {
-                        replace('/organization/create')
-                    }
-                    return
-                } else if (!user.team) {
-                    if (location.pathname !== '/project/create') {
-                        replace('/project/create')
-                    }
-                    return
-                }
-
-                // If ingestion tutorial not completed, redirect to it
-                if (
-                    !user.team?.completed_snippet_onboarding &&
-                    !location.pathname.startsWith('/ingestion') &&
-                    !location.pathname.startsWith('/personalization')
-                ) {
-                    replace('/ingestion')
-                    return
-                }
-            }
-        }
-    }, [scene, user])
 
     const SceneComponent: (...args: any[]) => JSX.Element | null =
         (scene ? loadedScenes[scene]?.component : null) || (() => (showingDelayedSpinner ? <SceneLoading /> : null))

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -1,6 +1,7 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { loginLogicType } from './loginLogicType'
+import { router } from 'kea-router'
 
 interface AuthenticateResponseType {
     success: boolean
@@ -8,18 +9,11 @@ interface AuthenticateResponseType {
     errorDetail?: string
 }
 
+export function afterLoginRedirect(): string {
+    return router.values.searchParams['next'] || '/'
+}
+
 export const loginLogic = kea<loginLogicType<AuthenticateResponseType>>({
-    actions: {
-        setNext: (next: string) => ({ next }),
-    },
-    reducers: {
-        nextUrl: [
-            null as string | null,
-            {
-                setNext: (_, { next }) => next,
-            },
-        ],
-    },
     loaders: {
         authenticateResponse: [
             null as AuthenticateResponseType | null,
@@ -35,18 +29,11 @@ export const loginLogic = kea<loginLogicType<AuthenticateResponseType>>({
             },
         ],
     },
-    listeners: ({ values }) => ({
-        authenticateSuccess: () => {
-            if (values.authenticateResponse?.success) {
-                window.location.href = values.nextUrl ? values.nextUrl : '/'
+    listeners: {
+        authenticateSuccess: ({ authenticateResponse }) => {
+            if (authenticateResponse?.success) {
+                window.location.href = afterLoginRedirect()
             }
         },
-    }),
-    urlToAction: ({ actions }) => ({
-        '/login': (_: any, { next }: { next: string }) => {
-            if (next) {
-                actions.setNext(next)
-            }
-        },
-    }),
+    },
 })

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -208,11 +208,12 @@ export const routes: Record<string, Scene> = {
 
 export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneConfig>>({
     actions: {
-        // 1. Start opening the scene, yet the listener may override and do something else (calls loadScene)
+        /* 1. Prepares to open the scene, as the listener may override and do something 
+            else (e.g. redirecting if unauthenticated), then calls (2) `loadScene`*/
         openScene: (scene: Scene, params: Params) => ({ scene, params }),
-        // 2. Start loading the scene JavaScript and mount any logic, then call setScene
+        // 2. Start loading the scene's Javascript and mount any logic, then calls (3) `setScene`
         loadScene: (scene: Scene, params: Params) => ({ scene, params }),
-        // 3. Set the scene reducer
+        // 3. Set the `scene` reducer
         setScene: (scene: Scene, params: Params) => ({ scene, params }),
 
         setLoadedScene: (scene: Scene, loadedScene: LoadedScene) => ({ scene, loadedScene }),
@@ -309,13 +310,13 @@ export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneCo
             const { preflight } = preflightLogic.values
 
             if (scene === Scene.Signup && preflight && !preflight.cloud && preflight.initiated) {
-                // If user is on an initiated self-hosted instance, redirect away from signup
+                // If user is on an already initiated self-hosted instance, redirect away from signup
                 router.actions.replace('/login')
                 return
             }
 
             if (user) {
-                // If user is already logged in, redirect away from unauthenticated-only routes like signup
+                // If user is already logged in, redirect away from unauthenticated-only routes (e.g. /signup)
                 if (sceneConfig.onlyUnauthenticated) {
                     if (scene === Scene.Login && router.values.searchParams['next']) {
                         router.actions.replace(router.values.searchParams['next'])

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -10,6 +10,7 @@ import { preflightLogic } from './PreflightCheck/logic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { userLogic } from 'scenes/userLogic'
+import { afterLoginRedirect } from 'scenes/authentication/loginLogic'
 
 export enum Scene {
     Error404 = '404',
@@ -318,8 +319,8 @@ export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneCo
             if (user) {
                 // If user is already logged in, redirect away from unauthenticated-only routes (e.g. /signup)
                 if (sceneConfig.onlyUnauthenticated) {
-                    if (scene === Scene.Login && router.values.searchParams['next']) {
-                        router.actions.replace(router.values.searchParams['next'])
+                    if (scene === Scene.Login) {
+                        router.actions.replace(afterLoginRedirect())
                     } else {
                         router.actions.replace('/')
                     }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -9,6 +9,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { preflightLogic } from './PreflightCheck/logic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { userLogic } from 'scenes/userLogic'
 
 export enum Scene {
     Error404 = '404',
@@ -207,8 +208,13 @@ export const routes: Record<string, Scene> = {
 
 export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneConfig>>({
     actions: {
+        // 1. Start opening the scene, yet the listener may override and do something else (calls loadScene)
+        openScene: (scene: Scene, params: Params) => ({ scene, params }),
+        // 2. Start loading the scene JavaScript and mount any logic, then call setScene
         loadScene: (scene: Scene, params: Params) => ({ scene, params }),
+        // 3. Set the scene reducer
         setScene: (scene: Scene, params: Params) => ({ scene, params }),
+
         setLoadedScene: (scene: Scene, loadedScene: LoadedScene) => ({ scene, loadedScene }),
         showUpgradeModal: (featureName: string, featureCaption: string) => ({ featureName, featureCaption }),
         hideUpgradeModal: true,
@@ -272,8 +278,9 @@ export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneCo
                 router.actions.replace(typeof redirect === 'function' ? redirect(params) : redirect)
             }
         }
+
         for (const [path, scene] of Object.entries(routes)) {
-            mapping[path] = (params) => actions.loadScene(scene, params)
+            mapping[path] = (params) => actions.openScene(scene, params)
         }
 
         mapping['/*'] = () => actions.loadScene(Scene.Error404, {})
@@ -295,6 +302,52 @@ export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneCo
         setScene: () => {
             posthog.capture('$pageview')
             document.title = values.scene ? `${identifierToHuman(values.scene)} • PostHog` : 'PostHog'
+        },
+        openScene: ({ scene, params }) => {
+            const sceneConfig = sceneConfigurations[scene] || {}
+            const { user } = userLogic.values
+            const { preflight } = preflightLogic.values
+
+            if (scene === Scene.Signup && preflight && !preflight.cloud && preflight.initiated) {
+                // If user is on an initiated self-hosted instance, redirect away from signup
+                router.actions.replace('/login')
+                return
+            }
+
+            if (user) {
+                // If user is already logged in, redirect away from unauthenticated-only routes like signup
+                if (sceneConfig.onlyUnauthenticated) {
+                    router.actions.replace('/')
+                    return
+                }
+
+                // Redirect to org/project creation if there's no org/project respectively, unless using invite
+                if (scene !== Scene.InviteSignup) {
+                    if (!user.organization) {
+                        if (location.pathname !== '/organization/create') {
+                            router.actions.replace('/organization/create')
+                        }
+                        return
+                    } else if (!user.team) {
+                        if (location.pathname !== '/project/create') {
+                            router.actions.replace('/project/create')
+                        }
+                        return
+                    }
+
+                    // If ingestion tutorial not completed, redirect to it
+                    if (
+                        !user.team?.completed_snippet_onboarding &&
+                        !location.pathname.startsWith('/ingestion') &&
+                        !location.pathname.startsWith('/personalization')
+                    ) {
+                        router.actions.replace('/ingestion')
+                        return
+                    }
+                }
+            }
+
+            actions.loadScene(scene, params)
         },
         loadScene: async ({ scene, params = {} }: { scene: Scene; params: Params }, breakpoint) => {
             if (values.scene === scene) {

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -330,21 +330,19 @@ export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneCo
                     if (!user.organization) {
                         if (location.pathname !== '/organization/create') {
                             router.actions.replace('/organization/create')
+                            return
                         }
-                        return
                     } else if (!user.team) {
                         if (location.pathname !== '/project/create') {
                             router.actions.replace('/project/create')
+                            return
                         }
-                        return
-                    }
-
-                    // If ingestion tutorial not completed, redirect to it
-                    if (
-                        !user.team?.completed_snippet_onboarding &&
+                    } else if (
+                        !user.team.completed_snippet_onboarding &&
                         !location.pathname.startsWith('/ingestion') &&
                         !location.pathname.startsWith('/personalization')
                     ) {
+                        // If ingestion tutorial not completed, redirect to it
                         router.actions.replace('/ingestion')
                         return
                     }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -317,7 +317,11 @@ export const sceneLogic = kea<sceneLogicType<Scene, Params, LoadedScene, SceneCo
             if (user) {
                 // If user is already logged in, redirect away from unauthenticated-only routes like signup
                 if (sceneConfig.onlyUnauthenticated) {
-                    router.actions.replace('/')
+                    if (scene === Scene.Login && router.values.searchParams['next']) {
+                        router.actions.replace(router.values.searchParams['next'])
+                    } else {
+                        router.actions.replace('/')
+                    }
                     return
                 }
 


### PR DESCRIPTION
## Changes

- Finally fixes https://github.com/PostHog/posthog/issues/3868
- Moves all the URL override logic (e.g. redirect to /login if not logged in) into `sceneLogic`, away from the component and useEffect. This makes everything smoother, as we don't have to render the pre-set scene before doing the redirection.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
