### PR TITLE
Paginate / use infinite scroll for event property definitions

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -14,7 +14,7 @@ interface PropertyDefinitionStorage {
 }
 
 export const propertyDefinitionsModel = kea<
-    propertyDefinitionsModelType<PropertyDefinitionStorage, PropertySelectOption, PropertyDefinition>
+    propertyDefinitionsModelType<PropertyDefinitionStorage, PropertySelectOption>
 >({
     loaders: ({ values }) => ({
         propertyStorage: [

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -48,7 +48,7 @@ export const logicFromInsight = (insight: string, logicProps: Record<string, any
     }
 }
 
-export const insightLogic = kea<insightLogicType<ViewType, FilterType, Timeout>>({
+export const insightLogic = kea<insightLogicType<Timeout, ViewType>>({
     actions: () => ({
         setActiveView: (type: ViewType) => ({ type }),
         updateActiveView: (type: ViewType) => ({ type }),
@@ -77,8 +77,14 @@ export const insightLogic = kea<insightLogicType<ViewType, FilterType, Timeout>>
             false,
             {
                 // Only show timeout message if timer is still running
-                setShowTimeoutMessage: (_, { showTimeoutMessage }: { showTimeoutMessage: boolean }) =>
-                    showTimeoutMessage,
+                setShowTimeoutMessage: (
+                    _,
+                    {
+                        showTimeoutMessage,
+                    }: {
+                        showTimeoutMessage: boolean
+                    }
+                ) => showTimeoutMessage,
                 endQuery: (_, { exception }) => {
                     if (exception && exception.status !== 500) {
                         return true

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -152,13 +152,13 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             function = "jsonb_object_keys"
 
         people = self.get_queryset()
-        people = (
+        properties = (
             people.annotate(keys=JsonKeys("properties"))
             .values("keys")
             .annotate(count=Count("id"))
             .order_by("-count", "keys")
         )
-        return [{"name": event["keys"], "count": event["count"]} for event in people]
+        return [{"name": property["keys"], "count": property["count"]} for property in properties]
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -153,9 +153,12 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             .annotate(count=Count("id"))
             .order_by("-count", "keys")
         )
-        result = [{"name": property["keys"], "count": property["count"]} for property in properties]
-
-        return response.Response(result)
+        page = self.paginate_queryset(properties)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(properties, many=True)
+        return response.Response(serializer.data)  # EXPECT ERROR: Trying to index on 'id'
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -143,11 +143,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     @action(methods=["GET"], detail=False)
     def properties(self, request: request.Request, **kwargs) -> response.Response:
-        result = self.get_properties(request)
-
-        return response.Response(result)
-
-    def get_properties(self, request) -> List[Dict[str, Any]]:
         class JsonKeys(Func):
             function = "jsonb_object_keys"
 
@@ -158,7 +153,9 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             .annotate(count=Count("id"))
             .order_by("-count", "keys")
         )
-        return [{"name": property["keys"], "count": property["count"]} for property in properties]
+        result = [{"name": property["keys"], "count": property["count"]} for property in properties]
+
+        return response.Response(result)
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:


### PR DESCRIPTION
## Changes

This isn't quite working yet, but serves as a proof of concept for using `InfiniteLoader` from react-virtualized.

This branch will probably not take further commits, at least until:

- a design direction is chosen in #4267
- the SelectBox component is refactored to take into account any data structure changes introduced by the above.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
