### PR TITLE
Improve action creation process for elements

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.js
+++ b/frontend/src/scenes/actions/ActionStep.js
@@ -25,9 +25,10 @@ export class ActionStep extends Component {
 
         return (
             <div className="mb">
-                <label>
+                <label style={{ fontWeight: 'bold' }}>
                     {props.label} {props.extra_options}
                 </label>
+                {props.caption && <div className="action-step-caption">{props.caption}</div>}
                 {props.item === 'selector' ? (
                     <Input.TextArea allowClear onChange={onChange} value={this.props.step[props.item] || ''} />
                 ) : (
@@ -101,17 +102,32 @@ export class ActionStep extends Component {
                 </span>
                 <this.Option
                     item="href"
-                    label="Link href equals"
+                    label="Link target equals"
+                    caption={
+                        <>
+                            If your element is a link, the location that the link opens (<code>href</code> tag)
+                        </>
+                    }
                     selector={this.state.element && 'a[href="' + this.state.element.getAttribute('href') + '"]'}
                 />
                 <AndC />
-                <this.Option item="text" label="Text equals" />
+                <this.Option item="text" label="Text equals" caption="Text content inside your element" />
                 <AndC />
-                <this.Option item="selector" label="HTML selector matches" selector={step.selector} />
+                <this.Option
+                    item="selector"
+                    label="HTML selector matches"
+                    selector={step.selector}
+                    caption="CSS selector that ideally uniquely identifies your element"
+                />
                 <div style={{ marginBottom: 18 }}>
                     <AndC />
                 </div>
-                <this.Option item="url" extra_options={<this.URLMatching step={step} />} label="URL" />
+                <this.Option
+                    item="url"
+                    extra_options={<this.URLMatching step={step} />}
+                    label="Page URL"
+                    caption="Elements will match only when triggered from the URL (particularly useful if you have non-unique elements in different pages)."
+                />
                 {step?.url_matching && step.url_matching in URL_MATCHING_HINTS && (
                     <small style={{ display: 'block', marginTop: -12 }}>{URL_MATCHING_HINTS[step.url_matching]}</small>
                 )}
@@ -128,7 +144,6 @@ export class ActionStep extends Component {
                 onChange={handleURLMatchChange}
                 value={step.url_matching || 'contains'}
                 size="small"
-                style={{ paddingBottom: 16 }}
             >
                 <Radio.Button value="contains">contains</Radio.Button>
                 <Radio.Button value="regex">matches regex</Radio.Button>

--- a/frontend/src/scenes/actions/Actions.scss
+++ b/frontend/src/scenes/actions/Actions.scss
@@ -63,6 +63,12 @@
     margin-bottom: 0;
     height: 100%;
 
+    .action-step-caption {
+        font-size: 0.8em;
+        color: $text_muted;
+        padding-bottom: $default_spacing;
+    }
+
     .remove-wrapper {
         position: absolute;
         right: 0;

--- a/frontend/src/toolbar/actions/ActionsTab.scss
+++ b/frontend/src/toolbar/actions/ActionsTab.scss
@@ -29,6 +29,12 @@
         font-size: 12px;
         margin-top: 4px;
     }
+
+    .action-field-caption {
+        font-size: 0.8em;
+        color: rgba(0, 0, 0, 0.5);
+        padding: 8px 0;
+    }
 }
 
 .actions-list {

--- a/frontend/src/toolbar/actions/EditAction.tsx
+++ b/frontend/src/toolbar/actions/EditAction.tsx
@@ -109,14 +109,38 @@ export function EditAction(): JSX.Element {
 
                                         {step?.event === '$autocapture' || inspectingElement === index ? (
                                             <>
-                                                <StepField field={field} step={step} item="href" label="Link href" />
-                                                <StepField field={field} step={step} item="text" label="Text" />
-                                                <StepField field={field} step={step} item="selector" label="Selector" />
+                                                <StepField
+                                                    field={field}
+                                                    step={step}
+                                                    item="href"
+                                                    label="Link target"
+                                                    caption={
+                                                        <>
+                                                            If your element is a link, the location that the link opens
+                                                            (<code>href</code> tag)
+                                                        </>
+                                                    }
+                                                />
+                                                <StepField
+                                                    field={field}
+                                                    step={step}
+                                                    item="text"
+                                                    label="Text"
+                                                    caption="Text content inside your element"
+                                                />
+                                                <StepField
+                                                    field={field}
+                                                    step={step}
+                                                    item="selector"
+                                                    label="Selector"
+                                                    caption="CSS selector that uniquely identifies your element"
+                                                />
                                                 <StepField
                                                     field={field}
                                                     step={step}
                                                     item="url"
-                                                    label="URL of current page"
+                                                    label="Page URL"
+                                                    caption="URL of the page where the element should match (useful if you have non-unique elements in different pages)"
                                                 />
                                             </>
                                         ) : null}

--- a/frontend/src/toolbar/actions/EditAction.tsx
+++ b/frontend/src/toolbar/actions/EditAction.tsx
@@ -140,7 +140,7 @@ export function EditAction(): JSX.Element {
                                                     step={step}
                                                     item="url"
                                                     label="Page URL"
-                                                    caption="URL of the page where the element should match (useful if you have non-unique elements in different pages)"
+                                                    caption="Elements will match only when triggered from the URL."
                                                 />
                                             </>
                                         ) : null}

--- a/frontend/src/toolbar/actions/StepField.tsx
+++ b/frontend/src/toolbar/actions/StepField.tsx
@@ -10,10 +10,11 @@ interface StepFieldProps {
     item: 'href' | 'text' | 'selector' | 'url'
     step: ActionStepForm
     label: string | JSX.Element
+    caption?: string | JSX.Element
     field: { name: number; fieldKey: number; key: number }
 }
 
-export function StepField({ field, step, item, label }: StepFieldProps): JSX.Element {
+export function StepField({ field, step, item, label, caption }: StepFieldProps): JSX.Element {
     const selected = step && ((step as any)[`${item}_selected`] as boolean)
     const fieldStyle = selected ? {} : { opacity: 0.5 }
 
@@ -31,6 +32,7 @@ export function StepField({ field, step, item, label }: StepFieldProps): JSX.Ele
                 >
                     <Checkbox>{label}</Checkbox>
                 </Form.Item>
+                {caption && <div className="action-field-caption">{caption}</div>}
             </Form.Item>
             {item === 'url' ? (
                 <Form.Item


### PR DESCRIPTION
## Changes

Closes #4504 (full context there). This PR adds more details to each of the options available when creating a new action for an element(s). 

**On toolbar**
<img width="676" alt="" src="https://user-images.githubusercontent.com/5864173/122048150-38403600-cde1-11eb-9220-6db89470ab4f.png">

**On main app**
<img width="643" alt="" src="https://user-images.githubusercontent.com/5864173/122048155-3a09f980-cde1-11eb-8423-a61853f5854e.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
