### PR TITLE
Fix breakdown value containing event_

### DIFF
--- a/frontend/src/scenes/insights/BreakdownFilter/BreakdownFilter.js
+++ b/frontend/src/scenes/insights/BreakdownFilter/BreakdownFilter.js
@@ -23,7 +23,7 @@ function PropertyFilter({ breakdown, onChange }) {
             style={{ width: '100%' }}
             placeholder={'Break down by'}
             value={breakdown ? breakdown : undefined}
-            onChange={(_, item) => onChange(item.value.replace(/event_|person_/gi, ''), item.type)}
+            onChange={(_, item) => onChange(item.value, item.type)}
             filterOption={(input, option) => option.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
             data-attr="prop-breakdown-select"
         >
@@ -32,7 +32,7 @@ function PropertyFilter({ breakdown, onChange }) {
                     {Object.entries(eventProperties).map(([key, item], index) => (
                         <Select.Option
                             key={'event_' + key}
-                            value={'event_' + item.value}
+                            value={item.value}
                             type="event"
                             data-attr={'prop-breakdown-' + index}
                         >
@@ -46,7 +46,7 @@ function PropertyFilter({ breakdown, onChange }) {
                     {Object.entries(personProperties).map(([key, item], index) => (
                         <Select.Option
                             key={'person_' + key}
-                            value={'person_' + item.name}
+                            value={item.name}
                             type="person"
                             data-attr={'prop-filter-person-' + (eventProperties.length + index)}
                         >


### PR DESCRIPTION
## Changes

If you wanted to break down by a property key that had `event_` in the name, it would strip out the `event_` meaning you couldn't use it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
