### PR TITLE
Remove Pie as an option for stickiness

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -28,7 +28,8 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
     const cumulativeDisabled =
         !!filters.session || filters.insight === ViewType.STICKINESS || filters.insight === ViewType.RETENTION
     const tableDisabled = false
-    const pieDisabled = !!filters.session || filters.insight === ViewType.RETENTION
+    const pieDisabled =
+        !!filters.session || filters.insight === ViewType.RETENTION || filters.insight === ViewType.STICKINESS
     const barDisabled = !!filters.session || filters.insight === ViewType.RETENTION
     const barValueDisabled =
         barDisabled || filters.insight === ViewType.STICKINESS || filters.insight === ViewType.RETENTION


### PR DESCRIPTION
## Changes

Stickiness + Pie doesn't really make sense, it also just shows NaN
![image](https://user-images.githubusercontent.com/1727427/126514533-5a975d4a-b8c9-4bbc-9731-1697334e24c3.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
