### PR TITLE
Fix 'cannot read toString() of null' in SelectGradientOverflow

### DIFF
--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -28,7 +28,7 @@ type CustomTagProps = Parameters<Exclude<SelectProps<any>['tagRender'], undefine
 
 function CustomTag({ label, onClose, value }: CustomTagProps): JSX.Element {
     return (
-        <Tooltip title={value.toString()}>
+        <Tooltip title={value?.toString() || ''}>
             <Tag>
                 <span className="label">{label}</span>
                 <CloseButton onClick={onClose} />


### PR DESCRIPTION
## Changes

Fixes #4665; note that PR #4662 may have caused the bug and was reverted.

This PR adds and additional coercion to empty string rather than `null`, which directly addresses the failure at render-time.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
