### PR TITLE
Return a 512 error if query would be estimated to time out

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import re
 from time import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -8,6 +9,7 @@ import sqlparse
 from aioch import Client
 from asgiref.sync import async_to_sync
 from clickhouse_driver import Client as SyncClient
+from clickhouse_driver.errors import ServerException
 from clickhouse_pool import ChPool
 from django.conf import settings as app_settings
 from django.core.cache import cache
@@ -16,6 +18,7 @@ from sentry_sdk.api import capture_exception
 
 from posthog import redis
 from posthog.constants import RDBMS
+from posthog.exceptions import EstimatedQueryExecutionTimeTooLong
 from posthog.internal_metrics import timing
 from posthog.settings import (
     CLICKHOUSE_ASYNC,
@@ -131,10 +134,10 @@ else:
             try:
                 sql, tags = _annotate_tagged_query(query, args)
                 result = client.execute(sql, args, settings=settings, with_column_types=with_column_types)
-            except Exception as e:
+            except Exception as err:
                 tags["failed"] = True
-                tags["reason"] = type(e).__name__
-                raise e
+                tags["reason"] = type(err).__name__
+                raise _wrap_api_error(err)
             finally:
                 execution_time = time() - start_time
                 timing("clickhouse_sync_execution_time", execution_time * 1000.0, tags=tags)
@@ -170,6 +173,18 @@ def _annotate_tagged_query(query, args):
         query = f"/* {_request_information['kind']}:{_request_information['id'].replace('/', '_')} */ {query}"
 
     return query, tags
+
+
+def _wrap_api_error(err: Exception) -> Exception:
+    if not isinstance(err, ServerException):
+        return err
+
+    # Return a 512 error for queries which would time out
+    match = re.search(r"Estimated query execution time \(.* seconds\) is too long.", err.message)
+    if match:
+        return EstimatedQueryExecutionTimeTooLong(detail=match.group(0))
+
+    return err
 
 
 def format_sql(sql, params, colorize=True):

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -15,6 +15,11 @@ class EnterpriseFeatureException(APIException):
     default_detail = "This is an Enterprise feature."
 
 
+class EstimatedQueryExecutionTimeTooLong(APIException):
+    status_code = 512  # Custom error code
+    default_detail = "Estimated query execution time is too long"
+
+
 def exception_reporting(exception: Exception, *args, **kwargs) -> None:
     """
     Determines which exceptions to report and sends them to Sentry.


### PR DESCRIPTION
## Changes

This makes measuring performance stats easier

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
