### PR TITLE
Load session events async on clickhouse

### DIFF
--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -9,7 +9,7 @@ from posthog.queries.base import BaseQuery
 from posthog.queries.sessions.session_recording import DistinctId
 from posthog.queries.sessions.session_recording import SessionRecording as BaseSessionRecording
 from posthog.queries.sessions.session_recording import Snapshots
-from posthog.queries.sessions.session_recording import filter_sessions_by_recordings as _filter_sessions_by_recordings
+from posthog.queries.sessions.session_recording import join_with_session_recordings as _join_with_session_recordings
 
 OPERATORS = {"gt": ">", "lt": "<"}
 
@@ -58,8 +58,8 @@ class SessionRecording(BaseSessionRecording):
         return response[0][0], response[0][1], [json.loads(snapshot_data) for _, _, snapshot_data in response]
 
 
-def filter_sessions_by_recordings(team: Team, sessions_results: List[Any], filter: SessionsFilter) -> List[Any]:
-    return _filter_sessions_by_recordings(team, sessions_results, filter, query=query_sessions_in_range)
+def join_with_session_recordings(team: Team, sessions_results: List[Any], filter: SessionsFilter) -> List[Any]:
+    return _join_with_session_recordings(team, sessions_results, filter, query=query_sessions_in_range)
 
 
 def query_sessions_in_range(

--- a/ee/clickhouse/queries/sessions/events.py
+++ b/ee/clickhouse/queries/sessions/events.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict, List, cast
+
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.event import ClickhouseEventSerializer
+from ee.clickhouse.queries.util import parse_timestamps
+from ee.clickhouse.sql.sessions.list import SESSION_EVENTS
+from posthog.models import Team
+from posthog.models.filters.sessions_filter import SessionEventsFilter
+from posthog.queries.base import BaseQuery
+
+
+class SessionsListEvents(BaseQuery):
+    def run(self, filter: SessionEventsFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        date_from, date_to, _ = parse_timestamps(filter, team.pk)
+
+        raw_events = sync_execute(
+            SESSION_EVENTS.format(date_from=date_from, date_to=date_to),
+            {"team_id": team.pk, "distinct_id": filter.distinct_id},
+        )
+
+        return self._serialize(raw_events, filter.distinct_id, team.pk)
+
+    def _serialize(self, events: List[List[Any]], distinct_id: str, team_id: int) -> List[Dict]:
+        data = []
+        for uuid, event, properties, timestamp, elements_chain in events:
+            data.append([uuid, event, properties, timestamp, team_id, None, distinct_id, elements_chain, None, None])
+        return cast(List[Dict[str, Any]], ClickhouseEventSerializer(data, many=True, context={"people": None}).data)

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -6,7 +6,7 @@ from ee.clickhouse.models.action import format_entity_filter
 from ee.clickhouse.models.event import ClickhouseEventSerializer
 from ee.clickhouse.models.person import get_persons_by_distinct_ids
 from ee.clickhouse.models.property import parse_prop_clauses
-from ee.clickhouse.queries.clickhouse_session_recording import filter_sessions_by_recordings
+from ee.clickhouse.queries.clickhouse_session_recording import join_with_session_recordings
 from ee.clickhouse.queries.sessions.clickhouse_sessions import set_default_dates
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.sessions.list import SESSION_SQL, SESSIONS_DISTINCT_ID_SQL
@@ -61,7 +61,7 @@ class ClickhouseSessionsList(SessionsList):
 
         self._add_person_properties(result)
 
-        return filter_sessions_by_recordings(self.team, result, self.filter), pagination
+        return join_with_session_recordings(self.team, result, self.filter), pagination
 
     def fetch_distinct_ids(
         self, action_filters: ActionFiltersSQL, date_from: str, date_to: str, limit: int, distinct_id_offset: int

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -114,8 +114,10 @@ class ClickhouseSessionsList(SessionsList):
                 "length": result[2],
                 "start_time": result[3],
                 "end_time": result[4],
+                "start_url": result[5].strip('"') if isinstance(result[5], str) else result[5],
+                "end_url": result[5].strip('"') if isinstance(result[6], str) else result[5],
                 "properties": {},
-                "matching_events": list(sorted(set(flatten(result[5:])))),
+                "matching_events": list(sorted(set(flatten(result[7:])))),
             }
             for result in results
         ]

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -116,7 +116,6 @@ class ClickhouseSessionsList(SessionsList):
                 "end_time": result[4],
                 "start_url": result[5].strip('"') if isinstance(result[5], str) else result[5],
                 "end_url": result[5].strip('"') if isinstance(result[6], str) else result[5],
-                "properties": {},
                 "matching_events": list(sorted(set(flatten(result[7:])))),
             }
             for result in results

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -109,20 +109,20 @@ class ClickhouseSessionsList(SessionsList):
     def _parse_list_results(self, results: List[Tuple]):
         final = []
         for result in results:
-            events = []
-            for i in range(len(result[4])):
-                event = [
-                    result[4][i],  # uuid
-                    result[5][i],  # event
-                    result[6][i],  # properties
-                    result[7][i],  # timestamp
-                    None,  # team_id,
-                    result[0],  # distinct_id
-                    result[8][i],  # elements_chain
-                    None,  # properties keys
-                    None,  # properties values
-                ]
-                events.append(ClickhouseEventSerializer(event, many=False).data)
+            # events = []
+            # for i in range(len(result[4])):
+            #     event = [
+            #         result[4][i],  # uuid
+            #         result[5][i],  # event
+            #         result[6][i],  # properties
+            #         result[7][i],  # timestamp
+            #         None,  # team_id,
+            #         result[0],  # distinct_id
+            #         result[8][i],  # elements_chain
+            #         None,  # properties keys
+            #         None,  # properties values
+            #     ]
+            #     events.append(ClickhouseEventSerializer(event, many=False).data)
 
             final.append(
                 {
@@ -132,7 +132,7 @@ class ClickhouseSessionsList(SessionsList):
                     "start_time": result[3],
                     "end_time": result[9],
                     "event_count": len(result[4]),
-                    "events": list(events),
+                    # "events": list(events),
                     "properties": {},
                     "matching_events": list(sorted(set(flatten(result[10:])))),
                 }

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -107,38 +107,18 @@ class ClickhouseSessionsList(SessionsList):
                 session["email"] = distinct_to_person[session["distinct_id"]].properties.get("email")
 
     def _parse_list_results(self, results: List[Tuple]):
-        final = []
-        for result in results:
-            # events = []
-            # for i in range(len(result[4])):
-            #     event = [
-            #         result[4][i],  # uuid
-            #         result[5][i],  # event
-            #         result[6][i],  # properties
-            #         result[7][i],  # timestamp
-            #         None,  # team_id,
-            #         result[0],  # distinct_id
-            #         result[8][i],  # elements_chain
-            #         None,  # properties keys
-            #         None,  # properties values
-            #     ]
-            #     events.append(ClickhouseEventSerializer(event, many=False).data)
-
-            final.append(
-                {
-                    "distinct_id": result[0],
-                    "global_session_id": result[1],
-                    "length": result[2],
-                    "start_time": result[3],
-                    "end_time": result[9],
-                    "event_count": len(result[4]),
-                    # "events": list(events),
-                    "properties": {},
-                    "matching_events": list(sorted(set(flatten(result[10:])))),
-                }
-            )
-
-        return final
+        return [
+            {
+                "distinct_id": result[0],
+                "global_session_id": result[1],
+                "length": result[2],
+                "start_time": result[3],
+                "end_time": result[4],
+                "properties": {},
+                "matching_events": list(sorted(set(flatten(result[5:])))),
+            }
+            for result in results
+        ]
 
 
 def format_action_filters(filter: SessionsFilter) -> ActionFiltersSQL:

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -114,8 +114,8 @@ class ClickhouseSessionsList(SessionsList):
                 "length": result[2],
                 "start_time": result[3],
                 "end_time": result[4],
-                "start_url": result[5].strip('"') if isinstance(result[5], str) else result[5],
-                "end_url": result[5].strip('"') if isinstance(result[6], str) else result[5],
+                "start_url": _process_url(result[5]),
+                "end_url": _process_url(result[6]),
                 "matching_events": list(sorted(set(flatten(result[7:])))),
             }
             for result in results
@@ -159,3 +159,11 @@ def format_action_filter_aggregate(entity: Entity, prepend: str):
         params = {**params, **filter_params}
 
     return filter_sql, params
+
+
+def _process_url(url: Optional[str]) -> Optional[str]:
+    if url is not None:
+        url = url.strip('"')
+    if url == "":
+        url = None
+    return url

--- a/ee/clickhouse/queries/test/test_session_recording.py
+++ b/ee/clickhouse/queries/test/test_session_recording.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from ee.clickhouse.models.session_recording_event import create_session_recording_event
-from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording, filter_sessions_by_recordings
+from ee.clickhouse.queries.clickhouse_session_recording import SessionRecording, join_with_session_recordings
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.queries.sessions.test.test_session_recording import session_recording_test_factory
 
@@ -13,6 +13,6 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseSessionRecording(
-    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, _create_event)  # type: ignore
+    ClickhouseTestMixin, session_recording_test_factory(SessionRecording, join_with_session_recordings, _create_event)  # type: ignore
 ):
     pass

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -8,11 +8,14 @@ from rest_framework.exceptions import ValidationError
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import GET_EARLIEST_TIMESTAMP_SQL
 from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
+from posthog.models.filters.sessions_filter import SessionEventsFilter
 from posthog.queries.base import TIME_IN_SECONDS
 from posthog.types import FilterType
 
 
-def parse_timestamps(filter: FilterType, team_id: int, table: str = "") -> Tuple[str, str, dict]:
+def parse_timestamps(
+    filter: Union[FilterType, SessionEventsFilter], team_id: int, table: str = ""
+) -> Tuple[str, str, dict]:
     date_from = None
     date_to = None
     params = {}

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -18,6 +18,8 @@ SESSION_SQL = """
         dateDiff('second', toDateTime(arrayReduce('min', groupArray(timestamp))), toDateTime(arrayReduce('max', groupArray(timestamp)))) AS elapsed,
         arrayReduce('min', groupArray(timestamp)) as start_time,
         arrayReduce('max', groupArray(timestamp)) as end_time,
+        JSONExtractString(arrayElement(groupArray(properties), 1), '$current_url') as start_url,
+        JSONExtractString(arrayElement(groupArray(properties), -1), '$current_url') as end_url
         {filters_select_clause}
     FROM (
         SELECT

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -100,3 +100,19 @@ SESSION_SQL = """
         end_time DESC
     {sessions_limit}
 """
+
+SESSION_EVENTS = """
+SELECT
+    uuid,
+    event,
+    properties,
+    timestamp,
+    elements_chain
+FROM events
+WHERE team_id = %(team_id)s
+  AND event != '$feature_flag_called'
+  AND distinct_id = %(distinct_id)s
+  {date_from}
+  {date_to}
+ORDER BY timestamp
+"""

--- a/ee/clickhouse/sql/sessions/list.py
+++ b/ee/clickhouse/sql/sessions/list.py
@@ -17,12 +17,7 @@ SESSION_SQL = """
         gid,
         dateDiff('second', toDateTime(arrayReduce('min', groupArray(timestamp))), toDateTime(arrayReduce('max', groupArray(timestamp)))) AS elapsed,
         arrayReduce('min', groupArray(timestamp)) as start_time,
-        groupArray(uuid) uuids,
-        groupArray(event) events,
-        groupArray(properties) properties,
-        groupArray(timestamp) timestamps,
-        groupArray(elements_chain) elements_chain,
-        arrayReduce('max', groupArray(timestamp)) as end_time
+        arrayReduce('max', groupArray(timestamp)) as end_time,
         {filters_select_clause}
     FROM (
         SELECT

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -24,7 +24,7 @@ from ee.clickhouse.sql.events import (
 from posthog.api.event import EventViewSet
 from posthog.models import Filter, Person, Team
 from posthog.models.action import Action
-from posthog.models.filters.sessions_filter import SessionsFilter
+from posthog.models.filters.sessions_filter import SessionEventsFilter, SessionsFilter
 from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.models.utils import UUIDT
 from posthog.utils import convert_property_value, flatten
@@ -152,6 +152,13 @@ class ClickhouseEventsViewSet(EventViewSet):
 
         sessions, pagination = ClickhouseSessionsList.run(team=self.team, filter=filter)
         return Response({"result": sessions, "pagination": pagination})
+
+    @action(methods=["GET"], detail=False)
+    def session_events(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        from ee.clickhouse.queries.sessions.events import SessionsListEvents
+
+        filter = SessionEventsFilter(request=request)
+        return Response({"result": SessionsListEvents().run(filter=filter, team=self.team)})
 
     # ******************************************
     # /event/session_recording

--- a/frontend/src/scenes/sessions/SessionDetails.tsx
+++ b/frontend/src/scenes/sessions/SessionDetails.tsx
@@ -19,7 +19,7 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
 
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(50)
-    const events = session.events || filteredSessionEvents[session.global_session_id]
+    const events = filteredSessionEvents[session.global_session_id]
     const matchingEventIds = useMemo(() => new Set(session.matching_events || []), [session.matching_events])
 
     useEffect(() => {

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -141,8 +141,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
         {
             title: 'Start Point',
             render: function RenderStartPoint(session: SessionType) {
-                const url = session.start_url || (session.events && session.events[0].properties?.$current_url)
-                return <span>{url ? stripHTTP(url) : 'N/A'}</span>
+                return <span>{session.start_url ? stripHTTP(session.start_url) : 'N/A'}</span>
             },
             ellipsis: true,
             span: 4,
@@ -150,10 +149,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
         {
             title: 'End Point',
             render: function RenderEndPoint(session: SessionType) {
-                const url =
-                    session.end_url ||
-                    (session.events && session.events[session.events.length - 1].properties?.$current_url)
-                return <span>{url ? stripHTTP(url) : 'N/A'}</span>
+                return <span>{session.end_url ? stripHTTP(session.end_url) : 'N/A'}</span>
             },
             ellipsis: true,
             span: 4,

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -64,7 +64,7 @@ export const MATCHING_EVENT_ICON_SIZE = 26
 export function SessionsView({ personIds, isPersonPage = false }: SessionsTableProps): JSX.Element {
     const logic = sessionsTableLogic({ personIds })
     const {
-        filteredSessions,
+        sessions,
         sessionsLoading,
         pagination,
         isLoadingNext,
@@ -235,8 +235,6 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                                 id="show-only-matches"
                                 onChange={setShowOnlyMatches}
                                 checked={showOnlyMatches}
-                                //size="small"
-                                disabled={filteredSessions.length === 0}
                             />
                             <label className="ml-025" htmlFor="show-only-matches">
                                 <b>Show only event matches</b>
@@ -272,7 +270,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 rowKey="global_session_id"
                 pagination={{ pageSize: 99999, hideOnSinglePage: true }}
                 rowClassName="cursor-pointer"
-                dataSource={filteredSessions}
+                dataSource={sessions}
                 columns={columns}
                 loading={sessionsLoading}
                 expandable={{

--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -152,7 +152,7 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Se
         ],
         shouldLoadSessionEvents: [
             (selectors) => [selectors.session, selectors.loadedSessionEvents],
-            (session, sessionEvents) => session && !session.events && !sessionEvents[session.global_session_id],
+            (session, sessionEvents) => session && !sessionEvents[session.global_session_id],
         ],
         highlightedSessionEvents: [
             (selectors) => [selectors.session, selectors.loadedSessionEvents],
@@ -160,7 +160,7 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Se
                 if (!session) {
                     return []
                 }
-                const events = session.events || sessionEvents[session.global_session_id] || []
+                const events = sessionEvents[session.global_session_id] || []
                 return events.filter((e) => (session.matching_events || []).includes(e.id))
             },
         ],

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -151,29 +151,6 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
             (selectors) => [selectors.filters, selectors.lastAppliedFilters],
             (filters, lastFilters): boolean => !equal(filters, lastFilters),
         ],
-        filteredSessions: [
-            (selectors) => [selectors.sessions, selectors.showOnlyMatches],
-            (sessions: SessionType[], showOnlyMatches: boolean): SessionType[] =>
-                sessions
-                    // only get sessions with matched events
-                    // !s?.events = clickhouse returns all events, postgres loads events on demand and doesn't populate `events`
-                    .filter((s) => !s?.events || !showOnlyMatches || s.matching_events.length > 0)
-                    // filter events
-                    .map((s) => {
-                        const setOfMatchedEventIds = new Set(s.matching_events)
-                        return {
-                            ...s,
-                            ...(s?.events
-                                ? {
-                                      events:
-                                          s?.events?.filter(
-                                              (e) => !showOnlyMatches || setOfMatchedEventIds.has(e.id)
-                                          ) || [],
-                                  }
-                                : {}),
-                        }
-                    }),
-        ],
         filteredSessionEvents: [
             (selectors) => [selectors.loadedSessionEvents, selectors.sessions, selectors.showOnlyMatches],
             (

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -151,21 +151,26 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
             (selectors) => [selectors.filters, selectors.lastAppliedFilters],
             (filters, lastFilters): boolean => !equal(filters, lastFilters),
         ],
+        // :NOTE: This recalculates whenever opening a new session or loading new sessions. Memoize per-session instead.
         filteredSessionEvents: [
             (selectors) => [selectors.loadedSessionEvents, selectors.sessions, selectors.showOnlyMatches],
             (
                 loadedSessionEvents: Record<string, EventType[] | undefined>,
                 sessions: SessionType[],
                 showOnlyMatches: boolean
-            ): Record<string, EventType[] | undefined> =>
-                fromEntries(
-                    Object.entries(loadedSessionEvents).map(([id, events]) => {
-                        const setOfMatchedEventIds = new Set(
-                            sessions.find((s) => s.global_session_id === id)?.matching_events || []
-                        )
-                        return [id, events?.filter((e) => !showOnlyMatches || setOfMatchedEventIds.has(e.id)) || []]
+            ): Record<string, EventType[] | undefined> => {
+                if (!showOnlyMatches) {
+                    return loadedSessionEvents
+                }
+
+                return fromEntries(
+                    sessions.map((session) => {
+                        const events = loadedSessionEvents[session.global_session_id] || []
+                        const matchingEvents = new Set(session.matching_events)
+                        return [session.global_session_id, events.filter((e) => matchingEvents.has(e.id))]
                     })
-                ),
+                )
+            },
         ],
         expandedRowKeysProps: [
             (selectors) => [selectors.sessions, selectors.rowExpandState, selectors.manualRowExpansion],

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -165,9 +165,9 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
 
                 return fromEntries(
                     sessions.map((session) => {
-                        const events = loadedSessionEvents[session.global_session_id] || []
+                        const events = loadedSessionEvents[session.global_session_id]
                         const matchingEvents = new Set(session.matching_events)
-                        return [session.global_session_id, events.filter((e) => matchingEvents.has(e.id))]
+                        return [session.global_session_id, events?.filter((e) => matchingEvents.has(e.id))]
                     })
                 )
             },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -384,16 +384,14 @@ export interface EventFormattedType {
 
 export interface SessionType {
     distinct_id: string
-    event_count: number
-    events?: EventType[]
     global_session_id: string
     length: number
     start_time: string
     end_time: string
     session_recordings: SessionTypeSessionRecording[]
-    start_url?: string
-    end_url?: string
-    email?: string
+    start_url?: string | null
+    end_url?: string | null
+    email?: string | null
     matching_events: Array<number | string>
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -389,8 +389,8 @@ export interface SessionType {
     start_time: string
     end_time: string
     session_recordings: SessionTypeSessionRecording[]
-    start_url?: string | null
-    end_url?: string | null
+    start_url: string | null
+    end_url: string | null
     email?: string | null
     matching_events: Array<number | string>
 }

--- a/posthog/models/filters/sessions_filter.py
+++ b/posthog/models/filters/sessions_filter.py
@@ -11,4 +11,4 @@ class SessionsFilter(SessionsFiltersMixin, DistinctIdMixin, PaginationMixin, Use
 
 
 class SessionEventsFilter(DistinctIdMixin, DateMixin, BaseFilter):
-    pass
+    interval = "minute"

--- a/posthog/queries/sessions/session_recording.py
+++ b/posthog/queries/sessions/session_recording.py
@@ -102,7 +102,7 @@ def query_sessions_in_range(
 
 
 # :TRICKY: This mutates sessions list
-def filter_sessions_by_recordings(
+def join_with_session_recordings(
     team: Team, sessions_results: List[Any], filter: SessionsFilter, query: Callable = query_sessions_in_range
 ) -> List[Any]:
     if len(sessions_results) == 0:

--- a/posthog/queries/sessions/sessions_list.py
+++ b/posthog/queries/sessions/sessions_list.py
@@ -13,7 +13,7 @@ from posthog.models import Event, Person, Team
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.base import entity_to_Q, properties_to_Q
-from posthog.queries.sessions.session_recording import filter_sessions_by_recordings
+from posthog.queries.sessions.session_recording import join_with_session_recordings
 from posthog.queries.sessions.sessions_list_builder import SessionListBuilder
 
 Session = Dict
@@ -63,7 +63,7 @@ class SessionsList:
         sessions_builder.build()
 
         return (
-            filter_sessions_by_recordings(self.team, sessions_builder.sessions, self.filter),
+            join_with_session_recordings(self.team, sessions_builder.sessions, self.filter),
             sessions_builder.pagination,
         )
 

--- a/posthog/queries/sessions/sessions_list_builder.py
+++ b/posthog/queries/sessions/sessions_list_builder.py
@@ -110,7 +110,6 @@ class SessionListBuilder:
         self.running_sessions[distinct_id] = {
             "distinct_id": distinct_id,
             "end_time": timestamp,
-            "event_count": 0,
             "start_url": current_url,
             "email": self.emails.get(distinct_id),
             "matching_events": [[] for _ in range(self.action_filter_count)],
@@ -120,7 +119,6 @@ class SessionListBuilder:
     def _session_update(self, event: EventWithCurrentUrl):
         distinct_id, timestamp, id, current_url, *action_filter_matches = event
         self.running_sessions[distinct_id]["start_time"] = timestamp
-        self.running_sessions[distinct_id]["event_count"] += 1
         self.running_sessions[distinct_id]["end_url"] = current_url
 
         for index, is_match in enumerate(action_filter_matches):

--- a/posthog/queries/sessions/sessions_list_builder.py
+++ b/posthog/queries/sessions/sessions_list_builder.py
@@ -110,7 +110,7 @@ class SessionListBuilder:
         self.running_sessions[distinct_id] = {
             "distinct_id": distinct_id,
             "end_time": timestamp,
-            "start_url": current_url,
+            "end_url": current_url,
             "email": self.emails.get(distinct_id),
             "matching_events": [[] for _ in range(self.action_filter_count)],
         }
@@ -119,7 +119,7 @@ class SessionListBuilder:
     def _session_update(self, event: EventWithCurrentUrl):
         distinct_id, timestamp, id, current_url, *action_filter_matches = event
         self.running_sessions[distinct_id]["start_time"] = timestamp
-        self.running_sessions[distinct_id]["end_url"] = current_url
+        self.running_sessions[distinct_id]["start_url"] = current_url
 
         for index, is_match in enumerate(action_filter_matches):
             if is_match:

--- a/posthog/queries/sessions/test/test_session_recording.py
+++ b/posthog/queries/sessions/test/test_session_recording.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from posthog.models import Person, User
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.models.session_recording_event import SessionRecordingEvent, SessionRecordingViewed
-from posthog.queries.sessions.session_recording import SessionRecording, filter_sessions_by_recordings
+from posthog.queries.sessions.session_recording import SessionRecording, join_with_session_recordings
 from posthog.test.base import BaseTest
 
 
@@ -75,7 +75,7 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
 
                 self.assertEqual([r["session_recordings"] for r in results], expected)
 
-        def test_filter_sessions_by_recordings(self):
+        def test_join_with_session_recordings(self):
             _, team2, user2 = User.objects.bootstrap("Test2", "sessions@posthog.com", None)
 
             SessionRecordingViewed.objects.create(team=self.team, user_id=self.user.pk, session_id="1")
@@ -157,6 +157,6 @@ def session_recording_test_factory(session_recording, filter_sessions, event_fac
 
 
 class DjangoSessionRecordingTest(
-    session_recording_test_factory(SessionRecording, filter_sessions_by_recordings, SessionRecordingEvent.objects.create)  # type: ignore
+    session_recording_test_factory(SessionRecording, join_with_session_recordings, SessionRecordingEvent.objects.create)  # type: ignore
 ):
     pass

--- a/posthog/queries/sessions/test/test_sessions_list.py
+++ b/posthog/queries/sessions/test/test_sessions_list.py
@@ -29,6 +29,21 @@ def sessions_list_test_factory(sessions, event_factory, session_recording_event_
                 response, _ = self.run_query(SessionsFilter(data={"properties": [{"key": "$os", "value": "Mac OS X"}]}))
                 self.assertEqual(len(response), 1)
 
+                self.assertEqual(
+                    set(response[0].keys()) - {"email"},
+                    {
+                        "distinct_id",
+                        "global_session_id",
+                        "length",
+                        "start_time",
+                        "end_time",
+                        "start_url",
+                        "end_url",
+                        "matching_events",
+                        "session_recordings",
+                    },
+                )
+
         def test_sessions_and_cohort(self):
             self.create_test_data()
             cohort = Cohort.objects.create(team=self.team, groups=[{"properties": {"email": "bla"}}])

--- a/posthog/queries/sessions/test/test_sessions_list.py
+++ b/posthog/queries/sessions/test/test_sessions_list.py
@@ -17,32 +17,48 @@ def _create_action(team, name, properties=[]):
 
 def sessions_list_test_factory(sessions, event_factory, session_recording_event_factory):
     class TestSessionsList(BaseTest):
+        @freeze_time("2012-01-15T04:01:34.000Z")
         def test_sessions_list(self):
             self.create_test_data()
 
-            with freeze_time("2012-01-15T04:01:34.000Z"):
-                response, _ = self.run_query(SessionsFilter(data={"properties": []}))
+            response, _ = self.run_query(SessionsFilter(data={"properties": []}))
 
-                self.assertEqual(len(response), 2)
-                self.assertEqual(response[0]["distinct_id"], "2")
+            self.assertEqual(len(response), 2)
+            self.assertEqual(response[0]["distinct_id"], "2")
 
-                response, _ = self.run_query(SessionsFilter(data={"properties": [{"key": "$os", "value": "Mac OS X"}]}))
-                self.assertEqual(len(response), 1)
+            response, _ = self.run_query(SessionsFilter(data={"properties": [{"key": "$os", "value": "Mac OS X"}]}))
+            self.assertEqual(len(response), 1)
+            self.assertEqual(response[0]["distinct_id"], "1")
 
-                self.assertEqual(
-                    set(response[0].keys()) - {"email"},
-                    {
-                        "distinct_id",
-                        "global_session_id",
-                        "length",
-                        "start_time",
-                        "end_time",
-                        "start_url",
-                        "end_url",
-                        "matching_events",
-                        "session_recordings",
-                    },
-                )
+        @freeze_time("2012-01-15T04:01:34.000Z")
+        def test_sessions_list_keys(self):
+            self.create_test_data()
+
+            response, _ = self.run_query(SessionsFilter(data={"properties": []}))
+            self.assertEqual(
+                set(response[0].keys()) - {"email"},
+                {
+                    "distinct_id",
+                    "global_session_id",
+                    "length",
+                    "start_time",
+                    "end_time",
+                    "start_url",
+                    "end_url",
+                    "matching_events",
+                    "session_recordings",
+                },
+            )
+
+        @freeze_time("2012-01-15T04:01:34.000Z")
+        def test_start_end_url(self):
+            self.create_test_data()
+
+            response, _ = self.run_query(SessionsFilter(data={"properties": []}))
+            self.assertDictContainsSubset(
+                {"distinct_id": "2", "start_url": "aloha.com/2", "end_url": "aloha.com/lastpage"}, response[0]
+            )
+            self.assertDictContainsSubset({"distinct_id": "1", "start_url": None, "end_url": None}, response[1])
 
         def test_sessions_and_cohort(self):
             self.create_test_data()
@@ -243,13 +259,21 @@ def sessions_list_test_factory(sessions, event_factory, session_recording_event_
         def create_test_data(self):
             with freeze_time("2012-01-14T03:21:34.000Z"):
                 event_factory(team=self.team, event="$pageview", distinct_id="1")
-                event_factory(team=self.team, event="$pageview", distinct_id="2")
+                event_factory(
+                    team=self.team, event="$pageview", distinct_id="2", properties={"$current_url": "aloha.com/1"}
+                )
             with freeze_time("2012-01-14T03:25:34.000Z"):
                 event_factory(team=self.team, event="$pageview", distinct_id="1")
                 event_factory(team=self.team, event="$pageview", distinct_id="2")
+            with freeze_time("2012-01-15T03:58:34.000Z"):
+                event_factory(
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id="2",
+                    properties={"$os": "Windows 95", "$current_url": "aloha.com/2"},
+                )
             with freeze_time("2012-01-15T03:59:34.000Z"):
-                event_factory(team=self.team, event="$pageview", distinct_id="2")
-                event_factory(team=self.team, event="custom-event", distinct_id="2", properties={"$os": "Windows 95"})
+                event_factory(team=self.team, event="custom-event", distinct_id="2")
             with freeze_time("2012-01-15T03:59:35.000Z"):
                 event_factory(team=self.team, event="$pageview", distinct_id="1")
                 event_factory(team=self.team, event="custom-event", distinct_id="2", properties={"$os": "Windows 95"})
@@ -257,7 +281,12 @@ def sessions_list_test_factory(sessions, event_factory, session_recording_event_
                 event_factory(team=self.team, event="custom-event", distinct_id="1", properties={"$os": "Mac OS X"})
                 event_factory(team=self.team, event="another-event", distinct_id="2", properties={"$os": "Windows 95"})
             with freeze_time("2012-01-15T04:13:22.000Z"):
-                event_factory(team=self.team, event="$pageview", distinct_id="2")
+                event_factory(
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id="2",
+                    properties={"$current_url": "aloha.com/lastpage"},
+                )
             team_2 = Organization.objects.bootstrap(None)[2]
             Person.objects.create(team=self.team, distinct_ids=["1", "3", "4"], properties={"email": "bla"})
             # Test team leakage

--- a/posthog/queries/sessions/test/test_sessions_list_builder.py
+++ b/posthog/queries/sessions/test/test_sessions_list_builder.py
@@ -35,7 +35,6 @@ class TestSessionListBuilder(BaseTest):
                 "distinct_id": "1",
                 "end_time": now(),
                 "start_time": now() - relativedelta(minutes=35),
-                "event_count": 4,
                 "length": 35 * 60,
                 "end_url": None,
                 "start_url": None,
@@ -47,7 +46,6 @@ class TestSessionListBuilder(BaseTest):
                 "distinct_id": "1",
                 "end_time": now() - relativedelta(minutes=99),
                 "start_time": now() - relativedelta(minutes=102),
-                "event_count": 2,
                 "length": 3 * 60,
                 "end_url": None,
                 "start_url": None,
@@ -74,15 +72,13 @@ class TestSessionListBuilder(BaseTest):
 
         self.assertEqual(len(page1), 2)
         self.assertDictContainsSubset(
-            {"distinct_id": "1", "end_time": now(), "start_time": now() - relativedelta(minutes=35), "event_count": 3},
-            page1[0],
+            {"distinct_id": "1", "end_time": now(), "start_time": now() - relativedelta(minutes=35)}, page1[0],
         )
         self.assertDictContainsSubset(
             {
                 "distinct_id": "2",
                 "end_time": now() - relativedelta(minutes=3),
                 "start_time": now() - relativedelta(minutes=45),
-                "event_count": 3,
             },
             page1[1],
         )
@@ -106,7 +102,6 @@ class TestSessionListBuilder(BaseTest):
                 "distinct_id": "3",
                 "end_time": now() - relativedelta(minutes=7),
                 "start_time": now() - relativedelta(minutes=7),
-                "event_count": 1,
             },
             page2[0],
         )
@@ -115,7 +110,6 @@ class TestSessionListBuilder(BaseTest):
                 "distinct_id": "1",
                 "end_time": now() - relativedelta(minutes=85),
                 "start_time": now() - relativedelta(minutes=88),
-                "event_count": 2,
             },
             page2[1],
         )

--- a/posthog/queries/sessions/test/test_sessions_list_builder.py
+++ b/posthog/queries/sessions/test/test_sessions_list_builder.py
@@ -120,11 +120,11 @@ class TestSessionListBuilder(BaseTest):
         sessions = self.build(
             [
                 mock_event("1", now()),
-                mock_event("2", now() - relativedelta(minutes=3), current_url="http://foo.bar/landing"),
+                mock_event("2", now() - relativedelta(minutes=3), current_url="http://foo.bar/subpage"),
                 mock_event("2", now() - relativedelta(minutes=25)),
                 mock_event("1", now() - relativedelta(minutes=27)),
                 mock_event("1", now() - relativedelta(minutes=35)),
-                mock_event("2", now() - relativedelta(minutes=45), current_url="http://foo.bar/subpage"),
+                mock_event("2", now() - relativedelta(minutes=45), current_url="http://foo.bar/landing"),
             ],
             emails={"2": "foo@bar.com"},
         )

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -3,6 +3,7 @@ from typing import Union
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
+from posthog.models.filters.sessions_filter import SessionEventsFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 
-FilterType = Union[Filter, PathFilter, RetentionFilter, StickinessFilter]
+FilterType = Union[Filter, PathFilter, RetentionFilter, StickinessFilter, SessionEventsFilter]

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -3,7 +3,6 @@ from typing import Union
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
-from posthog.models.filters.sessions_filter import SessionEventsFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 
-FilterType = Union[Filter, PathFilter, RetentionFilter, StickinessFilter, SessionEventsFilter]
+FilterType = Union[Filter, PathFilter, RetentionFilter, StickinessFilter]


### PR DESCRIPTION
- Load session events asynchronously from a separate endpoint

The behavior is now identical to postgres, so no frontend changes needed there.

This is a performance improvement. Potentially solves https://github.com/PostHog/posthog/issues/5045

Getting this done required quite a bit of related refactoring:
- Fixing sessions-related frontend code
- Fixing start and end url calculation
- Renaming `filter_sessions_by_recordings` as according to suggestion from @fuziontech 

## TODOs

- [x] Start and end point columns do not work (both CH + PG)
- [x] Fix BE Linting error
- [x] `filteredSessions` logic added by @alexkim205 is now broken - verify intent and fix
- [x] Fix `.events` hidden dependencies
- [x] Update tests
    - [x] Add test for start_url/end_url column
    - [x] Add test around data shape of list output
    - [x] Add test for endpoint in both CH + PG (including 2 different time ranges)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
