### PR TITLE
Add missing funnel trends param

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -74,7 +74,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
         team = self.team
         filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS})
 
-        if filter.funnel_viz_type == FunnelVizType.TRENDS:
+        if filter.funnel_viz_type == FunnelVizType.TRENDS or filter.display == TRENDS_LINEAR:
             return {"result": ClickhouseFunnelTrends(team=team, filter=filter).run()}
         elif filter.funnel_order_type == FunnelOrderType.UNORDERED:
             return {"result": ClickhouseFunnelUnordered(team=team, filter=filter).run()}


### PR DESCRIPTION
## Changes

*Please describe.*  
- make sure funnel trends is backwards compatible
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
