### PR TITLE
Temp fix for start point in user paths

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
@@ -16,9 +16,10 @@ export function PropertyValue({
     value,
     operator,
     outerOptions = undefined,
+    isPathsSelector = false,
 }) {
     const isMultiSelect = isOperatorMulti(operator)
-    const [input, setInput] = useState(isMultiSelect ? '' : value)
+    const [input, setInput] = useState(isMultiSelect || isPathsSelector ? '' : value)
     const [optionsCache, setOptionsCache] = useState({})
     const [options, setOptions] = useState({})
 
@@ -67,7 +68,7 @@ export function PropertyValue({
     const commonInputProps = {
         autoFocus: !value && !isMobile(),
         style: { width: '100%', ...style },
-        value: isMultiSelect ? value : input,
+        value: isMultiSelect || isPathsSelector ? value : input,
         loading: optionsCache[input] === 'loading',
         onSearch: (newInput) => {
             setInput(newInput)
@@ -90,38 +91,11 @@ export function PropertyValue({
         },
     }
 
+    console.log(input, value)
+
     return (
         <>
-            {!isMultiSelect ? (
-                <AutoComplete
-                    {...commonInputProps}
-                    onChange={(val) => {
-                        setInput(val ?? null)
-                    }}
-                    onSelect={(val) => {
-                        setValue(val ?? null)
-                    }}
-                >
-                    {input && (
-                        <Select.Option key={input} value={input} className="ph-no-capture">
-                            Specify: {input}
-                        </Select.Option>
-                    )}
-                    {displayOptions.map(({ name, id }, index) => (
-                        <AutoComplete.Option
-                            key={id || name}
-                            value={id || name}
-                            data-attr={'prop-val-' + index}
-                            className="ph-no-capture"
-                            title={name}
-                        >
-                            {name === true && 'true'}
-                            {name === false && 'false'}
-                            {name}
-                        </AutoComplete.Option>
-                    ))}
-                </AutoComplete>
-            ) : (
+            {isMultiSelect ? (
                 <SelectGradientOverflow
                     {...commonInputProps}
                     mode={isMultiSelect ? 'multiple' : undefined}
@@ -153,6 +127,40 @@ export function PropertyValue({
                         </Select.Option>
                     ))}
                 </SelectGradientOverflow>
+            ) : (
+                <AutoComplete
+                    {...commonInputProps}
+                    onChange={(val) => {
+                        setInput(val ?? null)
+                    }}
+                    onSelect={(val) => {
+                        console.log(val)
+                        setValue(val ?? null)
+                    }}
+                >
+                    {input || isPathsSelector ? (
+                        <Select.Option
+                            key={`specify-${isPathsSelector ? value : input}`}
+                            value={isPathsSelector ? value : input}
+                            className="ph-no-capture"
+                        >
+                            Specify: {isPathsSelector ? value : input}
+                        </Select.Option>
+                    ) : null}
+                    {displayOptions.map(({ name, id }, index) => (
+                        <AutoComplete.Option
+                            key={id || name}
+                            value={id || name}
+                            data-attr={'prop-val-' + index}
+                            className="ph-no-capture"
+                            title={name}
+                        >
+                            {name === true && 'true'}
+                            {name === false && 'false'}
+                            {name}
+                        </AutoComplete.Option>
+                    ))}
+                </AutoComplete>
             )}
             {validationError && <p className="text-danger">{validationError}</p>}
         </>

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
@@ -19,7 +19,7 @@ export function PropertyValue({
     isPathsSelector = false,
 }) {
     const isMultiSelect = isOperatorMulti(operator)
-    const [input, setInput] = useState(isMultiSelect ? '' : value)
+    const [input, setInput] = useState(isMultiSelect ? '' : isPathsSelector && value ? String(value) : '')
     const [optionsCache, setOptionsCache] = useState({})
     const [options, setOptions] = useState({})
 
@@ -133,17 +133,17 @@ export function PropertyValue({
                 <AutoComplete
                     {...commonInputProps}
                     onChange={(val) => {
-                        setInput(val ?? null)
+                        setInput(val ? String(val) : null)
                     }}
                     onSelect={(val) => {
                         setValue(val ?? null)
                         if (isPathsSelector) {
-                            setInput(val ?? '')
+                            setInput(val ? String(val) : null)
                         }
                     }}
                 >
                     {input || isPathsSelector ? (
-                        <Select.Option key="specify" value={input ?? value} className="ph-no-capture">
+                        <Select.Option key="specify-value" value={input ?? value} className="ph-no-capture">
                             Specify: {input ?? value}
                         </Select.Option>
                     ) : null}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
@@ -19,7 +19,7 @@ export function PropertyValue({
     isPathsSelector = false,
 }) {
     const isMultiSelect = isOperatorMulti(operator)
-    const [input, setInput] = useState(isMultiSelect || isPathsSelector ? '' : value)
+    const [input, setInput] = useState(isMultiSelect ? '' : value)
     const [optionsCache, setOptionsCache] = useState({})
     const [options, setOptions] = useState({})
 
@@ -65,10 +65,12 @@ export function PropertyValue({
 
     const validationError = getValidationError(operator, value)
 
+    const pathSelectorValue = typeof input === 'string' ? input : value
+
     const commonInputProps = {
         autoFocus: !value && !isMobile(),
         style: { width: '100%', ...style },
-        value: isMultiSelect || isPathsSelector ? value : input,
+        value: isMultiSelect ? value : isPathsSelector ? pathSelectorValue : input,
         loading: optionsCache[input] === 'loading',
         onSearch: (newInput) => {
             setInput(newInput)
@@ -90,8 +92,8 @@ export function PropertyValue({
             }
         },
     }
-
-    console.log(input, value)
+    console.log('input', input)
+    console.log('value', value)
 
     return (
         <>
@@ -134,17 +136,15 @@ export function PropertyValue({
                         setInput(val ?? null)
                     }}
                     onSelect={(val) => {
-                        console.log(val)
                         setValue(val ?? null)
+                        if (isPathsSelector) {
+                            setInput(val ?? '')
+                        }
                     }}
                 >
                     {input || isPathsSelector ? (
-                        <Select.Option
-                            key={`specify-${isPathsSelector ? value : input}`}
-                            value={isPathsSelector ? value : input}
-                            className="ph-no-capture"
-                        >
-                            Specify: {isPathsSelector ? value : input}
+                        <Select.Option key="specify" value={input ?? value} className="ph-no-capture">
+                            Specify: {input ?? value}
                         </Select.Option>
                     ) : null}
                     {displayOptions.map(({ name, id }, index) => (

--- a/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
@@ -63,6 +63,7 @@ function DefaultPathTab(): JSX.Element {
                 value={filter.start_point}
                 placeholder={'Select start element'}
                 operator={null}
+                isPathsSelector
             />
             <hr />
             <h4 className="secondary">Filters</h4>

--- a/frontend/src/scenes/insights/InsightTabs/PathTabHorizontal.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTabHorizontal.tsx
@@ -68,6 +68,7 @@ export function PathTabHorizontal({ annotationsToCreate }: BaseTabProps): JSX.El
                             value={filter.start_point}
                             placeholder={'Select start element'}
                             operator={null}
+                            isPathsSelector
                         />
                     </Col>
                 </Row>


### PR DESCRIPTION
## Changes

### EDIT: I messed up typing though, looking into it now

Ultimately all of these filters need refactoring.

However, this PR is a temp fix that:

- Makes `START POINT` input in paths open a selector on click
- Makes it display the correct value
- Flips some logic around from a negative conditional to a positive one (more readable)
- Fixes an issue with duplicate keys due to the key used by `Specify`

https://user-images.githubusercontent.com/38760734/121378323-7a690380-c919-11eb-89b1-3a24f5e7774d.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
