### PR TITLE
Add staleness monitoring GitHub action

### DIFF
--- a/.github/workflows/staleness.yaml
+++ b/.github/workflows/staleness.yaml
@@ -1,0 +1,22 @@
+name: 'Handle stale issues and PRs'
+on:
+    schedule:
+        - cron: '30 1 * * *'
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v4
+              with:
+                  stale-issue-message: "This issue hasn't seen activity in a year! Is it worth being kept open?"
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise it will be closed in a week."
+                  close-issue-message: 'This issue was closed due to 2 years of inactivity. Feel free to reopen it if still relevant.'
+                  close-pr-message: 'This PR was closed due to 2 weeks of inactivity. Feel free to reopen it if still relevant.'
+                  days-before-issue-stale: 365
+                  days-before-pr-stale: 7
+                  days-before-issue-close: 730
+                  days-before-pr-close: 14
+                  stale-issue-label: stale
+                  stale-pr-label: stale
+                  repo-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

This adds https://github.com/actions/stale, following a conversation with Tim about avoiding stale PRs.