### PR TITLE
Set PISCINA_ATOMICS_TIMEOUT

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -71,6 +71,10 @@
                 {
                     "name": "PLUGIN_SERVER_ACTION_MATCHING",
                     "value": "1"
+                },
+                {
+                    "name": "PISCINA_ATOMICS_TIMEOUT",
+                    "value": "1000"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

### Only merge after https://github.com/PostHog/plugin-server/pull/494!

Context on this is spread between https://github.com/PostHog/plugin-server/issues/487 and https://github.com/PostHog/piscina/pull/3.

**TL;DR**

Before, workers would block until they got a new task. After https://github.com/PostHog/piscina/pull/4, they now only block for `atomicsTimeout` (worry not, no tasks are lost after the timeout though). We can afford to set this lower than the default on Cloud because we have potentially 1000s tasks per sec, so workers don't really have to block for long to get a new task. 5000 is a good default for local dev/self-hosted though.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
