### PR TITLE
Only show person modal actions for trends and stickiness

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -87,7 +87,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             footer={
                 <Row style={{ justifyContent: 'space-between', alignItems: 'center', padding: '6px 0px' }}>
                     <Row style={{ alignItems: 'center' }}>
-                        {people && people.count > 0 && (
+                        {people && people.count > 0 && (view === ViewType.TRENDS || view === ViewType.STICKINESS) && (
                             <>
                                 {showSaveCohortButton ? (
                                     <div style={{ paddingRight: 8 }}>

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -74,9 +74,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
         [filters, people, isInitialLoad]
     )
 
-    const showSaveCohortButton =
-        clickhouseFeaturesEnabled &&
-        (view === ViewType.TRENDS || view === ViewType.STICKINESS || view === ViewType.FUNNELS)
+    const showModalActions = clickhouseFeaturesEnabled && (view === ViewType.TRENDS || view === ViewType.STICKINESS)
 
     return (
         <Modal
@@ -87,16 +85,14 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             footer={
                 <Row style={{ justifyContent: 'space-between', alignItems: 'center', padding: '6px 0px' }}>
                     <Row style={{ alignItems: 'center' }}>
-                        {people && people.count > 0 && (view === ViewType.TRENDS || view === ViewType.STICKINESS) && (
+                        {people && people.count > 0 && showModalActions && (
                             <>
-                                {showSaveCohortButton ? (
-                                    <div style={{ paddingRight: 8 }}>
-                                        <Button onClick={onSaveCohort}>
-                                            <UsergroupAddOutlined />
-                                            Save as cohort
-                                        </Button>
-                                    </div>
-                                ) : null}
+                                <div style={{ paddingRight: 8 }}>
+                                    <Button onClick={onSaveCohort}>
+                                        <UsergroupAddOutlined />
+                                        Save as cohort
+                                    </Button>
+                                </div>
                                 <Button
                                     icon={<DownloadOutlined />}
                                     href={`/api/action/people.csv?/?${parsePeopleParams(


### PR DESCRIPTION
## Changes

*Please describe.*  
- CSV and cohort creation support is limited to trends and stickiness at the moment
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
