### PR TITLE
Session events vs. grammar

### DIFF
--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -4,7 +4,7 @@ import { decodeParams } from 'kea-router'
 import { Button, Spin, Space, Tooltip, Badge, Switch, Row } from 'antd'
 import { Link } from 'lib/components/Link'
 import { ExpandState, sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
-import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP } from '~/lib/utils'
+import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP, pluralize } from '~/lib/utils'
 import { SessionDetails } from './SessionDetails'
 import dayjs from 'dayjs'
 import { SessionType } from '~/types'
@@ -287,7 +287,12 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                             <ExpandIcon {...expandProps}>
                                 {session?.matching_events?.length > 0 ? (
                                     <Tooltip
-                                        title={`${session.matching_events.length} events match your event filters`}
+                                        title={`${pluralize(session.matching_events.length, 'event')} ${pluralize(
+                                            session.matching_events.length,
+                                            'matches',
+                                            'match',
+                                            false
+                                        )} your event filters`}
                                     >
                                         <Badge
                                             className="sessions-matching-events-icon cursor-pointer"


### PR DESCRIPTION
## Bug

Bad sessions events grammar

<img width="271" alt="Screen Shot 2021-07-15 at 1 33 12 PM" src="https://user-images.githubusercontent.com/13460330/125854644-2f8fbe5d-c20e-40cd-8f97-babe70bbb0a4.png">

## Changes

<img width="255" alt="Screen Shot 2021-07-15 at 1 40 17 PM" src="https://user-images.githubusercontent.com/13460330/125854651-453b6575-6041-4c8d-be59-c196e62d9296.png">
<img width="281" alt="Screen Shot 2021-07-15 at 1 40 24 PM" src="https://user-images.githubusercontent.com/13460330/125854652-4f1d9a0a-706d-4ba5-bc6f-a39f873cf38c.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [X] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
