### PR TITLE
Fix various funnels empty state UX postgres

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -335,7 +335,8 @@ export const funnelLogic = kea<funnelLogicType>({
         ],
         filtersDirty: [
             () => [selectors.filters, selectors.lastAppliedFilters],
-            (filters, lastFilters): boolean => !equal(filters, lastFilters),
+            (filters, lastFilters): boolean =>
+                !equal(cleanFunnelParams(filters, true), cleanFunnelParams(lastFilters, true)),
         ],
         barGraphLayout: [() => [selectors.filters], ({ layout }): FunnelLayout => layout || FunnelLayout.vertical],
         clickhouseFeaturesEnabled: [

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -32,6 +32,7 @@ import { calcPercentage, cleanBinResult, getLastFilledStep, getReferenceStep } f
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { router } from 'kea-router'
 import { getDefaultEventName } from 'lib/utils/getAppContext'
+import equal from 'fast-deep-equal'
 
 function aggregateBreakdownResult(
     breakdownList: FunnelStep[][],
@@ -154,6 +155,7 @@ export const funnelLogic = kea<funnelLogicType>({
         setStepReference: (stepReference: FunnelStepReference) => ({ stepReference }),
         changeHistogramStep: (from_step: number, to_step: number) => ({ from_step, to_step }),
         setIsGroupingOutliers: (isGroupingOutliers) => ({ isGroupingOutliers }),
+        setLastAppliedFilters: (filters: FilterType) => ({ filters }),
     }),
 
     connect: {
@@ -287,6 +289,12 @@ export const funnelLogic = kea<funnelLogicType>({
                 setIsGroupingOutliers: (_, { isGroupingOutliers }) => isGroupingOutliers,
             },
         ],
+        lastAppliedFilters: [
+            (props.filters || {}) as FilterType,
+            {
+                setLastAppliedFilters: (_, { filters }) => filters,
+            },
+        ],
     }),
 
     selectors: ({ props, selectors }) => ({
@@ -324,6 +332,10 @@ export const funnelLogic = kea<funnelLogicType>({
                 }
                 return false
             },
+        ],
+        filtersDirty: [
+            () => [selectors.filters, selectors.lastAppliedFilters],
+            (filters, lastFilters): boolean => !equal(filters, lastFilters),
         ],
         barGraphLayout: [() => [selectors.filters], ({ layout }): FunnelLayout => layout || FunnelLayout.vertical],
         clickhouseFeaturesEnabled: [
@@ -525,6 +537,8 @@ export const funnelLogic = kea<funnelLogicType>({
 
     listeners: ({ actions, values, props }) => ({
         loadResultsSuccess: async () => {
+            actions.setLastAppliedFilters(values.filters)
+
             // load the old people table
             if (!values.clickhouseFeaturesEnabled) {
                 if ((values.stepsWithCount[0]?.people?.length ?? 0) > 0) {
@@ -536,7 +550,11 @@ export const funnelLogic = kea<funnelLogicType>({
             // FUNNEL_BAR_VIZ removes the calculate button on Clickhouse
             // Query performance is suboptimal on psql
             const { clickhouseFeaturesEnabled } = values
-            if (refresh || clickhouseFeaturesEnabled) {
+            // If user started from empty state (<2 steps) and added a new step
+            const shouldRefresh =
+                values.filters?.events?.length === 2 && values.lastAppliedFilters?.events?.length === 1
+
+            if (refresh || shouldRefresh || clickhouseFeaturesEnabled) {
                 actions.loadResults()
             }
             const cleanedParams = cleanFunnelParams(values.filters)

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useValues, useActions, useMountedLogic } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 
@@ -35,7 +35,6 @@ export function FunnelTab(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { loadResults, clearFunnel, setFilters, saveFunnelInsight } = useActions(funnelLogic())
     const [savingModal, setSavingModal] = useState<boolean>(false)
-    const [isCalcModalOpen, setIsCalcModalOpen] = useState<boolean>(false)
 
     const showModal = (): void => setSavingModal(true)
     const closeModal = (): void => setSavingModal(false)
@@ -43,10 +42,6 @@ export function FunnelTab(): JSX.Element {
         saveFunnelInsight(input)
         closeModal()
     }
-
-    useEffect(() => {
-        setIsCalcModalOpen(areFiltersValid && filtersDirty)
-    }, [areFiltersValid, filtersDirty])
 
     console.log('FILTERS DIRTY', filtersDirty, lastAppliedFilters, filters)
 
@@ -160,8 +155,7 @@ export function FunnelTab(): JSX.Element {
                                         </Button>
                                     </span>
                                 }
-                                visible={isCalcModalOpen}
-                                onVisibleChange={(visible) => setIsCalcModalOpen(visible)}
+                                visible={areFiltersValid && filtersDirty}
                             >
                                 <Button
                                     style={{ marginLeft: 4 }}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -4,7 +4,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { ActionFilter } from '../../ActionFilter/ActionFilter'
-import { Button, Popover, Row, Tooltip } from 'antd'
+import { Button, Row, Tooltip } from 'antd'
 import { useState } from 'react'
 import { SaveModal } from '../../SaveModal'
 import { funnelCommandLogic } from './funnelCommandLogic'
@@ -23,15 +23,9 @@ import { BreakdownType, FunnelVizType } from '~/types'
 
 export function FunnelTab(): JSX.Element {
     useMountedLogic(funnelCommandLogic)
-    const {
-        isStepsEmpty,
-        areFiltersValid,
-        filters,
-        lastAppliedFilters,
-        stepsWithCount,
-        clickhouseFeaturesEnabled,
-        filtersDirty,
-    } = useValues(funnelLogic())
+    const { isStepsEmpty, areFiltersValid, filters, stepsWithCount, clickhouseFeaturesEnabled } = useValues(
+        funnelLogic()
+    )
     const { featureFlags } = useValues(featureFlagLogic)
     const { loadResults, clearFunnel, setFilters, saveFunnelInsight } = useActions(funnelLogic())
     const [savingModal, setSavingModal] = useState<boolean>(false)
@@ -42,8 +36,6 @@ export function FunnelTab(): JSX.Element {
         saveFunnelInsight(input)
         closeModal()
     }
-
-    console.log('FILTERS DIRTY', filtersDirty, lastAppliedFilters, filters)
 
     return (
         <div data-attr="funnel-tab">
@@ -144,29 +136,16 @@ export function FunnelTab(): JSX.Element {
                                     Clear
                                 </Button>
                             )}
-                            <Popover
-                                placement="right"
-                                overlayClassName="funnel-tab-btn-popover"
-                                content={
-                                    <span className="text-muted-alt">
-                                        Ready for an update?
-                                        <Button type="link" onClick={loadResults}>
-                                            Calculate changes
-                                        </Button>
-                                    </span>
-                                }
-                                visible={areFiltersValid && filtersDirty}
+
+                            <Button
+                                style={{ marginLeft: 4 }}
+                                type="primary"
+                                htmlType="submit"
+                                disabled={!areFiltersValid}
+                                data-attr="save-funnel-button"
                             >
-                                <Button
-                                    style={{ marginLeft: 4 }}
-                                    type="primary"
-                                    htmlType="submit"
-                                    disabled={!areFiltersValid}
-                                    data-attr="save-funnel-button"
-                                >
-                                    Calculate
-                                </Button>
-                            </Popover>
+                                Calculate
+                            </Button>
                         </Row>
                     </>
                 )}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -161,7 +161,7 @@ export function FunnelTab(): JSX.Element {
                                     </span>
                                 }
                                 visible={isCalcModalOpen}
-                                handleVisibleChange={(visible) => setIsCalcModalOpen(visible)}
+                                onVisibleChange={(visible) => setIsCalcModalOpen(visible)}
                             >
                                 <Button
                                     style={{ marginLeft: 4 }}

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -191,6 +191,19 @@
         position: relative;
         margin-bottom: 0;
     }
+    &.dirty-state {
+        position: relative;
+        .dirty-label {
+            position: absolute;
+            width: 100%;
+            top: 10px;
+            z-index: 2;
+        }
+        .funnel-bar-graph {
+            z-index: 1;
+            opacity: 0.5;
+        }
+    }
 }
 
 .funnel-tab-btn-popover {

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -192,3 +192,14 @@
         margin-bottom: 0;
     }
 }
+
+.funnel-tab-btn-popover {
+    .ant-popover-inner-content {
+        padding: 4px 15px; // same as antd button padding
+
+        button.ant-btn-link {
+            padding: 0;
+            margin: 0 0 0 4px;
+        }
+    }
+}

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -73,6 +73,7 @@ export function Insights(): JSX.Element {
     const { setActiveView, toggleControlsCollapsed } = useActions(insightLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
     const { showingPeople } = useValues(personsModalLogic)
+    const { areFiltersValid } = useValues(funnelLogic)
     const { saveCohortWithFilters, refreshCohort } = useActions(personsModalLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
@@ -394,6 +395,7 @@ export function Insights(): JSX.Element {
                                 (featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] && !preflight?.is_clickhouse_enabled)) &&
                                 !showErrorMessage &&
                                 !showTimeoutMessage &&
+                                areFiltersValid &&
                                 activeView === ViewType.FUNNELS &&
                                 allFilters.display === FUNNEL_VIZ && <People />}
                             {featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] &&

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -5,7 +5,7 @@ import { isMobile, Loading } from 'lib/utils'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
-import { Tabs, Row, Col, Card, Button, Tooltip } from 'antd'
+import { Tabs, Row, Col, Card, Button, Tooltip, Alert } from 'antd'
 import { FUNNEL_VIZ, ACTIONS_TABLE, ACTIONS_BAR_CHART_VALUE, FEATURE_FLAGS } from 'lib/constants'
 import { annotationsLogic } from '~/lib/components/Annotations'
 import { router } from 'kea-router'
@@ -436,9 +436,10 @@ function FunnelInsight(): JSX.Element {
         isLoading,
         filters: { funnel_viz_type },
         areFiltersValid,
+        filtersDirty,
+        clickhouseFeaturesEnabled,
     } = useValues(funnelLogic({}))
-    const { clickhouseFeaturesEnabled } = useValues(funnelLogic)
-
+    const { loadResults } = useActions(funnelLogic({}))
     const { featureFlags } = useValues(featureFlagLogic)
 
     return (
@@ -448,8 +449,23 @@ function FunnelInsight(): JSX.Element {
                     isValidFunnel &&
                     areFiltersValid &&
                     (!featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] || funnel_viz_type === FunnelVizType.Trends),
+                'dirty-state': filtersDirty && !clickhouseFeaturesEnabled,
             })}
         >
+            {filtersDirty && !isLoading && !clickhouseFeaturesEnabled ? (
+                <div className="dirty-label">
+                    <Alert
+                        message={
+                            <>
+                                The filters have changed.{' '}
+                                <Button onClick={loadResults}>Click to recalculate the funnel.</Button>
+                            </>
+                        }
+                        type="warning"
+                        showIcon
+                    />
+                </div>
+            ) : null}
             {isLoading && <Loading />}
             {isValidFunnel ? (
                 <Funnel filters={{ funnel_viz_type }} />


### PR DESCRIPTION
## Changes

Fixes #5298.

Changes 
- [x] Auto calculate if leaving empty funnel state
- [x] Add recalculate tooltip nudge
- [x] Hide people table if filters aren't valid (<2 steps)
- [x] Disable calculate button if filters aren't valid


https://user-images.githubusercontent.com/13460330/126726960-5a983126-e378-4a1b-9f95-463bf089ef1a.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
