### PR TITLE
Add "Query time breakdown" graph to internal metrics dashboard

### DIFF
--- a/posthog/internal_metrics/team.py
+++ b/posthog/internal_metrics/team.py
@@ -157,6 +157,29 @@ CLICKHOUSE_DASHBOARD = {
             },
         },
         {
+            "name": "Clickhouse: query time total breakdown (ms)",
+            "filters": {
+                "events": [
+                    {
+                        "id": "$$clickhouse_sync_execution_time",
+                        "math": "sum",
+                        "name": "$$clickhouse_sync_execution_time",
+                        "type": "events",
+                        "order": 0,
+                        "properties": [],
+                        "math_property": "value",
+                    },
+                ],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "hour",
+                "date_from": "-24h",
+                "breakdown": "table",
+                "breakdown_type": "event",
+                "properties": [],
+            },
+        },
+        {
             "name": "Clickhouse mutations count",
             "filters": {
                 "events": [


### PR DESCRIPTION
This came up debugging client performance woes - they were spending 33h
per day updating dashboard item caches.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
