### PR TITLE
Don't error if trying to filter by person_id which does not exist

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -191,9 +191,9 @@ def determine_event_conditions(
             params.update({"before": timestamp})
         elif k == "person_id":
             result += """AND distinct_id IN (%(distinct_ids)s)"""
-            distinct_ids = Person.objects.filter(pk=v, team_id=team.pk)[0].distinct_ids
-            distinct_ids = [distinct_id.__str__() for distinct_id in distinct_ids]
-            params.update({"distinct_ids": distinct_ids})
+            person = Person.objects.filter(pk=v, team_id=team.pk).first()
+            distinct_ids = person.distinct_ids if person is not None else []
+            params.update({"distinct_ids": list(map(str, distinct_ids))})
         elif k == "distinct_id":
             result += "AND distinct_id = %(distinct_id)s"
             params.update({"distinct_id": v})

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -103,9 +103,14 @@ def factory_test_event_api(event_factory, person_factory, _):
                 event="random event", team=self.team, distinct_id="some-other-one", properties={"$ip": "8.8.8.8"}
             )
 
-            response = self.client.get("/api/event/?person_id=%s" % person.pk).json()
+            response = self.client.get(f"/api/event/?person_id={person.pk}").json()
             self.assertEqual(len(response["results"]), 2)
             self.assertEqual(response["results"][0]["elements"], [])
+
+        def test_filter_by_nonexisting_person(self):
+            response = self.client.get(f"/api/event/?person_id=5555555555")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json()["results"]), 0)
 
         def _signup_event(self, distinct_id: str):
             sign_up = event_factory(


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/2240057229/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
