### PR TITLE
Fix NPS reporting bug II

### DIFF
--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -75,7 +75,7 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
             }
         },
         dismiss: () => {
-            const result = typeof values.payload?.score !== 'undefined' ? 'partial' : 'dimissed'
+            const result = typeof values.payload?.score !== 'undefined' ? 'partial' : 'dismissed'
             actions.hide()
             actions.send(result)
         },

--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -75,8 +75,9 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
             }
         },
         dismiss: () => {
+            const result = typeof values.payload?.score !== 'undefined' ? 'partial' : 'dimissed'
             actions.hide()
-            actions.send('dismissed')
+            actions.send(result)
         },
         submit: ({ completed }) => {
             const result = completed ? 'completed' : 'partial'

--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -45,7 +45,9 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
         setStep: (step: Step) => ({ step }),
         stepBack: true,
         setPayload: (payload: NPSPayload | null) => ({ payload }),
-        submit: true,
+        submit: (completed?: boolean) => ({ completed }),
+        dismiss: true,
+        send: (result: 'completed' | 'partial' | 'dismissed') => ({ result }), // Sends response data to PostHog
     },
     reducers: {
         step: [
@@ -53,6 +55,7 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
             {
                 setStep: (_, { step }) => step,
                 stepBack: (state) => Math.max(state - 1, 0) as Step,
+                submit: () => 3,
                 // go to step 1 when selecting the score on step 0
                 setPayload: (state, { payload }) => (state === 0 && typeof payload?.score !== 'undefined' ? 1 : state),
             },
@@ -71,13 +74,22 @@ const npsLogic = kea<npsLogicType<NPSPayload, Step, UserType>>({
                 actions.setPayload(null)
             }
         },
-        submit: () => {
-            const result = ['dismissed', 'partial', 'partial', 'completed'][values.step]
+        dismiss: () => {
+            actions.hide()
+            actions.send('dismissed')
+        },
+        submit: ({ completed }) => {
+            const result = completed ? 'completed' : 'partial'
+            actions.send(result)
+            cache.timeout = window.setTimeout(() => actions.hide(), NPS_HIDE_TIMEOUT)
+        },
+        send: ({ result }) => {
             posthog.capture('nps feedback', { ...values.payload, result })
+
             // `nps_2106` is used to identify users who have replied to the NPS survey (via cohorts)
             posthog.people.set({ nps_2106: true })
+
             localStorage.setItem(NPS_LOCALSTORAGE_KEY, 'true')
-            cache.timeout = window.setTimeout(() => actions.hide(), NPS_HIDE_TIMEOUT)
         },
         show: () => {
             posthog.capture('nps modal shown')
@@ -103,7 +115,7 @@ be shown to a user, we follow these rules:
     which excludes a user from the feature flag.
 */
 export function NPSPrompt(): JSX.Element | null {
-    const { setStep, setPayload, stepBack, submit } = useActions(npsLogic)
+    const { setStep, setPayload, stepBack, submit, dismiss } = useActions(npsLogic)
     const { step, payload, hidden, npsPromptEnabled } = useValues(npsLogic)
 
     if (!npsPromptEnabled) {
@@ -126,7 +138,7 @@ export function NPSPrompt(): JSX.Element | null {
     return (
         <>
             <div className={`nps-prompt${hidden ? ' hide' : ''}`}>
-                <span className="nps-dismiss" onClick={submit}>
+                <span className="nps-dismiss" onClick={dismiss}>
                     <CloseOutlined />
                 </span>
                 <div className="prompt-inner">
@@ -160,7 +172,7 @@ export function NPSPrompt(): JSX.Element | null {
                                 onKeyDown={(e) => e.key === 'Enter' && e.metaKey && setStep(2)}
                             />
                             <div style={{ textAlign: 'left' }} className="mt">
-                                <Button type="link" style={{ paddingLeft: 0 }} onClick={submit}>
+                                <Button type="link" style={{ paddingLeft: 0 }} onClick={() => submit(false)}>
                                     Finish
                                 </Button>
                                 <Button style={{ float: 'right' }} onClick={() => setStep(2)}>
@@ -180,10 +192,10 @@ export function NPSPrompt(): JSX.Element | null {
                                 placeholder="You can describe their role, background, company or team size, ..."
                                 value={payload?.feedback_persona || ''}
                                 onChange={(e) => setPayload({ feedback_persona: e.target.value })}
-                                onKeyDown={(e) => e.key === 'Enter' && e.metaKey && setStep(3) && submit()}
+                                onKeyDown={(e) => e.key === 'Enter' && e.metaKey && submit(true)}
                             />
                             <div style={{ textAlign: 'left' }} className="mt">
-                                <Button style={{ float: 'right' }} onClick={() => setStep(3) && submit()}>
+                                <Button style={{ float: 'right' }} onClick={() => submit(true)}>
                                     Finish
                                 </Button>
                             </div>


### PR DESCRIPTION
## Changes

Fixes problem reported in #4678 but changes how we handle the `result` of the NPS survey.
- `dismissed` means the user closed the window without answering any question.
- `completed` means the user reached the end of the survey (saw the last question) and submitted the form, regardless of how the form was submitted (i.e. clicking the finish button, cmd/ctrl + enter or clicking the close window).
- `partial` is the else case, i.e. user answered at least question 1, but didn't get to the last step.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
