### PR TITLE
Remove free clickhouse license

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -52,7 +52,6 @@ class License(models.Model):
     max_users: models.IntegerField = models.IntegerField(default=None, null=True)  # None = no restriction
 
     ENTERPRISE_PLAN = "enterprise"
-    FREE_CLICKHOUSE_PLAN = "free_clickhouse"
     ENTERPRISE_FEATURES = [
         "zapier",
         "organizations_projects",
@@ -62,7 +61,6 @@ class License(models.Model):
     ]  # Base premium features
     PLANS = {
         ENTERPRISE_PLAN: ENTERPRISE_FEATURES + ["clickhouse"],
-        FREE_CLICKHOUSE_PLAN: ["clickhouse"],
     }
 
     @property

--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useValues } from 'kea'
-import { WarningOutlined, ToolFilled, KeyOutlined } from '@ant-design/icons'
+import { WarningOutlined, ToolFilled } from '@ant-design/icons'
 import { Button, Card } from 'antd'
 import { billingLogic, BillingAlertType } from 'scenes/billing/billingLogic'
 import { LinkButton } from './LinkButton'
@@ -51,25 +51,6 @@ export function BillingAlerts(): JSX.Element | null {
                         <div style={{ display: 'flex', alignItems: 'center', paddingLeft: 16 }}>
                             <LinkButton type="primary" to="/organization/billing">
                                 <ToolFilled /> Manage billing
-                            </LinkButton>
-                        </div>
-                    </div>
-                </Card>
-            )}
-
-            {alertToShow === BillingAlertType.ClickhouseLicenseMissing && (
-                <Card>
-                    <div style={{ display: 'flex' }}>
-                        <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
-                            <WarningOutlined className="text-warning" style={{ paddingRight: 16 }} />
-                            <div>
-                                You've set up Clickhouse, but you don't have an active license to use Clickhouse yet.
-                                Contact us at <a href="mailto:sales@posthog.com">sales@posthog.com</a> to get a license.
-                            </div>
-                        </div>
-                        <div style={{ display: 'flex', alignItems: 'center', paddingLeft: 16 }}>
-                            <LinkButton type="primary" to="/instance/licenses">
-                                <KeyOutlined /> Activate License
                             </LinkButton>
                         </div>
                     </div>

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -5,7 +5,6 @@ import { PlanInterface, UserType, BillingType, PreflightStatus } from '~/types'
 import { sceneLogic, Scene } from 'scenes/sceneLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import posthog from 'posthog-js'
-import { userLogic } from 'scenes/userLogic'
 
 export const UTM_TAGS = 'utm_medium=in-product&utm_campaign=billing-management'
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
@@ -13,7 +12,6 @@ export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of e
 export enum BillingAlertType {
     SetupBilling = 'setup_billing',
     UsageNearLimit = 'usage_near_limit',
-    ClickhouseLicenseMissing = 'clickhouse_license_missing',
 }
 
 export const billingLogic = kea<billingLogicType<PlanInterface, UserType, BillingType, PreflightStatus, Scene>>({
@@ -85,20 +83,8 @@ export const billingLogic = kea<billingLogicType<PlanInterface, UserType, Billin
             },
         ],
         alertToShow: [
-            (s) => [
-                s.eventAllocation,
-                s.billing,
-                sceneLogic.selectors.scene,
-                preflightLogic.selectors.preflight,
-                userLogic.selectors.user,
-            ],
-            (
-                eventAllocation: number | null,
-                billing: BillingType,
-                scene: Scene,
-                preflight: PreflightStatus,
-                user: UserType
-            ): BillingAlertType | undefined => {
+            (s) => [s.eventAllocation, s.billing, sceneLogic.selectors.scene],
+            (eventAllocation: number | null, billing: BillingType, scene: Scene): BillingAlertType | undefined => {
                 // Determines which billing alert/warning to show to the user (if any)
 
                 // Priority 1: In-progress incomplete billing setup
@@ -114,17 +100,6 @@ export const billingLogic = kea<billingLogicType<PlanInterface, UserType, Billin
                     billing.current_usage / eventAllocation >= ALLOCATION_THRESHOLD_ALERT
                 ) {
                     return BillingAlertType.UsageNearLimit
-                }
-
-                // Priority 3: Clickhouse enabled without a Clickhouse license
-                // In practical terms, this would be priority 1 for self-hosted (as the other alerts are cloud-based only)
-                if (
-                    !preflight?.cloud &&
-                    preflight?.is_clickhouse_enabled &&
-                    !user?.organization?.available_features.includes('clickhouse') &&
-                    scene !== Scene.InstanceLicenses
-                ) {
-                    return BillingAlertType.ClickhouseLicenseMissing
                 }
             },
         ],


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/vpc/issues/48

Remove the need for a license to use Clickhouse

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
