### PR TITLE
Fix paths start element selector

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
@@ -67,7 +67,7 @@ export function PropertyValue({
     const commonInputProps = {
         autoFocus: !value && !isMobile(),
         style: { width: '100%', ...style },
-        value: (isMultiSelect ? value : input) || placeholder,
+        value: isMultiSelect ? value : input,
         loading: optionsCache[input] === 'loading',
         onSearch: (newInput) => {
             setInput(newInput)


### PR DESCRIPTION
## Changes

We were setting the paths placeholder as the actual value of the select start element input. This made it so that it had to be manually erased by the user, but when it got to the falsy empty string, it would reset the placeholder.

This keeps the placeholder as what it's supposed to be: a placeholder.

<img width="382" alt="Screenshot 2021-06-09 at 09 38 51" src="https://user-images.githubusercontent.com/38760734/121355932-c65e7d00-c906-11eb-9a24-6239c885ba4a.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)

