### PR TITLE
Set `PLUGIN_SERVER_ACTION_MATCHING` to `1`

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -67,6 +67,10 @@
                 {
                     "name": "CAPTURE_INTERNAL_METRICS",
                     "value": "True"
+                },
+                {
+                    "name": "PLUGIN_SERVER_ACTION_MATCHING",
+                    "value": "1"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

This enables a dry run of plugin server action matching.