### PR TITLE
Disable auto-extending toolbar buttons

### DIFF
--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -116,6 +116,7 @@ export function ToolbarButton(): JSX.Element {
             }
             labelStyle={{ opacity: extensionPercentage > 0.8 ? (extensionPercentage - 0.8) / 0.2 : 0, marginTop: 16 }}
             {...clickEvents}
+            onMouseOver={isAuthenticated ? undefined : () => setExtensionPercentage(1)}
             style={{ borderRadius: 10, height: 46, marginTop: -23 }}
             zIndex={3}
         >

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -57,32 +57,25 @@ export function ToolbarButton(): JSX.Element {
     })
 
     useEffect(() => {
-        globalMouseMove.current = function (e: MouseEvent): void {
-            const buttonDiv = getShadowRoot()?.getElementById('button-toolbar')
-            if (buttonDiv) {
-                const rect = buttonDiv.getBoundingClientRect()
-                const x = rect.left + rect.width / 2
-                const y = rect.top + rect.height / 2
-                const distance = Math.sqrt((e.clientX - x) * (e.clientX - x) + (e.clientY - y) * (e.clientY - y))
+        if (isAuthenticated) {
+            globalMouseMove.current = function (e: MouseEvent): void {
+                const buttonDiv = getShadowRoot()?.getElementById('button-toolbar')
+                if (buttonDiv) {
+                    const rect = buttonDiv.getBoundingClientRect()
+                    const x = rect.left + rect.width / 2
+                    const y = rect.top + rect.height / 2
+                    const distance = Math.sqrt((e.clientX - x) * (e.clientX - x) + (e.clientY - y) * (e.clientY - y))
+                    const maxDistance = 300
 
-                const startDistance = isAuthenticated ? 230 : 130
-                const endDistance = isAuthenticated ? 160 : 60
-
-                if (distance >= startDistance) {
-                    if (toolbarButtonLogic.values.extensionPercentage !== 0) {
+                    // pull in the toolbar buttons if more than 300px away from the center
+                    if (distance >= maxDistance && toolbarButtonLogic.values.extensionPercentage !== 0) {
                         setExtensionPercentage(0)
-                    }
-                } else if (distance >= endDistance && distance < startDistance) {
-                    setExtensionPercentage((startDistance - distance) / (startDistance - endDistance))
-                } else if (distance < endDistance) {
-                    if (toolbarButtonLogic.values.extensionPercentage !== 1) {
-                        setExtensionPercentage(1)
                     }
                 }
             }
+            window.addEventListener('mousemove', globalMouseMove.current)
+            return () => window.removeEventListener('mousemove', globalMouseMove.current)
         }
-        window.addEventListener('mousemove', globalMouseMove.current)
-        return () => window.removeEventListener('mousemove', globalMouseMove.current)
     }, [isAuthenticated])
 
     // using useLongPress for short presses (clicks) since it detects if the element was dragged (no click) or not (click)

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -105,16 +105,6 @@ export function ToolbarButton(): JSX.Element {
             width={62}
             className="floating-toolbar-button"
             content={<HogLogo style={{ width: 45, cursor: 'pointer' }} />}
-            label={
-                isAuthenticated ? null : (
-                    <div style={{ lineHeight: '22px', paddingTop: 15 }}>
-                        Click here to
-                        <br />
-                        authenticate
-                    </div>
-                )
-            }
-            labelStyle={{ opacity: extensionPercentage > 0.8 ? (extensionPercentage - 0.8) / 0.2 : 0, marginTop: 16 }}
             {...clickEvents}
             onMouseOver={isAuthenticated ? undefined : () => setExtensionPercentage(1)}
             style={{ borderRadius: 10, height: 46, marginTop: -23 }}

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -57,25 +57,23 @@ export function ToolbarButton(): JSX.Element {
     })
 
     useEffect(() => {
-        if (isAuthenticated) {
-            globalMouseMove.current = function (e: MouseEvent): void {
-                const buttonDiv = getShadowRoot()?.getElementById('button-toolbar')
-                if (buttonDiv) {
-                    const rect = buttonDiv.getBoundingClientRect()
-                    const x = rect.left + rect.width / 2
-                    const y = rect.top + rect.height / 2
-                    const distance = Math.sqrt((e.clientX - x) * (e.clientX - x) + (e.clientY - y) * (e.clientY - y))
-                    const maxDistance = 300
+        globalMouseMove.current = function (e: MouseEvent): void {
+            const buttonDiv = getShadowRoot()?.getElementById('button-toolbar')
+            if (buttonDiv) {
+                const rect = buttonDiv.getBoundingClientRect()
+                const x = rect.left + rect.width / 2
+                const y = rect.top + rect.height / 2
+                const distance = Math.sqrt((e.clientX - x) * (e.clientX - x) + (e.clientY - y) * (e.clientY - y))
 
-                    // pull in the toolbar buttons if more than 300px away from the center
-                    if (distance >= maxDistance && toolbarButtonLogic.values.extensionPercentage !== 0) {
-                        setExtensionPercentage(0)
-                    }
+                const maxDistance = isAuthenticated ? 300 : 100
+
+                if (distance >= maxDistance && toolbarButtonLogic.values.extensionPercentage !== 0) {
+                    setExtensionPercentage(0)
                 }
             }
-            window.addEventListener('mousemove', globalMouseMove.current)
-            return () => window.removeEventListener('mousemove', globalMouseMove.current)
         }
+        window.addEventListener('mousemove', globalMouseMove.current)
+        return () => window.removeEventListener('mousemove', globalMouseMove.current)
     }, [isAuthenticated])
 
     // using useLongPress for short presses (clicks) since it detects if the element was dragged (no click) or not (click)

--- a/posthog/templates/demo.html
+++ b/posthog/templates/demo.html
@@ -6,12 +6,13 @@
     <script>
         posthog.init('{{api_token}}', {
             api_host: window.location.origin,
-            loaded: function (posthog) { 
+            loaded: (posthog) => {
                 posthog.onFeatureFlags(() => {
-                    if (posthog.isFeatureEnabled('sign-up-cta')) {
-                    document.getElementById('sign-up-cta').innerText = 'Get started now'
-                }
-            })},
+                    if (posthog.isFeatureEnabled('sign-up-cta') && document.getElementById('sign-up-cta')) {
+                        document.getElementById('sign-up-cta').innerText = 'Get started now'
+                    }
+                })
+            },
         })
     </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.min.css" />


### PR DESCRIPTION
## Changes

Prevent the toolbar from auto-extending when approaching it with a mouse. This was always getting in the way of things when the toolbar was authenticated.

Before (authenticated):
![2021-06-09 22 36 44](https://user-images.githubusercontent.com/53387/121426954-71f1e680-c974-11eb-8410-9e01fb518fe1.gif)


After (authenticated):
![2021-06-09 22 41 13](https://user-images.githubusercontent.com/53387/121426963-74ecd700-c974-11eb-94be-929d9dc949cb.gif)

Logged out I also removed the "expand when approaching" behaviour, instead I added "expand on hover" and removed the label that was always getting in the way. Since when authenticated, you need to click anyway, I don't think there's a need to make the unauthenticated view much different with the extra label.

We need to show the close button somehow, and this seemed like a better compromise than asking the user to click twice (once to show the two options). Making the close button always visible added a lot of visual noise, even if much closer to the toolbar button.


Before (unauthenticated):
![2021-06-09 23 25 55](https://user-images.githubusercontent.com/53387/121431744-14f92f00-c97a-11eb-9282-d408b1a7048d.gif)


After (unauthenticated): 
![2021-06-09 23 22 18](https://user-images.githubusercontent.com/53387/121431377-9b614100-c979-11eb-9d44-e1b5fddcb38f.gif)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
