### PR TITLE
Fix demo error

### DIFF
--- a/posthog/templates/demo.html
+++ b/posthog/templates/demo.html
@@ -6,12 +6,13 @@
     <script>
         posthog.init('{{api_token}}', {
             api_host: window.location.origin,
-            loaded: function (posthog) { 
+            loaded: (posthog) => {
                 posthog.onFeatureFlags(() => {
-                    if (posthog.isFeatureEnabled('sign-up-cta')) {
-                    document.getElementById('sign-up-cta').innerText = 'Get started now'
-                }
-            })},
+                    if (posthog.isFeatureEnabled('sign-up-cta') && document.getElementById('sign-up-cta')) {
+                        document.getElementById('sign-up-cta').innerText = 'Get started now'
+                    }
+                })
+            },
         })
     </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.min.css" />


### PR DESCRIPTION
## Changes

Pages like http://localhost:8000/demo/2 (all that are not /demo) used to throw an error when visited, now they don't. 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
