### PR TITLE
Fix direct navigation to graph

### DIFF
--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -3,6 +3,15 @@ describe('Trends', () => {
         cy.visit('/insights')
     })
 
+    it('Can load a graph from a URL directly', () => {
+        // regression test, the graph wouldn't load when going directly to a URL
+        cy.visit(
+            '/insights?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&filter_test_accounts=false&breakdown=%24referrer&breakdown_type=event&properties=%5B%7B"key"%3A"%24current_url"%2C"value"%3A"http%3A%2F%2Fhogflix.com"%2C"operator"%3A"icontains"%2C"type"%3A"event"%7D%5D'
+        )
+
+        cy.get('[data-attr=trend-line-graph]').should('exist')
+    })
+
     it('Insight History Panel Rendered', () => {
         cy.get('.insights-page').should('exist')
         cy.wait(500)

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -67,8 +67,11 @@ export function Insights(): JSX.Element {
     } = useValues(insightLogic)
     const { setActiveView, toggleControlsCollapsed } = useActions(insightLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
-    const { showingPeople } = useValues(trendsLogic())
-    const { refreshCohort, saveCohortWithFilters } = useActions(trendsLogic())
+    const { showingPeople } = useValues(trendsLogic({ dashboardItemId: null, view: activeView, filters: allFilters }))
+    const { refreshCohort, saveCohortWithFilters } = useActions(
+        trendsLogic({ dashboardItemId: null, view: activeView, filters: allFilters })
+    )
+
     const { funnelPersonsEnabled } = useValues(funnelLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -67,10 +67,9 @@ export function Insights(): JSX.Element {
     } = useValues(insightLogic)
     const { setActiveView, toggleControlsCollapsed } = useActions(insightLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
-    const { showingPeople } = useValues(trendsLogic({ dashboardItemId: null, view: activeView, filters: allFilters }))
-    const { refreshCohort, saveCohortWithFilters } = useActions(
-        trendsLogic({ dashboardItemId: null, view: activeView, filters: allFilters })
-    )
+    const trendsLogicLoaded = trendsLogic({ dashboardItemId: null, view: activeView, filters: allFilters })
+    const { showingPeople } = useValues(trendsLogicLoaded)
+    const { refreshCohort, saveCohortWithFilters } = useActions(trendsLogicLoaded)
 
     const { funnelPersonsEnabled } = useValues(funnelLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)


### PR DESCRIPTION
## Changes

#5013 broke direct linking to a graph. It would show up as "We couldn't find any matching events". I have added a test to prevent further regressions.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
