### PR TITLE
Do not show funnel people table only if new funnel feature flag is on and clickhouse enabled

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -39,6 +39,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { PersonModal } from 'scenes/trends/PersonModal'
 import { SaveCohortModal } from 'scenes/trends/SaveCohortModal'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
 
 export interface BaseTabProps {
     annotationsToCreate: any[] // TODO: Type properly
@@ -70,6 +71,8 @@ export function Insights(): JSX.Element {
     const trendsLogicLoaded = trendsLogic({ dashboardItemId: null, view: activeView, filters: allFilters })
     const { showingPeople } = useValues(trendsLogicLoaded)
     const { refreshCohort, saveCohortWithFilters } = useActions(trendsLogicLoaded)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { preflight } = useValues(preflightLogic)
 
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
@@ -374,7 +377,9 @@ export function Insights(): JSX.Element {
                                     </div>
                                 </div>
                             </Card>
-                            {!showErrorMessage &&
+                            {(!featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] ||
+                                (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && !preflight?.is_clickhouse_enabled)) &&
+                                !showErrorMessage &&
                                 !showTimeoutMessage &&
                                 activeView === ViewType.FUNNELS &&
                                 allFilters.display === FUNNEL_VIZ && (


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Fixes #5032 

note: I didn't remove `funnelPersonsEnabled` because I'm still using that selector elsewhere 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
