### PR TITLE
Fix static cohort using precalculated query bug

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -180,6 +180,7 @@ def is_precalculated_query(cohort: Cohort) -> bool:
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER
         and settings.USE_PRECALCULATED_CH_COHORT_PEOPLE
+        and not cohort.is_static  # static cohorts are handled within the regular cohort filter query path
     ):
         return True
     else:


### PR DESCRIPTION
## Changes

*Please describe.*  
-static cohorts were using the precalculated cohort query which caused empty results
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
