### PR TITLE
api/user endpoint deprecation notice to direct to api/users/@me

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -527,33 +527,6 @@ class TestUserAPILegacy(APIBaseTest):
         )
 
 
-class TestUserChangePassword(APIBaseTest):
-    ENDPOINT: str = "/api/user/change_password/"
-
-    def send_request(self, payload):
-        return self.client.patch(self.ENDPOINT, payload)
-
-    def test_change_password_no_data(self):
-        response = self.send_request({})
-        self.assertEqual(response.status_code, 400)
-
-    def test_change_password_invalid_old_password(self):
-        response = self.send_request({"currentPassword": "12345", "newPassword": "12345"})
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["error"], "Incorrect old password")
-
-    def test_change_password_invalid_new_password(self):
-        response = self.send_request({"currentPassword": self.CONFIG_PASSWORD, "newPassword": "123456"})
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["error"], "This password is too short. It must contain at least 8 characters.")
-
-    def test_change_password_success(self):
-        response = self.send_request(
-            {"currentPassword": self.CONFIG_PASSWORD, "newPassword": "prettyhardpassword123456"}
-        )
-        self.assertEqual(response.status_code, 200)
-
-
 class TestUserSlackWebhook(APIBaseTest):
     ENDPOINT: str = "/api/user/test_slack_webhook/"
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -173,14 +173,15 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, viewsets.G
         if lookup_value == "@me":
             return self.request.user
         raise serializers.ValidationError(
-            "Currently this endpoint only supports retrieving `@me` instance.", code="invalid_parameter",
+            "Currently this endpoint only supports retrieving `@me` instance.",
+            code="invalid_parameter",
         )
 
 
 @authenticate_secondarily
 def user(request):
     """
-    DEPRECATED: This endpoint (/api/user/) has been deprecated in favor of /api/v2/user/
+    DEPRECATED: This endpoint (/api/user/) has been deprecated in favor of /api/users/@me/
     and will be removed soon.
     """
     organization: Optional[Organization] = request.user.organization
@@ -198,10 +199,12 @@ def user(request):
             team.anonymize_ips = data["team"].get("anonymize_ips", team.anonymize_ips)
             team.session_recording_opt_in = data["team"].get("session_recording_opt_in", team.session_recording_opt_in)
             team.session_recording_retention_period_days = data["team"].get(
-                "session_recording_retention_period_days", team.session_recording_retention_period_days,
+                "session_recording_retention_period_days",
+                team.session_recording_retention_period_days,
             )
             team.completed_snippet_onboarding = data["team"].get(
-                "completed_snippet_onboarding", team.completed_snippet_onboarding,
+                "completed_snippet_onboarding",
+                team.completed_snippet_onboarding,
             )
             team.test_account_filters = data["team"].get("test_account_filters", team.test_account_filters)
             team.timezone = data["team"].get("timezone", team.timezone)
@@ -238,7 +241,7 @@ def user(request):
 
     return JsonResponse(
         {
-            "deprecation": "Endpoint has been deprecated. Please use `/api/v2/user/`.",
+            "deprecation": "Endpoint has been deprecated. Please use `/api/users/@me/`.",
             "id": user.pk,
             "distinct_id": user.distinct_id,
             "name": user.first_name,
@@ -334,7 +337,7 @@ def redirect_to_site(request):
 @authenticate_secondarily
 def change_password(request):
     """
-    DEPRECATED: This endpoint has been deprecated in favor of /api/v2/user/ 
+    DEPRECATED: This endpoint has been deprecated in favor of /api/v2/user/
     and will be removed in PostHog V2.
     """
     try:

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -173,8 +173,7 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, viewsets.G
         if lookup_value == "@me":
             return self.request.user
         raise serializers.ValidationError(
-            "Currently this endpoint only supports retrieving `@me` instance.",
-            code="invalid_parameter",
+            "Currently this endpoint only supports retrieving `@me` instance.", code="invalid_parameter",
         )
 
 
@@ -199,12 +198,10 @@ def user(request):
             team.anonymize_ips = data["team"].get("anonymize_ips", team.anonymize_ips)
             team.session_recording_opt_in = data["team"].get("session_recording_opt_in", team.session_recording_opt_in)
             team.session_recording_retention_period_days = data["team"].get(
-                "session_recording_retention_period_days",
-                team.session_recording_retention_period_days,
+                "session_recording_retention_period_days", team.session_recording_retention_period_days,
             )
             team.completed_snippet_onboarding = data["team"].get(
-                "completed_snippet_onboarding",
-                team.completed_snippet_onboarding,
+                "completed_snippet_onboarding", team.completed_snippet_onboarding,
             )
             team.test_account_filters = data["team"].get("test_account_filters", team.test_account_filters)
             team.timezone = data["team"].get("timezone", team.timezone)
@@ -331,42 +328,6 @@ def redirect_to_site(request):
         return redirect("{}#__posthog={}".format(app_url, state))
     else:
         return redirect("{}#state={}".format(app_url, state))
-
-
-@require_http_methods(["PATCH"])
-@authenticate_secondarily
-def change_password(request):
-    """
-    DEPRECATED: This endpoint has been deprecated in favor of /api/v2/user/
-    and will be removed in PostHog V2.
-    """
-    try:
-        body = json.loads(request.body)
-    except (TypeError, json.decoder.JSONDecodeError):
-        return JsonResponse({"error": "Cannot parse request body"}, status=400)
-
-    old_password = body.get("currentPassword")
-    new_password = body.get("newPassword")
-
-    user = cast(User, request.user)
-
-    if user.has_usable_password():
-        if not old_password or not new_password:
-            return JsonResponse({"error": "Missing payload"}, status=400)
-
-        if not user.check_password(old_password):
-            return JsonResponse({"error": "Incorrect old password"}, status=400)
-
-    try:
-        validate_password(new_password, user)
-    except ValidationError as err:
-        return JsonResponse({"error": err.messages[0]}, status=400)
-
-    user.set_password(new_password)
-    user.save()
-    update_session_auth_hash(request, user)
-
-    return JsonResponse({})
 
 
 @require_http_methods(["POST"])

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -206,7 +206,6 @@ urlpatterns = [
     # api
     path("api/", include(router.urls)),
     opt_slash_path("api/user/redirect_to_site", user.redirect_to_site),
-    opt_slash_path("api/user/change_password", user.change_password),
     opt_slash_path("api/user/test_slack_webhook", user.test_slack_webhook),
     opt_slash_path("api/user", user.user),
     opt_slash_path("api/signup", organization.OrganizationSignupViewset.as_view()),


### PR DESCRIPTION
## Changes

Issue: https://github.com/PostHog/posthog.com/issues/1464

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
