### PR TITLE
Allow passing project api key to api/feature_flag

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -9,12 +9,13 @@ from rest_framework import status
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
 
+from posthog.api.utils import clean_token, get_token
 from posthog.exceptions import RequestParsingError, generate_exception_response
 from posthog.models import Team, User
 from posthog.models.feature_flag import get_active_feature_flags
 from posthog.utils import cors_response, load_data_from_request
 
-from .capture import _clean_token, _get_project_id, _get_token
+from .capture import _get_project_id
 
 
 def on_permitted_domain(team: Team, request: HttpRequest) -> bool:
@@ -88,8 +89,8 @@ def get_decide(request: HttpRequest):
                 request,
                 generate_exception_response("decide", f"Malformed request data: {error}", code="malformed_data"),
             )
-        token = _get_token(data, request)
-        token, is_test_environment = _clean_token(token)
+        token = get_token(data, request)
+        token, _ = clean_token(token)
         team = Team.objects.get_team_from_token(token)
         if team is None and token:
             project_id = _get_project_id(data, request)

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -102,7 +102,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions]
 
     def get_queryset(self) -> QuerySet:
-        queryset = super().get_queryset()
+        queryset = FeatureFlag.objects.filter(team=self.team)
         if self.action == "list":
             queryset = queryset.filter(deleted=False)
         return queryset.order_by("-created_at")

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -10,6 +10,8 @@ from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.utils import load_data_from_request
 
+ENDPOINTS_ALLOWING_TEAM_OVERRIDE = {"/api/feature_flag", "/api/feature_flag/"}
+
 
 class DefaultRouterPlusPlus(ExtendedDefaultRouter):
     """DefaultRouter with optional trailing slash and drf-extensions nesting."""
@@ -32,9 +34,10 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     @property
     def team_id(self) -> int:
-        team_from_token = self._get_team_from_request()
-        if team_from_token:
-            return team_from_token.id
+        if self.request.path in ENDPOINTS_ALLOWING_TEAM_OVERRIDE:
+            team_from_token = self._get_team_from_request()
+            if team_from_token:
+                return team_from_token.id
 
         if self.legacy_team_compatibility:
             team = self.request.user.team
@@ -44,9 +47,10 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     @property
     def team(self) -> Team:
-        team_from_token = self._get_team_from_request()
-        if team_from_token:
-            return team_from_token
+        if self.request.path in ENDPOINTS_ALLOWING_TEAM_OVERRIDE:
+            team_from_token = self._get_team_from_request()
+            if team_from_token:
+                return team_from_token
 
         if self.legacy_team_compatibility:
             team = self.request.user.team

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -10,8 +10,6 @@ from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.utils import load_data_from_request
 
-ENDPOINTS_ALLOWING_TEAM_OVERRIDE = {"/api/feature_flag", "/api/feature_flag/"}
-
 
 class DefaultRouterPlusPlus(ExtendedDefaultRouter):
     """DefaultRouter with optional trailing slash and drf-extensions nesting."""
@@ -34,10 +32,9 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     @property
     def team_id(self) -> int:
-        if self.request.path in ENDPOINTS_ALLOWING_TEAM_OVERRIDE:
-            team_from_token = self._get_team_from_request()
-            if team_from_token:
-                return team_from_token.id
+        team_from_token = self._get_team_from_request()
+        if team_from_token:
+            return team_from_token.id
 
         if self.legacy_team_compatibility:
             team = self.request.user.team
@@ -47,10 +44,9 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     @property
     def team(self) -> Team:
-        if self.request.path in ENDPOINTS_ALLOWING_TEAM_OVERRIDE:
-            team_from_token = self._get_team_from_request()
-            if team_from_token:
-                return team_from_token
+        team_from_token = self._get_team_from_request()
+        if team_from_token:
+            return team_from_token
 
         if self.legacy_team_compatibility:
             team = self.request.user.team
@@ -125,8 +121,7 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     def _get_team_from_request(self) -> Optional["Team"]:
         team_found = None
-        data = load_data_from_request(self.request)
-        token = get_token(data, self.request)
+        token = get_token(None, self.request)
 
         if token:
             token, _ = clean_token(token)

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -5,8 +5,10 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 from rest_framework_extensions.settings import extensions_api_settings
 
+from posthog.api.utils import clean_token, get_token
 from posthog.models.organization import Organization
 from posthog.models.team import Team
+from posthog.utils import load_data_from_request
 
 
 class DefaultRouterPlusPlus(ExtendedDefaultRouter):
@@ -30,6 +32,10 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     @property
     def team_id(self) -> int:
+        team_from_token = self._get_team_from_request()
+        if team_from_token:
+            return team_from_token.id
+
         if self.legacy_team_compatibility:
             team = self.request.user.team
             assert team is not None
@@ -38,6 +44,10 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     @property
     def team(self) -> Team:
+        team_from_token = self._get_team_from_request()
+        if team_from_token:
+            return team_from_token
+
         if self.legacy_team_compatibility:
             team = self.request.user.team
             assert team is not None
@@ -108,3 +118,18 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     def get_serializer_context(self) -> Dict[str, Any]:
         return {**super().get_serializer_context(), **self.get_parents_query_dict()}
+
+    def _get_team_from_request(self) -> Optional["Team"]:
+        team_found = None
+        data = load_data_from_request(self.request)
+        token = get_token(data, self.request)
+
+        if token:
+            token, _ = clean_token(token)
+            team = Team.objects.get_team_from_token(token)
+            if team:
+                team_found = team
+            else:
+                raise AuthenticationFailed()
+
+        return team_found

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -33,10 +33,11 @@ def format_next_url(request: request.Request, offset: int, page_size: int):
 
 
 def get_token(data, request) -> Optional[str]:
-    if request.GET.get("token"):
-        return request.GET.get("token")  # token passed as query param
-    if request.GET.get("api_key"):
-        return request.GET.get("api_key")  # api_key passed as query param
+    if request.GET:
+        if request.GET.get("token"):
+            return request.GET.get("token")  # token passed as query param
+        if request.GET.get("api_key"):
+            return request.GET.get("api_key")  # api_key passed as query param
     if request.POST.get("api_key"):
         return request.POST["api_key"]
     if request.POST.get("token"):

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -33,7 +33,7 @@ def format_next_url(request: request.Request, offset: int, page_size: int):
 
 
 def get_token(data, request) -> Optional[str]:
-    if request.GET:
+    if request.method == "GET":
         if request.GET.get("token"):
             return request.GET.get("token")  # token passed as query param
         if request.GET.get("api_key"):

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -30,3 +30,34 @@ def format_next_url(request: request.Request, offset: int, page_size: int):
             "{}{}offset={}".format(next_url, "&" if "?" in next_url else "?", offset + page_size)
         )
     return next_url
+
+
+def get_token(data, request) -> Optional[str]:
+    if request.GET.get("token"):
+        return request.GET.get("token")  # token passed as query param
+    if request.GET.get("api_key"):
+        return request.GET.get("api_key")  # api_key passed as query param
+    if request.POST.get("api_key"):
+        return request.POST["api_key"]
+    if request.POST.get("token"):
+        return request.POST["token"]
+    if data:
+        if isinstance(data, list):
+            data = data[0]  # Mixpanel Swift SDK
+        if isinstance(data, dict):
+            if data.get("$token"):
+                return data["$token"]  # JS identify call
+            if data.get("token"):
+                return data["token"]  # JS reloadFeatures call
+            if data.get("api_key"):
+                return data["api_key"]  # server-side libraries like posthog-python and posthog-ruby
+            if data.get("properties") and data["properties"].get("token"):
+                return data["properties"]["token"]  # JS capture call
+    return None
+
+
+# Support test_[apiKey] for users with multiple environments
+def clean_token(token):
+    is_test_environment = token.startswith("test_")
+    token = token[5:] if is_test_environment else token
+    return token, is_test_environment

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -344,8 +344,6 @@ def base64_decode(data):
 
 # Used by non-DRF endpoins from capture.py and decide.py (/decide, /batch, /capture, etc)
 def load_data_from_request(request):
-    print(request.GET.get("token", ""))
-    print(request.GET)
     data = None
     if request.method == "POST":
         if request.content_type in ["", "text/plain", "application/json"]:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -344,6 +344,8 @@ def base64_decode(data):
 
 # Used by non-DRF endpoins from capture.py and decide.py (/decide, /batch, /capture, etc)
 def load_data_from_request(request):
+    print(request.GET.get("token", ""))
+    print(request.GET)
     data = None
     if request.method == "POST":
         if request.content_type in ["", "text/plain", "application/json"]:


### PR DESCRIPTION
## Changes

Addresses #4713.

This is a temp fix that only applies to `api/feature_flag`. This special handling is perhaps bad practice, but I'd like to get this in ASAP, so I can update all our feature flag libs, given they currently have a major flaw that can lead to significant issues for users.

With this in, I'll update Go, Node, Python, and Ruby, and postpone the discussion in #4713 to next sprint, when I'll work on a more robust solution and again update the libs accordingly. 

### Lib PRs

- [x] Node: https://github.com/PostHog/posthog-node/pull/36
- [x] Go: https://github.com/PostHog/posthog-go/pull/3
- [x] Python: https://github.com/PostHog/posthog-python/pull/41

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
