### PR TITLE
Change home default behavior, don't route by default

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -244,17 +244,12 @@ export function MainNavigation(): JSX.Element {
             >
                 <div className="navigation-inner" ref={navRef} onScroll={handleNavScroll}>
                     <div className="nav-logo">
-                        {featureFlags[FEATURE_FLAGS.PROJECT_HOME] ? (
-                            <Link to="/home">
-                                <img src={smLogo} className="logo-sm" alt="" />
-                                <img src={lgLogo} className="logo-lg" alt="" />
-                            </Link>
-                        ) : (
+                        {
                             <Link to="/insights">
                                 <img src={smLogo} className="logo-sm" alt="" />
                                 <img src={lgLogo} className="logo-lg" alt="" />
                             </Link>
-                        )}
+                        }
                     </div>
                     {currentOrganization?.setup.is_active && (
                         <MenuItem
@@ -266,7 +261,7 @@ export function MainNavigation(): JSX.Element {
                         />
                     )}
                     {featureFlags[FEATURE_FLAGS.PROJECT_HOME] && (
-                        <MenuItem title="Home" icon={<HomeOutlined />} identifier="home" to="/home" />
+                        <MenuItem title="Overview" icon={<HomeOutlined />} identifier="overview" to="/overview" />
                     )}
                     <MenuItem
                         title="Insights"

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -9,7 +9,7 @@ import {
     PushpinFilled,
     PlusOutlined,
     SettingOutlined,
-    HomeOutlined,
+    InboxOutlined,
 } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
@@ -261,7 +261,7 @@ export function MainNavigation(): JSX.Element {
                         />
                     )}
                     {featureFlags[FEATURE_FLAGS.PROJECT_HOME] && (
-                        <MenuItem title="Home" icon={<HomeOutlined />} identifier="home" to="/home" />
+                        <MenuItem title="Overview" icon={<InboxOutlined />} identifier="home" to="/overview" />
                     )}
                     <MenuItem
                         title="Insights"

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -9,7 +9,7 @@ import {
     PushpinFilled,
     PlusOutlined,
     SettingOutlined,
-    InboxOutlined,
+    HomeOutlined,
 } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
@@ -261,7 +261,7 @@ export function MainNavigation(): JSX.Element {
                         />
                     )}
                     {featureFlags[FEATURE_FLAGS.PROJECT_HOME] && (
-                        <MenuItem title="Overview" icon={<InboxOutlined />} identifier="home" to="/overview" />
+                        <MenuItem title="Home" icon={<HomeOutlined />} identifier="home" to="/home" />
                     )}
                     <MenuItem
                         title="Insights"

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -261,7 +261,7 @@ export function MainNavigation(): JSX.Element {
                         />
                     )}
                     {featureFlags[FEATURE_FLAGS.PROJECT_HOME] && (
-                        <MenuItem title="Overview" icon={<HomeOutlined />} identifier="overview" to="/overview" />
+                        <MenuItem title="Home" icon={<HomeOutlined />} identifier="home" to="/home" />
                     )}
                     <MenuItem
                         title="Insights"

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -6,8 +6,9 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { saveToDashboardModalLogicType } from './saveToDashboardModalLogicType'
 
 export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType>({
-    props: {} as { fromDashboard: boolean },
-
+    props: {} as {
+        fromDashboard: boolean
+    },
     actions: {
         addNewDashboard: true,
         setDashboardId: (id: number) => ({ id }),

--- a/frontend/src/scenes/onboarding/home/Home.tsx
+++ b/frontend/src/scenes/onboarding/home/Home.tsx
@@ -64,7 +64,7 @@ export function Home(): JSX.Element {
             <div style={{ marginBottom: 128 }}>
                 <Space direction="vertical">
                     <PageHeader
-                        title="Overview"
+                        title="Home"
                         caption={
                             teamHasData ? undefined : 'Welcome to PostHog! Install one of our libraries to get started.'
                         }

--- a/frontend/src/scenes/onboarding/home/Home.tsx
+++ b/frontend/src/scenes/onboarding/home/Home.tsx
@@ -64,7 +64,7 @@ export function Home(): JSX.Element {
             <div style={{ marginBottom: 128 }}>
                 <Space direction="vertical">
                     <PageHeader
-                        title="Home"
+                        title="Overview"
                         caption={
                             teamHasData ? undefined : 'Welcome to PostHog! Install one of our libraries to get started.'
                         }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -160,6 +160,7 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
 
 export const redirects: Record<string, string | ((params: Params) => any)> = {
     '/': '/insights',
+    '/home': '/overview',
     '/plugins': '/project/plugins',
     '/actions': '/events/actions',
     '/organization/members': '/organization/settings',
@@ -202,7 +203,7 @@ export const routes: Record<string, Scene> = {
     '/ingestion': Scene.Ingestion,
     '/ingestion/*': Scene.Ingestion,
     '/setup': Scene.OnboardingSetup,
-    '/home': Scene.Home,
+    '/overview': Scene.Home,
 }
 
 export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneConfig>>({

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -44,7 +44,7 @@ export enum Scene {
     Personalization = 'personalization',
     Ingestion = 'ingestion',
     OnboardingSetup = 'onboardingSetup',
-    Overview = 'overview',
+    Home = 'home',
 }
 
 interface LoadedScene {
@@ -101,7 +101,7 @@ export const scenes: Record<Scene, () => any> = {
     [Scene.Personalization]: () => import(/* webpackChunkName: 'personalization' */ './onboarding/Personalization'),
     [Scene.OnboardingSetup]: () => import(/* webpackChunkName: 'onboardingSetup' */ './onboarding/OnboardingSetup'),
     [Scene.Login]: () => import(/* webpackChunkName: 'login' */ './authentication/Login'),
-    [Scene.Overview]: () => import(/* webpackChunkName: 'home' */ './onboarding/home/Home'),
+    [Scene.Home]: () => import(/* webpackChunkName: 'home' */ './onboarding/home/Home'),
 }
 
 interface SceneConfig {
@@ -202,7 +202,7 @@ export const routes: Record<string, Scene> = {
     '/ingestion': Scene.Ingestion,
     '/ingestion/*': Scene.Ingestion,
     '/setup': Scene.OnboardingSetup,
-    '/overview': Scene.Overview,
+    '/home': Scene.Home,
 }
 
 export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneConfig>>({

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -7,8 +7,6 @@ import posthog from 'posthog-js'
 import { sceneLogicType } from './sceneLogicType'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { preflightLogic } from './PreflightCheck/logic'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { userLogic } from 'scenes/userLogic'
 import { afterLoginRedirect } from 'scenes/authentication/loginLogic'
 
@@ -46,7 +44,7 @@ export enum Scene {
     Personalization = 'personalization',
     Ingestion = 'ingestion',
     OnboardingSetup = 'onboardingSetup',
-    Home = 'home',
+    Overview = 'overview',
 }
 
 interface LoadedScene {
@@ -103,7 +101,7 @@ export const scenes: Record<Scene, () => any> = {
     [Scene.Personalization]: () => import(/* webpackChunkName: 'personalization' */ './onboarding/Personalization'),
     [Scene.OnboardingSetup]: () => import(/* webpackChunkName: 'onboardingSetup' */ './onboarding/OnboardingSetup'),
     [Scene.Login]: () => import(/* webpackChunkName: 'login' */ './authentication/Login'),
-    [Scene.Home]: () => import(/* webpackChunkName: 'home' */ './onboarding/home/Home'),
+    [Scene.Overview]: () => import(/* webpackChunkName: 'home' */ './onboarding/home/Home'),
 }
 
 interface SceneConfig {
@@ -204,7 +202,7 @@ export const routes: Record<string, Scene> = {
     '/ingestion': Scene.Ingestion,
     '/ingestion/*': Scene.Ingestion,
     '/setup': Scene.OnboardingSetup,
-    '/home': Scene.Home,
+    '/overview': Scene.Overview,
 }
 
 export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneConfig>>({
@@ -271,12 +269,7 @@ export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneCo
 
         for (const path of Object.keys(redirects)) {
             mapping[path] = (params) => {
-                let redirect = redirects[path]
-
-                if (path === '/' && featureFlagLogic.values.featureFlags[FEATURE_FLAGS.PROJECT_HOME]) {
-                    redirect = '/home'
-                }
-
+                const redirect = redirects[path]
                 router.actions.replace(typeof redirect === 'function' ? redirect(params) : redirect)
             }
         }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -160,7 +160,6 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
 
 export const redirects: Record<string, string | ((params: Params) => any)> = {
     '/': '/insights',
-    '/home': '/overview',
     '/plugins': '/project/plugins',
     '/actions': '/events/actions',
     '/organization/members': '/organization/settings',
@@ -203,7 +202,7 @@ export const routes: Record<string, Scene> = {
     '/ingestion': Scene.Ingestion,
     '/ingestion/*': Scene.Ingestion,
     '/setup': Scene.OnboardingSetup,
-    '/overview': Scene.Home,
+    '/home': Scene.Home,
 }
 
 export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneConfig>>({


### PR DESCRIPTION
I'm hopping back over to the activation side of things. This is a quick change for project home to make the experience more usable while we work on planning the next set of stages.

## Changes
- Switch routing back to insights by default.

Theory motivating these changes:
- It's going to be a better experience for activated users to go directly to insights. Right now, the home page has diminishing results once you know what you're doing.
- For confused users, even without routing, this is easy enough to find.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
