### PR TITLE
Fix persons modal loading

### DIFF
--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -120,6 +120,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
             }
         },
         loadPeople: async ({ peopleParams }, breakpoint) => {
+            actions.setPeopleLoading(true)
             let people = []
             const {
                 label,
@@ -156,6 +157,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 people = await api.get(`api/action/people/?${filterParams}${searchTermParam}`)
             }
             breakpoint()
+            actions.setPeopleLoading(false)
             const peopleResult = {
                 people: people.results[0]?.people,
                 count: people.results[0]?.count || 0,


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

The `setPeopleLoading` action call might've been accidentally deleted during a merge? Adding it back in so the loading state actually happens~


https://user-images.githubusercontent.com/25164963/126086680-89ef42f7-b5e6-4dce-8687-d2b57936aec3.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
