### PR TITLE
Keep toolbar closer to the screen edge

### DIFF
--- a/frontend/src/toolbar/button/toolbarButtonLogic.ts
+++ b/frontend/src/toolbar/button/toolbarButtonLogic.ts
@@ -13,6 +13,7 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
         hideActionsInfo: true,
         setExtensionPercentage: (percentage: number) => ({ percentage }),
         saveDragPosition: (x: number, y: number) => ({ x, y }),
+        setDragPosition: (x: number, y: number) => ({ x, y }),
         saveHeatmapPosition: (x: number, y: number) => ({ x, y }),
         saveActionsPosition: (x: number, y: number) => ({ x, y }),
     }),
@@ -51,7 +52,7 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
             null as null | { x: number; y: number },
             { persist: true },
             {
-                saveDragPosition: (_, { x, y }) => ({ x, y }),
+                setDragPosition: (_, { x, y }) => ({ x, y }),
             },
         ],
         heatmapPosition: [
@@ -74,17 +75,17 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
             (lastDragPosition, windowWidth, windowHeight) => {
                 const widthPadding = 35
                 const heightPadding = 30
+
+                const { x, y } = lastDragPosition || {
+                    x: -widthPadding,
+                    y: 60,
+                }
+                const dragX = x < 0 ? windowWidth + x : x
+                const dragY = y < 0 ? windowHeight + y : y
+
                 return {
-                    x: inBounds(
-                        widthPadding,
-                        !lastDragPosition ? windowWidth - widthPadding : lastDragPosition.x,
-                        windowWidth - widthPadding
-                    ),
-                    y: inBounds(
-                        heightPadding,
-                        !lastDragPosition ? 60 : lastDragPosition.y,
-                        windowHeight - heightPadding
-                    ),
+                    x: inBounds(widthPadding, dragX, windowWidth - widthPadding),
+                    y: inBounds(heightPadding, dragY, windowHeight - heightPadding),
                 }
             },
         ],
@@ -136,9 +137,16 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
             (actionsInfoVisible, buttonActionsVisible) => actionsInfoVisible && buttonActionsVisible,
         ],
     },
-    listeners: () => ({
+    listeners: ({ actions, values }) => ({
         hideActionsInfo: () => {
             actionsTabLogic.actions.selectAction(null)
+        },
+        saveDragPosition: ({ x, y }) => {
+            const { windowWidth, windowHeight } = values
+            actions.setDragPosition(
+                x > windowWidth / 2 ? -(windowWidth - x) : x,
+                y > windowHeight / 2 ? -(windowHeight - y) : y
+            )
         },
     }),
 })


### PR DESCRIPTION
## Changes

Simple fix for something that again annoyed me to no end :)

Before:
![2021-06-10 14 14 55](https://user-images.githubusercontent.com/53387/121523254-4adbf900-c9f6-11eb-9f68-c3171cca05c1.gif)

After:
![2021-06-10 14 13 41](https://user-images.githubusercontent.com/53387/121523244-47e10880-c9f6-11eb-805e-eeeb02d1da5d.gif)

Until now the toolbar button coordinates were always stored from `(0,0)` (top left). Now they're stored relative to the edge of the quadrant of the screen the toolbar is in. 

In other words, if you move the button to the edge of the screen, it'll now stay there.



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
