### PR TITLE
Use redis for axes handler

### DIFF
--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -153,7 +153,7 @@ class TestCreateAction(APIBaseTest):
         )
 
         # test queries
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             self.client.get("/api/action/")
 
     def test_update_action_remove_all_steps(self, *args):

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -91,7 +91,7 @@ class TestAuthenticationAPI(APIBaseTest):
         User.objects.create(email="new_user@posthog.com", password="87654321")
 
         # Fill the attempt limit
-        with self.settings(AXES_FAILURE_LIMIT=3):
+        with self.settings(AXES_ENABLED=True, AXES_FAILURE_LIMIT=3):
             for _ in range(0, 2):
                 response = self.client.post("/api/login", {"email": "new_user@posthog.com", "password": "invalid"})
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -69,7 +69,7 @@ class TestCapture(BaseTest):
         }
         now = timezone.now()
         with freeze_time(now):
-            with self.assertNumQueries(2):
+            with self.assertNumQueries(1):
                 response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",)
         self.assertEqual(response.get("access-control-allow-origin"), "https://localhost")
         arguments = self._to_arguments(patch_process_event_with_plugins)
@@ -103,7 +103,7 @@ class TestCapture(BaseTest):
         }
         now = timezone.now()
         with freeze_time(now):
-            with self.assertNumQueries(2):
+            with self.assertNumQueries(1):
                 response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",)
         self.assertEqual(response.get("access-control-allow-origin"), "https://localhost")
         arguments = self._to_arguments(patch_process_event_with_plugins)
@@ -139,7 +139,7 @@ class TestCapture(BaseTest):
         }
         now = timezone.now()
         with freeze_time(now):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",)
         self.assertEqual(response.get("access-control-allow-origin"), "https://localhost")
         arguments = self._to_arguments(patch_process_event_with_plugins)

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -140,7 +140,7 @@ class TestDashboard(APIBaseTest):
         self.assertAlmostEqual(item.last_refresh, now(), delta=timezone.timedelta(seconds=5))
         self.assertEqual(item.filters_hash, generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)))
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             response = self.client.get("/api/dashboard/%s/" % dashboard.pk).json()
 
         self.assertAlmostEqual(Dashboard.objects.get().last_accessed_at, now(), delta=timezone.timedelta(seconds=5))

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -134,14 +134,14 @@ class TestDecide(BaseTest):
             created_by=self.user,
         )
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self._post_decide()
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("default-flag", response.json()["featureFlags"])
         self.assertIn("beta-feature", response.json()["featureFlags"])
         self.assertIn("filer-by-property-2", response.json()["featureFlags"])
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self._post_decide({"token": self.team.api_token, "distinct_id": "another_id"})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["featureFlags"], ["default-flag"])

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -76,7 +76,7 @@ def factory_test_element(create_event: Callable) -> Callable:
                 elements=[Element(tag_name="img")],
             )
 
-            with self.assertNumQueries(7):
+            with self.assertNumQueries(6):
                 response = self.client.get("/api/element/stats/").json()
             self.assertEqual(response[0]["count"], 2)
             self.assertEqual(response[0]["hash"], event1.elements_hash)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -42,7 +42,7 @@ def factory_test_event_api(event_factory, person_factory, _):
                 event="$pageview", team=self.team, distinct_id="some-other-one", properties={"$ip": "8.8.8.8"}
             )
 
-            expected_queries = 4 if settings.PRIMARY_DB == RDBMS.CLICKHOUSE else 11
+            expected_queries = 3 if settings.PRIMARY_DB == RDBMS.CLICKHOUSE else 10
 
             with self.assertNumQueries(expected_queries):
                 response = self.client.get("/api/event/?distinct_id=2").json()
@@ -65,7 +65,7 @@ def factory_test_event_api(event_factory, person_factory, _):
                 event="another event", team=self.team, distinct_id="2", properties={"$ip": "8.8.8.8"},
             )
 
-            expected_queries = 4 if settings.PRIMARY_DB == RDBMS.CLICKHOUSE else 8
+            expected_queries = 3 if settings.PRIMARY_DB == RDBMS.CLICKHOUSE else 7
 
             with self.assertNumQueries(expected_queries):
                 response = self.client.get("/api/event/?event=event_name").json()
@@ -82,7 +82,7 @@ def factory_test_event_api(event_factory, person_factory, _):
                 event="event_name", team=self.team, distinct_id="2", properties={"$browser": "Safari"},
             )
 
-            expected_queries = 4 if settings.PRIMARY_DB == RDBMS.CLICKHOUSE else 8
+            expected_queries = 3 if settings.PRIMARY_DB == RDBMS.CLICKHOUSE else 7
 
             with self.assertNumQueries(expected_queries):
                 response = self.client.get(

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -218,6 +218,7 @@ CAPTURE_INTERNAL_METRICS = get_from_env("CAPTURE_INTERNAL_METRICS", False, type_
 
 # django-axes settings to lockout after too many attempts
 AXES_ENABLED = get_from_env("AXES_ENABLED", True, type_cast=str_to_bool)
+AXES_HANDLER = "axes.handlers.cache.AxesCacheHandler"
 AXES_FAILURE_LIMIT = int(os.getenv("AXES_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=15)
 AXES_LOCKOUT_CALLABLE = "posthog.api.authentication.axess_logout"

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -217,7 +217,7 @@ STATSD_SEPARATOR = "_"
 CAPTURE_INTERNAL_METRICS = get_from_env("CAPTURE_INTERNAL_METRICS", False, type_cast=str_to_bool)
 
 # django-axes settings to lockout after too many attempts
-AXES_ENABLED = get_from_env("AXES_ENABLED", True, type_cast=str_to_bool)
+AXES_ENABLED = get_from_env("AXES_ENABLED", not TEST, type_cast=str_to_bool)
 AXES_HANDLER = "axes.handlers.cache.AxesCacheHandler"
 AXES_FAILURE_LIMIT = int(os.getenv("AXES_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=15)


### PR DESCRIPTION
Original motivation: axes is running into `InterfaceError: connection already closed` error
for database (pg) connections. Not sure what that is caused by, but it's
causing api requests to sporatically fail hence reducing reliability.

Sentry issue: https://sentry.io/organizations/posthog/issues/1905826905/?project=1899813&statsPeriod=14d

This error seems to be only occurring in axes hence making me think
switching out the handler will work wonders.

Switching the handler to redis has other benefits as well. As axes is
hit every request this should speed things up. To quote documentation:

> axes.handlers.cache.AxesCacheHandler only uses the cache for monitoring attempts and does not persist data other than in the cache backend; this data can be purged automatically depending on your cache configuration, so the cache handler is by design less secure than the database backend but offers higher throughput and can perform better with less bottlenecks.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
