### PR TITLE
Fix persons modal load more people

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -96,7 +96,7 @@ class ClickhouseActionsViewSet(ActionViewSet):
 
         return Response(
             {
-                "results": [{"people": serialized_people[0:100], "count": len(serialized_people[0:99])}],
+                "results": [{"people": serialized_people[0:100], "count": len(serialized_people[0:100])}],
                 "next": next_url,
                 "previous": current_url[1:],
             }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -237,6 +237,7 @@ export const FEATURE_FLAGS = {
     SESSIONS_TABLE: '4964-sessions-table', // Expand/collapse all in sessions table (performance consideration)
     TAXONOMIC_PROPERTY_FILTER: '4267-taxonomic-property-filter',
     PERSONS_MODAL_SEARCH: 'persons-modal-search',
+    SAVE_COHORT_ON_MODAL: 'save-cohort-on-modal',
 }
 
 export const ENVIRONMENT_LOCAL_STORAGE_KEY = '$environment'

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -34,20 +34,24 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                 </>
             )}
             {allFilters.funnel_viz_type !== FunnelVizType.Trends && (
-                <span className="text-muted-alt">
-                    <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
-                        <InfoCircleOutlined className="info-indicator left" />
-                    </Tooltip>
-                    Average time to convert:{' '}
-                </span>
+                <>
+                    <span className="text-muted-alt">
+                        <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
+                            <InfoCircleOutlined className="info-indicator left" />
+                        </Tooltip>
+                        Average time to convert:{' '}
+                    </span>
+                    <Button
+                        type="link"
+                        onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}
+                        disabled={
+                            !clickhouseFeaturesEnabled || allFilters.funnel_viz_type === FunnelVizType.TimeToConvert
+                        }
+                    >
+                        {humanFriendlyDuration(conversionMetrics.averageTime)}
+                    </Button>
+                </>
             )}
-            <Button
-                type="link"
-                onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}
-                disabled={!clickhouseFeaturesEnabled || allFilters.funnel_viz_type === FunnelVizType.TimeToConvert}
-            >
-                {humanFriendlyDuration(conversionMetrics.averageTime, 2)}
-            </Button>
         </div>
     )
 }

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -40,14 +40,16 @@ interface Props {
 }
 
 export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JSX.Element {
-    const { people, loadingMorePeople, firstLoadedPeople, searchTerm, peopleLoading } = useValues(personsModalLogic)
+    const { people, loadingMorePeople, firstLoadedPeople, searchTerm, peopleLoading, isInitialLoad } = useValues(
+        personsModalLogic
+    )
     const { hidePeople, loadMorePeople, setFirstLoadedPeople, setPersonsModalFilters, setSearchTerm } = useActions(
         personsModalLogic
     )
     const { featureFlags } = useValues(featureFlagLogic)
     const title = useMemo(
         () =>
-            peopleLoading ? (
+            isInitialLoad ? (
                 'Loading persons list...'
             ) : filters.shown_as === 'Stickiness' ? (
                 `"${people?.label}" stickiness ${people?.day} day${people?.day === 1 ? '' : 's'}`
@@ -64,7 +66,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                     <DateDisplay interval={filters.interval || 'day'} date={people?.day.toString() || ''} />
                 </>
             ),
-        [filters, people, peopleLoading]
+        [filters, people, isInitialLoad]
     )
 
     return (
@@ -112,12 +114,12 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             width={600}
             className="person-modal"
         >
-            {peopleLoading && (
+            {isInitialLoad && (
                 <div style={{ padding: 16 }}>
                     <Skeleton active />
                 </div>
             )}
-            {!peopleLoading && people && (
+            {!isInitialLoad && people && (
                 <>
                     <div
                         style={{

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -157,11 +157,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                                 />
                             )}
                             <span style={{ paddingTop: 9 }}>
-                                Showing{' '}
-                                <b>
-                                    {people.count > 99 ? '99' : people.count} of {people.count}
-                                </b>{' '}
-                                persons
+                                Showing <b>{people.count}</b> persons
                             </span>
                         </div>
                     </div>

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -76,7 +76,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             footer={
                 <Row style={{ justifyContent: 'space-between', alignItems: 'center', padding: '6px 0px' }}>
                     <Row style={{ alignItems: 'center' }}>
-                        {featureFlags['save-cohort-on-modal'] &&
+                        {featureFlags[FEATURE_FLAGS.SAVE_COHORT_ON_MODAL] &&
                             (view === ViewType.TRENDS || view === ViewType.STICKINESS || view === ViewType.FUNNELS) && (
                                 <div style={{ paddingRight: 8 }}>
                                     <Button onClick={onSaveCohort}>

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -40,9 +40,7 @@ interface Props {
 }
 
 export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JSX.Element {
-    const { people, loadingMorePeople, firstLoadedPeople, searchTerm, peopleLoading, isInitialLoad } = useValues(
-        personsModalLogic
-    )
+    const { people, loadingMorePeople, firstLoadedPeople, searchTerm, isInitialLoad } = useValues(personsModalLogic)
     const { hidePeople, loadMorePeople, setFirstLoadedPeople, setPersonsModalFilters, setSearchTerm } = useActions(
         personsModalLogic
     )
@@ -78,17 +76,19 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             footer={
                 <Row style={{ justifyContent: 'space-between', alignItems: 'center', padding: '6px 0px' }}>
                     <Row style={{ alignItems: 'center' }}>
-                        {featureFlags[FEATURE_FLAGS.SAVE_COHORT_ON_MODAL] &&
-                            (view === ViewType.TRENDS || view === ViewType.STICKINESS || view === ViewType.FUNNELS) && (
-                                <div style={{ paddingRight: 8 }}>
-                                    <Button onClick={onSaveCohort}>
-                                        <UsergroupAddOutlined />
-                                        Save as cohort
-                                    </Button>
-                                </div>
-                            )}
-                        {!peopleLoading && people && (
+                        {people && (
                             <>
+                                {featureFlags[FEATURE_FLAGS.SAVE_COHORT_ON_MODAL] &&
+                                    (view === ViewType.TRENDS ||
+                                        view === ViewType.STICKINESS ||
+                                        view === ViewType.FUNNELS) && (
+                                        <div style={{ paddingRight: 8 }}>
+                                            <Button onClick={onSaveCohort}>
+                                                <UsergroupAddOutlined />
+                                                Save as cohort
+                                            </Button>
+                                        </div>
+                                    )}
                                 <Button
                                     icon={<DownloadOutlined />}
                                     href={`/api/action/people.csv?/?${parsePeopleParams(
@@ -159,7 +159,12 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                                 />
                             )}
                             <span style={{ paddingTop: 9 }}>
-                                Showing <b>{people.count}</b> persons
+                                Found{' '}
+                                <b>
+                                    {people.count}
+                                    {people.next ? '+' : ''}
+                                </b>{' '}
+                                {people.count === 1 ? 'person' : 'persons'}
                             </span>
                         </div>
                     </div>

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -96,6 +96,12 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
             },
         ],
     }),
+    selectors: {
+        isInitialLoad: [
+            (s) => [s.peopleLoading, s.loadingMorePeople],
+            (peopleLoading, loadingMorePeople) => peopleLoading && !loadingMorePeople,
+        ],
+    },
     loaders: ({ actions, values }) => ({
         people: {
             loadPeople: async ({ peopleParams }, breakpoint) => {

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -38,7 +38,6 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
         setFirstLoadedPeople: (firstLoadedPeople: TrendPeople | null) => ({ firstLoadedPeople }),
         refreshCohort: true,
         savePeopleParams: (peopleParams: PersonModalParams) => ({ peopleParams }),
-        setLoadMorePeople: (morePeople: TrendPeople) => ({ morePeople }),
     }),
     reducers: () => ({
         searchTerm: [
@@ -67,7 +66,6 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 }),
                 setFilters: () => null,
                 setFirstLoadedPeople: (_, { firstLoadedPeople }) => firstLoadedPeople,
-                setLoadMorePeople: (_, { morePeople }) => morePeople,
             },
         ],
         firstLoadedPeople: [
@@ -98,7 +96,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
             },
         ],
     }),
-    loaders: ({ actions }) => ({
+    loaders: ({ actions, values }) => ({
         people: {
             loadPeople: async ({ peopleParams }, breakpoint) => {
                 let people = []
@@ -163,6 +161,24 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 }
                 return peopleResult
             },
+            loadMorePeople: async ({}, breakpoint) => {
+                if (values.people) {
+                    const { people: currPeople, count, action, label, day, breakdown_value, next } = values.people
+                    const people = await api.get(next)
+                    breakpoint()
+
+                    return {
+                        people: [...currPeople, ...people.results[0]?.people],
+                        count: count + people.results[0]?.count,
+                        action,
+                        label,
+                        day,
+                        breakdown_value,
+                        next: people.next,
+                    }
+                }
+                return null
+            },
         },
     }),
     listeners: ({ actions, values }) => ({
@@ -176,23 +192,6 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 id: 'personsModalNew',
                 groups: [],
             })
-        },
-        loadMorePeople: async ({}, breakpoint) => {
-            if (values.people) {
-                const { people: currPeople, count, action, label, day, breakdown_value, next } = values.people
-                const morePeopleResults = await api.get(next)
-                breakpoint()
-                const morePeople = {
-                    people: [...currPeople, ...morePeopleResults.results[0]?.people],
-                    count: count + morePeopleResults.results[0]?.count,
-                    action,
-                    label,
-                    day,
-                    breakdown_value,
-                    next: morePeopleResults.next,
-                }
-                actions.setLoadMorePeople(morePeople)
-            }
         },
         saveCohortWithFilters: ({ cohortName, filters }) => {
             if (values.people) {


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

before:

https://user-images.githubusercontent.com/25164963/126570084-243f9c02-01ab-4733-9fae-a3f1d2f437b9.mov

after:

https://user-images.githubusercontent.com/25164963/126570182-909d50fb-5133-4263-812c-3f8c64863987.mov



This PR:

1. fixes where clicking "load more people" would reload people completely, instead of just rendering more people below

2. Adjusts the `showing x people` wording so that it's less incorrect. See https://github.com/PostHog/posthog/pull/5268 for more details on that. Suggestion by @EDsCODE was to have the `load more people` button be higher up so it's more obvious there are more results? Instead of a user having to scroll to the bottom to know that there's more people. Or some sort of "next" button that just tells you there's more people to load 🤠 Paging @clarkus for superior UX input

3. Snuck in a quick fix for this lil button that leads you back to the time conversion chart that shouldn't show up on funnel trends
<img width="635" alt="Screen Shot 2021-07-21 at 7 01 03 PM" src="https://user-images.githubusercontent.com/25164963/126570568-fd18b3d6-2486-43bc-8567-33560e0365ae.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
