### PR TITLE
Encode filter search params

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -117,7 +117,7 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse, Person
                             .reduce(function (result, key) {
                                 const value = values.listFilters[key]
                                 if (value !== undefined && value !== null) {
-                                    result.push(`${key}=${value}`)
+                                    result.push(`${key}=${encodeURIComponent(value)}`)
                                 }
                                 return result
                             }, [] as string[])


### PR DESCRIPTION
## Changes
Fixes an issue where properties with special characters weren't being returned. 

Best example is to search for an email address that contains a '+'.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
