### PR TITLE
Show funnel empty state on Steps if less than 2 steps 

### DIFF
--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -1,4 +1,4 @@
-import { BindLogic, useActions, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import React, { useEffect } from 'react'
 import { ChartParams, FunnelVizType } from '~/types'
 import { FunnelBarGraph } from './FunnelBarGraph'
@@ -20,18 +20,7 @@ export function Funnel(props: Omit<ChartParams, 'view'>): JSX.Element | null {
     }, [])
 
     if (!areFiltersValid) {
-        return (
-            <BindLogic
-                logic={funnelLogic}
-                props={{
-                    dashboardItemId: props.dashboardItemId,
-                    cachedResults: props.cachedResults,
-                    filters: props.filters,
-                }}
-            >
-                <FunnelEmptyState />
-            </BindLogic>
-        )
+        return <FunnelEmptyState />
     }
 
     if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]) {

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import React, { useEffect } from 'react'
 import { ChartParams, FunnelVizType } from '~/types'
 import { FunnelBarGraph } from './FunnelBarGraph'
@@ -7,16 +7,32 @@ import { funnelLogic } from './funnelLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FunnelViz } from 'scenes/funnels/FunnelViz'
+import { FunnelEmptyState } from 'scenes/insights/EmptyStates/EmptyStates'
 
 export function Funnel(props: Omit<ChartParams, 'view'>): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     const logic = funnelLogic({ dashboardItemId: props.dashboardItemId, filters: props.filters })
-    const { filters } = useValues(logic)
+    const { filters, areFiltersValid } = useValues(logic)
     const { loadResults } = useActions(logic)
 
     useEffect(() => {
         loadResults()
     }, [])
+
+    if (!areFiltersValid) {
+        return (
+            <BindLogic
+                logic={funnelLogic}
+                props={{
+                    dashboardItemId: props.dashboardItemId,
+                    cachedResults: props.cachedResults,
+                    filters: props.filters,
+                }}
+            >
+                <FunnelEmptyState />
+            </BindLogic>
+        )
+    }
 
     if (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ]) {
         const funnel_viz_type = filters.funnel_viz_type || props.filters.funnel_viz_type

--- a/frontend/src/scenes/funnels/People.tsx
+++ b/frontend/src/scenes/funnels/People.tsx
@@ -9,8 +9,9 @@ import './FunnelPeople.scss'
 import { Card } from 'antd'
 
 export function People(): JSX.Element | null {
-    const { stepsWithCount, peopleSorted, peopleLoading } = useValues(funnelLogic({}))
-    if (!stepsWithCount) {
+    const { stepsWithCount, peopleSorted, peopleLoading, areFiltersValid } = useValues(funnelLogic({}))
+
+    if (!stepsWithCount && !areFiltersValid) {
         return null
     }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Think this was removed by accident

<img width="830" alt="Screen Shot 2021-07-22 at 9 54 14 AM" src="https://user-images.githubusercontent.com/25164963/126650846-2281ad16-1434-4b8f-bf16-20e0a4f9c1f1.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
