### PR TITLE
Fix cypress component tests

### DIFF
--- a/frontend/src/lib/hooks/useEventListener.ts
+++ b/frontend/src/lib/hooks/useEventListener.ts
@@ -32,7 +32,7 @@ export function useEventListener(
             element.addEventListener(eventName, eventListener)
             // Remove event listener on cleanup
             return () => {
-                element.removeEventListener(eventName, eventListener)
+                element?.removeEventListener(eventName, eventListener)
             }
         },
         [eventName, element, ...(deps || [])] // Re-run if eventName or element changes

--- a/frontend/src/scenes/sessions/Sessions.cy-spec.js
+++ b/frontend/src/scenes/sessions/Sessions.cy-spec.js
@@ -78,7 +78,7 @@ describe('<Sessions />', () => {
 
         cy.get('[data-attr="sessions-filter-open"]').click()
         cy.focused().type('br').wait(150).type('{downarrow}').wait(150).type('{enter}').wait(150)
-        cy.get('.sessions-filter-row input').last().click().type('Chrome').wait(150).type('{enter}').wait(150)
+        cy.get('.sessions-filter-row input').last().click().wait(150).type('Chrome').wait(150).type('{enter}').wait(150)
 
         cy.contains('There are unapplied filters').should('be.visible')
         cy.get('[data-attr="sessions-apply-filters"]').click()


### PR DESCRIPTION
## Changes

Seems like #4686 broke Cypress Component Tests. Problem is the new component we use for filters is set to `readonly` until we click on it. This should fix it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
