### PR TITLE
Run broken down analyses in one SQL query like others 

### DIFF
--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Any, Dict, List, Tuple
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.property import parse_prop_clauses
@@ -9,6 +9,8 @@ from ee.clickhouse.sql.trends.top_elements import TOP_ELEMENTS_ARRAY_OF_KEY_SQL
 from ee.clickhouse.sql.trends.top_person_props import TOP_PERSON_PROPS_ARRAY_OF_KEY_SQL
 from posthog.models.entity import Entity
 from posthog.models.filters.filter import Filter
+
+# DEPRECATED (still used by Trends)
 
 
 def _get_top_elements(filter: Filter, team_id: int, query: str, limit, params: Dict = {}) -> List:
@@ -94,3 +96,121 @@ def get_breakdown_event_prop_values(
     )
 
     return top_elements_array
+
+
+# NEW (used by Funnels)
+
+BREAKDOWN_LIMIT = 21  # 1 more than 20 to check if there's more than 20
+
+QueryWithParams = Tuple[str, Dict[str, Any]]
+
+
+def get_breakdown_person_prop_query(
+    filter: Filter, entity: Entity, aggregate_operation: str, team_id: int, limit: int = 25
+) -> QueryWithParams:
+    parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
+    prop_filters, prop_filter_params = parse_prop_clauses(
+        filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
+    )
+    person_prop_filters, person_prop_params = parse_prop_clauses(
+        [prop for prop in filter.properties if prop.type == "person"],
+        team_id,
+        table_name="e",
+        filter_test_accounts=filter.filter_test_accounts,
+        is_person_query=True,
+    )
+
+    entity_params, entity_format_params = populate_entity_params(entity)
+
+    elements_query = """
+        SELECT prop FROM (
+            SELECT prop, {aggregate_operation} AS count
+            FROM events e 
+            INNER JOIN (
+                SELECT person_id, distinct_id FROM ({latest_distinct_id_sql}) WHERE team_id = %(team_id)s
+            ) pdi
+            ON e.distinct_id = pdi.distinct_id
+            INNER JOIN (
+                SELECT * FROM (
+                    SELECT
+                    id,
+                    array_property_keys AS key,
+                    array_property_values AS prop
+                    from (
+                        SELECT
+                            id,
+                            arrayMap(k -> toString(k.1), JSONExtractKeysAndValuesRaw(properties)) AS array_property_keys,
+                            arrayMap(k -> toString(k.2), JSONExtractKeysAndValuesRaw(properties)) AS array_property_values
+                        FROM ({latest_person_sql}) person WHERE team_id = %(team_id)s {person_prop_filters}
+                    )
+                    ARRAY JOIN array_property_keys, array_property_values
+                ) ep
+                WHERE key = %(breakdown_key)s
+            ) ep
+            ON person_id = ep.id
+            WHERE
+                e.team_id = %(team_id)s {entity_query} {parsed_date_from} {parsed_date_to} {prop_filters}
+            GROUP BY prop
+            ORDER BY count DESC
+            LIMIT %(breakdown_limit)s OFFSET %(breakdown_offset)s
+        )
+    """.format(
+        parsed_date_from=parsed_date_from,
+        parsed_date_to=parsed_date_to,
+        latest_person_sql=GET_LATEST_PERSON_SQL.format(query=""),
+        prop_filters=prop_filters,
+        person_prop_filters=person_prop_filters,
+        aggregate_operation=aggregate_operation,
+        latest_distinct_id_sql=GET_LATEST_PERSON_DISTINCT_ID_SQL,
+        **entity_format_params
+    )
+    breakdown_params = {
+        **prop_filter_params,
+        **person_prop_params,
+        **entity_params,
+        "breakdown_key": filter.breakdown,
+        "breakdown_limit": BREAKDOWN_LIMIT,
+        "breakdown_offset": filter.offset,
+    }
+
+    return elements_query, breakdown_params
+
+
+def get_breakdown_event_prop_query(
+    filter: Filter, entity: Entity, aggregate_operation: str, team_id: int, limit: int = 25
+) -> QueryWithParams:
+    parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
+    prop_filters, prop_filter_params = parse_prop_clauses(
+        filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
+    )
+
+    entity_params, entity_format_params = populate_entity_params(entity)
+
+    elements_query = """
+        SELECT prop FROM (
+            SELECT
+                JSONExtractRaw(properties, %(breakdown_key)s) AS prop,
+                {aggregate_operation} AS count
+            FROM events e
+            WHERE
+                team_id = %(team_id)s {entity_query} {parsed_date_from} {parsed_date_to} {prop_filters}
+            AND JSONHas(properties, %(breakdown_key)s)
+            GROUP BY prop
+            ORDER BY count DESC
+            LIMIT %(breakdown_limit)s OFFSET %(breakdown_offset)s
+        )
+    """.format(
+        parsed_date_from=parsed_date_from,
+        parsed_date_to=parsed_date_to,
+        prop_filters=prop_filters,
+        aggregate_operation=aggregate_operation,
+        **entity_format_params
+    )
+    breakdown_params = {
+        **prop_filter_params,
+        **entity_params,
+        "breakdown_key": filter.breakdown,
+        "breakdown_limit": BREAKDOWN_LIMIT,
+        "breakdown_offset": filter.offset,
+    }
+    return elements_query, breakdown_params

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -1,4 +1,3 @@
-import operator
 from uuid import uuid4
 
 from ee.clickhouse.models.event import create_event

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -6,17 +6,16 @@ from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.property import parse_prop_clauses
-from ee.clickhouse.queries.breakdown_props import get_breakdown_event_prop_values, get_breakdown_person_prop_values
-from ee.clickhouse.queries.trends.util import (
-    enumerate_time_range,
-    get_active_user_params,
-    parse_response,
-    populate_entity_params,
-    process_math,
+from ee.clickhouse.queries.breakdown_props import (
+    get_breakdown_event_prop_query,
+    get_breakdown_event_prop_values,
+    get_breakdown_person_prop_query,
+    get_breakdown_person_prop_values,
 )
+from ee.clickhouse.queries.trends.util import enumerate_time_range, get_active_user_params, parse_response, process_math
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
 from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL
-from ee.clickhouse.sql.person import GET_LATEST_PERSON_DISTINCT_ID_SQL, GET_LATEST_PERSON_SQL
+from ee.clickhouse.sql.person import GET_LATEST_PERSON_SQL
 from ee.clickhouse.sql.trends.breakdown import (
     BREAKDOWN_ACTIVE_USER_CONDITIONS_SQL,
     BREAKDOWN_ACTIVE_USER_INNER_SQL,
@@ -29,10 +28,7 @@ from ee.clickhouse.sql.trends.breakdown import (
     NONE_BREAKDOWN_PERSON_PROP_JOIN_SQL,
     NONE_BREAKDOWN_PROP_JOIN_SQL,
 )
-from ee.clickhouse.sql.trends.top_elements import TOP_ELEMENTS_ARRAY_OF_KEY_SQL
-from ee.clickhouse.sql.trends.top_person_props import TOP_PERSON_PROPS_ARRAY_OF_KEY_SQL
 from posthog.constants import MONTHLY_ACTIVE, TREND_FILTER_TYPE_ACTIONS, TRENDS_DISPLAY_BY_VALUE, WEEKLY_ACTIVE
-from posthog.models.action import Action
 from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filters import Filter


### PR DESCRIPTION
## Changes

Currently our ClickHouse analyses require an additional SQL query when using breakdown – for obtaining values to break down by. This impact speed and therefore user experience, because an additional query round trip before the _proper_ query takes time. We can do away with this using common table expressions though – this way the same breakdown values query is ran before the proper analysis one all in the same query string.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests