### PR TITLE
Fix prop values not loading if object

### DIFF
--- a/frontend/src/scenes/events/definitions/EventPropertiesStats.tsx
+++ b/frontend/src/scenes/events/definitions/EventPropertiesStats.tsx
@@ -72,11 +72,15 @@ export function EventPropertiesStats(): JSX.Element {
             title: 'Example',
             key: 'example',
             render: function renderExample({ name }: PropertyDefinition) {
+                let example = propertyExamples[name]
+                // Just show a json stringify if it's an array or object
+                example =
+                    Array.isArray(example) || example instanceof Object
+                        ? JSON.stringify(example).substr(0, 140)
+                        : example
                 return (
                     <div style={{ backgroundColor: '#F0F0F0', padding: '4px, 15px', textAlign: 'center' }}>
-                        <span style={{ fontSize: 10, fontWeight: 400, fontFamily: 'monaco' }}>
-                            {propertyExamples[name]}
-                        </span>
+                        <span style={{ fontSize: 10, fontWeight: 400, fontFamily: 'monaco' }}>{example}</span>
                     </div>
                 )
             },


### PR DESCRIPTION
## Changes

Drawer of event stats would error if a property had an object or array inside.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
