### PR TITLE
Don't show average time conversion for funnel trends

### DIFF
--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -33,12 +33,14 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                     <span style={{ margin: '2px 8px', borderLeft: '1px solid var(--border)' }} />
                 </>
             )}
-            <span className="text-muted-alt">
-                <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
-                    <InfoCircleOutlined className="info-indicator left" />
-                </Tooltip>
-                Average time to convert:{' '}
-            </span>
+            {allFilters.funnel_viz_type !== FunnelVizType.Trends && (
+                <span className="text-muted-alt">
+                    <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
+                        <InfoCircleOutlined className="info-indicator left" />
+                    </Tooltip>
+                    Average time to convert:{' '}
+                </span>
+            )}
             <Button
                 type="link"
                 onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Funnel trends doesn't have average time conversion

<img width="650" alt="Screen Shot 2021-07-21 at 11 42 18 AM" src="https://user-images.githubusercontent.com/25164963/126518180-c34ef27c-3c25-4dc1-95ec-69407bacd76f.png">

<img width="674" alt="Screen Shot 2021-07-21 at 11 40 05 AM" src="https://user-images.githubusercontent.com/25164963/126518140-39f8f303-2caf-4e2b-82d8-a09d4da0a6b5.png">



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
