### PR TITLE
App context + persist feature flags + joy

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -15,7 +15,7 @@ beforeEach(() => {
         cy.clock(1578225600000, ['Date'])
     } else {
         if (Cypress.spec.name.includes('Premium')) {
-            cy.visit('/login')
+            cy.visit('/login?next=/?no-preloaded-app-context=true')
             cy.intercept('/api/users/@me/', { fixture: 'api/user-enterprise' })
             cy.login()
         } else {

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -56,6 +56,7 @@ export const featureFlagLogic = kea<featureFlagLogicType<FeatureFlagsSet>>({
     reducers: {
         featureFlags: [
             {} as FeatureFlagsSet,
+            { persist: true },
             {
                 setFeatureFlags: (_, { featureFlags }) => {
                     const flags: FeatureFlagsSet = {}

--- a/frontend/src/lib/utils/getAppContext.ts
+++ b/frontend/src/lib/utils/getAppContext.ts
@@ -1,0 +1,5 @@
+import { AppContext } from '~/types'
+
+export function getAppContext(): AppContext | null {
+    return (window as any)['POSTHOG_APP_CONTEXT'] || null
+}

--- a/frontend/src/lib/utils/getAppContext.ts
+++ b/frontend/src/lib/utils/getAppContext.ts
@@ -1,5 +1,5 @@
 import { AppContext } from '~/types'
 
-export function getAppContext(): AppContext | null {
-    return (window as any)['POSTHOG_APP_CONTEXT'] || null
+export function getAppContext(): AppContext | undefined {
+    return (window as any)['POSTHOG_APP_CONTEXT'] || undefined
 }

--- a/frontend/src/scenes/PreflightCheck/logic.ts
+++ b/frontend/src/scenes/PreflightCheck/logic.ts
@@ -3,6 +3,7 @@ import api from 'lib/api'
 import { PreflightStatus } from '~/types'
 import { preflightLogicType } from './logicType'
 import posthog from 'posthog-js'
+import { getAppContext } from 'lib/utils/getAppContext'
 
 type PreflightMode = 'experimentation' | 'live'
 
@@ -94,7 +95,12 @@ export const preflightLogic = kea<preflightLogicType<PreflightStatus, PreflightM
     }),
     events: ({ actions }) => ({
         afterMount: () => {
-            actions.loadPreflight()
+            const preflight = getAppContext()?.preflight
+            if (preflight) {
+                actions.loadPreflightSuccess(preflight)
+            } else {
+                actions.loadPreflight()
+            }
         },
     }),
     actionToUrl: ({ values }) => ({

--- a/frontend/src/scenes/PreflightCheck/logic.ts
+++ b/frontend/src/scenes/PreflightCheck/logic.ts
@@ -8,18 +8,14 @@ import { getAppContext } from 'lib/utils/getAppContext'
 type PreflightMode = 'experimentation' | 'live'
 
 export const preflightLogic = kea<preflightLogicType<PreflightStatus, PreflightMode>>({
-    loaders: ({ actions }) => ({
+    loaders: {
         preflight: [
             null as PreflightStatus | null,
             {
-                loadPreflight: async () => {
-                    const response = await api.get('_preflight/')
-                    actions.registerInstrumentationProps()
-                    return response
-                },
+                loadPreflight: async () => await api.get('_preflight/'),
             },
         ],
-    }),
+    },
     actions: {
         registerInstrumentationProps: true,
         setPreflightMode: (mode: PreflightMode | null, noReload?: boolean) => ({ mode, noReload }),
@@ -75,6 +71,9 @@ export const preflightLogic = kea<preflightLogicType<PreflightStatus, PreflightM
         ],
     },
     listeners: ({ values, actions }) => ({
+        loadPreflightSuccess: () => {
+            actions.registerInstrumentationProps()
+        },
         registerInstrumentationProps: async (_, breakpoint) => {
             await breakpoint(100)
             if (posthog && values.preflight) {

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -5,6 +5,7 @@ import { userLogicType } from './userLogicType'
 import { UserType } from '~/types'
 import posthog from 'posthog-js'
 import { toast } from 'react-toastify'
+import { getAppContext } from 'lib/utils/getAppContext'
 
 interface UpdateUserPayload {
     user: Partial<UserType>
@@ -133,10 +134,9 @@ export const userLogic = kea<userLogicType<UserType, UpdateUserPayload>>({
     }),
     events: ({ actions }) => ({
         afterMount: () => {
-            const preloadedUser = (window as any)['POSTHOG_APP_USER']
+            const preloadedUser = getAppContext()?.current_user
             if (preloadedUser) {
                 actions.loadUserSuccess(preloadedUser)
-                window.document.getElementById('posthog-app-user-preload')?.remove()
             } else if (preloadedUser === null) {
                 actions.loadUserFailure('Logged out')
             } else {

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -21,7 +21,7 @@ export const userLogic = kea<userLogicType<UserType, UpdateUserPayload>>({
     }),
     reducers: {
         user: [
-            (window as any)['POSTHOG_APP_USER'] || (null as UserType | null),
+            null as UserType | null,
             {
                 setUser: (_, payload) => payload.user,
                 userUpdateSuccess: (_, payload) => payload.user,

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -19,23 +19,6 @@ export const userLogic = kea<userLogicType<UserType, UpdateUserPayload>>({
         updateCurrentOrganization: (organizationId: string, destination?: string) => ({ organizationId, destination }),
         logout: true,
     }),
-    reducers: {
-        user: [
-            null as UserType | null,
-            {
-                setUser: (_, payload) => payload.user,
-                userUpdateSuccess: (_, payload) => payload.user,
-            },
-        ],
-        userUpdateLoading: [
-            false,
-            {
-                userUpdateRequest: () => true,
-                userUpdateSuccess: () => false,
-                userUpdateFailure: () => false,
-            },
-        ],
-    },
     selectors: ({ selectors }) => ({
         demoOnlyProject: [
             () => [selectors.user],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -830,4 +830,5 @@ export interface TiledIconModuleProps {
 
 export interface AppContext {
     current_user: UserType | null
+    preflight: PreflightStatus
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -827,3 +827,7 @@ export interface TiledIconModuleProps {
     subHeader?: string
     analyticsModuleKey?: string
 }
+
+export interface AppContext {
+    current_user: UserType | null
+}

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -23,3 +23,6 @@
 {% if sentry_dsn %}
     <script>window.SENTRY_DSN = '{{sentry_dsn}}';</script>
 {% endif %}
+<script id='posthog-app-user-preload'>
+    window.POSTHOG_APP_USER = {{ user_api_response | safe }};
+</script>

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -24,5 +24,5 @@
     <script>window.SENTRY_DSN = '{{sentry_dsn}}';</script>
 {% endif %}
 <script id='posthog-app-user-preload'>
-    window.POSTHOG_APP_USER = {{ user_api_response | safe }};
+    window.POSTHOG_APP_CONTEXT = {{ posthog_app_context | safe }};
 </script>

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -216,8 +216,21 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     context["js_capture_internal_metrics"] = settings.CAPTURE_INTERNAL_METRICS
 
+    if request.user.pk:
+        from posthog.api.user import UserSerializer
+
+        user = UserSerializer(request.user, context={"request": request}, many=False)
+        context["user_api_response"] = json.dumps(user.data, default=json_uuid_convert)
+    else:
+        context["user_api_response"] = "null"
+
     html = template.render(context, request=request)
     return HttpResponse(html)
+
+
+def json_uuid_convert(o):
+    if isinstance(o, uuid.UUID):
+        return str(o)
 
 
 def friendly_time(seconds: float):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -215,11 +215,14 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
         context["js_posthog_host"] = "'https://app.posthog.com'"
 
     context["js_capture_internal_metrics"] = settings.CAPTURE_INTERNAL_METRICS
-    posthog_app_context: Dict = {"current_user": None}
+
+    # Set the frontend app context
+    from posthog.api.user import UserSerializer
+    from posthog.views import preflight_check
+
+    posthog_app_context: Dict = {"current_user": None, "preflight": json.loads(preflight_check(request).getvalue())}
 
     if request.user.pk:
-        from posthog.api.user import UserSerializer
-
         user = UserSerializer(request.user, context={"request": request}, many=False)
         posthog_app_context["current_user"] = user.data
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -215,14 +215,15 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
         context["js_posthog_host"] = "'https://app.posthog.com'"
 
     context["js_capture_internal_metrics"] = settings.CAPTURE_INTERNAL_METRICS
+    posthog_app_context: Dict = {"current_user": None}
 
     if request.user.pk:
         from posthog.api.user import UserSerializer
 
         user = UserSerializer(request.user, context={"request": request}, many=False)
-        context["user_api_response"] = json.dumps(user.data, default=json_uuid_convert)
-    else:
-        context["user_api_response"] = "null"
+        posthog_app_context["current_user"] = user.data
+
+    context["posthog_app_context"] = json.dumps(posthog_app_context, default=json_uuid_convert)
 
     html = template.render(context, request=request)
     return HttpResponse(html)


### PR DESCRIPTION
## Changes

Probably not ready for prime time (hence draft), but can be nitted to shreds.

It's subtle, but see if you can notice it: (pressing cmd + shift + r both cases)

Before:
![2021-06-09 00 45 00](https://user-images.githubusercontent.com/53387/121267113-f896bd00-c8bb-11eb-9c33-b6b83d5b8233.gif)

After:
![2021-06-09 00 46 21](https://user-images.githubusercontent.com/53387/121267211-254ad480-c8bc-11eb-8f6a-a477ef5d110f.gif)

This PR creates a system called "app context", which is a way to send data from the backend to the frontend, via regular django views. This data is available when the frontend loads, skipping previously blocking API requests.

I added two things into this app context: `/api/users/@me` and `/_preflight`.

Before: Reload -> Load JS -> Display a white screen -> Wait for API requests -> Display App
After: Reload -> Load JS -> Display App (or Login)

I assume the difference will be bigger on cloud compared to localhost.

There was a third blocker for displaying the app: feature flags. To get around this, I added `{ persist: true }` to the feature flags reducers, which is how you tell [kea-localstorage](https://kea.js.org/docs/plugins/localstorage) to persist a value (indefinitely) in localstorage. Whatever is in there will get overridden as soon as posthog-js loads.

I await your nits and deeper comments!

To check independently: will and should posthog.reset() also reset the feature flags? 🤔 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
