### PR TITLE
Update local filters on filter delete

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -150,6 +150,7 @@ export const entityFilterLogic = kea<entityFilterLogicType<BareEntity, LocalFilt
         removeLocalFilter: async ({ index }) => {
             eventUsageLogic.actions.reportInsightFilterRemoved(index)
             actions.setFilters(values.localFilters.filter((_, i) => i !== index))
+            actions.setLocalFilters({ filters: values.localFilters.filter((_, i) => i !== index) } as FilterType)
         },
         addFilter: async () => {
             const previousLength = values.localFilters.length


### PR DESCRIPTION
## Changes

before: visual/state bug really where the filters didn't seem to properly update 

https://user-images.githubusercontent.com/25164963/123817845-7e5bc600-d8c6-11eb-9406-a230bd609ea1.mov

after: we update `localFilters` to pass down this filter change

https://user-images.githubusercontent.com/25164963/123817880-8451a700-d8c6-11eb-8a8e-4253bc777fa1.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
