### PR TITLE
Minor refactor: abstract SeriesLetter into SeriesGlyph

### DIFF
--- a/frontend/src/lib/components/InsightLabel/InsightLabel.scss
+++ b/frontend/src/lib/components/InsightLabel/InsightLabel.scss
@@ -29,7 +29,7 @@ $inter_items_padding: 0.3rem;
         color: $primary_alt;
     }
 
-    .graph-series-letter {
+    .graph-series-glyph {
         padding: 0 6px;
         margin-right: 4px;
         margin-left: 2px;

--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -5,7 +5,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { capitalizeFirstLetter, hexToRGBA } from 'lib/utils'
 import './InsightLabel.scss'
 import { MATHS } from 'lib/constants'
-import { SeriesLetter } from '../SeriesLetter'
+import { SeriesLetter } from 'lib/components/SeriesGlyph'
 
 // InsightsLabel pretty prints the action (or event) returned from /insights
 interface InsightsLabelProps {

--- a/frontend/src/lib/components/SeriesGlyph.tsx
+++ b/frontend/src/lib/components/SeriesGlyph.tsx
@@ -14,7 +14,7 @@ export function SeriesLetter({ hasBreakdown, seriesIndex, seriesColor }: SeriesL
 
     return (
         <span
-            className="graph-series-letter"
+            className="graph-series-glyph"
             style={
                 !hasBreakdown
                     ? {

--- a/frontend/src/lib/components/SeriesGlyph.tsx
+++ b/frontend/src/lib/components/SeriesGlyph.tsx
@@ -2,6 +2,19 @@ import { getChartColors } from 'lib/colors'
 import { alphabet, hexToRGBA } from 'lib/utils'
 import React from 'react'
 
+interface SeriesGlyphProps {
+    children: React.ReactNode
+    style?: React.CSSProperties
+}
+
+export function SeriesGlyph({ style, children }: SeriesGlyphProps): JSX.Element {
+    return (
+        <span className="graph-series-glyph" style={style}>
+            {children}
+        </span>
+    )
+}
+
 interface SeriesLetterProps {
     hasBreakdown: boolean
     seriesIndex: number
@@ -13,8 +26,7 @@ export function SeriesLetter({ hasBreakdown, seriesIndex, seriesColor }: SeriesL
     const color = seriesColor || colorList[seriesIndex % colorList.length]
 
     return (
-        <span
-            className="graph-series-glyph"
+        <SeriesGlyph
             style={
                 !hasBreakdown
                     ? {
@@ -26,6 +38,6 @@ export function SeriesLetter({ hasBreakdown, seriesIndex, seriesColor }: SeriesL
             }
         >
             {alphabet[seriesIndex]}
-        </span>
+        </SeriesGlyph>
     )
 }

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
@@ -14,7 +14,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { pluralize } from 'lib/utils'
 import './index.scss'
-import { SeriesLetter } from 'lib/components/SeriesLetter'
+import { SeriesLetter } from 'lib/components/SeriesGlyph'
 
 const EVENT_MATH_ENTRIES = Object.entries(MATHS).filter(([, item]) => item.type == EVENT_MATH_TYPE)
 const PROPERTY_MATH_ENTRIES = Object.entries(MATHS).filter(([, item]) => item.type == PROPERTY_MATH_TYPE)

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -472,7 +472,7 @@ code.code {
     font-size: 12px;
 }
 
-.graph-series-letter {
+.graph-series-glyph {
     border-radius: 50%;
     border: 2px solid $text_default;
     font-weight: bold;


### PR DESCRIPTION
## Changes

`SeriesLetter`, the round badge component used for identifying graph series by color and letter, has been given a more abstract parent, `SeriesGlyph`.

SeriesGlyph can take any child (for instance an icon) and style attributes. SeriesLetter is now considered a special instance of SeriesGlyph.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
