### PR TITLE
Index the cohort params

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -30,7 +30,7 @@ from posthog.models import Action, Cohort, Filter, Team
 TEMP_PRECALCULATED_MARKER = parser.parse("2021-06-07T15:00:00+00:00")
 
 
-def format_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
+def format_person_query(cohort: Cohort, index: int, **kwargs) -> Tuple[str, Dict[str, Any]]:
     filters = []
     params: Dict[str, Any] = {}
 
@@ -38,8 +38,8 @@ def format_person_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
 
     if cohort.is_static:
         return (
-            f"{custom_match_field} IN (SELECT person_id FROM {PERSON_STATIC_COHORT_TABLE} WHERE cohort_id = %(cohort_id)s AND team_id = %(team_id)s)",
-            {"cohort_id": cohort.pk, "team_id": cohort.team_id},
+            f"{custom_match_field} IN (SELECT person_id FROM {PERSON_STATIC_COHORT_TABLE} WHERE cohort_id = %(cohort_id_{index})s AND team_id = %(team_id)s)",
+            {f"cohort_id_{index}": cohort.pk, "team_id": cohort.team_id},
         )
 
     or_queries = []
@@ -178,16 +178,18 @@ def is_precalculated_query(cohort: Cohort) -> bool:
     if (
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
-        and settings.USE_PRECALCULATED_CH_COHORT_PEOPLE
+        and (settings.USE_PRECALCULATED_CH_COHORT_PEOPLE or settings.TEST)
     ):
         return True
     else:
         return False
 
 
-def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
+def format_filter_query(cohort: Cohort, index: int = 0) -> Tuple[str, Dict[str, Any]]:
     is_precalculated = is_precalculated_query(cohort)
-    person_query, params = get_precalculated_query(cohort) if is_precalculated else format_person_query(cohort)
+    person_query, params = (
+        get_precalculated_query(cohort, index) if is_precalculated else format_person_query(cohort, index)
+    )
 
     person_id_query = CALCULATE_COHORT_PEOPLE_SQL.format(
         query=person_query, latest_distinct_id_sql=GET_LATEST_PERSON_DISTINCT_ID_SQL
@@ -195,13 +197,14 @@ def format_filter_query(cohort: Cohort) -> Tuple[str, Dict[str, Any]]:
     return person_id_query, params
 
 
-def get_precalculated_query(cohort: Cohort, **kwargs) -> Tuple[str, Dict[str, Any]]:
+def get_precalculated_query(cohort: Cohort, index: int, **kwargs) -> Tuple[str, Dict[str, Any]]:
     custom_match_field = kwargs.get("custom_match_field", "person_id")
+    filter_query = GET_PERSON_ID_BY_COHORT_ID.format(index=index)
     return (
         f"""
-        {custom_match_field} IN ({GET_PERSON_ID_BY_COHORT_ID})
+        {custom_match_field} IN ({filter_query})
         """,
-        {"team_id": cohort.team_id, "cohort_id": cohort.pk},
+        {"team_id": cohort.team_id, f"cohort_id_{index}": cohort.pk},
     )
 
 
@@ -231,7 +234,7 @@ def insert_static_cohort(person_uuids: List[Optional[uuid.UUID]], cohort_id: int
 
 
 def recalculate_cohortpeople(cohort: Cohort):
-    cohort_filter, cohort_params = format_person_query(cohort, custom_match_field="id")
+    cohort_filter, cohort_params = format_person_query(cohort, 0, custom_match_field="id")
 
     cohort_filter = GET_PERSON_IDS_BY_FILTER.format(distinct_query="AND " + cohort_filter, query="")
 

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -175,10 +175,11 @@ def parse_cohort_timestamps(start_time: Optional[str], end_time: Optional[str]) 
 
 
 def is_precalculated_query(cohort: Cohort) -> bool:
+
     if (
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
-        and (settings.USE_PRECALCULATED_CH_COHORT_PEOPLE or settings.TEST)
+        and settings.USE_PRECALCULATED_CH_COHORT_PEOPLE
     ):
         return True
     else:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -43,7 +43,7 @@ def parse_prop_clauses(
             except Cohort.DoesNotExist:
                 final.append("AND 0 = 1")  # If cohort doesn't exist, nothing can match
             else:
-                person_id_query, cohort_filter_params = format_filter_query(cohort)
+                person_id_query, cohort_filter_params = format_filter_query(cohort, idx)
                 params = {**params, **cohort_filter_params}
                 final.append(
                     "AND {table_name}distinct_id IN ({clause})".format(table_name=table_name, clause=person_id_query)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -199,9 +199,9 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         is_precalculated = is_precalculated_query(cohort)
 
         person_id_query, cohort_filter_params = (
-            get_precalculated_query(cohort, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id")
+            get_precalculated_query(cohort, 0, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id")
             if is_precalculated
-            else format_person_query(cohort, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id")
+            else format_person_query(cohort, 0, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id")
         )
 
         return person_id_query, cohort_filter_params

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -324,8 +324,8 @@ class ClickhouseTrendsBreakdown:
     def _parse_breakdown_cohorts(self, cohorts: BaseManager) -> Tuple[List[str], Dict]:
         queries = []
         params: Dict[str, Any] = {}
-        for cohort in cohorts:
-            person_id_query, cohort_filter_params = format_filter_query(cohort)
+        for idx, cohort in enumerate(cohorts):
+            person_id_query, cohort_filter_params = format_filter_query(cohort, idx)
             params = {**params, **cohort_filter_params}
             cohort_query = person_id_query.replace(
                 "SELECT distinct_id", "SELECT distinct_id, {} as value".format(cohort.pk)

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -68,5 +68,5 @@ GROUP BY person_id HAVING count(*) {count_operator} %(count)s
 """
 
 GET_PERSON_ID_BY_COHORT_ID = """
-SELECT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s GROUP BY person_id, cohort_id, team_id HAVING sum(sign) > 0
+SELECT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id_{index})s GROUP BY person_id, cohort_id, team_id HAVING sum(sign) > 0
 """


### PR DESCRIPTION
## Changes

*Please describe.*  
- the cohort filter function wasn't indexing parameters so if you had more than one precalculated cohort in a query, it would be repeated and the results would make it seem as though all cohorts have the same values
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
