### PR TITLE
Add bin counts dropdown to Funnel Time Conversion

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -257,10 +257,7 @@ export enum FunnelLayout {
     vertical = 'vertical',
 }
 
-export enum BinCountPresets {
-    auto = 'auto',
-    custom = 'custom',
-}
+export const BinCountAuto = 'auto'
 
 export const ERROR_MESSAGES: Record<string, string> = {
     no_new_organizations:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -257,6 +257,11 @@ export enum FunnelLayout {
     vertical = 'vertical',
 }
 
+export enum BinCountPresets {
+    auto = 'auto',
+    custom = 'custom',
+}
+
 export const ERROR_MESSAGES: Record<string, string> = {
     no_new_organizations:
         'Your email address is not associated with an account. Please ask your administrator for an invite.',

--- a/frontend/src/scenes/funnels/FunnelViz.scss
+++ b/frontend/src/scenes/funnels/FunnelViz.scss
@@ -111,3 +111,18 @@
         }
     }
 }
+
+.funnel-bin-filter-dropdown {
+    .funnel-bins-custom-picker {
+        width: 43px; // enough to hold two characters
+        margin: 5px 0 5px 13px; // margin left comes from 24px (padding left select option) - 11px (padding inside input)
+
+        .ant-input-number-handler-wrap {
+            display: none;
+        }
+    }
+
+    .select-option-hidden {
+        display: none;
+    }
+}

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -171,6 +171,7 @@ export const funnelLogic = kea<funnelLogicType>({
             EMPTY_FUNNEL_RESULTS as LoadedRawFunnelResults,
             {
                 loadResults: async (refresh = false, breakpoint): Promise<LoadedRawFunnelResults> => {
+                    await breakpoint(250)
                     if (props.cachedResults && !refresh && values.filters === props.filters) {
                         // TODO: cache timeConversionResults? how does this cachedResults work?
                         return {
@@ -610,8 +611,7 @@ export const funnelLogic = kea<funnelLogicType>({
                 actions.setFilters(filters, true)
             }
         },
-        loadConversionWindow: async ({ days }, breakpoint) => {
-            await breakpoint(250)
+        loadConversionWindow: async ({ days }) => {
             actions.setConversionWindowInDays(days)
             actions.loadResults()
         },
@@ -627,12 +627,10 @@ export const funnelLogic = kea<funnelLogicType>({
                 funnelStep: stepNumber,
             })
         },
-        changeHistogramStep: async (_, breakpoint) => {
-            await breakpoint(250)
+        changeHistogramStep: async () => {
             actions.loadResults()
         },
-        setBinCount: async (_, breakpoint) => {
-            await breakpoint(250)
+        setBinCount: async () => {
             actions.loadResults()
         },
     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -184,7 +184,7 @@ export const funnelLogic = kea<funnelLogicType>({
                         return EMPTY_FUNNEL_RESULTS
                     }
 
-                    const { apiParams, eventCount, actionCount, interval, histogramStep, filters } = values
+                    const { apiParams, eventCount, actionCount, interval, histogramStep, filters, binCount } = values
 
                     async function loadFunnelResults(): Promise<FunnelResult<FunnelStep[] | FunnelStep[][]>> {
                         try {
@@ -223,7 +223,7 @@ export const funnelLogic = kea<funnelLogicType>({
                                 ...(refresh ? { refresh } : {}),
                                 ...(!isAllSteps ? { funnel_from_step: histogramStep.from_step } : {}),
                                 ...(!isAllSteps ? { funnel_to_step: histogramStep.to_step } : {}),
-                                ...(filters.bin_count ? { bin_count: filters.bin_count } : {}),
+                                ...(binCount && binCount !== BinCountPresets.auto ? { bin_count: binCount } : {}),
                             })
                             return cleanBinResult(binsResult.result)
                         }
@@ -627,7 +627,12 @@ export const funnelLogic = kea<funnelLogicType>({
                 funnelStep: stepNumber,
             })
         },
-        changeHistogramStep: () => {
+        changeHistogramStep: async (_, breakpoint) => {
+            await breakpoint(1000)
+            actions.loadResults()
+        },
+        setBinCount: async (_, breakpoint) => {
+            await breakpoint(1000)
             actions.loadResults()
         },
     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -23,10 +23,10 @@ import {
     LoadedRawFunnelResults,
     FlattenedFunnelStep,
     FunnelStepWithConversionMetrics,
-    BinCountValues,
+    BinCountValue,
 } from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { BinCountPresets, FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
+import { FEATURE_FLAGS, FunnelLayout, BinCountAuto } from 'lib/constants'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
 import { calcPercentage, cleanBinResult, getLastFilledStep, getReferenceStep } from './funnelUtils'
@@ -120,7 +120,7 @@ export const cleanFunnelParams = (filters: Partial<FilterType>, discardFiltersNo
         ...(filters.entrance_period_start ? { entrance_period_start: filters.entrance_period_start } : {}),
         ...(filters.drop_off ? { drop_off: filters.drop_off } : {}),
         ...(filters.funnel_step_breakdown ? { funnel_step_breakdown: filters.funnel_step_breakdown } : {}),
-        ...(filters.bin_count && filters.bin_count !== BinCountPresets.auto ? { bin_count: filters.bin_count } : {}),
+        ...(filters.bin_count && filters.bin_count !== BinCountAuto ? { bin_count: filters.bin_count } : {}),
         interval: autocorrectInterval(filters),
         breakdown: breakdownEnabled ? filters.breakdown || undefined : undefined,
         breakdown_type: breakdownEnabled ? filters.breakdown_type || undefined : undefined,
@@ -158,7 +158,7 @@ export const funnelLogic = kea<funnelLogicType>({
         changeHistogramStep: (from_step: number, to_step: number) => ({ from_step, to_step }),
         setIsGroupingOutliers: (isGroupingOutliers) => ({ isGroupingOutliers }),
         setLastAppliedFilters: (filters: FilterType) => ({ filters }),
-        setBinCount: (bin_count: BinCountValues) => ({ bin_count }),
+        setBinCount: (binCount: BinCountValue) => ({ binCount }),
     }),
 
     connect: {
@@ -223,7 +223,7 @@ export const funnelLogic = kea<funnelLogicType>({
                                 ...(refresh ? { refresh } : {}),
                                 ...(!isAllSteps ? { funnel_from_step: histogramStep.from_step } : {}),
                                 ...(!isAllSteps ? { funnel_to_step: histogramStep.to_step } : {}),
-                                ...(binCount && binCount !== BinCountPresets.auto ? { bin_count: binCount } : {}),
+                                ...(binCount && binCount !== BinCountAuto ? { bin_count: binCount } : {}),
                             })
                             return cleanBinResult(binsResult.result)
                         }
@@ -305,9 +305,9 @@ export const funnelLogic = kea<funnelLogicType>({
             },
         ],
         binCount: [
-            BinCountPresets.auto,
+            BinCountAuto as BinCountValue,
             {
-                setBinCount: (_, { bin_count }) => bin_count,
+                setBinCount: (_, { binCount }) => binCount,
             },
         ],
     }),
@@ -560,7 +560,7 @@ export const funnelLogic = kea<funnelLogicType>({
         numericBinCount: [
             () => [selectors.binCount, selectors.timeConversionBins],
             (binCount, bins): number => {
-                if (binCount === BinCountPresets.auto) {
+                if (binCount === BinCountAuto) {
                     return bins?.bins.length || 0
                 }
                 return binCount

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -223,6 +223,7 @@ export const funnelLogic = kea<funnelLogicType>({
                                 ...(refresh ? { refresh } : {}),
                                 ...(!isAllSteps ? { funnel_from_step: histogramStep.from_step } : {}),
                                 ...(!isAllSteps ? { funnel_to_step: histogramStep.to_step } : {}),
+                                ...(filters.bin_count ? { bin_count: filters.bin_count } : {}),
                             })
                             return cleanBinResult(binsResult.result)
                         }
@@ -554,6 +555,15 @@ export const funnelLogic = kea<funnelLogicType>({
                     }
                 })
                 return flattenedSteps
+            },
+        ],
+        numericBinCount: [
+            () => [selectors.binCount, selectors.timeConversionBins],
+            (binCount, bins): number => {
+                if (binCount === BinCountPresets.auto) {
+                    return bins?.bins.length || 0
+                }
+                return binCount
             },
         ],
     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -23,9 +23,10 @@ import {
     LoadedRawFunnelResults,
     FlattenedFunnelStep,
     FunnelStepWithConversionMetrics,
+    BinCountValues,
 } from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
+import { BinCountPresets, FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
 import { calcPercentage, cleanBinResult, getLastFilledStep, getReferenceStep } from './funnelUtils'
@@ -119,6 +120,7 @@ export const cleanFunnelParams = (filters: Partial<FilterType>, discardFiltersNo
         ...(filters.entrance_period_start ? { entrance_period_start: filters.entrance_period_start } : {}),
         ...(filters.drop_off ? { drop_off: filters.drop_off } : {}),
         ...(filters.funnel_step_breakdown ? { funnel_step_breakdown: filters.funnel_step_breakdown } : {}),
+        ...(filters.bin_count && filters.bin_count !== BinCountPresets.auto ? { bin_count: filters.bin_count } : {}),
         interval: autocorrectInterval(filters),
         breakdown: breakdownEnabled ? filters.breakdown || undefined : undefined,
         breakdown_type: breakdownEnabled ? filters.breakdown_type || undefined : undefined,
@@ -156,6 +158,7 @@ export const funnelLogic = kea<funnelLogicType>({
         changeHistogramStep: (from_step: number, to_step: number) => ({ from_step, to_step }),
         setIsGroupingOutliers: (isGroupingOutliers) => ({ isGroupingOutliers }),
         setLastAppliedFilters: (filters: FilterType) => ({ filters }),
+        setBinCount: (bin_count: BinCountValues) => ({ bin_count }),
     }),
 
     connect: {
@@ -298,6 +301,12 @@ export const funnelLogic = kea<funnelLogicType>({
             (props.filters || {}) as FilterType,
             {
                 setLastAppliedFilters: (_, { filters }) => filters,
+            },
+        ],
+        binCount: [
+            BinCountPresets.auto,
+            {
+                setBinCount: (_, { bin_count }) => bin_count,
             },
         ],
     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -611,7 +611,7 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         loadConversionWindow: async ({ days }, breakpoint) => {
-            await breakpoint(1000)
+            await breakpoint(250)
             actions.setConversionWindowInDays(days)
             actions.loadResults()
         },
@@ -628,11 +628,11 @@ export const funnelLogic = kea<funnelLogicType>({
             })
         },
         changeHistogramStep: async (_, breakpoint) => {
-            await breakpoint(1000)
+            await breakpoint(250)
             actions.loadResults()
         },
         setBinCount: async (_, breakpoint) => {
-            await breakpoint(1000)
+            await breakpoint(250)
             actions.loadResults()
         },
     }),

--- a/frontend/src/scenes/insights/Histogram/__snapshots__/histogramLogic.test.ts.snap
+++ b/frontend/src/scenes/insights/Histogram/__snapshots__/histogramLogic.test.ts.snap
@@ -35,7 +35,7 @@ Object {
       "barLabelPadding": 8,
       "btwnBins": 6,
       "labelLineHeight": 1.2,
-      "minBarWidth": 95,
+      "minBarWidth": 90,
       "xLabel": 8,
       "yLabel": 5,
     },

--- a/frontend/src/scenes/insights/Histogram/histogramUtils.ts
+++ b/frontend/src/scenes/insights/Histogram/histogramUtils.ts
@@ -37,7 +37,7 @@ export const INITIAL_CONFIG = {
         xLabel: 8, // x-axis label xOffset in horizontal position
         labelLineHeight: 1.2, // line height of wrapped label text in em's,
         barLabelPadding: 8, // padding between bar and bar label,
-        minBarWidth: 95, // minimum bar width
+        minBarWidth: 90, // minimum bar width
     },
 }
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -6,12 +6,6 @@ import { InputNumber, Select } from 'antd'
 import { BinCountValues } from '~/types'
 import { BarChartOutlined } from '@ant-design/icons'
 
-// export const binOptionsMapping: Record<string, number | 'auto' | 'custom'> = {
-//     custom: 'custom',
-//     auto: 'auto',
-//     ...Object.assign({}, ...Array.from([3, 5, 10, 25, 50, 75, 90], (v) => ({ [v]: v }))),
-// }
-
 const options = [
     {
         label: 'Automatic',
@@ -37,6 +31,8 @@ export function FunnelBinsPicker(): JSX.Element {
 
     return (
         <Select
+            id="funnel-bin-filter"
+            data-attr="funnel-bin-filter"
             defaultValue={BinCountPresets.auto}
             value={binCount}
             onChange={(count: BinCountValues) => {
@@ -63,7 +59,6 @@ export function FunnelBinsPicker(): JSX.Element {
             open={open || customPickerOpen}
             bordered={false}
             dropdownMatchSelectWidth={false}
-            data-attr="funnel-time-conversion-bin-selector"
             optionLabelProp="label"
             dropdownRender={(menu: React.ReactElement) => {
                 if (customPickerOpen) {
@@ -76,7 +71,12 @@ export function FunnelBinsPicker(): JSX.Element {
                                     fontWeight: 700,
                                 }}
                                 href="#"
-                                onClick={props.onClick}
+                                onClick={(e) => {
+                                    e.preventDefault()
+                                    setOpen(true)
+                                    setCustomPickerOpen(false)
+                                    document.getElementById('funnel-bin-filter')?.focus()
+                                }}
                             >
                                 &lt;
                             </a>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -11,7 +11,7 @@ import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 interface BinOption {
     key?: string
     label: string
-    value: BinCountValue
+    value: BinCountValue | 'custom'
     display: boolean
 }
 
@@ -59,7 +59,12 @@ export function FunnelBinsPicker(): JSX.Element {
                                 min={MIN}
                                 max={MAX}
                                 value={numericBinCount}
-                                onChange={(count) => setBinCount(count)}
+                                onChange={(count) => {
+                                    const parsedCount = typeof count === 'string' ? parseInt(count) : count
+                                    if (parsedCount) {
+                                        setBinCount(parsedCount)
+                                    }
+                                }}
                             />{' '}
                             bins
                         </div>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import { BinCountPresets } from 'lib/constants'
+import { BinCountAuto } from 'lib/constants'
 import { InputNumber, Select } from 'antd'
-import { BinCountValues } from '~/types'
+import { BinCountValue } from '~/types'
 import { BarChartOutlined } from '@ant-design/icons'
 import clsx from 'clsx'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
@@ -11,17 +11,17 @@ import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 interface BinOption {
     key?: string
     label: string
-    value: BinCountValues
+    value: BinCountValue
     display: boolean
 }
 
 const MIN = 0,
     MAX = 90 // constraints defined by backend #4995
-const NUMBER_PRESETS = new Set([5, 10, 15, 25, 50, 90])
+const NUMBER_PRESETS = new Set([5, 15, 25, 50, 90])
 const options: BinOption[] = [
     {
-        label: 'Automatic',
-        value: BinCountPresets.auto,
+        label: 'Auto bins',
+        value: BinCountAuto,
         display: true,
     },
     ...Array.from(Array.from(Array(MAX + 1).keys()), (v) => ({
@@ -31,7 +31,7 @@ const options: BinOption[] = [
     })),
     {
         label: 'Custom',
-        value: BinCountPresets.custom,
+        value: 'custom',
         display: true,
     },
 ]
@@ -45,8 +45,8 @@ export function FunnelBinsPicker(): JSX.Element {
             id="funnel-bin-filter"
             dropdownClassName="funnel-bin-filter-dropdown"
             data-attr="funnel-bin-filter"
-            defaultValue={BinCountPresets.auto}
-            value={binCount || BinCountPresets.auto}
+            defaultValue={BinCountAuto}
+            value={binCount || BinCountAuto}
             onSelect={(count) => setBinCount(count)}
             dropdownRender={(menu) => {
                 return (
@@ -59,7 +59,7 @@ export function FunnelBinsPicker(): JSX.Element {
                                 min={MIN}
                                 max={MAX}
                                 value={numericBinCount}
-                                onChange={(count) => setBinCount(count as BinCountValues)}
+                                onChange={(count) => setBinCount(count)}
                             />{' '}
                             bins
                         </div>
@@ -74,7 +74,7 @@ export function FunnelBinsPicker(): JSX.Element {
         >
             <Select.OptGroup label="Bin Count">
                 {options.map((option) => {
-                    if (option.value === BinCountPresets.custom) {
+                    if (option.value === 'custom') {
                         return null
                     }
                     return (

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react'
+import { useActions, useValues } from 'kea'
+import { funnelLogic } from 'scenes/funnels/funnelLogic'
+import { BinCountPresets } from 'lib/constants'
+import { InputNumber, Select } from 'antd'
+import { BinCountValues } from '~/types'
+import { BarChartOutlined } from '@ant-design/icons'
+
+// export const binOptionsMapping: Record<string, number | 'auto' | 'custom'> = {
+//     custom: 'custom',
+//     auto: 'auto',
+//     ...Object.assign({}, ...Array.from([3, 5, 10, 25, 50, 75, 90], (v) => ({ [v]: v }))),
+// }
+
+const options = [
+    {
+        label: 'Automatic',
+        value: BinCountPresets.auto,
+    },
+    ...Array.from([5, 10, 15, 25, 50, 90], (v) => ({ label: `${v} bins`, value: v })),
+    {
+        label: 'Custom',
+        value: BinCountPresets.custom,
+    },
+]
+
+export function FunnelBinsPicker(): JSX.Element {
+    const { binCount } = useValues(funnelLogic)
+    const { setBinCount } = useActions(funnelLogic)
+    const [open, setOpen] = useState(false)
+    const [customPickerOpen, setCustomPickerOpen] = useState(false)
+
+    function onClickOutside(): void {
+        setOpen(false)
+        setCustomPickerOpen(false)
+    }
+
+    return (
+        <Select
+            defaultValue={BinCountPresets.auto}
+            value={binCount}
+            onChange={(count: BinCountValues) => {
+                if (count === BinCountPresets.custom) {
+                    if (open) {
+                        setOpen(false)
+                        setCustomPickerOpen(true)
+                    }
+                } else {
+                    setBinCount(count)
+                }
+            }}
+            onBlur={() => {
+                if (!customPickerOpen) {
+                    onClickOutside()
+                }
+            }}
+            onClick={() => {
+                if (!customPickerOpen) {
+                    setOpen(!open)
+                }
+            }}
+            listHeight={440}
+            open={open || customPickerOpen}
+            bordered={false}
+            dropdownMatchSelectWidth={false}
+            data-attr="funnel-time-conversion-bin-selector"
+            optionLabelProp="label"
+            dropdownRender={(menu: React.ReactElement) => {
+                if (customPickerOpen) {
+                    return (
+                        <div>
+                            <a
+                                style={{
+                                    margin: '0 1rem',
+                                    color: 'rgba(0, 0, 0, 0.2)',
+                                    fontWeight: 700,
+                                }}
+                                href="#"
+                                onClick={props.onClick}
+                            >
+                                &lt;
+                            </a>
+                            <InputNumber />
+                        </div>
+                    )
+                }
+                return menu
+            }}
+        >
+            <Select.OptGroup label="Bin Count">
+                {options.map((option) => {
+                    // if (option.value === BinCountPresets.custom) {
+                    //     return null
+                    // }
+                    return (
+                        <Select.Option
+                            key={option.value}
+                            value={option.value}
+                            label={
+                                <>
+                                    <BarChartOutlined /> {option.label}
+                                </>
+                            }
+                        >
+                            {option.label}
+                        </Select.Option>
+                    )
+                })}
+            </Select.OptGroup>
+        </Select>
+    )
+}

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -13,6 +13,7 @@ import { FunnelStepReferencePicker } from './FunnelTab/FunnelStepReferencePicker
 import { FunnelDisplayLayoutPicker } from './FunnelTab/FunnelDisplayLayoutPicker'
 import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
 import { FunnelBinsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker'
+import { useValues } from 'kea'
 
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
@@ -84,7 +85,9 @@ export function InsightDisplayConfig({
     annotationsToCreate,
     clearAnnotationsToCreate,
 }: InsightDisplayConfigProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
     const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
+    const showFunnelBarOptions = activeView === ViewType.FUNNELS && featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]
 
     return (
         <div className="display-config-inner">
@@ -107,14 +110,14 @@ export function InsightDisplayConfig({
 
                 {activeView === ViewType.RETENTION && <RetentionDatePicker />}
 
-                {activeView === ViewType.FUNNELS && allFilters.funnel_viz_type === FunnelVizType.Steps && (
+                {showFunnelBarOptions && allFilters.funnel_viz_type === FunnelVizType.Steps && (
                     <>
                         <FunnelDisplayLayoutPicker />
                         <FunnelStepReferencePicker />
                     </>
                 )}
 
-                {activeView === ViewType.FUNNELS && allFilters.funnel_viz_type === FunnelVizType.TimeToConvert && (
+                {showFunnelBarOptions && allFilters.funnel_viz_type === FunnelVizType.TimeToConvert && (
                     <>
                         <FunnelBinsPicker />
                     </>

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -1,18 +1,18 @@
+import React from 'react'
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
 import { TZIndicator } from 'lib/components/TimezoneAware'
 import { ACTIONS_BAR_CHART_VALUE, ACTIONS_PIE_CHART, ACTIONS_TABLE, FEATURE_FLAGS } from 'lib/constants'
-import React from 'react'
 import { ChartDisplayType, FilterType, FunnelVizType, ViewType } from '~/types'
 import { CalendarOutlined } from '@ant-design/icons'
 import { InsightDateFilter } from '../InsightDateFilter'
 import { RetentionDatePicker } from '../RetentionDatePicker'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FunnelStepReferencePicker } from './FunnelTab/FunnelStepReferencePicker'
-import { useValues } from 'kea'
 import { FunnelDisplayLayoutPicker } from './FunnelTab/FunnelDisplayLayoutPicker'
 import { SaveToDashboard } from 'lib/components/SaveToDashboard/SaveToDashboard'
+import { FunnelBinsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker'
 
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
@@ -84,9 +84,7 @@ export function InsightDisplayConfig({
     annotationsToCreate,
     clearAnnotationsToCreate,
 }: InsightDisplayConfigProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
     const dateFilterDisabled = activeView === ViewType.FUNNELS && isFunnelEmpty(allFilters)
-    const showFunnelBarOptions = activeView === ViewType.FUNNELS && featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]
 
     return (
         <div className="display-config-inner">
@@ -109,10 +107,16 @@ export function InsightDisplayConfig({
 
                 {activeView === ViewType.RETENTION && <RetentionDatePicker />}
 
-                {showFunnelBarOptions && allFilters.funnel_viz_type === FunnelVizType.Steps && (
+                {activeView === ViewType.FUNNELS && allFilters.funnel_viz_type === FunnelVizType.Steps && (
                     <>
                         <FunnelDisplayLayoutPicker />
                         <FunnelStepReferencePicker />
+                    </>
+                )}
+
+                {activeView === ViewType.FUNNELS && allFilters.funnel_viz_type === FunnelVizType.TimeToConvert && (
+                    <>
+                        <FunnelBinsPicker />
                     </>
                 )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,7 +8,7 @@ import {
     RETENTION_FIRST_TIME,
     ENTITY_MATCH_TYPE,
     FunnelLayout,
-    BinCountPresets,
+    BinCountAuto,
 } from 'lib/constants'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginInstallationType } from 'scenes/plugins/types'
@@ -375,7 +375,7 @@ export interface SavedFunnel extends InsightHistory {
     created_by: string
 }
 
-export type BinCountValues = number | BinCountPresets
+export type BinCountValue = number | BinCountAuto
 
 export enum PersonsTabType {
     EVENTS = 'events',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,6 +8,7 @@ import {
     RETENTION_FIRST_TIME,
     ENTITY_MATCH_TYPE,
     FunnelLayout,
+    BinCountPresets,
 } from 'lib/constants'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginInstallationType } from 'scenes/plugins/types'
@@ -374,6 +375,8 @@ export interface SavedFunnel extends InsightHistory {
     created_by: string
 }
 
+export type BinCountValues = number | BinCountPresets
+
 export enum PersonsTabType {
     EVENTS = 'events',
     SESSIONS = 'sessions',
@@ -643,6 +646,7 @@ export interface FilterType {
     funnel_to_step?: number // used in time to convert: ending step index to compute time to convert
     funnel_step_breakdown?: string | number[] | number | null // used in steps breakdown: persons modal
     compare?: boolean
+    bin_count?: BinCountValues // used in time to convert: number of bins to show in histogram
 }
 
 export interface SystemStatusSubrows {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -375,7 +375,7 @@ export interface SavedFunnel extends InsightHistory {
     created_by: string
 }
 
-export type BinCountValue = number | BinCountAuto
+export type BinCountValue = number | typeof BinCountAuto
 
 export enum PersonsTabType {
     EVENTS = 'events',
@@ -646,7 +646,7 @@ export interface FilterType {
     funnel_to_step?: number // used in time to convert: ending step index to compute time to convert
     funnel_step_breakdown?: string | number[] | number | null // used in steps breakdown: persons modal
     compare?: boolean
-    bin_count?: BinCountValues // used in time to convert: number of bins to show in histogram
+    bin_count?: BinCountValue // used in time to convert: number of bins to show in histogram
 }
 
 export interface SystemStatusSubrows {


### PR DESCRIPTION
## Changes

Adds a custom bin counts dropdown with several presets and a custom number input bar. CC @Twixes and @neilkakkar to keep ya'll posted.

Bin counts are clamped between 1-90 as defined by the backend in #4995.

https://user-images.githubusercontent.com/13460330/127438594-ba21a0cb-ddd8-4d3e-b1b7-623dfb20f06f.mov

Changing bin counts

https://user-images.githubusercontent.com/13460330/127440607-1e42dd43-0b4d-4b98-a762-79c40a860311.mov

_Something I should address in a follow up PR_ - We don't show sparse data that nicely. Is there a better way to display empty bins w/o taking up too much space? @clarkus 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
