### PR TITLE
Add person select to new funnel query for backwards compatibility

### DIFF
--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -299,15 +299,6 @@ class ClickhouseFunnelBase(ABC, Funnel):
 
         return ", ".join(cols)
 
-    def _get_people_columns(self, max_steps: int):
-        cols: List[str] = []
-
-        for i in range(max_steps):
-            cols.append(f"groupArrayIf(100)(DISTINCT person_id, steps = {i + 1}) step_people_{i + 1}")
-
-        formatted = ", ".join(cols)
-        return f", {formatted}" if formatted else ""
-
     def _get_step_time_avgs(self, max_steps: int):
         conditions: List[str] = []
         for i in range(1, max_steps):

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -299,6 +299,15 @@ class ClickhouseFunnelBase(ABC, Funnel):
 
         return ", ".join(cols)
 
+    def _get_people_columns(self, max_steps: int):
+        cols: List[str] = []
+
+        for i in range(max_steps):
+            cols.append(f"groupArrayIf(100)(DISTINCT person_id, steps = {i + 1}) step_people_{i + 1}")
+
+        formatted = ", ".join(cols)
+        return f", {formatted}" if formatted else ""
+
     def _get_step_time_avgs(self, max_steps: int):
         conditions: List[str] = []
         for i in range(1, max_steps):

--- a/ee/clickhouse/queries/funnels/funnel.py
+++ b/ee/clickhouse/queries/funnels/funnel.py
@@ -23,6 +23,15 @@ class ClickhouseFunnelNew(ClickhouseFunnelBase):
         ) {'GROUP BY prop' if breakdown_clause != '' else ''} SETTINGS allow_experimental_window_functions = 1
         """
 
+    def _get_people_columns(self, max_steps: int):
+        cols: List[str] = []
+
+        for i in range(max_steps):
+            cols.append(f"groupArrayIf(100)(DISTINCT person_id, steps = {i + 1}) step_people_{i + 1}")
+
+        formatted = ", ".join(cols)
+        return f", {formatted}" if formatted else ""
+
     def get_step_counts_query(self):
         steps_per_person_query = self._get_steps_per_person_query()
         max_steps = len(self._filter.entities)

--- a/ee/clickhouse/queries/funnels/funnel.py
+++ b/ee/clickhouse/queries/funnels/funnel.py
@@ -18,7 +18,7 @@ class ClickhouseFunnelNew(ClickhouseFunnelBase):
         breakdown_clause = self._get_breakdown_prop()
 
         return f"""
-        SELECT {self._get_count_columns(max_steps)} {self._get_step_time_avgs(max_steps)} {breakdown_clause} FROM (
+        SELECT {self._get_count_columns(max_steps)} {self._get_people_columns(max_steps)} {self._get_step_time_avgs(max_steps)} {breakdown_clause} FROM (
                 {steps_per_person_query}
         ) {'GROUP BY prop' if breakdown_clause != '' else ''} SETTINGS allow_experimental_window_functions = 1
         """
@@ -45,18 +45,20 @@ class ClickhouseFunnelNew(ClickhouseFunnelBase):
     def _format_single_funnel(self, result, with_breakdown=False):
         # Format of this is [step order, person count (that reached that step), array of person uuids]
         steps = []
+        relevant_people = []
         total_people = 0
+
+        num_entities = len(self._filter.entities)
 
         for step in reversed(self._filter.entities):
 
             if result and len(result) > 0:
                 total_people += result[step.order]
+                relevant_people += result[step.order + num_entities]
 
-            serialized_result = self._serialize_step(step, total_people, [])
+            serialized_result = self._serialize_step(step, total_people, relevant_people[0:100])
             if step.order > 0:
-                serialized_result.update(
-                    {"average_conversion_time": result[step.order + len(self._filter.entities) - 1]}
-                )
+                serialized_result.update({"average_conversion_time": result[step.order + num_entities * 2 - 1]})
             else:
                 serialized_result.update({"average_conversion_time": None})
 

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -37,8 +37,8 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
-# class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
-#     pass
+class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
+    pass
 
 
 class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew, _create_event, _create_person)):  # type: ignore

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -37,8 +37,8 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
-class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
-    pass
+# class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
+#     pass
 
 
 class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew, _create_event, _create_person)):  # type: ignore
@@ -75,9 +75,11 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
 
         self.assertEqual(result[0]["name"], "user signed up")
         self.assertEqual(result[0]["count"], 1)
+        self.assertEqual(len(result[0]["people"]), 1)
 
         self.assertEqual(result[1]["name"], "paid")
         self.assertEqual(result[1]["count"], 1)
+        self.assertEqual(len(result[1]["people"]), 1)
 
     def test_basic_funnel_with_repeat_steps(self):
         filters = {
@@ -104,7 +106,9 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
 
         self.assertEqual(result[0]["name"], "user signed up")
         self.assertEqual(result[0]["count"], 2)
+        self.assertEqual(len(result[0]["people"]), 2)
         self.assertEqual(result[1]["count"], 1)
+        self.assertEqual(len(result[1]["people"]), 1)
 
         self.assertCountEqual(
             self._get_people_at_step(filter, 1),
@@ -173,10 +177,15 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
         self.assertEqual(result[1]["name"], "$pageview")
         self.assertEqual(result[4]["name"], "$pageview")
         self.assertEqual(result[0]["count"], 5)
+        self.assertEqual(len(result[0]["people"]), 5)
         self.assertEqual(result[1]["count"], 4)
+        self.assertEqual(len(result[1]["people"]), 4)
         self.assertEqual(result[2]["count"], 3)
+        self.assertEqual(len(result[2]["people"]), 3)
         self.assertEqual(result[3]["count"], 2)
+        self.assertEqual(len(result[3]["people"]), 2)
         self.assertEqual(result[4]["count"], 1)
+        self.assertEqual(len(result[4]["people"]), 1)
         # check ordering of people in every step
         self.assertCountEqual(
             self._get_people_at_step(filter, 1),
@@ -289,10 +298,15 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
         self.assertEqual(result[1]["name"], "$pageview")
         self.assertEqual(result[4]["name"], "$pageview")
         self.assertEqual(result[0]["count"], 5)
+        self.assertEqual(len(result[0]["people"]), 5)
         self.assertEqual(result[1]["count"], 4)
+        self.assertEqual(len(result[1]["people"]), 4)
         self.assertEqual(result[2]["count"], 1)
+        self.assertEqual(len(result[2]["people"]), 1)
         self.assertEqual(result[3]["count"], 1)
+        self.assertEqual(len(result[3]["people"]), 1)
         self.assertEqual(result[4]["count"], 1)
+        self.assertEqual(len(result[4]["people"]), 1)
         # check ordering of people in every step
         self.assertCountEqual(
             self._get_people_at_step(filter, 1),
@@ -358,7 +372,9 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
 
         self.assertEqual(result[0]["name"], "sign up")
         self.assertEqual(result[0]["count"], 2)
+        self.assertEqual(len(result[0]["people"]), 2)
         self.assertEqual(result[1]["count"], 1)
+        self.assertEqual(len(result[1]["people"]), 1)
         # check ordering of people in first step
         self.assertCountEqual(
             self._get_people_at_step(filter, 1),
@@ -752,7 +768,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "sign up",
                     "name": "sign up",
                     "order": 0,
-                    "people": [],
+                    "people": [person1.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": None,
@@ -762,7 +778,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "play movie",
                     "name": "play movie",
                     "order": 1,
-                    "people": [],
+                    "people": [person1.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": 3600.0,
@@ -772,7 +788,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "buy",
                     "name": "buy",
                     "order": 2,
-                    "people": [],
+                    "people": [person1.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": 7200.0,
@@ -787,7 +803,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "sign up",
                     "name": "sign up",
                     "order": 0,
-                    "people": [],
+                    "people": [person2.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": None,
@@ -797,7 +813,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "play movie",
                     "name": "play movie",
                     "order": 1,
-                    "people": [],
+                    "people": [person2.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": 7200.0,
@@ -879,7 +895,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "sign up",
                     "name": "sign up",
                     "order": 0,
-                    "people": [],
+                    "people": [person1.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": None,
@@ -889,7 +905,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "play movie",
                     "name": "play movie",
                     "order": 1,
-                    "people": [],
+                    "people": [person1.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": 3600.0,
@@ -899,7 +915,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "buy",
                     "name": "buy",
                     "order": 2,
-                    "people": [],
+                    "people": [person1.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": 7200.0,
@@ -914,7 +930,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "sign up",
                     "name": "sign up",
                     "order": 0,
-                    "people": [],
+                    "people": [person2.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": None,
@@ -924,7 +940,7 @@ class TestFunnelNew(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnelNew
                     "action_id": "play movie",
                     "name": "play movie",
                     "order": 1,
-                    "people": [],
+                    "people": [person2.uuid],
                     "count": 1,
                     "type": "events",
                     "average_conversion_time": 7200.0,


### PR DESCRIPTION
## Changes

*Please describe.*  
- merge this before merging #4923 in order to retain api compatibility
- this PR adds the static list of 100 users that currently is used
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
