### PR TITLE
Populate defaults on creating source plugins

### DIFF
--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -40,7 +40,12 @@ export function Plugins({ user }: { user: UserType }): JSX.Element | null {
                         </sup>
                     </>
                 }
-                caption="Plugins enable you to extend PostHog's core data processing functionality."
+                caption={
+                    <>
+                        Plugins enable you to extend PostHog's core data processing functionality. You can also{' '}
+                        <a href="https://posthog.com/docs/plugins/build">build your own.</a>
+                    </>
+                }
             />
             {canInstallPlugins(user.organization) ? (
                 <Tabs activeKey={pluginTab} onChange={(activeKey) => setPluginTab(activeKey as PluginTab)}>

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -69,7 +69,7 @@ export function PluginDrawer(): JSX.Element {
         } else {
             form.resetFields()
         }
-    }, [editingPlugin?.id])
+    }, [editingPlugin?.id, editingPlugin?.config_schema])
 
     const isValidChoiceConfig = (fieldConfig: PluginConfigChoice): boolean => {
         return (

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -101,7 +101,7 @@ export function PluginSource(): JSX.Element {
                 {editingSource ? (
                     <>
                         <p>
-                            <a href="https://posthog.com/docs/plugins/overview" target="_blank">
+                            <a href="https://posthog.com/docs/plugins/build" target="_blank">
                                 Read the documentation.
                             </a>
                         </p>

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -157,6 +157,7 @@ export const pluginsLogic = kea<
                     if (!editingPlugin) {
                         return pluginConfigs
                     }
+
                     const formData = getPluginConfigFormData(editingPlugin, pluginConfigChanges)
 
                     if (!editingPlugin.pluginConfig?.enabled) {

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -157,7 +157,6 @@ export const pluginsLogic = kea<
                     if (!editingPlugin) {
                         return pluginConfigs
                     }
-
                     const formData = getPluginConfigFormData(editingPlugin, pluginConfigChanges)
 
                     if (!editingPlugin.pluginConfig?.enabled) {


### PR DESCRIPTION
## Changes

Defaults weren't being respected for source plugins on creation.

Before: on installing new plugin ->

![image](https://user-images.githubusercontent.com/7115141/121350490-ab016b00-c922-11eb-8a28-af0cae2f8042.png)

After: on installing new plugin ->

![image](https://user-images.githubusercontent.com/7115141/121526091-faae6800-c9f0-11eb-8523-a021281feea1.png)

----

Plus, a caption change:

![image](https://user-images.githubusercontent.com/7115141/121526374-377a5f00-c9f1-11eb-8613-fa47e95a426a.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
