### PR TITLE
Handle cohort being filtered on not existing

### DIFF
--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -352,6 +352,16 @@ def factory_test_event_api(event_factory, person_factory, _):
             self.assertEqual(len(response["result"]), SESSIONS_LIST_DEFAULT_LIMIT)
             self.assertIsNotNone(response["pagination"])
 
+        def test_events_nonexistent_cohort_handling(self):
+            response_nonexistent_property = self.client.get(
+                f"/api/event/sessions/?filters={json.dumps([{'type':'property','key':'abc','value':'xyz'}])}"
+            ).json()
+            response_nonexistent_cohort = self.client.get(
+                f"/api/event/sessions/?filters={json.dumps([{'type':'cohort','key':'id','value':2137}])}"
+            ).json()
+
+            self.assertEqual(response_nonexistent_property, response_nonexistent_cohort)  # Both caes just empty
+
         def test_event_sessions_by_id(self):
             another_team = Team.objects.create(organization=self.organization)
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -142,6 +142,14 @@ def insight_test_factory(event_factory, person_factory):
             self.assertEqual(response["result"][0]["count"], 2)
             self.assertEqual(response["result"][0]["action"]["name"], "$pageview")
 
+        def test_nonexistent_cohort_is_handled(self):
+            with freeze_time("2012-01-15T04:01:34.000Z"):
+                response = self.client.get(
+                    f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':5}])}"
+                ).json()
+
+            self.assertEqual(response, self.validation_error_response("Cohort ID 5 doesn't exist.", "invalid_input"))
+
         def test_insight_trends_breakdown_pagination(self):
             with freeze_time("2012-01-14T03:21:34.000Z"):
                 for i in range(25):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -143,12 +143,15 @@ def insight_test_factory(event_factory, person_factory):
             self.assertEqual(response["result"][0]["action"]["name"], "$pageview")
 
         def test_nonexistent_cohort_is_handled(self):
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response = self.client.get(
-                    f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':5}])}"
+            with self.settings(DEBUG=1):
+                response_nonexistent_property = self.client.get(
+                    f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'property','key':'foo','value':'barabarab'}])}"
                 ).json()
+                response_nonexistent_cohort = self.client.get(
+                    f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':2137}])}"
+                ).json()  # This should not throw an error, just act like there's no event matches
 
-            self.assertEqual(response, self.validation_error_response("Cohort ID 5 doesn't exist.", "invalid_input"))
+            self.assertEqual(response_nonexistent_cohort, response_nonexistent_property)  # Both cases just empty
 
         def test_insight_trends_breakdown_pagination(self):
             with freeze_time("2012-01-14T03:21:34.000Z"):


### PR DESCRIPTION
## Changes

Resolves Sentry issue #4959.
Previously 500s were thrown, this way we act as if no data can be matched to a nonexistent cohort (which is intuitive).

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests