### PR TITLE
Convert FunnelViz to TS

### DIFF
--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -8,3 +8,51 @@ declare module '*.png' {
     const content: any
     export default content
 }
+
+// Rough outline of funnel-graph-js types, as no official ones exist
+
+declare module 'funnel-graph-js' {
+    interface FunnelGraphParams {
+        container: string
+        data: {
+            colors: string[]
+            labels: string[]
+            values: number[]
+        }
+        direction?: 'horizontal' | 'vertical'
+        gradientDirection?: 'horizontal' | 'vertical'
+        displayPercent?: boolean
+        width?: number
+        height?: number
+        subLabelValue?: 'percent' | 'raw'
+    }
+
+    export default class FunnelGraph implements FunnelGraphParams {
+        constructor(params: FunnelGraphParams) {}
+        container: string | HTMLElement | null
+        createContainer: (params: any) => unknown
+        graphContainer: HTMLElement
+        data: {
+            colors: string[]
+            labels: string[]
+            values: number[]
+        }
+        draw: () => unknown
+        makeVertical: () => unknown
+        makeHorizontal: () => unknown
+        toggleDirection: () => unknown
+        gradientMakeVertical: () => unknown
+        gradientMakeHorizontal: () => unknown
+        gradientToggleDirection: () => unknown
+        updateHeight: () => unknown
+        updateWidth: () => unknown
+        updateData: (data: any) => unknown
+        update: (options: any) => unknown
+        direction: 'horizontal' | 'vertical'
+        gradientDirection: 'horizontal' | 'vertical'
+        displayPercent: boolean
+        width: number
+        height: number
+        subLabelValue: 'percent' | 'raw'
+    }
+}

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -9,7 +9,7 @@ import PropertyFilterButton from './PropertyFilterButton'
 import 'scenes/actions/Actions.scss'
 import { TooltipPlacement } from 'antd/lib/tooltip'
 import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
-import { isFilledPropertyFilter } from 'lib/components/PropertyFilters/utils'
+import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 
 interface FilterRowProps {
     item: AnyPropertyFilter
@@ -38,7 +38,7 @@ export const FilterRow = React.memo(function FilterRow({
     const { key } = item
 
     const handleVisibleChange = (visible: boolean): void => {
-        if (!visible && isFilledPropertyFilter(item) && !item.key) {
+        if (!visible && isValidPropertyFilter(item) && !item.key) {
             remove(index)
         }
         setOpen(visible)
@@ -98,7 +98,7 @@ export const FilterRow = React.memo(function FilterRow({
                             />
                         }
                     >
-                        {isFilledPropertyFilter(item) ? (
+                        {isValidPropertyFilter(item) ? (
                             <PropertyFilterButton
                                 onClick={() => setOpen(!open)}
                                 item={item as PropertyFilterType /* not EmptyPropertyFilter */}

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -5,7 +5,7 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
 import { propertyFilterLogicType } from './propertyFilterLogicType'
 import { AnyPropertyFilter, EmptyPropertyFilter, PropertyFilter, PropertyFilterValue } from '~/types'
-import { isFilledPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
+import { isValidPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
 
 export const propertyFilterLogic = kea<propertyFilterLogicType>({
     props: {} as {
@@ -66,7 +66,7 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
         },
         remove: () => actions.update(),
         update: () => {
-            const cleanedFilters = [...values.filters].filter(isFilledPropertyFilter)
+            const cleanedFilters = [...values.filters].filter(isValidPropertyFilter)
 
             // If the last item has a key, we need to add a new empty filter so the button appears
             if ('key' in values.filters[values.filters.length - 1]) {
@@ -115,7 +115,7 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
 
     selectors: {
         filtersLoading: [() => [propertyDefinitionsModel.selectors.loaded], (loaded) => !loaded],
-        filledFilters: [(s) => [s.filters], (filters) => filters.filter(isFilledPropertyFilter)],
+        filledFilters: [(s) => [s.filters], (filters) => filters.filter(isValidPropertyFilter)],
     },
 
     events: ({ actions }) => ({

--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -1,7 +1,7 @@
 import { EmptyPropertyFilter, PropertyFilter, PropertyOperator } from '../../../types'
-import { isFilledPropertyFilter } from 'lib/components/PropertyFilters/utils'
+import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 
-describe('isFilledPropertyFilter()', () => {
+describe('isValidPropertyFilter()', () => {
     it('returns values correctly', () => {
         const emptyProperty: EmptyPropertyFilter = {}
         const realProperty: PropertyFilter = {
@@ -10,12 +10,12 @@ describe('isFilledPropertyFilter()', () => {
             type: 'cohort',
             operator: PropertyOperator.LessThan,
         }
-        expect(isFilledPropertyFilter(emptyProperty)).toEqual(false)
-        expect(isFilledPropertyFilter(realProperty)).toEqual(true)
-        expect(isFilledPropertyFilter(undefined as any)).toEqual(false)
-        expect(isFilledPropertyFilter(null as any)).toEqual(false)
-        expect(isFilledPropertyFilter({ bla: 'true' } as any)).toEqual(false)
-        expect(isFilledPropertyFilter({ key: undefined })).toEqual(false)
-        expect(isFilledPropertyFilter({ key: 'cohort', value: 123 })).toEqual(true)
+        expect(isValidPropertyFilter(emptyProperty)).toEqual(false)
+        expect(isValidPropertyFilter(realProperty)).toEqual(true)
+        expect(isValidPropertyFilter(undefined as any)).toEqual(false)
+        expect(isValidPropertyFilter(null as any)).toEqual(false)
+        expect(isValidPropertyFilter({ bla: 'true' } as any)).toEqual(false)
+        expect(isValidPropertyFilter({ key: undefined })).toEqual(false)
+        expect(isValidPropertyFilter({ key: 'cohort', value: 123 })).toEqual(true)
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -19,7 +19,7 @@ export function parseProperties(
 }
 
 /** Checks if the AnyPropertyFilter is a filled PropertyFilter */
-export function isFilledPropertyFilter(filter: AnyPropertyFilter): filter is PropertyFilter {
+export function isValidPropertyFilter(filter: AnyPropertyFilter): filter is PropertyFilter {
     return (
         !!filter && // is not falsy
         'key' in filter && // has a "key" property

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -10,16 +10,21 @@ import { router } from 'kea-router'
 import { IllustrationDanger } from 'lib/components/icons'
 import { InputNumber } from 'antd'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { ChartParams, FunnelStep } from '~/types'
+
+interface FunnelVizProps extends Omit<ChartParams, 'view'> {
+    steps: FunnelStep[]
+}
 
 export function FunnelViz({
     steps: stepsParam,
-    filters: defaultFilters = undefined,
-    dashboardItemId = undefined,
-    cachedResults = undefined,
-    inSharedMode = undefined,
+    filters: defaultFilters,
+    dashboardItemId,
+    cachedResults,
+    inSharedMode,
     color = 'white',
-}) {
-    const container = useRef(null)
+}: FunnelVizProps): JSX.Element | null {
+    const container = useRef<HTMLDivElement | null>(null)
     const [steps, setSteps] = useState(stepsParam)
     const logic = funnelLogic({ dashboardItemId, cachedResults, filters: defaultFilters })
     const { results: stepsResult, resultsLoading: funnelLoading, filters, conversionWindowInDays } = useValues(logic)
@@ -27,14 +32,14 @@ export function FunnelViz({
     const [{ fromItem }] = useState(router.values.hashParams)
     const { preflight } = useValues(preflightLogic)
 
-    function buildChart() {
+    function buildChart(): void {
         if (!steps || steps.length === 0) {
             return
         }
         if (container.current) {
             container.current.innerHTML = ''
         }
-        let graph = new FunnelGraph({
+        const graph = new FunnelGraph({
             container: '.funnel-graph',
             data: {
                 labels: steps.map(
@@ -115,7 +120,6 @@ export function FunnelViz({
                     % converted from first to last step
                 </div>
                 <LineGraph
-                    pageKey="trends-annotations"
                     data-attr="trend-line-graph-funnel"
                     type="line"
                     color={color}

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -91,7 +91,7 @@ export function FunnelViz({
     }, [stepsResult, funnelLoading])
 
     if (filters.display === ACTIONS_LINE_GRAPH_LINEAR) {
-        if (filters.events?.length + filters.actions?.length == 1) {
+        if ((filters.events?.length || 0) + (filters.actions?.length || 0) == 1) {
             return (
                 <div className="insight-empty-state error-message">
                     <div className="illustration-main">
@@ -112,7 +112,7 @@ export function FunnelViz({
                                 min={1}
                                 max={365}
                                 defaultValue={conversionWindowInDays}
-                                onChange={(days) => loadConversionWindow(days)}
+                                onChange={(days) => loadConversionWindow(Number(days))}
                             />
                             &nbsp;days =&nbsp;
                         </>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -11,7 +11,6 @@ import { funnelCommandLogic } from './funnelCommandLogic'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { BaseTabProps } from 'scenes/insights/Insights'
 import { InsightTitle } from '../InsightTitle'
-import { PropertyFilter } from '~/types'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 
 interface FunnelTabProps extends BaseTabProps {
@@ -29,14 +28,6 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
     const onSubmit = (input: string): void => {
         saveFunnelInsight(input)
         closeModal()
-    }
-
-    const toNullishFilter = (filter: PropertyFilter): PropertyFilter => {
-        return {
-            ...filter,
-            operator: filter.operator || null,
-            type: filter.type || '',
-        }
     }
 
     return (
@@ -68,7 +59,7 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
                     propertyFilters={filters.properties || []}
                     onChange={(anyProperties) => {
                         setFilters({
-                            properties: anyProperties.filter(isValidPropertyFilter).map(toNullishFilter),
+                            properties: anyProperties.filter(isValidPropertyFilter),
                         })
                     }}
                 />

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -11,7 +11,8 @@ import { funnelCommandLogic } from './funnelCommandLogic'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { BaseTabProps } from 'scenes/insights/Insights'
 import { InsightTitle } from '../InsightTitle'
-import { AnyPropertyFilter, PropertyFilter } from '~/types'
+import { PropertyFilter } from '~/types'
+import { isFilledPropertyFilter } from 'lib/components/PropertyFilters/utils'
 
 interface FunnelTabProps extends BaseTabProps {
     newUI: boolean
@@ -30,11 +31,7 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
         closeModal()
     }
 
-    const isValidPropertyFilter = (filter: AnyPropertyFilter): boolean => {
-        return Boolean(filter.key) && Boolean(filter.value)
-    }
-
-    const toNullishFilter = (filter: AnyPropertyFilter & { key: string; value: string }): PropertyFilter => {
+    const toNullishFilter = (filter: PropertyFilter): PropertyFilter => {
         return {
             ...filter,
             operator: filter.operator || null,
@@ -70,11 +67,8 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
                     pageKey={`EditFunnel-property`}
                     propertyFilters={filters.properties || []}
                     onChange={(anyProperties): void => {
-                        const properties = (anyProperties.filter(isValidPropertyFilter) as Array<
-                            AnyPropertyFilter & { key: string; value: string }
-                        >).map(toNullishFilter)
                         setFilters({
-                            properties,
+                            properties: anyProperties.filter(isFilledPropertyFilter).map(toNullishFilter),
                         })
                     }}
                 />

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -11,6 +11,7 @@ import { funnelCommandLogic } from './funnelCommandLogic'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { BaseTabProps } from 'scenes/insights/Insights'
 import { InsightTitle } from '../InsightTitle'
+import { AnyPropertyFilter, PropertyFilter } from '~/types'
 
 interface FunnelTabProps extends BaseTabProps {
     newUI: boolean
@@ -27,6 +28,18 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
     const onSubmit = (input: string): void => {
         saveFunnelInsight(input)
         closeModal()
+    }
+
+    const isValidPropertyFilter = (filter: AnyPropertyFilter): boolean => {
+        return Boolean(filter.key) && Boolean(filter.value)
+    }
+
+    const toNullishFilter = (filter: AnyPropertyFilter & { key: string; value: string }): PropertyFilter => {
+        return {
+            ...filter,
+            operator: filter.operator || null,
+            type: filter.type || '',
+        }
     }
 
     return (
@@ -56,11 +69,14 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
                 <PropertyFilters
                     pageKey={`EditFunnel-property`}
                     propertyFilters={filters.properties || []}
-                    onChange={(properties: Record<string, any>): void =>
+                    onChange={(anyProperties): void => {
+                        const properties = (anyProperties.filter(isValidPropertyFilter) as Array<
+                            AnyPropertyFilter & { key: string; value: string }
+                        >).map(toNullishFilter)
                         setFilters({
                             properties,
                         })
-                    }
+                    }}
                 />
                 <TestAccountFilter filters={filters} onChange={setFilters} />
                 <hr />

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -12,7 +12,7 @@ import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { BaseTabProps } from 'scenes/insights/Insights'
 import { InsightTitle } from '../InsightTitle'
 import { PropertyFilter } from '~/types'
-import { isFilledPropertyFilter } from 'lib/components/PropertyFilters/utils'
+import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 
 interface FunnelTabProps extends BaseTabProps {
     newUI: boolean
@@ -68,7 +68,7 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
                     propertyFilters={filters.properties || []}
                     onChange={(anyProperties): void => {
                         setFilters({
-                            properties: anyProperties.filter(isFilledPropertyFilter).map(toNullishFilter),
+                            properties: anyProperties.filter(isValidPropertyFilter).map(toNullishFilter),
                         })
                     }}
                 />

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -66,7 +66,7 @@ export function FunnelTab({ newUI }: FunnelTabProps): JSX.Element {
                 <PropertyFilters
                     pageKey={`EditFunnel-property`}
                     propertyFilters={filters.properties || []}
-                    onChange={(anyProperties): void => {
+                    onChange={(anyProperties) => {
                         setFilters({
                             properties: anyProperties.filter(isValidPropertyFilter).map(toNullishFilter),
                         })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -590,6 +590,7 @@ export interface FilterType {
     people_action?: any
     formula?: any
     filter_test_accounts?: boolean
+    from_dashboard?: boolean
 }
 
 export interface SystemStatusSubrows {
@@ -674,6 +675,13 @@ export interface FunnelStep {
     people: string[]
     type: string
     labels?: string[]
+}
+
+export interface FunnelResult {
+    is_cached: boolean
+    last_refresh: string | null
+    result: FunnelStep[]
+    type: 'Funnel'
 }
 
 export interface ChartParams {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -665,6 +665,17 @@ export interface TrendResultWithAggregate extends TrendResult {
     aggregated_value: number
 }
 
+export interface FunnelStep {
+    action_id: string
+    average_time: number
+    count: number
+    name: string
+    order: number
+    people: string[]
+    type: string
+    labels?: string[]
+}
+
 export interface ChartParams {
     dashboardItemId?: number
     color?: string


### PR DESCRIPTION
## Changes

Straightforward enough, I hope. Converts the FunnelViz component to TypeScript and adds custom type definitions for a 3rd-party lib that lacks them.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
