### PR TITLE
Send duration + pathname for failed requests

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -32,6 +32,7 @@ class Api {
         url = maybeAddEnvironmentProperty(url)
 
         let response
+        const startTime = new Date().getTime()
         try {
             response = await fetch(url)
         } catch (e) {
@@ -39,7 +40,7 @@ class Api {
         }
 
         if (!response.ok) {
-            posthog.capture('client_request_failure', { url, method: 'GET', status: response.status })
+            reportError('GET', url, response, startTime)
             const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }
@@ -50,6 +51,7 @@ class Api {
             url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }
         const isFormData = data instanceof FormData
+        const startTime = new Date().getTime()
         const response = await fetch(url, {
             method: 'PATCH',
             headers: {
@@ -59,7 +61,7 @@ class Api {
             body: isFormData ? data : JSON.stringify(data),
         })
         if (!response.ok) {
-            posthog.capture('client_request_failure', { url, method: 'PATCH', status: response.status })
+            reportError('PATCH', url, response, startTime)
             const jsonData = await getJSONOrThrow(response)
             if (Array.isArray(jsonData)) {
                 throw jsonData
@@ -73,6 +75,7 @@ class Api {
             url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }
         const isFormData = data instanceof FormData
+        const startTime = new Date().getTime()
         const response = await fetch(url, {
             method: 'POST',
             headers: {
@@ -82,7 +85,7 @@ class Api {
             body: isFormData ? data : JSON.stringify(data),
         })
         if (!response.ok) {
-            posthog.capture('client_request_failure', { url, method: 'POST', status: response.status })
+            reportError('POST', url, response, startTime)
             const jsonData = await getJSONOrThrow(response)
             if (Array.isArray(jsonData)) {
                 throw jsonData
@@ -95,6 +98,7 @@ class Api {
         if (url.indexOf('http') !== 0) {
             url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }
+        const startTime = new Date().getTime()
         const response = await fetch(url, {
             method: 'DELETE',
             headers: {
@@ -103,7 +107,7 @@ class Api {
             },
         })
         if (!response.ok) {
-            posthog.capture('client_request_failure', { url, method: 'DELETE', status: response.status })
+            reportError('DELETE', url, response, startTime)
             const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }
@@ -158,6 +162,12 @@ function maybeAddEnvironmentProperty(url) {
     } else {
         return url
     }
+}
+
+function reportError(method, url, response, startTime) {
+    const duration = new Date().getTime() - startTime
+    const pathname = new URL(url).pathname
+    posthog.capture('client_request_failure', { pathname, method, duration, status: response.status })
 }
 
 let api = new Api()


### PR DESCRIPTION
Duration measure/verify a hypothesis - are we seeing some (> 500) errors
due to them taking too long? https://github.com/PostHog/posthog/issues/4682

Previous full url was useless due to search parameters

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
