### PR TITLE
Remove faulty repo-dependent Cypress test

### DIFF
--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -51,24 +51,6 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })
 
-    it('Apply specific filter on custom action', () => {
-        cy.get('[data-attr=trend-element-subject-0]').click()
-        cy.get('li.ant-list-item').contains('Watched Movie').click()
-        cy.get('[data-attr=show-prop-filter-0]').click()
-        cy.get('[data-attr=property-filter-0]').contains('Add filter').click()
-        cy.get('[data-attr=property-filter-dropdown]').click()
-        cy.get('.rc-virtual-list').trigger('wheel', {
-            deltaX: 0,
-            deltaY: 200,
-        })
-        cy.get('.ant-select-item-option-content').contains('Continent Code').click({ force: true })
-        cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-0]').click({ force: true })
-        cy.get('.ant-select-selector').contains('equals').click()
-        cy.get('.ant-select-item-option-content').contains("doesn't equal").click()
-        cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
-    })
-
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.get('div.property-key-info').contains('Pageview').click()


### PR DESCRIPTION
## Changes

This is inane but one Cypress test ("Apply specific filter on custom action" in `trends.js`) ends up looking differently on internal branches (this repo) and on external branches (forks), so it CAN'T pass on both. Don't know why yet. Therefore removing it.

#### Comparison

- Internal
   ![Cypress external](https://user-images.githubusercontent.com/4550621/122439583-10e19880-cf9c-11eb-977f-6e6216714c73.png)

- External
   ![Cypress internal](https://user-images.githubusercontent.com/4550621/122439592-12ab5c00-cf9c-11eb-94dc-cb94d661b790.png)