### PR TITLE
Resolve caching issues with persons breakdown

### DIFF
--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -92,7 +92,7 @@ class FunnelPersonsStepBreakdownMixin(BaseParamMixin):
         return self._data.get(FUNNEL_STEP_BREAKDOWN)
 
     @include_dict
-    def funnel_step_to_dict(self):
+    def funnel_person_breakdown_to_dict(self):
         return {FUNNEL_STEP_BREAKDOWN: self.funnel_step_breakdown} if self.funnel_step_breakdown else {}
 
 


### PR DESCRIPTION
## Changes

Mixins with the same to_dict name aren't registered via `inspect` :/

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
