### PR TITLE
Filter steps missing icon

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
@@ -207,7 +207,7 @@ export function ActionFilterRow({
                         </Button>
                     </Col>
                 )}
-                {!horizontalUI && !singleFilter && filterCount > 1 && (
+                {!horizontalUI && !singleFilter && (
                     <Col>
                         <Button
                             type="link"


### PR DESCRIPTION
## Changes

Fixes #4669 

Super small change.

Allow user to delete all funnel filter steps, so that they can return to the default funnel state.

### Before

https://user-images.githubusercontent.com/13460330/121400300-4804d980-c90c-11eb-8063-e0263340010a.mov

### After


https://user-images.githubusercontent.com/13460330/121421712-4e528000-c923-11eb-9744-2ece0fb971d5.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] Jest frontend tests
- [x] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
