### PR TITLE
New doc links + copy for Plugins in Source Editor

### DIFF
--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -42,8 +42,10 @@ export function Plugins({ user }: { user: UserType }): JSX.Element | null {
                 }
                 caption={
                     <>
-                        Plugins enable you to extend PostHog's core data processing functionality. You can also{' '}
-                        <a href="https://posthog.com/docs/plugins/build">build your own.</a>
+                        Plugins enable you to extend PostHog's core data processing functionality. You can even{' '}
+                        <a href="https://posthog.com/docs/plugins/build" target="_blank">
+                            build your own.
+                        </a>
                     </>
                 }
             />

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -42,10 +42,17 @@ export function Plugins({ user }: { user: UserType }): JSX.Element | null {
                 }
                 caption={
                     <>
-                        Plugins enable you to extend PostHog's core data processing functionality. You can even{' '}
+                        Plugins enable you to extend PostHog's core data processing functionality.
+                        <br />
+                        Make use of verified plugins from the{' '}
+                        <a href="https://posthog.com/plugins" target="_blank">
+                            Plugin Library
+                        </a>{' '}
+                        – or{' '}
                         <a href="https://posthog.com/docs/plugins/build" target="_blank">
-                            build your own.
+                            build your own
                         </a>
+                        .
                     </>
                 }
             />

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -12,34 +12,36 @@ import SCAFFOLD_errors from '!raw-loader!@posthog/plugin-scaffold/dist/errors.d.
 // @ts-ignore
 import SCAFFOLD_types from '!raw-loader!@posthog/plugin-scaffold/dist/types.d.ts'
 
-const defaultSource = `// Learn more about plugins at: https://posthog.com/docs/plugins/overview
-import { Plugin } from '@posthog/plugin-scaffold'
+const defaultSource = `
+// Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
 
-type MyPluginType = Plugin<{
-  config: {
-    username: string
-  },
-  global: {},
-}>
-
-const MyPlugin: MyPluginType = {
-  setupPlugin: async (meta) => {
-    
-  },
-  onEvent: async (event, meta) => {
-    console.log(\`Event \${event.event} has been processed!\`)
-  },
+/* Runs on every event */
+function processEvent(event, { config }) {
+    // Some events (like $identify) don't have properties
+    if (event.properties) {
+        event.properties['hello'] = \`Hello \${config.name || 'world'}\`
+    }
+    // Return the event to ingest, return nothing to discard  
+    return event
 }
 
-export default MyPlugin
-`
+/* Runs once on plugin installation */
+function setupPlugin (meta) {
+
+}
+
+/* Runs once every full hour */
+// function runEveryHour(meta) {
+//     const weather = await (await fetch('https://weather.example.api/?city=New+York')).json()
+//     posthog.capture('weather', { degrees: weather.deg, fahrenheit: weather.us })
+}`
 
 const defaultConfig = [
     {
         markdown: 'Specify your config here',
     },
     {
-        key: 'username',
+        key: 'name',
         name: 'Person to greet',
         type: 'string',
         hint: 'Used to personalise the property `hello`',
@@ -101,8 +103,12 @@ export function PluginSource(): JSX.Element {
                 {editingSource ? (
                     <>
                         <p>
-                            <a href="https://posthog.com/docs/plugins/build" target="_blank">
+                            <a href="https://posthog.com/docs/plugins/build/overview" target="_blank">
                                 Read the documentation.
+                            </a>
+                            Happy with your plugin? You can also
+                            <a href="https://posthog.com/docs/plugins/build/tutorial#" target="_blank">
+                                submit it to the official plugin repository
                             </a>
                         </p>
                         <Form.Item label="Name" name="name" required rules={[requiredRule]}>

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -12,29 +12,30 @@ import SCAFFOLD_errors from '!raw-loader!@posthog/plugin-scaffold/dist/errors.d.
 // @ts-ignore
 import SCAFFOLD_types from '!raw-loader!@posthog/plugin-scaffold/dist/types.d.ts'
 
-const defaultSource = `
-// Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
+const defaultSource = `// Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
 
-/* Runs on every event */
+// Processes each event, optionally transforming it
 export function processEvent(event, { config }) {
-    // Some events (like $identify) don't have properties
+    // Some events (such as $identify) don't have properties
     if (event.properties) {
         event.properties['hello'] = \`Hello \${config.name}\`
     }
-    // Return the event to ingest, return nothing to discard  
+    // Return the event to be ingested, or return null to discard
     return event
 }
 
-/* Runs once on plugin installation */
+// Runs when the plugin is loaded, allows for preparing it as needed
 export function setupPlugin (meta) {
-
+    console.log(\`The date is \${new Date().toDateString()}\`)
 }
 
-/* Runs once every full hour */
-// function runEveryHour(meta) {
-//     const weather = await (await fetch('https://weather.example.api/?city=New+York')).json()
-//     posthog.capture('weather', { degrees: weather.deg, fahrenheit: weather.us })
-// }`
+// Runs every hour on the hour
+async function runEveryHour(meta) {
+    const response = await fetch('https://palabras-aleatorias-public-api.herokuapp.com/random')
+    const data = await response.json()
+    const randomSpanishWord = data.body.Word
+    console.log(\`¡\${randomSpanishWord.toUpperCase()}!\`)
+}`
 
 const defaultConfig = [
     {
@@ -102,18 +103,20 @@ export function PluginSource(): JSX.Element {
                 {editingSource ? (
                     <>
                         <p>
-                            Feeling lost?{' '}
+                            Read our{' '}
                             <a href="https://posthog.com/docs/plugins/build/overview" target="_blank">
-                                Read the documentation.
-                            </a>
+                                plugin building overview in PostHog Docs
+                            </a>{' '}
+                            for a good grasp of possibilities.
                             <br />
-                            Happy with your plugin?{' '}
+                            Once satisfied with your plugin, feel free to{' '}
                             <a
                                 href="https://posthog.com/docs/plugins/build/tutorial#submitting-your-plugin"
                                 target="_blank"
                             >
-                                Submit it to the official plugin repository.
+                                submit it to the official Plugin Library
                             </a>
+                            .
                         </p>
                         <Form.Item label="Name" name="name" required rules={[requiredRule]}>
                             <Input />

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -16,17 +16,17 @@ const defaultSource = `
 // Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
 
 /* Runs on every event */
-function processEvent(event, { config }) {
+export function processEvent(event, { config }) {
     // Some events (like $identify) don't have properties
     if (event.properties) {
-        event.properties['hello'] = \`Hello \${config.name || 'world'}\`
+        event.properties['hello'] = \`Hello \${config.name}\`
     }
     // Return the event to ingest, return nothing to discard  
     return event
 }
 
 /* Runs once on plugin installation */
-function setupPlugin (meta) {
+export function setupPlugin (meta) {
 
 }
 
@@ -34,7 +34,7 @@ function setupPlugin (meta) {
 // function runEveryHour(meta) {
 //     const weather = await (await fetch('https://weather.example.api/?city=New+York')).json()
 //     posthog.capture('weather', { degrees: weather.deg, fahrenheit: weather.us })
-}`
+// }`
 
 const defaultConfig = [
     {
@@ -45,9 +45,8 @@ const defaultConfig = [
         name: 'Person to greet',
         type: 'string',
         hint: 'Used to personalise the property `hello`',
-        default: '',
+        default: 'world',
         required: false,
-        order: 2,
     },
 ]
 
@@ -103,12 +102,17 @@ export function PluginSource(): JSX.Element {
                 {editingSource ? (
                     <>
                         <p>
+                            Feeling lost?{' '}
                             <a href="https://posthog.com/docs/plugins/build/overview" target="_blank">
                                 Read the documentation.
                             </a>
-                            Happy with your plugin? You can also
-                            <a href="https://posthog.com/docs/plugins/build/tutorial#" target="_blank">
-                                submit it to the official plugin repository
+                            <br />
+                            Happy with your plugin?{' '}
+                            <a
+                                href="https://posthog.com/docs/plugins/build/tutorial#submitting-your-plugin"
+                                target="_blank"
+                            >
+                                Submit it to the official plugin repository.
                             </a>
                         </p>
                         <Form.Item label="Name" name="name" required rules={[requiredRule]}>


### PR DESCRIPTION
## Changes

To come after https://github.com/PostHog/posthog.com/pull/1467.

Also reverting the basic example to export just the special functions we mention everywhere else in the documentation.

Our starter-kit template now points to a full fledged typescript example, which explains typescript support better.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
