### PR TITLE
Consolidate funnel feature flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -235,7 +235,7 @@ export const FEATURE_FLAGS: Record<string, string> = {
     NEW_TOOLTIPS: '4156-tooltips-legends',
     PLUGIN_METRICS: '4871-plugin-metrics',
     FUNNEL_BAR_VIZ: '4535-funnel-bar-viz', // Nail Funnels #4785
-    SESSIONS_TABLE: '4964-sessions-table',
+    SESSIONS_TABLE: '4964-sessions-table', // Expand/collapse all in sessions table (performance consideration)
     PERSONS_MODAL_SEARCH: 'persons-modal-search',
 }
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -233,9 +233,8 @@ export const FEATURE_FLAGS: Record<string, string> = {
     NPS_PROMPT: '4562-nps',
     INGESTION_TAXONOMY: '4267-event-property-taxonomy',
     NEW_TOOLTIPS: '4156-tooltips-legends',
-    FUNNEL_PERSONS_MODAL: '4819-funnel-persons-modal',
     PLUGIN_METRICS: '4871-plugin-metrics',
-    FUNNEL_BAR_VIZ: '4535-funnel-bar-viz',
+    FUNNEL_BAR_VIZ: '4535-funnel-bar-viz', // Nail Funnels #4785
     SESSIONS_TABLE: '4964-sessions-table',
     PERSONS_MODAL_SEARCH: 'persons-modal-search',
 }

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -307,7 +307,7 @@ export const funnelLogic = kea<funnelLogicType<LoadedRawFunnelResults, TimeStepO
         funnelPersonsEnabled: [
             () => [featureFlagLogic.selectors.featureFlags, selectors.preflight],
             (featureFlags, preflight): boolean =>
-                !!(featureFlags[FEATURE_FLAGS.FUNNEL_PERSONS_MODAL] && preflight?.is_clickhouse_enabled),
+                !!(featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && preflight?.is_clickhouse_enabled),
         ],
         histogramGraphData: [
             () => [selectors.timeConversionBins],


### PR DESCRIPTION
## Changes

This PR merges `4819-funnel-persons-modal` feature flag into the main `4535-funnel-bar-viz` flag as the features are basically part of the same thing. Needed to release funnels in a predictable way.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
