### PR TITLE
Fix toolbar dropdown z-index

### DIFF
--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -1,6 +1,6 @@
 import 'react-toastify/dist/ReactToastify.css'
-import '~/toolbar/styles.scss'
 import '~/styles'
+import '~/toolbar/styles.scss'
 
 import React from 'react'
 import ReactDOM from 'react-dom'


### PR DESCRIPTION
## Changes

`styles/style.scss` contains the following:

```scss
.ant-select-dropdown {
    z-index: 1065 !important;
}
```

`toolbar/styles.scss` contains the following:

```scss
.ant-select-dropdown {
    z-index: 2147483031 !important;
}
```

The former was overwriting the latter, causing this:

![2021-06-14 16 45 09](https://user-images.githubusercontent.com/53387/121911311-f30ffb80-cd2f-11eb-9fab-5d8c03955f95.gif)

Fixed by swapping them around.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
