### PR TITLE
Always show funnel persons table

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -71,7 +71,6 @@ export function Insights(): JSX.Element {
     const { showingPeople } = useValues(trendsLogicLoaded)
     const { refreshCohort, saveCohortWithFilters } = useActions(trendsLogicLoaded)
 
-    const { funnelPersonsEnabled } = useValues(funnelLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
 
@@ -375,8 +374,7 @@ export function Insights(): JSX.Element {
                                     </div>
                                 </div>
                             </Card>
-                            {!funnelPersonsEnabled &&
-                                !showErrorMessage &&
+                            {!showErrorMessage &&
                                 !showTimeoutMessage &&
                                 activeView === ViewType.FUNNELS &&
                                 allFilters.display === FUNNEL_VIZ && (


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Display the funnel persons table at all times 

<img width="624" alt="Screen Shot 2021-07-07 at 2 57 52 PM" src="https://user-images.githubusercontent.com/25164963/124814198-b650b200-df33-11eb-8e96-076767f2881a.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
