### PR TITLE
Handle spaces (and square brackets) in data-selector

### DIFF
--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -604,6 +604,13 @@ class TestSelectors(BaseTest):
         self.assertEqual(selector1.parts[1].direct_descendant, True)
         self.assertEqual(selector1.parts[1].unique_order, 0)
 
+    def test_selector_attribute_with_spaces(self):
+        selector1 = Selector('  [data-id="foo bar]"]  ')
+
+        self.assertEqual(selector1.parts[0].data, {"attributes__attr__data-id": "foo bar]"})
+        self.assertEqual(selector1.parts[0].direct_descendant, False)
+        self.assertEqual(selector1.parts[0].unique_order, 0)
+
     def test_selector_with_spaces(self):
         selector1 = Selector("span    ")
 


### PR DESCRIPTION
Closes issue https://github.com/PostHog/posthog/issues/5064

There's room for further improvement here (e.g. proper validation in parsing) but opting for a quick fix now.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
