### PR TITLE
Maintain default feature flags behavior on cloud

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -65,11 +65,15 @@ if E2E_TESTING:
 
 # These flags will be force-enabled on the frontend **in addition to** flags from `/decide`
 # The features here are released, but the flags are just not yet removed from the code.
-PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) or [
-    # Add flags here
-    "4267-taxonomic-property-filter",
-    "4535-funnel-bar-viz",
-]
+# To ignore this persisted feature flag behavior, set `PERSISTED_FEATURE_FLAGS = 0`
+env_feature_flags = os.getenv("PERSISTED_FEATURE_FLAGS", "")
+PERSISTED_FEATURE_FLAGS = []
+if env_feature_flags != "0" and env_feature_flags.lower() != "false":
+    PERSISTED_FEATURE_FLAGS = get_list(env_feature_flags) or [
+        # Add hard-coded feature flags for static releases here
+        "4267-taxonomic-property-filter",
+        "4535-funnel-bar-viz",
+    ]
 
 SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG, type_cast=str_to_bool)
 SHELL_PLUS_PRINT_SQL = get_from_env("PRINT_SQL", False, type_cast=str_to_bool)

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -103,6 +103,10 @@
                 {
                     "name": "USING_PGBOUNCER",
                     "value": "True"
+                },
+                {
+                    "name": "PERSISTED_FEATURE_FLAGS",
+                    "value": "0"
                 }
             ],
             "secrets": [

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -79,6 +79,10 @@
                 {
                     "name": "USING_PGBOUNCER",
                     "value": "True"
+                },
+                {
+                    "name": "PERSISTED_FEATURE_FLAGS",
+                    "value": "0"
                 }
             ],
             "secrets": [

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -121,6 +121,10 @@
                 {
                     "name": "USING_PGBOUNCER",
                     "value": "True"
+                },
+                {
+                    "name": "PERSISTED_FEATURE_FLAGS",
+                    "value": "0"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -115,6 +115,10 @@
                 {
                     "name": "USING_PGBOUNCER",
                     "value": "True"
+                },
+                {
+                    "name": "PERSISTED_FEATURE_FLAGS",
+                    "value": "0"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Following #5282 this maintains the default behavior on cloud for feature flags.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
