### PR TITLE
Use -Ofair for celery workers

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -64,6 +64,7 @@ if [ "$with_scheduler" == "true" ]; then
 fi
 
 FLAGS=()
+FLAGS+=("-Ofair")
 [ "$with_gossip" == "false" ]    && FLAGS+=("--without-gossip")
 [ "$with_mingle" == "false" ]    && FLAGS+=("--without-mingle")
 [ "$with_heartbeat" == "false" ] && FLAGS+=("--without-heartbeat")

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -5,7 +5,7 @@ set -e
 trap 'kill $(jobs -p)' EXIT
 
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair &
 
 # start celery plugin worker
 ./bin/plugin-server


### PR DESCRIPTION
From https://medium.com/@taylorhughes/three-quick-tips-from-two-years-with-celery-c05ff9d7f9eb

> By default, preforking Celery workers distribute tasks to their worker processes as soon as they are received, regardless of whether the process is currently busy with other tasks.
> If you have a set of tasks that take varying amounts of time to complete — either deliberately or due to unpredictable network conditions, etc. — this will cause unexpected delays in total execution time for tasks in the queue.

This is 100% the case for us. This should "load balance" the tasks
better across workers.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
