### PR TITLE
Update global button styles

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.scss
+++ b/frontend/src/scenes/trends/PersonModal.scss
@@ -1,6 +1,5 @@
 .person-modal {
     .ant-btn {
-        border-radius: 4px;
         color: var(--primary);
     }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -438,6 +438,10 @@ code.code {
 
 // Button styles
 
+button.ant-btn {
+    border-radius: $button_radius;
+}
+
 .btn-close {
     color: $text_muted;
 }

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -112,6 +112,7 @@ $gosha_sans: 'GoshaSans-Bold', -apple-system, BlinkMacSystemFont, 'Segoe UI', Ro
 
 $default_spacing: 16px;
 $radius: 2px;
+$button_radius: 4px;
 $top_nav_height: 50px;
 
 .text-ellipsis {


### PR DESCRIPTION
## Changes

Noticed that we had a special rounding in buttons on the persons modal (4px instead of 2px), which IMO looks better and more in line with our newer designs. This PR applies the new 4px border radius to all buttons. If we like this general direction, a next step would be to update the base rounding of everything from 2px to 4px.

<img width="1315" alt="" src="https://user-images.githubusercontent.com/5864173/126536319-0cccb316-21ff-4d19-ac26-c27bc61c6edb.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
