### PR TITLE
Return correct chart tooltip date

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -145,8 +145,7 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
         ]
         return summary
 
-    @staticmethod
-    def _format_results(summary):
+    def _format_results(self, summary):
         count = len(summary)
         data = []
         days = []
@@ -154,7 +153,13 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
 
         for row in summary:
             data.append(row["conversion_rate"])
-            days.append(row["timestamp"].strftime(HUMAN_READABLE_TIMESTAMP_FORMAT))
+            days.append(
+                row["timestamp"].strftime(
+                    "%Y-%m-%d{}".format(
+                        " %H:%M:%S" if self._filter.interval == "hour" or self._filter.interval == "minute" else ""
+                    )
+                )
+            )
             labels.append(row["timestamp"].strftime(HUMAN_READABLE_TIMESTAMP_FORMAT))
 
         return [{"count": count, "data": data, "days": days, "labels": labels,}]

--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -153,13 +153,8 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
 
         for row in summary:
             data.append(row["conversion_rate"])
-            days.append(
-                row["timestamp"].strftime(
-                    "%Y-%m-%d{}".format(
-                        " %H:%M:%S" if self._filter.interval == "hour" or self._filter.interval == "minute" else ""
-                    )
-                )
-            )
+            hour_min_sec = " %H:%M:%S" if self._filter.interval == "hour" or self._filter.interval == "minute" else ""
+            days.append(row["timestamp"].strftime(f"%Y-%m-%d{hour_min_sec}"))
             labels.append(row["timestamp"].strftime(HUMAN_READABLE_TIMESTAMP_FORMAT))
 
         return [{"count": count, "data": data, "days": days, "labels": labels,}]

--- a/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
@@ -93,8 +93,11 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
 
         funnel_trends = ClickhouseFunnelTrends(filter, self.team, ClickhouseFunnel)
         results = funnel_trends._exec_query()
+        formatted_results = funnel_trends._format_results(funnel_trends._summarize_data(results))
 
         self.assertEqual(len(results), 7)
+        print(formatted_results)
+        self.assertEqual(formatted_results["result"][0]["days"])
 
     def test_only_one_user_reached_one_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)

--- a/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
@@ -96,7 +96,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         formatted_results = funnel_trends._format_results(results)
 
         self.assertEqual(len(results), 7)
-        self.assertEqual(formatted_results[0]["days"][0], ["2021-06-07"])
+        self.assertEqual(formatted_results[0]["days"][0], "2021-06-07")
 
     def test_only_one_user_reached_one_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)

--- a/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
@@ -93,11 +93,11 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
 
         funnel_trends = ClickhouseFunnelTrends(filter, self.team, ClickhouseFunnel)
         results = funnel_trends._exec_query()
-        formatted_results = funnel_trends._format_results(funnel_trends._summarize_data(results))
+        formatted_results = funnel_trends._format_results(results)
 
         self.assertEqual(len(results), 7)
         print(formatted_results)
-        self.assertEqual(formatted_results["result"][0]["days"])
+        self.assertEqual(formatted_results["result"][0]["days"], 1)
 
     def test_only_one_user_reached_one_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)

--- a/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
@@ -96,8 +96,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         formatted_results = funnel_trends._format_results(results)
 
         self.assertEqual(len(results), 7)
-        print(formatted_results)
-        self.assertEqual(formatted_results["result"][0]["days"], 1)
+        self.assertEqual(formatted_results[0]["days"][0], ["2021-06-07"])
 
     def test_only_one_user_reached_one_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)

--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -1,4 +1,4 @@
-import dayjs, { Dayjs } from 'dayjs'
+import dayjs from 'dayjs'
 import React from 'react'
 import { IntervalType } from '~/types'
 import './DateDisplay.scss'
@@ -34,15 +34,11 @@ const dateHighlight = (parsedDate: dayjs.Dayjs, interval: IntervalType): string 
     }
 }
 
-const checkDateYear = (date: Dayjs): Dayjs => {
-    return date.get('year') === 2001 ? date.set('year', dayjs().year()) : date
-}
-
 /* Returns a single line standardized component to display the date depending on context.
     For example, a single date in a graph will be shown as: `Th` Apr 22.
 */
 export function DateDisplay({ date, interval, hideWeekRange }: DateDisplayProps): JSX.Element {
-    const parsedDate = checkDateYear(dayjs(date))
+    const parsedDate = dayjs(date)
 
     return (
         <>

--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import React from 'react'
 import { IntervalType } from '~/types'
 import './DateDisplay.scss'
@@ -34,11 +34,15 @@ const dateHighlight = (parsedDate: dayjs.Dayjs, interval: IntervalType): string 
     }
 }
 
+const checkDateYear = (date: Dayjs): Dayjs => {
+    return date.get('year') === 2001 ? date.set('year', dayjs().year()) : date
+}
+
 /* Returns a single line standardized component to display the date depending on context.
     For example, a single date in a graph will be shown as: `Th` Apr 22.
 */
 export function DateDisplay({ date, interval, hideWeekRange }: DateDisplayProps): JSX.Element {
-    const parsedDate = dayjs(date)
+    const parsedDate = checkDateYear(dayjs(date))
 
     return (
         <>


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.* 
closes #5131 

For the date of Thursday, June 24th: 

before: 
<img width="378" alt="Screen Shot 2021-07-14 at 4 12 36 PM" src="https://user-images.githubusercontent.com/25164963/125686628-4984085e-12fd-4195-8b17-7e070973ee1f.png">
 
after:
<img width="405" alt="Screen Shot 2021-07-14 at 4 11 06 PM" src="https://user-images.githubusercontent.com/25164963/125686575-bda105ed-cc58-4bc0-aa57-30038318f76a.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
