### PR TITLE
Revert "Stops Kea typegen from yelling into void during dev builds"

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -117,7 +117,6 @@ export const commandPaletteLogic = kea<
         CommandRegistrations,
         CommandResult,
         CommandResultDisplayable,
-        CommandResultTemplate,
         RegExpCommandPairs
     >
 >({

--- a/frontend/src/scenes/authentication/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/inviteSignupLogic.ts
@@ -21,7 +21,7 @@ interface AcceptInvitePayloadInterface {
     email_opt_in: boolean
 }
 
-export const inviteSignupLogic = kea<inviteSignupLogicType<AcceptInvitePayloadInterface, ErrorCodes, ErrorInterface>>({
+export const inviteSignupLogic = kea<inviteSignupLogicType<AcceptInvitePayloadInterface, ErrorInterface>>({
     actions: {
         setError: (payload: ErrorInterface) => ({ payload }),
     },

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -9,7 +9,7 @@ interface UrlParams {
     date_to?: string
 }
 
-export const insightDateFilterLogic = kea<insightDateFilterLogicType<UrlParams>>({
+export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
     actions: () => ({
         setDates: (dateFrom: string | Dayjs | undefined, dateTo: string | Dayjs | undefined) => ({
             dateFrom,

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -17,7 +17,7 @@ interface Params {
     filters?: Array<SessionsPropertyFilter>
 }
 
-export const sessionsTableLogic = kea<sessionsTableLogicType<Params, SessionRecordingId>>({
+export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>>({
     key: (props) => props.personIds || 'global',
     props: {} as {
         personIds?: string[]


### PR DESCRIPTION
Reverts PostHog/posthog#4897

Something didn't feel right. If I `yarn install` to get the latest typegen that's in the master branch, it wants to get to a state before this PR was added.