### PR TITLE
Show dropped off users in FunnelStepTable

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -95,11 +95,7 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
         title: 'Dropped off',
         render: function RenderDropoff({}, step: FlattenedFunnelStep): JSX.Element | null {
             return step.order === 0 ? null : (
-                <ValueInspectorButton
-                    onClick={() =>
-                        openPersonsModal(step, step.order + 1, step.breakdown)
-                    } /* TODO: does this modal support dropped off users? */
-                >
+                <ValueInspectorButton onClick={() => openPersonsModal(step, -(step.order + 1), step.breakdown)}>
                     {step.droppedOffFromPrevious}
                 </ValueInspectorButton>
             )


### PR DESCRIPTION
## Changes

Currently, we show users who completed step X in the persons modal for dropped off users

Before: - when clicking the drop off number

![image](https://user-images.githubusercontent.com/7115141/126778336-1a5cfafe-cea5-4063-8afa-8697c00f9589.png)


Now:

![image](https://user-images.githubusercontent.com/7115141/126778238-21b698af-aefb-44b7-863b-1c8f7b90c278.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
