### PR TITLE
Add limit to clickhouse sql events

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -47,7 +47,7 @@ class ClickhouseEventsViewSet(EventViewSet):
         self, filter: Filter, team: Team, request: Request, long_date_from: bool = False, limit: int = 100
     ) -> List:
         limit += 1
-        limit_sql = f"LIMIT %(limit)"
+        limit_sql = "LIMIT %(limit)s"
         conditions, condition_params = determine_event_conditions(
             team,
             {
@@ -86,7 +86,7 @@ class ClickhouseEventsViewSet(EventViewSet):
         if is_csv_request:
             limit = self.CSV_EXPORT_LIMIT
         elif self.request.GET.get("limit", None):
-            limit = int(self.request.GET.get("limit"))
+            limit = int(self.request.GET.get("limit"))  # type: ignore
         else:
             limit = 100
 

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -46,7 +46,8 @@ class ClickhouseEventsViewSet(EventViewSet):
     def _query_events_list(
         self, filter: Filter, team: Team, request: Request, long_date_from: bool = False, limit: int = 100
     ) -> List:
-        limit_sql = f"LIMIT {limit + 1}"
+        limit += 1
+        limit_sql = f"LIMIT %(limit)"
         conditions, condition_params = determine_event_conditions(
             team,
             {
@@ -72,17 +73,22 @@ class ClickhouseEventsViewSet(EventViewSet):
         if prop_filters != "":
             return sync_execute(
                 SELECT_EVENT_WITH_PROP_SQL.format(conditions=conditions, limit=limit_sql, filters=prop_filters),
-                {"team_id": team.pk, **condition_params, **prop_filter_params},
+                {"team_id": team.pk, "limit": limit, **condition_params, **prop_filter_params},
             )
         else:
             return sync_execute(
                 SELECT_EVENT_WITH_ARRAY_PROPS_SQL.format(conditions=conditions, limit=limit_sql),
-                {"team_id": team.pk, **condition_params},
+                {"team_id": team.pk, "limit": limit, **condition_params},
             )
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         is_csv_request = self.request.accepted_renderer.format == "csv"
-        limit = self.CSV_EXPORT_LIMIT if is_csv_request else 100
+        if is_csv_request:
+            limit = self.CSV_EXPORT_LIMIT
+        elif self.request.GET.get("limit", None):
+            limit = int(self.request.GET.get("limit"))
+        else:
+            limit = 100
 
         team = self.team
         filter = Filter(request=request)


### PR DESCRIPTION
## Changes

For the definitions drawer, we include a snippet of the events table. We want to be able to add a limit to the Clickhouse api call for events so we don't return unnecessary data

<img width="959" alt="Screen Shot 2021-06-14 at 10 58 47 AM" src="https://user-images.githubusercontent.com/25164963/121913863-bfb57880-ccff-11eb-9837-6a9032bc7715.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
