### PR TITLE
Stops Kea typegen from yelling into void during dev builds

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -117,6 +117,7 @@ export const commandPaletteLogic = kea<
         CommandRegistrations,
         CommandResult,
         CommandResultDisplayable,
+        CommandResultTemplate,
         RegExpCommandPairs
     >
 >({

--- a/frontend/src/scenes/authentication/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/inviteSignupLogic.ts
@@ -21,7 +21,7 @@ interface AcceptInvitePayloadInterface {
     email_opt_in: boolean
 }
 
-export const inviteSignupLogic = kea<inviteSignupLogicType<AcceptInvitePayloadInterface, ErrorInterface>>({
+export const inviteSignupLogic = kea<inviteSignupLogicType<AcceptInvitePayloadInterface, ErrorCodes, ErrorInterface>>({
     actions: {
         setError: (payload: ErrorInterface) => ({ payload }),
     },

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -9,7 +9,7 @@ interface UrlParams {
     date_to?: string
 }
 
-export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
+export const insightDateFilterLogic = kea<insightDateFilterLogicType<UrlParams>>({
     actions: () => ({
         setDates: (dateFrom: string | Dayjs | undefined, dateTo: string | Dayjs | undefined) => ({
             dateFrom,

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -17,7 +17,7 @@ interface Params {
     filters?: Array<SessionsPropertyFilter>
 }
 
-export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>>({
+export const sessionsTableLogic = kea<sessionsTableLogicType<Params, SessionRecordingId>>({
     key: (props) => props.personIds || 'global',
     props: {} as {
         personIds?: string[]


### PR DESCRIPTION
## Changes

Some auto generated kea typings weren't committed to the repo. They should be so that git stops flagging these files everytime anyone runs `yarn typegen:watch`.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
