### PR TITLE
Autofill signup form email address from query params

### DIFF
--- a/frontend/src/scenes/authentication/PasswordInput.tsx
+++ b/frontend/src/scenes/authentication/PasswordInput.tsx
@@ -5,7 +5,6 @@ import React, { lazy, Suspense } from 'react'
 const PasswordStrength = lazy(() => import('../../lib/components/PasswordStrength'))
 
 interface PasswordInputProps extends FormItemProps {
-    ref?: React.MutableRefObject<Input | null>
     showStrengthIndicator?: boolean
     label?: string
     style?: React.CSSProperties
@@ -14,7 +13,7 @@ interface PasswordInputProps extends FormItemProps {
 
 export const PasswordInput = React.forwardRef(function PasswordInputInternal(
     { label = 'Password', showStrengthIndicator, validateMinLength, style, ...props }: PasswordInputProps,
-    ref
+    ref: React.LegacyRef<Input>
 ): JSX.Element {
     return (
         <div style={style}>

--- a/frontend/src/scenes/authentication/PasswordInput.tsx
+++ b/frontend/src/scenes/authentication/PasswordInput.tsx
@@ -5,19 +5,17 @@ import React, { lazy, Suspense } from 'react'
 const PasswordStrength = lazy(() => import('../../lib/components/PasswordStrength'))
 
 interface PasswordInputProps extends FormItemProps {
+    ref?: React.MutableRefObject<Input | null>
     showStrengthIndicator?: boolean
     label?: string
     style?: React.CSSProperties
     validateMinLength?: boolean
 }
 
-export function PasswordInput({
-    label = 'Password',
-    showStrengthIndicator,
-    validateMinLength,
-    style,
-    ...props
-}: PasswordInputProps): JSX.Element {
+export const PasswordInput = React.forwardRef(function PasswordInputInternal(
+    { label = 'Password', showStrengthIndicator, validateMinLength, style, ...props }: PasswordInputProps,
+    ref
+): JSX.Element {
     return (
         <div style={style}>
             <Form.Item
@@ -36,7 +34,13 @@ export function PasswordInput({
                 style={showStrengthIndicator ? { marginBottom: 0 } : undefined}
                 {...props}
             >
-                <Input className="ph-ignore-input" type="password" data-attr="password" placeholder="********" />
+                <Input
+                    ref={ref}
+                    className="ph-ignore-input"
+                    type="password"
+                    data-attr="password"
+                    placeholder="********"
+                />
             </Form.Item>
             {showStrengthIndicator && (
                 <Form.Item shouldUpdate={(prevValues, currentValues) => prevValues.password !== currentValues.password}>
@@ -49,4 +53,4 @@ export function PasswordInput({
             )}
         </div>
     )
-}
+})

--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -18,14 +18,19 @@ import { userLogic } from '../userLogic'
 const UTM_TAGS = 'utm_campaign=in-product&utm_tag=signup-header'
 
 function FormStepOne(): JSX.Element {
-    const { formStep, signupResponse } = useValues(signupLogic)
+    const { formStep, signupResponse, initialEmail } = useValues(signupLogic)
     const emailInputRef = useRef<Input | null>(null)
+    const passwordInputRef = useRef<Input | null>(null)
 
     useEffect(() => {
         if (formStep === 1) {
-            emailInputRef?.current?.focus()
+            if (initialEmail) {
+                passwordInputRef?.current?.focus()
+            } else {
+                emailInputRef?.current?.focus()
+            }
         }
-    }, [formStep])
+    }, [formStep, initialEmail])
 
     return (
         <div className={`form-step form-step-one${formStep !== 1 ? ' hide' : ''}`}>
@@ -51,6 +56,7 @@ function FormStepOne(): JSX.Element {
                 />
             </Form.Item>
             <PasswordInput
+                ref={passwordInputRef}
                 label="Create a password"
                 showStrengthIndicator
                 validateStatus={signupResponse?.errorAttribute === 'password' ? 'error' : undefined}
@@ -166,7 +172,7 @@ export function Signup(): JSX.Element | false {
     const { useBreakpoint } = Grid
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
-    const { formStep, signupResponse, signupResponseLoading } = useValues(signupLogic)
+    const { formStep, signupResponse, signupResponseLoading, initialEmail } = useValues(signupLogic)
     const { setFormStep, signup } = useActions(signupLogic)
     const screens = useBreakpoint()
     const isSmallScreen = (Object.keys(screens) as Breakpoint[]).filter((key) => screens[key]).length <= 2 // xs; sm
@@ -233,7 +239,13 @@ export function Signup(): JSX.Element | false {
                                         style={{ marginBottom: 16 }}
                                     />
                                 )}
-                            <Form layout="vertical" form={form} onFinish={handleFormSubmit} requiredMark={false}>
+                            <Form
+                                layout="vertical"
+                                form={form}
+                                onFinish={handleFormSubmit}
+                                requiredMark={false}
+                                initialValues={{ email: initialEmail }}
+                            >
                                 <FormStepOne />
                                 <FormStepTwo />
                             </Form>

--- a/frontend/src/scenes/authentication/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signupLogic.ts
@@ -13,12 +13,19 @@ interface AccountResponse {
 export const signupLogic = kea<signupLogicType<AccountResponse>>({
     actions: {
         setFormStep: (step: 1 | 2) => ({ step }),
+        setInitialEmail: (email: string) => ({ email }),
     },
     reducers: {
         formStep: [
             1,
             {
                 setFormStep: (_, { step }) => step,
+            },
+        ],
+        initialEmail: [
+            '',
+            {
+                setInitialEmail: (_, { email }) => email,
             },
         ],
     },
@@ -45,6 +52,13 @@ export const signupLogic = kea<signupLogicType<AccountResponse>>({
                 if (['email', 'password'].includes(signupResponse?.errorAttribute || '')) {
                     actions.setFormStep(1)
                 }
+            }
+        },
+    }),
+    urlToAction: ({ actions }) => ({
+        '/signup': ({}, { email }) => {
+            if (email) {
+                actions.setInitialEmail(email)
             }
         },
     }),


### PR DESCRIPTION
## Changes

Related to https://github.com/PostHog/product-internal/issues/111. Specifying a URL like `/signup?email=newuser@example.co` will autofill the appropriate field in the signup form, and focus the Password field.

This allows us to pass in an email from an arbitrary source, like our website or an email marketing message.

To test this locally you will want to:
- log out
- comment out the block in `sceneLogic.ts:306-310` that automatically redirects the user to login if the instance is initialized

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
