### PR TITLE
Revert "Quick hotfix of broken frontend"

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -152,8 +152,8 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             null as string | null,
             {
                 loadLatestVersion: async () => {
-                    const versions = (await api.get('https://update.posthog.com/versions')) || []
-                    return versions[0]?.version || '1.25.0' // HACK: Super quick fix so the frontend doesn't fail terribly
+                    const versions = await api.get('https://update.posthog.com/versions')
+                    return versions[0].version
                 },
             },
         ],

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -33,7 +33,7 @@ export const propertyDefinitionsModel = kea<
                     const propertyStorage = await api.get(url)
                     return {
                         count: propertyStorage.count,
-                        results: [...(values.propertyStorage.results || []), ...(propertyStorage.results || [])],
+                        results: [...values.propertyStorage.results, ...propertyStorage.results],
                         next: propertyStorage.next,
                     }
                 },


### PR DESCRIPTION
Reverts PostHog/posthog#4452 which had an unmaintainable default value. Instead, I'll try loading available versions with a certain number of retries.