### PR TITLE
Make saved funnel links backwards compatible with new funnel types

### DIFF
--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -40,7 +40,9 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
     }),
     urlToAction: ({ actions }) => ({
         '/insights': (_, { display, insight, funnel_viz_type }) => {
-            if (display && !funnel_viz_type) {
+            if (display === ChartDisplayType.FunnelViz && !funnel_viz_type) {
+                actions.setChartFilter(FunnelVizType.Steps)
+            } else if (display && !funnel_viz_type) {
                 actions.setChartFilter(display)
             } else if (insight === ViewType.RETENTION) {
                 actions.setChartFilter(ChartDisplayType.ActionsTable)

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -99,7 +99,9 @@ export const cleanFunnelParams = (filters: Partial<FilterType>, discardFiltersNo
         ...(filters.properties ? { properties: filters.properties } : {}),
         ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
         ...(filters.funnel_step ? { funnel_step: filters.funnel_step } : {}),
-        ...(filters.funnel_viz_type ? { funnel_viz_type: filters.funnel_viz_type } : {}),
+        ...(filters.funnel_viz_type
+            ? { funnel_viz_type: filters.funnel_viz_type }
+            : { funnel_viz_type: FunnelVizType.Steps }),
         ...(filters.funnel_step ? { funnel_to_step: filters.funnel_step } : {}),
         ...(filters.entrance_period_start ? { entrance_period_start: filters.entrance_period_start } : {}),
         ...(filters.drop_off ? { drop_off: filters.drop_off } : {}),


### PR DESCRIPTION
## Changes

Fixes #5291

https://user-images.githubusercontent.com/13460330/126687013-406ef24c-c8b9-4901-982b-70ec881eeeff.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
