### PR TITLE
Fix missing graph types funnel

### DIFF
--- a/cypress/integration/funnels.js
+++ b/cypress/integration/funnels.js
@@ -9,7 +9,7 @@ describe('Funnels', () => {
     })
 
     it('Add only events to funnel', () => {
-        cy.get('[data-attr=add-action-event-button]').click()
+        cy.get('[data-attr=add-action-event-button]').first().click()
 
         cy.get('[data-attr=save-funnel-button]').click() // `save-funnel-button` is actually calculate, keeping around to avoid losing data
 
@@ -60,7 +60,7 @@ describe('Funnels', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.contains('HogFlix homepage view').click()
 
-        cy.get('[data-attr=add-action-event-button]').click()
+        cy.get('[data-attr=add-action-event-button]').first().click()
         cy.get('[data-attr=trend-element-subject-1]').click()
         cy.contains('HogFlix paid').click()
 

--- a/cypress/integration/funnels.js
+++ b/cypress/integration/funnels.js
@@ -17,7 +17,7 @@ describe('Funnels', () => {
     })
 
     it('Add 1 action to funnel and navigate to persons', () => {
-        cy.get('[data-attr=add-action-event-button]').click()
+        cy.get('[data-attr=add-action-event-button]').first().click()
         cy.get('[data-attr=trend-element-subject-0]').click()
 
         cy.wait(200)
@@ -41,7 +41,7 @@ describe('Funnels', () => {
     })
 
     it('Apply date filter to funnel', () => {
-        cy.get('[data-attr=add-action-event-button]').click()
+        cy.get('[data-attr=add-action-event-button]').first().click()
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.contains('HogFlix homepage view').click()
         cy.get('[data-attr=save-funnel-button]').click()
@@ -56,7 +56,7 @@ describe('Funnels', () => {
     })
 
     it('Add 2 actions to funnel', () => {
-        cy.get('[data-attr=add-action-event-button]').click()
+        cy.get('[data-attr=add-action-event-button]').first().click()
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.contains('HogFlix homepage view').click()
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -25,7 +25,7 @@ export function ToggleButtonChartFilter({
         {
             value: ChartDisplayType.FunnelViz,
             label: <Tooltip title="Track users' progress between steps of the funnel">Conversion steps</Tooltip>,
-            visible: clickhouseFeatures,
+            visible: true,
         },
         {
             value: ChartDisplayType.FunnelsTimeToConvert,
@@ -35,7 +35,7 @@ export function ToggleButtonChartFilter({
         {
             value: ChartDisplayType.ActionsLineGraphLinear,
             label: <Tooltip title="Track how this funnel's conversion rate is trending over time">Historical</Tooltip>,
-            visible: clickhouseFeatures,
+            visible: true,
         },
     ]
 


### PR DESCRIPTION
## Changes

<img width="388" alt="Screenshot 2021-07-14 at 6 28 36 PM" src="https://user-images.githubusercontent.com/13460330/125706441-d58938bb-17b0-4896-b80a-11784ce8a775.png">


Unhide funnel graph types for non-CH users.

Original intent was to hide time-conversion histogram from Postgres users because the new funnels api isn't available on Postgres.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
