### PR TITLE
hide funnel persons if not clickhouse

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -227,10 +227,10 @@ export const funnelLogic = kea<funnelLogicType>({
             },
         ],
         funnelPersonsEnabled: [
-            () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags) => featureFlags[FEATURE_FLAGS.FUNNEL_PERSONS_MODAL],
+            () => [selectors.featureFlags, selectors.preflight],
+            (featureFlags, preflight) =>
+                featureFlags[FEATURE_FLAGS.FUNNEL_PERSONS_MODAL] && preflight?.is_clickhouse_enabled,
         ],
-        clickhouseEnabled: [() => [selectors.preflight], (preflight) => preflight?.is_clickhouse_enabled],
     }),
 
     listeners: ({ actions, values, props }) => ({


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

clickhouse boolean check for funnel persons

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
