### PR TITLE
Carry event and action filters between tabs

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -7,7 +7,7 @@ import { retentionTableLogic } from 'scenes/retention/retentionTableLogic'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
 import { trendsLogic } from '../trends/trendsLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import { FilterType, FunnelVizType, PropertyFilter, ViewType } from '~/types'
+import { Entity, FilterType, FunnelVizType, PropertyFilter, ViewType } from '~/types'
 import { captureInternalMetric } from 'lib/internalMetrics'
 export const TRENDS_BASED_INSIGHTS = ['TRENDS', 'SESSIONS', 'STICKINESS', 'LIFECYCLE'] // Insights that are based on the same `Trends` components
 import { Scene, sceneLogic } from 'scenes/sceneLogic'
@@ -28,6 +28,8 @@ interface UrlParams {
     filter_test_accounts: boolean
     funnel_viz_type?: string
     display?: string
+    events?: Entity[]
+    actions?: Entity[]
 }
 
 export const logicFromInsight = (insight: string, logicProps: Record<string, any>): Logic & BuiltLogic => {
@@ -240,6 +242,8 @@ export const insightLogic = kea<insightLogicType>({
                 insight: type,
                 properties: values.allFilters.properties,
                 filter_test_accounts: defaultFilterTestAccounts(),
+                events: (values.allFilters.events || []) as Entity[],
+                actions: (values.allFilters.actions || []) as Entity[],
             }
 
             if (type === ViewType.FUNNELS) {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/5231
- I had to remove the previous insights tab URL caching solution, as otherwise you can't go between Trends & Funnels and keep adding one step/event each time. It would just go back to the old tab as it initially was opened.

![2021-07-21 15 43 04](https://user-images.githubusercontent.com/53387/126499263-911c4bd2-a6a2-4f45-9090-b15d0f2ab5f1.gif)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
