### PR TITLE
Handle orgs more safely on private instances

### DIFF
--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -90,7 +90,7 @@ export function TopNavigation(): JSX.Element {
         filteredEnvironment,
     } = useValues(navigationLogic)
     const { user } = useValues(userLogic)
-    const { preflight } = useValues(preflightLogic)
+    const { preflight, organizationCreationAllowed } = useValues(preflightLogic)
     const { billing } = useValues(billingLogic)
     const { logout, updateCurrentTeam, updateCurrentOrganization } = useActions(userLogic)
     const { showUpgradeModal } = useActions(sceneLogic)
@@ -179,42 +179,32 @@ export function TopNavigation(): JSX.Element {
                     </Link>
                 </div>
             </div>
-            <div className="divider mt-05" />
-            <div className="organizations">
-                {user?.organizations.map((organization) => {
-                    if (organization.id == user.organization?.id) {
-                        return undefined
-                    }
-                    return (
-                        <a key={organization.id} onClick={() => updateCurrentOrganization(organization.id)}>
-                            <IconBuilding /> {organization.name}
-                        </a>
-                    )
-                })}
-                <a
-                    style={{ color: 'var(--muted)', display: 'flex', justifyContent: 'center' }}
-                    onClick={() =>
-                        guardPremiumFeature(
-                            user,
-                            preflight,
-                            showUpgradeModal,
-                            'organizations_projects',
-                            'multiple organizations',
-                            'Organizations group people building products together. An organization can then have multiple projects.',
-                            () => {
-                                setOrganizationModalShown(true)
-                            },
-                            {
-                                cloud: false,
-                                selfHosted: true,
+            {organizationCreationAllowed ? (
+                <>
+                    <div className="divider mt-05" />
+                    <div className="organizations">
+                        {user?.organizations.map((organization) => {
+                            if (organization.id == user.organization?.id) {
+                                return undefined
                             }
-                        )
-                    }
-                >
-                    <PlusOutlined style={{ marginRight: 8, fontSize: 18 }} /> New organization
-                </a>
-            </div>
-            <div className="divider mb-05" />
+                            return (
+                                <a key={organization.id} onClick={() => updateCurrentOrganization(organization.id)}>
+                                    <IconBuilding /> {organization.name}
+                                </a>
+                            )
+                        })}
+                        <a
+                            style={{ color: 'var(--muted)', display: 'flex', justifyContent: 'center' }}
+                            onClick={() => setOrganizationModalShown(true)}
+                        >
+                            <PlusOutlined style={{ marginRight: 8, fontSize: 18 }} /> New organization
+                        </a>
+                    </div>
+                    <div className="divider mb-05" />
+                </>
+            ) : (
+                <div className="divider mt-05 mb-05" />
+            )}
             <div className="text-center">
                 <a onClick={logout} data-attr="top-menu-item-logout">
                     Log out

--- a/frontend/src/scenes/PreflightCheck/logic.ts
+++ b/frontend/src/scenes/PreflightCheck/logic.ts
@@ -52,6 +52,13 @@ export const preflightLogic = kea<preflightLogicType<PreflightStatus, PreflightM
                 return Boolean(preflight && (!preflight.site_url || preflight.site_url != window.location.origin))
             },
         ],
+        organizationCreationAllowed: [
+            (s) => [s.preflight],
+            (preflight): boolean => {
+                // Organization creation is disallowed on initiated private instances for security
+                return !preflight || preflight.cloud || !preflight.initiated
+            },
+        ],
         configOptions: [
             (s) => [s.preflight],
             (preflight): Record<string, string>[] => {

--- a/frontend/src/scenes/organization/Create/index.tsx
+++ b/frontend/src/scenes/organization/Create/index.tsx
@@ -2,5 +2,5 @@ import React from 'react'
 import { CreateOrganizationModal } from '../CreateOrganizationModal'
 
 export function Create(): JSX.Element {
-    return <CreateOrganizationModal isVisible={true} />
+    return <CreateOrganizationModal isVisible />
 }

--- a/frontend/src/scenes/organization/Create/index.tsx
+++ b/frontend/src/scenes/organization/Create/index.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { CreateOrganizationModal } from '../CreateOrganizationModal'
 
 export function Create(): JSX.Element {
-    return <CreateOrganizationModal isVisible />
+    const [isVisible, setIsVisible] = useState(true)
+
+    return <CreateOrganizationModal isVisible={isVisible} setIsVisible={setIsVisible} />
 }

--- a/frontend/src/scenes/organization/CreateOrganizationModal.tsx
+++ b/frontend/src/scenes/organization/CreateOrganizationModal.tsx
@@ -42,7 +42,7 @@ export function CreateOrganizationModal({
                         <>
                             No more organizations can be created in this PostHog instance.
                             <br />
-                            If you don't belong to a organization, you'll need to ask for an invite.
+                            If you don't belong to an organization, you'll need to ask for an invite.
                         </>
                     }
                 />

--- a/frontend/src/scenes/organization/CreateOrganizationModal.tsx
+++ b/frontend/src/scenes/organization/CreateOrganizationModal.tsx
@@ -29,7 +29,13 @@ export function CreateOrganizationModal({
 
     if (!organizationCreationAllowed) {
         return (
-            <Modal title="Creating an Organization" closable={false} visible={isVisible} footer={null}>
+            <Modal
+                title="Creating an Organization"
+                closable={!!setIsVisible}
+                onCancel={closeModal}
+                visible={isVisible}
+                footer={null}
+            >
                 <Alert
                     type="error"
                     message={

--- a/frontend/src/scenes/organization/CreateOrganizationModal.tsx
+++ b/frontend/src/scenes/organization/CreateOrganizationModal.tsx
@@ -1,8 +1,9 @@
 import { Alert, Input } from 'antd'
 import Modal from 'antd/lib/modal/Modal'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import React, { Dispatch, SetStateAction, useCallback, useRef, useState } from 'react'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { preflightLogic } from '../PreflightCheck/logic'
 
 export function CreateOrganizationModal({
     isVisible,
@@ -12,6 +13,7 @@ export function CreateOrganizationModal({
     setIsVisible?: Dispatch<SetStateAction<boolean>>
 }): JSX.Element {
     const { createOrganization } = useActions(organizationLogic)
+    const { organizationCreationAllowed } = useValues(preflightLogic)
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
     const inputRef = useRef<Input | null>(null)
 
@@ -24,6 +26,23 @@ export function CreateOrganizationModal({
             }
         }
     }, [inputRef, setIsVisible])
+
+    if (!organizationCreationAllowed) {
+        return (
+            <Modal title="Creating an Organization" closable={false} visible={isVisible} footer={null}>
+                <Alert
+                    type="error"
+                    message={
+                        <>
+                            No more organizations can be created in this PostHog instance.
+                            <br />
+                            If you don't belong to a organization, you'll need to ask for an invite.
+                        </>
+                    }
+                />
+            </Modal>
+        )
+    }
 
     return (
         <Modal

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -74,7 +74,10 @@ class StructuredViewSetMixin(NestedViewSetMixin):
         if self.legacy_team_compatibility:
             if not self.request.user.is_authenticated:
                 raise AuthenticationFailed()
-            return {"team_id": self.request.user.team.id}
+            project = self.request.user.team
+            if project is None:
+                raise NotFound("There's no current project.")
+            return {"team_id": project.id}
         result = {}
         # process URL paremetrs (here called kwargs), such as organization_id in /api/organizations/:organization_id/
         for kwarg_name, kwarg_value in self.kwargs.items():
@@ -90,12 +93,12 @@ class StructuredViewSetMixin(NestedViewSetMixin):
                     if query_lookup == "team_id":
                         project = self.request.user.team
                         if project is None:
-                            raise NotFound("Current project not found.")
+                            raise NotFound("There's no current project.")
                         query_value = project.id
                     elif query_lookup == "organization_id":
                         organization = self.request.user.organization
                         if organization is None:
-                            raise NotFound("Current organization not found.")
+                            raise NotFound("There's no current organization.")
                         query_value = organization.id
                 elif query_lookup == "team_id":
                     try:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -126,7 +126,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         if lookup_value == "@current":
             team = cast(User, self.request.user).team
             if team is None:
-                raise exceptions.NotFound("Current project not found.")
+                raise exceptions.NotFound("There's no current project.")
             return team
         queryset = self.filter_queryset(self.get_queryset())
         filter_kwargs = {self.lookup_field: lookup_value}

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -7,7 +7,7 @@ from rest_framework import status
 
 from posthog.constants import RDBMS
 from posthog.models import User
-from posthog.models.organization import OrganizationInvite
+from posthog.models.organization import Organization, OrganizationInvite
 from posthog.test.base import APIBaseTest
 from posthog.version import VERSION
 
@@ -72,7 +72,7 @@ class TestPreflight(APIBaseTest):
     def test_cloud_preflight_request_unauthenticated(self):
 
         self.client.logout()  # make sure it works anonymously
-        User.objects.all().delete()
+        Organization.objects.all().delete()
 
         with self.settings(MULTI_TENANCY=True, PRIMARY_DB=RDBMS.CLICKHOUSE):
             response = self.client.get("/_preflight/")

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -15,6 +15,7 @@ from django.views.decorators.cache import never_cache
 from posthog.ee import is_clickhouse_enabled
 from posthog.email import is_email_available
 from posthog.models import User
+from posthog.permissions import is_instance_initiated
 from posthog.utils import (
     get_available_social_auth_providers,
     get_available_timezones_with_offsets,
@@ -85,7 +86,9 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
         "plugins": is_plugin_server_alive() or settings.TEST,
         "celery": is_celery_alive() or settings.TEST,
         "db": is_postgres_alive(),
-        "initiated": User.objects.exists() if not settings.E2E_TESTING else False,  # Enables E2E testing of signup flow
+        "initiated": is_instance_initiated()
+        if not settings.E2E_TESTING
+        else False,  # Enables E2E testing of signup flow
         "cloud": settings.MULTI_TENANCY,
         "available_social_auth_providers": get_available_social_auth_providers(),
     }


### PR DESCRIPTION
## Changes

Finally resolves #3657 by disallowing creation of orgs beyond the first one in initiated private instances of PostHog.

This is reflected in the frontend:
- the orgs selector and org creation button is no longer shown in **private** instances
   <img width="246" alt="No org selector" src="https://user-images.githubusercontent.com/4550621/121253120-0727a900-c8a9-11eb-9116-0986f47a74c4.png">
- a user that is not in any org (e.g. after being kicked out) in a **private** instance only sees the following alert instead of org creation UI
   <img width="1203" alt="No org creation" src="https://user-images.githubusercontent.com/4550621/121253722-bc5a6100-c8a9-11eb-9e4c-e034ecc3e8ab.png">

Also subtly changes the definition of an initiated instance, from one that has any user(s), to one that has any organization(s).

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] ~~Jest frontend tests~~
- [ ] ~~Cypress end-to-end tests~~
- [ ] ~~Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious~~
- [x] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
