### PR TITLE
Don't force _health endpoint redirect to https

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -100,6 +100,7 @@ TOOLBAR_COOKIE_SECURE = secure_cookies
 SESSION_COOKIE_SECURE = secure_cookies
 CSRF_COOKIE_SECURE = secure_cookies
 SECURE_SSL_REDIRECT = secure_cookies
+SECURE_REDIRECT_EXEMPT = [r"^_health/?"]
 
 if not TEST:
     if os.getenv("SENTRY_DSN"):


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/4726

Note that this does not work on cloud - we'd need to exclude the
endpoint in the AWS ELB as well.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
