### PR TITLE
Add to dashboard button in funnels

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -16,11 +16,12 @@ import { CalendarOutlined } from '@ant-design/icons'
 import { InsightDateFilter } from '../InsightDateFilter'
 import { RetentionDatePicker } from '../RetentionDatePicker'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
     allFilters: FilterType
     activeView: ViewType
-    annotationsToCreate?: Record<string, any>[] // TODO: Annotate properly
+    annotationsToCreate: Record<string, any>[] // TODO: Annotate properly
 }
 
 const showIntervalFilter = function (activeView: ViewType, filter: FilterType): boolean {
@@ -82,6 +83,7 @@ const isFunnelEmpty = (filters: FilterType): boolean => {
 export function InsightDisplayConfig({
     allFilters,
     activeView,
+    annotationsToCreate,
     clearAnnotationsToCreate,
 }: InsightDisplayConfigProps): JSX.Element {
     const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
@@ -120,6 +122,17 @@ export function InsightDisplayConfig({
                             )}
                         />
                     </>
+                )}
+
+                {activeView === ViewType.FUNNELS && (
+                    <SaveToDashboard
+                        item={{
+                            entity: {
+                                filters: allFilters,
+                                annotations: annotationsToCreate,
+                            },
+                        }}
+                    />
                 )}
 
                 {showComparePrevious[activeView] && <CompareFilter />}


### PR DESCRIPTION
## Changes

Brings back "Add to dashboard" button on funnels view. Looks like it may have been accidentally removed when rebasing/merging #4893.

<img width="911" alt="" src="https://user-images.githubusercontent.com/5864173/124446274-9200a400-dd80-11eb-88e8-0888363f5da1.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
