### PR TITLE
Date filter range UI bug

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -146,7 +146,6 @@ function HorizontalDefaultInsightDisplayConfig({
                 <TZIndicator style={{ float: 'left', fontSize: '0.75rem', marginRight: 16 }} placement="topRight" />
             </span>
             <div style={{ width: '100%', textAlign: 'right' }}>
-                {showComparePrevious[activeView] && <CompareFilter />}
                 {showChartFilter(activeView, featureFlags) && (
                     <ChartFilter
                         onChange={(display: DisplayType) => {
@@ -176,6 +175,8 @@ function HorizontalDefaultInsightDisplayConfig({
                         />
                     </>
                 )}
+
+                {showComparePrevious[activeView] && <CompareFilter />}
             </div>
         </div>
     )


### PR DESCRIPTION
## Changes
Closes #4345 
Re-order the config options so that date filter doesn't get cut off

<img width="784" alt="Screen Shot 2021-06-14 at 3 21 00 PM" src="https://user-images.githubusercontent.com/25164963/121947757-6c095600-cd24-11eb-98d8-8ebdba24e466.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
