### PR TITLE
Time conversion histogram paint optimization

### DIFF
--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -2,7 +2,6 @@
 
 .histogram-container {
     display: flex;
-    min-height: 600px;
     width: 100%;
 
     svg {

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -1,5 +1,8 @@
+@import '~/vars';
+
 .histogram-container {
     display: flex;
+    min-height: 600px;
     width: 100%;
 
     svg {
@@ -9,6 +12,10 @@
         left: 0;
         margin-left: 0;
         margin-right: 0;
+
+        g#bars {
+            fill: $funnel_alt;
+        }
 
         g#y-gridlines,
         g#y-axis {

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 import * as d3 from 'd3'
 import { D3Selector, useD3, getOrCreateEl, animate, D3Transition } from 'lib/hooks/useD3'
 import { FunnelLayout } from 'lib/constants'
-import { getChartColors } from 'lib/colors'
 import { createRoundedRectPath, getConfig, INITIAL_CONFIG } from './histogramUtils'
 
 import './Histogram.scss'
@@ -20,7 +19,6 @@ export interface HistogramDatum {
 interface HistogramProps {
     data: HistogramDatum[]
     layout?: FunnelLayout
-    color?: string
     isAnimated?: boolean
     width?: number
     height?: number
@@ -31,12 +29,10 @@ export function Histogram({
     layout = FunnelLayout.vertical,
     width = INITIAL_CONFIG.width,
     height = INITIAL_CONFIG.height,
-    color = 'white',
     isAnimated = false,
 }: HistogramProps): JSX.Element {
     const { config } = useValues(histogramLogic)
     const { setConfig } = useActions(histogramLogic)
-    const colorList = getChartColors(color)
     const isEmpty = data.length === 0 || d3.sum(data.map((d) => d.count)) === 0
 
     // TODO: All D3 state outside of useD3 hook will be moved into separate kea histogramLogic
@@ -107,35 +103,6 @@ export function Histogram({
                     _svg.selectAll('#x-axis,#y-axis,#y-gridlines').remove()
                 }
 
-                // bars
-                _svg.attr('fill', colorList[0])
-                    .selectAll('path')
-                    .data(data)
-                    .join('path')
-                    .call(animate, config.transitionDuration, isAnimated, (it: D3Transition) => {
-                        return it.attr('d', (d: HistogramDatum) => {
-                            if (layout === FunnelLayout.vertical) {
-                                return createRoundedRectPath(
-                                    x(d.bin0) + config.spacing.btwnBins / 2,
-                                    y(d.count),
-                                    Math.max(0, x(d.bin1) - x(d.bin0) - config.spacing.btwnBins),
-                                    y(0) - y(d.count),
-                                    config.borderRadius,
-                                    'top'
-                                )
-                            }
-                            // is horizontal
-                            return createRoundedRectPath(
-                                y(0),
-                                x(d.bin0) + config.spacing.btwnBins / 2,
-                                y(d.count) - y(0),
-                                Math.max(0, x(d.bin1) - x(d.bin0) - config.spacing.btwnBins),
-                                config.borderRadius,
-                                'right'
-                            )
-                        })
-                    })
-
                 // x-axis
                 const _xAxis = getOrCreateEl(_svg, 'g#x-axis', () =>
                     _svg.append('svg:g').attr('id', 'x-axis').attr('transform', config.transforms.x)
@@ -181,6 +148,36 @@ export function Histogram({
                                 .attr('transform', config.transforms.yGrid)
                     )
                 }
+
+                // bars
+                const _bars = getOrCreateEl(_svg, 'g#bars', () => _svg.append('svg:g').attr('id', 'bars'))
+                _bars
+                    .selectAll('path')
+                    .data(data)
+                    .join('path')
+                    .call(animate, config.transitionDuration, isAnimated, (it: D3Transition) => {
+                        return it.attr('d', (d: HistogramDatum) => {
+                            if (layout === FunnelLayout.vertical) {
+                                return createRoundedRectPath(
+                                    x(d.bin0) + config.spacing.btwnBins / 2,
+                                    y(d.count),
+                                    Math.max(0, x(d.bin1) - x(d.bin0) - config.spacing.btwnBins),
+                                    y(0) - y(d.count),
+                                    config.borderRadius,
+                                    'top'
+                                )
+                            }
+                            // is horizontal
+                            return createRoundedRectPath(
+                                y(0),
+                                x(d.bin0) + config.spacing.btwnBins / 2,
+                                y(d.count) - y(0),
+                                Math.max(0, x(d.bin1) - x(d.bin0) - config.spacing.btwnBins),
+                                config.borderRadius,
+                                'right'
+                            )
+                        })
+                    })
 
                 return _svg
             }

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -43,6 +43,7 @@ $lifecycle_dormant: #f86234;
 
 // Funnels
 $funnel_default: $primary;
+$funnel_alt: $primary_alt;
 $funnel_background: #e7e8ee;
 
 .bg-mid {


### PR DESCRIPTION
## Changes

- [x] Use the same color in time conversion graph as we do in steps
- [x] Paint histogram bars over gridlines

**Before**

<img width="1033" alt="Screen Shot 2021-07-21 at 12 32 44 AM" src="https://user-images.githubusercontent.com/13460330/126535022-d8577188-22e0-4b10-af82-f9b9a6363ee9.png">

**After**

<img width="1011" alt="Screen Shot 2021-07-21 at 10 40 45 AM" src="https://user-images.githubusercontent.com/13460330/126534889-b9d18696-e223-4a6e-94d5-2ac382c3fa62.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
