### PR TITLE
Speed up /api/person/properties under clickhouse

### DIFF
--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -302,3 +302,12 @@ AND person_id IN
     WHERE 1 = 1 {filters}
 )
 """
+
+GET_PERSON_PROPERTIES_COUNT = """
+SELECT tupleElement(keysAndValues, 1) as key, count(*) as count
+FROM person
+ARRAY JOIN JSONExtractKeysAndValuesRaw(properties) as keysAndValues
+WHERE team_id = %(team_id)s
+GROUP BY tupleElement(keysAndValues, 1)
+ORDER BY count DESC, key ASC
+"""


### PR DESCRIPTION
For our largest teams this currently times out on postgres. Tested and
this query works well on clickhouse.

Sentry issue: https://sentry.io/organizations/posthog/issues/1724065650/events/a038f0a1624e4e68bd47142731f26018/?project=1899813&statsPeriod=14d

Note sentry is rolling multiple similar errors into one.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
