### PR TITLE
Track realm on sign up events

### DIFF
--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from posthog.models import Dashboard, Organization, OrganizationMembership, Team, User
 from posthog.models.organization import OrganizationInvite
 from posthog.test.base import APIBaseTest
+from posthog.utils import get_instance_realm
 
 
 class TestOrganizationAPI(APIBaseTest):
@@ -204,7 +205,7 @@ class TestSignup(APIBaseTest):
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationSignupSerializer",
                 "signup_social_provider": "",
-                "realm": "hosted",
+                "realm": get_instance_realm(),
             },
         )
 
@@ -277,7 +278,7 @@ class TestSignup(APIBaseTest):
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationSignupSerializer",
                 "signup_social_provider": "",
-                "realm": "hosted",
+                "realm": get_instance_realm(),
             },
         )
 
@@ -557,7 +558,7 @@ class TestInviteSignup(APIBaseTest):
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationInviteSignupSerializer",
                 "signup_social_provider": "",
-                "realm": "hosted",
+                "realm": get_instance_realm(),
             },
         )
 

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -204,6 +204,7 @@ class TestSignup(APIBaseTest):
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationSignupSerializer",
                 "signup_social_provider": "",
+                "realm": "hosted",
             },
         )
 
@@ -276,6 +277,7 @@ class TestSignup(APIBaseTest):
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationSignupSerializer",
                 "signup_social_provider": "",
+                "realm": "hosted",
             },
         )
 

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -555,6 +555,7 @@ class TestInviteSignup(APIBaseTest):
                 "new_onboarding_enabled": False,
                 "signup_backend_processor": "OrganizationInviteSignupSerializer",
                 "signup_social_provider": "",
+                "realm": "hosted",
             },
         )
 

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -7,6 +7,7 @@ from typing import List
 import posthoganalytics
 
 from posthog.models import Organization, User
+from posthog.utils import get_instance_realm
 
 
 def report_user_signed_up(
@@ -28,6 +29,7 @@ def report_user_signed_up(
         "new_onboarding_enabled": new_onboarding_enabled,
         "signup_backend_processor": backend_processor,
         "signup_social_provider": social_provider,
+        "realm": get_instance_realm(),
     }
 
     # TODO: This should be $set_once as user props.


### PR DESCRIPTION
## Changes
Adds realm to sign up events so we can track user growth by realm. 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
