### PR TITLE
Do not create Kafka or mv tables on backup hosts during migrations

### DIFF
--- a/ee/clickhouse/migrations/0001_initial.py
+++ b/ee/clickhouse/migrations/0001_initial.py
@@ -2,6 +2,8 @@ from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.events import EVENTS_TABLE_SQL
 
-operations = [
-    migrations.RunSQL(EVENTS_TABLE_SQL),
-]
+
+def operations(**kwargs):
+    return [
+        migrations.RunSQL(EVENTS_TABLE_SQL),
+    ]

--- a/ee/clickhouse/migrations/0002_events_materialized.py
+++ b/ee/clickhouse/migrations/0002_events_materialized.py
@@ -2,6 +2,8 @@ from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.events import EVENTS_WITH_PROPS_TABLE_SQL
 
-operations = [
-    migrations.RunSQL(EVENTS_WITH_PROPS_TABLE_SQL),
-]
+
+def operations(**kwargs):
+    return [
+        migrations.RunSQL(EVENTS_WITH_PROPS_TABLE_SQL),
+    ]

--- a/ee/clickhouse/migrations/0003_person.py
+++ b/ee/clickhouse/migrations/0003_person.py
@@ -2,4 +2,6 @@ from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.person import PERSONS_DISTINCT_ID_TABLE_SQL, PERSONS_TABLE_SQL
 
-operations = [migrations.RunSQL(PERSONS_TABLE_SQL), migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_SQL)]
+
+def operations(**kwargs):
+    return [migrations.RunSQL(PERSONS_TABLE_SQL), migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_SQL)]

--- a/ee/clickhouse/migrations/0004_kafka.py
+++ b/ee/clickhouse/migrations/0004_kafka.py
@@ -8,11 +8,16 @@ from ee.clickhouse.sql.person import (
     PERSONS_TABLE_MV_SQL,
 )
 
-operations = [
-    migrations.RunSQL(KAFKA_EVENTS_TABLE_SQL),
-    migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
-    migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
-    migrations.RunSQL(EVENTS_TABLE_MV_SQL),
-    migrations.RunSQL(PERSONS_TABLE_MV_SQL),
-    migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),
-]
+
+def operations(is_backup_host):
+    if is_backup_host:
+        return []
+    else:
+        return [
+            migrations.RunSQL(KAFKA_EVENTS_TABLE_SQL),
+            migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
+            migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
+            migrations.RunSQL(EVENTS_TABLE_MV_SQL),
+            migrations.RunSQL(PERSONS_TABLE_MV_SQL),
+            migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),
+        ]

--- a/ee/clickhouse/migrations/0006_session_recording_events.py
+++ b/ee/clickhouse/migrations/0006_session_recording_events.py
@@ -6,8 +6,15 @@ from ee.clickhouse.sql.session_recording_events import (
     SESSION_RECORDING_EVENTS_TABLE_SQL,
 )
 
-operations = [
-    migrations.RunSQL(SESSION_RECORDING_EVENTS_TABLE_SQL),
-    migrations.RunSQL(KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL),
-    migrations.RunSQL(SESSION_RECORDING_EVENTS_TABLE_MV_SQL),
-]
+
+def operations(is_backup_host):
+    if is_backup_host:
+        return [
+            migrations.RunSQL(SESSION_RECORDING_EVENTS_TABLE_SQL),
+        ]
+    else:
+        return [
+            migrations.RunSQL(SESSION_RECORDING_EVENTS_TABLE_SQL),
+            migrations.RunSQL(KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL),
+            migrations.RunSQL(SESSION_RECORDING_EVENTS_TABLE_MV_SQL),
+        ]

--- a/ee/clickhouse/migrations/0007_static_cohorts_table.py
+++ b/ee/clickhouse/migrations/0007_static_cohorts_table.py
@@ -2,6 +2,8 @@ from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.person import PERSON_STATIC_COHORT_TABLE_SQL
 
-operations = [
-    migrations.RunSQL(PERSON_STATIC_COHORT_TABLE_SQL),
-]
+
+def operations(**kwargs):
+    return [
+        migrations.RunSQL(PERSON_STATIC_COHORT_TABLE_SQL),
+    ]

--- a/ee/clickhouse/migrations/0008_plugin_log_entries.py
+++ b/ee/clickhouse/migrations/0008_plugin_log_entries.py
@@ -6,8 +6,15 @@ from ee.clickhouse.sql.plugin_log_entries import (
     PLUGIN_LOG_ENTRIES_TABLE_SQL,
 )
 
-operations = [
-    migrations.RunSQL(PLUGIN_LOG_ENTRIES_TABLE_SQL),
-    migrations.RunSQL(KAFKA_PLUGIN_LOG_ENTRIES_TABLE_SQL),
-    migrations.RunSQL(PLUGIN_LOG_ENTRIES_TABLE_MV_SQL),
-]
+
+def operations(is_backup_host):
+    if is_backup_host:
+        return [
+            migrations.RunSQL(PLUGIN_LOG_ENTRIES_TABLE_SQL),
+        ]
+    else:
+        return [
+            migrations.RunSQL(PLUGIN_LOG_ENTRIES_TABLE_SQL),
+            migrations.RunSQL(KAFKA_PLUGIN_LOG_ENTRIES_TABLE_SQL),
+            migrations.RunSQL(PLUGIN_LOG_ENTRIES_TABLE_MV_SQL),
+        ]

--- a/ee/clickhouse/migrations/0009_person_deleted_column.py
+++ b/ee/clickhouse/migrations/0009_person_deleted_column.py
@@ -2,10 +2,17 @@ from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.person import KAFKA_PERSONS_TABLE_SQL, PERSONS_TABLE_MV_SQL
 
-operations = [
-    migrations.RunSQL("DROP TABLE person_mv"),
-    migrations.RunSQL("DROP TABLE kafka_person"),
-    migrations.RunSQL("ALTER TABLE person ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT 0"),
-    migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
-    migrations.RunSQL(PERSONS_TABLE_MV_SQL),
-]
+
+def operations(is_backup_host):
+    if is_backup_host:
+        return [
+            migrations.RunSQL("ALTER TABLE person ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT 0"),
+        ]
+    else:
+        return [
+            migrations.RunSQL("DROP TABLE person_mv"),
+            migrations.RunSQL("DROP TABLE kafka_person"),
+            migrations.RunSQL("ALTER TABLE person ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT 0"),
+            migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
+            migrations.RunSQL(PERSONS_TABLE_MV_SQL),
+        ]

--- a/ee/clickhouse/migrations/0010_cohortpeople.py
+++ b/ee/clickhouse/migrations/0010_cohortpeople.py
@@ -2,4 +2,6 @@ from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.cohort import CREATE_COHORTPEOPLE_TABLE_SQL
 
-operations = [migrations.RunSQL(CREATE_COHORTPEOPLE_TABLE_SQL)]
+
+def operations(**kwargs):
+    return [migrations.RunSQL(CREATE_COHORTPEOPLE_TABLE_SQL)]

--- a/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
+++ b/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
@@ -1,7 +1,8 @@
 from infi.clickhouse_orm import migrations
 
 from ee.clickhouse.sql.cohort import CREATE_COHORTPEOPLE_TABLE_SQL, DROP_COHORTPEOPLE_TABLE_SQL
-from posthog.settings import CLICKHOUSE_REPLICATION
+
 
 # run create table again with proper configuration
-operations = [migrations.RunSQL(DROP_COHORTPEOPLE_TABLE_SQL), migrations.RunSQL(CREATE_COHORTPEOPLE_TABLE_SQL)]
+def operations(**kwargs):
+    return [migrations.RunSQL(DROP_COHORTPEOPLE_TABLE_SQL), migrations.RunSQL(CREATE_COHORTPEOPLE_TABLE_SQL)]

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -3,6 +3,7 @@ from infi.clickhouse_orm import Database
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.plugin_log_entries import DROP_PLUGIN_LOG_ENTRIES_TABLE_SQL, PLUGIN_LOG_ENTRIES_TABLE_SQL
+from ee.management.commands.migrate_clickhouse import MigrateClickhouseCommand
 from posthog.settings import (
     CLICKHOUSE_DATABASE,
     CLICKHOUSE_HTTP_URL,
@@ -32,7 +33,7 @@ def django_db_setup(django_db_setup, django_db_keepdb):
     if not django_db_keepdb or not database.db_exists:
         database.create_database()
 
-    database.migrate("ee.clickhouse.migrations")
+    MigrateClickhouseCommand().migrate(CLICKHOUSE_HTTP_URL, {"upto": 99_999})
     # Make DELETE / UPDATE synchronous to avoid flaky tests
     sync_execute("SET mutations_sync = 1")
 

--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -17,7 +17,7 @@ from posthog.settings import (
 MIGRATIONS_PACKAGE_NAME = "ee.clickhouse.migrations"
 
 
-class Command(BaseCommand):
+class MigrateClickhouseCommand(BaseCommand):
     help = "Migrate clickhouse"
 
     def add_arguments(self, parser):
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             print(f"Updating host {host} ({index + 1}/{len(CLICKHOUSE_MIGRATION_HOSTS_HTTP_URLS)})")
             self.migrate(host, options)
 
-    def migrate(self, host, options):
+    def migrate(self, host, options={}):
         database = Database(
             CLICKHOUSE_DATABASE,
             db_url=host,
@@ -48,9 +48,9 @@ class Command(BaseCommand):
             verify_ssl_cert=False,
         )
 
-        if options["plan"]:
+        if options.get("plan"):
             self.perform_plan(database, host, options)
-        elif options["fake"]:
+        elif options.get("fake"):
             self.perform_fake(database, host, options)
         else:
             self.perform_migrations(database, host, options)
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             print(f"Migration would get applied: {migration_name}")
             for op in operations:
                 sql = getattr(op, "_sql")
-                if options["print_sql"] and sql is not None:
+                if options.get("print_sql") and sql is not None:
                     print(indent("\n\n".join(sql), "    "))
         if len(migrations) == 0:
             print("Clickhouse migrations up to date!")

--- a/ee/management/commands/setup_test_environment.py
+++ b/ee/management/commands/setup_test_environment.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from ee.management.commands.migrate_clickhouse import MigrateClickhouseCommand
 from posthog.ee import is_clickhouse_enabled
 
 
@@ -36,4 +37,5 @@ class Command(BaseCommand):
                 database.create_database()
             except:
                 pass
-            database.migrate("ee.clickhouse.migrations")
+
+            MigrateClickhouseCommand().migrate(CLICKHOUSE_HTTP_URL, {"upto": 99_999})

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -161,12 +161,14 @@ if CLICKHOUSE_SECURE:
     _clickhouse_http_protocol = "https://"
     _clickhouse_http_port = "8443"
 
-CLICKHOUSE_HTTP_URL = f"{_clickhouse_http_protocol}{CLICKHOUSE_HOST}:{_clickhouse_http_port}/"
+_make_clickhouse_url = lambda host: f"{_clickhouse_http_protocol}{host}:{_clickhouse_http_port}/"
+
+CLICKHOUSE_HTTP_URL = _make_clickhouse_url(CLICKHOUSE_HOST)
 
 _clickhouse_hosts = get_from_env("CLICKHOUSE_MIGRATION_HOSTS", CLICKHOUSE_HOST).split(",")
-CLICKHOUSE_MIGRATION_HOSTS_HTTP_URLS = [
-    f"{_clickhouse_http_protocol}{host}:{_clickhouse_http_port}/" for host in _clickhouse_hosts
-]
+_clickhouse_backup_hosts = get_from_env("CLICKHOUSE_BACKUP_HOSTS", "").split(",")
+CLICKHOUSE_MIGRATION_HOSTS_HTTP_URLS = list(map(_make_clickhouse_url, _clickhouse_hosts))
+CLICKHOUSE_BACKUP_HOSTS_HTTP_URLS = list(map(_make_clickhouse_url, _clickhouse_backup_hosts))
 
 IS_HEROKU = get_from_env("IS_HEROKU", False, type_cast=str_to_bool)
 

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -119,6 +119,10 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_MIGRATION_HOSTS::"
                 },
                 {
+                    "name": "CLICKHOUSE_BACKUP_HOSTS",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_BACKUP_HOSTS::"
+                },
+                {
                     "name": "DATABASE_URL",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:DATABASE_URL::"
                 },

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -133,6 +133,10 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_MIGRATION_HOSTS::"
                 },
                 {
+                    "name": "CLICKHOUSE_BACKUP_HOSTS",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_BACKUP_HOSTS::"
+                },
+                {
                     "name": "CLICKHOUSE_PASSWORD",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_PASSWORD::"
                 },

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -127,6 +127,10 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_MIGRATION_HOSTS::"
                 },
                 {
+                    "name": "CLICKHOUSE_BACKUP_HOSTS",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_BACKUP_HOSTS::"
+                },
+                {
                     "name": "CLICKHOUSE_PASSWORD",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_PASSWORD::"
                 },


### PR DESCRIPTION
This brings migrations logic more in-line with what's running on cloud

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
