### PR TITLE
Switch copy icon and text placement in feature flags table

### DIFF
--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -34,10 +34,14 @@ export function FeatureFlags(): JSX.Element {
                                 <DisconnectOutlined style={{ marginRight: 4 }} />
                             </Tooltip>
                         )}
-                        <span style={{ marginRight: 4 }}>{featureFlag.key}</span>
                         <div onClick={(e) => e.stopPropagation()}>
-                            <CopyToClipboardInline iconPosition="start" explicitValue={featureFlag.key} />
+                            <CopyToClipboardInline
+                                iconStyle={{ color: 'var(--primary)' }}
+                                iconPosition="start"
+                                explicitValue={featureFlag.key}
+                            />
                         </div>
+                        <span style={{ marginRight: 4 }}>{featureFlag.key}</span>
                     </div>
                 )
             },


### PR DESCRIPTION
## Changes

I didn't open up an issue for this b/c figured this was a small enough tweak. 

It makes it easier to scan left-aligned feature flag keys if the copy icons are also left-aligned.

**Before (Feature Flags Table)**
<img width="288" alt="Screen Shot 2021-06-21 at 12 17 13 PM" src="https://user-images.githubusercontent.com/13460330/122815833-d5d8b100-d28a-11eb-8f06-6ea57feac767.png">

**After (Feature Flags Table)**
<img width="194" alt="Screen Shot 2021-06-21 at 12 17 18 PM" src="https://user-images.githubusercontent.com/13460330/122815839-d7a27480-d28a-11eb-9d5f-f5a918d5873a.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [X] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [X] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
