### PR TITLE
Add clause and test for static cohorts event query

### DIFF
--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -106,10 +106,12 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
 
     def _does_cohort_need_persons(self, prop: Property) -> bool:
         try:
-            cohort = Cohort.objects.get(pk=prop.value, team_id=self._team_id)
+            cohort: Cohort = Cohort.objects.get(pk=prop.value, team_id=self._team_id)
         except Cohort.DoesNotExist:
             return False
         if is_precalculated_query(cohort):
+            return True
+        if cohort.is_static:
             return True
         for group in cohort.groups:
             if group.get("properties"):

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -29,7 +29,8 @@ def _create_cohort(**kwargs):
     team = kwargs.pop("team")
     name = kwargs.pop("name")
     groups = kwargs.pop("groups")
-    cohort = Cohort.objects.create(team=team, name=name, groups=groups)
+    is_static = kwargs.pop("is_static")
+    cohort = Cohort.objects.create(team=team, name=name, groups=groups, is_static=is_static)
     return cohort
 
 
@@ -180,4 +181,21 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         query, params = TrendsEventQuery(filter=filter, entity=entity, team_id=self.team.pk).get_query()
         sync_execute(query, params)
-        print(sqlparse.format(query, reindent=True))
+
+    # smoke test make sure query is formatted and runs
+    def test_static_cohort_filter(self):
+        cohort = _create_cohort(team=self.team, name="cohort1", groups=[], is_static=True)
+
+        filter = Filter(
+            data={
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+                "events": [{"id": "viewed", "order": 0},],
+                "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
+            }
+        )
+
+        entity = Entity({"id": "viewed", "type": "events",})
+
+        query, params = TrendsEventQuery(filter=filter, entity=entity, team_id=self.team.pk).get_query()
+        sync_execute(query, params)

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -29,7 +29,7 @@ def _create_cohort(**kwargs):
     team = kwargs.pop("team")
     name = kwargs.pop("name")
     groups = kwargs.pop("groups")
-    is_static = kwargs.pop("is_static")
+    is_static = kwargs.pop("is_static", False)
     cohort = Cohort.objects.create(team=team, name=name, groups=groups, is_static=is_static)
     return cohort
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- follow up to #5132 needed an extra clause in the event query class
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
