### PR TITLE
Fix broken color issue

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -148,7 +148,7 @@ export function LineGraph({
 
         return {
             borderColor: mainColor,
-            hoverBorderColor: type === 'bar' || type === 'doughnut' ? lightenDarkenColor(mainColor, -20) : hoverColor,
+            hoverBorderColor: BACKGROUND_BASED_CHARTS.includes(type) ? lightenDarkenColor(mainColor, -20) : hoverColor,
             hoverBackgroundColor: BACKGROUND_BASED_CHARTS.includes(type)
                 ? lightenDarkenColor(mainColor, -20)
                 : undefined,

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -34,9 +34,9 @@ style files without adding already imported styles. */
     --cyan: #17a2b8;
     --pink: #e83e8c;
     --white: #f4f6ff;
-    --maroon: #800000;
+    --maroon: #7f0000;
     --mint: #aaffc3;
-    --olive: #808000;
+    --olive: #807500;
     --navy: #000075;
     --orange: #f58231;
     --lime: #bfef45;


### PR DESCRIPTION
## Changes

Fixes bug that was patched in #4761. Pesky bug, turns out the problem was that `getComputedStyle` evaluated two special colors ("olive" and "maroon") as specially named colors. So instead of `getComputedStyle(document.body).getPropertyValue('--olive')` returning `#808000` as expected, it returned `olive`, the color name. Fix was quite simple, changed G & B properties of each color by 1 respectively, and bug is now fixed.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
