### PR TITLE
Add null param to funnel breakdown

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -101,6 +101,8 @@ export const funnelLogic = kea<funnelLogicType>({
                         ...(from_dashboard ? { from_dashboard } : {}),
                         ...cleanedParams,
                         funnel_window_days: values.conversionWindowInDays,
+                        breakdown: null,
+                        breakdown_type: null,
                     }
 
                     let result: FunnelResult

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -101,7 +101,7 @@ export const funnelLogic = kea<funnelLogicType>({
                         ...(from_dashboard ? { from_dashboard } : {}),
                         ...cleanedParams,
                         funnel_window_days: values.conversionWindowInDays,
-                        ...(values.featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]
+                        ...(!values.featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]
                             ? { breakdown: null, breakdown_type: null }
                             : {}),
                     }

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -101,8 +101,9 @@ export const funnelLogic = kea<funnelLogicType>({
                         ...(from_dashboard ? { from_dashboard } : {}),
                         ...cleanedParams,
                         funnel_window_days: values.conversionWindowInDays,
-                        breakdown: null,
-                        breakdown_type: null,
+                        ...(values.featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]
+                            ? { breakdown: null, breakdown_type: null }
+                            : {}),
                     }
 
                     let result: FunnelResult


### PR DESCRIPTION
## Changes

*Please describe.*  
- stops breakdown params from being sent when unneeded
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
