### PR TITLE
Temporarily use forked version of clickhouse-pool

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,13 +1,13 @@
 # pip-compile requirements.in
 
 git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
+git+https://github.com/macobo/clickhouse-pool.git@fix-clickhouse-pool-release-on-error
 amqp==2.5.2
 asgiref==3.3.1
 aioch==0.0.2
 celery==4.4.2
 celery-redbeat==2.0.0
 clickhouse-driver==0.2.0
-clickhouse-pool==0.4.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
 Django==3.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ clickhouse-driver==0.2.0
     #   -r requirements.in
     #   aioch
     #   clickhouse-pool
-clickhouse-pool==0.4.3
+git+https://github.com/macobo/clickhouse-pool.git@fix-clickhouse-pool-release-on-error
     # via -r requirements.in
 cryptography==3.4.7
     # via


### PR DESCRIPTION
Fixed a bug upstream, waiting for it to get released. https://github.com/ericmccarthy7/clickhouse-pool/pull/12

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
