### PR TITLE
Enable funnel-trends-1269 for everyone

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -1,10 +1,8 @@
-import { useValues } from 'kea'
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
 import { TZIndicator } from 'lib/components/TimezoneAware'
 import { ACTIONS_BAR_CHART_VALUE, ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_PIE_CHART, ACTIONS_TABLE } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import React from 'react'
 import { ChartDisplayType, FilterType } from '~/types'
 import { ViewType } from '../insightLogic'
@@ -35,15 +33,14 @@ const showIntervalFilter = function (activeView: ViewType, filter: FilterType): 
     }
 }
 
-const showChartFilter = function (activeView: ViewType, featureFlags: Record<string, boolean>): boolean {
+const showChartFilter = function (activeView: ViewType): boolean {
     switch (activeView) {
         case ViewType.TRENDS:
         case ViewType.STICKINESS:
         case ViewType.SESSIONS:
         case ViewType.RETENTION:
-            return true
         case ViewType.FUNNELS:
-            return featureFlags['funnel-trends-1269']
+            return true
         case ViewType.LIFECYCLE:
         case ViewType.PATHS:
             return false
@@ -81,7 +78,6 @@ export function InsightDisplayConfig({
     activeView,
     clearAnnotationsToCreate,
 }: InsightDisplayConfigProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
     const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
 
     return (
@@ -90,7 +86,7 @@ export function InsightDisplayConfig({
                 <TZIndicator style={{ float: 'left', fontSize: '0.75rem', marginRight: 16 }} placement="topRight" />
             </span>
             <div style={{ width: '100%', textAlign: 'right' }}>
-                {showChartFilter(activeView, featureFlags) && (
+                {showChartFilter(activeView) && (
                     <ChartFilter
                         onChange={(display: ChartDisplayType) => {
                             if (display === ACTIONS_TABLE || display === ACTIONS_PIE_CHART) {


### PR DESCRIPTION
## Changes

- Original feature PR https://github.com/PostHog/posthog/pull/3079
- This has been enabled for 50% of users and for all teams who have ingested an event. Let's round up to "everything"
- ... even if the feature has some issue with clickhouse possibly? It won't make a difference if you have no data at all -> you'll still see a white box.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
