### PR TITLE
Remove funnel step checkboxes, logic, and associated types

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -19,6 +19,7 @@ interface InsightsLabelProps {
     fallbackName?: string // Name to display for the series if it can be determined from `action`
     hasMultipleSeries?: boolean // Whether the graph has multiple discrete series (not breakdown values)
     showCountedByTag?: boolean // Force 'counted by' tag to show (always shown when action.math is set)
+    allowWrap?: boolean // Allow wrapping to multiple lines (useful for long values like URLs)
 }
 
 function MathTag({ math, mathProperty }: Record<string, string | undefined>): JSX.Element {
@@ -55,6 +56,7 @@ export function InsightLabel({
     fallbackName,
     hasMultipleSeries,
     showCountedByTag,
+    allowWrap = false,
 }: InsightsLabelProps): JSX.Element {
     const showEventName = !breakdownValue || hasMultipleSeries
     const eventName = seriesStatus ? capitalizeFirstLetter(seriesStatus) : action?.name || fallbackName || ''
@@ -78,8 +80,10 @@ export function InsightLabel({
                         hasBreakdown={!!breakdownValue}
                     />
                 )}
-                <div className="protect-width">
-                    {showEventName && <PropertyKeyInfo disableIcon disablePopover value={eventName} />}
+                <div className={allowWrap ? '' : 'protect-width'}>
+                    {showEventName && (
+                        <PropertyKeyInfo disableIcon disablePopover value={eventName} ellipsis={!allowWrap} />
+                    )}
 
                     {((action?.math && action.math !== 'total') || showCountedByTag) && (
                         <MathTag math={action?.math} mathProperty={action?.math_property} />

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -281,7 +281,6 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
         stepReference,
         barGraphLayout: layout,
         clickhouseFeaturesEnabled,
-        visibilityMap,
     } = useValues(logic)
     const { openPersonsModal } = useActions(funnelLogic)
 
@@ -329,9 +328,6 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                 {Array.isArray(step.nested_breakdown) && step.nested_breakdown?.length ? (
                                     <>
                                         {step.nested_breakdown.map((breakdown, index) => {
-                                            if (breakdown.breakdown && !visibilityMap[breakdown.breakdown]) {
-                                                return null
-                                            }
                                             const barSizePercentage = calcPercentage(breakdown.count, basisStep.count)
                                             return (
                                                 <Bar

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -457,7 +457,7 @@ export const funnelLogic = kea<funnelLogicType>({
                     const nestedBreakdown = step.nested_breakdown?.map((breakdown, breakdownIndex) => {
                         const previousBreakdownCount =
                             (i > 0 && steps[i - 1].nested_breakdown?.[breakdownIndex].count) || 0
-                        const firstBreakdownCount = steps[0].nested_breakdown?.[breakdownIndex].count || 0
+                        const firstBreakdownCount = steps[0]?.nested_breakdown?.[breakdownIndex].count || 0
                         const _droppedOffFromPrevious = Math.max(previousBreakdownCount - breakdown.count, 0)
                         const conversionRates = {
                             fromPrevious:

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -21,7 +21,6 @@ import {
     FunnelTimeConversionMetrics,
     FunnelRequestParams,
     LoadedRawFunnelResults,
-    BreakdownVisibilityMap,
     FlattenedFunnelStep,
     FunnelStepWithConversionMetrics,
 } from '~/types'
@@ -154,11 +153,6 @@ export const funnelLogic = kea<funnelLogicType>({
         setStepReference: (stepReference: FunnelStepReference) => ({ stepReference }),
         changeHistogramStep: (from_step: number, to_step: number) => ({ from_step, to_step }),
         setIsGroupingOutliers: (isGroupingOutliers) => ({ isGroupingOutliers }),
-        setVisibilityMap: (visibilityMap: BreakdownVisibilityMap) => ({ visibilityMap }),
-        setVisibility: (breakdownValue: string, visible: boolean) => ({
-            breakdownValue,
-            visible,
-        }),
     }),
 
     connect: {
@@ -290,18 +284,6 @@ export const funnelLogic = kea<funnelLogicType>({
             true,
             {
                 setIsGroupingOutliers: (_, { isGroupingOutliers }) => isGroupingOutliers,
-            },
-        ],
-        visibilityMap: [
-            {} as BreakdownVisibilityMap, // A map of breakdown values to shown/hidden states, set via checkboxes
-            {
-                setVisibilityMap: (_, { visibilityMap }) => visibilityMap,
-                setVisibility: (state, { breakdownValue, visible }) => {
-                    return {
-                        ...state,
-                        [breakdownValue]: visible,
-                    }
-                },
             },
         ],
     }),
@@ -548,14 +530,6 @@ export const funnelLogic = kea<funnelLogicType>({
                     actions.loadPeople(values.stepsWithCount)
                 }
             }
-            // set visibility of all breakdown values
-            const visibilityMap: BreakdownVisibilityMap = {}
-            values.steps[0].nested_breakdown?.forEach(({ breakdown }) => {
-                if (breakdown) {
-                    visibilityMap[breakdown] = true
-                }
-            })
-            actions.setVisibilityMap(visibilityMap)
         },
         setFilters: ({ refresh }) => {
             // FUNNEL_BAR_VIZ removes the calculate button on Clickhouse

--- a/frontend/src/scenes/insights/InsightsTable/components/SeriesToggleWrapper.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/components/SeriesToggleWrapper.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 interface SeriesToggleWrapperProps {
     id: number
     children: React.ReactNode | string
-    toggleVisibility: (index: number) => void
+    toggleVisibility?: (index: number) => void
     isSingleEntity?: boolean
     style?: React.CSSProperties
 }
@@ -17,8 +17,8 @@ export function SeriesToggleWrapper({
 }: SeriesToggleWrapperProps): JSX.Element {
     return (
         <div
-            style={{ cursor: isSingleEntity ? undefined : 'pointer', ...style }}
-            onClick={() => !isSingleEntity && toggleVisibility(id)}
+            style={{ cursor: isSingleEntity || !toggleVisibility ? undefined : 'pointer', ...style }}
+            onClick={() => !isSingleEntity && toggleVisibility?.(id)}
         >
             {children}
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -780,8 +780,6 @@ export interface LoadedRawFunnelResults {
     timeConversionResults: FunnelsTimeConversionBins
 }
 
-export type BreakdownVisibilityMap = Record<string, boolean>
-
 export interface FunnelStepWithConversionMetrics extends FunnelStep {
     droppedOffFromPrevious: number
     conversionRates: {


### PR DESCRIPTION
## Changes

Removes checkboxes introduced in #5233 and replaces them with the same indicators we use on Trends graphs.

Example:

<img width="374" alt="Screen Shot 2021-07-22 at 6 07 04 PM" src="https://user-images.githubusercontent.com/4645779/126715614-6ba7d3aa-bddb-4f05-aaf1-af4674c5ff21.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
