### PR TITLE
Revert "[Frontend Change] Funnels API GET -> POST|GET (#4769)"

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.js
+++ b/frontend/src/scenes/funnels/funnelLogic.js
@@ -1,9 +1,9 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { ViewType, insightLogic } from 'scenes/insights/insightLogic'
-import { autocorrectInterval, objectsEqual, uuid } from 'lib/utils'
+import { autocorrectInterval, objectsEqual, toParams, uuid } from 'lib/utils'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
-import { funnelsModel } from '~/models/funnelsModel'
+import { funnelsModel } from '../../models/funnelsModel'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
@@ -15,12 +15,12 @@ function wait(ms = 1000) {
 const SECONDS_TO_POLL = 3 * 60
 
 async function pollFunnel(params = {}) {
-    const { refresh, ...bodyParams } = params
-    let result = await api.create('api/insight/funnel/?' + (refresh ? 'refresh=true' : ''), bodyParams)
+    let result = await api.get('api/insight/funnel/?' + toParams(params))
     let start = window.performance.now()
     while (result.result.loading && (window.performance.now() - start) / 1000 < SECONDS_TO_POLL) {
         await wait()
-        result = await api.create('api/insight/funnel', bodyParams)
+        const { refresh: _, ...restParams } = params // eslint-disable-line
+        result = await api.get('api/insight/funnel/?' + toParams(restParams))
     }
     // if endpoint is still loading after 3 minutes just return default
     if (result.loading) {


### PR DESCRIPTION
This reverts commit bbf7af29208691c5158ebd749d98e254f8858f32.

## Changes


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
