### PR TITLE
Only send error class name to statsd

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -130,7 +130,7 @@ else:
                 result = client.execute(sql, args, settings=settings, with_column_types=with_column_types)
             except Exception as e:
                 tags["failed"] = True
-                tags["reason"] = str(e)
+                tags["reason"] = type(e).__name__
                 raise e
             finally:
                 execution_time = time() - start_time


### PR DESCRIPTION
This seems to have caused some errors in sentry:
- https://sentry.io/organizations/posthog/issues/2476537458/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d
- https://sentry.io/organizations/posthog/issues/2476551877/?project=1899813&query=is%3Aunassigned+is%3Aunresolved&statsPeriod=14d

Given we don't need the whole error message in sentry this might be
enough :)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
