### PR TITLE
Set USING_PGBOUNCER env var everywhere

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -99,6 +99,10 @@
                 {
                     "name": "PLUGIN_SERVER_ACTION_MATCHING",
                     "value": "1"
+                },
+                {
+                    "name": "USING_PGBOUNCER",
+                    "value": "True"
                 }
             ],
             "secrets": [

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -75,6 +75,10 @@
                 {
                     "name": "PISCINA_ATOMICS_TIMEOUT",
                     "value": "3000"
+                },
+                {
+                    "name": "USING_PGBOUNCER",
+                    "value": "True"
                 }
             ],
             "secrets": [

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -117,6 +117,10 @@
                 {
                     "name": "PLUGIN_SERVER_ACTION_MATCHING",
                     "value": "1"
+                },
+                {
+                    "name": "USING_PGBOUNCER",
+                    "value": "True"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -111,6 +111,10 @@
                 {
                     "name": "PLUGIN_SERVER_ACTION_MATCHING",
                     "value": "1"
+                },
+                {
+                    "name": "USING_PGBOUNCER",
+                    "value": "True"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
We use it in settings.py to disable server-side cursors, but do not
explicitly set it. Fixing this.

Chart PR: https://github.com/PostHog/charts-clickhouse/pull/50

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
