### PR TITLE
Do not request time to convert funnel if there are less than 2 steps

### DIFF
--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -149,6 +149,16 @@ export function FunnelViz({
         ) : null
     }
     if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && filters.display == ChartDisplayType.FunnelsTimeToConvert) {
+        if (steps && steps.length < 2) {
+            return (
+                <div className="insight-empty-state error-message">
+                    <div className="illustration-main">
+                        <IllustrationDanger />
+                    </div>
+                    <h3 className="l3">You can only use time conversion with more than one funnel step.</h3>
+                </div>
+            )
+        }
         return timeConversionBins && timeConversionBins.length > 0 ? <FunnelHistogram /> : null
     }
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -150,7 +150,7 @@ export const funnelLogic = kea<funnelLogicType<TimeStepOption>>({
                     insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, result.last_refresh)
                     actions.setSteps(result.result as FunnelStep[])
                     let binsResult: FunnelsTimeConversionResult
-                    if (params.display === ChartDisplayType.FunnelsTimeToConvert) {
+                    if (params.display === ChartDisplayType.FunnelsTimeToConvert && values.stepsWithCount.length > 1) {
                         try {
                             params.funnel_viz_type = 'time_to_convert'
                             params.funnel_to_step = values.histogramStep


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Time to convert requires at least 2 funnel steps, otherwise the API will error from it. 

<img width="827" alt="Screen Shot 2021-07-14 at 10 45 36 AM" src="https://user-images.githubusercontent.com/25164963/125642353-9ebf84ef-68b2-4f55-a5ba-448f54d43130.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
