### PR TITLE
Event query class

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -86,33 +86,36 @@ def parse_action_timestamps(days: int) -> Tuple[str, Dict[str, str]]:
     )
 
 
-def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
-    person_query, params = determine_precalculated_or_live_person_query(cohort)
-    person_id_query = CALCULATE_COHORT_PEOPLE_SQL.format(
-        query=person_query, latest_distinct_id_sql=GET_LATEST_PERSON_DISTINCT_ID_SQL
-    )
-    return person_id_query, params
-
-
-def determine_precalculated_or_live_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
-
-    custom_match_field = kwargs.get("custom_match_field", "person_id")
-
+def is_precalculated_query(cohort: Cohort) -> bool:
     if (
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
         and not settings.DEBUG
         and not settings.TEST
     ):
-        return (
-            f"""
+        return True
+    else:
+        return False
+
+
+def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
+    is_precalculated = is_precalculated_query(cohort)
+    person_query, params = get_precalculated_query(cohort) if is_precalculated else format_person_query(cohort)
+
+    person_id_query = CALCULATE_COHORT_PEOPLE_SQL.format(
+        query=person_query, latest_distinct_id_sql=GET_LATEST_PERSON_DISTINCT_ID_SQL
+    )
+    return person_id_query, params
+
+
+def get_precalculated_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
+    custom_match_field = kwargs.get("custom_match_field", "person_id")
+    return (
+        f"""
         {custom_match_field} IN ({GET_PERSON_ID_BY_COHORT_ID})
         """,
-            {"team_id": cohort.team_id, "cohort_id": cohort.pk},
-        )
-    else:
-        person_query, params = format_person_query(cohort, custom_match_field=custom_match_field)
-        return person_query, params
+        {"team_id": cohort.team_id, "cohort_id": cohort.pk},
+    )
 
 
 def get_person_ids_by_cohort_id(team: Team, cohort_id: int):

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -94,7 +94,10 @@ def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
     return person_id_query, params
 
 
-def determine_precalculated_or_live_person_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
+def determine_precalculated_or_live_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
+
+    custom_match_field = kwargs.get("custom_match_field", "person_id")
+
     if (
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
@@ -103,12 +106,12 @@ def determine_precalculated_or_live_person_query(cohort: Cohort) -> Tuple[str, D
     ):
         return (
             f"""
-        person_id IN ({GET_PERSON_ID_BY_COHORT_ID})
+        {custom_match_field} IN ({GET_PERSON_ID_BY_COHORT_ID})
         """,
             {"team_id": cohort.team_id, "cohort_id": cohort.pk},
         )
     else:
-        person_query, params = format_person_query(cohort)
+        person_query, params = format_person_query(cohort, custom_match_field=custom_match_field)
         return person_query, params
 
 

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -51,7 +51,13 @@ class ClickhouseEventQuery:
 
         self._should_round_interval = round_interval
 
-    def get_query(self, fields) -> Tuple[str, Dict[str, Any]]:
+    def get_query(self) -> Tuple[str, Dict[str, Any]]:
+        _fields = (
+            "e.timestamp as timestamp, e.properties as properties"
+            + (", pdi.person_id as person_id" if self._should_join_pdi else "")
+            + (", person.person_props as person_props" if self._should_join_persons else "")
+        )
+
         prop_query, prop_params = self._get_props()
         self.params.update(prop_params)
 
@@ -62,7 +68,7 @@ class ClickhouseEventQuery:
         self.params.update(date_params)
 
         query = f"""
-            SELECT {fields} FROM events {self.EVENT_TABLE_ALIAS}
+            SELECT {_fields} FROM events {self.EVENT_TABLE_ALIAS}
             {self._get_pdi_query()}
             {self._get_person_query()}
             WHERE team_id = %(team_id)s

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -19,7 +19,7 @@ class ClickhouseEventQuery:
     _should_join_pdi = False
     _should_join_persons = False
     _should_round_interval = False
-    _date_filter = False
+    _date_filter = None
 
     def __init__(
         self,

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -1,0 +1,152 @@
+from typing import Any, Dict, Tuple
+
+from ee.clickhouse.models.cohort import format_filter_query
+from ee.clickhouse.models.property import filter_element, prop_filter_json_extract
+from posthog.model import Cohort, Entity, Filter, Property, Team
+
+
+class ClickhouseEventQuery:
+    PDI_TABLE_ALIAS = "pdi"
+    PERSON_TABLE_ALIAS = "person"
+    EVENT_TABLE_ALIAS = "e"
+
+    _PERSON_PROPERTIES_ALIAS = "person_props"
+    _filter: Filter
+    _team: Team
+    _should_join_pdi = False
+    _should_join_persons = False
+
+    def __init__(self, filter: Filter, entity: Entity, team: Team, **kwargs) -> None:
+        self._filter = filter
+        self._team = team
+        self.params = {
+            "team_id": self._team.pk,
+        }
+
+        self._should_join_pdi = self._determine_should_join_pdi(entity)
+        self._should_join_persons = self._determine_should_join_persons(filter, entity)
+
+    def get_query(self, fields) -> Tuple[str, Dict[str, Any]]:
+        prop_query, prop_params = self._get_props(filter)
+        self.params.update(prop_params)
+
+        query = f"""
+            SELECT {fields} FROM events {self.EVENT_TABLE_ALIAS}
+            {self._get_pdi_query()}
+            {self._get_person_query()}
+            WHERE team_id = %(team_id)s
+            {prop_query}
+        """
+
+        return query, self.params
+
+    def _determine_should_join_pdi(self, entity: Entity) -> None:
+        if entity.math == "dau":
+            self._should_join_pdi = True
+            return
+
+    def _get_pdi_query(self) -> str:
+        if self._should_join_pdi:
+            return f"""
+            INNER JOIN (
+                SELECT person_id,
+                    distinct_id
+                FROM (
+                        SELECT *
+                        FROM person_distinct_id
+                        JOIN (
+                                SELECT distinct_id,
+                                    max(_offset) as _offset
+                                FROM person_distinct_id
+                                WHERE team_id = %(team_id)s
+                                GROUP BY distinct_id
+                            ) as person_max
+                            ON person_distinct_id.distinct_id = person_max.distinct_id
+                        AND person_distinct_id._offset = person_max._offset
+                        WHERE team_id = %(team_id)s
+                    )
+                WHERE team_id = %(team_id)s
+            ) AS {self.DI_TABLE_NAME}
+            ON events.distinct_id = {self.PDI_TABLE_NAME}.distinct_id
+            """
+        else:
+            return ""
+
+    def _determine_should_join_persons(self, filter: Filter, entity: Entity) -> None:
+        for prop in filter.properties:
+            if prop.type == "person":
+                self._should_join_pdi = True
+                self._should_join_persons = True
+                return
+
+        for prop in entity.properties:
+            if prop.type == "person":
+                self._should_join_pdi = True
+                self._should_join_persons = True
+                return
+
+        if filter.breakdown_type == "person":
+            self._should_join_pdi = True
+            self._should_join_persons = True
+
+    def _get_person_query(self) -> str:
+        if self._should_join_persons:
+            return f"""
+            INNER JOIN (
+                SELECT id, properties as person_props
+                FROM (
+                    SELECT id,
+                        argMax(properties, person._timestamp) as properties,
+                        max(is_deleted) as is_deleted
+                    FROM person
+                    WHERE team_id = %(team_id)s
+                    GROUP BY id
+                    HAVING is_deleted = 0
+                )
+            ) {self.PERSON_TABLE_ALIAS} 
+            ON {self.PERSON_TABLE_ALIAS}.id = {self.PDI_TABLE_NAME}.person_id
+            """
+
+    def _get_props(self, filter: Filter, allow_denormalized_props: bool = False,) -> Tuple[str, Dict]:
+
+        filters = filter.properties
+        filter_test_accounts = filter.filter_test_accounts
+        team_id = self._team.pk
+        table_name = f"{self.EVENT_TABLE_ALIAS}."
+        prepend = "global"
+
+        final = []
+        params: Dict[str, Any] = {}
+
+        if filter_test_accounts:
+            test_account_filters = Team.objects.only("test_account_filters").get(id=team_id).test_account_filters
+            filters.extend([Property(**prop) for prop in test_account_filters])
+
+        for idx, prop in enumerate(filters):
+            if prop.type == "cohort":
+                cohort = Cohort.objects.get(pk=prop.value, team_id=team_id)
+                person_id_query, cohort_filter_params = format_filter_query(cohort)
+                params = {**params, **cohort_filter_params}
+                final.append(f"AND {table_name}distinct_id IN ({person_id_query})")
+            elif prop.type == "person":
+                filter_query, filter_params = prop_filter_json_extract(
+                    prop,
+                    idx,
+                    "{}person".format(prepend),
+                    allow_denormalized_props=allow_denormalized_props,
+                    prop_var=self._PERSON_PROPERTIES_ALIAS,
+                )
+                final.append(filter_query)
+                params.update(filter_params)
+            elif prop.type == "element":
+                query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
+                final.append("AND {}".format(query[0]))
+                params.update(filter_params)
+            else:
+                filter_query, filter_params = prop_filter_json_extract(
+                    prop, idx, prepend, prop_var="properties", allow_denormalized_props=allow_denormalized_props,
+                )
+
+                final.append(filter_query)
+                params.update(filter_params)
+        return " ".join(final), params

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -176,16 +176,8 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        entity = Entity(
-            {
-                "id": "viewed",
-                "type": "events",
-                "properties": [
-                    {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"},
-                    {"key": "key", "value": "val"},
-                ],
-            }
-        )
+        entity = Entity({"id": "viewed", "type": "events",})
 
         query, params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query()
         sync_execute(query, params)
+        print(sqlparse.format(query, reindent=True))

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -43,10 +43,11 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         entity = Entity({"id": "viewed", "type": "events"})
 
-        query, params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query("event")
+        query, params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query()
 
         correct = """
-        SELECT event
+        SELECT e.timestamp as timestamp,
+        e.properties as properties
         FROM events e
         WHERE team_id = %(team_id)s
             AND event = %(event)s
@@ -80,9 +81,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         entity = Entity({"id": "viewed", "type": "events"})
 
-        global_prop_query, global_prop_query_params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query(
-            "event"
-        )
+        global_prop_query, global_prop_query_params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query()
         sync_execute(global_prop_query, global_prop_query_params)
 
         filter = Filter(
@@ -104,9 +103,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        entity_prop_query, entity_prop_query_params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query(
-            "event"
-        )
+        entity_prop_query, entity_prop_query_params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query()
 
         # global queries and enttiy queries should be the same
         self.assertEqual(

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -1,0 +1,121 @@
+from uuid import uuid4
+
+import sqlparse
+
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.event import create_event
+from ee.clickhouse.queries.event_query import ClickhouseEventQuery
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.models.entity import Entity
+from posthog.models.filters import Filter
+from posthog.models.person import Person
+from posthog.test.base import APIBaseTest
+
+
+def _create_person(**kwargs):
+    person = Person.objects.create(**kwargs)
+    return Person(id=person.uuid, uuid=person.uuid)
+
+
+def _create_event(**kwargs):
+    kwargs.update({"event_uuid": uuid4()})
+    create_event(**kwargs)
+
+
+class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        self._create_sample_data()
+        super().setUp()
+
+    def _create_sample_data(self):
+        _create_person(distinct_ids=["user_one"], team=self.team)
+
+        _create_event(event="viewed", distinct_id="user_one", team=self.team, timestamp="2021-05-01 00:00:00")
+
+    def test_basic_event_filter(self):
+        filter = Filter(
+            data={
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+                "events": [{"id": "viewed", "order": 0},],
+            }
+        )
+
+        entity = Entity({"id": "viewed", "type": "events"})
+
+        query, params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query("event")
+
+        correct = """
+        SELECT event
+        FROM events e
+        WHERE team_id = %(team_id)s
+            AND event = %(event)s
+            AND timestamp >= '2021-05-01 00:00:00'
+            AND timestamp <= '2021-05-07 23:59:59'
+        """
+        correct_params = {
+            "team_id": self.team.pk,
+            "event": "viewed",
+            "date_from": "2021-05-01 00:00:00",
+            "date_to": "2021-05-07 23:59:59",
+        }
+
+        self.assertEqual(sqlparse.format(query, reindent=True), sqlparse.format(correct, reindent=True))
+        self.assertEqual(params, correct_params)
+
+        sync_execute(query, params)
+
+    def test_properties_filter(self):
+        filter = Filter(
+            data={
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+                "events": [{"id": "viewed", "order": 0},],
+                "properties": [
+                    {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"},
+                    {"key": "key", "value": "val"},
+                ],
+            }
+        )
+
+        entity = Entity({"id": "viewed", "type": "events"})
+
+        global_prop_query, global_prop_query_params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query(
+            "event"
+        )
+        sync_execute(global_prop_query, global_prop_query_params)
+
+        filter = Filter(
+            data={
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+                "events": [{"id": "viewed", "order": 0},],
+            }
+        )
+
+        entity = Entity(
+            {
+                "id": "viewed",
+                "type": "events",
+                "properties": [
+                    {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"},
+                    {"key": "key", "value": "val"},
+                ],
+            }
+        )
+
+        entity_prop_query, entity_prop_query_params = ClickhouseEventQuery(filter, entity, self.team.pk).get_query(
+            "event"
+        )
+
+        # global queries and enttiy queries should be the same
+        self.assertEqual(
+            sqlparse.format(global_prop_query, reindent=True), sqlparse.format(entity_prop_query, reindent=True)
+        )
+        sync_execute(entity_prop_query, entity_prop_query_params)
+
+    def test_cohort_filter(self):
+        pass
+
+    def test_action_entity(self):
+        pass

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -50,7 +50,7 @@ class ClickhouseTrendsTotalVolume:
                 entity,
                 team_id,
                 date_filter="{parsed_date_from} {parsed_date_to}",
-                should_join_pdi=True if join_condition != "" else False,
+                should_join_distinct_ids=True if join_condition != "" else False,
             ).get_query()
             event_query = event_query.format(**content_sql_params)
             params = {**params, **event_query_params}
@@ -72,7 +72,7 @@ class ClickhouseTrendsTotalVolume:
                     entity,
                     team_id,
                     date_filter="{parsed_date_from_prev_range} {parsed_date_to}",
-                    should_join_pdi=True,
+                    should_join_distinct_ids=True,
                 ).get_query()
                 sql_params = get_active_user_params(filter, entity, team_id)
                 params = {**params, **event_query_params}
@@ -84,7 +84,7 @@ class ClickhouseTrendsTotalVolume:
                     entity,
                     team_id,
                     date_filter="{parsed_date_from} {parsed_date_to}",
-                    should_join_pdi=True if join_condition != "" else False,
+                    should_join_distinct_ids=True if join_condition != "" else False,
                 ).get_query()
                 event_query = event_query.format(**content_sql_params)
                 params = {**params, **event_query_params}

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from ee.clickhouse.client import format_sql, sync_execute
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.property import parse_prop_clauses
+from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from ee.clickhouse.queries.trends.util import (
     get_active_user_params,
     parse_response,
@@ -31,31 +32,29 @@ class ClickhouseTrendsTotalVolume:
         )
         _, parsed_date_to, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
-        props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
-        )
-
         aggregate_operation, join_condition, math_params = process_math(entity)
 
-        params: Dict = {"team_id": team_id}
-        params = {**params, **prop_filter_params, **math_params, **date_params}
         content_sql_params = {
+            "aggregate_operation": aggregate_operation,
+            "timestamp": "e.timestamp",
             "interval": interval_annotation,
             "parsed_date_from": date_from_clause(interval_annotation, round_interval),
             "parsed_date_to": parsed_date_to,
-            "timestamp": "timestamp",
-            "filters": prop_filters,
-            "event_join": join_condition,
-            "aggregate_operation": aggregate_operation,
         }
-
-        entity_params, entity_format_params = populate_entity_params(entity)
-        content_sql_params = {**content_sql_params, **entity_format_params}
-        params = {**params, **entity_params}
+        params: Dict = {"team_id": team_id}
+        params = {**params, **math_params, **date_params}
 
         if filter.display in TRENDS_DISPLAY_BY_VALUE:
-            content_sql = VOLUME_TOTAL_AGGREGATE_SQL.format(**content_sql_params)
+            event_query, event_query_params = ClickhouseEventQuery(
+                filter,
+                entity,
+                team_id,
+                date_filter="{parsed_date_from} {parsed_date_to}",
+                should_join_pdi=True if join_condition != "" else False,
+            ).get_query("*")
+            event_query = event_query.format(**content_sql_params)
+            params = {**params, **event_query_params}
+            content_sql = VOLUME_TOTAL_AGGREGATE_SQL.format(event_query=event_query, **content_sql_params)
             time_range = self._enumerate_time_range(filter, seconds_in_interval)
 
             return (
@@ -68,10 +67,30 @@ class ClickhouseTrendsTotalVolume:
         else:
 
             if entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
+                event_query, event_query_params = ClickhouseEventQuery(
+                    filter,
+                    entity,
+                    team_id,
+                    date_filter="{parsed_date_from_prev_range} {parsed_date_to}",
+                    should_join_pdi=True,
+                ).get_query("*")
                 sql_params = get_active_user_params(filter, entity, team_id)
-                content_sql = ACTIVE_USER_SQL.format(**content_sql_params, **sql_params)
+                params = {**params, **event_query_params}
+                event_query = event_query.format(**sql_params, parsed_date_to=parsed_date_to)
+                content_sql = ACTIVE_USER_SQL.format(event_query=event_query, **content_sql_params, **sql_params)
             else:
-                content_sql = VOLUME_SQL.format(**content_sql_params)
+                event_query, event_query_params = ClickhouseEventQuery(
+                    filter,
+                    entity,
+                    team_id,
+                    date_filter="{parsed_date_from} {parsed_date_to}",
+                    should_join_pdi=True if join_condition != "" else False,
+                ).get_query(
+                    "e.timestamp as timestamp" + (", pdi.person_id as person_id" if entity.math == "dau" else "")
+                )
+                event_query = event_query.format(**content_sql_params)
+                params = {**params, **event_query_params}
+                content_sql = VOLUME_SQL.format(event_query=event_query, **content_sql_params)
 
             null_sql = NULL_SQL.format(
                 interval=interval_annotation,

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -86,7 +86,8 @@ class ClickhouseTrendsTotalVolume:
                     date_filter="{parsed_date_from} {parsed_date_to}",
                     should_join_pdi=True if join_condition != "" else False,
                 ).get_query(
-                    "e.timestamp as timestamp" + (", pdi.person_id as person_id" if entity.math == "dau" else "")
+                    "e.timestamp as timestamp, e.properties as properties"
+                    + (", pdi.person_id as person_id" if entity.math == "dau" else "")
                 )
                 event_query = event_query.format(**content_sql_params)
                 params = {**params, **event_query_params}

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -51,7 +51,7 @@ class ClickhouseTrendsTotalVolume:
                 team_id,
                 date_filter="{parsed_date_from} {parsed_date_to}",
                 should_join_pdi=True if join_condition != "" else False,
-            ).get_query("*")
+            ).get_query()
             event_query = event_query.format(**content_sql_params)
             params = {**params, **event_query_params}
             content_sql = VOLUME_TOTAL_AGGREGATE_SQL.format(event_query=event_query, **content_sql_params)
@@ -73,7 +73,7 @@ class ClickhouseTrendsTotalVolume:
                     team_id,
                     date_filter="{parsed_date_from_prev_range} {parsed_date_to}",
                     should_join_pdi=True,
-                ).get_query("*")
+                ).get_query()
                 sql_params = get_active_user_params(filter, entity, team_id)
                 params = {**params, **event_query_params}
                 event_query = event_query.format(**sql_params, parsed_date_to=parsed_date_to)
@@ -85,10 +85,7 @@ class ClickhouseTrendsTotalVolume:
                     team_id,
                     date_filter="{parsed_date_from} {parsed_date_to}",
                     should_join_pdi=True if join_condition != "" else False,
-                ).get_query(
-                    "e.timestamp as timestamp, e.properties as properties"
-                    + (", pdi.person_id as person_id" if entity.math == "dau" else "")
-                )
+                ).get_query()
                 event_query = event_query.format(**content_sql_params)
                 params = {**params, **event_query_params}
                 content_sql = VOLUME_SQL.format(event_query=event_query, **content_sql_params)

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -17,7 +17,7 @@ def parse_timestamps(filter: FilterType, team_id: int, table: str = "") -> Tuple
     params = {}
     if filter.date_from:
 
-        date_from = "and {table}timestamp >= '{}'".format(format_ch_timestamp(filter.date_from, filter), table=table,)
+        date_from = "AND {table}timestamp >= '{}'".format(format_ch_timestamp(filter.date_from, filter), table=table,)
         params.update({"date_from": format_ch_timestamp(filter.date_from, filter)})
     else:
         try:
@@ -25,12 +25,12 @@ def parse_timestamps(filter: FilterType, team_id: int, table: str = "") -> Tuple
         except IndexError:
             date_from = ""
         else:
-            date_from = "and {table}timestamp >= '{}'".format(format_ch_timestamp(earliest_date, filter), table=table,)
+            date_from = "AND {table}timestamp >= '{}'".format(format_ch_timestamp(earliest_date, filter), table=table,)
             params.update({"date_from": format_ch_timestamp(earliest_date, filter)})
 
     _date_to = filter.date_to
 
-    date_to = "and {table}timestamp <= '{}'".format(format_ch_timestamp(_date_to, filter, " 23:59:59"), table=table,)
+    date_to = "AND {table}timestamp <= '{}'".format(format_ch_timestamp(_date_to, filter, " 23:59:59"), table=table,)
     params.update({"date_to": format_ch_timestamp(_date_to, filter, " 23:59:59")})
 
     return date_from or "", date_to or "", params

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -1,9 +1,9 @@
 VOLUME_SQL = """
-SELECT {aggregate_operation} as data, toDateTime({interval}({timestamp}), 'UTC') as date from events {event_join} where team_id = %(team_id)s {entity_query} {filters} {parsed_date_from} {parsed_date_to} GROUP BY {interval}({timestamp})
+SELECT {aggregate_operation} as data, toDateTime({interval}(timestamp), 'UTC') as date FROM ({event_query}) GROUP BY {interval}(timestamp)
 """
 
 VOLUME_TOTAL_AGGREGATE_SQL = """
-SELECT {aggregate_operation} as data from events {event_join} where team_id = %(team_id)s {entity_query} {filters} {parsed_date_from} {parsed_date_to}
+SELECT {aggregate_operation} as data FROM ({event_query}) events
 """
 
 ACTIVE_USER_SQL = """
@@ -12,27 +12,7 @@ SELECT counts as total, timestamp as day_start FROM (
         SELECT toStartOfDay(timestamp) as timestamp FROM events WHERE team_id = %(team_id)s {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp 
     ) d
     CROSS JOIN (
-        SELECT toStartOfDay(timestamp) as timestamp, person_id FROM events INNER JOIN (
-            SELECT person_id,
-                distinct_id
-            FROM (
-                    SELECT *
-                    FROM person_distinct_id
-                    JOIN (
-                            SELECT distinct_id,
-                                max(_offset) as _offset
-                            FROM person_distinct_id
-                            WHERE team_id = %(team_id)s
-                            GROUP BY distinct_id
-                        ) as person_max
-                        ON person_distinct_id.distinct_id = person_max.distinct_id
-                    AND person_distinct_id._offset = person_max._offset
-                    WHERE team_id = %(team_id)s
-                )
-            WHERE team_id = %(team_id)s
-        ) as pid
-        ON events.distinct_id = pid.distinct_id
-        WHERE team_id = %(team_id)s {entity_query} {filters} {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, person_id
+        SELECT toStartOfDay(timestamp) as timestamp, person_id FROM ({event_query}) events WHERE 1 = 1 {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, person_id
     ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
     GROUP BY d.timestamp
     ORDER BY d.timestamp


### PR DESCRIPTION
## Changes

*Please describe.*  

**Current Problem:**
Our query building logic has bubbled into adding many repeated clauses. For example, in our `parse_prop_clause` class, for every person related property, we are adding an `IN` condition that inserts an entire person related subquery (`GET_DISTINCT_IDS_BY_PROPERTY_SQL`)

**Solution:**
- Create a dedicated class that will format the event query as best as possible given the entity and filter parameters. This class will generate an events query that can be then wrapped by any of the insight queries (trends, funnels, etc.) as they all rely on a subquery on events. 
- The class should guarantee the simplest format of the query so it would solve the problem mentioned above by joining in the persons table once and filtering on persons property in a non-nested manner without extra subquerying.

_should see improvements around person prop related queries and query readability_

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
