### PR TITLE
Kill dead code around updating person properties

### DIFF
--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -16,7 +16,6 @@ from ee.clickhouse.sql.person import (
     DELETE_PERSON_EVENTS_BY_ID,
     INSERT_PERSON_DISTINCT_ID,
     INSERT_PERSON_SQL,
-    UPDATE_PERSON_PROPERTIES,
 )
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
@@ -71,10 +70,6 @@ def create_person(
     p = ClickhouseProducer()
     p.produce(topic=KAFKA_PERSON, sql=INSERT_PERSON_SQL, data=data, sync=sync)
     return uuid
-
-
-def update_person_properties(team_id: int, id: str, properties: Dict) -> None:
-    sync_execute(UPDATE_PERSON_PROPERTIES, {"team_id": team_id, "id": id, "properties": json.dumps(properties)})
 
 
 def create_person_distinct_id(id: int, team_id: int, distinct_id: str, person_id: str) -> None:

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -215,10 +215,6 @@ INSERT_PERSON_DISTINCT_ID = """
 INSERT INTO person_distinct_id SELECT %(id)s, %(distinct_id)s, %(person_id)s, %(team_id)s, now(), 0 VALUES
 """
 
-UPDATE_PERSON_PROPERTIES = """
-ALTER TABLE person UPDATE properties = %(properties)s where id = %(id)s
-"""
-
 DELETE_PERSON_BY_ID = """
 INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, 1
 """


### PR DESCRIPTION
This caused some confusion around mutations that got queued. Dead code =
bad code

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
