### PR TITLE
Fix NPS reporting bug

### DIFF
--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -73,9 +73,16 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
             }
         },
         submit: () => {
+            const payload = values.payload
+            let result = 'dismissed'
+            if (payload) {
+                result = 'partial'
+                if (payload.score && payload.feedback_score && payload.feedback_persona) {
+                    result = 'completed'
+                }
+            }
+            posthog.capture('nps feedback', { ...payload, result })
             // `nps_2106` is used to identify users who have replied to the NPS survey (via cohorts)
-            const result = ['dismissed', 'partial', 'partial', 'completed'][values.step]
-            posthog.capture('nps feedback', { ...values.payload, result })
             posthog.people.set({ nps_2106: true })
             localStorage.setItem(NPS_LOCALSTORAGE_KEY, 'true')
             cache.timeout = window.setTimeout(() => actions.hide(), NPS_HIDE_TIMEOUT)


### PR DESCRIPTION
## Changes

Noticed that scores were not coming back in NPS reports that had a result of completed. Also the conversion rate looked _really_ high.

Did some digging:
- Anytime someone clicks the X, a listener fires and sets the step to 3
- Submit fires and checks the step # against in array, which was incorrectly saying the result set was complete

Change is to define the result based on how much information has been filled.  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
