### PR TITLE
Reload actions once one is created

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -4,26 +4,33 @@ describe('Actions', () => {
         cy.get('[data-attr=events-actions-tab]').click()
     })
 
-    it('Actions loaded', () => {
-        cy.get('[data-attr=actions-table]').should('exist')
-    })
-
-    it('Click on an action', () => {
-        cy.get('[data-attr=action-link-0]').click()
-        cy.get('h1').should('contain', 'Editing action')
-    })
-
     it('Create action', () => {
+        let name = Cypress._.random(0, 1e6)
         cy.get('[data-attr=create-action]').click()
         cy.get('.ant-card-head-title').should('contain', 'event or pageview')
         cy.get('[data-attr=new-action-pageview]').click()
         cy.get('h1').should('contain', 'Creating action')
 
-        cy.get('[data-attr=edit-action-input]').type(Cypress._.random(0, 1e6))
+        cy.get('[data-attr=edit-action-input]').type(name)
         cy.get('.ant-radio-group > :nth-child(3)').click()
         cy.get('[data-attr=edit-action-url-input]').type(Cypress.config().baseUrl)
         cy.get('[data-attr=save-action-button]').click()
 
         cy.contains('Action saved').should('exist')
+
+        // Test the action is immediately available
+        cy.clickNavMenu('insights')
+
+        cy.contains('Add graph series').click()
+        cy.get('[data-attr=trend-element-subject-1]').click()
+        cy.get('[data-attr="select-box-input"]').type(name)
+        cy.contains(name).click()
+        cy.get('[data-attr=trend-element-subject-1] span').should('contain', name)
+    })
+
+    it('Click on an action', () => {
+        cy.get('[data-attr=actions-table]').should('exist')
+        cy.get('[data-attr=action-link-0]').click()
+        cy.get('h1').should('contain', 'Editing action')
     })
 })

--- a/frontend/src/scenes/actions/actionEditLogic.js
+++ b/frontend/src/scenes/actions/actionEditLogic.js
@@ -2,6 +2,7 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { uuid } from 'lib/utils'
 import { toast } from 'react-toastify'
+import { actionsModel } from '~/models/actionsModel'
 
 export const actionEditLogic = kea({
     key: (props) => props.id || 'new',
@@ -65,6 +66,7 @@ export const actionEditLogic = kea({
             }
             toast('Action saved')
             props.onSave(action, values.createNew)
+            actionsModel.actions.loadActions() // reload actions so they are immediately available
         },
     }),
 


### PR DESCRIPTION
## Changes

Before users would have to refresh posthog before an action was available.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
