### PR TITLE
Load action matching event count async

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -42,21 +42,6 @@ from posthog.models.team import Team
 class ClickhouseActionSerializer(ActionSerializer):
     is_calculating = serializers.SerializerMethodField()
 
-    def get_count(self, action: Action) -> Optional[int]:
-        if self.context.get("view") and self.context["view"].action != "list":
-            query, params = format_action_filter(action)
-            if query == "":
-                return None
-            try:
-                return sync_execute(
-                    "SELECT count(1) FROM events WHERE team_id = %(team_id)s AND {}".format(query),
-                    {"team_id": action.team_id, **params},
-                )[0][0]
-            except Exception as e:
-                capture_exception(e)
-                return None
-        return None
-
     def get_is_calculating(self, action: Action) -> bool:
         return False
 
@@ -117,6 +102,19 @@ class ClickhouseActionsViewSet(ActionViewSet):
                 "previous": current_url[1:],
             }
         )
+
+    @action(methods=["GET"], detail=True)
+    def count(self, request: Request, **kwargs) -> Response:
+        action = self.get_object()
+        query, params = format_action_filter(action)
+        if query == "":
+            return Response({"count": 0})
+
+        results = sync_execute(
+            "SELECT count(1) FROM events WHERE team_id = %(team_id)s AND {}".format(query),
+            {"team_id": action.team_id, **params},
+        )
+        return Response({"count": results[0][0]})
 
 
 def _handle_date_interval(filter: Filter) -> Filter:

--- a/ee/clickhouse/views/test/test_clickhouse_action.py
+++ b/ee/clickhouse/views/test/test_clickhouse_action.py
@@ -37,7 +37,7 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
-class TestActionApi(ClickhouseTestMixin, factory_test_action_api(_create_event)):
+class TestActionApi(ClickhouseTestMixin, factory_test_action_api(_create_event)):  # type: ignore
     pass
 
 

--- a/ee/clickhouse/views/test/test_clickhouse_action.py
+++ b/ee/clickhouse/views/test/test_clickhouse_action.py
@@ -5,6 +5,7 @@ from rest_framework import status
 
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.api.test.test_action import factory_test_action_api
 from posthog.api.test.test_action_people import action_people_test_factory
 from posthog.constants import ENTITY_ID, ENTITY_MATH, ENTITY_TYPE
 from posthog.models import Action, ActionStep, Cohort, Organization, Person
@@ -36,7 +37,11 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
-class TestAction(
+class TestActionApi(ClickhouseTestMixin, factory_test_action_api(_create_event)):
+    pass
+
+
+class TestActionPeople(
     ClickhouseTestMixin, action_people_test_factory(_create_event, _create_person, _create_action, _create_cohort)  # type: ignore
 ):
     @patch("posthog.tasks.calculate_action.calculate_action.delay")
@@ -59,20 +64,6 @@ class TestAction(
         self.assertEqual(response.json()["name"], "ooh")
         self.assertEqual(response.json()["is_calculating"], False)
         self.assertFalse(patch_delay.called)
-
-    def test_only_get_count_on_retrieve(self):
-        team2 = Organization.objects.bootstrap(None, team_fields={"name": "bla"})[2]
-        action = Action.objects.create(team=self.team, name="bla")
-        ActionStep.objects.create(action=action, event="custom event")
-        _create_event(event="custom event", team=self.team, distinct_id="test")
-        _create_event(event="another event", team=self.team, distinct_id="test")
-        # test team leakage
-        _create_event(event="custom event", team=team2, distinct_id="test")
-        response = self.client.get("/api/action/").json()
-        self.assertEqual(response["results"][0]["count"], None)
-
-        response = self.client.get("/api/action/%s/" % action.pk).json()
-        self.assertEqual(response["count"], 1)
 
     def test_active_user_weekly_people(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -6,7 +6,7 @@ import { actionEditLogic } from './actionEditLogic'
 import './Actions.scss'
 import { ActionStep } from './ActionStep'
 import { Button, Col, Input, Row } from 'antd'
-import { InfoCircleOutlined, PlusOutlined, SaveOutlined, DeleteOutlined } from '@ant-design/icons'
+import { InfoCircleOutlined, PlusOutlined, SaveOutlined, DeleteOutlined, LoadingOutlined } from '@ant-design/icons'
 import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { actionsModel } from '~/models/actionsModel'
@@ -27,7 +27,7 @@ export function ActionEdit({ action: loadedAction, actionId, apiURL, onSave, tem
         onSave: (action, createNew) => onSave(action, !actionId, createNew),
         temporaryToken,
     })
-    const { action, errorActionId } = useValues(logic)
+    const { action, errorActionId, actionCount, actionCountLoading } = useValues(logic)
     const { setAction, saveAction } = useActions(logic)
     const { loadActions } = useActions(actionsModel)
     const { preflight } = useValues(preflightLogic)
@@ -89,20 +89,25 @@ export function ActionEdit({ action: loadedAction, actionId, apiURL, onSave, tem
                         data-attr="edit-action-input"
                         id="actionName"
                     />
-                    {action.count > -1 && (
+                    {actionId && (
                         <div>
                             <span className="text-muted mb-05">
-                                This action matches <b>{compactNumber(action.count)}</b> events
-                                {preflight.db_backend !== 'clickhouse' && (
+                                {actionCountLoading && <LoadingOutlined />}
+                                {actionCount !== null && actionCount > -1 && (
                                     <>
-                                        {' '}
-                                        (last calculated{' '}
-                                        {action.last_calculated_at ? (
-                                            <b>{dayjs(action.last_calculated_at).fromNow()}</b>
-                                        ) : (
-                                            'a while ago'
+                                        This action matches <b>{compactNumber(actionCount)}</b> events
+                                        {preflight.db_backend !== 'clickhouse' && (
+                                            <>
+                                                {' '}
+                                                (last calculated{' '}
+                                                {action.last_calculated_at ? (
+                                                    <b>{dayjs(action.last_calculated_at).fromNow()}</b>
+                                                ) : (
+                                                    'a while ago'
+                                                )}
+                                                )
+                                            </>
                                         )}
-                                        )
                                     </>
                                 )}
                             </span>

--- a/frontend/src/scenes/actions/actionEditLogic.js
+++ b/frontend/src/scenes/actions/actionEditLogic.js
@@ -34,6 +34,14 @@ export const actionEditLogic = kea({
         ],
     }),
 
+    loaders: ({ props }) => ({
+        actionCount: {
+            loadActionCount: async () => {
+                return (await api.get('api/action/' + props.id + '/count')).count
+            },
+        },
+    }),
+
     listeners: ({ values, props, actions }) => ({
         saveAction: async () => {
             let action = { ...values.action }
@@ -62,7 +70,9 @@ export const actionEditLogic = kea({
 
     events: ({ actions, props }) => ({
         afterMount: async () => {
-            if (!props.id) {
+            if (props.id) {
+                actions.loadActionCount()
+            } else {
                 actions.setAction({ name: '', steps: [{ isNew: uuid() }] })
             }
         },

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -163,11 +163,6 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
         )
         return instance
 
-    @action(methods=["GET"], detail=True)
-    def count(self, request: request.Request) -> Response:
-        action = self.get_object()
-        return Response({"count": action.count})
-
 
 def get_actions(queryset: QuerySet, params: dict, team_id: int) -> QuerySet:
     queryset = queryset.annotate(count=Count(TREND_FILTER_TYPE_EVENTS))
@@ -310,6 +305,11 @@ class ActionViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             "next": next_url,
             "previous": current_url[1:],
         }
+
+    @action(methods=["GET"], detail=True)
+    def count(self, request: request.Request, **kwargs) -> Response:
+        count = self.get_queryset().first().count
+        return Response({"count": count})
 
 
 def filter_by_type(entity: Entity, team: Team, filter: Filter) -> QuerySet:

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -2,244 +2,262 @@ from unittest.mock import patch
 
 from rest_framework import status
 
-from posthog.models import Action, ActionStep, Element, Event
+from posthog.models import Action, ActionStep, Element, Event, Organization
 from posthog.test.base import APIBaseTest
 
 
-@patch("posthog.tasks.calculate_action.calculate_action.delay")
-class TestCreateAction(APIBaseTest):
-    @patch("posthoganalytics.capture")
-    def test_create_action(self, patch_capture, *args):
-        Event.objects.create(
-            team=self.team,
-            event="$autocapture",
-            elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div")],
-        )
-        response = self.client.post(
-            "/api/action/",
-            data={
-                "name": "user signed up",
-                "steps": [{"text": "sign up", "selector": "div > button", "url": "/signup", "isNew": "asdf"}],
-            },
-            HTTP_ORIGIN="http://testserver",
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.json()["is_calculating"], False)
-        self.assertIn("last_calculated_at", response.json())
-        action = Action.objects.get()
-        self.assertEqual(action.name, "user signed up")
-        self.assertEqual(action.team, self.team)
-        self.assertEqual(action.steps.get().selector, "div > button")
-        self.assertEqual(response.json()["steps"][0]["text"], "sign up")
-        self.assertEqual(response.json()["steps"][0]["url"], "/signup")
-        self.assertNotIn("isNew", response.json()["steps"][0])
-
-        # Assert analytics are sent
-        patch_capture.assert_called_once_with(
-            self.user.distinct_id,
-            "action created",
-            {
-                "post_to_slack": False,
-                "name_length": 14,
-                "custom_slack_message_format": False,
-                "event_count_precalc": 0,
-                "step_count": 1,
-                "match_text_count": 1,
-                "match_href_count": 0,
-                "match_selector_count": 1,
-                "match_url_count": 1,
-                "has_properties": False,
-                "deleted": False,
-            },
-        )
-
-    def test_cant_create_action_with_the_same_name(self, *args):
-
-        Action.objects.create(name="user signed up", team=self.team)
-        user2 = self._create_user("tim2")
-        self.client.force_login(user2)
-
-        count = Action.objects.count()
-        steps_count = ActionStep.objects.count()
-
-        # Make sure the endpoint works with and without the trailing slash
-        response = self.client.post("/api/action", {"name": "user signed up"}, HTTP_ORIGIN="http://testserver",)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.json(),
-            {
-                "type": "validation_error",
-                "code": "unique",
-                "detail": "This project already has an action with that name.",
-                "attr": "name",
-            },
-        )
-
-        self.assertEqual(Action.objects.count(), count)
-        self.assertEqual(ActionStep.objects.count(), steps_count)
-
-    @patch("posthoganalytics.capture")
-    def test_update_action(self, patch_capture, *args):
-
-        user = self._create_user("test_user_update")
-        self.client.force_login(user)
-
-        action = Action.objects.create(name="user signed up", team=self.team)
-        ActionStep.objects.create(action=action, text="sign me up!")
-        event2 = Event.objects.create(
-            team=self.team,
-            event="$autocapture",
-            properties={"$browser": "Chrome"},
-            elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div"),],
-        )
-        action_id = action.steps.get().pk
-        response = self.client.patch(
-            "/api/action/%s/" % action.pk,
-            data={
-                "name": "user signed up 2",
-                "steps": [
-                    {
-                        "id": action_id,
-                        "isNew": "asdf",
-                        "text": "sign up NOW",
-                        "selector": "div > button",
-                        "properties": [{"key": "$browser", "value": "Chrome"}],
-                        "url": None,
-                    },
-                    {"href": "/a-new-link"},
-                ],
-                "created_by": {
-                    "id": 1,
-                    "distinct_id": "BLKJzxHq4z2d8P1icfpg5wo4eIHaSrMtnotkwdtD8Ok",
-                    "first_name": "person",
-                    "email": "person@email.com",
+def factory_test_action_api(event_factory):
+    @patch("posthog.tasks.calculate_action.calculate_action.delay")
+    class TestActionApi(APIBaseTest):
+        @patch("posthoganalytics.capture")
+        def test_create_action(self, patch_capture, *args):
+            Event.objects.create(
+                team=self.team,
+                event="$autocapture",
+                elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div")],
+            )
+            response = self.client.post(
+                "/api/action/",
+                data={
+                    "name": "user signed up",
+                    "steps": [{"text": "sign up", "selector": "div > button", "url": "/signup", "isNew": "asdf"}],
                 },
-            },
-            HTTP_ORIGIN="http://testserver",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["name"], "user signed up 2")
-        self.assertEqual(response.json()["created_by"], None)
-        self.assertEqual(response.json()["steps"][0]["id"], str(action_id))
-        self.assertEqual(response.json()["steps"][1]["href"], "/a-new-link")
+                HTTP_ORIGIN="http://testserver",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(response.json()["is_calculating"], False)
+            self.assertIn("last_calculated_at", response.json())
+            action = Action.objects.get()
+            self.assertEqual(action.name, "user signed up")
+            self.assertEqual(action.team, self.team)
+            self.assertEqual(action.steps.get().selector, "div > button")
+            self.assertEqual(response.json()["steps"][0]["text"], "sign up")
+            self.assertEqual(response.json()["steps"][0]["url"], "/signup")
+            self.assertNotIn("isNew", response.json()["steps"][0])
 
-        action.refresh_from_db()
-        action.calculate_events()
-        steps = action.steps.all().order_by("id")
-        self.assertEqual(action.name, "user signed up 2")
-        self.assertEqual(steps[0].text, "sign up NOW")
-        self.assertEqual(steps[1].href, "/a-new-link")
-        self.assertEqual(action.events.get(), event2)
-        self.assertEqual(action.events.count(), 1)
+            # Assert analytics are sent
+            patch_capture.assert_called_once_with(
+                self.user.distinct_id,
+                "action created",
+                {
+                    "post_to_slack": False,
+                    "name_length": 14,
+                    "custom_slack_message_format": False,
+                    "event_count_precalc": 0,
+                    "step_count": 1,
+                    "match_text_count": 1,
+                    "match_href_count": 0,
+                    "match_selector_count": 1,
+                    "match_url_count": 1,
+                    "has_properties": False,
+                    "deleted": False,
+                },
+            )
 
-        # Assert analytics are sent
-        patch_capture.assert_called_with(
-            user.distinct_id,
-            "action updated",
-            {
-                "post_to_slack": False,
-                "name_length": 16,
-                "custom_slack_message_format": False,
-                "event_count_precalc": 0,
-                "step_count": 2,
-                "match_text_count": 1,
-                "match_href_count": 1,
-                "match_selector_count": 1,
-                "match_url_count": 0,
-                "has_properties": True,
-                "updated_by_creator": False,
-                "deleted": False,
-            },
-        )
+        def test_cant_create_action_with_the_same_name(self, *args):
 
-        # test queries
-        with self.assertNumQueries(5):
-            self.client.get("/api/action/")
+            Action.objects.create(name="user signed up", team=self.team)
+            user2 = self._create_user("tim2")
+            self.client.force_login(user2)
 
-    def test_update_action_remove_all_steps(self, *args):
+            count = Action.objects.count()
+            steps_count = ActionStep.objects.count()
 
-        action = Action.objects.create(name="user signed up", team=self.team)
-        ActionStep.objects.create(action=action, text="sign me up!")
+            # Make sure the endpoint works with and without the trailing slash
+            response = self.client.post("/api/action", {"name": "user signed up"}, HTTP_ORIGIN="http://testserver",)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.json(),
+                {
+                    "type": "validation_error",
+                    "code": "unique",
+                    "detail": "This project already has an action with that name.",
+                    "attr": "name",
+                },
+            )
 
-        response = self.client.patch(
-            "/api/action/%s/" % action.pk,
-            data={"name": "user signed up 2", "steps": [],},
-            HTTP_ORIGIN="http://testserver",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.json()["steps"]), 0)
-        self.assertEqual(ActionStep.objects.count(), 0)
+            self.assertEqual(Action.objects.count(), count)
+            self.assertEqual(ActionStep.objects.count(), steps_count)
 
-    # When we send a user to their own site, we give them a token.
-    # Make sure you can only create actions if that token is set,
-    # otherwise evil sites could create actions with a users' session.
-    # NOTE: Origin header is only set on cross domain request
-    def test_create_from_other_domain(self, patch_delay):
-        # FIXME: BaseTest is using Django client to performe calls to a DRF endpoint.
-        # Django HttpResponse does not have an attribute `data`. Better use rest_framework.test.APIClient.
-        response = self.client.post(
-            "/api/action/", data={"name": "user signed up",}, HTTP_ORIGIN="https://evilwebsite.com",
-        )
-        self.assertEqual(response.status_code, 403)
+        @patch("posthoganalytics.capture")
+        def test_update_action(self, patch_capture, *args):
 
-        self.user.temporary_token = "token123"
-        self.user.save()
+            user = self._create_user("test_user_update")
+            self.client.force_login(user)
 
-        response = self.client.post(
-            "/api/action/?temporary_token=token123",
-            data={"name": "user signed up",},
-            HTTP_ORIGIN="https://somewebsite.com",
-        )
-        self.assertEqual(response.status_code, 201)
+            action = Action.objects.create(name="user signed up", team=self.team)
+            ActionStep.objects.create(action=action, text="sign me up!")
+            event2 = Event.objects.create(
+                team=self.team,
+                event="$autocapture",
+                properties={"$browser": "Chrome"},
+                elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div"),],
+            )
+            action_id = action.steps.get().pk
+            response = self.client.patch(
+                "/api/action/%s/" % action.pk,
+                data={
+                    "name": "user signed up 2",
+                    "steps": [
+                        {
+                            "id": action_id,
+                            "isNew": "asdf",
+                            "text": "sign up NOW",
+                            "selector": "div > button",
+                            "properties": [{"key": "$browser", "value": "Chrome"}],
+                            "url": None,
+                        },
+                        {"href": "/a-new-link"},
+                    ],
+                    "created_by": {
+                        "id": 1,
+                        "distinct_id": "BLKJzxHq4z2d8P1icfpg5wo4eIHaSrMtnotkwdtD8Ok",
+                        "first_name": "person",
+                        "email": "person@email.com",
+                    },
+                },
+                HTTP_ORIGIN="http://testserver",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["name"], "user signed up 2")
+            self.assertEqual(response.json()["created_by"], None)
+            self.assertEqual(response.json()["steps"][0]["id"], str(action_id))
+            self.assertEqual(response.json()["steps"][1]["href"], "/a-new-link")
 
-        response = self.client.post(
-            "/api/action/?temporary_token=token123",
-            data={"name": "user signed up and post to slack", "post_to_slack": True,},
-            HTTP_ORIGIN="https://somewebsite.com",
-        )
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json()["post_to_slack"], True)
+            action.refresh_from_db()
+            action.calculate_events()
+            steps = action.steps.all().order_by("id")
+            self.assertEqual(action.name, "user signed up 2")
+            self.assertEqual(steps[0].text, "sign up NOW")
+            self.assertEqual(steps[1].href, "/a-new-link")
+            self.assertEqual(action.events.get(), event2)
+            self.assertEqual(action.events.count(), 1)
 
-        list_response = self.client.get("/api/action/", HTTP_ORIGIN="https://evilwebsite.com",)
-        self.assertEqual(list_response.status_code, 403)
+            # Assert analytics are sent
+            patch_capture.assert_called_with(
+                user.distinct_id,
+                "action updated",
+                {
+                    "post_to_slack": False,
+                    "name_length": 16,
+                    "custom_slack_message_format": False,
+                    "event_count_precalc": 0,
+                    "step_count": 2,
+                    "match_text_count": 1,
+                    "match_href_count": 1,
+                    "match_selector_count": 1,
+                    "match_url_count": 0,
+                    "has_properties": True,
+                    "updated_by_creator": False,
+                    "deleted": False,
+                },
+            )
 
-        detail_response = self.client.get(
-            f"/api/action/{response.json()['id']}/", HTTP_ORIGIN="https://evilwebsite.com",
-        )
-        self.assertEqual(detail_response.status_code, 403)
+            # test queries
+            with self.assertNumQueries(5):
+                self.client.get("/api/action/")
 
-        self.client.logout()
-        list_response = self.client.get(
-            "/api/action/", data={"temporary_token": "token123",}, HTTP_ORIGIN="https://somewebsite.com",
-        )
-        self.assertEqual(list_response.status_code, 200)
+        def test_update_action_remove_all_steps(self, *args):
 
-        response = self.client.post(
-            "/api/action/?temporary_token=token123",
-            data={"name": "user signed up 22",},
-            HTTP_ORIGIN="https://somewebsite.com",
-        )
-        self.assertEqual(response.status_code, 201, response.json())
+            action = Action.objects.create(name="user signed up", team=self.team)
+            ActionStep.objects.create(action=action, text="sign me up!")
 
-    # This case happens when someone is running behind a proxy, but hasn't set `IS_BEHIND_PROXY`
-    def test_http_to_https(self, patch_delay):
-        response = self.client.post(
-            "/api/action/", data={"name": "user signed up again",}, HTTP_ORIGIN="https://testserver/",
-        )
-        self.assertEqual(response.status_code, 201, response.json())
+            response = self.client.patch(
+                "/api/action/%s/" % action.pk,
+                data={"name": "user signed up 2", "steps": [],},
+                HTTP_ORIGIN="http://testserver",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.json()["steps"]), 0)
+            self.assertEqual(ActionStep.objects.count(), 0)
 
-    @patch("posthoganalytics.capture")
-    def test_create_action_event_with_space(self, patch_capture, *args):
-        Event.objects.create(
-            team=self.team,
-            event="test_event ",  # notice trailing space
-            elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div")],
-        )
-        response = self.client.post(
-            "/api/action/",
-            data={"name": "test event", "steps": [{"event": "test_event "}],},
-            HTTP_ORIGIN="http://testserver",
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        action = Action.objects.get()
-        self.assertEqual(action.steps.get().event, "test_event ")
+        # When we send a user to their own site, we give them a token.
+        # Make sure you can only create actions if that token is set,
+        # otherwise evil sites could create actions with a users' session.
+        # NOTE: Origin header is only set on cross domain request
+        def test_create_from_other_domain(self, *args):
+            # FIXME: BaseTest is using Django client to performe calls to a DRF endpoint.
+            # Django HttpResponse does not have an attribute `data`. Better use rest_framework.test.APIClient.
+            response = self.client.post(
+                "/api/action/", data={"name": "user signed up",}, HTTP_ORIGIN="https://evilwebsite.com",
+            )
+            self.assertEqual(response.status_code, 403)
+
+            self.user.temporary_token = "token123"
+            self.user.save()
+
+            response = self.client.post(
+                "/api/action/?temporary_token=token123",
+                data={"name": "user signed up",},
+                HTTP_ORIGIN="https://somewebsite.com",
+            )
+            self.assertEqual(response.status_code, 201)
+
+            response = self.client.post(
+                "/api/action/?temporary_token=token123",
+                data={"name": "user signed up and post to slack", "post_to_slack": True,},
+                HTTP_ORIGIN="https://somewebsite.com",
+            )
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.json()["post_to_slack"], True)
+
+            list_response = self.client.get("/api/action/", HTTP_ORIGIN="https://evilwebsite.com",)
+            self.assertEqual(list_response.status_code, 403)
+
+            detail_response = self.client.get(
+                f"/api/action/{response.json()['id']}/", HTTP_ORIGIN="https://evilwebsite.com",
+            )
+            self.assertEqual(detail_response.status_code, 403)
+
+            self.client.logout()
+            list_response = self.client.get(
+                "/api/action/", data={"temporary_token": "token123",}, HTTP_ORIGIN="https://somewebsite.com",
+            )
+            self.assertEqual(list_response.status_code, 200)
+
+            response = self.client.post(
+                "/api/action/?temporary_token=token123",
+                data={"name": "user signed up 22",},
+                HTTP_ORIGIN="https://somewebsite.com",
+            )
+            self.assertEqual(response.status_code, 201, response.json())
+
+        # This case happens when someone is running behind a proxy, but hasn't set `IS_BEHIND_PROXY`
+        def test_http_to_https(self, *args):
+            response = self.client.post(
+                "/api/action/", data={"name": "user signed up again",}, HTTP_ORIGIN="https://testserver/",
+            )
+            self.assertEqual(response.status_code, 201, response.json())
+
+        @patch("posthoganalytics.capture")
+        def test_create_action_event_with_space(self, patch_capture, *args):
+            Event.objects.create(
+                team=self.team,
+                event="test_event ",  # notice trailing space
+                elements=[Element(tag_name="button", text="sign up NOW"), Element(tag_name="div")],
+            )
+            response = self.client.post(
+                "/api/action/",
+                data={"name": "test event", "steps": [{"event": "test_event "}],},
+                HTTP_ORIGIN="http://testserver",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            action = Action.objects.get()
+            self.assertEqual(action.steps.get().event, "test_event ")
+
+        def test_get_event_count(self, *args):
+            team2 = Organization.objects.bootstrap(None, team_fields={"name": "bla"})[2]
+            action = Action.objects.create(team=self.team, name="bla")
+            ActionStep.objects.create(action=action, event="custom event")
+            event_factory(event="custom event", team=self.team, distinct_id="test")
+            event_factory(event="another event", team=self.team, distinct_id="test")
+            # test team leakage
+            event_factory(event="custom event", team=team2, distinct_id="test")
+            response = self.client.get(f"/api/action/{action.id}/count").json()
+            self.assertEqual(response, {"count": 1})
+
+    return TestActionApi
+
+
+class TestAction(factory_test_action_api(Event.objects.create)):  # type: ignore
+    pass

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -253,6 +253,8 @@ def factory_test_action_api(event_factory):
             event_factory(event="another event", team=self.team, distinct_id="test")
             # test team leakage
             event_factory(event="custom event", team=team2, distinct_id="test")
+
+            action.calculate_events()
             response = self.client.get(f"/api/action/{action.id}/count").json()
             self.assertEqual(response, {"count": 1})
 


### PR DESCRIPTION
- Load action event count asynchronously
- Add test for /api/action/{id}/count endpoint

Closes https://github.com/PostHog/posthog/issues/5006, helps with https://github.com/PostHog/product-internal/issues/5

It feels like this could be cleared up even more, but taking one step at a time.

Testing changes bring the new code under test.

https://user-images.githubusercontent.com/148820/124766685-cd959c80-df3f-11eb-81fe-ad72d9610e9e.mp4



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
