### PR TITLE
LineGraph: coercion to avoid spreading non-iterable instance

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -177,9 +177,9 @@ export function LineGraph({
             datasets = [
                 ...datasets.map((dataset, index) => {
                     let datasetCopy = Object.assign({}, dataset)
-                    let data = [...dataset.data]
-                    let _labels = [...dataset.labels]
-                    let days = [...dataset.days]
+                    let data = [...(dataset.data || [])]
+                    let _labels = [...(dataset.labels || [])]
+                    let days = [...(dataset.days || [])]
                     data.pop()
                     _labels.pop()
                     days.pop()
@@ -190,7 +190,7 @@ export function LineGraph({
                 }),
                 ...datasets.map((dataset, index) => {
                     let datasetCopy = Object.assign({}, dataset)
-                    let datasetLength = datasetCopy.data.length
+                    let datasetLength = datasetCopy.data?.length ?? 0
                     datasetCopy.dotted = true
 
                     // if last date is still active show dotted line


### PR DESCRIPTION
## Changes

Should fix an app whitescreen problem on insights I encountered today. Similar, but not exactly the same, as #5157

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
