### PR TITLE
Fix funnel trends step indexes

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -120,16 +120,16 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
 
     def get_steps_reached_conditions(self) -> Tuple[str, str, str]:
         # How many steps must have been done to count for the denominator of a funnel trends data point
-        from_step = self._filter.funnel_from_step or 1
+        from_step = self._filter.funnel_from_step or 0
         # How many steps must have been done to count for the numerator of a funnel trends data point
         to_step = self._filter.funnel_to_step or len(self._filter.entities) - 1
 
         # Those who converted OR dropped off
-        reached_from_step_count_condition = f"steps_completed >= {from_step}"
+        reached_from_step_count_condition = f"steps_completed >= {from_step+1}"
         # Those who converted
-        reached_to_step_count_condition = f"steps_completed >= {to_step}"
+        reached_to_step_count_condition = f"steps_completed >= {to_step+1}"
         # Those who dropped off
-        did_not_reach_to_step_count_condition = f"{reached_from_step_count_condition} AND steps_completed < {to_step}"
+        did_not_reach_to_step_count_condition = f"{reached_from_step_count_condition} AND steps_completed < {to_step+1}"
         return reached_from_step_count_condition, reached_to_step_count_condition, did_not_reach_to_step_count_condition
 
     def _summarize_data(self, results):

--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -122,7 +122,7 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
         # How many steps must have been done to count for the denominator of a funnel trends data point
         from_step = self._filter.funnel_from_step or 1
         # How many steps must have been done to count for the numerator of a funnel trends data point
-        to_step = self._filter.funnel_to_step or len(self._filter.entities)
+        to_step = self._filter.funnel_to_step or len(self._filter.entities) - 1
 
         # Those who converted OR dropped off
         reached_from_step_count_condition = f"steps_completed >= {from_step}"

--- a/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_trends.py
@@ -661,7 +661,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "date_from": "2021-05-01 00:00:00",
                 "date_to": "2021-05-02 23:59:59",
                 "funnel_window_days": 3,
-                "funnel_from_step": 2,
+                "funnel_from_step": 1,
                 "events": [
                     {"id": "step one", "order": 0},
                     {"id": "step two", "order": 1},
@@ -715,7 +715,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "date_from": "2021-05-01 00:00:00",
                 "date_to": "2021-05-02 23:59:59",
                 "funnel_window_days": 3,
-                "funnel_to_step": 2,
+                "funnel_to_step": 1,
                 "events": [
                     {"id": "step one", "order": 0},
                     {"id": "step two", "order": 1},


### PR DESCRIPTION
## Changes

Basically #5154 for funnel trends.

#### Breaking change
Previously funnel trends had a discrepancy, in that step indexes were 1-based, while 0-based elsewhere. This moves funnel trends to 0-based too, so -1 indexes compared to before.