### PR TITLE
Hotfix for funnel historical trends & histogram being always hidden

### DIFF
--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -7,14 +7,16 @@ import { funnelLogic } from './funnelLogic'
 
 export function Funnel(props: Omit<ChartParams, 'view'>): JSX.Element | null {
     const logic = funnelLogic({ dashboardItemId: props.dashboardItemId, filters: props.filters })
-    const { timeConversionBins } = useValues(logic)
+    const { timeConversionBins, filters } = useValues(logic)
     const { loadResults } = useActions(logic)
 
     useEffect(() => {
         loadResults()
     }, [])
 
-    if (props.filters.display == ChartDisplayType.FunnelsTimeToConvert) {
+    const display = filters.display || props.filters.display
+
+    if (display == ChartDisplayType.FunnelsTimeToConvert) {
         return timeConversionBins?.bins?.length ? <FunnelHistogram {...props} /> : null
     }
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -305,6 +305,11 @@ export const funnelLogic = kea<funnelLogicType>({
                 )
             },
         ],
+        showBarGraph: [
+            () => [selectors.filters],
+            ({ display }: { display: ChartDisplayType }) =>
+                display === ChartDisplayType.FunnelViz || display === ChartDisplayType.FunnelsTimeToConvert,
+        ],
         clickhouseFeaturesEnabled: [
             () => [featureFlagLogic.selectors.featureFlags, selectors.preflight],
             // Controls auto-calculation of results and ability to break down values

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -436,6 +436,7 @@ function FunnelInsight(): JSX.Element {
         isLoading,
         areFiltersValid,
         filters: { display },
+        showBarGraph,
     } = useValues(funnelLogic({}))
     const { clickhouseFeaturesEnabled } = useValues(funnelLogic)
 
@@ -452,7 +453,7 @@ function FunnelInsight(): JSX.Element {
         >
             {isLoading && <Loading />}
             {isValidFunnel ? (
-                featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] ? (
+                featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && showBarGraph ? (
                     <FunnelBarGraph filters={{ display }} />
                 ) : (
                     <FunnelViz filters={{ display }} />

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -48,8 +48,8 @@ import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { FunnelHistogramHeader } from 'scenes/funnels/FunnelHistogram'
-import { FunnelBarGraph } from 'scenes/funnels/FunnelBarGraph'
 import clsx from 'clsx'
+import { Funnel } from 'scenes/funnels/Funnel'
 
 export interface BaseTabProps {
     annotationsToCreate: any[] // TODO: Type properly
@@ -454,7 +454,7 @@ function FunnelInsight(): JSX.Element {
             {isLoading && <Loading />}
             {isValidFunnel ? (
                 featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && showBarGraph ? (
-                    <FunnelBarGraph filters={{ display }} />
+                    <Funnel filters={{ display }} />
                 ) : (
                     <FunnelViz filters={{ display }} />
                 )


### PR DESCRIPTION
## Changes

Recent changes and likely some mistakes while rebasing / resolving merge conflicts caused 2/3 funnel views (Historical and Time to Convert) to never be shown.

This PR:
- adds a correct selector for the render condition of Steps and Time to Convert, which resolves the issue.
- uses Funnel component instead of FunnelBarGraph which has an additional render condition to delineate Steps vs Time to Convert.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
