### PR TITLE
Use pytest-xdist for parallel tests.

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -101,7 +101,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -n auto posthog/
+                  pytest --nomigrations -n auto posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -109,13 +109,12 @@ jobs:
                   CLICKHOUSE_HOST: 'localhost'
                   CLICKHOUSE_SECURE: 'False'
                   CLICKHOUSE_VERIFY: 'False'
-                  TEST: 1
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -n auto ee/
+                  pytest ee/
 
     cloud:
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -101,7 +101,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --nomigrations --durations=10 -n auto posthog/
+                  pytest --reruns 5 --nomigrations --durations=10 -n auto posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -115,7 +115,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --durations=10 -n auto ee/
+                  pytest --reruns 5 --durations=10 -n 4 ee/
 
     cloud:
         name: Django tests – Cloud
@@ -171,7 +171,7 @@ jobs:
                   cd deploy
                   python -m pip install --upgrade pip
                   python -m pip install -r requirements.txt
-                  python -m pip install freezegun fakeredis pytest pytest-mock pytest-django pytest-xdist
+                  python -m pip install freezegun fakeredis pytest pytest-mock pytest-django pytest-xdist pytest-rerunfailures
 
             - name: Link posthog-cloud at current branch
               run: |
@@ -200,7 +200,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --nomigrations -n auto --reuse-db -m "not skip_on_multitenancy" posthog
+                  pytest --reruns 5 --nomigrations -n auto --reuse-db -m "not skip_on_multitenancy" posthog
 
             - name: Run cloud tests (posthog-cloud)
               env:
@@ -213,7 +213,7 @@ jobs:
               run: |
                   source .env.template
                   cd deploy
-                  pytest -n auto multi_tenancy messaging -m "not skip_on_multitenancy"
+                  pytest --reruns 5 -n auto multi_tenancy messaging -m "not skip_on_multitenancy"
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -224,7 +224,7 @@ jobs:
                   TEST: 1
               run: |
                   cd deploy/
-                  pytest -n auto ee -s -m "not skip_on_multitenancy"
+                  pytest --reruns 5 -n auto ee -s -m "not skip_on_multitenancy"
 
     foss:
         name: Django tests – FOSS

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -101,7 +101,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --nomigrations -n auto posthog/
+                  pytest --nomigrations --durations=10 -n auto posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -114,7 +114,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest ee/
+                  pytest --durations=10 ee/
 
     cloud:
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -100,7 +100,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog/
+                  pytest --nomigrations -n auto posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -113,7 +113,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest ee/
+                  pytest -n auto ee/
 
     cloud:
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -101,7 +101,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --nomigrations -n auto posthog/
+                  pytest -n auto posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -115,7 +115,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --nomigrations -n auto ee/
+                  pytest -n auto ee/
 
     cloud:
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -95,6 +95,7 @@ jobs:
             - name: Run posthog tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+                  TEST: 1
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html
@@ -108,6 +109,7 @@ jobs:
                   CLICKHOUSE_HOST: 'localhost'
                   CLICKHOUSE_SECURE: 'False'
                   CLICKHOUSE_VERIFY: 'False'
+                  TEST: 1
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -114,7 +114,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest --durations=10 ee/
+                  pytest --durations=10 -n auto ee/
 
     cloud:
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -171,7 +171,7 @@ jobs:
                   cd deploy
                   python -m pip install --upgrade pip
                   python -m pip install -r requirements.txt
-                  python -m pip install freezegun fakeredis pytest pytest-mock pytest-django
+                  python -m pip install freezegun fakeredis pytest pytest-mock pytest-django pytest-xdist
 
             - name: Link posthog-cloud at current branch
               run: |
@@ -193,13 +193,14 @@ jobs:
             - name: Run posthog tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+                  TEST: 1
               run: |
                   cd deploy
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog --reuse-db -m "not skip_on_multitenancy"
+                  pytest --nomigrations -n auto --reuse-db -m "not skip_on_multitenancy" posthog
 
             - name: Run cloud tests (posthog-cloud)
               env:
@@ -208,10 +209,11 @@ jobs:
                   CLICKHOUSE_HOST: 'localhost'
                   CLICKHOUSE_SECURE: 'False'
                   CLICKHOUSE_VERIFY: 'False'
+                  TEST: 1
               run: |
                   source .env.template
                   cd deploy
-                  pytest multi_tenancy messaging -m "not skip_on_multitenancy"
+                  pytest -n auto multi_tenancy messaging -m "not skip_on_multitenancy"
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -219,9 +221,10 @@ jobs:
                   CLICKHOUSE_HOST: 'localhost'
                   CLICKHOUSE_SECURE: 'False'
                   CLICKHOUSE_VERIFY: 'False'
+                  TEST: 1
               run: |
                   cd deploy/
-                  pytest ee -s -m "not skip_on_multitenancy"
+                  pytest -n auto ee -s -m "not skip_on_multitenancy"
 
     foss:
         name: Django tests – FOSS
@@ -269,9 +272,10 @@ jobs:
             - name: Run tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:${{ job.services.postgres.ports[5432] }}/posthog'
+                  TEST: 1
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -m "not ee"
+                  pytest --nomigrations -n auto -m "not ee"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -115,7 +115,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -n auto ee/
+                  pytest --nomigrations -n auto ee/
 
     cloud:
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -109,6 +109,7 @@ jobs:
                   CLICKHOUSE_HOST: 'localhost'
                   CLICKHOUSE_SECURE: 'False'
                   CLICKHOUSE_VERIFY: 'False'
+                  TEST: 1
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -4,8 +4,6 @@ import pytest
 from django.conf import settings
 from infi.clickhouse_orm import Database
 
-from ee.clickhouse.client import sync_execute
-from ee.clickhouse.sql.plugin_log_entries import DROP_PLUGIN_LOG_ENTRIES_TABLE_SQL, PLUGIN_LOG_ENTRIES_TABLE_SQL
 from posthog.settings import (
     CLICKHOUSE_DATABASE,
     CLICKHOUSE_HTTP_URL,
@@ -38,6 +36,8 @@ def django_db_setup(django_db_setup, django_db_keepdb, worker_id):
         database.create_database()
 
     with patch.object(settings, "CLICKHOUSE_DATABASE", CLICKHOUSE_TEST_DB):
+        from ee.clickhouse.client import sync_execute
+
         database.migrate("ee.clickhouse.migrations")
         # Make DELETE / UPDATE synchronous to avoid flaky tests
         sync_execute("SET mutations_sync = 1")
@@ -52,39 +52,44 @@ def django_db_setup(django_db_setup, django_db_keepdb, worker_id):
 
 
 @pytest.fixture
-def db(db):
-    from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
-    from ee.clickhouse.sql.person import (
-        DROP_PERSON_DISTINCT_ID_TABLE_SQL,
-        DROP_PERSON_STATIC_COHORT_TABLE_SQL,
-        DROP_PERSON_TABLE_SQL,
-        PERSON_STATIC_COHORT_TABLE_SQL,
-        PERSONS_DISTINCT_ID_TABLE_SQL,
-        PERSONS_TABLE_SQL,
-    )
-    from ee.clickhouse.sql.session_recording_events import (
-        DROP_SESSION_RECORDING_EVENTS_TABLE_SQL,
-        SESSION_RECORDING_EVENTS_TABLE_SQL,
-    )
+def db(db, worker_id):
+    CLICKHOUSE_TEST_DB = f"{CLICKHOUSE_DATABASE}_{worker_id}"
 
-    yield
+    with patch.object(settings, "CLICKHOUSE_DATABASE", CLICKHOUSE_TEST_DB):
+        from ee.clickhouse.client import sync_execute
+        from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
+        from ee.clickhouse.sql.person import (
+            DROP_PERSON_DISTINCT_ID_TABLE_SQL,
+            DROP_PERSON_STATIC_COHORT_TABLE_SQL,
+            DROP_PERSON_TABLE_SQL,
+            PERSON_STATIC_COHORT_TABLE_SQL,
+            PERSONS_DISTINCT_ID_TABLE_SQL,
+            PERSONS_TABLE_SQL,
+        )
+        from ee.clickhouse.sql.plugin_log_entries import DROP_PLUGIN_LOG_ENTRIES_TABLE_SQL, PLUGIN_LOG_ENTRIES_TABLE_SQL
+        from ee.clickhouse.sql.session_recording_events import (
+            DROP_SESSION_RECORDING_EVENTS_TABLE_SQL,
+            SESSION_RECORDING_EVENTS_TABLE_SQL,
+        )
 
-    try:
-        sync_execute(DROP_EVENTS_TABLE_SQL)
-        sync_execute(DROP_PERSON_TABLE_SQL)
-        sync_execute(DROP_PERSON_DISTINCT_ID_TABLE_SQL)
-        sync_execute(DROP_PERSON_STATIC_COHORT_TABLE_SQL)
-        sync_execute(DROP_SESSION_RECORDING_EVENTS_TABLE_SQL)
-        sync_execute(DROP_PLUGIN_LOG_ENTRIES_TABLE_SQL)
+        yield
 
-        sync_execute(EVENTS_TABLE_SQL)
-        sync_execute(SESSION_RECORDING_EVENTS_TABLE_SQL)
-        sync_execute(PERSONS_TABLE_SQL)
-        sync_execute(PERSONS_DISTINCT_ID_TABLE_SQL)
-        sync_execute(PERSON_STATIC_COHORT_TABLE_SQL)
-        sync_execute(PLUGIN_LOG_ENTRIES_TABLE_SQL)
-    except:
-        pass
+        try:
+            sync_execute(DROP_EVENTS_TABLE_SQL)
+            sync_execute(DROP_PERSON_TABLE_SQL)
+            sync_execute(DROP_PERSON_DISTINCT_ID_TABLE_SQL)
+            sync_execute(DROP_PERSON_STATIC_COHORT_TABLE_SQL)
+            sync_execute(DROP_SESSION_RECORDING_EVENTS_TABLE_SQL)
+            sync_execute(DROP_PLUGIN_LOG_ENTRIES_TABLE_SQL)
+
+            sync_execute(EVENTS_TABLE_SQL)
+            sync_execute(SESSION_RECORDING_EVENTS_TABLE_SQL)
+            sync_execute(PERSONS_TABLE_SQL)
+            sync_execute(PERSONS_DISTINCT_ID_TABLE_SQL)
+            sync_execute(PERSON_STATIC_COHORT_TABLE_SQL)
+            sync_execute(PLUGIN_LOG_ENTRIES_TABLE_SQL)
+        except:
+            pass
 
 
 @pytest.fixture

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -37,11 +37,11 @@ def django_db_setup(django_db_setup, django_db_keepdb, worker_id):
     if not django_db_keepdb or not database.db_exists:
         database.create_database()
 
-    database.migrate("ee.clickhouse.migrations")
-    # Make DELETE / UPDATE synchronous to avoid flaky tests
-    sync_execute("SET mutations_sync = 1")
-
     with patch.object(settings, "CLICKHOUSE_DATABASE", CLICKHOUSE_TEST_DB):
+        database.migrate("ee.clickhouse.migrations")
+        # Make DELETE / UPDATE synchronous to avoid flaky tests
+        sync_execute("SET mutations_sync = 1")
+
         yield
 
     if not django_db_keepdb:

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -42,6 +42,7 @@ def django_db_setup(django_db_setup, django_db_keepdb, worker_id):
             "ee.clickhouse.sql.events",
             "ee.clickhouse.sql.plugin_log_entries",
             "ee.clickhouse.sql.session_recording_events",
+            "ee.clickhouse.client",
         ]:
             module = importlib.import_module(path)
             importlib.reload(module)
@@ -72,6 +73,7 @@ def db(db, worker_id):
             "ee.clickhouse.sql.events",
             "ee.clickhouse.sql.plugin_log_entries",
             "ee.clickhouse.sql.session_recording_events",
+            "ee.clickhouse.client",
         ]:
             module = importlib.import_module(path)
             importlib.reload(module)

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 import pytest
-from django.conf import settings
 from infi.clickhouse_orm import Database
 
+from posthog import settings
 from posthog.settings import (
     CLICKHOUSE_DATABASE,
     CLICKHOUSE_HTTP_URL,

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 from unittest.mock import patch
 
 import pytest
@@ -36,6 +37,15 @@ def django_db_setup(django_db_setup, django_db_keepdb, worker_id):
         database.create_database()
 
     with patch.object(settings, "CLICKHOUSE_DATABASE", CLICKHOUSE_TEST_DB):
+        for path in [
+            "ee.clickhouse.sql.person",
+            "ee.clickhouse.sql.events",
+            "ee.clickhouse.sql.plugin_log_entries",
+            "ee.clickhouse.sql.session_recording_events",
+        ]:
+            module = importlib.import_module(path)
+            importlib.reload(module)
+
         from ee.clickhouse.client import sync_execute
 
         database.migrate("ee.clickhouse.migrations")
@@ -56,6 +66,16 @@ def db(db, worker_id):
     CLICKHOUSE_TEST_DB = f"{CLICKHOUSE_DATABASE}_{worker_id}"
 
     with patch.object(settings, "CLICKHOUSE_DATABASE", CLICKHOUSE_TEST_DB):
+
+        for path in [
+            "ee.clickhouse.sql.person",
+            "ee.clickhouse.sql.events",
+            "ee.clickhouse.sql.plugin_log_entries",
+            "ee.clickhouse.sql.session_recording_events",
+        ]:
+            module = importlib.import_module(path)
+            importlib.reload(module)
+
         from ee.clickhouse.client import sync_execute
         from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
         from ee.clickhouse.sql.person import (

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -24,3 +24,4 @@ isort
 pytest
 pytest-django
 pytest-mock
+pytest-xdist

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -25,3 +25,4 @@ pytest
 pytest-django
 pytest-mock
 pytest-xdist
+pytest-rerunfailures

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -125,6 +125,8 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-mock==3.5.1
     # via -r requirements-dev.in
+pytest-rerunfailures==10.1
+    # via -r requirements-dev.in
 pytest-xdist==2.3.0
     # via -r requirements-dev.in
 pytest==6.2.2
@@ -133,6 +135,7 @@ pytest==6.2.2
     #   pytest-django
     #   pytest-forked
     #   pytest-mock
+    #   pytest-rerunfailures
     #   pytest-xdist
 python-dateutil==2.8.1
     # via freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,6 +45,8 @@ djangorestframework==3.12.2
     # via -r requirements-dev.in
 entrypoints==0.3
     # via flake8
+execnet==1.9.0
+    # via pytest-xdist
 fakeredis==1.4.5
     # via -r requirements-dev.in
 flake8-bugbear==20.1.4
@@ -105,7 +107,9 @@ pip-tools==5.5.0
 pluggy==0.13.1
     # via pytest
 py==1.10.0
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-forked
 pycodestyle==2.5.0
     # via
     #   flake8
@@ -117,13 +121,19 @@ pyparsing==2.4.7
     # via packaging
 pytest-django==4.1.0
     # via -r requirements-dev.in
+pytest-forked==1.3.0
+    # via pytest-xdist
 pytest-mock==3.5.1
+    # via -r requirements-dev.in
+pytest-xdist==2.3.0
     # via -r requirements-dev.in
 pytest==6.2.2
     # via
     #   -r requirements-dev.in
     #   pytest-django
+    #   pytest-forked
     #   pytest-mock
+    #   pytest-xdist
 python-dateutil==2.8.1
     # via freezegun
 pytz==2021.1


### PR DESCRIPTION
## Changes

Use pytest-xdist for parallel tests. Use `--nomigrations` for some more speed boost.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
