### PR TITLE
Make funnel persons api call return values structure consistent with others

### DIFF
--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -44,7 +44,7 @@ class ClickhousePersonViewSet(PersonViewSet):
         results = ClickhouseFunnelTrendsPersons(filter, team).run()
 
         next_url = format_next_absolute_url(request, filter.offset, 100) if len(results) > 99 else None
-        return response.Response(data={"results": results, "next": next_url})
+        return response.Response({"results": [{"people": results, "count": len(results)}], "next": next_url})
 
     def get_properties(self, request: request.Request):
         rows = sync_execute(GET_PERSON_PROPERTIES_COUNT, {"team_id": self.team.pk})

--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -32,7 +32,7 @@ class ClickhousePersonViewSet(PersonViewSet):
         results = ClickhouseFunnelPersons(filter, team).run()
 
         next_url = format_next_absolute_url(request, filter.offset, 100) if len(results) > 99 else None
-        return response.Response(data={"results": results, "next": next_url})
+        return response.Response({"results": [{"people": results, "count": len(results)}], "next": next_url})
 
     @action(methods=["GET"], detail=False)
     def funnel_trends(self, request: request.Request, **kwargs) -> response.Response:

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
@@ -48,9 +48,9 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
 
         response = self.client.get("/api/person/funnel/", data=request_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        j = response.json()
-        self.assertEqual(5, len(j["results"]))
-        self.assertTrue("id" in j["results"][0] and "name" in j["results"][0] and "distinct_ids" in j["results"][0])
+        people = response.json()["results"][0]["people"]
+        self.assertEqual(5, len(people))
+        self.assertTrue("id" in people[0] and "name" in people[0] and "distinct_ids" in people[0])
 
     def test_basic_pagination(self):
         self._create_sample_data(250)
@@ -73,18 +73,21 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get("/api/person/funnel/", data=request_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
+        people = j["results"][0]["people"]
         next = j["next"]
-        self.assertEqual(100, len(j["results"]))
+        self.assertEqual(100, len(people))
 
         response = self.client.get(next)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
+        people = j["results"][0]["people"]
         next = j["next"]
-        self.assertEqual(100, len(j["results"]))
+        self.assertEqual(100, len(people))
         self.assertNotEqual(None, next)
 
         response = self.client.get(next)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
-        self.assertEqual(50, len(j["results"]))
+        people = j["results"][0]["people"]
+        self.assertEqual(50, len(people))
         self.assertEqual(None, j["next"])

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
@@ -49,12 +49,9 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get("/api/person/funnel/", data=request_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
+        first_person = j["reults"][0]["people"][0]
         self.assertEqual(5, len(j["results"][0]["people"]))
-        self.assertTrue(
-            "id" in j["results"][0]["people"]
-            and "name" in j["results"][0]["people"]
-            and "distinct_ids" in j["results"][0]["people"]
-        )
+        self.assertTrue("id" in first_person and "name" in first_person and "distinct_ids" in first_person)
         self.assertEqual(5, j["results"][0]["count"])
 
     def test_basic_pagination(self):

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
@@ -49,8 +49,9 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get("/api/person/funnel/", data=request_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
-        self.assertEqual(5, len(j["results"]))
-        self.assertTrue("id" in j["results"][0] and "name" in j["results"][0] and "distinct_ids" in j["results"][0])
+        self.assertEqual(5, len(j["results"][0]["people"]))
+        self.assertTrue("id" in j["results"][0]["people"] and "name" in j["results"][0]["people"] and "distinct_ids" in j["results"][0]["people"])
+        self.assertEqual(5, j["results"][0]["count"])
 
     def test_basic_pagination(self):
         self._create_sample_data(250)

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
@@ -50,7 +50,11 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
         self.assertEqual(5, len(j["results"][0]["people"]))
-        self.assertTrue("id" in j["results"][0]["people"] and "name" in j["results"][0]["people"] and "distinct_ids" in j["results"][0]["people"])
+        self.assertTrue(
+            "id" in j["results"][0]["people"]
+            and "name" in j["results"][0]["people"]
+            and "distinct_ids" in j["results"][0]["people"]
+        )
         self.assertEqual(5, j["results"][0]["count"])
 
     def test_basic_pagination(self):

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
@@ -49,7 +49,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get("/api/person/funnel/", data=request_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         j = response.json()
-        first_person = j["reults"][0]["people"][0]
+        first_person = j["results"][0]["people"][0]
         self.assertEqual(5, len(j["results"][0]["people"]))
         self.assertTrue("id" in first_person and "name" in first_person and "distinct_ids" in first_person)
         self.assertEqual(5, j["results"][0]["count"])


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Standardize the format of the results from the funnel persons call so I don't have to index it two different ways on the frontend

side note: personally I think for all persons calls the results should just be { people: [], count: x } instead of [{ people: [], count: x }] but maybe we're passing in other objects into the array that I haven't encountered 😄 

<img width="578" alt="Screen Shot 2021-07-01 at 8 59 54 AM" src="https://user-images.githubusercontent.com/25164963/124128357-b68c1180-da4a-11eb-9669-fa810e4651c4.png">

<img width="712" alt="Screen Shot 2021-07-01 at 9 00 22 AM" src="https://user-images.githubusercontent.com/25164963/124128419-c73c8780-da4a-11eb-898d-308715432e42.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
