### PR TITLE
Remove 5439 EE Postgres port and restore 5432

### DIFF
--- a/ee/docker-compose.ch.test.yml
+++ b/ee/docker-compose.ch.test.yml
@@ -8,7 +8,7 @@ services:
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
         ports:
-            - '5439:5432'
+            - '5432:5432'
     redis:
         image: 'redis:alpine'
         ports:

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -8,7 +8,7 @@ services:
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
         ports:
-            - '5439:5432'
+            - '5432:5432'
     redis:
         image: 'redis:alpine'
         ports:


### PR DESCRIPTION
## Changes

- Removes another point of mistakes, exceptions and confusion
- Docs changes to come later.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
