### PR TITLE
Resolve /decide endpoint errors due to invalid token

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -85,28 +85,25 @@ def _clean_token(token) -> Tuple[Optional[str], bool]:
     return token, is_test_environment
 
 
-def _get_token(data, request) -> Optional[str]:
+def get_token(data, request) -> Tuple[Optional[str], bool]:
+    token = None
     if request.POST.get("api_key"):
-        return request.POST["api_key"]
-    if request.POST.get("token"):
-        return request.POST["token"]
-    if data:
+        token = request.POST["api_key"]
+    elif request.POST.get("token"):
+        token = request.POST["token"]
+    elif data:
         if isinstance(data, list):
             data = data[0]  # Mixpanel Swift SDK
         if isinstance(data, dict):
             if data.get("$token"):
-                return data["$token"]  # JS identify call
-            if data.get("token"):
-                return data["token"]  # JS reloadFeatures call
-            if data.get("api_key"):
-                return data["api_key"]  # server-side libraries like posthog-python and posthog-ruby
-            if data.get("properties") and data["properties"].get("token"):
-                return data["properties"]["token"]  # JS capture call
-    return None
+                token = data["$token"]  # JS identify call
+            elif data.get("token"):
+                token = data["token"]  # JS reloadFeatures call
+            elif data.get("api_key"):
+                token = data["api_key"]  # server-side libraries like posthog-python and posthog-ruby
+            elif data.get("properties") and data["properties"].get("token"):
+                token = data["properties"]["token"]  # JS capture call
 
-
-def get_token(data, request) -> Tuple[Optional[str], bool]:
-    token = _get_token(data, request)
     if token:
         return _clean_token(token)
     return None, False

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -153,8 +153,7 @@ def get_event(request):
     except RequestParsingError as error:
         capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
         return cors_response(
-            request,
-            generate_exception_response("capture", f"Malformed request data: {error}", code="invalid_payload"),
+            request, generate_exception_response("capture", f"Malformed request data: {error}", code="invalid_payload"),
         )
     if not data:
         return cors_response(
@@ -286,10 +285,7 @@ def get_event(request):
 
     timer.stop()
     statsd.incr(
-        f"posthog_cloud_raw_endpoint_success",
-        tags={
-            "endpoint": "capture",
-        },
+        f"posthog_cloud_raw_endpoint_success", tags={"endpoint": "capture",},
     )
     return cors_response(request, JsonResponse({"status": 1}))
 
@@ -314,13 +310,5 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id):
         celery_app.send_task(
             name=task_name,
             queue=celery_queue,
-            args=[
-                distinct_id,
-                ip,
-                site_url,
-                event,
-                team_id,
-                now.isoformat(),
-                sent_at,
-            ],
+            args=[distinct_id, ip, site_url, event, team_id, now.isoformat(), sent_at,],
         )

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -124,9 +124,6 @@ def get_decide(request: HttpRequest):
             if team.session_recording_opt_in and (on_permitted_domain(team, request) or len(team.app_urls) == 0):
                 response["sessionRecording"] = {"endpoint": "/s/"}
     statsd.incr(
-        f"posthog_cloud_raw_endpoint_success",
-        tags={
-            "endpoint": "decide",
-        },
+        f"posthog_cloud_raw_endpoint_success", tags={"endpoint": "decide",},
     )
     return cors_response(request, JsonResponse(response))

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -14,7 +14,7 @@ from posthog.models import Team, User
 from posthog.models.feature_flag import get_active_feature_flags
 from posthog.utils import cors_response, load_data_from_request
 
-from .capture import _clean_token, _get_project_id, _get_token
+from .capture import _get_project_id, get_token
 
 
 def on_permitted_domain(team: Team, request: HttpRequest) -> bool:
@@ -88,8 +88,8 @@ def get_decide(request: HttpRequest):
                 request,
                 generate_exception_response("decide", f"Malformed request data: {error}", code="malformed_data"),
             )
-        token = _get_token(data, request)
-        token, is_test_environment = _clean_token(token)
+
+        token, _ = get_token(data, request)
         team = Team.objects.get_team_from_token(token)
         if team is None and token:
             project_id = _get_project_id(data, request)
@@ -123,5 +123,10 @@ def get_decide(request: HttpRequest):
             response["featureFlags"] = get_active_feature_flags(team, data["distinct_id"])
             if team.session_recording_opt_in and (on_permitted_domain(team, request) or len(team.app_urls) == 0):
                 response["sessionRecording"] = {"endpoint": "/s/"}
-    statsd.incr(f"posthog_cloud_raw_endpoint_success", tags={"endpoint": "decide",})
+    statsd.incr(
+        f"posthog_cloud_raw_endpoint_success",
+        tags={
+            "endpoint": "decide",
+        },
+    )
     return cors_response(request, JsonResponse(response))

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -5,7 +5,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 from rest_framework_extensions.settings import extensions_api_settings
 
-from posthog.api.utils import clean_token, get_token
+from posthog.api.utils import get_token
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.utils import load_data_from_request
@@ -121,10 +121,9 @@ class StructuredViewSetMixin(NestedViewSetMixin):
 
     def _get_team_from_request(self) -> Optional["Team"]:
         team_found = None
-        token = get_token(None, self.request)
+        token, _ = get_token(None, self.request)
 
         if token:
-            token, _ = clean_token(token)
             team = Team.objects.get_team_from_token(token)
             if team:
                 team_found = team

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -107,11 +107,7 @@ class TestDecide(BaseTest):
         self.client.logout()
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
         FeatureFlag.objects.create(
-            team=self.team,
-            rollout_percentage=50,
-            name="Beta feature",
-            key="beta-feature",
-            created_by=self.user,
+            team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user,
         )
         FeatureFlag.objects.create(
             team=self.team,
@@ -155,19 +151,10 @@ class TestDecide(BaseTest):
         key.save()
         Person.objects.create(team=self.team, distinct_ids=["example_id"])
         FeatureFlag.objects.create(
-            team=self.team,
-            rollout_percentage=100,
-            name="Test",
-            key="test",
-            created_by=self.user,
+            team=self.team, rollout_percentage=100, name="Test", key="test", created_by=self.user,
         )
         FeatureFlag.objects.create(
-            team=self.team,
-            rollout_percentage=100,
-            name="Disabled",
-            key="disabled",
-            created_by=self.user,
-            active=False,
+            team=self.team, rollout_percentage=100, name="Disabled", key="disabled", created_by=self.user, active=False,
         )  # disabled flag
         FeatureFlag.objects.create(
             team=self.team,
@@ -202,11 +189,7 @@ class TestDecide(BaseTest):
         key.save()
         Person.objects.create(team=self.team, distinct_ids=["example_id"])
         FeatureFlag.objects.create(
-            team=self.team,
-            rollout_percentage=100,
-            name="Test",
-            key="test",
-            created_by=self.user,
+            team=self.team, rollout_percentage=100, name="Test", key="test", created_by=self.user,
         )
         response = self._post_decide({"distinct_id": "example_id", "api_key": None, "project_id": self.team.id})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -224,8 +207,7 @@ class TestDecide(BaseTest):
             response_data = response.json()
             detail = response_data.pop("detail")
             self.assertEqual(
-                response.json(),
-                {"type": "validation_error", "code": "malformed_data", "attr": None},
+                response.json(), {"type": "validation_error", "code": "malformed_data", "attr": None},
             )
             self.assertIn("Malformed request data:", detail)
 
@@ -241,7 +223,6 @@ class TestDecide(BaseTest):
         response_data = response.json()
         detail = response_data.pop("detail")
         self.assertEqual(
-            response.json(),
-            {"type": "validation_error", "code": "malformed_data", "attr": None},
+            response.json(), {"type": "validation_error", "code": "malformed_data", "attr": None},
         )
         self.assertIn("Malformed request data:", detail)

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -107,7 +107,11 @@ class TestDecide(BaseTest):
         self.client.logout()
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
         FeatureFlag.objects.create(
-            team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user,
+            team=self.team,
+            rollout_percentage=50,
+            name="Beta feature",
+            key="beta-feature",
+            created_by=self.user,
         )
         FeatureFlag.objects.create(
             team=self.team,
@@ -151,10 +155,19 @@ class TestDecide(BaseTest):
         key.save()
         Person.objects.create(team=self.team, distinct_ids=["example_id"])
         FeatureFlag.objects.create(
-            team=self.team, rollout_percentage=100, name="Test", key="test", created_by=self.user,
+            team=self.team,
+            rollout_percentage=100,
+            name="Test",
+            key="test",
+            created_by=self.user,
         )
         FeatureFlag.objects.create(
-            team=self.team, rollout_percentage=100, name="Disabled", key="disabled", created_by=self.user, active=False,
+            team=self.team,
+            rollout_percentage=100,
+            name="Disabled",
+            key="disabled",
+            created_by=self.user,
+            active=False,
         )  # disabled flag
         FeatureFlag.objects.create(
             team=self.team,
@@ -184,6 +197,23 @@ class TestDecide(BaseTest):
             },
         )
 
+    def test_missing_token(self):
+        key = PersonalAPIKey(label="X", user=self.user)
+        key.save()
+        Person.objects.create(team=self.team, distinct_ids=["example_id"])
+        FeatureFlag.objects.create(
+            team=self.team,
+            rollout_percentage=100,
+            name="Test",
+            key="test",
+            created_by=self.user,
+        )
+        response = self._post_decide({"distinct_id": "example_id", "api_key": None, "project_id": self.team.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = response.json()
+        self.assertEqual(response_json["featureFlags"], [])
+        self.assertFalse(response_json["sessionRecording"])
+
     def test_invalid_payload_on_decide_endpoint(self):
 
         invalid_payloads = [base64.b64encode("1-1".encode("utf-8")).decode("utf-8"), "1==1", "{distinct_id-1}"]
@@ -194,7 +224,8 @@ class TestDecide(BaseTest):
             response_data = response.json()
             detail = response_data.pop("detail")
             self.assertEqual(
-                response.json(), {"type": "validation_error", "code": "malformed_data", "attr": None},
+                response.json(),
+                {"type": "validation_error", "code": "malformed_data", "attr": None},
             )
             self.assertIn("Malformed request data:", detail)
 
@@ -210,6 +241,7 @@ class TestDecide(BaseTest):
         response_data = response.json()
         detail = response_data.pop("detail")
         self.assertEqual(
-            response.json(), {"type": "validation_error", "code": "malformed_data", "attr": None},
+            response.json(),
+            {"type": "validation_error", "code": "malformed_data", "attr": None},
         )
         self.assertIn("Malformed request data:", detail)

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -32,32 +32,39 @@ def format_next_url(request: request.Request, offset: int, page_size: int):
     return next_url
 
 
+def get_token(data, request) -> Tuple[Optional[str], bool]:
+    token = None
+    if request.method == "GET":
+        if request.GET.get("token"):
+            token = request.GET.get("token")  # token passed as query param
+        elif request.GET.get("api_key"):
+            token = request.GET.get("api_key")  # api_key passed as query param
+
+    if not token:
+        if request.POST.get("api_key"):
+            token = request.POST["api_key"]
+        elif request.POST.get("token"):
+            token = request.POST["token"]
+        elif data:
+            if isinstance(data, list):
+                data = data[0]  # Mixpanel Swift SDK
+            if isinstance(data, dict):
+                if data.get("$token"):
+                    token = data["$token"]  # JS identify call
+                elif data.get("token"):
+                    token = data["token"]  # JS reloadFeatures call
+                elif data.get("api_key"):
+                    token = data["api_key"]  # server-side libraries like posthog-python and posthog-ruby
+                elif data.get("properties") and data["properties"].get("token"):
+                    token = data["properties"]["token"]  # JS capture call
+
+    if token:
+        return clean_token(token)
+    return None, False
+
+
 # Support test_[apiKey] for users with multiple environments
 def clean_token(token):
     is_test_environment = token.startswith("test_")
     token = token[5:] if is_test_environment else token
     return token, is_test_environment
-
-
-def get_token(data, request) -> Tuple[Optional[str], bool]:
-    token = None
-    if request.POST.get("api_key"):
-        token = request.POST["api_key"]
-    elif request.POST.get("token"):
-        token = request.POST["token"]
-    elif data:
-        if isinstance(data, list):
-            data = data[0]  # Mixpanel Swift SDK
-        if isinstance(data, dict):
-            if data.get("$token"):
-                token = data["$token"]  # JS identify call
-            elif data.get("token"):
-                token = data["token"]  # JS reloadFeatures call
-            elif data.get("api_key"):
-                token = data["api_key"]  # server-side libraries like posthog-python and posthog-ruby
-            elif data.get("properties") and data["properties"].get("token"):
-                token = data["properties"]["token"]  # JS capture call
-
-    if token:
-        return clean_token(token)
-    return None, False


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog/issues/4712

The problem was just a missing check for token being None, but I refactored this code a bit to ensure we don't have to remember to check this, if we use `get_token` anywhere in the future.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [x] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [x] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [x] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
