### PR TITLE
Pass in cohort id as value for cohort filter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/UnifiedPropertyFilter.tsx
@@ -188,13 +188,13 @@ export function UnifiedPropertyFilter({ index, onComplete }: PropertyFilterInter
                     ?.map((cohort) => ({
                         name: cohort.name || '',
                         key: `cohort_${cohort.id}`,
-                        value: cohort.name,
+                        value: cohort.id,
                         cohort,
                     })) || [],
             renderInfo: CohortPropertiesInfo,
             type: 'cohort',
             key: 'cohorts',
-            getValue: (item) => item.name || '',
+            getValue: (item) => item.value || '',
             getLabel: (item) => item.name || '',
         },
     ]
@@ -253,10 +253,9 @@ export function UnifiedPropertyFilter({ index, onComplete }: PropertyFilterInter
                                 }
                                 setOpen(false)
                             }}
-                            onSelect={(itemType, _, name) => {
+                            onSelect={(itemType, val, name) => {
                                 if (itemType === 'cohort') {
-                                    const val = cohorts.find((c) => c.name === name)
-                                    setThisFilter('id', val?.id, operator, itemType)
+                                    setThisFilter('id', val, operator, itemType)
                                 } else {
                                     setThisFilter(name, undefined, operator, itemType)
                                 }


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Addresses a potential bug where two cohorts could have the same name https://github.com/PostHog/posthog/pull/4861

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
