### PR TITLE
Insights table - New UI

### DIFF
--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -6,6 +6,7 @@ import './DateDisplay.scss'
 interface DateDisplayProps {
     date: string
     interval: IntervalType
+    hideWeekRange?: boolean
 }
 
 const DISPLAY_DATE_FORMAT: Record<IntervalType, string> = {
@@ -29,21 +30,21 @@ const dateHighlight = (parsedDate: dayjs.Dayjs, interval: IntervalType): string 
         case 'month':
             return parsedDate.format('YYYY')
         default:
-            return ''
+            return parsedDate.format('dd')
     }
 }
 
 /* Returns a single line standardized component to display the date depending on context.
     For example, a single date in a graph will be shown as: `Th` Apr 22.
 */
-export function DateDisplay({ date, interval }: DateDisplayProps): JSX.Element {
+export function DateDisplay({ date, interval, hideWeekRange }: DateDisplayProps): JSX.Element {
     const parsedDate = dayjs(date)
 
     return (
         <>
             <span className="dated-highlight">{dateHighlight(parsedDate, interval)}</span>
             {parsedDate.format(DISPLAY_DATE_FORMAT[interval])}
-            {interval === 'week' && (
+            {interval === 'week' && !hideWeekRange && (
                 <>
                     {/* TODO: @EDsCODE will help validate; this should probably come from the backend  */}
                     {' - '}

--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -79,7 +79,7 @@ export function InsightLabel({
                     />
                 )}
                 <div className="protect-width">
-                    {showEventName && <PropertyKeyInfo disableIcon value={eventName} />}
+                    {showEventName && <PropertyKeyInfo disableIcon disablePopover value={eventName} />}
 
                     {hasMultipleSeries && ((action?.math && action.math !== 'total') || showCountedByTag) && (
                         <MathTag math={action?.math} mathProperty={action?.math_property} />

--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -13,6 +13,8 @@ interface InsightsLabelProps {
     action?: ActionFilter
     value?: string
     breakdownValue?: string
+    hideBreakdown?: boolean // Whether to hide the breakdown detail in the label
+    hideIcon?: boolean // Whether to hide the icon that showcases the color of the series
     seriesStatus?: string // Used by lifecycle chart to display the series name
     fallbackName?: string // Name to display for the series if it can be determined from `action`
     hasMultipleSeries?: boolean // Whether the graph has multiple discrete series (not breakdown values)
@@ -47,6 +49,8 @@ export function InsightLabel({
     action,
     value,
     breakdownValue,
+    hideBreakdown,
+    hideIcon,
     seriesStatus,
     fallbackName,
     hasMultipleSeries,
@@ -58,7 +62,7 @@ export function InsightLabel({
     return (
         <Row className="insights-label" wrap={false}>
             <Col style={{ display: 'flex', alignItems: 'center' }} flex="auto">
-                {!(hasMultipleSeries && !breakdownValue) && (
+                {!(hasMultipleSeries && !breakdownValue) && !hideIcon && (
                     <div
                         className="color-icon"
                         style={{
@@ -81,7 +85,7 @@ export function InsightLabel({
                         <MathTag math={action?.math} mathProperty={action?.math_property} />
                     )}
 
-                    {breakdownValue && (
+                    {breakdownValue && !hideBreakdown && (
                         <>
                             {hasMultipleSeries && <span style={{ padding: '0 2px' }}>-</span>}
                             {breakdownValue === 'total' ? <i>Total</i> : breakdownValue}

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -10,6 +10,8 @@ import {
     endWithPunctation,
     dateFilterToText,
     hexToRGBA,
+    average,
+    median,
 } from './utils'
 
 describe('capitalizeFirstLetter()', () => {
@@ -166,5 +168,22 @@ describe('hexToRGBA()', () => {
         expect(hexToRGBA('#ff0000', 0.3)).toEqual('rgba(255,0,0,0.3)')
         expect(hexToRGBA('#0000Cc', 0)).toEqual('rgba(0,0,204,0)')
         expect(hexToRGBA('#5375ff', 1)).toEqual('rgba(83,117,255,1)')
+    })
+})
+
+describe('average()', () => {
+    it('calculates average correctly', () => {
+        expect(average([9, 4, 1, 3, 5, 7])).toEqual(4.8)
+        expect(average([72, 35, 68, 66, 70, 9, 81])).toEqual(57.3) // Tests rounding too
+        expect(average([86.4, 46.321, 45.304, 34.1, 147])).toEqual(71.8) // Tests rounding too
+    })
+})
+
+describe('median()', () => {
+    it('returns middle number if array length is odd', () => {
+        expect(median([9, 4, 1, 3, 5, 7, 3, 6, 14])).toEqual(5)
+    })
+    it('returns avg of middle numbers if array length is even', () => {
+        expect(median([9, 4, 0, 5, 7, 3, 6, 14])).toEqual(5.5)
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -908,3 +908,25 @@ export function lightenDarkenColor(hex: string, pct: number): string {
 export function toString(input?: any | null): string {
     return input?.toString() || ''
 }
+
+export function average(input: number[]): number {
+    /**
+     * Returns the average of an array
+     * @param input e.g. [100,50, 75]
+     */
+    return Math.round((input.reduce((acc, val) => acc + val, 0) / input.length) * 10) / 10
+}
+
+export function median(input: number[]): number {
+    /**
+     * Returns the median of an array
+     * @param input e.g. [3,7,10]
+     */
+    const sorted = input.sort((a, b) => a - b)
+    const half = Math.floor(sorted.length / 2)
+
+    if (sorted.length % 2) {
+        return sorted[half]
+    }
+    return average([sorted[half - 1], sorted[half]])
+}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -922,7 +922,7 @@ export function median(input: number[]): number {
      * Returns the median of an array
      * @param input e.g. [3,7,10]
      */
-    const sorted = input.sort((a, b) => a - b)
+    const sorted = [...input].sort((a, b) => a - b)
     const half = Math.floor(sorted.length / 2)
 
     if (sorted.length % 2) {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -123,6 +123,7 @@ export const eventUsageLogic = kea<
         reportSavedInsightToDashboard: true,
         reportInsightsTabReset: true,
         reportInsightsControlsCollapseToggle: (collapsed: boolean) => ({ collapsed }),
+        reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -430,8 +431,11 @@ export const eventUsageLogic = kea<
         reportInsightsTabReset: async () => {
             posthog.capture('insights tab reset')
         },
-        reportInsightsControlsCollapseToggle: async ({ collapsed }) => {
-            posthog.capture('insight controls collapse toggled', { collapsed })
+        reportInsightsControlsCollapseToggle: async (payload) => {
+            posthog.capture('insight controls collapse toggled', payload)
+        },
+        reportInsightsTableCalcToggled: async (payload) => {
+            posthog.capture('insights table calc toggled', payload)
         },
     },
 })

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -363,7 +363,7 @@ export function Insights(): JSX.Element {
                                 !showTimeoutMessage &&
                                 activeView === ViewType.FUNNELS &&
                                 allFilters.display === FUNNEL_VIZ && (
-                                    <Card style={{ marginTop: 16 }}>
+                                    <Card style={{ marginTop: 8 }}>
                                         <FunnelPeople />
                                     </Card>
                                 )}
@@ -371,11 +371,12 @@ export function Insights(): JSX.Element {
                                 allFilters.display === ACTIONS_LINE_GRAPH_LINEAR ||
                                 allFilters.display === ACTIONS_LINE_GRAPH_CUMULATIVE) &&
                                 (activeView === ViewType.TRENDS || activeView === ViewType.SESSIONS) && (
-                                    <Card style={{ marginTop: 16 }}>
+                                    <Card style={{ marginTop: 8 }}>
                                         <BindLogic
                                             logic={trendsLogic}
                                             props={{ dashboardItemId: null, view: activeView }}
                                         >
+                                            <h3 className="l3">Details table</h3>
                                             <InsightsTable showTotalCount={activeView !== ViewType.SESSIONS} />
                                         </BindLogic>
                                     </Card>

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -376,7 +376,7 @@ export function Insights(): JSX.Element {
                                             logic={trendsLogic}
                                             props={{ dashboardItemId: null, view: activeView }}
                                         >
-                                            <InsightsTable />
+                                            <InsightsTable showTotalCount={activeView !== ViewType.SESSIONS} />
                                         </BindLogic>
                                     </Card>
                                 )}

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 import { Tabs, Row, Col, Card, Button, Tooltip } from 'antd'
-import { ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_LINE_GRAPH_CUMULATIVE, FUNNEL_VIZ, FEATURE_FLAGS } from 'lib/constants'
+import { FUNNEL_VIZ, FEATURE_FLAGS, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE } from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'
 import { router } from 'kea-router'
 
@@ -368,9 +368,14 @@ export function Insights(): JSX.Element {
                                     </Card>
                                 )}
                             {(!allFilters.display ||
-                                allFilters.display === ACTIONS_LINE_GRAPH_LINEAR ||
-                                allFilters.display === ACTIONS_LINE_GRAPH_CUMULATIVE) &&
+                                (allFilters.display !== ACTIONS_TABLE &&
+                                    allFilters.display !== ACTIONS_BAR_CHART_VALUE)) &&
                                 (activeView === ViewType.TRENDS || activeView === ViewType.SESSIONS) && (
+                                    /* InsightsTable is loaded for all trend views (except below), plus the sessions view.
+                                    Exclusions:
+                                        1. Table view. Because table is already loaded anyways in `Trends.tsx` as the main component.
+                                        2. Bar value chart. Because this view displays data in completely different dimensions.
+                                    */
                                     <Card style={{ marginTop: 8 }}>
                                         <BindLogic
                                             logic={trendsLogic}

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
@@ -139,7 +139,7 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
             title: (
                 <DateDisplay
                     interval={(filters.interval as IntervalType) || 'day'}
-                    date={indexedResults[0].days[index]}
+                    date={(indexedResults[0].dates || indexedResults[0].days)[index]}
                     hideWeekRange
                 />
             ),

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
@@ -5,7 +5,7 @@ import { IndexedTrendResult, trendsLogic } from 'scenes/trends/trendsLogic'
 import { PHCheckbox } from 'lib/components/PHCheckbox'
 import { getChartColors } from 'lib/colors'
 import { cohortsModel } from '~/models/cohortsModel'
-import { CohortType } from '~/types'
+import { CohortType, IntervalType } from '~/types'
 import { ColumnsType } from 'antd/lib/table'
 import { average, median, maybeAddCommasToInteger } from 'lib/utils'
 import { InsightLabel } from 'lib/components/InsightLabel'
@@ -13,6 +13,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
 import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DateDisplay } from 'lib/components/DateDisplay'
 
 interface InsightsTableProps {
     isLegend?: boolean // `true` -> Used as a supporting legend at the bottom of another graph; `false` -> used as it's own display
@@ -135,7 +136,13 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
 
     if (indexedResults && indexedResults.length > 0) {
         const valueColumns: ColumnsType<IndexedTrendResult> = indexedResults[0].data.map(({}, index: number) => ({
-            title: indexedResults[0].labels[index],
+            title: (
+                <DateDisplay
+                    interval={(filters.interval as IntervalType) || 'day'}
+                    date={indexedResults[0].days[index]}
+                    hideWeekRange
+                />
+            ),
             render: function RenderPeriod({}, item: IndexedTrendResult) {
                 return maybeAddCommasToInteger(item.data[index])
             },

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
@@ -44,9 +44,9 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
 
     const isSingleEntity = indexedResults.length === 1
     const colorList = getChartColors('white')
-    const showCountedByTag = !!indexedResults.find(({ action: { math } }) => math && math !== 'total')
+    const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
 
-    function SeriesToggleWrapper({ children, id }: { children: JSX.Element; id: number }): JSX.Element {
+    function SeriesToggleWrapper({ children, id }: { children: JSX.Element | string; id: number }): JSX.Element {
         return (
             <div
                 style={{ cursor: isSingleEntity ? undefined : 'pointer' }}
@@ -101,7 +101,7 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
             render: function RenderBreakdownValue({}, item: IndexedTrendResult) {
                 return (
                     <SeriesToggleWrapper id={item.id}>
-                        <>{formatBreakdownLabel(item.breakdown_value, cohorts)}</>
+                        {formatBreakdownLabel(item.breakdown_value, cohorts)}
                     </SeriesToggleWrapper>
                 )
             },

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
@@ -14,6 +14,7 @@ import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
 import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DateDisplay } from 'lib/components/DateDisplay'
+import { ACTIONS_LINE_GRAPH_CUMULATIVE } from 'lib/constants'
 
 interface InsightsTableProps {
     isLegend?: boolean // `true` -> Used as a supporting legend at the bottom of another graph; `false` -> used as it's own display
@@ -166,7 +167,7 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
                     return average(item.data).toLocaleString()
                 } else if (calcColumnState === 'median') {
                     return median(item.data).toLocaleString()
-                } else if (calcColumnState === 'total' && filters.display === 'ActionsLineGraphCumulative') {
+                } else if (calcColumnState === 'total' && filters.display === ACTIONS_LINE_GRAPH_CUMULATIVE) {
                     // Special handling because `count` will contain the last amount, instead of the cumulative sum.
                     return item.data.reduce((acc, val) => acc + val, 0).toLocaleString()
                 }

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
@@ -31,10 +31,10 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
     const { toggleVisibility } = useActions(trendsLogic)
     const { cohorts } = useValues(cohortsModel)
     const { reportInsightsTableCalcToggled } = useActions(eventUsageLogic)
-    const hasUniqueFilter = !!(
+    const hasMathUniqueFilter = !!(
         filters.actions?.find(({ math }) => math === 'dau') || filters.events?.find(({ math }) => math === 'dau')
     )
-    const logic = insightsTableLogic({ hasUniqueFilter })
+    const logic = insightsTableLogic({ hasMathUniqueFilter })
     const { calcColumnState } = useValues(logic)
     const { setCalcColumnState } = useActions(logic)
 
@@ -166,6 +166,9 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
                     return average(item.data).toLocaleString()
                 } else if (calcColumnState === 'median') {
                     return median(item.data).toLocaleString()
+                } else if (calcColumnState === 'total' && filters.display === 'ActionsLineGraphCumulative') {
+                    // Special handling because `count` will contain the last amount, instead of the cumulative sum.
+                    return item.data.reduce((acc, val) => acc + val, 0).toLocaleString()
                 }
                 return (
                     <>

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTableV2.tsx
@@ -28,7 +28,7 @@ const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
 }
 
 export function InsightsTableV2({ isLegend = true, showTotalCount = false }: InsightsTableProps): JSX.Element | null {
-    const { indexedResults, visibilityMap, filters, numberOfSeries } = useValues(trendsLogic)
+    const { indexedResults, visibilityMap, filters } = useValues(trendsLogic)
     const { toggleVisibility } = useActions(trendsLogic)
     const { cohorts } = useValues(cohortsModel)
     const { reportInsightsTableCalcToggled } = useActions(eventUsageLogic)
@@ -111,29 +111,27 @@ export function InsightsTableV2({ isLegend = true, showTotalCount = false }: Ins
         })
     }
 
-    if (!(numberOfSeries === 1 && indexedResults[0].breakdown_value)) {
-        columns.push({
-            title: 'Event or Action',
-            render: function RenderLabel({}, item: IndexedTrendResult, index: number): JSX.Element {
-                return (
-                    <SeriesToggleWrapper id={item.id}>
-                        <InsightLabel
-                            seriesColor={colorList[index]}
-                            action={item.action}
-                            fallbackName={item.label}
-                            hasMultipleSeries={indexedResults.length > 1}
-                            showCountedByTag={showCountedByTag}
-                            breakdownValue={item.breakdown_value?.toString()}
-                            hideBreakdown
-                            hideIcon
-                        />
-                    </SeriesToggleWrapper>
-                )
-            },
-            fixed: 'left',
-            width: 200,
-        })
-    }
+    columns.push({
+        title: 'Event or Action',
+        render: function RenderLabel({}, item: IndexedTrendResult, index: number): JSX.Element {
+            return (
+                <SeriesToggleWrapper id={item.id}>
+                    <InsightLabel
+                        seriesColor={colorList[index]}
+                        action={item.action}
+                        fallbackName={item.label}
+                        hasMultipleSeries={indexedResults.length > 1}
+                        showCountedByTag={showCountedByTag}
+                        breakdownValue={item.breakdown_value?.toString()}
+                        hideBreakdown
+                        hideIcon
+                    />
+                </SeriesToggleWrapper>
+            )
+        },
+        fixed: 'left',
+        width: 200,
+    })
 
     if (indexedResults && indexedResults.length > 0) {
         const valueColumns: ColumnsType<IndexedTrendResult> = indexedResults[0].data.map(({}, index: number) => ({

--- a/frontend/src/scenes/insights/InsightsTable/index.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/index.tsx
@@ -99,15 +99,6 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
         })
     }
 
-    if (showTotalCount) {
-        columns.push({
-            title: 'Total',
-            dataIndex: 'count',
-            fixed: 'left',
-            width: 100,
-        })
-    }
-
     if (indexedResults && indexedResults.length > 0) {
         const valueColumns = indexedResults[0].data.map(({}, index: number) => ({
             title: indexedResults[0].labels[index],
@@ -117,6 +108,15 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
         }))
 
         columns.push(...valueColumns)
+    }
+
+    if (showTotalCount) {
+        columns.push({
+            title: 'Total',
+            dataIndex: 'count',
+            fixed: 'right',
+            width: 100,
+        })
     }
 
     return (

--- a/frontend/src/scenes/insights/InsightsTable/index.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/index.tsx
@@ -9,6 +9,7 @@ import { CohortType } from '~/types'
 import { ColumnsType } from 'antd/lib/table'
 import { maybeAddCommasToInteger } from 'lib/utils'
 import { InsightLabel } from 'lib/components/InsightLabel'
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 
 function formatBreakdownLabel(breakdown_value: string | number | undefined, cohorts: CohortType[]): string {
     if (breakdown_value && typeof breakdown_value == 'number') {
@@ -60,9 +61,20 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
         })
     }
 
+    if (filters.breakdown) {
+        columns.push({
+            title: <PropertyKeyInfo disableIcon disablePopover value={filters.breakdown || 'Breakdown Value'} />,
+            render: function RenderBreakdownValue({}, item: IndexedTrendResult) {
+                return formatBreakdownLabel(item.breakdown_value, cohorts)
+            },
+            fixed: 'left',
+            width: 150,
+        })
+    }
+
     if (!(numberOfSeries === 1 && indexedResults[0].breakdown_value)) {
         columns.push({
-            title: 'Series',
+            title: 'Event or Action',
             render: function RenderLabel({}, item: IndexedTrendResult, index: number): JSX.Element {
                 return (
                     <div
@@ -93,17 +105,6 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
             dataIndex: 'count',
             fixed: 'left',
             width: 100,
-        })
-    }
-
-    if (filters.breakdown) {
-        columns.push({
-            title: 'Breakdown Value',
-            render: function RenderBreakdownValue({}, item: IndexedTrendResult) {
-                return formatBreakdownLabel(item.breakdown_value, cohorts)
-            },
-            fixed: 'left',
-            width: 150,
         })
     }
 

--- a/frontend/src/scenes/insights/InsightsTable/index.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/index.tsx
@@ -26,7 +26,7 @@ interface InsightsTableProps {
 }
 
 export function InsightsTable({ isLegend = true, showTotalCount = false }: InsightsTableProps): JSX.Element | null {
-    const { indexedResults, visibilityMap, filters } = useValues(trendsLogic)
+    const { indexedResults, visibilityMap, filters, numberOfSeries } = useValues(trendsLogic)
     const { toggleVisibility } = useActions(trendsLogic)
     const { cohorts } = useValues(cohortsModel)
     const isSingleEntity = indexedResults.length === 1
@@ -60,30 +60,32 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
         })
     }
 
-    columns.push({
-        title: 'Series',
-        render: function RenderLabel({}, item: IndexedTrendResult, index: number): JSX.Element {
-            return (
-                <div
-                    style={{ cursor: isSingleEntity ? undefined : 'pointer' }}
-                    onClick={() => !isSingleEntity && toggleVisibility(item.id)}
-                >
-                    <InsightLabel
-                        seriesColor={colorList[index]}
-                        action={item.action}
-                        fallbackName={item.label}
-                        hasMultipleSeries={indexedResults.length > 1}
-                        showCountedByTag={showCountedByTag}
-                        breakdownValue={item.breakdown_value?.toString()}
-                        hideBreakdown
-                        hideIcon
-                    />
-                </div>
-            )
-        },
-        fixed: 'left',
-        width: 200,
-    })
+    if (!(numberOfSeries === 1 && indexedResults[0].breakdown_value)) {
+        columns.push({
+            title: 'Series',
+            render: function RenderLabel({}, item: IndexedTrendResult, index: number): JSX.Element {
+                return (
+                    <div
+                        style={{ cursor: isSingleEntity ? undefined : 'pointer' }}
+                        onClick={() => !isSingleEntity && toggleVisibility(item.id)}
+                    >
+                        <InsightLabel
+                            seriesColor={colorList[index]}
+                            action={item.action}
+                            fallbackName={item.label}
+                            hasMultipleSeries={indexedResults.length > 1}
+                            showCountedByTag={showCountedByTag}
+                            breakdownValue={item.breakdown_value?.toString()}
+                            hideBreakdown
+                            hideIcon
+                        />
+                    </div>
+                )
+            },
+            fixed: 'left',
+            width: 200,
+        })
+    }
 
     if (showTotalCount) {
         columns.push({

--- a/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
@@ -1,0 +1,18 @@
+import { kea } from 'kea'
+import { insightsTableLogicType } from './insightsTableLogicType'
+
+export type CalcColumnState = 'total' | 'average' | 'median'
+
+export const insightsTableLogic = kea<insightsTableLogicType<CalcColumnState>>({
+    actions: {
+        setCalcColumnState: (state: CalcColumnState) => ({ state }),
+    },
+    reducers: {
+        calcColumnState: [
+            'total' as CalcColumnState,
+            {
+                setCalcColumnState: (_, { state }) => state,
+            },
+        ],
+    },
+})

--- a/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
@@ -4,15 +4,18 @@ import { insightsTableLogicType } from './insightsTableLogicType'
 export type CalcColumnState = 'total' | 'average' | 'median'
 
 export const insightsTableLogic = kea<insightsTableLogicType<CalcColumnState>>({
+    props: {} as {
+        hasUniqueFilter: boolean
+    },
     actions: {
         setCalcColumnState: (state: CalcColumnState) => ({ state }),
     },
-    reducers: {
+    reducers: ({ props }) => ({
         calcColumnState: [
-            'total' as CalcColumnState,
+            (props.hasUniqueFilter ? 'average' : 'total') as CalcColumnState,
             {
                 setCalcColumnState: (_, { state }) => state,
             },
         ],
-    },
+    }),
 })

--- a/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
@@ -5,14 +5,14 @@ export type CalcColumnState = 'total' | 'average' | 'median'
 
 export const insightsTableLogic = kea<insightsTableLogicType<CalcColumnState>>({
     props: {} as {
-        hasUniqueFilter: boolean
+        hasMathUniqueFilter: boolean
     },
     actions: {
         setCalcColumnState: (state: CalcColumnState) => ({ state }),
     },
     reducers: ({ props }) => ({
         calcColumnState: [
-            (props.hasUniqueFilter ? 'average' : 'total') as CalcColumnState,
+            (props.hasMathUniqueFilter ? 'average' : 'total') as CalcColumnState,
             {
                 setCalcColumnState: (_, { state }) => state,
             },

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { PersonModal } from './PersonModal'
 import {
     ACTIONS_LINE_GRAPH_LINEAR,
@@ -47,7 +47,11 @@ export function TrendInsight({ view }: Props): JSX.Element {
             if (view === ViewType.SESSIONS && _filters.session === 'dist') {
                 return <ActionsTable filters={_filters} view={view} />
             }
-            return <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
+            return (
+                <BindLogic logic={trendsLogic} props={{ dashboardItemId: null, view, filters: null }}>
+                    <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
+                </BindLogic>
+            )
         }
         if (_filters.display === ACTIONS_PIE_CHART) {
             return <ActionsPie filters={_filters} view={view} />

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -8,7 +8,6 @@ import {
     ACTIONS_PIE_CHART,
     ACTIONS_BAR_CHART,
     ACTIONS_BAR_CHART_VALUE,
-    FEATURE_FLAGS,
 } from 'lib/constants'
 
 import { ActionsPie, ActionsLineGraph, ActionsBarValueGraph, ActionsTable } from './viz'
@@ -17,7 +16,6 @@ import { trendsLogic } from './trendsLogic'
 import { ViewType } from 'scenes/insights/insightLogic'
 import { InsightsTable } from 'scenes/insights/InsightsTable'
 import { Button } from 'antd'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 interface Props {
     view: ViewType
@@ -35,7 +33,6 @@ export function TrendInsight({ view }: Props): JSX.Element {
     const { saveCohortWithFilters, refreshCohort, loadMoreBreakdownValues } = useActions(
         trendsLogic({ dashboardItemId: null, view, filters: null })
     )
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const renderViz = (): JSX.Element | undefined => {
         if (
@@ -50,12 +47,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
             if (view === ViewType.SESSIONS && _filters.session === 'dist') {
                 return <ActionsTable filters={_filters} view={view} />
             }
-            return (
-                <InsightsTable
-                    isLegend={false}
-                    showTotalCount={featureFlags[FEATURE_FLAGS.NEW_TOOLTIPS] && view !== ViewType.SESSIONS}
-                />
-            )
+            return <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
         }
         if (_filters.display === ACTIONS_PIE_CHART) {
             return <ActionsPie filters={_filters} view={view} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -643,6 +643,7 @@ export interface TrendResult {
     count: number
     data: number[]
     days: string[]
+    dates?: string[]
     label: string
     labels: string[]
     breakdown_value?: string | number


### PR DESCRIPTION
## Changes

Closes #4492.
- Improves insights table to display smart/useful column and row names.
- Adds median and average options for row calculation.

<img width="1232" alt="" src="https://user-images.githubusercontent.com/5864173/121706725-e5464600-caa3-11eb-8759-02909d0d8a29.png">
<img width="1227" alt="" src="https://user-images.githubusercontent.com/5864173/121706733-e7100980-caa3-11eb-991d-8bd6cf3d30c9.png">
<img width="1224" alt="" src="https://user-images.githubusercontent.com/5864173/121706742-e8d9cd00-caa3-11eb-93d5-ac82b442fc95.png">
<img width="1279" alt="" src="https://user-images.githubusercontent.com/5864173/121706748-eaa39080-caa3-11eb-97db-03cb9fab088d.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
