### PR TITLE
Fix properties for funnels

### DIFF
--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, Optional
 
-from django.http import HttpRequest
+from rest_framework import request
 from rest_framework.exceptions import ValidationError
 
 from posthog.constants import PROPERTIES
@@ -60,14 +60,19 @@ class Filter(
     funnel_id: Optional[int] = None
     _data: Dict
 
-    def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
+    def __init__(
+        self, data: Optional[Dict[str, Any]] = None, request: Optional[request.Request] = None, **kwargs
+    ) -> None:
         if request:
-            properties = data.get("properties", {})
+            properties = {}
             if request.GET.get(PROPERTIES):
                 try:
                     properties = json.loads(request.GET[PROPERTIES])
                 except json.decoder.JSONDecodeError:
                     raise ValidationError("Properties are unparsable!")
+            elif request.data and request.data.get(PROPERTIES):
+                properties = request.data[PROPERTIES]
+
             data = {
                 **request.GET.dict(),
                 **(data if data else {}),

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -62,7 +62,7 @@ class Filter(
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[HttpRequest] = None, **kwargs) -> None:
         if request:
-            properties = {}
+            properties = data.get("properties", {})
             if request.GET.get(PROPERTIES):
                 try:
                     properties = json.loads(request.GET[PROPERTIES])


### PR DESCRIPTION
## Changes

- After moving to POST funnels, the filter properties got overridden by `{}` due to the changed lines in this PR.
- This caused global filters in funnels to not work

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
