### PR TITLE
Fix funnels on new interface

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -10,6 +10,7 @@ import { SaveModal } from '../../SaveModal'
 import { funnelCommandLogic } from './funnelCommandLogic'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { InsightTitle } from '../InsightTitle'
+import { SaveOutlined } from '@ant-design/icons'
 
 export function FunnelTab(): JSX.Element {
     useMountedLogic(funnelCommandLogic)
@@ -57,28 +58,28 @@ export function FunnelTab(): JSX.Element {
                 />
                 <TestAccountFilter filters={filters} onChange={setFilters} />
                 <hr />
-                <Row justify="space-between">
-                    <Row justify="start">
-                        <Button
-                            style={{ marginRight: 4 }}
-                            type="primary"
-                            htmlType="submit"
-                            disabled={isStepsEmpty}
-                            data-attr="save-funnel-button"
-                        >
-                            Calculate
-                        </Button>
-                        {!isStepsEmpty && (
-                            <Button onClick={(): void => clearFunnel()} data-attr="save-funnel-clear-button">
-                                Clear
-                            </Button>
-                        )}
-                    </Row>
+                <Row style={{ justifyContent: 'flex-end' }}>
                     {!isStepsEmpty && Array.isArray(stepsWithCount) && !!stepsWithCount.length && (
-                        <Button type="primary" onClick={showModal}>
-                            Save
+                        <div style={{ flexGrow: 1 }}>
+                            <Button type="primary" onClick={showModal} icon={<SaveOutlined />}>
+                                Save
+                            </Button>
+                        </div>
+                    )}
+                    {!isStepsEmpty && (
+                        <Button onClick={(): void => clearFunnel()} data-attr="save-funnel-clear-button">
+                            Clear
                         </Button>
                     )}
+                    <Button
+                        style={{ marginLeft: 4 }}
+                        type="primary"
+                        htmlType="submit"
+                        disabled={isStepsEmpty}
+                        data-attr="save-funnel-button"
+                    >
+                        Calculate
+                    </Button>
                 </Row>
             </form>
             <SaveModal

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -11,12 +11,13 @@ import { ViewType } from '../insightLogic'
 import { CalendarOutlined } from '@ant-design/icons'
 import { InsightDateFilter } from '../InsightDateFilter'
 import { RetentionDatePicker } from '../RetentionDatePicker'
+import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
     allFilters: FilterType
     activeView: ViewType
-    annotationsToCreate: any[] // TODO: Annotate properly
+    annotationsToCreate: Record<string, any>[] // TODO: Annotate properly
 }
 
 const showIntervalFilter = function (activeView: ViewType, filter: FilterType): boolean {
@@ -79,6 +80,7 @@ const isFunnelEmpty = (filters: FilterType): boolean => {
 export function InsightDisplayConfig({
     allFilters,
     activeView,
+    annotationsToCreate,
     clearAnnotationsToCreate,
 }: InsightDisplayConfigProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
@@ -121,6 +123,17 @@ export function InsightDisplayConfig({
                 )}
 
                 {showComparePrevious[activeView] && <CompareFilter />}
+
+                {activeView === ViewType.FUNNELS && (
+                    <SaveToDashboard
+                        item={{
+                            entity: {
+                                filters: allFilters,
+                                annotations: annotationsToCreate,
+                            },
+                        }}
+                    />
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -64,6 +64,8 @@ export function Insights(): JSX.Element {
     const { setActiveView, toggleControlsCollapsed } = useActions(insightLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
 
+    const verticalLayout = activeView === ViewType.FUNNELS // Whether to display the control tab on the side instead of on top
+
     const { loadResults } = useActions(logicFromInsight(activeView, { dashboardItemId: null, filters: allFilters }))
 
     const handleHotkeyNavigation = (view: ViewType, hotkey: HotKeys): void => {
@@ -218,7 +220,7 @@ export function Insights(): JSX.Element {
                     </Col>
                 ) : (
                     <>
-                        <Col span={24}>
+                        <Col span={24} lg={verticalLayout ? 7 : undefined}>
                             <Card
                                 className={`insight-controls${controlsCollapsed ? ' collapsed' : ''}`}
                                 onClick={() => controlsCollapsed && toggleControlsCollapsed()}
@@ -284,7 +286,7 @@ export function Insights(): JSX.Element {
                                 </Card>
                             )}
                         </Col>
-                        <Col span={24}>
+                        <Col span={24} lg={verticalLayout ? 17 : undefined}>
                             {/* TODO: extract to own file. Props: activeView, allFilters, showDateFilter, dateFilterDisabled, annotationsToCreate; lastRefresh, showErrorMessage, showTimeoutMessage, isLoading; ... */}
                             {/* These are filters that are reused between insight features. They
                                 each have generic logic that updates the url


### PR DESCRIPTION
## Changes

Releasing the new query interface introduced a few issues on funnels. See [context](https://posthog.slack.com/archives/C01G8S5T08Z/p1624623112308000). This PR:
1. Keeps funnels in vertical columned layout when the screen width is larger than 992px.

<img width="1437" alt="" src="https://user-images.githubusercontent.com/5864173/123435910-5f131f00-d5ce-11eb-8e70-ddb97adcc4b7.png">

2. Brings back the add to dashboard button in the insight display config component (only for funnels).
3. Adjusts the action button buttons of funnels a tiny bit to have intuitive order and positioning. (we're redoing this anyways in a couple of days, but spent about 40 seconds making this improvement).

<img width="200" alt="" src="https://user-images.githubusercontent.com/5864173/123435864-53bff380-d5ce-11eb-9fc1-18d0f4013d97.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
