### PR TITLE
Property tags can be undefined

### DIFF
--- a/frontend/src/scenes/events/definitions/DefinitionDrawer.tsx
+++ b/frontend/src/scenes/events/definitions/DefinitionDrawer.tsx
@@ -68,7 +68,7 @@ export function DefinitionDrawer(): JSX.Element {
                                             <Col>
                                                 <h4 className="l4">Tags</h4>
                                                 <ObjectTags
-                                                    tags={definition.tags}
+                                                    tags={definition.tags || []}
                                                     onTagSave={saveNewTag}
                                                     onTagDelete={deleteTag}
                                                     saving={definitionLoading}

--- a/frontend/src/scenes/events/definitions/DefinitionDrawer.tsx
+++ b/frontend/src/scenes/events/definitions/DefinitionDrawer.tsx
@@ -73,7 +73,7 @@ export function DefinitionDrawer(): JSX.Element {
                                                     onTagDelete={deleteTag}
                                                     saving={definitionLoading}
                                                     tagsAvailable={eventDefinitionTags.filter(
-                                                        (tag) => !definition.tags.includes(tag)
+                                                        (tag) => !definition.tags?.includes(tag)
                                                     )}
                                                 />
                                             </Col>

--- a/frontend/src/scenes/events/definitions/definitionDrawerLogic.ts
+++ b/frontend/src/scenes/events/definitions/definitionDrawerLogic.ts
@@ -99,11 +99,12 @@ export const definitionDrawerLogic = kea<definitionDrawerLogicType<EventOrPropTy
     selectors: () => ({
         eventDefinitionTags: [
             () => [eventDefinitionsModel.selectors.eventDefinitions],
-            (definitions: EventDefinition[]): string[] =>
-                uniqueBy(
-                    definitions.flatMap(({ tags }) => tags),
-                    (item) => item
-                ).sort(),
+            (definitions: EventDefinition[]): string[] => {
+                const allTags = definitions
+                    .flatMap(({ tags }) => tags)
+                    .filter((a) => typeof a !== 'undefined') as string[]
+                return uniqueBy(allTags, (item) => item).sort()
+            },
         ],
     }),
     listeners: ({ actions, values }) => ({
@@ -116,7 +117,7 @@ export const definitionDrawerLogic = kea<definitionDrawerLogicType<EventOrPropTy
             actions.loadEventsSnippet(response)
         },
         saveNewTag: ({ tag }) => {
-            if (values.definition?.tags.includes(tag)) {
+            if (values.definition?.tags?.includes(tag)) {
                 errorToast('Oops! This tag is already set', 'This event already includes the proposed tag.')
                 return
             }
@@ -125,7 +126,7 @@ export const definitionDrawerLogic = kea<definitionDrawerLogicType<EventOrPropTy
         },
         deleteTag: async ({ tag }, breakpoint) => {
             await breakpoint(100)
-            const tags = values.definition?.tags.filter((_tag: string) => _tag !== tag)
+            const tags = values.definition?.tags?.filter((_tag: string) => _tag !== tag) || []
             actions.updateDefinition({ tags })
         },
         changeOwner: ({ ownerId }) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -776,7 +776,7 @@ export interface EventDefinition {
     id: string
     name: string
     description: string
-    tags: string[]
+    tags?: string[]
     volume_30_day: number | null
     query_usage_30_day: number | null
     owner?: UserBasicType | null
@@ -788,7 +788,7 @@ export interface PropertyDefinition {
     id: string
     name: string
     description: string
-    tags: string[]
+    tags?: string[]
     volume_30_day: number | null
     query_usage_30_day: number | null
     owner?: UserBasicType | null


### PR DESCRIPTION
## Changes

- Tries to fix [this sentry error](https://sentry.io/organizations/posthog/issues/2455013503/?referrer=slack)
- Looking at API responses, tags were often `undefined`, yet the interface doesn't think so.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
