### PR TITLE
Convert existing pie charts to D3

### DIFF
--- a/frontend/src/lib/components/Charts/PieChart.scss
+++ b/frontend/src/lib/components/Charts/PieChart.scss
@@ -1,0 +1,12 @@
+.graph-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+
+    .annotations-root {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+    }
+}

--- a/frontend/src/lib/components/Charts/PieChart.tsx
+++ b/frontend/src/lib/components/Charts/PieChart.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect /*useRef*/ } from 'react'
+import * as d3 from 'd3'
+
+// import { useActions, useValues } from 'kea'
+import /*formatLabel, compactNumber,*/ '~/lib/utils'
+// import { useWindowSize } from 'lib/hooks/useWindowSize'
+import { useEscapeKey } from 'lib/hooks/useEscapeKey'
+// import dayjs from 'dayjs'
+// import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+// import { InsightLabel } from 'lib/components/InsightLabel'
+// import { FEATURE_FLAGS } from 'lib/constants'
+// import { InsightTooltip } from '../InsightTooltip'
+import { TrendResult } from '~/types'
+import { PieArcDatum } from 'd3'
+
+export type Dataset = TrendResult & {
+    borderColor: string[]
+    hoverBorderColor: string[]
+    backgroundColor: string[]
+    hoverBackgroundColor: string[]
+    borderWidth: number
+    hoverBorderWidth: number
+}
+
+type PieArc = PieArcDatum<number | { valueOf(): number }>
+
+interface PieChartProps {
+    datasets: Dataset[]
+    // labels: string[] //TODO
+    color: string
+    // type: any //TODO
+    // onClick: CallableFunction
+    ['data-attr']: string
+    // dashboardItemId?: number
+    // inSharedMode?: boolean,
+    // percentage?: boolean,
+}
+
+const CHART_DEFAULTS = {
+    borderColor: '#fff',
+    hoverBorderColor: '#fff',
+    backgroundColor: '#999',
+    hoverBackgroundColor: '#999',
+    borderWidth: 1,
+    hoverBorderWidth: 1,
+}
+
+// const noop = () => {}
+export function PieChart({
+    datasets: inputDatasets,
+    // labels,
+    color,
+    // type,
+    // onClick,
+    ['data-attr']: dataAttr,
+}: // dashboardItemId,
+// inSharedMode,
+// percentage = false,
+PieChartProps): JSX.Element {
+    const [focused, setFocused] = useState(false)
+    const [arcs, setArcs] = useState<PieArc[]>([])
+    const chartData = inputDatasets[0] // Eventually, we'll support multiple pie series
+
+    useEscapeKey(() => setFocused(false), [focused])
+
+    useEffect(() => {
+        buildChart()
+    }, [chartData, color])
+
+    function buildChart(): void {
+        const _arcs = d3.pie()(chartData.data)
+        console.log('arcs:', _arcs)
+        setArcs(_arcs)
+    }
+
+    return (
+        <div
+            className="graph-container"
+            data-attr={dataAttr}
+            // onMouseMove={() => setEnabled(true)}
+            // onMouseLeave={() => setEnabled(false)}
+        >
+            <svg>
+                {arcs
+                    .map((arc) =>
+                        d3.arc()({
+                            ...arc,
+                            innerRadius: 0,
+                            outerRadius: 50,
+                        })
+                    )
+                    .map((d, index) =>
+                        d ? (
+                            <path
+                                d={d}
+                                fill={chartData.backgroundColor[index] || CHART_DEFAULTS.backgroundColor}
+                                stroke={chartData.borderColor[index] || CHART_DEFAULTS.borderColor}
+                                strokeWidth={chartData.borderWidth ?? CHART_DEFAULTS.borderWidth}
+                                strokeLinejoin="round"
+                                transform="translate(50,50)"
+                            />
+                        ) : null
+                    )}
+            </svg>
+            {/* <pre>
+                inputDatasets: {JSON.stringify(inputDatasets)}
+                labels: {JSON.stringify(labels)}
+                dashboardItemId: {JSON.stringify(dashboardItemId)}
+                inSharedMode: {JSON.stringify(inSharedMode)}
+            </pre> */}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/Charts/PieChart.tsx
+++ b/frontend/src/lib/components/Charts/PieChart.tsx
@@ -26,14 +26,14 @@ type PieArc = PieArcDatum<number | { valueOf(): number }>
 
 interface PieChartProps {
     datasets: Dataset[]
-    // labels: string[] //TODO
+    labels: string[] //TODO
     color: string
     // type: any //TODO
     // onClick: CallableFunction
     ['data-attr']: string
-    // dashboardItemId?: number
-    // inSharedMode?: boolean,
-    // percentage?: boolean,
+    dashboardItemId?: number
+    inSharedMode?: boolean,
+    percentage?: boolean,
 }
 
 const CHART_DEFAULTS = {
@@ -45,17 +45,51 @@ const CHART_DEFAULTS = {
     hoverBorderWidth: 1,
 }
 
+interface ArcPathProps {
+    d: string | null
+    backgroundColor?: string
+    borderColor?: string
+    borderWidth?: number
+    hoverBorderWidth?: number
+    transform: string
+}
+
+function ArcPath({ d, backgroundColor, borderColor, borderWidth, hoverBorderWidth, transform }: ArcPathProps): JSX.Element | null {
+    if (!d) {
+        return null
+    }
+    const [hover, setHover] = useState(false)
+    const strokeWidth = borderWidth ?? CHART_DEFAULTS.borderWidth
+    const hoverStrokeWidth = hoverBorderWidth ?? CHART_DEFAULTS.hoverBorderWidth
+    const stroke = borderColor ?? backgroundColor ?? CHART_DEFAULTS.borderColor
+    return (
+        <path
+            d={d}
+            fill={backgroundColor || CHART_DEFAULTS.backgroundColor}
+            transform="translate(50,50)"
+            onMouseOver={() => setHover(true)}
+            onMouseOut={() => setHover(false)}
+            style={{
+                stroke,
+                strokeWidth: hover ? hoverStrokeWidth : strokeWidth,
+                strokeLinejoin: 'bevel',
+            }}
+        />
+    )
+}
+
 // const noop = () => {}
 export function PieChart({
     datasets: inputDatasets,
-    // labels,
+    labels,
     color,
     // type,
     // onClick,
     ['data-attr']: dataAttr,
-}: // dashboardItemId,
-// inSharedMode,
-// percentage = false,
+    dashboardItemId,
+    inSharedMode,
+    percentage = false,
+}:
 PieChartProps): JSX.Element {
     const [focused, setFocused] = useState(false)
     const [arcs, setArcs] = useState<PieArc[]>([])
@@ -88,19 +122,17 @@ PieChartProps): JSX.Element {
                             innerRadius: 0,
                             outerRadius: 50,
                         })
-                    )
-                    .map((d, index) =>
-                        d ? (
-                            <path
-                                d={d}
-                                fill={chartData.backgroundColor[index] || CHART_DEFAULTS.backgroundColor}
-                                stroke={chartData.borderColor[index] || CHART_DEFAULTS.borderColor}
-                                strokeWidth={chartData.borderWidth ?? CHART_DEFAULTS.borderWidth}
-                                strokeLinejoin="round"
-                                transform="translate(50,50)"
-                            />
-                        ) : null
-                    )}
+                    ).map((d, index) => (
+                        <ArcPath
+                            d={d}
+                            key={index}
+                            backgroundColor={chartData.backgroundColor[index]}
+                            borderColor={chartData.borderColor[index]}
+                            borderWidth={chartData.borderWidth}
+                            hoverBorderWidth={chartData.hoverBorderWidth}
+                            transform="translate(50,50)"
+                        />
+                    ))}
             </svg>
             {/* <pre>
                 inputDatasets: {JSON.stringify(inputDatasets)}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -229,6 +229,7 @@ export const FEATURE_FLAGS: Record<string, string> = {
     NPS_PROMPT: '4562-nps',
     INGESTION_TAXONOMY: '4267-event-property-taxonomy',
     NEW_TOOLTIPS: '4156-tooltips-legends',
+    D3_PIECHARTS_DEFAULT: 'd3-piecharts-default',
 }
 
 export const ENVIRONMENT_LOCAL_STORAGE_KEY = '$environment'

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -7,6 +7,9 @@ import { getChartColors } from 'lib/colors'
 import { useValues, useActions } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { ChartParams, TrendResultWithAggregate } from '~/types'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { Dataset, PieChart } from 'lib/components/Charts/PieChart'
 
 export function ActionsPie({
     dashboardItemId,
@@ -16,6 +19,8 @@ export function ActionsPie({
     cachedResults,
     inSharedMode,
 }: ChartParams): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const d3DefaultChart = featureFlags[FEATURE_FLAGS.D3_PIECHARTS_DEFAULT]
     const [data, setData] = useState<Record<string, any>[] | null>(null)
     const [total, setTotal] = useState(0)
     const logic = trendsLogic({ dashboardItemId, view, filters: filtersParam, cachedResults })
@@ -56,23 +61,34 @@ export function ActionsPie({
         data[0] && data[0].labels ? (
             <div className="actions-pie-component">
                 <div className="pie-chart">
-                    <LineGraph
-                        data-attr="trend-pie-graph"
-                        color={color}
-                        type="doughnut"
-                        datasets={data}
-                        labels={data[0].labels}
-                        inSharedMode={inSharedMode}
-                        dashboardItemId={dashboardItemId}
-                        onClick={(point) => {
-                            const { dataset } = point
-                            const action = dataset.actions[point.index]
-                            const label = dataset.labels[point.index]
-                            const date_from = dataset.days[0]
-                            const date_to = dataset.days[dataset.days.length - 1]
-                            loadPeople(action, label, date_from, date_to, null)
-                        }}
-                    />
+                    {d3DefaultChart ? (
+                        <PieChart
+                            datasets={data as Dataset[]}
+                            labels={data[0].labels}
+                            color={color}
+                            data-attr="trend-pie-graph-d3"
+                            dashboardItemId={dashboardItemId}
+                            inSharedMode={inSharedMode}
+                        />
+                    ) : (
+                        <LineGraph
+                            data-attr="trend-pie-graph"
+                            color={color}
+                            type="doughnut"
+                            datasets={data}
+                            labels={data[0].labels}
+                            inSharedMode={inSharedMode}
+                            dashboardItemId={dashboardItemId}
+                            onClick={(point) => {
+                                const { dataset } = point
+                                const action = dataset.actions[point.index]
+                                const label = dataset.labels[point.index]
+                                const date_from = dataset.days[0]
+                                const date_to = dataset.days[dataset.days.length - 1]
+                                loadPeople(action, label, date_from, date_to, null)
+                            }}
+                        />
+                    )}
                 </div>
                 <h1>
                     <span className="label">Total: </span>

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -67,8 +67,6 @@ export function ActionsPie({
                             labels={data[0].labels}
                             color={color}
                             data-attr="trend-pie-graph-d3"
-                            dashboardItemId={dashboardItemId}
-                            inSharedMode={inSharedMode}
                         />
                     ) : (
                         <LineGraph

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
         "@babel/preset-typescript": "^7.10.4",
         "@hot-loader/react-dom": "^16.13.0",
         "@types/chart.js": "^2.9.32",
+        "@types/d3": "^6.7.0",
         "@types/jest": "^26.0.15",
         "@types/react": "^16.14.2",
         "@types/react-dom": "^16.9.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,10 +1924,230 @@
   resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.4.tgz#94a835e27d1af444c65cba88523533c174463d64"
   integrity sha512-ENdXf7MW4m9HeDojB2Ukbi7lYMIuQNBHVf98dbzaiG4EEJREBd6oleVAjrLRCrp7dm6CK1mmdmU9tcgF61acbw==
 
+"@types/d3-array@*":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-2.12.1.tgz#bee6857b812f1ecfd5e6832fd67f617b667dd024"
+  integrity sha512-kVHqB3kfLpU0WYEmx5Y2hi3LRhUGIEIQXFdGazNNWQhyhzHx8xrgLtpAOKYzpfS3a+GjFMdKsI82QUH4q5dACQ==
+
+"@types/d3-axis@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-2.1.0.tgz#5314adec80e4303d4eb02d23bdb5b8c600f6ee2c"
+  integrity sha512-6ekm+D+EG/LVT3oiwwU9wsm0+SBAQpxSSOsZq92fp+tnpaa19YMHpj8sRZQAeksSBcqNWzEMjuRPXR9s38YFaw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-2.1.0.tgz#c51ad1ab93887b23be7637d2100540f1df0dac00"
+  integrity sha512-rLQqxQeXWF4ArXi81GlV8HBNwJw9EDpz0jcWvvzv548EDE4tXrayBTOHYi/8Q4FZ/Df8PGXFzxpAVQmJMjOtvQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-2.0.1.tgz#45c72b28c9686eb4b02c8a1bb0fe174723053890"
+  integrity sha512-mqGww8qDtGZRnDsFizzobAVizd85hgaYNEri095ZI7/aYtW7hxa9a20enwuoVTWm0YqdCtLPoyV9ZPYgfyaTZw==
+
+"@types/d3-color@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-2.0.1.tgz#570ea7f8b853461301804efa52bd790a640a26db"
+  integrity sha512-u7LTCL7RnaavFSmob2rIAJLNwu50i6gFwY9cHFr80BrQURYQBRkJ+Yv47nA3Fm7FeRhdWTiVTeqvSeOuMAOzBQ==
+
+"@types/d3-contour@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-2.0.0.tgz#6e079f281b29a8df3fcbd3ec193f2cf1d0b4a584"
+  integrity sha512-PS9UO6zBQqwHXsocbpdzZFONgK1oRUgWtjjh/iz2vM06KaXLInLiKZ9e3OLBRerc1cU2uJYpO+8zOnb6frvCGQ==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-5.3.0.tgz#416169bb5c67a510c87b55d092a404fcab49def3"
+  integrity sha512-gJYcGxLu0xDZPccbUe32OUpeaNtd1Lz0NYJtko6ZLMyG2euF4pBzrsQXms67LHZCDFzzszw+dMhSL/QAML3bXw==
+
+"@types/d3-dispatch@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-2.0.0.tgz#1f8803041b73b81f2c751e026b7bb63dd5f24ce0"
+  integrity sha512-Sh0KW6z/d7uxssD7K4s4uCSzlEG/+SP+U47q098NVdOfFvUKNTvKAIV4XqjxsUuhE/854ARAREHOxkr9gQOCyg==
+
+"@types/d3-drag@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-2.0.0.tgz#ef66acc422576fbe10b8bd66af45a9fb8525199a"
+  integrity sha512-VaUJPjbMnDn02tcRqsHLRAX5VjcRIzCjBfeXTLGe6QjMn5JccB5Cz4ztMRXMJfkbC45ovgJFWuj6DHvWMX1thA==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-2.0.1.tgz#44ce09b025cf365d27cbe11fc13cd10954369627"
+  integrity sha512-wovgiG9Mgkr/SZ/m/c0m+RwrIT4ozsuCWeLxJyoObDWsie2DeQT4wzMdHZPR9Ya5oZLQT3w3uSl0NehG0+0dCA==
+
+"@types/d3-ease@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-2.0.0.tgz#798cbd9908d26cfe9f1a295a3a75164da9a3666e"
+  integrity sha512-6aZrTyX5LG+ptofVHf+gTsThLRY1nhLotJjgY4drYqk1OkJMu2UvuoZRlPw2fffjRHeYepue3/fxTufqKKmvsA==
+
+"@types/d3-fetch@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-2.0.0.tgz#580846256ed0011b36a08ebb36924e0dff70e27e"
+  integrity sha512-WnLepGtxepFfXRdPI8I5FTgNiHn9p4vMTTqaNCzJJfAswXx0rOY2jjeolzEU063em3iJmGZ+U79InnEeFOrCRw==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-2.1.1.tgz#a18b6f029d056eb0f8f84a09471e6228e4469b14"
+  integrity sha512-3r+CQv2K/uDTAVg0DGxsbBjV02vgOxb8RhPIv3gd6cp3pdPAZ7wEXpDjUZSoqycAQLSDOxG/AZ54Vx6YXZSbmQ==
+
+"@types/d3-format@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-2.0.0.tgz#607d261cb268f0a027f100575491031539a40ee6"
+  integrity sha512-uagdkftxnGkO4pZw5jEYOM5ZnZOEsh7z8j11Qxk85UkB2RzfUUxRl7R9VvvJZHwKn8l+x+rpS77Nusq7FkFmIg==
+
+"@types/d3-geo@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-2.0.0.tgz#6f179512343c2d30e06acde190abfacf44b2d264"
+  integrity sha512-DHHgYXW36lnAEQMYU2udKVOxxljHrn2EdOINeSC9jWCAXwOnGn7A19B8sNsHqgpu4F7O2bSD7//cqBXD3W0Deg==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz#92079d9dbcec1dfe2736fb050a8bf916e5850a1c"
+  integrity sha512-YxdskUvwzqggpnSnDQj4KVkicgjpkgXn/g/9M9iGsiToLS3nG6Ytjo1FoYhYVAAElV/fJBGVL3cQ9Hb7tcv+lw==
+
+"@types/d3-interpolate@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-2.0.0.tgz#325029216dc722c1c68c33ccda759f1209d35823"
+  integrity sha512-Wt1v2zTlEN8dSx8hhx6MoOhWQgTkz0Ukj7owAEIOF2QtI0e219paFX9rf/SLOr/UExWb1TcUzatU8zWwFby6gg==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-2.0.0.tgz#dcc7f5ecadf52b0c0c39f6c1def3733195e4b199"
+  integrity sha512-tXcR/9OtDdeCIsyl6eTNHC3XOAOdyc6ceF3QGBXOd9jTcK+ex/ecr00p9L9362e/op3UEPpxrToi1FHrtTSj7Q==
+
+"@types/d3-path@^1":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
+  integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
+
+"@types/d3-polygon@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-2.0.0.tgz#8b1df0a1358016e62c4961b01e8dc8e5ab4c64e5"
+  integrity sha512-fISnMd8ePED1G4aa4V974Jmt+ajHSgPoxMa2D0ULxMybpx0Vw4WEzhQEaMIrL3hM8HVRcKTx669I+dTy/4PhAw==
+
+"@types/d3-quadtree@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-2.0.0.tgz#b17e953dc061e083966075bba0d3a9a259812150"
+  integrity sha512-YZuJuGBnijD0H+98xMJD4oZXgv/umPXy5deu3IimYTPGH3Kr8Th6iQUff0/6S80oNBD7KtOuIHwHUCymUiRoeQ==
+
+"@types/d3-random@*":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-2.2.0.tgz#fc44cabb966917459490b758f31f5359adeabe5b"
+  integrity sha512-Hjfj9m68NmYZzushzEG7etPvKH/nj9b9s9+qtkNG3/dbRBjQZQg1XS6nRuHJcCASTjxXlyXZnKu2gDxyQIIu9A==
+
+"@types/d3-scale-chromatic@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz#8d4a6f07cbbf2a9f2a4bec9c9476c27ed76a96ea"
+  integrity sha512-Y62+2clOwZoKua84Ha0xU77w7lePiaBoTjXugT4l8Rd5LAk+Mn/ZDtrgs087a+B5uJ3jYUHHtKw5nuEzp0WBHw==
+
+"@types/d3-scale@*":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-3.3.0.tgz#7ab91db0186bac0f24834ceb33f970e829f2fba1"
+  integrity sha512-rJj4nh/71Rw5bZgTF5cA5rW60WT3x8RbivEsScgQ66sqFnYZRmuyKSayyo7JiP+c9KJJiQhY9JXBmY16FZa3+g==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-2.0.0.tgz#59df94a8e47ed1050a337d4ffb4d4d213aa590a8"
+  integrity sha512-EF0lWZ4tg7oDFg4YQFlbOU3936e3a9UmoQ2IXlBy1+cv2c2Pv7knhKUzGlH5Hq2sF/KeDTH1amiRPey2rrLMQA==
+
+"@types/d3-shape@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-2.1.0.tgz#cc7bbc9fc2c25f092bd457887a3224a21a55ca55"
+  integrity sha512-xTMEs8eITRksXclcVxMHIONRdyjj2TjDIwO4XFOPTVBNK9/oC4ZOhUbvTz1IpcsEsS/mClwuulP+OoawSAbSGA==
+  dependencies:
+    "@types/d3-path" "^1"
+
+"@types/d3-time-format@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-3.0.0.tgz#913e984362a59792dc8d8b122dd17625991eade2"
+  integrity sha512-UpLg1mn/8PLyjr+J/JwdQJM/GzysMvv2CS8y+WYAL5K0+wbvXv/pPSLEfdNaprCZsGcXTxPsFMy8QtkYv9ueew==
+
+"@types/d3-time@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.1.0.tgz#95708e5c92b199959806fd2116eeb3dfa0e9661c"
+  integrity sha512-qVCiT93utxN0cawScyQuNx8H82vBvZXSClZfgOu3l3dRRlRO6FjKEZlaPgXG9XUFjIAOsA4kAJY101vobHeJLQ==
+
+"@types/d3-timer@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-2.0.0.tgz#9901bb02af38798764674df17d66b07329705632"
+  integrity sha512-l6stHr1VD1BWlW6u3pxrjLtJfpPZq9I3XmKIQtq7zHM/s6fwEtI1Yn6Sr5/jQTrUDCC5jkS6gWqlFGCDArDqNg==
+
+"@types/d3-transition@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-2.0.0.tgz#6f073f0b567c13b7a3dcd1d54214c89f48c5a873"
+  integrity sha512-UJDzI98utcZQUJt3uIit/Ho0/eBIANzrWJrTmi4+TaKIyWL2iCu7ShP0o4QajCskhyjOA7C8+4CE3b1YirTzEQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-2.0.1.tgz#6f0d993042124947314053c937784e24d8b003cf"
+  integrity sha512-FuiGLfaHmp84b9wsj0dG03E/aJl5k98OLnJ2/5p7bQOHEpWqR+z5WCoWYMAbdGxaca7VNd9tCT5i6AJnpauNTQ==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-6.7.0.tgz#e801778cfcf3b5e52ad4dae0d21263b2511d314f"
+  integrity sha512-QOf+58QAvNcqpfIdAfdHe7wDWnIra1YvgCJh2Lxw5FY9dZ+6XVbN63DVoJLnDGpGNBycqUvj5rjHlKZkoz1PtQ==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/geojson@*":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
 
 "@types/glob@^7.1.1":
   version "7.1.3"


### PR DESCRIPTION
## Changes

WIP. Converts existing pie charts to bare D3 implementation. Use `d3-piecharts-default` flag to test.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
