### PR TITLE
Fix white screen of death in sessions insight

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -16,16 +16,14 @@ const convertToSessionFilters = (people: TrendPeople, filters: Partial<FilterTyp
     if (!people?.action) {
         return []
     }
-    const action = people.action as ActionFilter
-    return [
-        {
-            key: 'id',
-            value: action.id,
-            label: action.name as string,
-            type: action.type === EntityTypes.ACTIONS ? ACTION_TYPE : EVENT_TYPE,
-            properties: [...action.properties, ...(filters?.properties || [])] as EventPropertyFilter[], // combine global properties into action/event filter
-        },
-    ]
+    const actions: ActionFilter[] = people.action === 'session' ? (filters.events as ActionFilter[]) : [people.action]
+    return actions.map((a) => ({
+        key: 'id',
+        value: a.id,
+        label: a.name as string,
+        type: a.type === EntityTypes.ACTIONS ? ACTION_TYPE : EVENT_TYPE,
+        properties: [...(a.properties || []), ...(filters.properties || [])] as EventPropertyFilter[], // combine global properties into action/event filter
+    }))
 }
 
 interface Props {


### PR DESCRIPTION
## Changes

Fixes #4981.

There was a bug where if you clicked a data point in the sessions insights page, the page would crash. I fixed the way we handle action and global filters from the sessions page and also made sure that all insight actions were being converted into session filters (instead of just the first one).

**Before**

https://user-images.githubusercontent.com/13460330/124309702-f96be900-db1f-11eb-8da4-6550682be5bc.mov

**After**

https://user-images.githubusercontent.com/13460330/124309716-0092f700-db20-11eb-9462-c4319c4ba735.mov

**After - multiple filters**


https://user-images.githubusercontent.com/13460330/124309914-4d76cd80-db20-11eb-938a-ce81aed506db.mov


## Root Cause

This happened because the way that we construct `actions` and `filters` in the sessions insight page is a little different from how we do it everywhere else. It is possible that in a sessions line graph, _multiple_ actions may be relevant for any given data point. In other line visualizations (i.e., trends), we separate out the keys for each action type so that there is a _single_ action attributed to each data point.  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [X] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] Frontend/CSS is usable at 320px (iPhone SE) and decent at 360px (most phones)
- [ ] Breaking changes are backwards-compatible. Ensure old/new frontend requests work with new/old backends, and vice versa.
