### PR TITLE
Handle AnonymousUser() in api/team endpoint

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -102,7 +102,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         Special permissions handling for create requests as the organization is inferred from the current user.
         """
         if self.request.method == "POST" or self.request.method == "DELETE":
-            organization = cast(User, self.request.user).organization
+            organization = getattr(self.request.user, "organization", None)
 
             if not organization:
                 raise exceptions.ValidationError("You need to belong to an organization.")
@@ -124,7 +124,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
     def get_object(self):
         lookup_value = self.kwargs[self.lookup_field]
         if lookup_value == "@current":
-            team = cast(User, self.request.user).team
+            team = getattr(self.request.user, "team", None)
             if team is None:
                 raise exceptions.NotFound("Current project not found.")
             return team


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/2462252497/?project=1899813&query=is%3Aunresolved+is%3Aunassigned

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
