### PR TITLE
Warn when exiting plugin source edit with changes

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -84,7 +84,14 @@ export function PluginSource(): JSX.Element {
         <Drawer
             forceRender={true}
             visible={editingSource}
-            onClose={() => setEditingSource(false)}
+            onClose={() => {
+                if (form.getFieldValue('source') !== editingPlugin?.source) {
+                    confirm('You have unsaved changes in your plugin. Are you sure you want to exit?') &&
+                        setEditingSource(false)
+                } else {
+                    setEditingSource(false)
+                }
+            }}
             width={'min(90vw, 64rem)'}
             title={`Coding Plugin: ${editingPlugin?.name}`}
             placement="left"


### PR DESCRIPTION
## Changes

Show warning message when closing or esc'ing from the plugin edit source if you have made changes.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
