### PR TITLE
Fix Django 4.0 compatibility warnings regarding ugettext_lazy.

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from posthog.models import (
     Action,

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models, transaction
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
 
 from posthog.utils import get_instance_realm


### PR DESCRIPTION
## Changes

This fixes below deprecation warnings that were removed in Django 4.0 : https://docs.djangoproject.com/en/dev/releases/4.0/#internationalization

```
/root/posthog/posthog/models/user.py:107: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  email = models.EmailField(_("email address"), unique=True)
/root/posthog/posthog/admin.py:74: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (_("Personal info"), {"fields": ("first_name", "last_name")}),
/root/posthog/posthog/admin.py:75: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (_("Permissions"), {"fields": ("is_active", "is_staff",)},),
/root/posthog/posthog/admin.py:76: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (_("Important dates"), {"fields": ("last_login", "date_joined")}),
/root/posthog/posthog/admin.py:77: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (_("PostHog"), {"fields": ("temporary_token",)}),
```

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
