### PR TITLE
 Fix inappropriate install instructions for Snippet

### DIFF
--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -93,7 +93,7 @@ export function ProjectSettings(): JSX.Element {
                 </h2>
                 To integrate PostHog into your website and get event autocapture with no additional work, include the
                 following snippet in your&nbsp;website's&nbsp;HTML. Ideally, put it just above the&nbsp;
-                <code>{'<head>'}</code>&nbsp;tag.
+                <code>{'</head>'}</code>&nbsp;tag.
                 <br />
                 For more guidance, including on identifying users,{' '}
                 <a href="https://posthog.com/docs/integrations/js-integration">see PostHog Docs</a>.


### PR DESCRIPTION
The current instructions contradict the docs and potentially break a functional install.

## Changes

The existing instructions contradict the docs. The js snippet should be inserted inside HEAD, before the closing tag, not before HEAD.

## Checklist
This is a minor text correction, so I presume these will run. However, this should obviously be addressed by appropriate reviewer. 
- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
