### PR TITLE
Auto generated kea typing for sessionsTableLogic

### DIFF
--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -246,7 +246,14 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
         const buildURL = (
             overrides: Partial<Params> = {},
             replace = false
-        ): [string, Params, Record<string, any>, { replace: boolean }] => {
+        ): [
+            string,
+            Params,
+            Record<string, any>,
+            {
+                replace: boolean
+            }
+        ] => {
             const today = dayjs().startOf('day').format('YYYY-MM-DD')
 
             const { properties } = router.values.searchParams


### PR DESCRIPTION
## Changes

Minor typing fix.

`yarn typegen:watch` was auto generating these types. Merging in so that git diff chills out during development.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
