### PR TITLE
Fix funnel visualisation

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -435,8 +435,14 @@ function FunnelInsight(): JSX.Element {
     } = useValues(funnelLogic({}))
     const { clickhouseFeatures } = useValues(funnelLogic())
 
+    const { featureFlags } = useValues(featureFlagLogic)
+
     return (
-        <div>
+        <div
+            style={
+                featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] ? {} : { height: 300, position: 'relative', marginBottom: 0 }
+            }
+        >
             {stepsWithCountLoading && <Loading />}
             {isValidFunnel ? (
                 <FunnelViz filters={{ display }} steps={stepsWithCount} timeConversionBins={timeConversionBins} />


### PR DESCRIPTION
## Changes

Funnel visualisation broke when removing the fixed height on the div.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
