### PR TITLE
Don't disable Cypress suite for bot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,6 @@ jobs:
     cypress:
         name: Cypress E2E tests
         runs-on: ubuntu-18.04
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         strategy:
             # when one test fails, DO NOT cancel the other


### PR DESCRIPTION
## Changes

We used to disable E2E tests for bot PRs, since they are unlikely to really matter for them, but since Cypress is now required to merge, automerge doesn't work without those tests (see #4962 suffering from this). Hence removing the conditional in the workflow.
