### PR TITLE
Feature flags - UI fixes

### DIFF
--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -31,14 +31,6 @@ export function FeatureFlags(): JSX.Element {
             width: '15%',
             sorter: (a: FeatureFlagType, b: FeatureFlagType) => ('' + a.key).localeCompare(b.key),
             render: function Render(_: string, featureFlag: FeatureFlagType) {
-                if (!featureFlag.active) {
-                    return (
-                        <Tooltip title="This feature flag is disabled.">
-                            <DisconnectOutlined style={{ marginRight: 4 }} />
-                        </Tooltip>
-                    )
-                }
-
                 return (
                     <div
                         style={{
@@ -48,6 +40,11 @@ export function FeatureFlags(): JSX.Element {
                             width: 'auto',
                         }}
                     >
+                        {!featureFlag.active && (
+                            <Tooltip title="This feature flag is disabled.">
+                                <DisconnectOutlined style={{ marginRight: 4 }} />
+                            </Tooltip>
+                        )}
                         <div onClick={(e) => e.stopPropagation()}>
                             <CopyToClipboardInline
                                 iconStyle={{ color: 'var(--primary)' }}

--- a/frontend/src/scenes/experimentation/featureFlagLogic.tsx
+++ b/frontend/src/scenes/experimentation/featureFlagLogic.tsx
@@ -130,7 +130,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
     urlToAction: ({ actions }) => ({
         '/feature_flags/*': ({ _: id }) => {
             if (id) {
-                actions.setFeatureFlagId(parseInt(id))
+                const parsedId = id === 'new' ? 'new' : parseInt(id)
+                actions.setFeatureFlagId(parsedId)
             }
             actions.loadFeatureFlag()
         },


### PR DESCRIPTION
## Changes

Recent PRs broke this (no sense finding them to reference, fix is here). This PR:
1. Fixes this bug where names were not shown for inactive flags.
<img width="527" alt="" src="https://user-images.githubusercontent.com/5864173/123938333-4ff9eb80-d997-11eb-8255-e09dfd1a355d.png">
2. Fixes this bug when the changing key warning was shown when adding a new feature flag (which doesn't make sense).
<img width="645" alt="" src="https://user-images.githubusercontent.com/5864173/123938347-51c3af00-d997-11eb-81b4-9d39f5b62bb0.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
