### PR TITLE
Plugin metrics tooltip fixes

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -81,7 +81,7 @@ export function InsightLabel({
                 <div className="protect-width">
                     {showEventName && <PropertyKeyInfo disableIcon disablePopover value={eventName} />}
 
-                    {hasMultipleSeries && ((action?.math && action.math !== 'total') || showCountedByTag) && (
+                    {((action?.math && action.math !== 'total') || showCountedByTag) && (
                         <MathTag math={action?.math} mathProperty={action?.math_property} />
                     )}
 

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -265,6 +265,10 @@ export const keyMapping: KeyMappingInterface = {
                 </>
             ),
         },
+        $$plugin_metrics: {
+            label: 'Plugin Metric',
+            description: 'Performance metrics for a given plugin.',
+        },
 
         // UTM tags
         utm_source: {

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -39,6 +39,7 @@ export function LineGraph({
     percentage = false,
     interval = undefined,
     totalValue,
+    showPersonsModal = true,
 }) {
     const chartRef = useRef()
     const myLineChart = useRef()
@@ -220,7 +221,7 @@ export function LineGraph({
             precision: 0,
         }
 
-        const inspectUsersLabel = !dashboardItemId && onClick
+        const inspectUsersLabel = !dashboardItemId && onClick && showPersonsModal
 
         const newUITooltipOptions = {
             enabled: false, // disable builtin tooltip (use custom markup)

--- a/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
+++ b/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
@@ -49,7 +49,7 @@ export function MetricsChart({ plugin }: { plugin: PluginTypeWithConfig }): JSX.
 
     return (
         <div className="metrics-chart-wrapper">
-            <ActionsLineGraph view={ViewType.TRENDS} filters={filters} />
+            <ActionsLineGraph view={ViewType.TRENDS} filters={filters} showPersonsModal={false} />
         </div>
     )
 }

--- a/frontend/src/scenes/plugins/plugin/styles/metrics-drawer.scss
+++ b/frontend/src/scenes/plugins/plugin/styles/metrics-drawer.scss
@@ -4,5 +4,8 @@
             max-width: 90%;
             max-height: 80%;
         }
+        canvas:hover {
+            cursor: default !important;
+        }
     }
 }

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -15,6 +15,7 @@ export function ActionsLineGraph({
     filters: filtersParam,
     cachedResults,
     inSharedMode = false,
+    showPersonsModal = true,
     view,
 }: ChartParams): JSX.Element {
     const logic = trendsLogic({
@@ -40,6 +41,7 @@ export function ActionsLineGraph({
                 dashboardItemId={dashboardItemId || fromItem}
                 inSharedMode={inSharedMode}
                 interval={filters.interval}
+                showPersonsModal={showPersonsModal}
                 onClick={
                     dashboardItemId
                         ? null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -711,6 +711,7 @@ export interface ChartParams {
     color?: string
     filters?: Partial<FilterType>
     inSharedMode?: boolean
+    showPersonsModal?: boolean
     cachedResults?: TrendResult
     view: ViewType
 }


### PR DESCRIPTION
## Changes

A few tweaks to finalize the look for plugin metrics.

- No persons modal
- No click cursor
- Display math operations
- Add event info

Regarding math operations, I made a change that will affect other places too, which is removing the `hasMultipleSeries` condition to parse math labels. I think it's useful to show the math even when it's just one series (even though the problem here was just that this wasn't set for the plugin metrics chart)

<img width="931" alt="Screenshot 2021-07-13 at 08 24 56" src="https://user-images.githubusercontent.com/38760734/125444142-4e172287-0c17-4534-a2ed-1fbef0bbc88d.png">

Closes #5016 


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
