### PR TITLE
Fixes various time conversion bugs

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -35,6 +35,14 @@ export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
             adjustY: 0,
         },
     },
+    bottomRight: {
+        points: ['tr', 'br'],
+        offset: [0, 4],
+        overflow: {
+            adjustX: 0,
+            adjustY: 0,
+        },
+    },
     topLeft: {
         points: ['bl', 'tl'],
         offset: [0, -4],

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -11,7 +11,7 @@ import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
 import { FunnelVizType } from '~/types'
 
 export function FunnelCanvasLabel(): JSX.Element | null {
-    const { stepsWithCount, histogramStep, conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic)
+    const { conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic)
     const { allFilters } = useValues(insightLogic)
     const { setChartFilter } = useActions(chartFilterLogic)
 
@@ -25,7 +25,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                 <>
                     <span className="text-muted-alt">
                         <Tooltip title="Overall conversion rate for all users on the entire funnel.">
-                            <InfoCircleOutlined style={{ marginRight: 3 }} />
+                            <InfoCircleOutlined className="info-indicator left" />
                         </Tooltip>
                         Total conversion rate:{' '}
                     </span>
@@ -33,25 +33,19 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                     <span style={{ margin: '2px 8px', borderLeft: '1px solid var(--border)' }} />
                 </>
             )}
-            {stepsWithCount[histogramStep.from_step]?.average_conversion_time !== null && (
-                <>
-                    <span className="text-muted-alt">
-                        <Tooltip title="Average (arithmetic mean) of the total time each user spent in the enitre funnel.">
-                            <InfoCircleOutlined style={{ marginRight: 3 }} />
-                        </Tooltip>
-                        Average time to convert:{' '}
-                    </span>
-                    <Button
-                        type="link"
-                        onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}
-                        disabled={
-                            !clickhouseFeaturesEnabled || allFilters.funnel_viz_type === FunnelVizType.TimeToConvert
-                        }
-                    >
-                        {humanFriendlyDuration(conversionMetrics.averageTime)}
-                    </Button>
-                </>
-            )}
+            <span className="text-muted-alt">
+                <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
+                    <InfoCircleOutlined className="info-indicator left" />
+                </Tooltip>
+                Average time to convert:{' '}
+            </span>
+            <Button
+                type="link"
+                onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}
+                disabled={!clickhouseFeaturesEnabled || allFilters.funnel_viz_type === FunnelVizType.TimeToConvert}
+            >
+                {humanFriendlyDuration(conversionMetrics.averageTime)}
+            </Button>
         </div>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -31,7 +31,7 @@ export function FunnelHistogramHeader(): JSX.Element | null {
                         changeHistogramStep(from_step, from_step + 1)
                     }}
                     dropdownMatchSelectWidth={false}
-                    dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomLeft}
+                    dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
                     data-attr="funnel-bar-layout-selector"
                     optionLabelProp="label"
                 >

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -163,6 +163,11 @@ export const funnelLogic = kea<funnelLogicType>({
                             const result = await pollFunnel<FunnelStep[] | FunnelStep[][]>({
                                 ...apiParams,
                                 ...(refresh ? { refresh } : {}),
+                                // Time to convert requires steps funnel api to be called for now. Remove once two api's are functionally separated
+                                funnel_viz_type:
+                                    filters.funnel_viz_type === FunnelVizType.TimeToConvert
+                                        ? FunnelVizType.Steps
+                                        : apiParams.funnel_viz_type,
                             })
                             eventUsageLogic.actions.reportFunnelCalculated(eventCount, actionCount, interval, true)
                             return result

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -180,27 +180,23 @@ export const funnelLogic = kea<funnelLogicType>({
                                 false,
                                 e.message
                             )
-                            throw new Error('Could not load funnel results')
+                            throw e
                         }
                     }
 
                     async function loadBinsResults(): Promise<FunnelsTimeConversionBins> {
                         if (filters.funnel_viz_type === FunnelVizType.TimeToConvert) {
-                            try {
-                                // API specs (#5110) require neither funnel_{from|to}_step to be provided if querying
-                                // for all steps
-                                const isAllSteps = values.histogramStep.from_step === -1
+                            // API specs (#5110) require neither funnel_{from|to}_step to be provided if querying
+                            // for all steps
+                            const isAllSteps = values.histogramStep.from_step === -1
 
-                                const binsResult = await pollFunnel<FunnelsTimeConversionBins>({
-                                    ...apiParams,
-                                    ...(refresh ? { refresh } : {}),
-                                    ...(!isAllSteps ? { funnel_from_step: histogramStep.from_step } : {}),
-                                    ...(!isAllSteps ? { funnel_to_step: histogramStep.to_step } : {}),
-                                })
-                                return cleanBinResult(binsResult.result)
-                            } catch (e) {
-                                throw new Error('Could not load funnel time conversion bins')
-                            }
+                            const binsResult = await pollFunnel<FunnelsTimeConversionBins>({
+                                ...apiParams,
+                                ...(refresh ? { refresh } : {}),
+                                ...(!isAllSteps ? { funnel_from_step: histogramStep.from_step } : {}),
+                                ...(!isAllSteps ? { funnel_to_step: histogramStep.to_step } : {}),
+                            })
+                            return cleanBinResult(binsResult.result)
                         }
                         return EMPTY_FUNNEL_RESULTS.timeConversionResults
                     }
@@ -218,8 +214,8 @@ export const funnelLogic = kea<funnelLogicType>({
                     } catch (e) {
                         if (!isBreakpoint(e)) {
                             insightLogic.actions.endQuery(queryId, ViewType.FUNNELS, null, e)
+                            console.error(e)
                         }
-                        console.error(e)
                         return EMPTY_FUNNEL_RESULTS
                     }
                 },

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -17,5 +17,10 @@
                 display: none; // hide axis line
             }
         }
+
+        g#x-axis,
+        g#y-axis {
+            font-size: 14px;
+        }
     }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -457,6 +457,11 @@ code.code {
     color: $primary !important;
     cursor: pointer;
     margin-left: 5px;
+
+    &.left {
+        margin-left: 0;
+        margin-right: 5px;
+    }
 }
 
 .btn-lg-2x {


### PR DESCRIPTION
## Changes

- [x] Bring back missing steps dropdown
- [x] Bottom right align steps dropdown to fix page overflow
- [x] Standardize info indicator look
- [x] Copy typo
- [x] Show missing average time and fix value
- [x] Standardize histogram axes font sizes

**Some after pics**

<img width="1033" alt="Screen Shot 2021-07-21 at 12 32 44 AM" src="https://user-images.githubusercontent.com/13460330/126449529-c58b3fbe-c126-4ed5-8599-eadfa1d4b648.png">

<img width="417" alt="Screen Shot 2021-07-21 at 12 32 48 AM" src="https://user-images.githubusercontent.com/13460330/126449525-a2e25352-338f-4513-b030-fe2e6411b77e.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
