### PR TITLE
Fix trends bar graph + modal data mismatch bug

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsBarValueGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsBarValueGraph.tsx
@@ -78,8 +78,8 @@ export function ActionsBarValueGraph({
                               const { dataset } = point
                               const action = dataset.actions[point.index]
                               const label = dataset.labels[point.index]
-                              const date_from = dataset?.days?.length ? dataset.days[0] : null
-                              const date_to = dataset?.days?.length ? dataset.days[dataset.days.length - 1] : null
+                              const date_from = filtersParam?.date_from
+                              const date_to = filtersParam?.date_to
                               loadPeople(action, label, date_from, date_to, null)
                           }
                 }


### PR DESCRIPTION
Fixes #4532

My brain hasn't been working since this morning so please excuse the mind dump below 😬

## Root Cause

Dug into this more and the root cause became a lot clearer when I got my hands on the SQL. 

The timestamp ranges specified in the [SQL for bar trends](https://github.com/PostHog/posthog/blob/f6d24270d36e15ab8c0d71b6d8c2e7f4eb7b8890/ee/clickhouse/sql/trends/volume.py#L5-L5), and the [one for the users list modal](https://github.com/PostHog/posthog/blob/f6d24270d36e15ab8c0d71b6d8c2e7f4eb7b8890/ee/clickhouse/sql/person.py#L242-L242) are different. For a sparse dataset like DAU trends with a specific filter, the former fetches for a larger time range while the latter fetches data within the timeframe flanking the earliest and latest data points. 

## Why? Deep Dive

I spent some time in the backend looking for a bug, but eventually discovered it in the frontend layer. 

The reason why the two SQL commands are different is because `date_from` and `date_to` are calculated from the earliest and latest timestamps in the bar graph's dataset. For a sparse dataset such as [DAU](https://app.posthog.com/insights?insight=TRENDS&interval=day&actions=%5B%7B%22id%22%3A2671%2C%22name%22%3A%22User%20Signed%20Up%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A0%2C%22properties%22%3A%5B%7B%22key%22%3A%22email%22%2C%22value%22%3A%22%40doppler%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22person%22%7D%5D%2C%22math%22%3A%22dau%22%7D%5D&events=%5B%5D&properties=%5B%5D&filter_test_accounts=false&new_entity=%5B%5D&date_from=all&compare=false&display=ActionsBarValue), the deduped date ranges do not capture the entire time range of data points we observed. For example if there are 3 user signups that happened on 1/1/2020, 1/1/2021, 1/5/2021, and the first and last event were triggered by the same user, today's bar graph code would generate an SQL query for timerange 1/1/2020 - 1/5/2021, which will capture all 2 users. However when we click the bar graph to view those users, a new SQL would be created for timerange 1/1/2021 - 1/5/2021 since it only captures the min-max timestamps of the deduped users.

## Solution

The solution isn't as complicated as the bug. This can be fixed by generating the request from the filter parameters instead of the bar graph's data points [[code]](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/trends/viz/ActionsBarValueGraph.tsx#L81-L82)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [X] Django backend tests
- [ ] Jest frontend tests
- [X] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
