### PR TITLE
Fix no funnel time conversion

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1,4 +1,4 @@
-import { kea, isBreakpoint } from 'kea'
+import { kea } from 'kea'
 import api from 'lib/api'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { autocorrectInterval, objectsEqual, uuid } from 'lib/utils'
@@ -132,7 +132,6 @@ export const funnelLogic = kea<funnelLogicType>({
         }),
         setStepReference: (stepReference: FunnelStepReference) => ({ stepReference }),
         setBarGraphLayout: (barGraphLayout: FunnelLayout) => ({ barGraphLayout }),
-        setTimeConversionBins: (timeConversionBins: FunnelsTimeConversionBins) => ({ timeConversionBins }),
         changeHistogramStep: (from_step: number, to_step: number) => ({ from_step, to_step }),
         setIsGroupingOutliers: (isGroupingOutliers) => ({ isGroupingOutliers }),
     }),
@@ -148,13 +147,10 @@ export const funnelLogic = kea<funnelLogicType>({
             {
                 loadResults: async (refresh = false, breakpoint): Promise<LoadedRawFunnelResults> => {
                     if (props.cachedResults && !refresh && values.filters === props.filters) {
-                        // TODO: cache timeConversionBins? how does this cachedResults work?
+                        // TODO: cache timeConversionResults? how does this cachedResults work?
                         return {
                             results: props.cachedResults as FunnelStep[] | FunnelStep[][],
-                            timeConversionResults: {
-                                bins: [],
-                                average_conversion_time: 0,
-                            },
+                            timeConversionResults: EMPTY_FUNNEL_RESULTS.timeConversionResults,
                         }
                     }
 
@@ -215,9 +211,7 @@ export const funnelLogic = kea<funnelLogicType>({
 
                         return { results: result.result, timeConversionResults }
                     } catch (e) {
-                        if (!isBreakpoint(e)) {
-                            insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, null, e)
-                        }
+                        insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, null, e)
                         return EMPTY_FUNNEL_RESULTS
                     }
                 },
@@ -263,15 +257,6 @@ export const funnelLogic = kea<funnelLogicType>({
             FunnelLayout.vertical as FunnelLayout,
             {
                 setBarGraphLayout: (_, { barGraphLayout }) => barGraphLayout,
-            },
-        ],
-        timeConversionBins: [
-            {
-                bins: [] as [number, number][],
-                average_conversion_time: 0,
-            },
-            {
-                setTimeConversionBins: (_, { timeConversionBins }) => timeConversionBins,
             },
         ],
         histogramStep: [

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { isBreakpoint, kea } from 'kea'
 import api from 'lib/api'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { autocorrectInterval, objectsEqual, uuid } from 'lib/utils'
@@ -211,7 +211,9 @@ export const funnelLogic = kea<funnelLogicType>({
 
                         return { results: result.result, timeConversionResults }
                     } catch (e) {
-                        insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, null, e)
+                        if (!isBreakpoint(e)) {
+                            insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, null, e)
+                        }
                         return EMPTY_FUNNEL_RESULTS
                     }
                 },


### PR DESCRIPTION
## Changes

- Remove duplicate timeConversionBins kea value and always end query

Fixes #5211

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
