### PR TITLE
Disable funnel average conversion time label behind FF and clickhouse check

### DIFF
--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -3,17 +3,20 @@ import { useActions, useValues } from 'kea'
 import { humanFriendlyDuration } from 'lib/utils'
 import React from 'react'
 import { Button, Tooltip } from 'antd'
+import { InfoCircleOutlined } from '@ant-design/icons'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { funnelLogic } from './funnelLogic'
 import './FunnelCanvasLabel.scss'
 import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
 import { ChartDisplayType } from '~/types'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function FunnelCanvasLabel(): JSX.Element | null {
     const { stepsWithCount, histogramStep, conversionMetrics } = useValues(funnelLogic)
     const { allFilters } = useValues(insightLogic)
     const { setChartFilter } = useActions(chartFilterLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     if (allFilters.insight !== 'FUNNELS') {
         return null
@@ -43,7 +46,10 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                     </span>
                     <Button
                         type="link"
-                        disabled={allFilters.display === ChartDisplayType.FunnelsTimeToConvert}
+                        disabled={
+                            !featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] ||
+                            allFilters.display === ChartDisplayType.FunnelsTimeToConvert
+                        }
                         onClick={() => setChartFilter(ChartDisplayType.FunnelsTimeToConvert)}
                     >
                         {humanFriendlyDuration(conversionMetrics.averageTime)}

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -9,14 +9,11 @@ import { funnelLogic } from './funnelLogic'
 import './FunnelCanvasLabel.scss'
 import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
 import { ChartDisplayType } from '~/types'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export function FunnelCanvasLabel(): JSX.Element | null {
-    const { stepsWithCount, histogramStep, conversionMetrics } = useValues(funnelLogic)
+    const { stepsWithCount, histogramStep, conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic)
     const { allFilters } = useValues(insightLogic)
     const { setChartFilter } = useActions(chartFilterLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     if (allFilters.insight !== 'FUNNELS') {
         return null
@@ -47,8 +44,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                     <Button
                         type="link"
                         disabled={
-                            !featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] ||
-                            allFilters.display === ChartDisplayType.FunnelsTimeToConvert
+                            !clickhouseFeaturesEnabled || allFilters.display === ChartDisplayType.FunnelsTimeToConvert
                         }
                         onClick={() => setChartFilter(ChartDisplayType.FunnelsTimeToConvert)}
                     >


### PR DESCRIPTION
## Changes

The average conversion time should not be clickable if the funnels FF isn't enabled or if clickhouse isn't enabled. Today it is clickable and takes the user to a white screen.

**Today**

<img width="459" alt="Screen Shot 2021-07-19 at 12 19 18 PM" src="https://user-images.githubusercontent.com/13460330/126215292-7cb29a3e-a7da-43e7-ad82-2a6520f55d68.png">

**Tomorrow (or probably later today)**

<img width="451" alt="Screen Shot 2021-07-19 at 12 22 38 PM" src="https://user-images.githubusercontent.com/13460330/126215344-f6f1e3f8-720a-404c-8df5-8689f630c215.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
