### PR TITLE
Add viewport keys to special prop list

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -57,22 +57,22 @@ export const keyMapping: KeyMappingInterface = {
         },
         $screen_height: {
             label: 'Screen Height',
-            description: "The height of the user's screen in pixels.",
+            description: "The height of the user's entire screen (in pixels).",
             examples: ['2160', '1050'],
         },
         $screen_width: {
             label: 'Screen Width',
-            description: "The width of the user's screen in pixels.",
+            description: "The width of the user's entire screen (in pixels).",
             examples: ['1440', '1920'],
         },
         $viewport_height: {
             label: 'Viewport Height',
-            description: "The height of the user's browser window in pixels.",
+            description: "The height of the user's actual browser window (in pixels).",
             examples: ['2094', '1031'],
         },
         $viewport_width: {
             label: 'Viewport Width',
-            description: "The width of the user's browser window in pixels.",
+            description: "The width of the user's actual browser window (in pixels).",
             examples: ['1439', '1915'],
         },
         $lib: {

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -65,6 +65,16 @@ export const keyMapping: KeyMappingInterface = {
             description: "The width of the user's screen in pixels.",
             examples: ['1440', '1920'],
         },
+        $viewport_height: {
+            label: 'Viewport Height',
+            description: "The height of the user's browser window in pixels.",
+            examples: ['2094', '1031'],
+        },
+        $viewport_width: {
+            label: 'Viewport Width',
+            description: "The width of the user's browser window in pixels.",
+            examples: ['1439', '1915'],
+        },
         $lib: {
             label: 'Library',
             description: 'What library was used to send the event.',


### PR DESCRIPTION
## Changes

I added a couple of new props to the posthog-js library (https://github.com/PostHog/posthog-js/pull/246), this adds the transformation to make them display nicely.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
