### PR TITLE
Fix feature flag proxy JSON serialization bug

### DIFF
--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -27,6 +27,9 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
             {},
             {
                 get(_, flag) {
+                    if (flag === 'toJSON') {
+                        return JSON.stringify(featureFlags)
+                    }
                     const flagString = flag.toString()
                     const flagState = !!featureFlags[flagString]
                     notifyFlagIfNeeded(flagString, flagState)
@@ -40,6 +43,9 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
         for (const flag of Object.keys(featureFlags)) {
             Object.defineProperty(flags, flag, {
                 get: function () {
+                    if (flag === 'toJSON') {
+                        return JSON.stringify(featureFlags)
+                    }
                     notifyFlagIfNeeded(flag, true)
                     return true
                 },


### PR DESCRIPTION
## Changes

- Found a small bug with flags, but not the one I was looking for.
- Sometimes redux calls `JSON.stringify` on the object to compare it with the old object when things change. This always returned "false" and caused a different tiny bug.
- The real bug seems to be somewhere in the backend. Maybe.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
