### PR TITLE
Logic tests

### DIFF
--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -1,107 +1,10 @@
 import { Button, Input } from 'antd'
-import { kea, useActions, useValues } from 'kea'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { useActions, useValues } from 'kea'
 import { CloseOutlined, ArrowLeftOutlined } from '@ant-design/icons'
 import React from 'react'
 import './NPSPrompt.scss'
-import { npsLogicType } from './NPSPromptType'
-import posthog from 'posthog-js'
 import nps from './nps.svg'
-import { userLogic } from 'scenes/userLogic'
-import { UserType } from '~/types'
-import dayjs from 'dayjs'
-
-const NPS_APPEAR_TIMEOUT = 10000
-const NPS_HIDE_TIMEOUT = 3500
-const NPS_LOCALSTORAGE_KEY = 'experimental-nps-v8'
-
-type Step = 0 | 1 | 2 | 3
-
-interface NPSPayload {
-    score?: 1 | 3 | 5 // 1 = not disappointed; 3 = somewhat disappointed; 5 = very disappointed
-    feedback_score?: string
-    feedback_persona?: string
-}
-
-const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
-    selectors: {
-        featureFlagEnabled: [
-            () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags) => featureFlags[FEATURE_FLAGS.NPS_PROMPT],
-        ],
-        userIsOldEnough: [
-            () => [userLogic.selectors.user],
-            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-15, 'day')),
-        ],
-        npsPromptEnabled: [
-            (s) => [s.featureFlagEnabled, s.userIsOldEnough],
-            (featureFlagEnabled, userIsOldEnough) => featureFlagEnabled && userIsOldEnough,
-        ],
-    },
-    actions: {
-        show: true,
-        hide: true,
-        setStep: (step: Step) => ({ step }),
-        stepBack: true,
-        setPayload: (payload: NPSPayload | null) => ({ payload }),
-        submit: true,
-    },
-    reducers: {
-        step: [
-            0 as Step,
-            {
-                setStep: (_, { step }) => step,
-                stepBack: (state) => Math.max(state - 1, 0) as Step,
-                submit: () => 3,
-                // go to step 1 when selecting the score on step 0
-                setPayload: (state, { payload }) => (state === 0 && typeof payload?.score !== 'undefined' ? 1 : state),
-            },
-        ],
-        hidden: [true, { show: () => false, hide: () => true }],
-        payload: [
-            null as NPSPayload | null,
-            {
-                setPayload: (state, { payload }) => ({ ...state, ...payload }),
-            },
-        ],
-    },
-    listeners: ({ values, actions, cache }) => ({
-        stepBack: () => {
-            if (values.step === 1) {
-                actions.setPayload(null)
-            }
-        },
-        submit: () => {
-            const payload = values.payload
-            let result = 'dismissed'
-            if (payload) {
-                result = 'partial'
-                if (payload.score && payload.feedback_score && payload.feedback_persona) {
-                    result = 'completed'
-                }
-            }
-            posthog.capture('nps feedback', { ...payload, result })
-            // `nps_2106` is used to identify users who have replied to the NPS survey (via cohorts)
-            posthog.people.set({ nps_2106: true })
-            localStorage.setItem(NPS_LOCALSTORAGE_KEY, 'true')
-            cache.timeout = window.setTimeout(() => actions.hide(), NPS_HIDE_TIMEOUT)
-        },
-        show: () => {
-            posthog.capture('nps modal shown')
-        },
-    }),
-    events: ({ actions, values, cache }) => ({
-        afterMount: () => {
-            if (values.npsPromptEnabled && !localStorage.getItem(NPS_LOCALSTORAGE_KEY)) {
-                cache.timeout = window.setTimeout(() => actions.show(), NPS_APPEAR_TIMEOUT)
-            }
-        },
-        beforeUnmount: () => {
-            window.clearTimeout(cache.timeout)
-        },
-    }),
-})
+import { npsLogic } from 'lib/experimental/npsLogic'
 
 /* Asks user for NPS-like score feedback (see product-internal#9 for details). To determine if the component should
 be shown to a user, we follow these rules:

--- a/frontend/src/lib/experimental/npsLogic.test.ts
+++ b/frontend/src/lib/experimental/npsLogic.test.ts
@@ -1,0 +1,38 @@
+import { npsLogic } from 'lib/experimental/npsLogic'
+import { initKea } from '~/initKea'
+
+jest.mock('posthog-js')
+
+describe('NPS Logic', () => {
+    let unmount: () => void
+    beforeEach(() => {
+        initKea()
+        unmount = npsLogic.mount()
+    })
+    afterEach(() => {
+        unmount?.()
+    })
+
+    test('defaults', () => {
+        expect(Object.keys(npsLogic.values)).toEqual([
+            'step',
+            'hidden',
+            'payload',
+            'featureFlagEnabled',
+            'userIsOldEnough',
+            'npsPromptEnabled',
+        ])
+
+        expect(npsLogic.values.featureFlagEnabled).toEqual(false)
+        expect(npsLogic.values.userIsOldEnough).toEqual(false)
+        expect(npsLogic.values.npsPromptEnabled).toEqual(false)
+    })
+
+    test('can update step', () => {
+        expect(npsLogic.values.step).toEqual(0)
+        npsLogic.actions.setStep(1)
+        expect(npsLogic.values.step).toEqual(1)
+        npsLogic.actions.setStep(2)
+        expect(npsLogic.values.step).toEqual(2)
+    })
+})

--- a/frontend/src/lib/experimental/npsLogic.ts
+++ b/frontend/src/lib/experimental/npsLogic.ts
@@ -1,0 +1,99 @@
+import { kea } from 'kea'
+import { npsLogicType } from 'lib/experimental/NPSPromptType'
+import { UserType } from '~/types'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { userLogic } from 'scenes/userLogic'
+import dayjs from 'dayjs'
+import posthog from 'posthog-js'
+
+const NPS_APPEAR_TIMEOUT = 10000
+const NPS_HIDE_TIMEOUT = 3500
+const NPS_LOCALSTORAGE_KEY = 'experimental-nps-v8'
+
+type Step = 0 | 1 | 2 | 3
+
+interface NPSPayload {
+    score?: 1 | 3 | 5 // 1 = not disappointed; 3 = somewhat disappointed; 5 = very disappointed
+    feedback_score?: string
+    feedback_persona?: string
+}
+
+export const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
+    selectors: {
+        featureFlagEnabled: [
+            () => [featureFlagLogic.selectors.featureFlags],
+            (featureFlags) => featureFlags[FEATURE_FLAGS.NPS_PROMPT],
+        ],
+        userIsOldEnough: [
+            () => [userLogic.selectors.user],
+            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-15, 'day')),
+        ],
+        npsPromptEnabled: [
+            (s) => [s.featureFlagEnabled, s.userIsOldEnough],
+            (featureFlagEnabled, userIsOldEnough) => featureFlagEnabled && userIsOldEnough,
+        ],
+    },
+    actions: {
+        show: true,
+        hide: true,
+        setStep: (step: Step) => ({ step }),
+        stepBack: true,
+        setPayload: (payload: NPSPayload | null) => ({ payload }),
+        submit: true,
+    },
+    reducers: {
+        step: [
+            0 as Step,
+            {
+                setStep: (_, { step }) => step,
+                stepBack: (state) => Math.max(state - 1, 0) as Step,
+                submit: () => 3,
+                // go to step 1 when selecting the score on step 0
+                setPayload: (state, { payload }) => (state === 0 && typeof payload?.score !== 'undefined' ? 1 : state),
+            },
+        ],
+        hidden: [true, { show: () => false, hide: () => true }],
+        payload: [
+            null as NPSPayload | null,
+            {
+                setPayload: (state, { payload }) => ({ ...state, ...payload }),
+            },
+        ],
+    },
+    listeners: ({ values, actions, cache }) => ({
+        stepBack: () => {
+            if (values.step === 1) {
+                actions.setPayload(null)
+            }
+        },
+        submit: () => {
+            const payload = values.payload
+            let result = 'dismissed'
+            if (payload) {
+                result = 'partial'
+                if (payload.score && payload.feedback_score && payload.feedback_persona) {
+                    result = 'completed'
+                }
+            }
+            posthog.capture('nps feedback', { ...payload, result })
+            // `nps_2106` is used to identify users who have replied to the NPS survey (via cohorts)
+            posthog.people.set({ nps_2106: true })
+            localStorage.setItem(NPS_LOCALSTORAGE_KEY, 'true')
+            cache.timeout = window.setTimeout(() => actions.hide(), NPS_HIDE_TIMEOUT)
+        },
+        show: () => {
+            posthog.capture('nps modal shown')
+        },
+    }),
+    events: ({ actions, values, cache }) => ({
+        afterMount: () => {
+            if (values.npsPromptEnabled && !localStorage.getItem(NPS_LOCALSTORAGE_KEY)) {
+                cache.timeout = window.setTimeout(() => actions.show(), NPS_APPEAR_TIMEOUT)
+            }
+        },
+        beforeUnmount: () => {
+            window.clearTimeout(cache.timeout)
+        },
+    }),
+})

--- a/frontend/src/lib/experimental/npsLogic.ts
+++ b/frontend/src/lib/experimental/npsLogic.ts
@@ -1,11 +1,11 @@
 import { kea } from 'kea'
-import { npsLogicType } from 'lib/experimental/NPSPromptType'
 import { UserType } from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { userLogic } from 'scenes/userLogic'
 import dayjs from 'dayjs'
 import posthog from 'posthog-js'
+import { npsLogicType } from 'lib/experimental/npsLogicType'
 
 const NPS_APPEAR_TIMEOUT = 10000
 const NPS_HIDE_TIMEOUT = 3500
@@ -23,11 +23,11 @@ export const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
     selectors: {
         featureFlagEnabled: [
             () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags) => featureFlags[FEATURE_FLAGS.NPS_PROMPT],
+            (featureFlags) => !!featureFlags[FEATURE_FLAGS.NPS_PROMPT],
         ],
         userIsOldEnough: [
             () => [userLogic.selectors.user],
-            (user) => user && dayjs(user.date_joined).isBefore(dayjs().add(-15, 'day')),
+            (user) => !!user && dayjs(user.date_joined).isBefore(dayjs().add(-15, 'day')),
         ],
         npsPromptEnabled: [
             (s) => [s.featureFlagEnabled, s.userIsOldEnough],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -81,7 +81,11 @@ export default {
     // ],
 
     // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-    // moduleNameMapper: {},
+    moduleNameMapper: {
+        '^~/(.*)$': '<rootDir>/$1',
+        '^lib/(.*)$': '<rootDir>/lib/$1',
+        '^scenes/(.*)$': '<rootDir>/scenes/$1',
+    },
 
     // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
     // modulePathIgnorePatterns: [],
@@ -126,7 +130,7 @@ export default {
     // runner: "jest-runner",
 
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
+    setupFiles: ['../../jest.setup.js'],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
     setupFilesAfterEnv: ['givens/setup'],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import 'whatwg-fetch'


### PR DESCRIPTION
## Changes

As discussed in the standup, here's a draft PR that adds a partial test for `npsLogic`. While I chose this logic pseudorandomly (worked on it recently, and it had [a bug](https://github.com/PostHog/posthog/pull/4678) not so long ago), the approach here is generic enough to work for any logic.

For more context, if we go deep in the [data-first mindset](https://kea.js.org/blog/2021/05/14/data-first-frontend-revolution/) that Kea imposes, it makes sense to test that our data looks and behaves according to its spec... and won't break in the future. Hence frontend logic tests. This won't solve inconsistencies between kea <-> react (data <-> template), but if we get our data right, the views *should* be relatively trivial to get right.

My only worry is that if we fully embrace this approach, we'll have to write *a lot* more frontend JS code with every change, slowing us down. It might very well be worth it in the end.

Thoughts? Opinions? :)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
