### PR TITLE
Wrap d3 histogram labels

### DIFF
--- a/frontend/src/lib/hooks/useD3.ts
+++ b/frontend/src/lib/hooks/useD3.ts
@@ -4,30 +4,6 @@ import * as d3 from 'd3'
 export type D3Selector = d3.Selection<any, any, any, any>
 export type D3Transition = d3.Transition<any, any, any, any>
 
-export const getOrCreateEl = (
-    container: D3Selector,
-    selector: string,
-    createCallback: () => D3Selector
-): D3Selector => {
-    const el = container.select(selector)
-    if (el.empty()) {
-        return createCallback()
-    }
-    return el
-}
-
-export const animate = (
-    it: D3Selector,
-    transitionDuration: number,
-    isAnimated: boolean,
-    toAnimate: (_it: D3Transition | D3Selector) => D3Transition | D3Selector = (_it) => _it // everything you want to animate goes here
-): D3Transition | D3Selector => {
-    if (isAnimated) {
-        return it.transition().duration(transitionDuration).call(toAnimate)
-    }
-    return it.call(toAnimate)
-}
-
 export const useD3 = (
     renderChartFn: (svg: D3Selector) => void,
     dependencies: any[] = []

--- a/frontend/src/lib/utils/d3Utils.ts
+++ b/frontend/src/lib/utils/d3Utils.ts
@@ -1,0 +1,69 @@
+import * as d3 from 'd3'
+import { INITIAL_CONFIG } from 'scenes/insights/Histogram/histogramUtils'
+import { D3Selector, D3Transition } from 'lib/hooks/useD3'
+
+export const getOrCreateEl = (
+    container: D3Selector,
+    selector: string,
+    createCallback: () => D3Selector
+): D3Selector => {
+    const el = container.select(selector)
+    if (el.empty()) {
+        return createCallback()
+    }
+    return el
+}
+
+export const animate = (
+    it: D3Selector,
+    transitionDuration: number,
+    isAnimated: boolean,
+    toAnimate: (_it: D3Transition | D3Selector) => D3Transition | D3Selector = (_it) => _it // everything you want to animate goes here
+): D3Transition | D3Selector => {
+    if (isAnimated) {
+        return it.transition().duration(transitionDuration).call(toAnimate)
+    }
+    return it.call(toAnimate)
+}
+
+export const wrap = (
+    text: D3Selector,
+    width: number,
+    lineHeight: number = INITIAL_CONFIG.spacing.labelLineHeight
+): D3Selector => {
+    const maxWidth = width - 6 // same as padding-{left|right}: 3px;
+    text.each(function () {
+        const _text = d3.select(this)
+        console.log(_text)
+        const words: string[] = _text.text().split(/\s+/)
+        const y = _text.attr('y'),
+            dy = parseFloat(_text.attr('dy'))
+
+        let line: string[] = [],
+            lineNumber = 0,
+            tspan = _text
+                .text(null)
+                .append('tspan')
+                .attr('x', 0)
+                .attr('y', y)
+                .attr('dy', dy + 'em')
+
+        words.forEach((word) => {
+            // try appending text. revert and break onto new line if it's just too long
+            line.push(word)
+            tspan.text(line.join(' '))
+            if ((tspan.node()?.getComputedTextLength() || 0) > maxWidth) {
+                line.pop()
+                tspan.text(line.join(' '))
+                line = [word]
+                tspan = _text
+                    .append('tspan')
+                    .attr('x', 0)
+                    .attr('y', y)
+                    .attr('dy', ++lineNumber * lineHeight + dy + 'em')
+                    .text(word)
+            }
+        })
+    })
+    return text
+}

--- a/frontend/src/lib/utils/d3Utils.ts
+++ b/frontend/src/lib/utils/d3Utils.ts
@@ -34,7 +34,6 @@ export const wrap = (
     const maxWidth = width - 6 // same as padding-{left|right}: 3px;
     text.each(function () {
         const _text = d3.select(this)
-        console.log(_text)
         const words: string[] = _text.text().split(/\s+/)
         const y = _text.attr('y'),
             dy = parseFloat(_text.attr('dy'))

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -79,7 +79,13 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
             data-attr="funnel-histogram"
         >
             {!dashboardItemId || (width && height) ? (
-                <Histogram key={key} data={histogramGraphData} width={width} height={height} />
+                <Histogram
+                    key={key}
+                    data={histogramGraphData}
+                    width={width}
+                    height={height}
+                    formatXTickLabel={(v) => humanFriendlyDuration(v, 2)}
+                />
             ) : null}
         </div>
     )

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -6,7 +6,6 @@ import { createRoundedRectPath, getConfig, INITIAL_CONFIG } from './histogramUti
 import { getOrCreateEl, animate, wrap } from 'lib/utils/d3Utils'
 
 import './Histogram.scss'
-import { humanFriendlyDuration } from 'lib/utils'
 import { useActions, useValues } from 'kea'
 import { histogramLogic } from 'scenes/insights/Histogram/histogramLogic'
 
@@ -23,6 +22,7 @@ interface HistogramProps {
     isAnimated?: boolean
     width?: number
     height?: number
+    formatXTickLabel?: (value: number) => number | string
 }
 
 export function Histogram({
@@ -31,6 +31,7 @@ export function Histogram({
     width = INITIAL_CONFIG.width,
     height = INITIAL_CONFIG.height,
     isAnimated = false,
+    formatXTickLabel = (value: number) => value,
 }: HistogramProps): JSX.Element {
     const { config } = useValues(histogramLogic)
     const { setConfig } = useActions(histogramLogic)
@@ -49,7 +50,7 @@ export function Histogram({
         // v === -2 || v === -1 represent bins that catch grouped outliers.
         // TODO: (-2, -1) are temporary placeholders for (-inf, +inf) and should be changed when backend specs are finalized
         .tickFormat((v: number) => {
-            const label = humanFriendlyDuration(v, 2)
+            const label = formatXTickLabel(v)
             if (v === -2) {
                 return `<${label}`
             }

--- a/frontend/src/scenes/insights/Histogram/histogramUtils.ts
+++ b/frontend/src/scenes/insights/Histogram/histogramUtils.ts
@@ -12,7 +12,7 @@ export interface HistogramConfig {
     transforms: { x: string; y: string; yGrid: string }
     axisFn: { x: any; y: any }
     transitionDuration: number
-    spacing: { btwnBins: number; yLabel: number }
+    spacing: { btwnBins: number; yLabel: number; labelLineHeight: number }
 }
 
 export const INITIAL_CONFIG = {
@@ -24,6 +24,7 @@ export const INITIAL_CONFIG = {
     spacing: {
         btwnBins: 6, // spacing between bins
         yLabel: 5, // y-axis label xOffset in vertical position
+        labelLineHeight: 1.2, // line height of wrapped label text in em's
     },
 }
 
@@ -142,12 +143,3 @@ export const createRoundedRectPath = (
         'z'
     )
 }
-
-export const HISTOGRAM_WIDTH_BREAKPOINTS = [
-    { width: 400, value: 1 },
-    {
-        width: 700,
-        value: 4 / 3,
-    },
-    { width: 1000, value: 5 / 3 },
-]


### PR DESCRIPTION
## Changes

Make x-axis text labels responsively wrap so that they don't overlap. No more squiggles 🦑 

#### Minor change

- [ ] Expose `formatXTickLabel` as prop in `<Histogram>`

<img width="442" alt="Screen Shot 2021-07-22 at 3 21 38 PM" src="https://user-images.githubusercontent.com/13460330/126718548-1c0f66e9-507a-4441-99bd-aef05b4fb316.png">

In action:


https://user-images.githubusercontent.com/13460330/126718633-37e9cf9b-a670-4954-a2bb-e814ed4a8e05.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [X] New/changed UI is decent on smartphones (viewport width around 360px)
