### PR TITLE
bump clickhouse_orm version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ gunicorn==20.1.0
 grpcio==1.33.1
 idna==2.8
 importlib-metadata==1.6.0
-git+git://github.com/PostHog/infi.clickhouse_orm@369320b390d132799804728844673215540a04b2
+git+git://github.com/PostHog/infi.clickhouse_orm@f6f4838a75513773696737c9ac37a164af9be632
 kafka-python==2.0.1
 kafka-helper==0.2
 kombu==4.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ idna==2.8
     #   requests
 importlib-metadata==1.6.0
     # via -r requirements.in
-git+git://github.com/PostHog/infi.clickhouse_orm@369320b390d132799804728844673215540a04b2
+git+git://github.com/PostHog/infi.clickhouse_orm@f6f4838a75513773696737c9ac37a164af9be632
     # via -r requirements.in
 iso8601==0.1.12
     # via infi.clickhouse-orm


### PR DESCRIPTION
## Changes

pulls in a fix for clickhouse migrations library for it to use the correct table name and columns.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
