### PR TITLE
Ignore breakdown in funnel trends

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -3,6 +3,9 @@ from typing import Union
 
 from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnelNew
 from ee.clickhouse.queries.util import get_time_diff, get_trunc_func_ch
+from posthog.constants import BREAKDOWN
+from posthog.models.filters.filter import Filter
+from posthog.models.team import Team
 
 DAY_START = 0
 TOTAL_COMPLETED_FUNNELS = 1
@@ -45,6 +48,12 @@ class ClickhouseFunnelTrends(ClickhouseFunnelNew):
 
     If no people have reached step {from_step} in the period, {conversion_rate} is zero.
     """
+
+    def __init__(self, filter: Filter, team: Team) -> None:
+        # TODO: allow breakdown
+        if BREAKDOWN in filter._data:
+            del filter._data[BREAKDOWN]
+        super().__init__(filter, team)
 
     def run(self, *args, **kwargs):
         if len(self._filter.entities) == 0:

--- a/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
@@ -685,3 +685,44 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(day_2["reached_to_step_count"], 1)
         self.assertEqual(day_2["conversion_rate"], 100)
         self.assertEqual(day_2["is_period_final"], True)
+
+    def test_window_size_one_day_not_broken_by_breakdown(self):
+        self._create_sample_data()
+
+        filter = Filter(
+            data={
+                "insight": INSIGHT_FUNNELS,
+                "display": TRENDS_LINEAR,
+                "interval": "day",
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+                "funnel_window_days": 1,
+                "events": [
+                    {"id": "step one", "order": 0},
+                    {"id": "step two", "order": 1},
+                    {"id": "step three", "order": 2},
+                ],
+            }
+        )
+        results = ClickhouseFunnelTrends(filter, self.team).perform_query()
+
+        filter_breakdown = Filter(
+            data={
+                "insight": INSIGHT_FUNNELS,
+                "display": TRENDS_LINEAR,
+                "interval": "day",
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+                "funnel_window_days": 1,
+                "breakdown": "x",
+                "breakdown_type": "event",
+                "events": [
+                    {"id": "step one", "order": 0},
+                    {"id": "step two", "order": 1},
+                    {"id": "step three", "order": 2},
+                ],
+            }
+        )
+        results_breakdown = ClickhouseFunnelTrends(filter_breakdown, self.team).perform_query()
+
+        self.assertEqual(results_breakdown, results)


### PR DESCRIPTION
## Changes

Fixes https://posthog.slack.com/archives/C02283301EK/p1625009861045200.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] ~~Jest frontend tests~~
- [ ] ~~Cypress end-to-end tests~~
- [ ] ~~Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious~~
- [ ] ~~Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)~~
- [ ] ~~Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.~~
