### PR TITLE
Persons modal session recordings?

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -15,6 +15,7 @@ import { Link } from 'lib/components/Link'
 import './PersonModal.scss'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { ExpandIcon, ExpandIconProps } from 'lib/components/ExpandIcon'
+import { PlayCircleOutlined } from '@ant-design/icons'
 // Utility function to handle filter conversion required for deeplinking to person -> sessions
 const convertToSessionFilters = (people: TrendPeople, filters: Partial<FilterType>): SessionsPropertyFilter[] => {
     if (!people?.action) {
@@ -28,6 +29,10 @@ const convertToSessionFilters = (people: TrendPeople, filters: Partial<FilterTyp
         type: a.type === EntityTypes.ACTIONS ? ACTION_TYPE : EVENT_TYPE,
         properties: [...(a.properties || []), ...(filters.properties || [])] as EventPropertyFilter[], // combine global properties into action/event filter
     }))
+}
+
+const toSessionRecording = (id: string): string => {
+    return `sessions?sessionRecordingId=${id}`
 }
 
 interface Props {
@@ -210,7 +215,7 @@ export function PersonRow({ person, people, filters }: PersonRowProps): JSX.Elem
                 borderBottom: '1px solid #D9D9D9',
             }}
         >
-            <Row style={{ justifyContent: 'space-between' }}>
+            <Row style={{ justifyContent: 'space-between', alignItems: 'center' }}>
                 <Row>
                     <ExpandIcon {...expandProps}>{undefined}</ExpandIcon>
                     <Col>
@@ -229,6 +234,17 @@ export function PersonRow({ person, people, filters }: PersonRowProps): JSX.Elem
                         </div>
                     </Col>
                 </Row>
+                {person.session_recording && (
+                    <Link
+                        to={toSessionRecording(person.session_recording)}
+                        key={person.id}
+                        onClick={(event) => event.stopPropagation()}
+                        data-attr="sessions-player-button"
+                    >
+                        <PlayCircleOutlined style={{ fontSize: 16 }} />
+                        <span style={{ paddingLeft: 8, color: 'var(--text-muted-alt)' }}>Watch</span>
+                    </Link>
+                )}
                 <Button>
                     <Link
                         to={deepLinkToPersonSessions(

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -3,7 +3,7 @@ import api from 'lib/api'
 import { errorToast, toParams } from 'lib/utils'
 import { cleanFunnelParams, funnelLogic } from 'scenes/funnels/funnelLogic'
 import { cohortLogic } from 'scenes/persons/cohortLogic'
-import { ActionFilter, FilterType, ViewType } from '~/types'
+import { ActionFilter, FilterType, PersonType, SessionType, ViewType } from '~/types'
 import { personsModalLogicType } from './personsModalLogicType'
 import { parsePeopleParams, TrendPeople } from './trendsLogic'
 
@@ -17,6 +17,129 @@ interface PersonModalParams {
     saveOriginal?: boolean
     searchTerm?: string
     funnelStep?: number
+}
+
+function matchSessionsWithPeople(people: PersonType[], sessions: SessionType[]): PersonType[] {
+    const mockPeople = [
+        {
+            id: 1988,
+            name: 'jayne.joseph@hotmail.com',
+            distinct_ids: ['017ac14e-9275-0000-f8db-4acfaf3faaa9'],
+            properties: {
+                name: {
+                    last: 'Joseph',
+                    first: 'Jayne',
+                },
+                email: 'jayne.joseph@hotmail.com',
+                phone: '+1 (849) 532-2569',
+                address: '463 Fayette Street, Gardiner, Rhode Island, 6302',
+                is_demo: true,
+            },
+            is_identified: true,
+            created_at: '2021-07-20T00:26:29.948169Z',
+            uuid: '017ac14e-9231-0001-d8c2-9921858c0b1e',
+        },
+        {
+            id: 1987,
+            name: 'hubbard.powell@gmail.com',
+            distinct_ids: ['017ac14e-9274-0007-d507-5c7a438ac6b6'],
+            properties: {
+                name: {
+                    last: 'Powell',
+                    first: 'Hubbard',
+                },
+                email: 'hubbard.powell@gmail.com',
+                phone: '+1 (916) 465-3645',
+                address: '250 Falmouth Street, Jardine, Nevada, 2810',
+                is_demo: true,
+            },
+            is_identified: true,
+            created_at: '2021-07-20T00:26:29.948095Z',
+            uuid: '017ac14e-9231-0000-55db-c8e5e6c23f31',
+        },
+        {
+            id: 1984,
+            name: 'smith.nunez@gmail.com',
+            distinct_ids: ['017ac14e-9274-0004-eac9-6ef7892fc19a'],
+            properties: {
+                name: {
+                    last: 'Nunez',
+                    first: 'Smith',
+                },
+                email: 'smith.nunez@gmail.com',
+                phone: '+1 (807) 451-2087',
+                address: '670 Stryker Street, Gloucester, Minnesota, 2058',
+                is_demo: true,
+            },
+            is_identified: true,
+            created_at: '2021-07-20T00:26:29.947836Z',
+            uuid: '017ac14e-9230-0000-74c4-034f2a978626',
+        },
+    ]
+    const mockSessions = [
+        {
+            distinct_id: 'jXxaWiOntMbCdOuRVJIxTNJ4a3k2TpzmkjnOUrMRLuS',
+            global_session_id: 41,
+            length: 175,
+            start_time: '2021-07-19T23:56:29.821000Z',
+            end_time: '2021-07-19T23:59:24.005000Z',
+            start_url: null,
+            end_url: 'https://teq-posthog-dev.herokuapp.com/events?properties=%7B%7D',
+            matching_events: [],
+            email: 'zeke+dev@tequitable.com',
+            session_recordings: [],
+        },
+        {
+            distinct_id: 'Orbit Love Report Sync',
+            global_session_id: 24,
+            length: 86339,
+            start_time: '2021-07-19T00:00:14.248000Z',
+            end_time: '2021-07-19T23:59:13.690000Z',
+            start_url: null,
+            end_url: null,
+            matching_events: [],
+            email: 'smith.nunez@gmail.com',
+            session_recordings: [
+                {
+                    id: '17ac1325a6e3c-04fadeb1b4be558-4c3f2d73-15f900-17ac1325a6f4ee',
+                    recording_duration: 165,
+                    viewed: false,
+                },
+            ],
+        },
+        {
+            distinct_id: '843738a51abceeb8b997d4f5b7b8ec0d',
+            global_session_id: 13,
+            length: 86340,
+            start_time: '2021-07-19T00:00:00.809000Z',
+            end_time: '2021-07-19T23:59:00.576000Z',
+            start_url: null,
+            end_url: null,
+            matching_events: [],
+            email: null,
+            session_recordings: [],
+        },
+    ]
+    const fakeResponse = mockPeople.map((p) => {
+        const sessionRecording = mockSessions.find(
+            (s) =>
+                s.email === p.properties.email &&
+                s.session_recordings.length > 0 &&
+                s.session_recordings[0].recording_duration > 0
+        )
+        p.session_recording = sessionRecording?.session_recordings[0].id
+        return p
+    })
+    return people.map((p) => {
+        const sessionRecording = sessions.find(
+            (s) =>
+                s.email === p.properties.email &&
+                s.session_recordings.length > 0 &&
+                s.session_recordings[0].recording_duration > 0
+        )
+        p.session_recording = sessionRecording?.session_recordings[0].id
+        return p
+    })
 }
 
 export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
@@ -159,7 +282,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
             breakpoint()
             actions.setPeopleLoading(false)
             const peopleResult = {
-                people: people.results[0]?.people,
+                people: matchSessionsWithPeople(people.results[0]?.people, people.results[0]?.sessions),
                 count: people.results[0]?.count || 0,
                 action,
                 label,

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -18,6 +18,7 @@ style files without adding already imported styles. */
     --success: #{$success};
     --danger: #{$danger};
     --warning: #{$warning};
+    --text-muted-alt: #{$text_muted_alt};
     --bg-menu: #{$bg_menu};
     --bg-mid: #{$bg_mid};
     --bg-charcoal: #{$bg_charcoal};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -326,6 +326,7 @@ export interface PersonType {
     properties: Record<string, any>
     is_identified: boolean
     created_at?: string
+    session_recording?: string
 }
 
 export interface CohortGroupType {


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Here we are matching a return list of sessions (for just TRENDS persons rn, but the same logic would be applied to the other person modal calls too), and not session recordings because adding the session recording filter on it makes the query extremely slow (on production that filter takes like 40 seconds)

And thennn we are trying to match it to the persons to see if any of those people have a valid session recording 😭 

Obviously this is less than ideal but we're looking for a super hacky temporary solution that could provide any quick value 

ALSO. My CH setup is messed up and I have no data on it right now. I left some mock data up

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
