### PR TITLE
Unblock funnel persons table for non clickhouse

### DIFF
--- a/frontend/src/scenes/funnels/People.tsx
+++ b/frontend/src/scenes/funnels/People.tsx
@@ -9,9 +9,8 @@ import './FunnelPeople.scss'
 import { Card } from 'antd'
 
 export function People(): JSX.Element | null {
-    const { stepsWithCount, peopleSorted, peopleLoading, areFiltersValid } = useValues(funnelLogic({}))
-
-    if (!stepsWithCount || !areFiltersValid) {
+    const { stepsWithCount, peopleSorted, peopleLoading } = useValues(funnelLogic({}))
+    if (!stepsWithCount) {
         return null
     }
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -443,8 +443,10 @@ export const funnelLogic = kea<funnelLogicType>({
     listeners: ({ actions, values, props }) => ({
         loadResultsSuccess: async () => {
             // load the old people table
-            if ((values.stepsWithCount[0]?.people?.length ?? 0) > 0) {
-                actions.loadPeople(values.stepsWithCount)
+            if (!values.clickhouseFeaturesEnabled) {
+                if ((values.stepsWithCount[0]?.people?.length ?? 0) > 0) {
+                    actions.loadPeople(values.stepsWithCount)
+                }
             }
         },
         setFilters: ({ refresh }) => {

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -443,10 +443,8 @@ export const funnelLogic = kea<funnelLogicType>({
     listeners: ({ actions, values, props }) => ({
         loadResultsSuccess: async () => {
             // load the old people table
-            if (!featureFlagLogic.values.featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]) {
-                if ((values.stepsWithCount[0]?.people?.length ?? 0) > 0) {
-                    actions.loadPeople(values.stepsWithCount)
-                }
+            if ((values.stepsWithCount[0]?.people?.length ?? 0) > 0) {
+                actions.loadPeople(values.stepsWithCount)
             }
         },
         setFilters: ({ refresh }) => {


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Since the persons modal for funnels is only available on clickhouse, we have to maintain the funnel people table that shows up below the graph for postgres

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
