### PR TITLE
Fix cohort filter bug

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
@@ -233,7 +233,13 @@ export function UnifiedPropertyFilter({ index, onComplete }: PropertyFilterInter
                         data-attr={'property-select-toggle-' + index}
                     >
                         <span className="text-overflow" style={{ maxWidth: '100%' }}>
-                            {key ? <PropertyKeyInfo value={key} /> : 'Add filter'}
+                            {key ? (
+                                <PropertyKeyInfo
+                                    value={type === 'cohort' ? cohorts?.find((c) => c.id === value)?.name || key : key}
+                                />
+                            ) : (
+                                'Add filter'
+                            )}
                         </span>
                         {key && <DownOutlined style={{ fontSize: 10 }} />}
                     </Button>
@@ -248,7 +254,12 @@ export function UnifiedPropertyFilter({ index, onComplete }: PropertyFilterInter
                                 setOpen(false)
                             }}
                             onSelect={(itemType, _, name) => {
-                                setThisFilter(name, undefined, operator, itemType)
+                                if (itemType === 'cohort') {
+                                    const val = cohorts.find((c) => c.name === name)
+                                    setThisFilter('id', val?.id, operator, itemType)
+                                } else {
+                                    setThisFilter(name, undefined, operator, itemType)
+                                }
                                 setOpen(false)
                             }}
                             items={selectBoxItems}


### PR DESCRIPTION
## Changes
*Please describe.*  
*If this affects the frontend, include screenshots.*  

Closes #4787 

The cohorts filter wasn't applying correctly to all graphs, not just lifecycles. This is because the cohort filter takes in different key values than the other filters.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
