### PR TITLE
feat(events): show stale events in separate section

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterDropdown.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterDropdown.tsx
@@ -161,10 +161,34 @@ export function ActionFilterDropdown({
                         )
                     },
                     dataSource:
-                        eventDefinitions.map((definition) => ({
-                            ...definition,
-                            key: EntityTypes.EVENTS + definition.id,
-                        })) || [],
+                        eventDefinitions
+                            .filter((definition) => definition.volume_30_day)
+                            .map((definition) => ({
+                                ...definition,
+                                key: EntityTypes.EVENTS + definition.id,
+                            })) || [],
+                    renderInfo: EventInfo,
+                    type: EntityTypes.EVENTS,
+                    getValue: (item: SelectedItem) => item.name || '',
+                    getLabel: (item: SelectedItem) => item.name || '',
+                },
+                {
+                    key: 'stale-events',
+                    name: 'Stale events',
+                    header: function eventHeader(label: string) {
+                        return (
+                            <>
+                                <ContainerOutlined /> {label}
+                            </>
+                        )
+                    },
+                    dataSource:
+                        eventDefinitions
+                            .filter((definition) => !definition.volume_30_day)
+                            .map((definition) => ({
+                                ...definition,
+                                key: EntityTypes.EVENTS + definition.id,
+                            })) || [],
                     renderInfo: EventInfo,
                     type: EntityTypes.EVENTS,
                     getValue: (item: SelectedItem) => item.name || '',


### PR DESCRIPTION
## Changes

Previously all events would be listed in one list, irrespective of if
they have recent activity. This makes it difficult to find relevent
events if you have lots of stale events.

This change:

 * adds a group "Stale events" based on `volume_30_days` being falsy
 * filters the main "Events" group by `volume_30_days` being truthy

Closes #4791

References #4502

Note that this also references #4502 as it achieves the functionality of
highlighting which events have had recent activity.

Using this issue as a test bed to get setup with the repo.

## Outstanding questions

 * What does it mean for `volume_30_days` to be null? I'm just going on the typescript here but is this a special case that needs to be considered
 * Handling of `preflight?.is_event_property_usage_enabled`
 * Do we need a different icon for this grouping?
 * Should we add an information hover to clarify that "Stale" means, or be explicit with the grouping name eg "Events not active in 30 days"
 * Is there a specific place that a test should be added

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [x] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [x] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
