### PR TITLE
Branch earlier on sessions view when filtering for sessions with recordings

### DIFF
--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -61,7 +61,9 @@ class ClickhouseSessionsList(SessionsList):
 
         self._add_person_properties(result)
 
-        return filter_sessions_by_recordings(self.team, result, self.filter), pagination
+        if self.filter.limit_by_recordings:
+            return filter_sessions_by_recordings(self.team, result, self.filter), pagination
+        return result, pagination
 
     def fetch_distinct_ids(
         self, action_filters: ActionFiltersSQL, date_from: str, date_to: str, limit: int, distinct_id_offset: int


### PR DESCRIPTION
## Changes

I noticed this when trying to debug a customer's issue. There is a lot of work done here even if you don't want to filter on sessions with recordings. We should be lazy and only do that work if you want to filter session with recordings and return fast.
