### PR TITLE
Funnel default event

### DIFF
--- a/frontend/src/lib/utils/getAppContext.ts
+++ b/frontend/src/lib/utils/getAppContext.ts
@@ -5,5 +5,5 @@ export function getAppContext(): AppContext | undefined {
 }
 
 export function getDefaultEventName(): string {
-    return getAppContext()?.default_event || PathType.PageView
+    return getAppContext()?.default_event_name || PathType.PageView
 }

--- a/frontend/src/lib/utils/getAppContext.ts
+++ b/frontend/src/lib/utils/getAppContext.ts
@@ -1,5 +1,9 @@
-import { AppContext } from '~/types'
+import { AppContext, PathType } from '~/types'
 
 export function getAppContext(): AppContext | undefined {
     return (window as any)['POSTHOG_APP_CONTEXT'] || undefined
+}
+
+export function getDefaultEventName(): string {
+    return getAppContext()?.default_event || PathType.PageView
 }

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -15,7 +15,6 @@ import {
     FunnelStep,
     FunnelsTimeConversionBins,
     FunnelTimeConversionStep,
-    PathType,
     PersonType,
     ViewType,
     FunnelStepWithNestedBreakdown,
@@ -27,10 +26,10 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
-import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
 import { calcPercentage, cleanBinResult, getLastFilledStep, getReferenceStep } from './funnelUtils'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { router } from 'kea-router'
+import { getDefaultEventName } from 'lib/utils/getAppContext'
 
 function aggregateBreakdownResult(breakdownList: FunnelStep[][]): FunnelStepWithNestedBreakdown[] {
     if (breakdownList.length) {
@@ -521,9 +520,7 @@ export const funnelLogic = kea<funnelLogicType>({
                 if (!objectsEqual(currentParams, paramsToCheck)) {
                     const cleanedParams = cleanFunnelParams(searchParams)
                     if (isStepsEmpty(cleanedParams)) {
-                        const event = eventDefinitionsModel.values.eventNames.includes(PathType.PageView)
-                            ? PathType.PageView
-                            : eventDefinitionsModel.values.eventNames[0]
+                        const event = getDefaultEventName()
                         cleanedParams.events = [
                             {
                                 id: event,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -974,7 +974,7 @@ export type EventOrPropType = EventDefinition & PropertyDefinition
 export interface AppContext {
     current_user: UserType | null
     preflight: PreflightStatus
-    default_event: string
+    default_event_name: string
 }
 
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -974,6 +974,7 @@ export type EventOrPropType = EventDefinition & PropertyDefinition
 export interface AppContext {
     current_user: UserType | null
     preflight: PreflightStatus
+    default_event: string
 }
 
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -81,7 +81,11 @@ export default {
     // ],
 
     // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-    // moduleNameMapper: {},
+    moduleNameMapper: {
+        '^~/(.*)$': '<rootDir>/$1',
+        '^lib/(.*)$': '<rootDir>/lib/$1',
+        '^scenes/(.*)$': '<rootDir>/scenes/$1',
+    },
 
     // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
     // modulePathIgnorePatterns: [],

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -222,7 +222,11 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
         from posthog.api.user import UserSerializer
         from posthog.views import preflight_check
 
-        posthog_app_context: Dict = {"current_user": None, "preflight": json.loads(preflight_check(request).getvalue())}
+        posthog_app_context: Dict = {
+            "current_user": None,
+            "preflight": json.loads(preflight_check(request).getvalue()),
+            "default_event": "$pageview",
+        }
 
         if request.user.pk:
             user = UserSerializer(request.user, context={"request": request}, many=False)


### PR DESCRIPTION
## Changes

The default event to show ($pageview or $screen) was captured from the event definitions, once they all had loaded. We don't wait for those to load before showing the filters, so that caused problems. This moves the default event name selection into django before the frontend loads.

Before:
![2021-07-22 14 37 51](https://user-images.githubusercontent.com/53387/126640270-72f101e4-cee5-4edc-b52f-4433c29b84e2.gif)

After:
![2021-07-22 14 36 53](https://user-images.githubusercontent.com/53387/126640139-3c77df94-133b-415f-ab31-72ac15f716c3.gif)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
