### PR TITLE
Fix broken color issue

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -862,7 +862,8 @@ function hexToRGB(hex: string): { r: number; g: number; b: number } {
     const originalColor = hasPoundSign ? originalString.slice(1) : originalString
 
     if (originalColor.length !== 6) {
-        throw new Error('Incorrectly formatted color string.')
+        console.log('Incorrectly formatted color string.')
+        return { r: 0, g: 0, b: 0 }
     }
 
     const originalBase16 = parseInt(originalColor, 16)


### PR DESCRIPTION
## Changes

[This graph (internal link)](https://app.posthog.com/insights?insight=TRENDS&interval=day&actions=%5B%7B%22id%22%3A2418%2C%22name%22%3A%22User%20viewed%20session%20recording%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A5%2C%22properties%22%3A%5B%5D%7D%5D&events=%5B%7B%22id%22%3A%22insight%20viewed%22%2C%22name%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22properties%22%3A%5B%7B%22key%22%3A%22insight%22%2C%22value%22%3A%5B%22FUNNELS%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%7B%22id%22%3A%22insight%20viewed%22%2C%22name%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A1%2C%22properties%22%3A%5B%7B%22key%22%3A%22insight%22%2C%22value%22%3A%5B%22RETENTION%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%7B%22id%22%3A%22insight%20viewed%22%2C%22name%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A2%2C%22properties%22%3A%5B%7B%22key%22%3A%22insight%22%2C%22value%22%3A%5B%22TRENDS%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%7B%22id%22%3A%22plugin%20enabled%22%2C%22name%22%3A%22plugin%20enabled%22%2C%22type%22%3A%22events%22%2C%22order%22%3A3%2C%22properties%22%3A%5B%7B%22key%22%3A%22plugin_name%22%2C%22value%22%3A%5B%22SnowFlake%20Export%20Plugin%22%2C%22S3%20Export%20Plugin%22%2C%22BigQuery%20Export%20Plugin%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%7B%22id%22%3A%22plugin%20enabled%22%2C%22name%22%3A%22plugin%20enabled%22%2C%22type%22%3A%22events%22%2C%22order%22%3A4%2C%22properties%22%3A%5B%7B%22key%22%3A%22plugin_installation_type%22%2C%22value%22%3A%5B%22custom%22%2C%22source%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%7B%22id%22%3A%22feature%20flag%20created%22%2C%22name%22%3A%22feature%20flag%20created%22%2C%22type%22%3A%22events%22%2C%22order%22%3A6%2C%22properties%22%3A%5B%5D%7D%5D&filter_test_accounts=false&new_entity=%5B%5D&display=ActionsBarValue&properties=%5B%7B%22key%22%3A%22realm%22%2C%22value%22%3A%5B%22hosted%22%2C%22hosted-clickhouse%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%2C%7B%22key%22%3A%22email%22%2C%22value%22%3A%22wisdomgarden.com%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22person%22%7D%5D&date_from=all&compare=false)

causes this issue which breaks the entire page: 
![image](https://user-images.githubusercontent.com/1727427/122056430-dd5f0c80-cde9-11eb-9af2-9fcdc60f88e8.png)

Quick and dirty fix.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
