### PR TITLE
Add backwards compatibility check to PR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@
 - [ ] Cypress end-to-end tests
 - [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
 - [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
+- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.


### PR DESCRIPTION
## Changes

![image](https://user-images.githubusercontent.com/13460330/122133332-5ada4b00-cdf1-11eb-8a7d-e89684d241bc.png)

See below

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [x] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.

