### PR TITLE
Fix organization creation

### DIFF
--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -27,6 +27,10 @@ class TestSignupAPI(APIBaseTest):
     @patch("posthog.api.organization.settings.EE_AVAILABLE", False)
     @patch("posthoganalytics.capture")
     def test_api_sign_up(self, mock_capture):
+
+        # Ensure the internal system metrics org doesn't prevent org-creation
+        Organization.objects.create(name="PostHog Internal Metrics", for_internal_metrics=True)
+
         response = self.client.post(
             "/api/signup/",
             {

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -538,7 +538,7 @@ def get_instance_realm() -> str:
 
 def get_can_create_org() -> bool:
     """Returns whether a new organization can be created in the current instance.
-    
+
     Organizations can be created only in the following cases:
     - if on PostHog Cloud
     - if running end-to-end tests
@@ -547,8 +547,11 @@ def get_can_create_org() -> bool:
     """
     from posthog.models.organization import Organization
 
-    print(settings.MULTI_TENANCY, settings.E2E_TESTING, not Organization.objects.exists(), settings.MULTI_ORG_ENABLED)
-    if settings.MULTI_TENANCY or settings.E2E_TESTING or not Organization.objects.exists():
+    if (
+        settings.MULTI_TENANCY
+        or settings.E2E_TESTING
+        or not Organization.objects.filter(for_internal_metrics=False).exists()
+    ):
         return True
 
     if settings.MULTI_ORG_ENABLED:


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/5108 broke organization creation
for self-hosted users using internal metrics (i.e. all clickhouse
users). This PR fixes that.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
