### PR TITLE
Return 404 instead of 500 when no project for user for legacy* endpoints

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -84,7 +84,10 @@ class StructuredViewSetMixin(NestedViewSetMixin):
         if self.legacy_team_compatibility:
             if not self.request.user.is_authenticated:
                 raise AuthenticationFailed()
-            return {"team_id": self.request.user.team.id}
+            project = self.request.user.team
+            if project is None:
+                raise NotFound("Current project not found.")
+            return {"team_id": project.id}
         result = {}
         # process URL paremetrs (here called kwargs), such as organization_id in /api/organizations/:organization_id/
         for kwarg_name, kwarg_value in self.kwargs.items():

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional, cast
 
-from rest_framework.exceptions import AuthenticationFailed, NotFound
+from rest_framework.exceptions import AuthenticationFailed, NotFound, ValidationError
 from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 from rest_framework_extensions.settings import extensions_api_settings
@@ -86,7 +86,7 @@ class StructuredViewSetMixin(NestedViewSetMixin):
                 raise AuthenticationFailed()
             project = self.request.user.team
             if project is None:
-                raise NotFound("Current project not found.")
+                raise ValidationError("This endpoint requires a project.")
             return {"team_id": project.id}
         result = {}
         # process URL paremetrs (here called kwargs), such as organization_id in /api/organizations/:organization_id/


### PR DESCRIPTION
## Changes

Previously this would 500/cause an uncaught error, causing noise in sentry.

Closes https://github.com/PostHog/posthog/issues/4898

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
