### PR TITLE
Fix some insights query building 500s

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -209,7 +209,7 @@ def get_person_ids_by_cohort_id(team: Team, cohort_id: int):
     from ee.clickhouse.models.property import parse_prop_clauses
 
     filters = Filter(data={"properties": [{"key": "id", "value": cohort_id, "type": "cohort"}],})
-    filter_query, filter_params = parse_prop_clauses(filters.properties, team.pk, table_name="pid")
+    filter_query, filter_params = parse_prop_clauses(filters.properties, team.pk, table_name="pdi")
 
     results = sync_execute(GET_PERSON_IDS_BY_FILTER.format(distinct_query=filter_query, query=""), filter_params,)
 

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -178,8 +178,7 @@ def is_precalculated_query(cohort: Cohort) -> bool:
     if (
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
-        and not settings.DEBUG
-        and not settings.TEST
+        and settings.USE_PRECALCULATED_CH_COHORT_PEOPLE
     ):
         return True
     else:

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -43,7 +43,13 @@ def format_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
         )
 
     or_queries = []
-    for group_idx, group in enumerate(cohort.groups):
+    groups = cohort.groups
+
+    if not groups:
+        # No person can match a cohort that has no match groups
+        return "0 = 1", {}
+
+    for group_idx, group in enumerate(groups):
         if group.get("action_id") or group.get("event_id"):
             entity_query, entity_params = get_entity_cohort_subquery(cohort, group, group_idx)
             params = {**params, **entity_params}

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -57,21 +57,21 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         if self._should_join_distinct_ids:
             return f"""
             INNER JOIN (
-                SELECT person_id,
+                SELECT
+                    person_id,
                     distinct_id
                 FROM (
-                        SELECT *
+                    SELECT *
+                    FROM person_distinct_id
+                    JOIN (
+                        SELECT distinct_id,
+                            max(_offset) as _offset
                         FROM person_distinct_id
-                        JOIN (
-                                SELECT distinct_id,
-                                    max(_offset) as _offset
-                                FROM person_distinct_id
-                                WHERE team_id = %(team_id)s
-                                GROUP BY distinct_id
-                            ) as person_max
-                            ON person_distinct_id.distinct_id = person_max.distinct_id
-                        AND person_distinct_id._offset = person_max._offset
                         WHERE team_id = %(team_id)s
+                        GROUP BY distinct_id
+                    ) as person_max
+                    USING (distinct_id, _offset)
+                    WHERE team_id = %(team_id)s
                     )
                 WHERE team_id = %(team_id)s
             ) AS {self.DISTINCT_ID_TABLE_ALIAS}
@@ -109,6 +109,8 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
             cohort = Cohort.objects.get(pk=prop.value, team_id=self._team_id)
         except Cohort.DoesNotExist:
             return False
+        if is_precalculated_query(cohort):
+            return True
         for group in cohort.groups:
             if group.get("properties"):
                 return True
@@ -190,7 +192,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
 
     def _get_cohort_subquery(self, prop) -> Tuple[str, Dict[str, Any]]:
         try:
-            cohort = Cohort.objects.get(pk=prop.value, team_id=self._team_id)
+            cohort: Cohort = Cohort.objects.get(pk=prop.value, team_id=self._team_id)
         except Cohort.DoesNotExist:
             return "0 = 1", {}  # If cohort doesn't exist, nothing can match
 

--- a/ee/clickhouse/queries/trends/clickhouse_trends.py
+++ b/ee/clickhouse/queries/trends/clickhouse_trends.py
@@ -47,8 +47,6 @@ class ClickhouseTrends(
     def _run_query(self, filter: Filter, entity: Entity, team_id: int) -> List[Dict[str, Any]]:
         sql, params, parse_function = self._get_sql_for_entity(filter, entity, team_id)
         try:
-            import sqlparse
-
             result = sync_execute(sql, params)
         except Exception as e:
             capture_exception(e)

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -54,7 +54,6 @@ class TrendsEventQuery(ClickhouseEventQuery):
     def _determine_should_join_distinct_ids(self) -> None:
         if self._entity.math == "dau":
             self._should_join_distinct_ids = True
-            return
 
     def _get_date_filter(self) -> Tuple[str, Dict]:
         date_filter = ""

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -61,8 +61,8 @@ INNER JOIN (
         distinct_id
     FROM ({latest_distinct_id_sql})
     WHERE team_id = %(team_id)s
-) as pid
-ON events.distinct_id = pid.distinct_id
+) as pdi
+ON events.distinct_id = pdi.distinct_id
 WHERE team_id = %(team_id)s {date_query} AND {entity_query}
 GROUP BY person_id HAVING count(*) {count_operator} %(count)s
 """

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -191,7 +191,7 @@ SELECT toUInt16(0) AS total, {interval}(toDateTime('{date_to}') - number * {seco
 """
 
 EVENT_JOIN_PERSON_SQL = """
-INNER JOIN (SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s) as pid ON events.distinct_id = pid.distinct_id
+INNER JOIN (SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s) as pdi ON events.distinct_id = pdi.distinct_id
 """.format(
     latest_distinct_id_sql=GET_LATEST_PERSON_DISTINCT_ID_SQL
 )

--- a/ee/clickhouse/sql/funnels/funnel.py
+++ b/ee/clickhouse/sql/funnels/funnel.py
@@ -1,7 +1,7 @@
 FUNNEL_SQL = """
 SELECT max_step {top_level_groupby}, count(1), groupArray(100)(id) FROM (
     SELECT
-        pid.person_id as id,
+        pdi.person_id as id,
         {extra_select}
         windowFunnel({within_time})(toUInt64(toUnixTimestamp64Micro(timestamp)),
             {steps}
@@ -10,12 +10,12 @@ SELECT max_step {top_level_groupby}, count(1), groupArray(100)(id) FROM (
         events
     JOIN (
         SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s
-    ) as pid
-    ON pid.distinct_id = events.distinct_id
+    ) as pdi
+    ON pdi.distinct_id = events.distinct_id
     WHERE
         team_id = %(team_id)s {filters} {parsed_date_from} {parsed_date_to}
         AND event IN %(events)s
-    GROUP BY pid.person_id {extra_groupby}
+    GROUP BY pdi.person_id {extra_groupby}
 )
 WHERE max_step > 0
 GROUP BY max_step {top_level_groupby}
@@ -28,7 +28,7 @@ SELECT max_step, id
 FROM
 (
     SELECT
-        pid.person_id as id,
+        pdi.person_id as id,
         {extra_select}
         windowFunnel({within_time})(toUInt64(toUnixTimestamp64Micro(timestamp)),
             {steps}
@@ -37,15 +37,15 @@ FROM
         events
     JOIN (
         SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s
-    ) as pid
-    ON pid.distinct_id = events.distinct_id
+    ) as pdi
+    ON pdi.distinct_id = events.distinct_id
     WHERE
         team_id = %(team_id)s
         {filters}
         {parsed_date_from}
         {parsed_date_to}
         AND event IN %(events)s
-    GROUP BY pid.person_id {extra_groupby}
+    GROUP BY pdi.person_id {extra_groupby}
 )
 WHERE max_step > 0
 GROUP BY max_step, id

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -181,7 +181,7 @@ INNER JOIN (
     SELECT person_id, distinct_id
     FROM ({latest_distinct_id_sql})
     WHERE team_id = %(team_id)s
-) AS pid ON p.id = pid.person_id
+) AS pdi ON p.id = pdi.person_id
 WHERE team_id = %(team_id)s
   {distinct_query}
 """.format(
@@ -197,9 +197,9 @@ INNER JOIN (
     SELECT person_id, distinct_id
     FROM ({latest_distinct_id_sql})
     WHERE team_id = %(team_id)s
-) AS pid ON p.id = pid.person_id
+) AS pdi ON p.id = pdi.person_id
 WHERE team_id = %(team_id)s
-  AND pid.distinct_id = %(distinct_id)s
+  AND pdi.distinct_id = %(distinct_id)s
   {distinct_query}
 """.format(
     latest_person_sql=GET_LATEST_PERSON_SQL,

--- a/ee/clickhouse/sql/stickiness/stickiness_people.py
+++ b/ee/clickhouse/sql/stickiness/stickiness_people.py
@@ -1,8 +1,8 @@
 STICKINESS_PEOPLE_SQL = """
-SELECT DISTINCT pid FROM (
-    SELECT DISTINCT person_distinct_id.person_id as pid, countDistinct({trunc_func}(toDateTime(timestamp))) as num_intervals
+SELECT DISTINCT pdi FROM (
+    SELECT DISTINCT person_distinct_id.person_id AS pdi, countDistinct({trunc_func}(toDateTime(timestamp))) AS num_intervals
     FROM events
-    LEFT JOIN (SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s) as person_distinct_id ON person_distinct_id.distinct_id = events.distinct_id
+    LEFT JOIN (SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s) AS person_distinct_id ON person_distinct_id.distinct_id = events.distinct_id
     WHERE team_id = %(team_id)s {entity_filter} {filters} {parsed_date_from} {parsed_date_to}
     GROUP BY person_distinct_id.person_id
 ) WHERE num_intervals = %(stickiness_day)s

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -59,8 +59,8 @@ FROM (
                     WHERE team_id = %(team_id)s
                 )
             WHERE team_id = %(team_id)s
-        ) as pid
-        ON e.distinct_id = pid.distinct_id
+        ) as pdi
+        ON e.distinct_id = pdi.distinct_id
         {event_join}
         {conditions}
         GROUP BY timestamp, person_id, breakdown_value

--- a/ee/clickhouse/sql/trends/top_person_props.py
+++ b/ee/clickhouse/sql/trends/top_person_props.py
@@ -3,7 +3,7 @@ SELECT groupArray(value) FROM (
     SELECT value, {aggregate_operation} as count
     FROM
     events e 
-    INNER JOIN (SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s) as pid ON e.distinct_id = pid.distinct_id
+    INNER JOIN (SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s) AS pdi ON e.distinct_id = pdi.distinct_id
     INNER JOIN
         (
             SELECT * FROM (

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -43,8 +43,8 @@ SELECT DISTINCT person_id FROM (
                     WHERE team_id = %(team_id)s
                 )
             WHERE team_id = %(team_id)s
-        ) as pid
-        ON events.distinct_id = pid.distinct_id
+        ) AS pdi
+        ON events.distinct_id = pdi.distinct_id
         WHERE team_id = %(team_id)s {entity_query} {filters} {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, person_id
     ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
 ) WHERE 1 = 1 {parsed_date_from} {parsed_date_to}

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1,11 +1,11 @@
 import json
 from datetime import timedelta
 
-from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 
+from posthog.constants import RDBMS
 from posthog.ee import is_clickhouse_enabled
 from posthog.models.cohort import Cohort
 from posthog.models.dashboard_item import DashboardItem
@@ -160,14 +160,38 @@ def insight_test_factory(event_factory, person_factory):
 
             response_nonexistent_property = self.client.get(
                 f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'property','key':'foo','value':'barabarab'}])}"
-            ).json()
+            )
             response_cohort_without_match_groups = self.client.get(
                 f"/api/insight/trend/?events={json.dumps([{'id':'$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':whatever_cohort_without_match_groups.pk}])}"
-            ).json()  # This should not throw an error, just act like there's no event matches
+            )  # This should not throw an error, just act like there's no event matches
 
+            self.assertEqual(response_nonexistent_property.status_code, 200)
             self.assertEqual(
-                response_nonexistent_property, response_cohort_without_match_groups
+                response_nonexistent_property.json(), response_cohort_without_match_groups.json()
             )  # Both cases just empty
+
+        def test_precalculated_cohort_works(self):
+            person_factory(team=self.team, distinct_ids=["person_1"], properties={"foo": "bar"})
+
+            whatever_cohort: Cohort = Cohort.objects.create(
+                id=113,
+                team=self.team,
+                groups=[{"properties": [{"type": "person", "key": "foo", "value": "bar", "operator": "exact"}]}],
+                last_calculation=timezone.now(),
+            )
+            whatever_cohort.calculate_people()
+            whatever_cohort.calculate_people_ch()
+
+            with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):  # Normally this is False in tests
+                response_user_property = self.client.get(
+                    f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'person','key':'foo','value':'bar'}])}"
+                )
+                response_precalculated_cohort = self.client.get(
+                    f"/api/insight/trend/?events={json.dumps([{'id':'$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':113}])}"
+                )
+
+            self.assertEqual(response_precalculated_cohort.status_code, 200)
+            self.assertEqual(response_precalculated_cohort.json(), response_user_property.json())
 
         def test_insight_trends_breakdown_pagination(self):
             with freeze_time("2012-01-14T03:21:34.000Z"):

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -12,6 +11,7 @@ from django.utils import timezone
 from sentry_sdk import capture_exception
 
 from posthog.ee import is_clickhouse_enabled
+from posthog.models.utils import sane_repr
 
 from .action import Action
 from .event import Event
@@ -247,6 +247,8 @@ class Cohort(models.Model):
                 filter = Filter(data=group)
                 filters |= Q(properties_to_Q(filter.properties, team_id=self.team_id, is_person_query=True))
         return filters
+
+    __repr__ = sane_repr("id", "name", "last_calculation")
 
 
 class CohortPeople(models.Model):

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -60,6 +60,7 @@ E2E_TESTING = get_from_env(
 )  # whether the app is currently running for E2E tests
 SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG, type_cast=str_to_bool)
 SHELL_PLUS_PRINT_SQL = get_from_env("PRINT_SQL", False, type_cast=str_to_bool)
+USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
 
 SITE_URL = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -48,7 +48,7 @@ def calculate_cohort(cohort_id: int) -> None:
 @shared_task(ignore_result=True, max_retries=2)
 def calculate_cohort_ch(cohort_id: int) -> None:
     if is_clickhouse_enabled():
-        cohort = Cohort.objects.get(pk=cohort_id)
+        cohort: Cohort = Cohort.objects.get(pk=cohort_id)
         cohort.calculate_people_ch()
 
 


### PR DESCRIPTION
## Changes

This fixes two 500-inducing bugs in our query building engine:
- Distinct IDs not being joined properly when filtering by cohort in trends AND using CH precalculated cohort people – this path was actually not tested before, because CH precalculated cohort people are disabled in tests (I assume to avoid potential flakyness) – resolves https://sentry.io/organizations/posthog/issues/2410985840/events/7e9f647a0cb848a1bad53d291889bd2f/
- Handling of cohorts without any match groups – this should not really be a thing in the wild, because a cohort without match groups doesn't make a lot of sense, but still it's better to handle this intuitively, by making sure nothing can match with no match groups (which is what the Postgres version of the query has already ben doing instead of returning a server error)

Also unified our JOIN-resulting person distinct ID table's name – it used to be `pdi` in some places and `pid` in others, settled on `pdi` everywhere to avoid query building mismatches.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests