### PR TITLE
Fix squished height funnel trends graph

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -11,7 +11,6 @@ import {
     ACTIONS_TABLE,
     ACTIONS_BAR_CHART_VALUE,
     FEATURE_FLAGS,
-    FUNNELS_TIME_TO_CONVERT,
     ACTIONS_LINE_GRAPH_LINEAR,
 } from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -6,7 +6,14 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 import { Tabs, Row, Col, Card, Button, Tooltip } from 'antd'
-import { FUNNEL_VIZ, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE, FEATURE_FLAGS } from 'lib/constants'
+import {
+    FUNNEL_VIZ,
+    ACTIONS_TABLE,
+    ACTIONS_BAR_CHART_VALUE,
+    FEATURE_FLAGS,
+    FUNNELS_TIME_TO_CONVERT,
+    ACTIONS_LINE_GRAPH_LINEAR,
+} from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'
 import { router } from 'kea-router'
 
@@ -437,7 +444,9 @@ function FunnelInsight(): JSX.Element {
     return (
         <div
             style={
-                featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] ? {} : { height: 300, position: 'relative', marginBottom: 0 }
+                featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && display !== ACTIONS_LINE_GRAPH_LINEAR
+                    ? {}
+                    : { height: 300, position: 'relative', marginBottom: 0 }
             }
         >
             {stepsWithCountLoading && <Loading />}


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

<img width="773" alt="Screen Shot 2021-07-15 at 1 32 48 PM" src="https://user-images.githubusercontent.com/25164963/125833894-dbc32ac3-c08c-46f2-9e72-61d894f93c2b.png">

<img width="736" alt="Screen Shot 2021-07-15 at 1 42 24 PM" src="https://user-images.githubusercontent.com/25164963/125833935-ed869dd4-8ac9-4de1-849f-1613d41698ad.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
