### PR TITLE
Pass in funnel_step_breakdown param for funnels breakdown persons modal

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -448,7 +448,11 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                 )}
                                 <div
                                     className="funnel-bar-empty-space"
-                                    style={{ flex: `${100 - conversionRate} 100 0` }}
+                                    onClick={() => openPersonsModal(step, -(i + 1))} // dropoff value for steps is negative
+                                    style={{
+                                        flex: `${100 - conversionRate} 100 0`,
+                                        cursor: `${clickhouseFeaturesEnabled && !dashboardItemId ? 'pointer' : ''}`,
+                                    }}
                                 />
                             </div>
                             <div className="funnel-conversion-metadata funnel-step-metadata">

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -349,7 +349,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                 }
                                                 percentage={_conversionRate}
                                                 name={breakdown.name}
-                                                onBarClick={() => openPersonsModal(step, i + 1, step.breakdown_value)}
+                                                onBarClick={() => openPersonsModal(step, i + 1, breakdown.breakdown)}
                                                 disabled={!!dashboardItemId}
                                                 layout={layout}
                                                 popoverTitle={

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -413,8 +413,16 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                         })}
                                         <div
                                             className="funnel-bar-empty-space"
+                                            onClick={() =>
+                                                clickhouseFeaturesEnabled &&
+                                                !dashboardItemId &&
+                                                openPersonsModal(step, -(i + 1))
+                                            } // dropoff value for steps is negative
                                             style={{
                                                 flex: `${100 - calcPercentage(breakdownSum, basisStep.count)} 100 0`,
+                                                cursor: `${
+                                                    clickhouseFeaturesEnabled && !dashboardItemId ? 'pointer' : ''
+                                                }`,
                                             }}
                                         />
                                     </>
@@ -466,10 +474,16 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                         />
                                         <div
                                             className="funnel-bar-empty-space"
-                                            onClick={() => openPersonsModal(step, -(i + 1))} // dropoff value for steps is negative
+                                            onClick={() =>
+                                                clickhouseFeaturesEnabled &&
+                                                !dashboardItemId &&
+                                                openPersonsModal(step, -(i + 1))
+                                            } // dropoff value for steps is negative
                                             style={{
                                                 flex: `${100 - step.conversionRates.fromBasisStep} 100 0`,
-                                                cursor: `${clickhouseFeaturesEnabled && !dashboardItemId ? 'pointer' : ''}`,
+                                                cursor: `${
+                                                    clickhouseFeaturesEnabled && !dashboardItemId ? 'pointer' : ''
+                                                }`,
                                             }}
                                         />
                                     </>

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -103,6 +103,7 @@ export const cleanFunnelParams = (filters: Partial<FilterType>, discardFiltersNo
         ...(filters.funnel_step ? { funnel_to_step: filters.funnel_step } : {}),
         ...(filters.entrance_period_start ? { entrance_period_start: filters.entrance_period_start } : {}),
         ...(filters.drop_off ? { drop_off: filters.drop_off } : {}),
+        ...(filters.funnel_step_breakdown ? { funnel_step_breakdown: filters.funnel_step_breakdown } : {}),
         interval: autocorrectInterval(filters),
         breakdown: breakdownEnabled ? filters.breakdown || undefined : undefined,
         breakdown_type: breakdownEnabled ? filters.breakdown_type || undefined : undefined,

--- a/frontend/src/scenes/trends/PersonModal.scss
+++ b/frontend/src/scenes/trends/PersonModal.scss
@@ -8,6 +8,16 @@
     .ant-btn {
         color: var(--primary);
     }
+
+    .ant-modal-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .ant-modal-header {
+        padding: 16px 16px;
+        width: 575px;
+    }
 }
 
 .person-modal-properties {

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -55,8 +55,9 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                 `"${people?.label}"`
             ) : filters.insight === ViewType.FUNNELS ? (
                 <>
-                    Persons who {people?.funnelStep ?? 0 >= 0 ? 'completed' : 'dropped off at'} step #
-                    {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />
+                    Persons who {(people?.funnelStep ?? 0) >= 0 ? 'completed' : 'dropped off at'} step #
+                    {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />{' '}
+                    - {people?.breakdown_value && people.breakdown_value}
                 </>
             ) : (
                 <>

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -64,7 +64,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                 <>
                     Persons who {(people?.funnelStep ?? 0) >= 0 ? 'completed' : 'dropped off at'} step #
                     {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />{' '}
-                    - {people?.breakdown_value && people.breakdown_value}
+                    {people?.breakdown_value && `- ${people.breakdown_value}`}
                 </>
             ) : (
                 <>

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -61,11 +61,14 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             ) : filters.display === 'ActionsBarValue' || filters.display === 'ActionsPie' ? (
                 `"${people?.label}"`
             ) : filters.insight === ViewType.FUNNELS ? (
-                <>
-                    Persons who {(people?.funnelStep ?? 0) >= 0 ? 'completed' : 'dropped off at'} step #
-                    {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />{' '}
-                    {people?.breakdown_value && `- ${people.breakdown_value}`}
-                </>
+                <span style={{ whiteSpace: 'nowrap' }}>
+                    <strong>
+                        Persons who {(people?.funnelStep ?? 0) >= 0 ? 'completed' : 'dropped off at'} step #
+                        {Math.abs(people?.funnelStep ?? 0)} -{' '}
+                        <PropertyKeyInfo value={people?.label || ''} disablePopover />{' '}
+                        {people?.breakdown_value && `- ${people.breakdown_value}`}
+                    </strong>
+                </span>
             ) : (
                 <>
                     <PropertyKeyInfo value={people?.label || ''} disablePopover /> on{' '}
@@ -79,7 +82,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
 
     return (
         <Modal
-            title={<strong>{title}</strong>}
+            title={title}
             visible={visible}
             onOk={hidePeople}
             onCancel={hidePeople}

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -173,7 +173,16 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
             },
             loadMorePeople: async ({}, breakpoint) => {
                 if (values.people) {
-                    const { people: currPeople, count, action, label, day, breakdown_value, next } = values.people
+                    const {
+                        people: currPeople,
+                        count,
+                        action,
+                        label,
+                        day,
+                        breakdown_value,
+                        next,
+                        funnelStep,
+                    } = values.people
                     const people = await api.get(next)
                     breakpoint()
 
@@ -185,6 +194,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                         day,
                         breakdown_value,
                         next: people.next,
+                        funnelStep,
                     }
                 }
                 return null

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -139,7 +139,11 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                         params = { ...filters, entrance_period_start, drop_off: false }
                     } else {
                         // regular funnel steps
-                        params = { ...filters, funnel_step: funnelStep }
+                        params = {
+                            ...filters,
+                            funnel_step: funnelStep,
+                            ...(breakdown_value && { funnel_step_breakdown: breakdown_value }),
+                        }
                     }
                     const cleanedParams = cleanFunnelParams(params)
                     const funnelParams = toParams(cleanedParams)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -641,6 +641,7 @@ export interface FilterType {
     funnel_viz_type?: string // parameter sent to funnels API for time conversion code path
     funnel_from_step?: number // used in time to convert: initial step index to compute time to convert
     funnel_to_step?: number // used in time to convert: ending step index to compute time to convert
+    funnel_step_breakdown?: string | number[] | number | null
     compare?: boolean
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -641,7 +641,7 @@ export interface FilterType {
     funnel_viz_type?: string // parameter sent to funnels API for time conversion code path
     funnel_from_step?: number // used in time to convert: initial step index to compute time to convert
     funnel_to_step?: number // used in time to convert: ending step index to compute time to convert
-    funnel_step_breakdown?: string | number[] | number | null
+    funnel_step_breakdown?: string | number[] | number | null // used in steps breakdown: persons modal
     compare?: boolean
 }
 


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

We have to pass in `funnel_step_breakdown` in order to get the breakdown persons back properly


https://user-images.githubusercontent.com/25164963/126684623-9c0a350c-6952-463c-a092-d74c587f3b5e.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
