### PR TITLE
Revert "Fix paths start element selector"

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.js
@@ -67,7 +67,7 @@ export function PropertyValue({
     const commonInputProps = {
         autoFocus: !value && !isMobile(),
         style: { width: '100%', ...style },
-        value: isMultiSelect ? value : input,
+        value: (isMultiSelect ? value : input) || placeholder,
         loading: optionsCache[input] === 'loading',
         onSearch: (newInput) => {
             setInput(newInput)


### PR DESCRIPTION
Reverts PostHog/posthog#4662. The Sessions component test error was actually meaningful; it appears it may have caused #4665.