### PR TITLE
Time conversion histogram

### DIFF
--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -18,18 +18,11 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
         ],
     },
     listeners: ({ values }) => ({
-        setChartFilter: (filter) => {
+        setChartFilter: () => {
             const { display, ...searchParams } = router.values.searchParams // eslint-disable-line
             const { pathname } = router.values.location
             searchParams.display = values.chartFilter
 
-            if (filter.filter === ChartDisplayType.FunnelsHistogram) {
-                searchParams.funnel_viz_type = 'time_to_convert'
-                searchParams.funnel_to_step = 1
-            } else {
-                delete searchParams.funnel_viz_type
-                delete searchParams.funnel_to_step
-            }
             if (!objectsEqual(display, values.chartFilter)) {
                 router.actions.replace(pathname, searchParams)
             }

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -18,12 +18,18 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
         ],
     },
     listeners: ({ values }) => ({
-        setChartFilter: () => {
+        setChartFilter: (filter) => {
             const { display, ...searchParams } = router.values.searchParams // eslint-disable-line
             const { pathname } = router.values.location
-
             searchParams.display = values.chartFilter
 
+            if (filter.filter === ChartDisplayType.FunnelsHistogram) {
+                searchParams.funnel_viz_type = 'time_to_convert'
+                searchParams.funnel_to_step = 1
+            } else {
+                delete searchParams.funnel_viz_type
+                delete searchParams.funnel_to_step
+            }
             if (!objectsEqual(display, values.chartFilter)) {
                 router.actions.replace(pathname, searchParams)
             }
@@ -36,7 +42,11 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
             } else if (insight === ViewType.RETENTION) {
                 actions.setChartFilter(ChartDisplayType.ActionsTable)
             } else if (insight === ViewType.FUNNELS) {
-                actions.setChartFilter(ChartDisplayType.FunnelViz)
+                if (display === ChartDisplayType.FunnelsHistogram) {
+                    actions.setChartFilter(ChartDisplayType.FunnelsHistogram)
+                } else {
+                    actions.setChartFilter(ChartDisplayType.FunnelViz)
+                }
             }
         },
     }),

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -35,8 +35,8 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
             } else if (insight === ViewType.RETENTION) {
                 actions.setChartFilter(ChartDisplayType.ActionsTable)
             } else if (insight === ViewType.FUNNELS) {
-                if (display === ChartDisplayType.FunnelsHistogram) {
-                    actions.setChartFilter(ChartDisplayType.FunnelsHistogram)
+                if (display === ChartDisplayType.FunnelsTimeToConvert) {
+                    actions.setChartFilter(ChartDisplayType.FunnelsTimeToConvert)
                 } else {
                     actions.setChartFilter(ChartDisplayType.FunnelViz)
                 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -11,6 +11,7 @@ export const ACTIONS_BAR_CHART = 'ActionsBar'
 export const ACTIONS_BAR_CHART_VALUE = 'ActionsBarValue'
 export const PATHS_VIZ = 'PathsViz'
 export const FUNNEL_VIZ = 'FunnelViz'
+export const FUNNELS_HISTOGRAM = 'FunnelsHistogram'
 
 export enum OrganizationMembershipLevel {
     Member = 1,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -11,7 +11,7 @@ export const ACTIONS_BAR_CHART = 'ActionsBar'
 export const ACTIONS_BAR_CHART_VALUE = 'ActionsBarValue'
 export const PATHS_VIZ = 'PathsViz'
 export const FUNNEL_VIZ = 'FunnelViz'
-export const FUNNELS_HISTOGRAM = 'FunnelsHistogram'
+export const FUNNELS_TIME_TO_CONVERT = 'FunnelsTimeToConvert'
 
 export enum OrganizationMembershipLevel {
     Member = 1,

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -40,6 +40,7 @@ import { ActionsBarValueGraph } from 'scenes/trends/viz'
 
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { FunnelHistogram } from 'scenes/funnels/FunnelHistogram'
 
 dayjs.extend(relativeTime)
 
@@ -126,6 +127,19 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
         element: FunnelViz,
         icon: FunnelPlotOutlined,
         viewText: 'View funnel',
+        link: ({ id, dashboard, name, filters }: DashboardItemType): string => {
+            return combineUrl(
+                `/insights`,
+                { insight: ViewType.FUNNELS, ...filters },
+                { fromItem: id, fromItemName: name, fromDashboard: dashboard }
+            ).url
+        },
+    },
+    FunnelsHistogram: {
+        className: 'funnel-histogram',
+        element: FunnelHistogram,
+        icon: BarChartOutlined,
+        viewText: 'View time conversion',
         link: ({ id, dashboard, name, filters }: DashboardItemType): string => {
             return combineUrl(
                 `/insights`,

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -135,8 +135,8 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
             ).url
         },
     },
-    FunnelsHistogram: {
-        className: 'funnel-histogram',
+    FunnelsTimeToConvert: {
+        className: 'funnel-time-to-convert',
         element: FunnelHistogram,
         icon: BarChartOutlined,
         viewText: 'View time conversion',

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -12,11 +12,7 @@ import { useThrottledCallback } from 'use-debounce'
 import './FunnelBarGraph.scss'
 import { useActions, useValues } from 'kea'
 import { FunnelBarLayout } from 'lib/constants'
-import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
-
-export function calcPercentage(numerator: number, denominator: number): number {
-    return (numerator / denominator) * 100 || 0
-}
+import { calcPercentage, getReferenceStep } from './funnelUtils'
 
 function humanizeOrder(order: number): number {
     return order + 1
@@ -200,21 +196,6 @@ function AverageTimeInspector({ onClick, disabled, averageTime }: AverageTimeIns
             </ValueInspectorButton>
         </div>
     )
-}
-
-export function getReferenceStep(steps: FunnelStep[], stepReference: FunnelStepReference, index?: number): FunnelStep {
-    // Step to serve as denominator of percentage calculations.
-    // step[0] is full-funnel conversion, previous is relative.
-    if (!index || index <= 0) {
-        return steps[0]
-    }
-    switch (stepReference) {
-        case FunnelStepReference.previous:
-            return steps[index - 1]
-        case FunnelStepReference.total:
-        default:
-            return steps[0]
-    }
 }
 
 export function FunnelBarGraph({ steps: stepsParam }: FunnelBarGraphProps): JSX.Element {

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -14,7 +14,7 @@ import { useActions, useValues } from 'kea'
 import { FunnelBarLayout } from 'lib/constants'
 import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
 
-function calcPercentage(numerator: number, denominator: number): number {
+export function calcPercentage(numerator: number, denominator: number): number {
     return (numerator / denominator) * 100 || 0
 }
 
@@ -202,7 +202,7 @@ function AverageTimeInspector({ onClick, disabled, averageTime }: AverageTimeIns
     )
 }
 
-function getReferenceStep(steps: FunnelStep[], stepReference: FunnelStepReference, index?: number): FunnelStep {
+export function getReferenceStep(steps: FunnelStep[], stepReference: FunnelStepReference, index?: number): FunnelStep {
     // Step to serve as denominator of percentage calculations.
     // step[0] is full-funnel conversion, previous is relative.
     if (!index || index <= 0) {

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -242,8 +242,12 @@ export function FunnelBarGraph({ steps: stepsParam }: FunnelBarGraphProps): JSX.
                                 <PropertyKeyInfo value={step.name} />
                             </div>
                             <div className={`funnel-step-metadata ${layout}`}>
-                                {step.average_time >= 0 + Number.EPSILON ? (
-                                    <AverageTimeInspector onClick={() => {}} averageTime={step.average_time} disabled />
+                                {step.average_conversion_time >= 0 + Number.EPSILON ? (
+                                    <AverageTimeInspector
+                                        onClick={() => {}}
+                                        averageTime={step.average_conversion_time}
+                                        disabled
+                                    />
                                 ) : null}
                             </div>
                         </header>

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -1,0 +1,24 @@
+import { useValues } from 'kea'
+import { humanFriendlyDuration } from 'lib/utils'
+import React from 'react'
+import { LineGraph } from 'scenes/insights/LineGraph'
+import { funnelLogic } from './funnelLogic'
+
+export function FunnelHistogram(): JSX.Element {
+    // const { timeToConvert } = useValues(funnelLogic)
+    const timeToConvert = [[2220.0, 2], [29080.0, 0], [55940.0, 0], [82800.0, 1]]
+    const labels = timeToConvert.map(bin => humanFriendlyDuration(`${bin[0]}`))
+    const binData = timeToConvert.map(bin => bin[1])
+    const dataset = [{data: binData, labels: labels, label: 'Time to convert', count: 3}]
+    
+    return (
+        <LineGraph 
+            data-attr="funnels-histogram"
+            type="bar"
+            color={'white'}
+            datasets={dataset}
+            labels={labels}
+            dashboardItemId={null}
+        />
+    )
+}

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -1,22 +1,59 @@
-import { useValues } from 'kea'
+import { Select } from 'antd'
+import { useActions, useValues } from 'kea'
 import { humanFriendlyDuration } from 'lib/utils'
 import React from 'react'
 import { LineGraph } from 'scenes/insights/LineGraph'
 import { funnelLogic } from './funnelLogic'
 
 export function FunnelHistogram(): JSX.Element {
-    const { timeConversionBins } = useValues(funnelLogic)
+    const { timeConversionBins, stepsWithCount } = useValues(funnelLogic)
+    const { changeHistogramStep } = useActions(funnelLogic)
     const labels = timeConversionBins.map((bin) => humanFriendlyDuration(`${bin[0]}`))
     const binData = timeConversionBins.map((bin) => bin[1])
     const dataset = [{ data: binData, labels: labels, label: 'Time to convert', count: 3 }]
+
+    const stepsDropdown = []
+    stepsWithCount.forEach((step, idx) => {
+        if (stepsWithCount[idx + 1]) {
+            stepsDropdown.push({ label: `Steps ${idx + 1} and ${idx + 2}`, value: idx + 1 })
+        }
+    })
     return (
-        <LineGraph
-            data-attr="funnels-histogram"
-            type="bar"
-            color={'white'}
-            datasets={dataset}
-            labels={labels}
-            dashboardItemId={null}
-        />
+        <>
+            <div>
+                Steps
+                {stepsDropdown.length > 0 && (
+                    <Select
+                        defaultValue={stepsDropdown[0]?.label}
+                        // value={barGraphLayout || FunnelBarLayout.vertical}
+                        onChange={changeHistogramStep}
+                        bordered={false}
+                        dropdownMatchSelectWidth={false}
+                        data-attr="funnel-bar-layout-selector"
+                        optionLabelProp="label"
+                    >
+                        <Select.OptGroup label="Graph display options">
+                            {stepsDropdown.map((option) => (
+                                <Select.Option
+                                    key={option?.value}
+                                    value={option?.value || 1}
+                                    label={<>{option?.label}</>}
+                                >
+                                    {option?.label}
+                                </Select.Option>
+                            ))}
+                        </Select.OptGroup>
+                    </Select>
+                )}
+            </div>
+            <LineGraph
+                data-attr="funnels-histogram"
+                type="bar"
+                color={'white'}
+                datasets={dataset}
+                labels={labels}
+                dashboardItemId={null}
+            />
+        </>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -5,14 +5,12 @@ import { LineGraph } from 'scenes/insights/LineGraph'
 import { funnelLogic } from './funnelLogic'
 
 export function FunnelHistogram(): JSX.Element {
-    // const { timeToConvert } = useValues(funnelLogic)
-    const timeToConvert = [[2220.0, 2], [29080.0, 0], [55940.0, 0], [82800.0, 1]]
-    const labels = timeToConvert.map(bin => humanFriendlyDuration(`${bin[0]}`))
-    const binData = timeToConvert.map(bin => bin[1])
-    const dataset = [{data: binData, labels: labels, label: 'Time to convert', count: 3}]
-    
+    const { timeConversionBins } = useValues(funnelLogic)
+    const labels = timeConversionBins.map((bin) => humanFriendlyDuration(`${bin[0]}`))
+    const binData = timeConversionBins.map((bin) => bin[1])
+    const dataset = [{ data: binData, labels: labels, label: 'Time to convert', count: 3 }]
     return (
-        <LineGraph 
+        <LineGraph
             data-attr="funnels-histogram"
             type="bar"
             color={'white'}

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -3,49 +3,30 @@ import { useActions, useValues } from 'kea'
 import { humanFriendlyDuration, humanizeNumber } from 'lib/utils'
 import React from 'react'
 import { LineGraph } from 'scenes/insights/LineGraph'
-import { calcPercentage, getReferenceStep } from './FunnelBarGraph'
+import { calcPercentage, getReferenceStep } from './funnelUtils'
 import { funnelLogic } from './funnelLogic'
 
-interface TimeStepOption {
-    label: string
-    value: number
-    average_conversion_time: number
-    count: number
-}
-
 export function FunnelHistogram(): JSX.Element {
-    const { timeConversionBins, stepsWithCount, stepReference } = useValues(funnelLogic)
+    const { stepsWithCount, stepReference, histogramGraphData, histogramStepsDropdown } = useValues(funnelLogic)
     const { changeHistogramStep } = useActions(funnelLogic)
-    const labels = timeConversionBins.map((bin) => humanFriendlyDuration(`${bin[0]}`))
-    const binData = timeConversionBins.map((bin) => bin[1])
-    const dataset = [{ data: binData, labels: labels, label: 'Time to convert', count: 3 }]
-
-    const stepsDropdown: TimeStepOption[] = []
-    stepsWithCount.forEach((_, idx) => {
-        if (stepsWithCount[idx + 1]) {
-            stepsDropdown.push({
-                label: `Steps ${idx + 1} and ${idx + 2}`,
-                value: idx + 1,
-                count: stepsWithCount[idx + 1].count,
-                average_conversion_time: stepsWithCount[idx + 1].average_conversion_time,
-            })
-        }
-    })
+    const dataset = [
+        { data: histogramGraphData.personsAmount, labels: histogramGraphData.time, label: 'Time to convert' },
+    ]
 
     return (
         <>
             <div>
                 Steps
-                {stepsDropdown.length > 0 && (
+                {histogramStepsDropdown.length > 0 && (
                     <Select
-                        defaultValue={stepsDropdown[0]?.value}
+                        defaultValue={histogramStepsDropdown[0]?.value}
                         onChange={changeHistogramStep}
                         dropdownMatchSelectWidth={false}
                         data-attr="funnel-bar-layout-selector"
                         optionLabelProp="label"
                         style={{ marginLeft: 8, marginBottom: 16 }}
                     >
-                        {stepsDropdown.map((option, i) => {
+                        {histogramStepsDropdown.map((option, i) => {
                             const basisStep = getReferenceStep(stepsWithCount, stepReference, i)
                             return (
                                 <Select.Option
@@ -76,7 +57,7 @@ export function FunnelHistogram(): JSX.Element {
                 type="bar"
                 color={'white'}
                 datasets={dataset}
-                labels={labels}
+                labels={histogramGraphData.time}
                 dashboardItemId={null}
             />
         </>

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -5,6 +5,11 @@ import React from 'react'
 import { LineGraph } from 'scenes/insights/LineGraph'
 import { funnelLogic } from './funnelLogic'
 
+interface TimeStepOption {
+    label: string
+    value: number
+}
+
 export function FunnelHistogram(): JSX.Element {
     const { timeConversionBins, stepsWithCount } = useValues(funnelLogic)
     const { changeHistogramStep } = useActions(funnelLogic)
@@ -12,8 +17,8 @@ export function FunnelHistogram(): JSX.Element {
     const binData = timeConversionBins.map((bin) => bin[1])
     const dataset = [{ data: binData, labels: labels, label: 'Time to convert', count: 3 }]
 
-    const stepsDropdown = []
-    stepsWithCount.forEach((step, idx) => {
+    const stepsDropdown: TimeStepOption[] = []
+    stepsWithCount.forEach((_, idx) => {
         if (stepsWithCount[idx + 1]) {
             stepsDropdown.push({ label: `Steps ${idx + 1} and ${idx + 2}`, value: idx + 1 })
         }
@@ -24,25 +29,18 @@ export function FunnelHistogram(): JSX.Element {
                 Steps
                 {stepsDropdown.length > 0 && (
                     <Select
-                        defaultValue={stepsDropdown[0]?.label}
-                        // value={barGraphLayout || FunnelBarLayout.vertical}
+                        defaultValue={stepsDropdown[0]?.value}
                         onChange={changeHistogramStep}
-                        bordered={false}
                         dropdownMatchSelectWidth={false}
                         data-attr="funnel-bar-layout-selector"
                         optionLabelProp="label"
+                        style={{ marginLeft: 8, marginBottom: 16 }}
                     >
-                        <Select.OptGroup label="Graph display options">
-                            {stepsDropdown.map((option) => (
-                                <Select.Option
-                                    key={option?.value}
-                                    value={option?.value || 1}
-                                    label={<>{option?.label}</>}
-                                >
-                                    {option?.label}
-                                </Select.Option>
-                            ))}
-                        </Select.OptGroup>
+                        {stepsDropdown.map((option) => (
+                            <Select.Option key={option?.value} value={option?.value || 1} label={<>{option?.label}</>}>
+                                {option?.label}
+                            </Select.Option>
+                        ))}
                     </Select>
                 )}
             </div>

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -37,11 +37,11 @@ export function FunnelHistogram(): JSX.Element {
                                     <Col style={{ minWidth: 300 }}>
                                         <Row style={{ justifyContent: 'space-between', padding: '8px 0px' }}>
                                             <span className="l4">{option?.label}</span>
-                                            <span className="text-muted-alt-light">
+                                            <span className="text-muted-alt">
                                                 Average time: {humanFriendlyDuration(option?.average_conversion_time)}
                                             </span>
                                         </Row>
-                                        <Row className="text-muted-alt-light">
+                                        <Row className="text-muted-alt">
                                             Total conversion rate:{' '}
                                             {humanizeNumber(calcPercentage(option.count, basisStep.count))}%
                                         </Row>

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -17,7 +17,7 @@ import { FunnelHistogram } from './FunnelHistogram'
 
 interface FunnelVizProps extends Omit<ChartParams, 'view'> {
     steps: FunnelStep[]
-    timeConversionBins: any[]
+    timeConversionBins: number[]
 }
 
 export function FunnelViz({

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -17,11 +17,13 @@ import { FunnelHistogram } from './FunnelHistogram'
 
 interface FunnelVizProps extends Omit<ChartParams, 'view'> {
     steps: FunnelStep[]
+    timeConversionBins: any[]
 }
 
 export function FunnelViz({
     steps: stepsParam,
     filters: defaultFilters,
+    timeConversionBins,
     dashboardItemId,
     cachedResults,
     inSharedMode,
@@ -144,9 +146,8 @@ export function FunnelViz({
             </>
         ) : null
     }
-
     if (filters.display == ChartDisplayType.FunnelsHistogram) {
-        return steps && steps.length > 0 ? <FunnelHistogram /> : null
+        return timeConversionBins && timeConversionBins.length > 0 ? <FunnelHistogram /> : null
     }
 
     if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]) {

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -11,8 +11,9 @@ import { router } from 'kea-router'
 import { IllustrationDanger } from 'lib/components/icons'
 import { InputNumber } from 'antd'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
-import { ChartParams, FunnelStep } from '~/types'
+import { ChartDisplayType, ChartParams, FunnelStep } from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FunnelHistogram } from './FunnelHistogram'
 
 interface FunnelVizProps extends Omit<ChartParams, 'view'> {
     steps: FunnelStep[]
@@ -142,6 +143,10 @@ export function FunnelViz({
                 />
             </>
         ) : null
+    }
+
+    if (filters.display == ChartDisplayType.FunnelsHistogram) {
+        return steps && steps.length > 0 ? <FunnelHistogram /> : null
     }
 
     if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]) {

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -146,7 +146,7 @@ export function FunnelViz({
             </>
         ) : null
     }
-    if (filters.display == ChartDisplayType.FunnelsHistogram) {
+    if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && filters.display == ChartDisplayType.FunnelsHistogram) {
         return timeConversionBins && timeConversionBins.length > 0 ? <FunnelHistogram /> : null
     }
 

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -58,7 +58,9 @@ export function FunnelViz({
                 labels: steps.map(
                     (step) =>
                         `${step.name} (${step.count})  ${
-                            step.average_time ? 'Avg Time: ' + humanFriendlyDuration(step.average_time) || '' : ''
+                            step.average_conversion_time
+                                ? 'Avg Time: ' + humanFriendlyDuration(step.average_conversion_time) || ''
+                                : ''
                         }`
                 ),
                 values: steps.map((step) => step.count),

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -148,7 +148,7 @@ export function FunnelViz({
             </>
         ) : null
     }
-    if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && filters.display == ChartDisplayType.FunnelsHistogram) {
+    if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && filters.display == ChartDisplayType.FunnelsTimeToConvert) {
         return timeConversionBins && timeConversionBins.length > 0 ? <FunnelHistogram /> : null
     }
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -79,7 +79,7 @@ export const funnelLogic = kea<funnelLogicType>({
         openPersonsModal: (step: FunnelStep, stepNumber: number) => ({ step, stepNumber }),
         setStepReference: (stepReference: FunnelStepReference) => ({ stepReference }),
         setBarGraphLayout: (barGraphLayout: FunnelBarLayout) => ({ barGraphLayout }),
-        setTimeConversionBins: (timeConversionBins: any) => ({ timeConversionBins }),
+        setTimeConversionBins: (timeConversionBins: number[]) => ({ timeConversionBins }),
     }),
 
     connect: {
@@ -89,12 +89,12 @@ export const funnelLogic = kea<funnelLogicType>({
 
     loaders: ({ props, values, actions }) => ({
         results: [
-            [] as FunnelStep[],
+            [] as FunnelStep[] | number[],
             {
-                loadResults: async (refresh = false, breakpoint): Promise<FunnelStep[]> => {
+                loadResults: async (refresh = false, breakpoint): Promise<FunnelStep[] | number[]> => {
                     actions.setStepsWithCountLoading(true)
                     if (props.cachedResults && !refresh && values.filters === props.filters) {
-                        return props.cachedResults as FunnelStep[]
+                        return props.cachedResults as FunnelStep[] | number[]
                     }
 
                     const { from_dashboard } = values.filters
@@ -129,9 +129,10 @@ export const funnelLogic = kea<funnelLogicType>({
                     }
                     breakpoint()
                     insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, result.last_refresh)
-                    actions.setSteps(result.result)
                     if (params.display === ChartDisplayType.FunnelsHistogram) {
-                        actions.setTimeConversionBins(result.result)
+                        actions.setTimeConversionBins(result.result as number[])
+                    } else {
+                        actions.setSteps(result.result as FunnelStep[])
                     }
                     return result.result
                 },
@@ -226,7 +227,7 @@ export const funnelLogic = kea<funnelLogicType>({
         propertiesForUrl: [() => [selectors.filters], (filters: FilterType) => cleanFunnelParams(filters)],
         isValidFunnel: [
             () => [selectors.stepsWithCount, selectors.timeConversionBins],
-            (stepsWithCount: FunnelStep[], timeConversionBins: any[]) => {
+            (stepsWithCount: FunnelStep[], timeConversionBins: number[]) => {
                 return (
                     (stepsWithCount && stepsWithCount[0] && stepsWithCount[0].count > -1) ||
                     timeConversionBins.length > 0

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -147,7 +147,7 @@ export const funnelLogic = kea<funnelLogicType<TimeStepOption>>({
                     insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, result.last_refresh)
                     actions.setSteps(result.result as FunnelStep[])
                     let binsResult: FunnelsTimeConversionResult
-                    if (params.display === ChartDisplayType.FunnelsHistogram) {
+                    if (params.display === ChartDisplayType.FunnelsTimeToConvert) {
                         try {
                             params.funnel_viz_type = 'time_to_convert'
                             params.funnel_to_step = values.histogramStep

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -1,0 +1,21 @@
+import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
+import { FunnelStep } from '~/types'
+
+export function calcPercentage(numerator: number, denominator: number): number {
+    return (numerator / denominator) * 100 || 0
+}
+
+export function getReferenceStep(steps: FunnelStep[], stepReference: FunnelStepReference, index?: number): FunnelStep {
+    // Step to serve as denominator of percentage calculations.
+    // step[0] is full-funnel conversion, previous is relative.
+    if (!index || index <= 0) {
+        return steps[0]
+    }
+    switch (stepReference) {
+        case FunnelStepReference.previous:
+            return steps[index - 1]
+        case FunnelStepReference.total:
+        default:
+            return steps[0]
+    }
+}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -28,6 +28,10 @@ export function ToggleButtonChartFilter({
             value: ChartDisplayType.ActionsLineGraphLinear,
             label: <Tooltip title="Track how this funnel's conversion rate is trending over time">Historical</Tooltip>,
         },
+        {
+            value: ChartDisplayType.FunnelsHistogram,
+            label: 'Time to convert'
+        }
     ]
 
     return (

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -30,8 +30,8 @@ export function ToggleButtonChartFilter({
         },
         {
             value: ChartDisplayType.FunnelsHistogram,
-            label: 'Time to convert'
-        }
+            label: 'Time to convert',
+        },
     ]
 
     return (

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -29,7 +29,7 @@ export function ToggleButtonChartFilter({
             label: <Tooltip title="Track how this funnel's conversion rate is trending over time">Historical</Tooltip>,
         },
         {
-            value: ChartDisplayType.FunnelsHistogram,
+            value: ChartDisplayType.FunnelsTimeToConvert,
             label: <Tooltip title="Track how long it takes for users to convert">Time to convert</Tooltip>,
         },
     ]

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -25,10 +25,6 @@ export function ToggleButtonChartFilter({
             label: <Tooltip title="Track users' progress between steps of the funnel">Conversion steps</Tooltip>,
         },
         {
-            value: ChartDisplayType.ActionsLineGraphLinear,
-            label: <Tooltip title="Track how this funnel's conversion rate is trending over time">Historical</Tooltip>,
-        },
-        {
             value: ChartDisplayType.FunnelsTimeToConvert,
             label: <Tooltip title="Track how long it takes for users to convert">Time to convert</Tooltip>,
         },

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -25,12 +25,12 @@ export function ToggleButtonChartFilter({
             label: <Tooltip title="Track users' progress between steps of the funnel">Conversion steps</Tooltip>,
         },
         {
-            value: ChartDisplayType.ActionsLineGraphLinear,
-            label: <Tooltip title="Track how this funnel's conversion rate is trending over time">Historical</Tooltip>,
-        },
-        {
             value: ChartDisplayType.FunnelsHistogram,
             label: <Tooltip title="Track how long it takes for users to convert">Time to convert</Tooltip>,
+        },
+        {
+            value: ChartDisplayType.ActionsLineGraphLinear,
+            label: <Tooltip title="Track how this funnel's conversion rate is trending over time">Historical</Tooltip>,
         },
     ]
 
@@ -49,6 +49,7 @@ export function ToggleButtonChartFilter({
             disabled={disabled}
             options={options}
             optionType="button"
+            size="small"
         />
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -30,7 +30,7 @@ export function ToggleButtonChartFilter({
         },
         {
             value: ChartDisplayType.FunnelsHistogram,
-            label: 'Time to convert',
+            label: <Tooltip title="Track how long it takes for users to convert">Time to convert</Tooltip>,
         },
     ]
 

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -8,7 +8,7 @@ import {
     ACTIONS_PIE_CHART,
     ACTIONS_TABLE,
     FEATURE_FLAGS,
-    FUNNELS_HISTOGRAM,
+    FUNNELS_TIME_TO_CONVERT,
 } from 'lib/constants'
 import React from 'react'
 import { ChartDisplayType, FilterType } from '~/types'
@@ -117,7 +117,7 @@ export function InsightDisplayConfig({
 
                 {activeView === ViewType.RETENTION && <RetentionDatePicker />}
 
-                {showFunnelBarOptions && allFilters.display !== FUNNELS_HISTOGRAM && (
+                {showFunnelBarOptions && allFilters.display !== FUNNELS_TIME_TO_CONVERT && (
                     <>
                         <FunnelDisplayLayoutPicker />
                         <FunnelStepReferencePicker />

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -8,6 +8,7 @@ import {
     ACTIONS_PIE_CHART,
     ACTIONS_TABLE,
     FEATURE_FLAGS,
+    FUNNELS_HISTOGRAM,
 } from 'lib/constants'
 import React from 'react'
 import { ChartDisplayType, FilterType } from '~/types'
@@ -116,7 +117,7 @@ export function InsightDisplayConfig({
 
                 {activeView === ViewType.RETENTION && <RetentionDatePicker />}
 
-                {showFunnelBarOptions && (
+                {showFunnelBarOptions && allFilters.display !== FUNNELS_HISTOGRAM && (
                     <>
                         <FunnelDisplayLayoutPicker />
                         <FunnelStepReferencePicker />

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -421,6 +421,7 @@ function FunnelInsight(): JSX.Element {
         isValidFunnel,
         stepsWithCountLoading,
         filters: { display },
+        timeConversionBins,
     } = useValues(funnelLogic({}))
     const { featureFlags } = useValues(featureFlagLogic)
     const { autoCalculate } = useValues(funnelLogic())
@@ -430,7 +431,7 @@ function FunnelInsight(): JSX.Element {
         <div style={fluidHeight ? {} : { height: 300, position: 'relative' }}>
             {stepsWithCountLoading && <Loading />}
             {isValidFunnel ? (
-                <FunnelViz steps={stepsWithCount} />
+                <FunnelViz steps={stepsWithCount} timeConversionBins={timeConversionBins} />
             ) : (
                 !stepsWithCountLoading && (
                     <div

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useActions, useMountedLogic, useValues, BindLogic } from 'kea'
 
-import { isMobile, Loading } from 'lib/utils'
+import { humanFriendlyDuration, isMobile, Loading } from 'lib/utils'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
@@ -20,7 +20,7 @@ import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic, logicFromInsight, ViewType } from './insightLogic'
 import { InsightHistoryPanel } from './InsightHistoryPanel'
 import { SavedFunnels } from './SavedCard'
-import { ReloadOutlined, DownOutlined, UpOutlined } from '@ant-design/icons'
+import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { insightCommandLogic } from './insightCommandLogic'
 
 import './Insights.scss'
@@ -73,6 +73,7 @@ export function Insights(): JSX.Element {
     const { refreshCohort, saveCohortWithFilters } = useActions(trendsLogicLoaded)
     const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
+    const { stepsWithCount, histogramStep } = useValues(funnelLogic())
 
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
@@ -333,22 +334,31 @@ export function Insights(): JSX.Element {
                                 className="insights-graph-container"
                             >
                                 <div>
-                                    {lastRefresh && dayjs().subtract(3, 'minutes') > dayjs(lastRefresh) && (
-                                        <small style={{ position: 'absolute', marginTop: -21, right: 24 }}>
-                                            Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
-                                            <Button
-                                                size="small"
-                                                type="link"
-                                                onClick={() => loadResults(true)}
-                                                style={{ margin: 0 }}
-                                            >
-                                                refresh
-                                                <ReloadOutlined
-                                                    style={{ cursor: 'pointer', marginTop: -3, marginLeft: 3 }}
-                                                />
-                                            </Button>
-                                        </small>
-                                    )}
+                                    <Row style={{ justifyContent: 'space-between', marginTop: -8, marginBottom: 16 }}>
+                                        {allFilters.display === FUNNELS_HISTOGRAM && (
+                                            <div>
+                                                Average time:{' '}
+                                                <span className="l4" style={{ color: 'var(--primary)' }}>
+                                                    {humanFriendlyDuration(
+                                                        stepsWithCount[histogramStep]?.average_conversion_time
+                                                    )}
+                                                </span>
+                                            </div>
+                                        )}
+                                        {lastRefresh && dayjs().subtract(3, 'minutes') > dayjs(lastRefresh) && (
+                                            <div style={{ marginLeft: 'auto' }}>
+                                                Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
+                                                <Button
+                                                    size="small"
+                                                    type="link"
+                                                    onClick={() => loadResults(true)}
+                                                    style={{ margin: 0 }}
+                                                >
+                                                    Refresh
+                                                </Button>
+                                            </div>
+                                        )}
+                                    </Row>
                                     {showErrorMessage ? (
                                         <ErrorMessage />
                                     ) : (

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -6,7 +6,13 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 import { Tabs, Row, Col, Card, Button, Tooltip } from 'antd'
-import { FUNNEL_VIZ, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE, FEATURE_FLAGS, FUNNELS_HISTOGRAM } from 'lib/constants'
+import {
+    FUNNEL_VIZ,
+    ACTIONS_TABLE,
+    ACTIONS_BAR_CHART_VALUE,
+    FEATURE_FLAGS,
+    FUNNELS_TIME_TO_CONVERT,
+} from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'
 import { router } from 'kea-router'
 
@@ -335,7 +341,7 @@ export function Insights(): JSX.Element {
                             >
                                 <div>
                                     <Row style={{ justifyContent: 'space-between', marginTop: -8, marginBottom: 16 }}>
-                                        {allFilters.display === FUNNELS_HISTOGRAM && (
+                                        {allFilters.display === FUNNELS_TIME_TO_CONVERT && (
                                             <div>
                                                 Average time:{' '}
                                                 <span className="l4" style={{ color: 'var(--primary)' }}>
@@ -436,7 +442,7 @@ function FunnelInsight(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { autoCalculate } = useValues(funnelLogic())
     const fluidHeight = featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && display === FUNNEL_VIZ
-    const funnelHistogram = display === FUNNELS_HISTOGRAM
+    const funnelHistogram = display === FUNNELS_TIME_TO_CONVERT
 
     return (
         <div

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -346,7 +346,7 @@ export function Insights(): JSX.Element {
                                             </div>
                                         )}
                                         {lastRefresh && dayjs().subtract(3, 'minutes') > dayjs(lastRefresh) && (
-                                            <div style={{ marginLeft: 'auto' }}>
+                                            <div className="text-muted-alt-light" style={{ marginLeft: 'auto' }}>
                                                 Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
                                                 <Button
                                                     size="small"
@@ -354,7 +354,7 @@ export function Insights(): JSX.Element {
                                                     onClick={() => loadResults(true)}
                                                     style={{ margin: 0 }}
                                                 >
-                                                    Refresh
+                                                    <span style={{ fontSize: 14 }}>Refresh</span>
                                                 </Button>
                                             </div>
                                         )}

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -346,7 +346,7 @@ export function Insights(): JSX.Element {
                                             </div>
                                         )}
                                         {lastRefresh && dayjs().subtract(3, 'minutes') > dayjs(lastRefresh) && (
-                                            <div className="text-muted-alt-light" style={{ marginLeft: 'auto' }}>
+                                            <div className="text-muted-alt" style={{ marginLeft: 'auto' }}>
                                                 Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
                                                 <Button
                                                     size="small"

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 import { Tabs, Row, Col, Card, Button, Tooltip } from 'antd'
-import { FUNNEL_VIZ, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE, FEATURE_FLAGS } from 'lib/constants'
+import { FUNNEL_VIZ, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE, FEATURE_FLAGS, FUNNELS_HISTOGRAM } from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'
 import { router } from 'kea-router'
 
@@ -426,9 +426,16 @@ function FunnelInsight(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { autoCalculate } = useValues(funnelLogic())
     const fluidHeight = featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && display === FUNNEL_VIZ
+    const funnelHistogram = display === FUNNELS_HISTOGRAM
 
     return (
-        <div style={fluidHeight ? {} : { height: 300, position: 'relative' }}>
+        <div
+            style={
+                fluidHeight
+                    ? {}
+                    : { height: 300, position: 'relative', marginBottom: `${funnelHistogram ? '32px' : 0}` }
+            }
+        >
             {stepsWithCountLoading && <Loading />}
             {isValidFunnel ? (
                 <FunnelViz steps={stepsWithCount} timeConversionBins={timeConversionBins} />

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -144,10 +144,6 @@ style files without adding already imported styles. */
     color: $text_muted_alt;
 }
 
-.text-muted-alt-light {
-    color: $text_muted_alt_light;
-}
-
 code.code {
     // Temporary: .code class to transition legacy elements
     color: $danger;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -144,6 +144,10 @@ style files without adding already imported styles. */
     color: $text_muted_alt;
 }
 
+.text-muted-alt-light {
+    color: $text_muted_alt_light;
+}
+
 code.code {
     // Temporary: .code class to transition legacy elements
     color: $danger;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -558,6 +558,7 @@ export enum ChartDisplayType {
     ActionsBarChartValue = 'ActionsBarValue',
     PathsViz = 'PathsViz',
     FunnelViz = 'FunnelViz',
+    FunnelsHistogram = 'FunnelsHistogram'
 }
 
 export type InsightType = 'TRENDS' | 'SESSIONS' | 'FUNNELS' | 'RETENTION' | 'PATHS' | 'LIFECYCLE' | 'STICKINESS'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -558,7 +558,7 @@ export enum ChartDisplayType {
     ActionsBarChartValue = 'ActionsBarValue',
     PathsViz = 'PathsViz',
     FunnelViz = 'FunnelViz',
-    FunnelsHistogram = 'FunnelsHistogram'
+    FunnelsHistogram = 'FunnelsHistogram',
 }
 
 export type InsightType = 'TRENDS' | 'SESSIONS' | 'FUNNELS' | 'RETENTION' | 'PATHS' | 'LIFECYCLE' | 'STICKINESS'
@@ -606,6 +606,7 @@ export interface FilterType {
     filter_test_accounts?: boolean
     from_dashboard?: boolean
     funnel_step?: number
+    funnel_viz_type?: string
 }
 
 export interface SystemStatusSubrows {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -696,7 +696,7 @@ export interface FunnelStep {
 export interface FunnelResult {
     is_cached: boolean
     last_refresh: string | null
-    result: FunnelStep[]
+    result: FunnelStep[] | number[]
     type: 'Funnel'
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -558,7 +558,7 @@ export enum ChartDisplayType {
     ActionsBarChartValue = 'ActionsBarValue',
     PathsViz = 'PathsViz',
     FunnelViz = 'FunnelViz',
-    FunnelsHistogram = 'FunnelsHistogram',
+    FunnelsTimeToConvert = 'FunnelsTimeToConvert',
 }
 
 export type InsightType = 'TRENDS' | 'SESSIONS' | 'FUNNELS' | 'RETENTION' | 'PATHS' | 'LIFECYCLE' | 'STICKINESS'
@@ -606,7 +606,7 @@ export interface FilterType {
     filter_test_accounts?: boolean
     from_dashboard?: boolean
     funnel_step?: number
-    funnel_viz_type?: string
+    funnel_viz_type?: string // this and the below param is used for funnels time to convert, it'll be updated soon
     funnel_to_step?: number
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -607,6 +607,7 @@ export interface FilterType {
     from_dashboard?: boolean
     funnel_step?: number
     funnel_viz_type?: string
+    funnel_to_step?: number
 }
 
 export interface SystemStatusSubrows {
@@ -696,7 +697,14 @@ export interface FunnelStep {
 export interface FunnelResult {
     is_cached: boolean
     last_refresh: string | null
-    result: FunnelStep[] | number[]
+    result: FunnelStep[]
+    type: 'Funnel'
+}
+
+export interface FunnelsTimeConversionResult {
+    result: number[]
+    last_refresh: string | null
+    is_cached: boolean
     type: 'Funnel'
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -685,7 +685,7 @@ export interface TrendResultWithAggregate extends TrendResult {
 
 export interface FunnelStep {
     action_id: string
-    average_time: number
+    average_conversion_time: number
     count: number
     name: string
     order: number

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -18,6 +18,7 @@ $text_default: #2d2d2d;
 $text_light: rgba(255, 255, 255, 0.88);
 $text_muted: rgba(0, 0, 0, 0.5);
 $text_muted_alt: #35416b;
+$text_muted_alt_light: #747ea1;
 
 // Background colors
 $bg_navy: #35416b;

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -17,8 +17,7 @@ $brand_yellow: #f9bd2b;
 $text_default: #2d2d2d;
 $text_light: rgba(255, 255, 255, 0.88);
 $text_muted: rgba(0, 0, 0, 0.5);
-$text_muted_alt: #35416b;
-$text_muted_alt_light: #747ea1;
+$text_muted_alt: #747ea1;
 
 // Background colors
 $bg_navy: #35416b;


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Functionality for displaying time to convert histogram and changing steps

<img width="551" alt="Screen Shot 2021-07-09 at 8 06 24 PM" src="https://user-images.githubusercontent.com/25164963/125146294-16da1d80-e0f3-11eb-9173-d5d1080c2c51.png">

https://user-images.githubusercontent.com/25164963/125139654-ed16fb80-e0de-11eb-9296-734ab351ab9b.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
