### PR TITLE
Make sure values are populated and persons paginate properly

### DIFF
--- a/ee/clickhouse/queries/funnels/test/test_funnel_persons.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_persons.py
@@ -213,7 +213,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         results = ClickhouseFunnelPersons(
             filter.with_data({"funnel_step_breakdown": "Chrome"}), self.team
         )._exec_query()
-        print(results)
+
         self.assertCountEqual([val[0] for val in results], [person1.uuid])
 
         results = ClickhouseFunnelPersons(


### PR DESCRIPTION
## Changes

*Please describe.*  
- one of the breakdown conditions wasn't populating correctly. When persons are being retrieved, just use the passed in breakdown values
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
