### PR TITLE
Use total count for persons modal

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -347,7 +347,9 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                 }
                                                 percentage={conversionRate}
                                                 name={breakdown.name}
-                                                onBarClick={() => openPersonsModal(step, i + 1, step.breakdown_value)}
+                                                onBarClick={() =>
+                                                    openPersonsModal(step, i + 1, step.count, step.breakdown_value)
+                                                }
                                                 layout={layout}
                                                 popoverTitle={
                                                     <div style={{ wordWrap: 'break-word' }}>
@@ -397,7 +399,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                     <Bar
                                         percentage={calcPercentage(step.count, basisStep.count)}
                                         name={step.name}
-                                        onBarClick={() => openPersonsModal(step, i + 1)}
+                                        onBarClick={() => openPersonsModal(step, i + 1, step.count)}
                                         layout={layout}
                                         popoverTitle={<PropertyKeyInfo value={step.name} />}
                                         popoverMetrics={[
@@ -446,7 +448,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                             <div className="funnel-conversion-metadata funnel-step-metadata">
                                 <div className="center-flex">
                                     <ValueInspectorButton
-                                        onClick={() => openPersonsModal(step, i + 1)}
+                                        onClick={() => openPersonsModal(step, i + 1, step.count)}
                                         disabled={!funnelPersonsEnabled}
                                     >
                                         <span className="value-inspector-button-icon">
@@ -467,7 +469,13 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                 </div>
                                 <div className="center-flex">
                                     <ValueInspectorButton
-                                        onClick={() => openPersonsModal(step, -(i + 1))} // dropoff value from step 1 to 2 is -2, 2 to 3 is -3
+                                        onClick={() =>
+                                            openPersonsModal(
+                                                step,
+                                                -(i + 1),
+                                                step.order > 0 ? steps[i - 1].count - step.count : 0
+                                            )
+                                        } // dropoff value from step 1 to 2 is -2, 2 to 3 is -3
                                         disabled={!funnelPersonsEnabled}
                                         style={{ paddingRight: '0.25em' }}
                                     >

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -131,10 +131,12 @@ export const funnelLogic = kea<funnelLogicType>({
         openPersonsModal: (
             step: FunnelStep | FunnelStepWithNestedBreakdown,
             stepNumber: number,
+            personsCount: number,
             breakdown_value?: string
         ) => ({
             step,
             stepNumber,
+            personsCount,
             breakdown_value,
         }),
         setStepReference: (stepReference: FunnelStepReference) => ({ stepReference }),
@@ -481,7 +483,7 @@ export const funnelLogic = kea<funnelLogicType>({
             actions.setConversionWindowInDays(days)
             actions.loadResults()
         },
-        openPersonsModal: ({ step, stepNumber, breakdown_value }) => {
+        openPersonsModal: ({ step, stepNumber, personsCount, breakdown_value }) => {
             personsModalLogic.actions.loadPeople({
                 action: { id: step.action_id, name: step.name, properties: [], type: step.type },
                 breakdown_value: breakdown_value || '',
@@ -490,6 +492,7 @@ export const funnelLogic = kea<funnelLogicType>({
                 )} - ${step.name}`,
                 date_from: '',
                 date_to: '',
+                count: personsCount,
                 filters: values.filters,
                 saveOriginal: true,
                 funnelStep: stepNumber,

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -15,6 +15,7 @@ interface PersonModalParams {
     date_from: string | number
     date_to: string | number
     filters: Partial<FilterType>
+    count: number
     breakdown_value?: string
     saveOriginal?: boolean
     searchTerm?: string
@@ -106,6 +107,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                     filters,
                     date_from,
                     date_to,
+                    count,
                     breakdown_value,
                     saveOriginal,
                     searchTerm,
@@ -148,7 +150,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 breakpoint()
                 const peopleResult = {
                     people: people.results[0]?.people,
-                    count: people.results[0]?.count || 0,
+                    count: count || people.results[0]?.count || 0,
                     action,
                     label,
                     day: date_from,
@@ -224,6 +226,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 date_from,
                 date_to,
                 filters,
+                count,
                 breakdown_value,
                 saveOriginal,
                 searchTerm,


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

<img width="844" alt="Screen Shot 2021-07-21 at 3 38 55 PM" src="https://user-images.githubusercontent.com/25164963/126549505-19f24a55-553a-4a44-8425-e7bdf3b21c15.png">

This will work for something like funnels in the above, where there's already a total number of "people" in the steps count pre-calculated, but for something like pageviews in trends, we don't have a real way of calculating the total number of users unless we remove the `LIMIT` in the sql query for it, right? Which I assume we don't want to do because then we'd have a slower query?

We could get the "total count" users back if we ran a unique users count on it but that seems like a detour to an actual solution

<img width="847" alt="Screen Shot 2021-07-21 at 3 43 52 PM" src="https://user-images.githubusercontent.com/25164963/126550195-e12f2ac9-85e8-4112-a67c-27518c1e28aa.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
