### PR TITLE
Closes #4679 fix deleting persons

### DIFF
--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -108,7 +108,7 @@ def delete_person(
         "team_id": team_id,
         "properties": json.dumps(properties),
         "is_identified": int(is_identified),
-        "created_at": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
+        "created_at": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
         "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
     }
 


### PR DESCRIPTION
## Changes

Annoyingly I can't reproduce this in a test, but looks like we shouldn't add the microseconds at the end? Though this might cause more race condition errors so not particularly confident about this fix.

Fixes this sentry error: https://sentry.io/organizations/posthog/issues/2443024201/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
