### PR TITLE
Don't error in celery for non-replicated clickhouse setups

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -124,14 +124,15 @@ def redis_heartbeat():
 
 CLICKHOUSE_TABLES = [
     "events",
-    "sharded_events",
     "person",
-    "sharded_person",
     "person_distinct_id",
-    "sharded_person_distinct_id",
     "session_recording_events",
-    "sharded_session_recording_events",
 ]
+
+if settings.CLICKHOUSE_REPLICATION:
+    CLICKHOUSE_TABLES.extend(
+        ["sharded_events", "sharded_person", "sharded_person_distinct_id", "sharded_session_recording_events",]
+    )
 
 
 @app.task(ignore_result=True)


### PR DESCRIPTION
Currently, some metrics queries fail for our clients on clickhouse
deployments since replication is not used there. The errors are ignored
on application-side but they make clickhouse logs impossible to read.

This PR fixes this issue

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
