### PR TITLE
Fix CH no data dev blocker

### DIFF
--- a/ee/bin/docker-ch-dev-backend
+++ b/ee/bin/docker-ch-dev-backend
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -e
+
+export CLICKHOUSE_REPLICATION=true
+
 python manage.py migrate
 python manage.py migrate_clickhouse
 


### PR DESCRIPTION
## Changes

There was a blocker where no data was showing up in local CH dev environments, making it really difficult to test or develop any CH features (funnels).

For those of us who've been blockedby this, these are the steps you can take to get unblocked:

1. Checkout `master` and `git pull` (pulls down [James's latest commit](https://github.com/PostHog/posthog/commit/1c1d4a11cdd2261369525e2ba50caa0ff4f8a5c1) and this one)
2. Delete `ee_web` Docker image
3. Run `yarn start-ch-web`  to rebuild with latest `requirements.txt`
    a. sanity check - make sure `requirements.txt` has this latest version of `PostHog/infi.clickhouse_orm@f6f4838a75513773696737c9ac37a164af9be632`
5. You should have data now!

**tl;dr - Kafka events were being flushed into the void because the CH `events` table wasn't being initialized as a Kafka consumer. This PR fixes that.**

EE Django migrations weren't running on local dev environments because of a recent `CLICKHOUSE_REPLICATION` toggle we introduced in this PR. It seems like the intent was to create a deduping source of truth for migrations already applied on CH; however, the default false flag was silencing all ee migrations triggered by `python manage.py migrate_clickhouse` . This was preventing an important migration to be run that would initialize the CH `events` table as a Kafka consumer. Because there were no consumers initialized, it makes sense that CH events  stayed empty which was reflected by emptiness in app.posthog.com. I believe this was affecting all dev setups based off of `docker-compose.ch.yml`.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
