### PR TITLE
Round less for small y-axis values

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -499,7 +499,8 @@ export function LineGraph({
                         ticks: percentage
                             ? {
                                   callback: function (value) {
-                                      return value.toFixed(0) + '%' // convert it to percentage
+                                      const fixedValue = value < 1 ? value.toFixed(2) : value.toFixed(0)
+                                      return `${fixedValue}%` // convert it to percentage
                                   },
                               }
                             : {


### PR DESCRIPTION
## Changes

closes #4637 

issue: Values < 1 would all round to 0, for graphs with small values it didn't display very well

fix:
ex: all values < 1
<img width="879" alt="Screen Shot 2021-06-18 at 4 53 43 PM" src="https://user-images.githubusercontent.com/25164963/122615424-8316b380-d056-11eb-82f1-8d56dcd2c81a.png">

ex: mix of values that are > and < 1
<img width="862" alt="Screen Shot 2021-06-18 at 4 54 47 PM" src="https://user-images.githubusercontent.com/25164963/122615425-8316b380-d056-11eb-84e5-e90a293dc1ad.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
