### PR TITLE
Fix cramped global filters dropdown

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -4,13 +4,13 @@
 .ant-popover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     font-size: 0.85rem;
-    max-width: 480px;
     overflow-x: hidden;
     z-index: $z_graph_tooltip;
     transition: all 0.4s;
 }
 
 .ph-graph-tooltip {
+    max-width: 480px;
     padding: 8px 0;
     border: 1px solid $border;
     border-radius: $radius;


### PR DESCRIPTION
## Changes

Remove the `max-width` we place on all antd popovers

**Before**

<img width="558" alt="Screen Shot 2021-07-19 at 2 12 32 PM" src="https://user-images.githubusercontent.com/13460330/126231142-7bfdb187-bb56-4889-a55e-322dec0fe004.png">

**After**

<img width="950" alt="Screen Shot 2021-07-19 at 2 57 21 PM" src="https://user-images.githubusercontent.com/13460330/126232681-043e60ad-8d29-41e6-8e07-677ffed2eb72.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
