### PR TITLE
Add default conditions properly to time to convert params

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -27,7 +27,7 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
         # Conversion from which step should be calculated
         from_step = self._filter.funnel_from_step or 0
         # Conversion to which step should be calculated
-        to_step = self._filter.funnel_to_step or len(self._filter.entities)
+        to_step = self._filter.funnel_to_step or len(self._filter.entities) - 1
 
         # Use custom bin_count if provided by user, otherwise infer an automatic one based on the number of samples
         bin_count = self._filter.bin_count


### PR DESCRIPTION
## Changes

*Please describe.*  
- addressed #5143 by shifting the default to_step parameter
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
