### PR TITLE
Bump clickhouse dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,13 +1,13 @@
 # pip-compile requirements.in
 
 git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
-git+https://github.com/macobo/clickhouse-pool.git@fix-clickhouse-pool-release-on-error
 amqp==2.5.2
 asgiref==3.3.1
 aioch==0.0.2
 celery==4.4.2
 celery-redbeat==2.0.0
-clickhouse-driver==0.2.0
+clickhouse-driver==0.2.1
+clickhouse-pool==0.5.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
 Django==3.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,12 +32,12 @@ cffi==1.14.5
     # via cryptography
 chardet==3.0.4
     # via requests
-clickhouse-driver==0.2.0
+clickhouse-driver==0.2.1
     # via
     #   -r requirements.in
     #   aioch
     #   clickhouse-pool
-git+https://github.com/macobo/clickhouse-pool.git@fix-clickhouse-pool-release-on-error
+clickhouse-pool==0.5.3
     # via -r requirements.in
 cryptography==3.4.7
     # via


### PR DESCRIPTION
## Changes

Bumps two libraries to latest versions.

Changelogs:
- https://github.com/mymarilyn/clickhouse-driver/blob/master/CHANGELOG.md
- https://github.com/ericmccarthy7/clickhouse-pool/releases/tag/v0.5.3

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
