### PR TITLE
Fix CSS overflow prop on filters

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.tsx
@@ -265,7 +265,7 @@ export function ActionFilterRow({
                 )}
 
             {visible && (
-                <div className="ml" style={{ maxWidth: '100%', overflow: 'hidden' }}>
+                <div className="ml" style={{ maxWidth: '100%' }}>
                     <PropertyFilters
                         pageKey={`${index}-${value}-filter`}
                         propertyFilters={filter.properties}


### PR DESCRIPTION
## Changes

`overflow: hidden` was breaking the filter dropdown.

Broken:

![image](https://user-images.githubusercontent.com/4645779/124497725-4b637780-dd89-11eb-94fa-ef38e3b99343.png)

Fixed:

<img width="676" alt="Screen Shot 2021-07-05 at 12 06 10 PM" src="https://user-images.githubusercontent.com/4645779/124497775-6504bf00-dd89-11eb-8736-7f8ac8b1278e.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
