### PR TITLE
Sessions table bug fixes

### DIFF
--- a/frontend/src/lib/components/ExpandIcon.tsx
+++ b/frontend/src/lib/components/ExpandIcon.tsx
@@ -13,7 +13,14 @@ interface ExpandIconProps {
     children?: JSX.Element
 }
 
-function ExpandIcon({ prefixCls, onExpand, record, expanded, expandable, children }: ExpandIconProps): JSX.Element {
+export function ExpandIcon({
+    prefixCls,
+    onExpand,
+    record,
+    expanded,
+    expandable,
+    children,
+}: ExpandIconProps): JSX.Element {
     const iconPrefix = `${prefixCls}-row-expand-icon`
     return (
         <div
@@ -36,5 +43,3 @@ function ExpandIcon({ prefixCls, onExpand, record, expanded, expandable, childre
         </div>
     )
 }
-
-export default ExpandIcon

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -232,6 +232,7 @@ export const FEATURE_FLAGS: Record<string, string> = {
     NEW_TOOLTIPS: '4156-tooltips-legends',
     PERSONS_MODAL_FILTERING: '4819-persons-modal-updates',
     FUNNEL_BAR_VIZ: '4535-funnel-bar-viz',
+    SESSIONS_TABLE: '4964-sessions-table',
 }
 
 export const ENVIRONMENT_LOCAL_STORAGE_KEY = '$environment'

--- a/frontend/src/scenes/sessions/SessionDetails.tsx
+++ b/frontend/src/scenes/sessions/SessionDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Table } from 'antd'
+import { Table, Tooltip } from 'antd'
 import { humanFriendlyDiff, humanFriendlyDetailedTime } from '~/lib/utils'
 import { EventDetails } from 'scenes/events'
 import { Property } from 'lib/components/Property'
@@ -8,6 +8,10 @@ import { EventType, SessionType } from '~/types'
 import { useActions, useValues } from 'kea'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import ExpandIcon from 'lib/components/ExpandIcon'
+import { IconEventsShort } from 'lib/components/icons'
+import { MATCHING_EVENT_ICON_SIZE } from 'scenes/sessions/SessionsView'
+import { ANTD_EXPAND_BUTTON_WIDTH } from 'lib/components/ResizableTable'
 
 export function SessionDetails({ session }: { session: SessionType }): JSX.Element {
     const { filteredSessionEvents } = useValues(sessionsTableLogic)
@@ -90,6 +94,23 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
                 },
                 rowExpandable: (event) => !!event,
                 expandRowByClick: true,
+                columnWidth: ANTD_EXPAND_BUTTON_WIDTH + MATCHING_EVENT_ICON_SIZE,
+                expandIcon: function _renderExpandIcon(expandProps) {
+                    const { record: event } = expandProps
+                    return (
+                        <ExpandIcon {...expandProps}>
+                            {(session.matching_events || []).includes(event.id) ? (
+                                <Tooltip title="This event matches your event filters">
+                                    <div className="sessions-matching-events-icon cursor-pointer">
+                                        <IconEventsShort size={MATCHING_EVENT_ICON_SIZE} />
+                                    </div>
+                                </Tooltip>
+                            ) : (
+                                <></>
+                            )}
+                        </ExpandIcon>
+                    )
+                },
             }}
         />
     )

--- a/frontend/src/scenes/sessions/SessionDetails.tsx
+++ b/frontend/src/scenes/sessions/SessionDetails.tsx
@@ -19,6 +19,7 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(50)
     const events = session.events || filteredSessionEvents[session.global_session_id]
+    const matchingEventIds = new Set(session.matching_events || [])
 
     useEffect(() => {
         if (!events) {
@@ -72,9 +73,7 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
         <Table
             columns={columns}
             rowKey="id"
-            rowClassName={(event: EventType) =>
-                (session.matching_events || []).includes(event.id) ? 'sessions-event-highlighted' : ''
-            }
+            rowClassName={(event: EventType) => (matchingEventIds.has(event.id) ? 'sessions-event-highlighted' : '')}
             dataSource={events}
             loading={!events}
             pagination={{
@@ -98,7 +97,7 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
                     const { record: event } = expandProps
                     return (
                         <ExpandIcon {...expandProps}>
-                            {(session.matching_events || []).includes(event.id) ? (
+                            {matchingEventIds.has(event.id) ? (
                                 <Tooltip title="Matches your event filters">
                                     <div className="sessions-event-matching-events-icon cursor-pointer text-extra-small ml-05">
                                         M

--- a/frontend/src/scenes/sessions/SessionDetails.tsx
+++ b/frontend/src/scenes/sessions/SessionDetails.tsx
@@ -8,10 +8,9 @@ import { EventType, SessionType } from '~/types'
 import { useActions, useValues } from 'kea'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import ExpandIcon from 'lib/components/ExpandIcon'
-import { IconEventsShort } from 'lib/components/icons'
-import { MATCHING_EVENT_ICON_SIZE } from 'scenes/sessions/SessionsView'
 import { ANTD_EXPAND_BUTTON_WIDTH } from 'lib/components/ResizableTable'
+import { MATCHING_EVENT_ICON_SIZE } from 'scenes/sessions/SessionsView'
+import ExpandIcon from 'lib/components/ExpandIcon'
 
 export function SessionDetails({ session }: { session: SessionType }): JSX.Element {
     const { filteredSessionEvents } = useValues(sessionsTableLogic)
@@ -100,9 +99,9 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
                     return (
                         <ExpandIcon {...expandProps}>
                             {(session.matching_events || []).includes(event.id) ? (
-                                <Tooltip title="This event matches your event filters">
-                                    <div className="sessions-matching-events-icon cursor-pointer">
-                                        <IconEventsShort size={MATCHING_EVENT_ICON_SIZE} />
+                                <Tooltip title="Matches your event filters">
+                                    <div className="sessions-event-matching-events-icon cursor-pointer text-extra-small ml-05">
+                                        M
                                     </div>
                                 </Tooltip>
                             ) : (

--- a/frontend/src/scenes/sessions/SessionDetails.tsx
+++ b/frontend/src/scenes/sessions/SessionDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Table, Tooltip } from 'antd'
 import { humanFriendlyDiff, humanFriendlyDetailedTime } from '~/lib/utils'
 import { EventDetails } from 'scenes/events'
@@ -10,7 +10,8 @@ import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { ANTD_EXPAND_BUTTON_WIDTH } from 'lib/components/ResizableTable'
 import { MATCHING_EVENT_ICON_SIZE } from 'scenes/sessions/SessionsView'
-import ExpandIcon from 'lib/components/ExpandIcon'
+import { ExpandIcon } from 'lib/components/ExpandIcon'
+import { MonitorOutlined } from '@ant-design/icons'
 
 export function SessionDetails({ session }: { session: SessionType }): JSX.Element {
     const { filteredSessionEvents } = useValues(sessionsTableLogic)
@@ -19,7 +20,7 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(50)
     const events = session.events || filteredSessionEvents[session.global_session_id]
-    const matchingEventIds = new Set(session.matching_events || [])
+    const matchingEventIds = useMemo(() => new Set(session.matching_events || []), [session.matching_events])
 
     useEffect(() => {
         if (!events) {
@@ -99,8 +100,8 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
                         <ExpandIcon {...expandProps}>
                             {matchingEventIds.has(event.id) ? (
                                 <Tooltip title="Matches your event filters">
-                                    <div className="sessions-event-matching-events-icon cursor-pointer text-extra-small ml-05">
-                                        M
+                                    <div className="sessions-event-matching-events-icon cursor-pointer ml-05">
+                                        <MonitorOutlined />
                                     </div>
                                 </Tooltip>
                             ) : (

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -222,13 +222,8 @@
 }
 
 .sessions-event-matching-events-icon {
-    background-color: $yellow_300;
-    color: $bg_navy;
-    height: 20px;
-    width: 20px;
-    font-weight: bold;
-    font-size: 9px;
-    border-radius: 5px;
+    color: $warning;
+    font-size: 1.4em;
 }
 
 .sessions-view-actions {

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -193,11 +193,18 @@
 }
 
 .sessions-event-highlighted {
-    background-color: #fdedc9;
+    background-color: $yellow_50;
+    font-weight: bold;
+}
+
+.ant-table-tbody > tr.ant-table-row:hover.sessions-event-highlighted > td {
+    background-color: $yellow_100;
 }
 
 .sessions-matching-events-icon {
     color: $bg_navy;
+    display: flex;
+    align-items: center;
 
     .badge-text {
         background-color: $yellow_50;
@@ -221,8 +228,8 @@
 
     .sessions-view-actions-left-items {
         display: flex;
-        flex-direction: column;
-        align-items: flex-start;
+        flex-direction: row;
+        align-items: center;
         flex-grow: 1;
 
         .action {
@@ -232,8 +239,10 @@
         }
     }
 
-    .ant-btn {
-        padding-left: 4px !important;
+    .sessions-view-actions-right-items {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
     }
 }
 

--- a/frontend/src/scenes/sessions/Sessions.scss
+++ b/frontend/src/scenes/sessions/Sessions.scss
@@ -221,6 +221,16 @@
     }
 }
 
+.sessions-event-matching-events-icon {
+    background-color: $yellow_300;
+    color: $bg_navy;
+    height: 20px;
+    width: 20px;
+    font-weight: bold;
+    font-size: 9px;
+    border-radius: 5px;
+}
+
 .sessions-view-actions {
     margin-top: $default_spacing;
     margin-bottom: $default_spacing;

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react'
 import { useValues, useActions, BindLogic } from 'kea'
 import { decodeParams } from 'kea-router'
-import { Button, Spin, Space, Tooltip, Badge, Switch, Row, Radio } from 'antd'
+import { Button, Spin, Space, Tooltip, Badge, Switch, Row } from 'antd'
 import { Link } from 'lib/components/Link'
-import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
+import { ExpandState, sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP } from '~/lib/utils'
 import { SessionDetails } from './SessionDetails'
 import dayjs from 'dayjs'
@@ -30,7 +30,7 @@ import generatePicker from 'antd/es/date-picker/generatePicker'
 import { ResizableTable, ResizableColumnType, ANTD_EXPAND_BUTTON_WIDTH } from 'lib/components/ResizableTable'
 import { teamLogic } from 'scenes/teamLogic'
 import { IconEventsShort } from 'lib/components/icons'
-import ExpandIcon from 'lib/components/ExpandIcon'
+import { ExpandIcon } from 'lib/components/ExpandIcon'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
@@ -75,6 +75,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
         expandedRowKeysProps,
         showOnlyMatches,
         filters,
+        rowExpandState,
     } = useValues(logic)
     const {
         fetchNextSessions,
@@ -82,8 +83,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
         nextDay,
         setFilters,
         applyFilters,
-        expandSessionRows,
-        collapseSessionRows,
+        toggleExpandSessionRows,
         onExpandedRowsChange,
         setShowOnlyMatches,
     } = useActions(logic)
@@ -226,30 +226,27 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
             <div className="sessions-view-actions">
                 <div className="sessions-view-actions-left-items">
                     <Row className="action">
-                        <Radio.Group>
-                            {featureFlags[FEATURE_FLAGS.SESSIONS_TABLE] && (
-                                <Radio.Button value="expand" onClick={expandSessionRows}>
-                                    Expand all
-                                </Radio.Button>
-                            )}
-                            <Radio.Button value="collapse" onClick={collapseSessionRows}>
-                                Collapse all
-                            </Radio.Button>
-                        </Radio.Group>
+                        {featureFlags[FEATURE_FLAGS.SESSIONS_TABLE] && (
+                            <Button data-attr="sessions-expand-collapse" onClick={toggleExpandSessionRows}>
+                                {rowExpandState === ExpandState.Expanded ? 'Collapse' : 'Expand'} all
+                            </Button>
+                        )}
                     </Row>
-                    <Row className="action ml-05">
-                        <Switch
-                            // @ts-expect-error `id` prop is valid on switch
-                            id="show-only-matches"
-                            onChange={setShowOnlyMatches}
-                            checked={showOnlyMatches}
-                            size="small"
-                            disabled={filteredSessions.length === 0 || filters.length === 0}
-                        />
-                        <label className="ml-025" htmlFor="show-only-matches">
-                            Show only matches
-                        </label>
-                    </Row>
+                    {filters.length > 0 && (
+                        <Row className="action ml-05">
+                            <Switch
+                                // @ts-expect-error `id` prop is valid on switch
+                                id="show-only-matches"
+                                onChange={setShowOnlyMatches}
+                                checked={showOnlyMatches}
+                                //size="small"
+                                disabled={filteredSessions.length === 0}
+                            />
+                            <label className="ml-025" htmlFor="show-only-matches">
+                                <b>Show only event matches</b>
+                            </label>
+                        </Row>
+                    )}
                 </div>
                 <div className="sessions-view-actions-right-items">
                     <Tooltip title={playAllCTA}>

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -70,7 +70,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
         properties,
         sessionRecordingId,
         firstRecordingId,
-        expandedRowKeys,
+        expandedRowKeysProps,
         showOnlyMatches,
         filters,
     } = useValues(logic)
@@ -312,7 +312,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                     rowExpandable: () => true,
                     onExpandedRowsChange: onExpandedRowsChange,
                     expandRowByClick: true,
-                    ...(!!expandedRowKeys && { expandedRowKeys: expandedRowKeys as string[] }),
+                    ...expandedRowKeysProps,
                 }}
             />
             {!!sessionRecordingId && <SessionPlayerDrawer isPersonPage={isPersonPage} />}

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -31,6 +31,8 @@ import { ResizableTable, ResizableColumnType, ANTD_EXPAND_BUTTON_WIDTH } from 'l
 import { teamLogic } from 'scenes/teamLogic'
 import { IconEventsShort } from 'lib/components/icons'
 import ExpandIcon from 'lib/components/ExpandIcon'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -87,6 +89,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
     } = useActions(logic)
     const { currentTeam } = useValues(teamLogic)
     const { shareFeedbackCommand } = useActions(commandPaletteLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const sessionsTableRef = useRef<HTMLInputElement>(null)
 
     const enableSessionRecordingCTA = (
@@ -224,9 +227,11 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 <div className="sessions-view-actions-left-items">
                     <Row className="action">
                         <Radio.Group>
-                            <Radio.Button value="expand" onClick={expandSessionRows}>
-                                Expand all
-                            </Radio.Button>
+                            {featureFlags[FEATURE_FLAGS.SESSIONS_TABLE] && (
+                                <Radio.Button value="expand" onClick={expandSessionRows}>
+                                    Expand all
+                                </Radio.Button>
+                            )}
                             <Radio.Button value="collapse" onClick={collapseSessionRows}>
                                 Collapse all
                             </Radio.Button>

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -11,9 +11,9 @@ import { sessionsFiltersLogic } from 'scenes/sessions/filters/sessionsFiltersLog
 type SessionRecordingId = string
 
 enum ExpandState {
-    expanded,
-    collapsed,
-    manual,
+    Expanded,
+    Collapsed,
+    Uncontrolled, // expand state is controlled by antd <Table/>
 }
 
 interface Params {
@@ -117,11 +117,11 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
             },
         ],
         rowExpandState: [
-            ExpandState.collapsed,
+            ExpandState.Collapsed,
             {
-                onExpandedRowsChange: () => ExpandState.manual,
-                expandSessionRows: () => ExpandState.expanded,
-                collapseSessionRows: () => ExpandState.collapsed,
+                onExpandedRowsChange: () => ExpandState.Uncontrolled,
+                expandSessionRows: () => ExpandState.Expanded,
+                collapseSessionRows: () => ExpandState.Collapsed,
             },
         ],
         showOnlyMatches: [
@@ -185,17 +185,17 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
                     })
                 ),
         ],
-        expandedRowKeys: [
+        expandedRowKeysProps: [
             (selectors) => [selectors.sessions, selectors.rowExpandState],
-            (sessions: SessionType[], rowExpandState: ExpandState): string[] | boolean => {
-                if (rowExpandState === ExpandState.collapsed) {
-                    return []
+            (sessions: SessionType[], rowExpandState: ExpandState): { expandedRowKeys?: string[] } => {
+                switch (rowExpandState) {
+                    case ExpandState.Collapsed:
+                        return { expandedRowKeys: [] }
+                    case ExpandState.Expanded:
+                        return { expandedRowKeys: sessions.map((s) => s.global_session_id) || [] }
+                    case ExpandState.Uncontrolled:
+                        return {}
                 }
-                if (rowExpandState === ExpandState.manual) {
-                    return false
-                }
-                // expand all
-                return sessions?.map((s) => s.global_session_id) || []
             },
         ],
     },


### PR DESCRIPTION
## Changes

Closes #4960. See discussion for more info.

1. Hide 'expand all' button behind FF for ux and performance reasons
<img width="667" alt="Screen Shot 2021-07-02 at 1 58 28 PM" src="https://user-images.githubusercontent.com/13460330/124312626-78fbb700-db24-11eb-8ff9-265c78fdc23d.png">

2. Darker highlighting

https://user-images.githubusercontent.com/13460330/124318685-db0cea00-db2d-11eb-84f0-e2ae5ca30e7f.mov

3. Change wording of tooltip

<img width="357" alt="Screen Shot 2021-07-02 at 3 47 39 PM" src="https://user-images.githubusercontent.com/13460330/124322089-b287ee80-db33-11eb-95e9-21aa35a9670c.png">

4. Emphasis and clear imaging for individual events

<img width="558" alt="Screen Shot 2021-07-02 at 3 48 09 PM" src="https://user-images.githubusercontent.com/13460330/124322125-c3386480-db33-11eb-840f-e144860b9a36.png">

+ a few more minor UI bugs

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [X] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [X] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
