### PR TITLE
Disable cypress component tests

### DIFF
--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -1,79 +1,79 @@
-name: Cypress Component
-
-on:
-    - pull_request
-
-jobs:
-    cypress-component:
-        name: Cypress component tests
-        runs-on: ubuntu-18.04
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 14
-            - uses: actions/cache@v2
-              id: cypress-node-modules-cache
-              with:
-                  path: |
-                      **/node_modules
-                  key: ${{ runner.os }}-cypress-node-modules-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-cypress-node-modules
-            - name: Yarn install deps
-              if: steps.cypress-node-modules-cache.outputs.cache-hit != 'true'
-              run: |
-                  yarn install --frozen-lockfile
-            - uses: actions/cache@v2
-              id: cypress-cache
-              with:
-                  path: |
-                      ~/.cache/Cypress
-                      **/node_modules/cypress
-                      **/node_modules/cypress-terminal-report
-                      **/node_modules/@cypress
-                  key: ${{ runner.os }}-cypress-6.7.0-v1
-            - name: Install cypress
-              if: steps.cypress-cache.outputs.cache-hit != 'true'
-              run: |
-                  yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
-            - uses: actions/cache@v1
-              name: Setup Yarn build cache
-              id: yarn-build-cache
-              with:
-                  path: frontend/dist
-                  key: ${{ runner.os }}-yarn-build-${{ hashFiles('frontend/src/') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-build-
-            - name: Yarn build
-              if: steps.yarn-build-cache.outputs.cache-hit != 'true'
-              run: |
-                  yarn build
-
-            - name: Cypress run
-              uses: cypress-io/github-action@v2
-              with:
-                  config-file: cypress.json
-                  record: true
-                  parallel: true
-                  group: 'PostHog Component'
-                  # We're already installing cypress above
-                  # We have to install it separately otherwise the tests fail.
-                  install: false
-                  # We already install cypress separately, we don't need to install it again here
-                  install-command: echo "no"
-              env:
-                  # pass the Dashboard record key as an environment variable
-                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  # Recommended: pass the GitHub token lets this action correctly
-                  # determine the unique run id necessary to re-run the checks
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Archive test screenshots
-              uses: actions/upload-artifact@v1
-              with:
-                  name: screenshots
-                  path: cypress/screenshots
-              if: ${{ failure() }}
+#name: Cypress Component
+#
+#on:
+#    - pull_request
+#
+#jobs:
+#    cypress-component:
+#        name: Cypress component tests
+#        runs-on: ubuntu-18.04
+#        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
+#
+#        steps:
+#            - name: Checkout
+#              uses: actions/checkout@v1
+#            - uses: actions/setup-node@v1
+#              with:
+#                  node-version: 14
+#            - uses: actions/cache@v2
+#              id: cypress-node-modules-cache
+#              with:
+#                  path: |
+#                      **/node_modules
+#                  key: ${{ runner.os }}-cypress-node-modules-${{ hashFiles('**/yarn.lock') }}
+#                  restore-keys: |
+#                      ${{ runner.os }}-cypress-node-modules
+#            - name: Yarn install deps
+#              if: steps.cypress-node-modules-cache.outputs.cache-hit != 'true'
+#              run: |
+#                  yarn install --frozen-lockfile
+#            - uses: actions/cache@v2
+#              id: cypress-cache
+#              with:
+#                  path: |
+#                      ~/.cache/Cypress
+#                      **/node_modules/cypress
+#                      **/node_modules/cypress-terminal-report
+#                      **/node_modules/@cypress
+#                  key: ${{ runner.os }}-cypress-6.7.0-v1
+#            - name: Install cypress
+#              if: steps.cypress-cache.outputs.cache-hit != 'true'
+#              run: |
+#                  yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
+#            - uses: actions/cache@v1
+#              name: Setup Yarn build cache
+#              id: yarn-build-cache
+#              with:
+#                  path: frontend/dist
+#                  key: ${{ runner.os }}-yarn-build-${{ hashFiles('frontend/src/') }}
+#                  restore-keys: |
+#                      ${{ runner.os }}-yarn-build-
+#            - name: Yarn build
+#              if: steps.yarn-build-cache.outputs.cache-hit != 'true'
+#              run: |
+#                  yarn build
+#
+#            - name: Cypress run
+#              uses: cypress-io/github-action@v2
+#              with:
+#                  config-file: cypress.json
+#                  record: true
+#                  parallel: true
+#                  group: 'PostHog Component'
+#                  # We're already installing cypress above
+#                  # We have to install it separately otherwise the tests fail.
+#                  install: false
+#                  # We already install cypress separately, we don't need to install it again here
+#                  install-command: echo "no"
+#              env:
+#                  # pass the Dashboard record key as an environment variable
+#                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+#                  # Recommended: pass the GitHub token lets this action correctly
+#                  # determine the unique run id necessary to re-run the checks
+#                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#            - name: Archive test screenshots
+#              uses: actions/upload-artifact@v1
+#              with:
+#                  name: screenshots
+#                  path: cypress/screenshots
+#              if: ${{ failure() }}


### PR DESCRIPTION
## Changes

1. PRs over issues
2. I'm definitely not a fan of committing commented out code/markup, but didn't want to delete the file while the tests still exist.

However, something needs to be done. These tests keep flaking. @paolodamico and I had a look at these for some time, but couldn't get anywhere stable. 

I'm also not sure if the [component tests](https://github.com/PostHog/posthog/pull/3233) are the right approach. For example, when you run them, the entire dev console is full of errors from failed and unmocked API requests. That feels like a smell and a possible can of weird untestable side effects.

I don't think mocking every API request and perpetually keeping them in sync with reality when the db schema changes is the best use of our time. This component approach doesn't work well with Kea, and it's currently causing us a lot of headache with failures on every other PR. Hence I'd personally be in favour of more/better e2e tests. 

Should we just remove them? 

Thoughts @macobo @paolodamico ?


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
