### PR TITLE
Revert "Fix CH no data dev blocker"

### DIFF
--- a/ee/bin/docker-ch-dev-backend
+++ b/ee/bin/docker-ch-dev-backend
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 set -e
-
-export CLICKHOUSE_REPLICATION=true
-
 python manage.py migrate
 python manage.py migrate_clickhouse
 


### PR DESCRIPTION
Reverts PostHog/posthog#5238

Thanks to @macobo for helping me debug this further.

### Root Cause

Local CH `infi_clickhouse_orm_migrations` volume was already populated with migrations. Volumes were persisting across `docker-compose up`'s which meant that certain business critical migrations like `0004_kafka` (which makes the CH events table a Kafka consumer) weren't being initialized.

### Revised steps to unbork dev environment and get CH data again

1. Checkout `master:latest`
2. Delete `ee_web` Docker image
2. Make sure all docker containers are stopped and removed - `docker-compose rm -v`
3. `docker volume prune`
4. `docker-compose up` or `yarn start-ch-dev`

### Context from @macobo via Slack about replicated CH nodes:

> So clickhouse is intended to run on scale, as we do. To do that you can't only scale vertically, but also horizontally across many nodes. To do analytics clickhouse has a bunch of table engines, with variants that support distributing the data across nodes. MergeTree family database table engines are the ones we use for analytics. ReplicatedMergeTree ones are the ones that replicate data across nodes. In local dev and elsewhere we only use single node for clickhouse for now - hence CLICKHOUSE_REPLICATION false. On cloud we have some very specific work done that isn't yet checked in that makes CLICKHOUSE_REPLICATION=true actually work (some tables not under our code management). Work will be done eventually to make CLICKHOUSE_REPLICATION=true work for all setups, but it doesn't really yet.

> For tracking migrations specifically there's a special table in clickhouse where the state of migrations is managed. To get migrations running better on cloud, james made it replicated, but this broke down in tests, so I made it not distributed in tests/dev based on the env flag. (tests didn't work since they tried to wipe/remigrate data a bunch of times in weird ways which the replicated table did not allow). I guess you set up your dev setup sometime between james' fix and mine, hence the issues.
