### PR TITLE
Add frontend local dev script for Clickhouse development

### DIFF
--- a/ee/bin/docker-ch-dev-backend
+++ b/ee/bin/docker-ch-dev-backend
@@ -4,4 +4,4 @@ set -e
 python manage.py migrate
 python manage.py migrate_clickhouse
 
-python manage.py runserver 0.0.0.0:8000 & yarn start-dev
+python manage.py runserver 0.0.0.0:8000

--- a/ee/bin/docker-ch-dev-frontend
+++ b/ee/bin/docker-ch-dev-frontend
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+python manage.py migrate
+python manage.py migrate_clickhouse
+
+python manage.py runserver 0.0.0.0:8000 & yarn start-dev

--- a/ee/bin/docker-ch-dev-web
+++ b/ee/bin/docker-ch-dev-web
@@ -1,7 +1,5 @@
 #!/bin/bash
 
 set -e
-python manage.py migrate
-python manage.py migrate_clickhouse
 
-python manage.py runserver 0.0.0.0:8000 & ./bin/docker-frontend
+./bin/ee/docker-ch-dev-backend & ./bin/docker-frontend

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -70,7 +70,7 @@ services:
             - kafka:kafka
     web:
         <<: *worker
-        command: ./ee/bin/docker-ch-dev-web
+        command: '${CH_WEB_SCRIPT:-./ee/bin/docker-ch-dev-web}'
         ports:
             - '8000:8000'
             - '8234:8234'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "start-http": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve",
         "start-https": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve --https",
         "start-docker": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve --host 0.0.0.0",
+        "start-dev": "concurrently -n WEBPACK,TYPEGEN -c blue,green \"yarn run start-http --host 0.0.0.0\" \"yarn run typegen:watch\"",
         "build": "echo \"Building Webpack\" && NODE_ENV=production webpack --config webpack.config.js && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts",
         "prettier": "prettier --write \"./frontend/src/**/*.{js,ts,tsx,json,yaml,yml,css,scss}\"",
         "prettier:check": "prettier --check \"./**/*.{js,ts,tsx,json,yaml,yml,css,scss}\"",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "start-http": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve",
         "start-https": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve --https",
         "start-docker": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve --host 0.0.0.0",
-        "start-dev": "concurrently -n WEBPACK,TYPEGEN -c blue,green \"yarn run start-http --host 0.0.0.0\" \"yarn run typegen:watch\"",
+        "start-ch-dev": "concurrently -n DOCKER,WEBPACK,TYPEGEN -c red,blue,green \"CH_WEB_SCRIPT=./ee/bin/docker-ch-dev-backend docker-compose -f ee/docker-compose.ch.yml up\" \"yarn run start-http --host 0.0.0.0\" \"yarn run typegen:watch\"",
         "build": "echo \"Building Webpack\" && NODE_ENV=production webpack --config webpack.config.js && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts",
         "prettier": "prettier --write \"./frontend/src/**/*.{js,ts,tsx,json,yaml,yml,css,scss}\"",
         "prettier:check": "prettier --check \"./**/*.{js,ts,tsx,json,yaml,yml,css,scss}\"",


### PR DESCRIPTION
## Changes

When I want to make frontend changes with Clickhouse, hot reloading doesn't work quite as you expect it to when running the frontend in a docker image. For every frontend change, the frontend app reloads 10-11 times so you have to wait 1-2min for every reload which makes for a suboptimal dx.

Let's make a equivalent `docker-backend.sh` script for Clickhouse, so that devs can spin up a local React application that can talk to a dockerized backend. I also added a one-liner script in `package.json` that you can run to get a dockerized backend and local frontend up and running in no time.

Also requires doc updates in this [PR](https://github.com/PostHog/posthog.com/pull/1538)

### Steps

1. `yarn start-ch-dev`

To quit everything

1. Ctrl/Cmd+C
2. 

```
docker compose -f ee/docker-compose.ch.yml down
DEBUG=1;DJANGO_SETTINGS_MODULE=posthog.settings;PRIMARY_DB=clickhouse;CLICKHOUSE_HOST=clickhouse;CLICKHOUSE_DATABASE=posthog;CLICKHOUSE_SECURE=false;CLICKHOUSE_VERIFY=false python migrate.py migrate_clickhouse
```
