### PR TITLE
Funnel steps conversion time per step

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel.py
+++ b/ee/clickhouse/queries/funnels/funnel.py
@@ -16,14 +16,45 @@ class ClickhouseFunnelNew(ClickhouseFunnelBase):
     def get_step_counts_query(self):
 
         steps_per_person_query = self._get_steps_per_person_query()
+        max_steps = len(self._filter.entities)
 
         return f"""
-        SELECT furthest, count(*), groupArray(100)(person_id) FROM (
-            SELECT person_id, max(steps) AS furthest FROM (
+        SELECT {self._get_count_columns(max_steps)} {self._get_step_time_avgs(max_steps)} FROM (
+            SELECT person_id, max(steps) AS furthest {self._get_step_time_avgs(max_steps)} FROM (
                 {steps_per_person_query}
             ) GROUP BY person_id
-        ) GROUP BY furthest SETTINGS allow_experimental_window_functions = 1
+        ) SETTINGS allow_experimental_window_functions = 1
         """
+
+    def _get_count_columns(self, max_steps: int):
+        cols: List[str] = []
+
+        for i in range(max_steps):
+            cols.append(f"countIf(furthest = {i + 1}) step_{i + 1}")
+
+        return ", ".join(cols)
+
+    def _format_results(self, results):
+        # Format of this is [step order, person count (that reached that step), array of person uuids]
+        steps = []
+        relevant_people = []
+        total_people = 0
+
+        for step in reversed(self._filter.entities):
+
+            if results[0] and len(results[0]) > 0:
+                total_people += results[0][step.order]
+                relevant_people = []
+            serialized_result = self._serialize_step(step, total_people, relevant_people)
+            if step.order > 0:
+                serialized_result.update(
+                    {"average_conversion_time": results[0][step.order + len(self._filter.entities) - 1]}
+                )
+            else:
+                serialized_result.update({"average_conversion_time": None})
+            steps.append(serialized_result)
+
+        return steps[::-1]  #  reverse
 
     # TODO: include in the inner query to handle breakdown
     def _get_breakdown_prop(self) -> str:
@@ -33,19 +64,10 @@ class ClickhouseFunnelNew(ClickhouseFunnelBase):
             return ""
 
     # TODO: include in the inner query to handle time to convert
-    def _get_step_times(self, max_steps: int):
-        conditions: List[str] = []
-        for i in range(1, max_steps):
-            conditions.append(
-                f"if(isNotNull(latest_{i}), dateDiff('second', toDateTime(latest_{i - 1}), toDateTime(latest_{i})), NULL) step{i-1}ToStep{i}Time"
-            )
-
-        return ", ".join(conditions)
-
-    # TODO: include in the inner query to handle time to convert
     def _get_step_time_avgs(self, max_steps: int):
         conditions: List[str] = []
         for i in range(1, max_steps):
-            conditions.append(f"avg(step{i-1}ToStep{i}Time) step{i-1}ToStep{i}Time")
+            conditions.append(f"avg(step_{i}_average_conversion_time) step_{i}_average_conversion_time")
 
-        return ", ".join(conditions)
+        formatted = ", ".join(conditions)
+        return f", {formatted}" if formatted else ""

--- a/ee/clickhouse/queries/funnels/funnel.py
+++ b/ee/clickhouse/queries/funnels/funnel.py
@@ -37,15 +37,14 @@ class ClickhouseFunnelNew(ClickhouseFunnelBase):
     def _format_results(self, results):
         # Format of this is [step order, person count (that reached that step), array of person uuids]
         steps = []
-        relevant_people = []
         total_people = 0
 
         for step in reversed(self._filter.entities):
 
             if results[0] and len(results[0]) > 0:
                 total_people += results[0][step.order]
-                relevant_people = []
-            serialized_result = self._serialize_step(step, total_people, relevant_people)
+
+            serialized_result = self._serialize_step(step, total_people, [])
             if step.order > 0:
                 serialized_result.update(
                     {"average_conversion_time": results[0][step.order + len(self._filter.entities) - 1]}

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -65,14 +65,6 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
 
         self.assertEqual(result[0]["name"], "user signed up")
         self.assertEqual(result[0]["count"], 2)
-        # check ordering of people in first step
-        self.assertCountEqual(
-            result[0]["people"], [person1_stopped_after_two_signups.uuid, person2_stopped_after_signup.uuid],
-        )
-
-        self.assertCountEqual(
-            result[1]["people"], [person1_stopped_after_two_signups.uuid],
-        )
 
     def test_advanced_funnel_with_repeat_steps(self):
         filters = {
@@ -132,44 +124,6 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
         self.assertEqual(result[1]["name"], "$pageview")
         self.assertEqual(result[4]["name"], "$pageview")
         self.assertEqual(result[0]["count"], 5)
-        # check ordering of people in every step
-        self.assertCountEqual(
-            result[0]["people"],
-            [
-                person1_stopped_after_signup.uuid,
-                person2_stopped_after_one_pageview.uuid,
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
-        )
-
-        self.assertCountEqual(
-            result[1]["people"],
-            [
-                person2_stopped_after_one_pageview.uuid,
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
-        )
-
-        self.assertCountEqual(
-            result[2]["people"],
-            [
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
-        )
-
-        self.assertCountEqual(
-            result[3]["people"], [person4_stopped_after_three_pageview.uuid, person5_stopped_after_many_pageview.uuid],
-        )
-
-        self.assertCountEqual(
-            result[4]["people"], [person5_stopped_after_many_pageview.uuid],
-        )
 
     def test_advanced_funnel_with_repeat_steps_out_of_order_events(self):
         filters = {
@@ -243,39 +197,6 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
         self.assertEqual(result[1]["name"], "$pageview")
         self.assertEqual(result[4]["name"], "$pageview")
         self.assertEqual(result[0]["count"], 5)
-        # check ordering of people in every step
-        self.assertCountEqual(
-            result[0]["people"],
-            [
-                person1_stopped_after_signup.uuid,
-                person2_stopped_after_one_pageview.uuid,
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
-        )
-
-        self.assertCountEqual(
-            result[1]["people"],
-            [
-                person2_stopped_after_one_pageview.uuid,
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
-        )
-
-        self.assertCountEqual(
-            result[2]["people"], [person5_stopped_after_many_pageview.uuid],
-        )
-
-        self.assertCountEqual(
-            result[3]["people"], [person5_stopped_after_many_pageview.uuid],
-        )
-
-        self.assertCountEqual(
-            result[4]["people"], [person5_stopped_after_many_pageview.uuid],
-        )
 
     def test_funnel_with_actions(self):
 
@@ -309,14 +230,6 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
 
         self.assertEqual(result[0]["name"], "sign up")
         self.assertEqual(result[0]["count"], 2)
-        # check ordering of people in first step
-        self.assertCountEqual(
-            result[0]["people"], [person1_stopped_after_two_signups.uuid, person2_stopped_after_signup.uuid],
-        )
-
-        self.assertCountEqual(
-            result[1]["people"], [person1_stopped_after_two_signups.uuid],
-        )
 
     def test_funnel_with_actions_and_events(self):
 
@@ -371,23 +284,6 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
             result = funnel.run()
 
         self.assertEqual(result[0]["name"], "user signed up")
-        # check ordering of people in steps
-        self.assertCountEqual(
-            result[0]["people"],
-            [person1_stopped_after_two_signups.uuid, person2_stopped_after_signup.uuid, person3.uuid, person4.uuid],
-        )
-
-        self.assertCountEqual(
-            result[1]["people"],
-            [person1_stopped_after_two_signups.uuid, person2_stopped_after_signup.uuid, person3.uuid, person4.uuid],
-        )
-
-        self.assertCountEqual(
-            result[2]["people"],
-            [person1_stopped_after_two_signups.uuid, person2_stopped_after_signup.uuid, person3.uuid,],
-        )
-
-        self.assertCountEqual(result[3]["people"], [person1_stopped_after_two_signups.uuid,])
 
     def test_funnel_with_matching_properties(self):
         filters = {
@@ -511,41 +407,84 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
         self.assertEqual(result[1]["name"], "$pageview")
         self.assertEqual(result[4]["name"], "$pageview")
         self.assertEqual(result[0]["count"], 5)
-        # check ordering of people in every step
-        self.assertCountEqual(
-            result[0]["people"],
-            [
-                person1_stopped_after_signup.uuid,
-                person2_stopped_after_one_pageview.uuid,
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
+
+    def test_funnel_step_conversion_times(self):
+
+        filters = {
+            "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}, {"id": "buy", "order": 2},],
+            "insight": INSIGHT_FUNNELS,
+            "date_from": "2020-01-01",
+            "date_to": "2020-01-08",
+            "funnel_window_days": 7,
+        }
+
+        filter = Filter(data=filters)
+        funnel = ClickhouseFunnelNew(filter, self.team)
+
+        # event
+        person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="sign up",
+            distinct_id="person1",
+            properties={"key": "val"},
+            timestamp="2020-01-01T12:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="play movie",
+            distinct_id="person1",
+            properties={"key": "val"},
+            timestamp="2020-01-01T13:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="buy",
+            distinct_id="person1",
+            properties={"key": "val"},
+            timestamp="2020-01-01T15:00:00Z",
         )
 
-        self.assertCountEqual(
-            result[1]["people"],
-            [
-                person2_stopped_after_one_pageview.uuid,
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
+        person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="sign up",
+            distinct_id="person2",
+            properties={"key": "val"},
+            timestamp="2020-01-02T14:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="play movie",
+            distinct_id="person2",
+            properties={"key": "val"},
+            timestamp="2020-01-02T16:00:00Z",
         )
 
-        self.assertCountEqual(
-            result[2]["people"],
-            [
-                person3_stopped_after_two_pageview.uuid,
-                person4_stopped_after_three_pageview.uuid,
-                person5_stopped_after_many_pageview.uuid,
-            ],
+        person3 = _create_person(distinct_ids=["person3"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="sign up",
+            distinct_id="person3",
+            properties={"key": "val"},
+            timestamp="2020-01-02T14:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="play movie",
+            distinct_id="person3",
+            properties={"key": "val"},
+            timestamp="2020-01-02T16:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="buy",
+            distinct_id="person3",
+            properties={"key": "val"},
+            timestamp="2020-01-02T17:00:00Z",
         )
 
-        self.assertCountEqual(
-            result[3]["people"], [person4_stopped_after_three_pageview.uuid, person5_stopped_after_many_pageview.uuid],
-        )
-
-        self.assertCountEqual(
-            result[4]["people"], [],
-        )
+        result = funnel.run()
+        self.assertEqual(result[0]["average_conversion_time"], None)
+        self.assertEqual(result[1]["average_conversion_time"], 6000)
+        self.assertEqual(result[2]["average_conversion_time"], 5400)

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -103,10 +103,6 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 result = funnel.run()
             self.assertEqual(result[0]["name"], "user signed up")
             self.assertEqual(result[0]["count"], 2)
-            # check ordering of people in first step
-            self.assertCountEqual(
-                result[0]["people"], [person1_stopped_after_signup.uuid, person2_stopped_after_signup.uuid],
-            )
 
         def test_funnel_events(self):
             funnel = self._basic_funnel()
@@ -141,21 +137,11 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             result = funnel.run()
             self.assertEqual(result[0]["name"], "user signed up")
             self.assertEqual(result[0]["count"], 4)
-            # check ordering of people in first step
-            self.assertCountEqual(
-                result[0]["people"],
-                [
-                    person_stopped_after_movie.uuid,
-                    person_stopped_after_pay.uuid,
-                    person_stopped_after_signup.uuid,
-                    person_wrong_order.uuid,
-                ],
-            )
+
             self.assertEqual(result[1]["name"], "paid")
             self.assertEqual(result[1]["count"], 2)
             self.assertEqual(result[2]["name"], "watched movie")
             self.assertEqual(result[2]["count"], 1)
-            self.assertEqual(result[2]["people"], [person_stopped_after_movie.uuid])
 
             # make sure it's O(n)
             person_wrong_order = person_factory(distinct_ids=["badalgo"], team_id=self.team.pk)


### PR DESCRIPTION
## Changes

*Please describe.*  
- change the step query result shape. Remove the last group by so that the average can be performed over entire list of results
- remove "people" check in funnel related queries as this will become deprecated in favor of a separate api call to retrieve funnel people
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
