### PR TITLE
Run all CI workflows even for posthog-bot

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -62,7 +62,6 @@ jobs:
     django:
         name: Django tests – Py ${{ matrix.python-version }}
         runs-on: ubuntu-latest
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         strategy:
             fail-fast: false
@@ -136,7 +135,6 @@ jobs:
     cloud:
         name: Django tests – Cloud
         runs-on: ubuntu-latest
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         services:
             postgres:
@@ -265,7 +263,6 @@ jobs:
     foss:
         name: Django tests – FOSS
         runs-on: ubuntu-latest
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         services:
             postgres:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -41,7 +41,6 @@ jobs:
     jest:
         name: Jest tests
         runs-on: ubuntu-20.04
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/cypress-component.yml
+++ b/.github/workflows/cypress-component.yml
@@ -7,7 +7,6 @@ jobs:
     cypress-component:
         name: Cypress component tests
         runs-on: ubuntu-18.04
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         steps:
             - name: Checkout

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -7,7 +7,6 @@ jobs:
     build:
         name: Test Docker image build
         runs-on: ubuntu-20.04
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         steps:
             - name: Checkout PR branch

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -8,7 +8,6 @@ jobs:
     check-description:
         name: Check that PR has description
         runs-on: ubuntu-20.04
-        if: ${{ github.actor != 'posthog-contributions-bot[bot]' }}
 
         steps:
             - name: Check if PR is shame-worthy


### PR DESCRIPTION
## Changes

We used to skip a lot of GitHub Actions jobs for bot PRs, but with many of them being required to pass now, it prevents the bot's PRs from being merged (see #5073).
