### PR TITLE
Plugin server action matching as default

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -82,7 +82,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
         sender.add_periodic_task(120, clickhouse_part_count.s(), name="clickhouse table parts count")
         sender.add_periodic_task(120, clickhouse_mutation_count.s(), name="clickhouse table mutations count")
-    else:
+    elif settings.PLUGIN_SERVER_ACTION_MATCHING >= 2:
         sender.add_periodic_task(
             ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
             calculate_event_action_mappings.s(),

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -76,7 +76,7 @@ PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
 ).split(",") if not DISABLE_MMDB else []
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
-PLUGIN_SERVER_ACTION_MATCHING = get_from_env("PLUGIN_SERVER_ACTION_MATCHING", 0, type_cast=int)
+PLUGIN_SERVER_ACTION_MATCHING = get_from_env("PLUGIN_SERVER_ACTION_MATCHING", 1, type_cast=int)
 
 # Tokens used when installing plugins, for example to get the latest commit SHA or to download private repositories.
 # Used mainly to get around API limits and only if no ?private_token=TOKEN found in the plugin URL.

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -76,7 +76,7 @@ PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
 ).split(",") if not DISABLE_MMDB else []
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
-PLUGIN_SERVER_ACTION_MATCHING = get_from_env("PLUGIN_SERVER_ACTION_MATCHING", 1, type_cast=int)
+PLUGIN_SERVER_ACTION_MATCHING = get_from_env("PLUGIN_SERVER_ACTION_MATCHING", 2, type_cast=int)
 
 # Tokens used when installing plugins, for example to get the latest commit SHA or to download private repositories.
 # Used mainly to get around API limits and only if no ?private_token=TOKEN found in the plugin URL.

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -550,23 +550,6 @@ class TestPreCalculation(BaseTest):
         self.assertEqual(action.events.count(), 0)
 
 
-class TestSendToSlack(BaseTest):
-    @patch("celery.current_app.send_task")
-    def test_send_to_slack(self, patch_post_to_slack):
-        self.team.slack_incoming_webhook = "http://slack.com/hook"
-        self.team.save()
-        action_user_paid = Action.objects.create(team=self.team, name="user paid", post_to_slack=True)
-        ActionStep.objects.create(action=action_user_paid, event="user paid")
-
-        event = Event.objects.create(team=self.team, event="user paid", site_url="http://testserver")
-        calculate_actions_from_last_calculation()
-        calculate_actions_from_last_calculation()  # intentionally twice to make sure the hook fires once
-        self.assertEqual(patch_post_to_slack.call_count, 1)
-        patch_post_to_slack.assert_has_calls(
-            [call("posthog.tasks.webhooks.post_event_to_webhook", (event.pk, "http://testserver"))]
-        )
-
-
 class TestSelectors(BaseTest):
     def test_selector_splitting(self):
         selector1 = Selector("div > span > a")


### PR DESCRIPTION
## Changes

Setting default change to fully move to doing action matching on the fly in the plugin server.