### PR TITLE
Set PISCINA_ATOMICS_TIMEOUT to 3000

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -74,7 +74,7 @@
                 },
                 {
                     "name": "PISCINA_ATOMICS_TIMEOUT",
-                    "value": "1000"
+                    "value": "3000"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

We recently doubled the number of plugins ECS tasks, so it might make sense to set this higher.

Without going too deeply into context, the fewer tasks per second a given worker sees, the higher this value can be. With 2x more workers, you'd expect a worker to see half the amount of tasks per second it used to, so we can set this higher for a performance benefit in case a worker takes more than 1s to pick up a new task. 

This value essentially sets how long a worker should block for in a "fast mode" that picks up tasks to process faster. After that it kicks into a non-blocking "slow mode" where it can process callbacks as needed. So the tradeoff is:

Higher  `PISCINA_ATOMICS_TIMEOUT` = Faster task discovery = Longer time to complete concurrent/background tasks (e.g. buffer flushes used in a lot of our plugins)



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
