### PR TITLE
Allow time to convert across multiple steps (or whole funnel)

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -92,7 +92,7 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
                     histogram_from_seconds + floor(({steps_average_conversion_time_expression_sum} - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_to_seconds,
                     count() AS person_count
                 FROM step_runs
-                -- We only need to check to_step here, before it depends on all the others being not null too
+                -- We only need to check step to_step here, because it depends on all the other ones being NOT NULL too
                 WHERE step_{to_step}_average_conversion_time IS NOT NULL
                 GROUP BY bin_to_seconds
             ) results

--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -24,8 +24,10 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
         self.params.update(self.funnel_order.params)
         # expects 1 person per row, whatever their max step is, and the step conversion times for this person
 
-        # Conversion to which step (from the immediately preceding one) should be calculated
-        to_step = self._filter.funnel_to_step
+        # Conversion from which step should be calculated
+        from_step = self._filter.funnel_from_step or 0
+        # Conversion to which step should be calculated
+        to_step = self._filter.funnel_to_step or len(self._filter.entities)
 
         # Use custom bin_count if provided by user, otherwise infer an automatic one based on the number of samples
         bin_count = self._filter.bin_count
@@ -50,6 +52,11 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
                 f'Filter parameter {FUNNEL_TO_STEP} can only be one of {", ".join(map(str, range(1, len(self._filter.entities))))} for time to convert!'
             )
 
+        steps_average_conversion_time_identifiers = [
+            f"step_{step+1}_average_conversion_time" for step in range(from_step, to_step)
+        ]
+        steps_average_conversion_time_expression_sum = " + ".join(steps_average_conversion_time_identifiers)
+
         query = f"""
             WITH
                 step_runs AS (
@@ -59,10 +66,12 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
                     -- Binning ensures that each sample belongs to a bin in results
                     -- If bin_count is not a custom number, it's calculated in bin_count_expression
                     SELECT
-                        floor(min(step_{to_step}_average_conversion_time)) AS from_seconds,
-                        ceil(max(step_{to_step}_average_conversion_time)) AS to_seconds,
+                        floor(min({steps_average_conversion_time_expression_sum})) AS from_seconds,
+                        ceil(max({steps_average_conversion_time_expression_sum})) AS to_seconds,
                         {bin_count_expression or ""}
-                        ceil((to_seconds - from_seconds) / {bin_count_identifier}) AS bin_width_seconds
+                        ceil((to_seconds - from_seconds) / {bin_count_identifier}) AS bin_width_seconds_raw,
+                        -- Use 60 seconds as fallback bin width in case of only one sample
+                        if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
                     FROM step_runs
                 ),
                 -- Below CTEs make histogram_params columns available to the query below as straightforward identifiers
@@ -80,9 +89,10 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
             FROM (
                 -- Calculating bins from step runs
                 SELECT
-                    histogram_from_seconds + floor((step_{to_step}_average_conversion_time - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_to_seconds,
+                    histogram_from_seconds + floor(({steps_average_conversion_time_expression_sum} - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_to_seconds,
                     count() AS person_count
                 FROM step_runs
+                -- We only need to check to_step here, before it depends on all the others being not null too
                 WHERE step_{to_step}_average_conversion_time IS NOT NULL
                 GROUP BY bin_to_seconds
             ) results

--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -26,7 +26,7 @@ def _create_event(**kwargs):
 class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
-    def test_auto_bin_count(self):
+    def test_auto_bin_count_single_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)
         _create_person(distinct_ids=["user c"], team=self.team)
@@ -50,6 +50,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "interval": "day",
                 "date_from": "2021-06-07 00:00:00",
                 "date_to": "2021-06-13 23:59:59",
+                "funnel_from_step": 0,
                 "funnel_to_step": 1,
                 "funnel_window_days": 7,
                 "events": [
@@ -74,7 +75,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_custom_bin_count(self):
+    def test_custom_bin_count_single_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)
         _create_person(distinct_ids=["user c"], team=self.team)
@@ -98,6 +99,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "interval": "day",
                 "date_from": "2021-06-07 00:00:00",
                 "date_to": "2021-06-13 23:59:59",
+                "funnel_from_step": 0,
                 "funnel_to_step": 1,
                 "funnel_window_days": 7,
                 "bin_count": 7,
@@ -127,6 +129,52 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
+    def test_auto_bin_count_total(self):
+        _create_person(distinct_ids=["user a"], team=self.team)
+        _create_person(distinct_ids=["user b"], team=self.team)
+        _create_person(distinct_ids=["user c"], team=self.team)
+
+        _create_event(event="step one", distinct_id="user a", team=self.team, timestamp="2021-06-08 18:00:00")
+        _create_event(event="step two", distinct_id="user a", team=self.team, timestamp="2021-06-08 19:00:00")
+        _create_event(event="step three", distinct_id="user a", team=self.team, timestamp="2021-06-08 21:00:00")
+        # Converted from 0 to 2 in 10_800 s
+
+        _create_event(event="step one", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:00:00")
+        _create_event(event="step two", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:37:00")
+
+        _create_event(event="step one", distinct_id="user c", team=self.team, timestamp="2021-06-11 07:00:00")
+        _create_event(event="step two", distinct_id="user c", team=self.team, timestamp="2021-06-12 06:00:00")
+
+        filter = Filter(
+            data={
+                "insight": INSIGHT_FUNNELS,
+                "interval": "day",
+                "date_from": "2021-06-07 00:00:00",
+                "date_to": "2021-06-13 23:59:59",
+                "funnel_from_step": 0,
+                "funnel_to_step": 2,
+                "funnel_window_days": 7,
+                "events": [
+                    {"id": "step one", "order": 0},
+                    {"id": "step two", "order": 1},
+                    {"id": "step three", "order": 2},
+                ],
+            }
+        )
+
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
+        results = funnel_trends.run()
+
+        self.assertEqual(
+            results,
+            [
+                (10800.0, 1),  # Reached step 2 from step 0 in at least 10_800 s but less than 10_860 s - users A
+                (10860.0, 0),  # Analogous to above, just an interval (in this case 60 s) up - no users
+                (10920.0, 0),  # And so on
+                (10980.0, 0),
+            ],
+        )
+
     def test_basic_unordered(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)
@@ -149,6 +197,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "interval": "day",
                 "date_from": "2021-06-07 00:00:00",
                 "date_to": "2021-06-13 23:59:59",
+                "funnel_from_step": 0,
                 "funnel_to_step": 1,
                 "funnel_window_days": 7,
                 "events": [
@@ -202,6 +251,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "interval": "day",
                 "date_from": "2021-06-07 00:00:00",
                 "date_to": "2021-06-13 23:59:59",
+                "funnel_from_step": 0,
                 "funnel_to_step": 1,
                 "funnel_window_days": 7,
                 "events": [

--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -168,7 +168,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             results,
             [
-                (10800.0, 1),  # Reached step 2 from step 0 in at least 10_800 s but less than 10_860 s - users A
+                (10800.0, 1),  # Reached step 2 from step 0 in at least 10_800 s but less than 10_860 s - user A
                 (10860.0, 0),  # Analogous to above, just an interval (in this case 60 s) up - no users
                 (10920.0, 0),  # And so on
                 (10980.0, 0),


### PR DESCRIPTION
## Changes

Resolves #4992.

Breaking change:
In time to convert, previously `funnel_to_step` equal `i` meant that the time calculated was of conversion from step `i-1` to step `i`. Now it'd be converted from step 0 to step `i`. That's because `funnel_from_step` is a thing now too – by default 0.
So, how to specify steps now?
Simply provide `funnel_from_step` AND `funel_to_step` indexes, just like in funnel trends already. If neither are provided, then TOTAL time to convert of the funnel is calculated.
CC @liyiy @alexkim205 

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests