### PR TITLE
Only report mutations that are not done (new flag in CH)

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -203,6 +203,7 @@ def clickhouse_mutation_count():
                 table,
                 count(1) AS freq
             FROM system.mutations
+            WHERE is_done = 0 
             GROUP BY table
             ORDER BY freq DESC
         """


### PR DESCRIPTION
## Changes

Mutations has a flag for `is_done` now which means that we are currently monitoring historical mutations, not just hanging mutations or mutations still queued to be completed.
This will result in less noise on pages with regard to `person_distinct_id`


https://clickhouse.tech/docs/en/operations/system-tables/mutations/

