### PR TITLE
Calculate average conversion time in ClickHouse for time to convert

### DIFF
--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -67,12 +67,15 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,
-            [
-                (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 29_080 s - users A and B
-                (29080.0, 0),  # Analogous to above, just an interval (in this case 26_880 s) up - no users
-                (55940.0, 0),  # Same as above
-                (82800.0, 1),  # Reached step 1 from step 0 in at least 82_800 s but less than 109_680 s - user C
-            ],
+            {
+                "bins": [
+                    (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 29_080 s - users A and B
+                    (29080.0, 0),  # Analogous to above, just an interval (in this case 26_880 s) up - no users
+                    (55940.0, 0),  # Same as above
+                    (82800.0, 1),  # Reached step 1 from step 0 in at least 82_800 s but less than 109_680 s - user C
+                ],
+                "average_conversion_time": 29_540,
+            },
         )
 
     def test_custom_bin_count_single_step(self):
@@ -117,16 +120,19 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         # 7 bins, autoscaled to work best with minimum time to convert and maximum time to convert at hand
         self.assertEqual(
             results,
-            [
-                (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 13_732 s - users A and B
-                (13732.0, 0),  # Analogous to above, just an interval (in this case 13_732 s) up - no users
-                (25244.0, 0),  # And so on
-                (36756.0, 0),
-                (48268.0, 0),
-                (59780.0, 0),
-                (71292.0, 1),  # Reached step 1 from step 0 in at least 71_292 s but less than 82_804 s - user C
-                (82804.0, 0),
-            ],
+            {
+                "bins": [
+                    (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 13_732 s - users A and B
+                    (13732.0, 0),  # Analogous to above, just an interval (in this case 13_732 s) up - no users
+                    (25244.0, 0),  # And so on
+                    (36756.0, 0),
+                    (48268.0, 0),
+                    (59780.0, 0),
+                    (71292.0, 1),  # Reached step 1 from step 0 in at least 71_292 s but less than 82_804 s - user C
+                    (82804.0, 0),
+                ],
+                "average_conversion_time": 29_540,
+            },
         )
 
     def test_auto_bin_count_total(self):
@@ -151,8 +157,6 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "interval": "day",
                 "date_from": "2021-06-07 00:00:00",
                 "date_to": "2021-06-13 23:59:59",
-                "funnel_from_step": 0,
-                "funnel_to_step": 2,
                 "funnel_window_days": 7,
                 "events": [
                     {"id": "step one", "order": 0},
@@ -167,42 +171,24 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             results,
-            [
-                (10800.0, 1),  # Reached step 2 from step 0 in at least 10_800 s but less than 10_860 s - user A
-                (10860.0, 0),  # Analogous to above, just an interval (in this case 60 s) up - no users
-                (10920.0, 0),  # And so on
-                (10980.0, 0),
-            ],
-        )
-
-        # check with no params
-        filter = Filter(
-            data={
-                "insight": INSIGHT_FUNNELS,
-                "interval": "day",
-                "date_from": "2021-06-07 00:00:00",
-                "date_to": "2021-06-13 23:59:59",
-                "funnel_window_days": 7,
-                "events": [
-                    {"id": "step one", "order": 0},
-                    {"id": "step two", "order": 1},
-                    {"id": "step three", "order": 2},
+            {
+                "bins": [
+                    (10800.0, 1),  # Reached step 2 from step 0 in at least 10_800 s but less than 10_860 s - user A
+                    (10860.0, 0),  # Analogous to above, just an interval (in this case 60 s) up - no users
+                    (10920.0, 0),  # And so on
+                    (10980.0, 0),
                 ],
-            }
+                "average_conversion_time": 10_800,
+            },
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
-        results = funnel_trends.run()
-
-        self.assertEqual(
-            results,
-            [
-                (10800.0, 1),  # Reached step 2 from step 0 in at least 10_800 s but less than 10_860 s - user A
-                (10860.0, 0),  # Analogous to above, just an interval (in this case 60 s) up - no users
-                (10920.0, 0),  # And so on
-                (10980.0, 0),
-            ],
+        # Let's verify that behavior with steps unspecified is the same as when first and last steps specified
+        funnel_trends_steps_specified = ClickhouseFunnelTimeToConvert(
+            Filter(data={**filter._data, "funnel_from_step": 0, "funnel_to_step": 2,}), self.team, ClickhouseFunnel
         )
+        results_steps_specified = funnel_trends_steps_specified.run()
+
+        self.assertEqual(results, results_steps_specified)
 
     def test_basic_unordered(self):
         _create_person(distinct_ids=["user a"], team=self.team)
@@ -212,12 +198,15 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         _create_event(event="step three", distinct_id="user a", team=self.team, timestamp="2021-06-08 18:00:00")
         _create_event(event="step one", distinct_id="user a", team=self.team, timestamp="2021-06-08 19:00:00")
         _create_event(event="step two", distinct_id="user a", team=self.team, timestamp="2021-06-08 21:00:00")
+        # Converted from 0 to 1 in 7200 s
 
         _create_event(event="step one", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:00:00")
         _create_event(event="step two", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:37:00")
+        # Converted from 0 to 1 in 2200 s
 
         _create_event(event="step two", distinct_id="user c", team=self.team, timestamp="2021-06-11 07:00:00")
         _create_event(event="step one", distinct_id="user c", team=self.team, timestamp="2021-06-12 06:00:00")
+        # Converted from 0 to 1 in 82_800 s
 
         filter = Filter(
             data={
@@ -243,12 +232,15 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,
-            [
-                (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 29_080 s - users A and B
-                (29080.0, 0),  # Analogous to above, just an interval (in this case 26_880 s) up - no users
-                (55940.0, 0),  # Same as above
-                (82800.0, 1),  # Reached step 1 from step 0 in at least 82_800 s but less than 109_680 s - user C
-            ],
+            {
+                "bins": [
+                    (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 29_080 s - users A and B
+                    (29080.0, 0),  # Analogous to above, just an interval (in this case 26_880 s) up - no users
+                    (55940.0, 0),  # Same as above
+                    (82800.0, 1),  # Reached step 1 from step 0 in at least 82_800 s but less than 109_680 s - user C
+                ],
+                "average_conversion_time": 29540,
+            },
         )
 
     def test_basic_strict(self):
@@ -259,18 +251,22 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
 
         _create_event(event="step one", distinct_id="user a", team=self.team, timestamp="2021-06-08 18:00:00")
         _create_event(event="step two", distinct_id="user a", team=self.team, timestamp="2021-06-08 19:00:00")
+        # Converted from 0 to 1 in 3600 s
         _create_event(event="step three", distinct_id="user a", team=self.team, timestamp="2021-06-08 21:00:00")
 
         _create_event(event="step one", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:00:00")
         _create_event(event="step two", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:37:00")
+        # Converted from 0 to 1 in 2200 s
         _create_event(event="blah", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:38:00")
         _create_event(event="step three", distinct_id="user b", team=self.team, timestamp="2021-06-09 13:39:00")
 
         _create_event(event="step one", distinct_id="user c", team=self.team, timestamp="2021-06-11 07:00:00")
         _create_event(event="step two", distinct_id="user c", team=self.team, timestamp="2021-06-12 06:00:00")
+        # Converted from 0 to 1 in 82_800 s
 
         _create_event(event="step one", distinct_id="user d", team=self.team, timestamp="2021-06-11 07:00:00")
         _create_event(event="blah", distinct_id="user d", team=self.team, timestamp="2021-06-12 07:00:00")
+        # Blah cancels conversion
         _create_event(event="step two", distinct_id="user d", team=self.team, timestamp="2021-06-12 09:00:00")
 
         filter = Filter(
@@ -297,10 +293,13 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,
-            [
-                (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 29_080 s - users A and B
-                (29080.0, 0),  # Analogous to above, just an interval (in this case 26_880 s) up - no users
-                (55940.0, 0),  # Same as above
-                (82800.0, 1),  # Reached step 1 from step 0 in at least 82_800 s but less than 109_680 s - user C
-            ],
+            {
+                "bins": [
+                    (2220.0, 2),  # Reached step 1 from step 0 in at least 2200 s but less than 29_080 s - users A and B
+                    (29080.0, 0),  # Analogous to above, just an interval (in this case 26_880 s) up - no users
+                    (55940.0, 0),  # Same as above
+                    (82800.0, 1),  # Reached step 1 from step 0 in at least 82_800 s but less than 109_680 s - user C
+                ],
+                "average_conversion_time": 29540,
+            },
         )


### PR DESCRIPTION
## Changes

This resolves the problem from https://github.com/PostHog/posthog/pull/5142/files/6c043c4f6f258cccb75a30f8cf99812d561aec3c#r671330595.

#### Breaking change
Changes the shape of time to convert results from
```TypeScript
[number, number][]
```
(array of `[bin_from_seconds, person_count]` tuples) to
```TypeScript
{
    bins: [number, number][]
	average_conversion_time: number
}
```

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests