### PR TITLE
Improvements to Persons Modal

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -3,7 +3,7 @@ import api from './api'
 import { toast } from 'react-toastify'
 import { Button, Spin } from 'antd'
 import dayjs from 'dayjs'
-import { EventType, FilterType, ActionFilter } from '~/types'
+import { EventType, FilterType, ActionFilter, IntervalType } from '~/types'
 import { tagColors } from 'lib/colors'
 import { CustomerServiceOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 import { featureFlagLogic } from './logic/featureFlagLogic'
@@ -814,7 +814,7 @@ export const disableHourFor: Record<string, boolean> = {
     other: false,
 }
 
-export function autocorrectInterval(filters: Partial<FilterType>): string {
+export function autocorrectInterval(filters: Partial<FilterType>): IntervalType {
     if (!filters.interval) {
         return 'day'
     } // undefined/uninitialized

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -46,7 +46,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                 onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}
                 disabled={!clickhouseFeaturesEnabled || allFilters.funnel_viz_type === FunnelVizType.TimeToConvert}
             >
-                {humanFriendlyDuration(conversionMetrics.averageTime)}
+                {humanFriendlyDuration(conversionMetrics.averageTime, 2)}
             </Button>
         </div>
     )

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -226,7 +226,7 @@ export const funnelLogic = kea<funnelLogicType>({
             },
         ],
         people: [
-            [] as any[],
+            [] as any[], // TODO: Type properly
             {
                 loadPeople: async (steps) => {
                     return (await api.get('api/person/?uuid=' + steps[0].people.join(','))).results
@@ -348,7 +348,7 @@ export const funnelLogic = kea<funnelLogicType>({
 
                 if (stepsWithCount.length > 1) {
                     stepsDropdown.push({
-                        label: `All steps`,
+                        label: 'All steps',
                         from_step: -1,
                         to_step: -1,
                         count: stepsWithCount[stepsWithCount.length - 1].count,
@@ -485,9 +485,7 @@ export const funnelLogic = kea<funnelLogicType>({
             personsModalLogic.actions.loadPeople({
                 action: { id: step.action_id, name: step.name, properties: [], type: step.type },
                 breakdown_value: breakdown_value || '',
-                label: `Persons who ${stepNumber >= 0 ? 'completed' : 'dropped off at'} Step #${Math.abs(
-                    stepNumber
-                )} - ${step.name}`,
+                label: step.name,
                 date_from: '',
                 date_to: '',
                 filters: values.filters,

--- a/frontend/src/scenes/trends/PersonModal.scss
+++ b/frontend/src/scenes/trends/PersonModal.scss
@@ -1,4 +1,10 @@
 .person-modal {
+    .ant-modal-body {
+        padding: 0;
+        max-height: 60vh;
+        overflow-y: scroll;
+    }
+
     .ant-btn {
         border-radius: 4px;
         color: var(--primary);

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -95,7 +95,6 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                 </Row>
             }
             width={600}
-            bodyStyle={{ padding: 0, maxHeight: 500, overflowY: 'scroll' }}
             className="person-modal"
         >
             {peopleLoading && (

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import dayjs from 'dayjs'
 import { TrendPeople, parsePeopleParams } from 'scenes/trends/trendsLogic'
@@ -15,6 +15,7 @@ import { Link } from 'lib/components/Link'
 import './PersonModal.scss'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { ExpandIcon, ExpandIconProps } from 'lib/components/ExpandIcon'
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 // Utility function to handle filter conversion required for deeplinking to person -> sessions
 const convertToSessionFilters = (people: TrendPeople, filters: Partial<FilterType>): SessionsPropertyFilter[] => {
     if (!people?.action) {
@@ -43,14 +44,24 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
         personsModalLogic
     )
     const { featureFlags } = useValues(featureFlagLogic)
-    const title =
-        filters.shown_as === 'Stickiness'
-            ? `"${people?.label}" stickiness ${people?.day} day${people?.day === 1 ? '' : 's'}`
-            : filters.display === 'ActionsBarValue' || filters.display === 'ActionsPie'
-            ? `"${people?.label}"`
-            : filters.insight === ViewType.FUNNELS
-            ? `${people?.label}`
-            : `"${people?.label}" on ${people?.day ? dayjs(people.day).format('ll') : '...'}`
+    const title = useMemo(
+        () =>
+            peopleLoading ? (
+                'Loading persons list...'
+            ) : filters.shown_as === 'Stickiness' ? (
+                `"${people?.label}" stickiness ${people?.day} day${people?.day === 1 ? '' : 's'}`
+            ) : filters.display === 'ActionsBarValue' || filters.display === 'ActionsPie' ? (
+                `"${people?.label}"`
+            ) : filters.insight === ViewType.FUNNELS ? (
+                <>
+                    Persons who {people?.funnelStep ?? 0 >= 0 ? 'completed' : 'dropped off at'} step #
+                    {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />
+                </>
+            ) : (
+                `"${people?.label}" on ${people?.day ? dayjs(people.day).format('ll') : '...'}`
+            ),
+        [filters, people, peopleLoading]
+    )
 
     return (
         <Modal

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -16,6 +16,7 @@ import './PersonModal.scss'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { ExpandIcon, ExpandIconProps } from 'lib/components/ExpandIcon'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { DateDisplay } from 'lib/components/DateDisplay'
 // Utility function to handle filter conversion required for deeplinking to person -> sessions
 const convertToSessionFilters = (people: TrendPeople, filters: Partial<FilterType>): SessionsPropertyFilter[] => {
     if (!people?.action) {
@@ -58,7 +59,10 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                     {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />
                 </>
             ) : (
-                `"${people?.label}" on ${people?.day ? dayjs(people.day).format('ll') : '...'}`
+                <>
+                    <PropertyKeyInfo value={people?.label || ''} disablePopover /> on{' '}
+                    <DateDisplay interval={filters.interval || 'day'} date={people?.day.toString() || ''} />
+                </>
             ),
         [filters, people, peopleLoading]
     )

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -11,7 +11,7 @@ import { parsePeopleParams, TrendPeople } from './trendsLogic'
 
 interface PersonModalParams {
     action: ActionFilter | 'session' // todo, refactor this session string param out
-    label: string
+    label: string // Contains the step name
     date_from: string | number
     date_to: string | number
     filters: Partial<FilterType>
@@ -154,6 +154,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                     day: date_from,
                     breakdown_value,
                     next: people.next,
+                    funnelStep,
                 } as TrendPeople
                 if (saveOriginal) {
                     actions.saveFirstLoadedPeople(peopleResult)

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -43,6 +43,7 @@ export interface TrendPeople {
     breakdown_value?: string
     next?: string
     loadingMore?: boolean
+    funnelStep?: number
 }
 
 interface PeopleParamType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -607,7 +607,7 @@ export type RetentionType = typeof RETENTION_RECURRING | typeof RETENTION_FIRST_
 export interface FilterType {
     insight?: InsightType
     display?: ChartDisplayType
-    interval?: string // TODO: Move to IntervalType
+    interval?: IntervalType
     date_from?: string
     date_to?: string
     properties?: PropertyFilter[]


### PR DESCRIPTION
## Changes

This PR implements a bunch of fixes around persons modal:
- Persons modal now renders better in shorter viewports (previously being significantly cut off).
    <img width="649" alt="" src="https://user-images.githubusercontent.com/5864173/126533892-c696fb9d-1375-42f6-bfbe-d131713cb302.png">
- Title of persons modal now parses the event name correctly, i.e. "$pageview" becomes "Pageview".
    <img width="645" alt="" src="https://user-images.githubusercontent.com/5864173/126533880-c1b6763d-f617-4d1d-9db0-f15b9f84115d.png">
- Persons modal in trends now displays date in line with new tooltips.
    <img width="623" alt="" src="https://user-images.githubusercontent.com/5864173/126533870-6e7d60ed-bfeb-4c55-a191-7647c1254a0a.png">
- Average conversion time now displays only the two most significant units.
- TS improvements.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
