### PR TITLE
Fix empty states funnel overflow

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter/taxonomicPropertyFilterLogic.ts
@@ -60,8 +60,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
             {
                 moveUp: () => false,
                 moveDown: () => false,
-                setActiveTab: () => true,
-                enableMouseInteractions: () => true,
+                setActiveTab: () => true, // reset immediately if clicked on a tab
+                enableMouseInteractions: () => true, // called 100ms after up/down
             },
         ],
     }),

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter/taxonomicPropertyFilterLogic.ts
@@ -60,8 +60,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
             {
                 moveUp: () => false,
                 moveDown: () => false,
-                setActiveTab: () => true, // reset immediately if clicked on a tab
-                enableMouseInteractions: () => true, // called 100ms after up/down
+                setActiveTab: () => true,
+                enableMouseInteractions: () => true,
             },
         ],
     }),

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -184,3 +184,11 @@
         }
     }
 }
+
+.funnel-insights-container {
+    &.non-empty-state {
+        height: 300px;
+        position: relative;
+        margin-bottom: 0;
+    }
+}

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -48,6 +48,7 @@ import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { FunnelHistogramHeader } from 'scenes/funnels/FunnelHistogram'
+import clsx from 'clsx'
 
 export interface BaseTabProps {
     annotationsToCreate: any[] // TODO: Type properly
@@ -432,6 +433,7 @@ function FunnelInsight(): JSX.Element {
     const {
         isValidFunnel,
         isLoading,
+        areFiltersValid,
         filters: { display },
     } = useValues(funnelLogic({}))
     const { clickhouseFeaturesEnabled } = useValues(funnelLogic)
@@ -440,11 +442,12 @@ function FunnelInsight(): JSX.Element {
 
     return (
         <div
-            style={
-                featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && display !== ACTIONS_LINE_GRAPH_LINEAR
-                    ? {}
-                    : { position: 'relative', marginBottom: 0 }
-            }
+            className={clsx('funnel-insights-container', {
+                'non-empty-state':
+                    isValidFunnel &&
+                    areFiltersValid &&
+                    (!featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] || display === ACTIONS_LINE_GRAPH_LINEAR),
+            })}
         >
             {isLoading && <Loading />}
             {isValidFunnel ? (

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -443,7 +443,7 @@ function FunnelInsight(): JSX.Element {
             style={
                 featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && display !== ACTIONS_LINE_GRAPH_LINEAR
                     ? {}
-                    : { height: 300, position: 'relative', marginBottom: 0 }
+                    : { position: 'relative', marginBottom: 0 }
             }
         >
             {isLoading && <Loading />}


### PR DESCRIPTION
## Changes

Fixes #5202

Fix empty state overflow for both old and new versions of funnels.

https://user-images.githubusercontent.com/13460330/126213450-b34afa7a-ceac-4cb7-ac66-044e7e3f994c.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
