### PR TITLE
Fix funnels time to convert dashboard item height

### DIFF
--- a/frontend/src/scenes/funnels/FunnelHistogram.scss
+++ b/frontend/src/scenes/funnels/FunnelHistogram.scss
@@ -6,3 +6,17 @@
         margin-right: 0.5rem;
     }
 }
+
+.dashboard-item-content {
+    .funnel-header-steps {
+        display: none;
+    }
+    .funnel-histogram-outer-container {
+        height: 100%;
+        .histogram-container {
+            min-height: 100%;
+            max-height: 100%;
+            width: 100%;
+        }
+    }
+}

--- a/frontend/src/scenes/funnels/FunnelHistogram.scss
+++ b/frontend/src/scenes/funnels/FunnelHistogram.scss
@@ -8,6 +8,9 @@
 }
 
 .dashboard-item-content {
+    .histogram-container {
+        max-height: 100%;
+    }
     .funnel-header-steps {
         display: none;
     }

--- a/frontend/src/scenes/funnels/FunnelHistogram.scss
+++ b/frontend/src/scenes/funnels/FunnelHistogram.scss
@@ -13,10 +13,6 @@
     }
     .funnel-histogram-outer-container {
         height: 100%;
-        .histogram-container {
-            min-height: 100%;
-            max-height: 100%;
-            width: 100%;
-        }
+        width: 100%;
     }
 }

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -68,7 +68,7 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
     const [width] = useSize(ref)
 
     return (
-        <div ref={ref}>
+        <div className="funnel-histogram-outer-container" ref={ref}>
             <Histogram data={histogramGraphData} width={width} />
         </div>
     )

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -68,7 +68,7 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
     const [width, height] = useSize(ref)
 
     return (
-        <div className="funnel-histogram-outer-container" ref={ref}>
+        <div className="funnel-histogram-outer-container" ref={ref} style={dashboardItemId ? {} : { maxHeight: 500 }}>
             <Histogram data={histogramGraphData} width={width} height={height} />
         </div>
     )

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -65,11 +65,11 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
     const logic = funnelLogic({ dashboardItemId, filters })
     const { histogramGraphData } = useValues(logic)
     const ref = useRef(null)
-    const [width] = useSize(ref)
+    const [width, height] = useSize(ref)
 
     return (
         <div className="funnel-histogram-outer-container" ref={ref}>
-            <Histogram data={histogramGraphData} width={width} />
+            <Histogram data={histogramGraphData} width={width} height={height} />
         </div>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import { Col, Row, Select } from 'antd'
 import { useActions, useValues } from 'kea'
 import useSize from '@react-hook/size'
-import { ANTD_TOOLTIP_PLACEMENTS, humanFriendlyDuration, humanizeNumber } from 'lib/utils'
+import { ANTD_TOOLTIP_PLACEMENTS, hashCodeForString, humanFriendlyDuration, humanizeNumber } from 'lib/utils'
 import { calcPercentage, getReferenceStep } from './funnelUtils'
 import { funnelLogic } from './funnelLogic'
 import { Histogram } from 'scenes/insights/Histogram'
@@ -67,9 +67,15 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
     const ref = useRef(null)
     const [width, height] = useSize(ref)
 
+    // Must reload the entire graph on a dashboard when values change, otherwise will run into random d3 bugs
+    // See: https://github.com/PostHog/posthog/pull/5259
+    const key = dashboardItemId ? hashCodeForString(JSON.stringify(histogramGraphData)) : 'staticGraph'
+
     return (
-        <div className="funnel-histogram-outer-container" ref={ref} style={dashboardItemId ? {} : { maxHeight: 500 }}>
-            <Histogram data={histogramGraphData} width={width} height={height} />
+        <div className="funnel-histogram-outer-container" style={dashboardItemId ? {} : { maxHeight: 500 }} ref={ref}>
+            {!dashboardItemId || (width && height) ? (
+                <Histogram key={key} data={histogramGraphData} width={width} height={height} />
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelViz.tsx
+++ b/frontend/src/scenes/funnels/FunnelViz.tsx
@@ -107,22 +107,24 @@ export function FunnelViz({
     if (filters.funnel_viz_type === FunnelVizType.Trends) {
         return steps && steps.length > 0 && steps[0].labels ? (
             <>
-                <Row style={{ marginTop: -16, justifyContent: 'center' }}>
-                    {preflight?.is_clickhouse_enabled && (
-                        <>
-                            converted within&nbsp;
-                            <InputNumber
-                                size="small"
-                                min={1}
-                                max={365}
-                                defaultValue={conversionWindowInDays}
-                                onChange={(days) => loadConversionWindow(Number(days))}
-                            />
-                            &nbsp;days =&nbsp;
-                        </>
-                    )}
-                    % converted from first to last step
-                </Row>
+                {!dashboardItemId ? (
+                    <Row style={{ marginTop: -16, justifyContent: 'center' }}>
+                        {preflight?.is_clickhouse_enabled && (
+                            <>
+                                converted within&nbsp;
+                                <InputNumber
+                                    size="small"
+                                    min={1}
+                                    max={365}
+                                    defaultValue={conversionWindowInDays}
+                                    onChange={(days) => loadConversionWindow(Number(days))}
+                                />
+                                &nbsp;days =&nbsp;
+                            </>
+                        )}
+                        % converted from first to last step
+                    </Row>
+                ) : null}
                 <LineGraph
                     data-attr="trend-line-graph-funnel"
                     type="line"

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -156,7 +156,7 @@ export const funnelLogic = kea<funnelLogicType>({
                         // TODO: cache timeConversionResults? how does this cachedResults work?
                         return {
                             results: props.cachedResults as FunnelStep[] | FunnelStep[][],
-                            timeConversionResults: EMPTY_FUNNEL_RESULTS.timeConversionResults,
+                            timeConversionResults: props.cachedResults as FunnelsTimeConversionBins,
                         }
                     }
 

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -1,6 +1,6 @@
 .histogram-container {
     display: flex;
-    min-height: 600px;
+    max-height: 500px;
     width: 100%;
 
     svg {

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -1,6 +1,5 @@
 .histogram-container {
     display: flex;
-    max-height: 500px;
     width: 100%;
 
     svg {


### PR DESCRIPTION
## Changes

Continues work on #5253

<img width="535" alt="Screen Shot 2021-07-21 at 8 55 17 AM" src="https://user-images.githubusercontent.com/13460330/126521468-26e0f10c-050f-4214-aa89-6a75f26f644d.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
