### PR TITLE
Trends breakdown table total sum bug

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -14,7 +14,7 @@ import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
 import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DateDisplay } from 'lib/components/DateDisplay'
-import { ACTIONS_LINE_GRAPH_CUMULATIVE } from 'lib/constants'
+import { ACTIONS_LINE_GRAPH_CUMULATIVE, ACTIONS_TABLE } from 'lib/constants'
 
 interface InsightsTableProps {
     isLegend?: boolean // `true` -> Used as a supporting legend at the bottom of another graph; `false` -> used as it's own display
@@ -167,9 +167,15 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
                     return average(item.data).toLocaleString()
                 } else if (calcColumnState === 'median') {
                     return median(item.data).toLocaleString()
-                } else if (calcColumnState === 'total' && filters.display === ACTIONS_LINE_GRAPH_CUMULATIVE) {
+                } else if (
+                    calcColumnState === 'total' &&
+                    (filters.display === ACTIONS_LINE_GRAPH_CUMULATIVE || filters.display === ACTIONS_TABLE)
+                ) {
                     // Special handling because `count` will contain the last amount, instead of the cumulative sum.
-                    return item.data.reduce((acc, val) => acc + val, 0).toLocaleString()
+                    return (
+                        item.aggregated_value?.toLocaleString() ||
+                        item.data.reduce((acc, val) => acc + val, 0).toLocaleString()
+                    )
                 }
                 return (
                     <>


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Total sum was previously 0 because it wasn't using the result's aggregated_value

<img width="926" alt="Screen Shot 2021-07-22 at 10 44 59 AM" src="https://user-images.githubusercontent.com/25164963/126659099-b46bc5fa-fe90-4717-8e06-25b69b58616e.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
