### PR TITLE
Set gunicorn keepalive to 120 (seconds)

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -3,6 +3,7 @@
 
 
 loglevel = "error"
+keepalive = 120
 
 
 def on_starting(server):


### PR DESCRIPTION
We're hosting gunicorn behind an ELB with idle timeout of 120 seconds.

I think this is leading to sporatic 504 errors:

https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/ts-elb-error-message.html

> HTTP 504: Gateway timeout
> Cause 2: Registered instances closing the connection to Elastic Load Balancing.
> Solution 2: Enable keep-alive settings on your EC2 instances and make sure that the keep-alive timeout is greater than the idle timeout settings of your load balancer.

Related reading: https://serverfault.com/questions/782022/keepalive-setting-for-gunicorn-behind-elb-without-nginx

Not 100% this is appropriate for setups without ELB but let's deploy,
see if it makes a dent on monitoring and then move appropriately (e.g.
env variable this)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
