### PR TITLE
Fix various histogram release bugs

### DIFF
--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -13,11 +13,11 @@ import { FunnelVizType } from '~/types'
 import { ChartParams } from '~/types'
 
 export function FunnelHistogramHeader(): JSX.Element | null {
-    const { stepsWithCount, stepReference, histogramStepsDropdown } = useValues(funnelLogic)
+    const { stepsWithCount, stepReference, histogramStepsDropdown, areFiltersValid } = useValues(funnelLogic)
     const { changeHistogramStep } = useActions(funnelLogic)
     const { allFilters } = useValues(insightLogic)
 
-    if (allFilters.funnel_viz_type !== FunnelVizType.TimeToConvert) {
+    if (allFilters.funnel_viz_type !== FunnelVizType.TimeToConvert || !areFiltersValid) {
         return null
     }
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -176,6 +176,11 @@ export const funnelLogic = kea<funnelLogicType>({
                         }
                     }
 
+                    // Don't bother making any requests if filters aren't valid
+                    if (!values.areFiltersValid) {
+                        return EMPTY_FUNNEL_RESULTS
+                    }
+
                     const { apiParams, eventCount, actionCount, interval, histogramStep, filters } = values
 
                     async function loadFunnelResults(): Promise<FunnelResult<FunnelStep[] | FunnelStep[][]>> {

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -27,7 +27,7 @@
         g#y-axis {
             font-size: 14px;
 
-            @media (max-width: 767px) {
+            @media (max-width: $md) {
                 font-size: 12px;
             }
         }

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -26,6 +26,10 @@
         g#x-axis,
         g#y-axis {
             font-size: 14px;
+
+            @media (max-width: 767px) {
+                font-size: 12px;
+            }
         }
     }
 }

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -23,7 +23,7 @@ import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { insightCommandLogic } from './insightCommandLogic'
 
 import './Insights.scss'
-import { ErrorMessage, TimeOut } from './EmptyStates'
+import { ErrorMessage, FunnelEmptyState, TimeOut } from './EmptyStates'
 import { People } from 'scenes/funnels/People'
 import { InsightsTable } from './InsightsTable'
 import { TrendInsight } from 'scenes/trends/Trends'
@@ -467,22 +467,7 @@ function FunnelInsight(): JSX.Element {
                 </div>
             ) : null}
             {isLoading && <Loading />}
-            {isValidFunnel ? (
-                <Funnel filters={{ funnel_viz_type }} />
-            ) : (
-                !isLoading && (
-                    <div
-                        style={{
-                            textAlign: 'center',
-                        }}
-                    >
-                        <span>
-                            Enter your funnel details {!clickhouseFeaturesEnabled && `and click 'calculate'`} to create
-                            a funnel visualization
-                        </span>
-                    </div>
-                )
-            )}
+            {isValidFunnel ? <Funnel filters={{ funnel_viz_type }} /> : !isLoading && <FunnelEmptyState />}
         </div>
     )
 }


### PR DESCRIPTION
## Changes

Fixes a few bugs that we found during "break the release"

- [x] dont make funnels request if filters are invalid
- [x] hide "Steps" if invalid funnel filters
- [x] replace old invalid funnel state
- [x] smaller axis label font size on smaller screens

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
