### PR TITLE
Use ellipsis for insight titles & make Reset, Save buttons less verbose

### DIFF
--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -25,6 +25,7 @@ interface FunnelPayload {
 
 export function SaveToDashboard({ item, displayComponent, tooltipOptions }: Props): JSX.Element {
     const [openModal, setOpenModal] = useState<boolean>(false)
+    const [openTooltip, setOpenTooltip] = useState<boolean>(false)
     const [{ fromItem, fromItemName, fromDashboard }] = useState(router.values.hashParams)
 
     let _name: string = ''
@@ -38,11 +39,28 @@ export function SaveToDashboard({ item, displayComponent, tooltipOptions }: Prop
         _name = item.entity.name
     }
 
+    function showTooltip(): void {
+        setOpenTooltip(true)
+    }
+
+    function hideTooltip(): void {
+        setOpenTooltip(false)
+    }
+
+    function showModal(): void {
+        setOpenModal(true)
+        hideTooltip()
+    }
+
+    function hideModal(): void {
+        setOpenModal(false)
+    }
+
     const innerContent = (
         <span className="save-to-dashboard">
             {openModal && (
                 <SaveToDashboardModal
-                    closeModal={() => setOpenModal(false)}
+                    closeModal={hideModal}
                     name={_name}
                     filters={_filters}
                     fromItem={fromItem}
@@ -52,14 +70,28 @@ export function SaveToDashboard({ item, displayComponent, tooltipOptions }: Prop
                 />
             )}
             {displayComponent ? (
-                <span onClick={() => setOpenModal(true)}>{displayComponent}</span>
+                <span onClick={showModal} onMouseOver={showTooltip} onMouseOut={hideTooltip}>
+                    {displayComponent}
+                </span>
             ) : (
-                <Button onClick={() => setOpenModal(true)} type="primary" data-attr="save-to-dashboard-button">
+                <Button
+                    onClick={showModal}
+                    type="primary"
+                    data-attr="save-to-dashboard-button"
+                    onMouseOver={showTooltip}
+                    onMouseOut={hideTooltip}
+                >
                     {fromItem ? 'Update Dashboard' : 'Add to dashboard'}
                 </Button>
             )}
         </span>
     )
 
-    return tooltipOptions ? <Tooltip {...tooltipOptions}>{innerContent}</Tooltip> : innerContent
+    return tooltipOptions ? (
+        <Tooltip {...tooltipOptions} visible={openTooltip}>
+            {innerContent}
+        </Tooltip>
+    ) : (
+        innerContent
+    )
 }

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react'
-import { Button } from 'antd'
+import { Button, Tooltip, TooltipProps } from 'antd'
 import { SaveToDashboardModal } from './SaveToDashboardModal'
 import { router } from 'kea-router'
 
 interface Props {
     item: DashboardItemAttributes
     displayComponent?: JSX.Element // Show custom component instead of default `Add to dashboard` button
+    tooltipOptions?: TooltipProps // Wrap button component in a tooltip with specified props
 }
 
 interface DashboardItemAttributes {
@@ -22,7 +23,7 @@ interface FunnelPayload {
     name: string
 }
 
-export function SaveToDashboard({ item, displayComponent }: Props): JSX.Element {
+export function SaveToDashboard({ item, displayComponent, tooltipOptions }: Props): JSX.Element {
     const [openModal, setOpenModal] = useState<boolean>(false)
     const [{ fromItem, fromItemName, fromDashboard }] = useState(router.values.hashParams)
 
@@ -37,7 +38,7 @@ export function SaveToDashboard({ item, displayComponent }: Props): JSX.Element 
         _name = item.entity.name
     }
 
-    return (
+    const innerContent = (
         <span className="save-to-dashboard">
             {openModal && (
                 <SaveToDashboardModal
@@ -59,4 +60,6 @@ export function SaveToDashboard({ item, displayComponent }: Props): JSX.Element 
             )}
         </span>
     )
+
+    return tooltipOptions ? <Tooltip {...tooltipOptions}>{innerContent}</Tooltip> : innerContent
 }

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -70,7 +70,7 @@ export function SaveToDashboard({ item, displayComponent, tooltipOptions }: Prop
                 />
             )}
             {displayComponent ? (
-                <span onClick={showModal} onMouseOver={showTooltip} onMouseOut={hideTooltip}>
+                <span onClick={showModal} onMouseEnter={showTooltip} onMouseLeave={hideTooltip}>
                     {displayComponent}
                 </span>
             ) : (
@@ -78,8 +78,8 @@ export function SaveToDashboard({ item, displayComponent, tooltipOptions }: Prop
                     onClick={showModal}
                     type="primary"
                     data-attr="save-to-dashboard-button"
-                    onMouseOver={showTooltip}
-                    onMouseOut={hideTooltip}
+                    onMouseEnter={showTooltip}
+                    onMouseLeave={hideTooltip}
                 >
                     {fromItem ? 'Update Dashboard' : 'Add to dashboard'}
                 </Button>

--- a/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Popconfirm } from 'antd'
+import { Button, Popconfirm, Tooltip } from 'antd'
 import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 import React from 'react'
 import { FilterType, InsightType } from '~/types'
@@ -27,16 +27,22 @@ export function InsightActionBar({ filters, annotations, insight, onReset }: Pro
                     reportInsightsTabReset()
                 }}
             >
-                <Button type="link" icon={<ClearOutlined />} className="btn-reset">
-                    Reset all
-                </Button>
+                <Tooltip placement="bottom" title="Reset all filters">
+                    <Button type="link" icon={<ClearOutlined />} className="btn-reset">
+                        Reset
+                    </Button>
+                </Tooltip>
             </Popconfirm>
             <SaveToDashboard
                 displayComponent={
                     <Button icon={<SaveOutlined />} className="btn-save">
-                        Save to dashboard
+                        Save
                     </Button>
                 }
+                tooltipOptions={{
+                    placement: 'bottom',
+                    title: 'Save to dashboard',
+                }}
                 item={{
                     entity: {
                         filters,

--- a/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightActionBar.tsx
@@ -6,6 +6,7 @@ import { SaveOutlined, ClearOutlined } from '@ant-design/icons'
 import { useActions } from 'kea'
 import { router } from 'kea-router'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 
 interface Props {
     filters: FilterType
@@ -17,6 +18,9 @@ interface Props {
 export function InsightActionBar({ filters, annotations, insight, onReset }: Props): JSX.Element {
     const { push } = useActions(router)
     const { reportInsightsTabReset } = useActions(eventUsageLogic)
+    const screens = useBreakpoint()
+    const isSmallScreen = screens.xs || (screens.sm && !screens.md)
+
     return (
         <div className="insights-tab-actions">
             <Popconfirm
@@ -29,14 +33,14 @@ export function InsightActionBar({ filters, annotations, insight, onReset }: Pro
             >
                 <Tooltip placement="bottom" title="Reset all filters">
                     <Button type="link" icon={<ClearOutlined />} className="btn-reset">
-                        Reset
+                        {isSmallScreen ? null : 'Reset'}
                     </Button>
                 </Tooltip>
             </Popconfirm>
             <SaveToDashboard
                 displayComponent={
                     <Button icon={<SaveOutlined />} className="btn-save">
-                        Save
+                        {isSmallScreen ? null : 'Save'}
                     </Button>
                 }
                 tooltipOptions={{

--- a/frontend/src/scenes/insights/InsightTabs/InsightTitle.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightTitle.tsx
@@ -6,14 +6,14 @@ export function InsightTitle({ actionBar = null }: { actionBar?: JSX.Element | n
     const [{ fromItemName, fromDashboard }] = useState(router.values.hashParams)
     return (
         <>
-            <h3 className="l3" style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+            <h3 className="l3 insight-title-container">
                 {fromDashboard && (
                     <DashboardOutlined
                         style={{ color: 'var(--warning)', marginRight: 4 }}
                         title="Insight saved on dashboard"
                     />
                 )}
-                {fromItemName || 'Unsaved query'}
+                <div className="insight-title-text">{fromItemName || 'Unsaved query'}</div>
                 {actionBar}
             </h3>
         </>

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -107,9 +107,23 @@
         }
     }
 
+    .insight-title-container {
+        display: flex;
+        align-items: center;
+
+        .insight-title-text {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+
     .insights-tab-actions {
         margin-left: auto;
         padding: 0 1rem;
+        display: flex;
+        flex-wrap: nowrap;
+
         .btn-reset {
             color: rgba($danger, 0.8);
         }


### PR DESCRIPTION
## Changes

Potentially fixes #4421.

**Problem**: Long insights titles, small screens, or both, cause the `Reset all` and `Save to dashboard` buttons to break the appearance of the insights tab. (They wrap to the next line, but look out of place).

@kpthatsme suggested moving these two buttons to the bottom, near `+ Add graph series`. However, I think that'd be confusing because a user might assume the Save button must be pressed in order to run a query, similar to the behavior in the Funnels tab. I think it is also valuable to keep these buttons near the title.

**Solution**:

Make the button titles less verbose and add tooltips to clarify functionality. Best-case scenario on large screen, no wrapping/truncation is observed at all:

<img width="1762" alt="Screen Shot 2021-06-16 at 11 33 32 AM" src="https://user-images.githubusercontent.com/4645779/122251468-85cbaa00-ce98-11eb-9926-66877d1132bc.png">

If the title runs into the buttons, ellipsis truncation is performed and text does not wrap:

<img width="904" alt="Screen Shot 2021-06-16 at 11 33 42 AM" src="https://user-images.githubusercontent.com/4645779/122251640-b01d6780-ce98-11eb-8851-06173a05ee19.png">

On a small viewport, button titles are replaced with standalone icons to preserve screen space:

<img width="572" alt="Screen Shot 2021-06-16 at 11 33 52 AM" src="https://user-images.githubusercontent.com/4645779/122251735-c9261880-ce98-11eb-86bb-50b20917a688.png">

---

Tooltips look like so:

<img width="881" alt="Screen Shot 2021-06-16 at 11 35 21 AM" src="https://user-images.githubusercontent.com/4645779/122251920-f1157c00-ce98-11eb-8cd7-833859662938.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [x] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
