### PR TITLE
Add migration for `distinct_id` column on clickhouse person table

### DIFF
--- a/ee/clickhouse/migrations/0013_persons_distinct_ids_column.py
+++ b/ee/clickhouse/migrations/0013_persons_distinct_ids_column.py
@@ -1,0 +1,14 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.person import KAFKA_PERSONS_TABLE_SQL, PERSONS_TABLE_MV_SQL
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(
+        f"ALTER TABLE person ON CLUSTER {CLICKHOUSE_CLUSTER} ADD COLUMN IF NOT EXISTS distinct_ids Array(VARCHAR)"
+    ),
+    migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
+    migrations.RunSQL(PERSONS_TABLE_MV_SQL),
+]

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -17,6 +17,7 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     team_id Int64,
     properties VARCHAR,
     is_identified Boolean,
+    distinct_ids Array(VARCHAR),
     is_deleted Boolean DEFAULT 0
     {extra_fields}
 ) ENGINE = {engine}
@@ -50,6 +51,7 @@ created_at,
 team_id,
 properties,
 is_identified,
+distinct_ids,
 is_deleted,
 _timestamp,
 _offset

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "private": true,
     "dependencies": {
-        "@posthog/plugin-server": "1.1.7"
+        "@posthog/plugin-server": "1.1.8"
     },
     "scripts": {
         "start": "posthog-plugin-server"

--- a/plugins/yarn.lock
+++ b/plugins/yarn.lock
@@ -1009,10 +1009,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.12.5.tgz#596539ea69df21f07640a2ce0a335c7ead940b06"
   integrity sha512-EuRoYM17vYI1m2SmXpYe7LC9hFPWsRnN6rAi6q3unFIW26pT40sV/TYSWnBEihZXIWdVShwiGXORQMHjpnJOig==
 
-"@posthog/plugin-server@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-1.1.7.tgz#d7c93d87e8709f3577ffc05eaa5aa17346db5487"
-  integrity sha512-F0Vl3FVF/MaE803Jyxs6Qb0tg5qQUkKCrvf+brBqc4bEviK1SD73XUngBMl8TJY1xlfC+5H4ZnPNhjWZUEjLJw==
+"@posthog/plugin-server@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-server/-/plugin-server-1.1.8.tgz#672277bd508bb4f185b97d3f259d83eccd3555c3"
+  integrity sha512-TY9bN3scd9TR2koOGItq0xR+qF6mf2GVx80zngqp0OcSD+Tys+RX2u8mos2dXWfoHscBVcFOXNAEqgG4+H4i5g==
   dependencies:
     "@babel/core" "^7.13.1"
     "@babel/preset-env" "^7.13.5"


### PR DESCRIPTION
Note that code under ee/clickhouse/models/person.py does not work
anymore since it does not populate the column correctly. That is fine -
will be handled when doing the actual migration, rather than for this
experiment.

Issue: https://github.com/PostHog/posthog/issues/5167

Depends on https://github.com/PostHog/plugin-server/pull/507 - should be deployed together with it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
