### PR TITLE
Proposal: Use `ValidationError` over `ValueError` in views

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple
 
 from django.forms.models import model_to_dict
+from rest_framework.exceptions import ValidationError
 
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Action, Entity, Filter
@@ -93,7 +94,7 @@ def format_entity_filter(entity: Entity, prepend: str = "action", filter_by_team
             action = Action.objects.get(pk=entity.id)
             entity_filter, params = format_action_filter(action, prepend=prepend, filter_by_team=filter_by_team)
         except Action.DoesNotExist:
-            raise ValueError("This action does not exist")
+            raise ValidationError("This action does not exist")
     else:
         key = f"{prepend}_event"
         entity_filter = f"event = %({key})s"

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from dateutil import parser
 from django.conf import settings
 from django.utils import timezone
+from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
@@ -113,7 +114,7 @@ def _get_count_operator(count_operator: Optional[str]) -> str:
     elif count_operator == "eq" or count_operator is None:
         return "="
     else:
-        raise ValueError("count_operator must be gte, lte, eq, or None")
+        raise ValidationError("count_operator must be gte, lte, eq, or None")
 
 
 def _get_entity_query(
@@ -126,7 +127,7 @@ def _get_entity_query(
         action_filter_query, action_params = format_action_filter(action, prepend="_{}_action".format(group_idx))
         return action_filter_query, action_params
     else:
-        raise ValueError("Cohort query requires action_id or event_id")
+        raise ValidationError("Cohort query requires action_id or event_id")
 
 
 def get_date_query(

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Optional, Tuple
 from django.conf import settings
 from django.db.models.expressions import F
 from django.utils import timezone
-from rest_framework.request import Request
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 from rest_framework.utils.serializer_helpers import ReturnDict
 from sentry_sdk.api import capture_exception
 

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db.models.expressions import F
 from django.utils import timezone
 from rest_framework.request import Request
+from rest_framework.exceptions import ValidationError
 from rest_framework.utils.serializer_helpers import ReturnDict
 from sentry_sdk.api import capture_exception
 
@@ -87,7 +88,7 @@ def _format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
             entity_filter = "AND {}".format(action_query)
 
         except Action.DoesNotExist:
-            raise ValueError("This action does not exist")
+            raise ValidationError("This action does not exist")
     else:
         entity_filter = "AND event = %(event)s"
         params = {"event": entity.id}

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from dateutil.relativedelta import relativedelta
 from django.db.models.query import Prefetch
 from rest_framework.request import Request
+from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
@@ -32,7 +33,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         elif interval == "month":
             return relativedelta(months=1), "1 MONTH", "1 DAY"
         else:
-            raise ValueError("{interval} not supported")
+            raise ValidationError("{interval} not supported")
 
     def _format_lifecycle_query(self, entity: Entity, filter: Filter, team_id: int) -> Tuple[str, Dict, Callable]:
         date_from = filter.date_from

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
 from django.db.models.query import Prefetch
-from rest_framework.request import Request
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
+from rest_framework.exceptions import ValidationError
+
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.queries.util import format_ch_timestamp, get_earliest_timestamp
 from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL
@@ -79,7 +81,7 @@ def get_active_user_params(filter: Filter, entity: Entity, team_id: int) -> Dict
         try:
             earliest_date = get_earliest_timestamp(team_id)
         except IndexError:
-            raise ValueError("Active User queries require a lower date bound")
+            raise ValidationError("Active User queries require a lower date bound")
         else:
             params.update(
                 {
@@ -99,7 +101,7 @@ def populate_entity_params(entity: Entity) -> Tuple[Dict, Dict]:
             params = {**action_params}
             content_sql_params = {"entity_query": "AND {action_query}".format(action_query=action_query)}
         except:
-            raise ValueError("Action does not exist")
+            raise ValidationError("Action does not exist")
     else:
         content_sql_params = {"entity_query": "AND event = %(event)s"}
         params = {"event": entity.id}

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
+from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import GET_EARLIEST_TIMESTAMP_SQL
@@ -98,7 +99,7 @@ def get_trunc_func_ch(period: Optional[str]) -> str:
     elif period == "month":
         return PERIOD_TRUNC_MONTH
     else:
-        raise ValueError(f"Period {period} is unsupported.")
+        raise ValidationError(f"Period {period} is unsupported.")
 
 
 def date_from_clause(interval_annotation: str, round_interval: bool) -> str:

--- a/posthog/models/filters/mixins/retention.py
+++ b/posthog/models/filters/mixins/retention.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional, Tuple, Union
 from dateutil.relativedelta import relativedelta
 from django.db.models.query_utils import Q
 from django.utils import timezone
+from rest_framework.exceptions import ValidationError
 
 from posthog.constants import (
     DISTINCT_ID_FILTER,
@@ -138,7 +139,7 @@ class RetentionDateDerivedMixin(PeriodMixin, TotalIntervalsMixin, DateMixin, Sel
         elif period == "Day":
             return timedelta(days=total_intervals), timedelta(days=1)
         else:
-            raise ValueError(f"Period {period} is unsupported.")
+            raise ValidationError(f"Period {period} is unsupported.")
 
 
 class EntitiesDerivedMixin(EntitiesMixin):

--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Callable, Optional, Union
 
+from rest_framework.exceptions import ValidationError
+
 from posthog.constants import DATE_FROM, DATE_TO, STICKINESS_DAYS
 from posthog.models.filters.mixins.common import BaseParamMixin, DateMixin, IntervalMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
@@ -65,6 +67,6 @@ class TotalIntervalsDerivedMixin(IntervalMixin, StickinessDateMixin):
         elif self.interval == "month":
             _num_intervals = (self.date_to.year - self.date_from.year) + (self.date_to.month - self.date_from.month)
         else:
-            raise ValueError(f"{self.interval} not supported")
+            raise ValidationError(f"{self.interval} not supported")
         _num_intervals += 2
         return _num_intervals

--- a/posthog/models/filters/stickiness_filter.py
+++ b/posthog/models/filters/stickiness_filter.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from django.db.models.functions.datetime import TruncDay, TruncHour, TruncMinute, TruncMonth, TruncWeek
 from django.http import HttpRequest
+from rest_framework.exceptions import ValidationError
 
 from posthog.models.filters.base_filter import BaseFilter
 from posthog.models.filters.mixins.common import (
@@ -36,11 +37,11 @@ class StickinessFilter(
         super().__init__(data, request, **kwargs)
         team: Optional[Team] = kwargs.get("team", None)
         if not team:
-            raise ValueError("Team must be provided to stickiness filter")
+            raise ValidationError("Team must be provided to stickiness filter")
         self.team = team
         get_earliest_timestamp: Optional[Callable] = kwargs.get("get_earliest_timestamp", None)
         if not get_earliest_timestamp:
-            raise ValueError("Callable must be provided when date filtering is all time")
+            raise ValidationError("Callable must be provided when date filtering is all time")
         self.get_earliest_timestamp = get_earliest_timestamp  # type: ignore
 
     def trunc_func(self, field_name: str) -> Union[TruncMinute, TruncHour, TruncDay, TruncWeek, TruncMonth]:
@@ -55,4 +56,4 @@ class StickinessFilter(
         elif self.interval == "month":
             return TruncMonth(field_name)
         else:
-            raise ValueError(f"{self.interval} not supported")
+            raise ValidationError(f"{self.interval} not supported")

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -2,10 +2,10 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser, BaseUserManager
-from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from rest_framework.exceptions import ValidationError
 
 from posthog.utils import get_instance_realm
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.db.models.query import Prefetch
 from rest_framework import request
+from rest_framework.exceptions import ValidationError
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
 from posthog.models.entity import Entity
@@ -33,7 +34,7 @@ def process_entity_for_events(entity: Entity, team_id: int, order_by="-id") -> Q
 
 def determine_compared_filter(filter) -> Filter:
     if not filter.date_to or not filter.date_from:
-        raise ValueError("You need date_from and date_to to compare")
+        raise ValidationError("You need date_from and date_to to compare")
     date_from, date_to = get_compare_period_dates(filter.date_from, filter.date_to)
     return filter.with_data({"date_from": date_from.date().isoformat(), "date_to": date_to.date().isoformat()})
 

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -6,6 +6,7 @@ from django.db import connection
 from django.db.models.query import Prefetch
 from django.utils import timezone
 from rest_framework.request import Request
+from rest_framework.exceptions import ValidationError
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.entity import Entity
@@ -335,7 +336,7 @@ def get_interval(period: str) -> Union[timedelta, relativedelta]:
     elif period == "month":
         return relativedelta(months=1)
     else:
-        raise ValueError("{} not supported".format(period))
+        raise ValidationError("{} not supported".format(period))
 
 
 def get_time_diff(
@@ -373,7 +374,7 @@ def get_trunc_func(period: str) -> Tuple[str, str]:
     elif period == "month":
         return "month", "day"
     else:
-        raise ValueError(f"Period {period} is unsupported.")
+        raise ValidationError(f"Period {period} is unsupported.")
 
 
 class LifecycleTrend:

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -5,8 +5,8 @@ from dateutil.relativedelta import relativedelta
 from django.db import connection
 from django.db.models.query import Prefetch
 from django.utils import timezone
-from rest_framework.request import Request
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.entity import Entity

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -6,6 +6,7 @@ from django.db.models.expressions import Exists, F, OuterRef
 from django.db.models.functions.datetime import TruncDay, TruncHour, TruncMonth, TruncWeek
 from django.db.models.query import Prefetch, QuerySet
 from django.db.models.query_utils import Q
+from rest_framework.exceptions import ValidationError
 from rest_framework.utils.serializer_helpers import ReturnDict
 from sentry_sdk.api import capture_exception
 
@@ -305,7 +306,7 @@ class Retention(BaseQuery):
         elif entity.type == TREND_FILTER_TYPE_ACTIONS:
             return Q(action__pk=entity.id), "{}.action_id = %s".format(table)
         else:
-            raise ValueError(f"Entity type not supported")
+            raise ValidationError(f"Entity type not supported")
 
     def _get_trunc_func(
         self, subject: str, period: str
@@ -335,7 +336,7 @@ class Retention(BaseQuery):
             """
             return TruncMonth(subject), fields
         else:
-            raise ValueError(f"Period {period} is unsupported.")
+            raise ValidationError(f"Period {period} is unsupported.")
 
 
 def appearance_to_markers(vals: List, num_intervals: int) -> List:

--- a/posthog/queries/stickiness.py
+++ b/posthog/queries/stickiness.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Union
 from django.db import connection
 from django.db.models import Count
 from django.db.models.query import Prefetch, QuerySet
-from rest_framework.request import Request
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
@@ -130,7 +130,7 @@ def stickiness_process_entity_type(target_entity: Entity, team: Team, filter: St
             base.filter_events(team.pk, filter, target_entity)
         )
     else:
-        raise ValidationError("target entity must be action or event")
+        raise ValidationError("Target entity must be action or event.")
     return events
 
 

--- a/posthog/queries/stickiness.py
+++ b/posthog/queries/stickiness.py
@@ -5,6 +5,7 @@ from django.db import connection
 from django.db.models import Count
 from django.db.models.query import Prefetch, QuerySet
 from rest_framework.request import Request
+from rest_framework.exceptions import ValidationError
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
@@ -129,7 +130,7 @@ def stickiness_process_entity_type(target_entity: Entity, team: Team, filter: St
             base.filter_events(team.pk, filter, target_entity)
         )
     else:
-        raise ValueError("target entity must be action or event")
+        raise ValidationError("target entity must be action or event")
     return events
 
 


### PR DESCRIPTION
This generates a nicer exception for our users (400 response instead of
500) and we cut down on 500 errors for things that are not expected to
work.

Example sentry error with someone reverse-engineering our api: https://sentry.io/organizations/posthog/issues/2482887379/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
