### PR TITLE
Retry fetching latest app version if request fails

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -152,8 +152,17 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             null as string | null,
             {
                 loadLatestVersion: async () => {
-                    const versions = await api.get('https://update.posthog.com/versions')
-                    return versions[0].version
+                    let retries = 0
+                    while (retries < 3) {
+                        const versions = await api.get('https://update.posthog.com/versions')
+                        if (!versions?.length || !versions[0]?.version) {
+                            retries++
+                            await setTimeout(() => {}, 150)
+                            continue
+                        }
+                        return versions[0].version
+                    }
+                    return null
                 },
             },
         ],

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -157,10 +157,11 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
                         const versions = await api.get('https://update.posthog.com/versions')
                         if (!versions?.length || !versions[0]?.version) {
                             retries++
-                            await setTimeout(() => {}, 150)
+                            await new Promise((resolve) => setTimeout(resolve, 150))
                             continue
+                        } else {
+                            return versions[0].version
                         }
-                        return versions[0].version
                     }
                     return null
                 },

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -33,7 +33,7 @@ export const propertyDefinitionsModel = kea<
                     const propertyStorage = await api.get(url)
                     return {
                         count: propertyStorage.count,
-                        results: [...values.propertyStorage.results, ...propertyStorage.results],
+                        results: [...values.propertyStorage.results, ...(propertyStorage.results || [])],
                         next: propertyStorage.next,
                     }
                 },


### PR DESCRIPTION
## Changes

Another pass at #4452, a crucial but infrequent problem wherein the app doesn't load state correctly if the latest version cannot be determined.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
