### PR TITLE
Ensure time_to_convert bins stay uniform

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -109,7 +109,7 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
                 FROM step_runs
                 GROUP BY bin_from_seconds
             ) results
-            FULL OUTER JOIN (
+            RIGHT OUTER JOIN (
                 /* Making sure bin_count bins are returned */
                 /* Those not present in the results query due to lack of data simply get person_count 0 */
                 SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds FROM system.numbers LIMIT {bin_count_identifier} + 1

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -23,7 +23,6 @@ from ee.clickhouse.sql.session_recording_events import (
 class ClickhouseTestMixin:
     def tearDown(self):
         try:
-            # pass
             self._destroy_event_tables()
             self._destroy_person_tables()
             self._destroy_session_recording_tables()

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -23,6 +23,7 @@ from ee.clickhouse.sql.session_recording_events import (
 class ClickhouseTestMixin:
     def tearDown(self):
         try:
+            # pass
             self._destroy_event_tables()
             self._destroy_person_tables()
             self._destroy_session_recording_tables()


### PR DESCRIPTION
## Changes

https://posthog.slack.com/archives/C01G8S5T08Z/p1626980526060300?thread_ts=1626980124.058400&cid=C01G8S5T08Z - sometimes, the bin sizes can stretch out unreasonably if the time to convert values are incorrect (similar to https://github.com/PostHog/posthog/issues/5116 ).

This ensures we discard those values, and stick to the "nice" buckets, which ensures the frontend doesn't look like: https://posthog.slack.com/files/U01SAS8J92Q/F029M7CN7LY/screen_cast_2021-07-22_at_2.43.10_pm.gif

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
