### PR TITLE
Standardize date and time formatting across app

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -9,7 +9,7 @@ from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 
 TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
-HUMAN_READABLE_TIMESTAMP_FORMAT = "%a. %-d %b"
+HUMAN_READABLE_TIMESTAMP_FORMAT = "%-d-%b-%Y"
 
 
 class ClickhouseFunnelTrends(ClickhouseFunnelBase):

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -48,7 +48,7 @@ def parse_response(stats: Dict, filter: Filter, additional_values: Dict = {}) ->
     ]
     labels = [
         item.strftime(
-            "%a. %-d %B{}".format(", %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
+            "%-d-%b-%Y{}".format(" %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
         )
         for item in stats[0]
     ]

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -199,18 +199,18 @@ describe('humanFriendlyDuration()', () => {
         expect(humanFriendlyDuration(90)).toEqual('1min 30s')
     })
     it('returns correct value for t > 120', () => {
-        expect(humanFriendlyDuration(360)).toEqual('6mins')
+        expect(humanFriendlyDuration(360)).toEqual('6min')
     })
     it('returns correct value for t >= 3600', () => {
-        expect(humanFriendlyDuration(3600)).toEqual('1hr')
-        expect(humanFriendlyDuration(3601)).toEqual('1hr 1s')
-        expect(humanFriendlyDuration(3961)).toEqual('1hr 6mins 1s')
+        expect(humanFriendlyDuration(3600)).toEqual('1h')
+        expect(humanFriendlyDuration(3601)).toEqual('1h 1s')
+        expect(humanFriendlyDuration(3961)).toEqual('1h 6min 1s')
     })
     it('returns correct value for t >= 86400', () => {
         expect(humanFriendlyDuration(86400)).toEqual('1d')
     })
     it('truncates to specified # of units', () => {
-        expect(humanFriendlyDuration(3961, 2)).toEqual('1hr 6mins')
+        expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6min')
         expect(humanFriendlyDuration(30, 2)).toEqual('30s') // no change
         expect(humanFriendlyDuration(30, 0)).toEqual('') // returns no units (useless)
     })

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -13,6 +13,7 @@ import {
     average,
     median,
     humanFriendlyDuration,
+    colonDelimitedDuration,
 } from './utils'
 
 describe('capitalizeFirstLetter()', () => {
@@ -216,5 +217,43 @@ describe('humanFriendlyDuration()', () => {
     it('returns an empty string for nullish inputs', () => {
         expect(humanFriendlyDuration('', 2)).toEqual('')
         expect(humanFriendlyDuration(null, 2)).toEqual('')
+    })
+})
+
+describe('colonDelimitedDuration()', () => {
+    it('returns correct value for <= 60', () => {
+        expect(colonDelimitedDuration(60)).toEqual('00:01:00')
+        expect(colonDelimitedDuration(45)).toEqual('00:00:45')
+    })
+    it('returns correct value for 60 < t < 120', () => {
+        expect(colonDelimitedDuration(90)).toEqual('00:01:30')
+    })
+    it('returns correct value for t > 120', () => {
+        expect(colonDelimitedDuration(360)).toEqual('00:06:00')
+    })
+    it('returns correct value for t >= 3600', () => {
+        expect(colonDelimitedDuration(3600)).toEqual('01:00:00')
+        expect(colonDelimitedDuration(3601)).toEqual('01:00:01')
+        expect(colonDelimitedDuration(3961)).toEqual('01:06:01')
+    })
+    it('returns correct value for t >= 86400', () => {
+        expect(colonDelimitedDuration(86400)).toEqual('24:00:00')
+        expect(colonDelimitedDuration(90000)).toEqual('25:00:00')
+    })
+    it('returns correct value for numUnits < 3', () => {
+        expect(colonDelimitedDuration(86400, 2)).toEqual('1440:00')
+        expect(colonDelimitedDuration(86400, 1)).toEqual('86400')
+    })
+    it('returns correct value for numUnits >= 4', () => {
+        expect(colonDelimitedDuration(86400, 4)).toEqual('01:00:00:00')
+        expect(colonDelimitedDuration(90000, 4)).toEqual('01:01:00:00')
+        expect(colonDelimitedDuration(90061, 4)).toEqual('01:01:01:01')
+        expect(colonDelimitedDuration(604800, 5)).toEqual('01:00:00:00:00')
+        expect(colonDelimitedDuration(604800, 6)).toEqual('01:00:00:00:00')
+    })
+    it('returns an empty string for nullish inputs', () => {
+        expect(colonDelimitedDuration('')).toEqual('')
+        expect(colonDelimitedDuration(null)).toEqual('')
+        expect(colonDelimitedDuration(undefined)).toEqual('')
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -435,8 +435,8 @@ export function humanFriendlyDuration(d: string | number | null | undefined, max
     const s = Math.floor((d % 3600) % 60)
 
     const dayDisplay = days > 0 ? days + 'd' : ''
-    const hDisplay = h > 0 ? h + (h == 1 ? 'hr' : 'hrs') : ''
-    const mDisplay = m > 0 ? m + (m == 1 ? 'min' : 'mins') : ''
+    const hDisplay = h > 0 ? h + 'h' : ''
+    const mDisplay = m > 0 ? m + 'min' : ''
     const sDisplay = s > 0 ? s + 's' : hDisplay || mDisplay ? '' : '0s'
 
     let units: string[] = []
@@ -475,6 +475,51 @@ export function humanFriendlyDetailedTime(date: dayjs.Dayjs | string | null, wit
         formatString += ' a'
     }
     return parsedDate.format(formatString)
+}
+
+// Pad numbers with leading zeros
+export const zeroPad = (num: number, places: number): string => String(num).padStart(places, '0')
+
+export function colonDelimitedDuration(d: string | number | null | undefined, numUnits: number = 3): string {
+    // Convert `d` (seconds) to a colon delimited duration. includes `numUnits` no. of units starting from right
+    // Example: `01:10:09:08 = 1d 10hrs 9mins 8s`
+    if (d === '' || d === null || d === undefined) {
+        return ''
+    }
+    d = Number(d)
+
+    let s = d
+    let weeks = 0,
+        days = 0,
+        h = 0,
+        m = 0
+
+    if (numUnits >= 5) {
+        weeks = Math.floor(s / 604800)
+        s -= weeks * 604800
+    }
+    if (numUnits >= 4) {
+        days = Math.floor(s / 86400)
+        s -= days * 86400
+    }
+    if (numUnits >= 3) {
+        h = Math.floor(s / 3600)
+        s -= h * 3600
+    }
+    if (numUnits >= 2) {
+        m = Math.floor(s / 60)
+        s -= m * 60
+    }
+
+    const units = [zeroPad(weeks, 2), zeroPad(days, 2), zeroPad(h, 2), zeroPad(m, 2), zeroPad(s, 2)]
+
+    // get the last `numUnits` elements
+    return units.slice(0).slice(-Math.min(numUnits, 5)).join(':')
+}
+
+export function colonDelimitedDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | string, maxUnits?: number): string {
+    const diff = dayjs(to).diff(dayjs(from), 'seconds')
+    return colonDelimitedDuration(diff, maxUnits)
 }
 
 export function stripHTTP(url: string): string {

--- a/frontend/src/scenes/sessions/SessionDetails.tsx
+++ b/frontend/src/scenes/sessions/SessionDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Table, Tooltip } from 'antd'
-import { humanFriendlyDiff, humanFriendlyDetailedTime } from '~/lib/utils'
+import { humanFriendlyDetailedTime, colonDelimitedDiff } from '~/lib/utils'
 import { EventDetails } from 'scenes/events'
 import { Property } from 'lib/components/Property'
 import { eventToName } from 'lib/utils'
@@ -11,7 +11,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { ANTD_EXPAND_BUTTON_WIDTH } from 'lib/components/ResizableTable'
 import { MATCHING_EVENT_ICON_SIZE } from 'scenes/sessions/SessionsView'
 import { ExpandIcon } from 'lib/components/ExpandIcon'
-import { MonitorOutlined } from '@ant-design/icons'
+import { InfoCircleOutlined, MonitorOutlined } from '@ant-design/icons'
 
 export function SessionDetails({ session }: { session: SessionType }): JSX.Element {
     const { filteredSessionEvents } = useValues(sessionsTableLogic)
@@ -55,11 +55,18 @@ export function SessionDetails({ session }: { session: SessionType }): JSX.Eleme
             },
         },
         {
-            title: 'Time Elapsed from Previous',
+            title: (
+                <span>
+                    Time Elapsed from Previous
+                    <Tooltip title="Time elapsed is formatted as HH:MM:SS.">
+                        <InfoCircleOutlined className="info-indicator" />
+                    </Tooltip>
+                </span>
+            ),
             render: function RenderElapsed({ timestamp }: EventType, _: any, index: number) {
                 const realIndex = (page - 1) * pageSize + index
                 const lastEvent = realIndex > 0 ? events?.[realIndex - 1] : null
-                return <span>{lastEvent ? humanFriendlyDiff(lastEvent.timestamp, timestamp) : 0}</span>
+                return <span>{lastEvent ? colonDelimitedDiff(lastEvent.timestamp, timestamp) : '00:00:00'}</span>
             },
         },
     ]

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -4,7 +4,7 @@ import { decodeParams } from 'kea-router'
 import { Button, Spin, Space, Tooltip, Badge, Switch, Row } from 'antd'
 import { Link } from 'lib/components/Link'
 import { ExpandState, sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
-import { humanFriendlyDuration, humanFriendlyDetailedTime, stripHTTP, pluralize } from '~/lib/utils'
+import { humanFriendlyDetailedTime, stripHTTP, pluralize, colonDelimitedDuration } from '~/lib/utils'
 import { SessionDetails } from './SessionDetails'
 import dayjs from 'dayjs'
 import { SessionType } from '~/types'
@@ -15,6 +15,7 @@ import {
     QuestionCircleOutlined,
     ArrowLeftOutlined,
     PlaySquareOutlined,
+    InfoCircleOutlined,
 } from '@ant-design/icons'
 import { SessionsPlayerButton, sessionPlayerUrl } from './SessionsPlayerButton'
 import { SessionsPlay } from './SessionsPlay'
@@ -121,13 +122,20 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
             span: 3,
         },
         {
-            title: 'Session duration',
+            title: (
+                <span>
+                    Session Duration
+                    <Tooltip title="Session duration is formatted as HH:MM:SS.">
+                        <InfoCircleOutlined className="info-indicator" />
+                    </Tooltip>
+                </span>
+            ),
             render: function RenderDuration(session: SessionType) {
                 if (session.session_recordings.length > 0) {
                     const seconds = getSessionRecordingsDurationSum(session)
-                    return <span>{humanFriendlyDuration(Math.max(seconds, session.length))}</span>
+                    return <span>{colonDelimitedDuration(Math.max(seconds, session.length))}</span>
                 }
-                return <span>{humanFriendlyDuration(session.length)}</span>
+                return <span>{colonDelimitedDuration(session.length)}</span>
             },
             span: 3,
         },

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -520,7 +520,7 @@ def parse_response(stats: Dict, filter: Filter, additional_values: Dict = {}) ->
     ]
     labels = [
         ((item - timedelta(days=1)) if filter.interval == "month" else item).strftime(
-            "%a. %-d %B{}".format(", %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
+            "%-d-%b-%Y{}".format(" %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
         )
         for item in stats[0]
     ]

--- a/posthog/queries/sessions/test/test_sessions.py
+++ b/posthog/queries/sessions/test/test_sessions.py
@@ -55,8 +55,8 @@ def sessions_test_factory(sessions, event_factory, person_factory):
             # time series
             self.assertEqual(response[0]["data"][0], 4.0)
             self.assertEqual(response[0]["data"][1], 2.0)
-            self.assertEqual(response[0]["labels"][0], "Sat. 14 January")
-            self.assertEqual(response[0]["labels"][1], "Sun. 15 January")
+            self.assertEqual(response[0]["labels"][0], "14-Jan-2012")
+            self.assertEqual(response[0]["labels"][1], "15-Jan-2012")
             self.assertEqual(response[0]["days"][0], "2012-01-14")
             self.assertEqual(response[0]["days"][1], "2012-01-15")
             self.assertEqual(response[0]["chartLabel"], "Average Session Length (minutes)")
@@ -106,8 +106,8 @@ def sessions_test_factory(sessions, event_factory, person_factory):
 
             self.assertEqual(month_response[0]["data"][0], 3.0)
             self.assertEqual(month_response[0]["data"][2], 3.0)
-            self.assertEqual(month_response[0]["labels"][0], "Tue. 31 January")
-            self.assertEqual(month_response[0]["labels"][1], "Wed. 29 February")
+            self.assertEqual(month_response[0]["labels"][0], "31-Jan-2012")
+            self.assertEqual(month_response[0]["labels"][1], "29-Feb-2012")
             self.assertEqual(month_response[0]["days"][0], "2012-01-31")
             self.assertEqual(month_response[0]["days"][1], "2012-02-29")
 
@@ -131,8 +131,8 @@ def sessions_test_factory(sessions, event_factory, person_factory):
             )
             self.assertEqual(week_response[0]["data"][2], 4.0)
             self.assertEqual(week_response[0]["data"][4], 2.0)
-            self.assertEqual(week_response[0]["labels"][0], "Sun. 25 December")
-            self.assertEqual(week_response[0]["labels"][2], "Sun. 8 January")
+            self.assertEqual(week_response[0]["labels"][0], "25-Dec-2011")
+            self.assertEqual(week_response[0]["labels"][2], "8-Jan-2012")
             self.assertEqual(week_response[0]["days"][1], "2012-01-01")
             self.assertEqual(week_response[0]["days"][2], "2012-01-08")
 
@@ -156,8 +156,8 @@ def sessions_test_factory(sessions, event_factory, person_factory):
             )
             self.assertEqual(hour_response[0]["data"][3], 4.0)
             self.assertEqual(hour_response[0]["data"][27], 2.0)
-            self.assertEqual(hour_response[0]["labels"][0], "Wed. 14 March, 00:00")
-            self.assertEqual(hour_response[0]["labels"][1], "Wed. 14 March, 01:00")
+            self.assertEqual(hour_response[0]["labels"][0], "14-Mar-2012 00:00")
+            self.assertEqual(hour_response[0]["labels"][1], "14-Mar-2012 01:00")
             self.assertEqual(hour_response[0]["days"][0], "2012-03-14 00:00:00")
             self.assertEqual(hour_response[0]["days"][1], "2012-03-14 01:00:00")
 

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -119,9 +119,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(data={"date_from": "-7d", "events": [{"id": "sign up"}, {"id": "no events"}],}), self.team,
                 )
             self.assertEqual(response[0]["label"], "sign up")
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 3.0)
-            self.assertEqual(response[0]["labels"][5], "Thu. 2 January")
+            self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 1.0)
 
         # just make sure this doesn't error
@@ -156,7 +156,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 )
 
             self.assertEqual(response[0]["data"][1], 1.0)
-            self.assertEqual(response[0]["labels"][1], "Thu. 2 January")
+            self.assertEqual(response[0]["labels"][1], "2-Jan-2020")
 
         def test_trends_per_day_cumulative(self):
             self._create_events()
@@ -174,9 +174,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 )
 
             self.assertEqual(response[0]["label"], "sign up")
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 3.0)
-            self.assertEqual(response[0]["labels"][5], "Thu. 2 January")
+            self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 4.0)
 
         def test_trends_single_aggregate_dau(self):
@@ -541,9 +541,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 )
 
             self.assertEqual(no_compare_response[0]["label"], "sign up")
-            self.assertEqual(no_compare_response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(no_compare_response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(no_compare_response[0]["data"][4], 3.0)
-            self.assertEqual(no_compare_response[0]["labels"][5], "Thu. 2 January")
+            self.assertEqual(no_compare_response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(no_compare_response[0]["data"][5], 1.0)
 
         def _test_events_with_dates(self, dates: List[str], result, query_time=None, **filter_params):
@@ -584,17 +584,17 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "count": 3.0,
                         "data": [1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                         "labels": [
-                            "Sun. 1 November, 10:20",
-                            "Sun. 1 November, 10:21",
-                            "Sun. 1 November, 10:22",
-                            "Sun. 1 November, 10:23",
-                            "Sun. 1 November, 10:24",
-                            "Sun. 1 November, 10:25",
-                            "Sun. 1 November, 10:26",
-                            "Sun. 1 November, 10:27",
-                            "Sun. 1 November, 10:28",
-                            "Sun. 1 November, 10:29",
-                            "Sun. 1 November, 10:30",
+                            "1-Nov-2020 10:20",
+                            "1-Nov-2020 10:21",
+                            "1-Nov-2020 10:22",
+                            "1-Nov-2020 10:23",
+                            "1-Nov-2020 10:24",
+                            "1-Nov-2020 10:25",
+                            "1-Nov-2020 10:26",
+                            "1-Nov-2020 10:27",
+                            "1-Nov-2020 10:28",
+                            "1-Nov-2020 10:29",
+                            "1-Nov-2020 10:30",
                         ],
                         "days": [
                             "2020-11-01 10:20:00",
@@ -634,13 +634,13 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "count": 3.0,
                         "data": [0.0, 2.0, 0.0, 0.0, 0.0, 1.0, 0.0],
                         "labels": [
-                            "Sun. 1 November, 12:00",
-                            "Sun. 1 November, 13:00",
-                            "Sun. 1 November, 14:00",
-                            "Sun. 1 November, 15:00",
-                            "Sun. 1 November, 16:00",
-                            "Sun. 1 November, 17:00",
-                            "Sun. 1 November, 18:00",
+                            "1-Nov-2020 12:00",
+                            "1-Nov-2020 13:00",
+                            "1-Nov-2020 14:00",
+                            "1-Nov-2020 15:00",
+                            "1-Nov-2020 16:00",
+                            "1-Nov-2020 17:00",
+                            "1-Nov-2020 18:00",
                         ],
                         "days": [
                             "2020-11-01 12:00:00",
@@ -676,13 +676,13 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "count": 4.0,
                         "data": [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
                         "labels": [
-                            "Sun. 1 November",
-                            "Mon. 2 November",
-                            "Tue. 3 November",
-                            "Wed. 4 November",
-                            "Thu. 5 November",
-                            "Fri. 6 November",
-                            "Sat. 7 November",
+                            "1-Nov-2020",
+                            "2-Nov-2020",
+                            "3-Nov-2020",
+                            "4-Nov-2020",
+                            "5-Nov-2020",
+                            "6-Nov-2020",
+                            "7-Nov-2020",
                         ],
                         "days": [
                             "2020-11-01",
@@ -717,13 +717,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 4.0,
                         "data": [0.0, 1.0, 2.0, 1.0, 0.0],
-                        "labels": [
-                            "Sun. 25 October",
-                            "Sun. 1 November",
-                            "Sun. 8 November",
-                            "Sun. 15 November",
-                            "Sun. 22 November",
-                        ],
+                        "labels": ["25-Oct-2020", "1-Nov-2020", "8-Nov-2020", "15-Nov-2020", "22-Nov-2020",],
                         "days": ["2020-10-25", "2020-11-01", "2020-11-08", "2020-11-15", "2020-11-22"],
                     }
                 ],
@@ -749,14 +743,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 3.0,
                         "data": [0.0, 2.0, 0.0, 0.0, 1.0, 0.0],
-                        "labels": [
-                            "Mon. 1 June",
-                            "Wed. 1 July",
-                            "Sat. 1 August",
-                            "Tue. 1 September",
-                            "Thu. 1 October",
-                            "Sun. 1 November",
-                        ],
+                        "labels": ["1-Jun-2020", "1-Jul-2020", "1-Aug-2020", "1-Sep-2020", "1-Oct-2020", "1-Nov-2020"],
                         "days": ["2020-06-01", "2020-07-01", "2020-08-01", "2020-09-01", "2020-10-01", "2020-11-01"],
                     }
                 ],
@@ -782,7 +769,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 4.0,
                         "data": [1.0, 2.0, 1.0, 0.0],
-                        "labels": ["Sun. 1 November", "Sun. 8 November", "Sun. 15 November", "Sun. 22 November"],
+                        "labels": ["1-Nov-2020", "8-Nov-2020", "15-Nov-2020", "22-Nov-2020"],
                         "days": ["2020-11-01", "2020-11-08", "2020-11-15", "2020-11-22"],
                     }
                 ],
@@ -808,7 +795,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 2.0,
                         "data": [1.0, 1.0,],
-                        "labels": ["Mon. 1 June", "Wed. 1 July",],
+                        "labels": ["1-Jun-2020", "1-Jul-2020"],
                         "days": ["2020-06-01", "2020-07-01",],
                     }
                 ],
@@ -833,7 +820,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 3,
                         "data": [3],
-                        "labels": ["Sun. 1 November"],
+                        "labels": ["1-Nov-2020"],
                         "days": ["2020-11-01"],
                     }
                 ],
@@ -859,7 +846,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 3.0,
                         "data": [3.0, 0.0],
-                        "labels": ["Sun. 1 November", "Mon. 2 November"],
+                        "labels": ["1-Nov-2020", "2-Nov-2020"],
                         "days": ["2020-11-01", "2020-11-02"],
                     }
                 ],
@@ -884,7 +871,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 3,
                         "data": [2, 1],
-                        "labels": ["Sun. 1 November", "Mon. 2 November"],
+                        "labels": ["1-Nov-2020", "2-Nov-2020"],
                         "days": ["2020-11-01", "2020-11-02"],
                     }
                 ],
@@ -909,7 +896,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 4.0,
                         "data": [0.0, 3.0, 1.0],
-                        "labels": ["Sat. 31 October", "Sun. 1 November", "Mon. 2 November"],
+                        "labels": ["31-Oct-2020", "1-Nov-2020", "2-Nov-2020"],
                         "days": ["2020-10-31", "2020-11-01", "2020-11-02"],
                     }
                 ],
@@ -935,14 +922,14 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "count": 4.0,
                         "data": [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0],
                         "labels": [
-                            "Sat. 31 October",
-                            "Sun. 1 November",
-                            "Mon. 2 November",
-                            "Tue. 3 November",
-                            "Wed. 4 November",
-                            "Thu. 5 November",
-                            "Fri. 6 November",
-                            "Sat. 7 November",
+                            "31-Oct-2020",
+                            "1-Nov-2020",
+                            "2-Nov-2020",
+                            "3-Nov-2020",
+                            "4-Nov-2020",
+                            "5-Nov-2020",
+                            "6-Nov-2020",
+                            "7-Nov-2020",
                         ],
                         "days": [
                             "2020-10-31",
@@ -985,21 +972,21 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "count": 6.0,
                         "data": [0.0, 1.0, 1.0, 0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
                         "labels": [
-                            "Sat. 31 October",
-                            "Sun. 1 November",
-                            "Mon. 2 November",
-                            "Tue. 3 November",
-                            "Wed. 4 November",
-                            "Thu. 5 November",
-                            "Fri. 6 November",
-                            "Sat. 7 November",
-                            "Sun. 8 November",
-                            "Mon. 9 November",
-                            "Tue. 10 November",
-                            "Wed. 11 November",
-                            "Thu. 12 November",
-                            "Fri. 13 November",
-                            "Sat. 14 November",
+                            "31-Oct-2020",
+                            "1-Nov-2020",
+                            "2-Nov-2020",
+                            "3-Nov-2020",
+                            "4-Nov-2020",
+                            "5-Nov-2020",
+                            "6-Nov-2020",
+                            "7-Nov-2020",
+                            "8-Nov-2020",
+                            "9-Nov-2020",
+                            "10-Nov-2020",
+                            "11-Nov-2020",
+                            "12-Nov-2020",
+                            "13-Nov-2020",
+                            "14-Nov-2020",
                         ],
                         "days": [
                             "2020-10-31",
@@ -1050,12 +1037,12 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "count": 6.0,
                         "data": [0.0, 3.0, 2.0, 0.0, 1.0, 0.0],
                         "labels": [
-                            "Sun. 25 October",
-                            "Sun. 1 November",
-                            "Sun. 8 November",
-                            "Sun. 15 November",
-                            "Sun. 22 November",
-                            "Sun. 29 November",
+                            "25-Oct-2020",
+                            "1-Nov-2020",
+                            "8-Nov-2020",
+                            "15-Nov-2020",
+                            "22-Nov-2020",
+                            "29-Nov-2020",
                         ],
                         "days": ["2020-10-25", "2020-11-01", "2020-11-08", "2020-11-15", "2020-11-22", "2020-11-29"],
                     }
@@ -1092,7 +1079,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 9,
                         "data": [1, 2, 6],
-                        "labels": ["Tue. 1 September", "Thu. 1 October", "Sun. 1 November"],
+                        "labels": ["1-Sep-2020", "1-Oct-2020", "1-Nov-2020"],
                         "days": ["2020-09-01", "2020-10-01", "2020-11-01"],
                     }
                 ],
@@ -1125,7 +1112,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 6,
                         "data": [6],
-                        "labels": ["Sun. 1 November"],
+                        "labels": ["1-Nov-2020"],
                         "days": ["2020-11-01"],
                     }
                 ],
@@ -1159,7 +1146,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 6,
                         "data": [6],
-                        "labels": ["Sun. 1 November"],
+                        "labels": ["1-Nov-2020"],
                         "days": ["2020-11-01"],
                     }
                 ],
@@ -1192,7 +1179,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 5.0,
                         "data": [2.0, 2.0, 1.0, 0.0],
-                        "labels": ["Wed. 1 January", "Sat. 1 February", "Sun. 1 March", "Wed. 1 April"],
+                        "labels": ["1-Jan-2020", "1-Feb-2020", "1-Mar-2020", "1-Apr-2020"],
                         "days": ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"],
                     }
                 ],
@@ -1224,7 +1211,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 5.0,
                         "data": [2.0, 2.0, 1.0, 0.0],
-                        "labels": ["Wed. 1 January", "Sat. 1 February", "Sun. 1 March", "Wed. 1 April"],
+                        "labels": ["1-Jan-2020", "1-Feb-2020", "1-Mar-2020", "1-Apr-2020"],
                         "days": ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"],
                     }
                 ],
@@ -1255,14 +1242,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         "label": "event_name",
                         "count": 3.0,
                         "data": [2.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-                        "labels": [
-                            "Sun. 5 January",
-                            "Mon. 6 January",
-                            "Tue. 7 January",
-                            "Wed. 8 January",
-                            "Thu. 9 January",
-                            "Fri. 10 January",
-                        ],
+                        "labels": ["5-Jan-2020", "6-Jan-2020", "7-Jan-2020", "8-Jan-2020", "9-Jan-2020", "10-Jan-2020"],
                         "days": ["2020-01-05", "2020-01-06", "2020-01-07", "2020-01-08", "2020-01-09", "2020-01-10"],
                     }
                 ],
@@ -1280,9 +1260,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 1.0)
-            self.assertEqual(response[0]["labels"][5], "Thu. 2 January")
+            self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 0)
 
         def test_filter_events_by_cohort(self):
@@ -1328,7 +1308,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(data={"date_from": "2020-01-01", "interval": "minute", "events": [{"id": "sign up"}]}),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][6], "Wed. 1 January, 00:06")
+            self.assertEqual(response[0]["labels"][6], "1-Jan-2020 00:06")
             self.assertEqual(response[0]["data"][6], 3.0)
 
             # test hour
@@ -1337,7 +1317,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(data={"date_from": "2019-12-24", "interval": "hour", "events": [{"id": "sign up"}]}),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][3], "Tue. 24 December, 03:00")
+            self.assertEqual(response[0]["labels"][3], "24-Dec-2019 03:00")
             self.assertEqual(response[0]["data"][3], 1.0)
             # 217 - 24 - 1
             self.assertEqual(response[0]["data"][192], 3.0)
@@ -1348,9 +1328,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(data={"date_from": "2019-11-24", "interval": "week", "events": [{"id": "sign up"}]}),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][5], "Sun. 22 December")
+            self.assertEqual(response[0]["labels"][5], "22-Dec-2019")
             self.assertEqual(response[0]["data"][5], 1.0)
-            self.assertEqual(response[0]["labels"][6], "Sun. 29 December")
+            self.assertEqual(response[0]["labels"][6], "29-Dec-2019")
             self.assertEqual(response[0]["data"][6], 4.0)
 
             # test month
@@ -1359,11 +1339,11 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(data={"date_from": "2019-9-24", "interval": "month", "events": [{"id": "sign up"}]}),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][0], "Sun. 1 September")
+            self.assertEqual(response[0]["labels"][0], "1-Sep-2019")
             self.assertEqual(response[0]["data"][0], 0)
-            self.assertEqual(response[0]["labels"][3], "Sun. 1 December")
+            self.assertEqual(response[0]["labels"][3], "1-Dec-2019")
             self.assertEqual(response[0]["data"][3], 1.0)
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 4.0)
 
             with freeze_time("2020-01-02 23:30"):
@@ -1374,7 +1354,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 response = trends().run(
                     Filter(data={"date_from": "dStart", "interval": "hour", "events": [{"id": "sign up"}]}), self.team
                 )
-            self.assertEqual(response[0]["labels"][23], "Thu. 2 January, 23:00")
+            self.assertEqual(response[0]["labels"][23], "2-Jan-2020 23:00")
             self.assertEqual(response[0]["data"][23], 1.0)
 
         def test_breakdown_label(self):
@@ -1681,10 +1661,10 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     self.team,
                 )
 
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 1)
             self.assertEqual(response[0]["count"], 1)
-            self.assertEqual(response[1]["labels"][5], "Thu. 2 January")
+            self.assertEqual(response[1]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[1]["data"][5], 1)
             self.assertEqual(response[1]["count"], 1)
 
@@ -1736,9 +1716,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 1.0)
-            self.assertEqual(response[0]["labels"][5], "Thu. 2 January")
+            self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 0)
 
         def test_breakdown_by_empty_cohort(self):
@@ -1838,7 +1818,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     self.team,
                 )
 
-            self.assertEqual(response[0]["labels"][6], "Wed. 1 January, 00:06")
+            self.assertEqual(response[0]["labels"][6], "1-Jan-2020 00:06")
             self.assertEqual(response[0]["data"][6], 3.0)
 
             # test hour
@@ -1855,7 +1835,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][3], "Tue. 24 December, 03:00")
+            self.assertEqual(response[0]["labels"][3], "24-Dec-2019 03:00")
             self.assertEqual(response[0]["data"][3], 1.0)
             # 217 - 24 - 1
             self.assertEqual(response[0]["data"][192], 3.0)
@@ -1874,9 +1854,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][5], "Sun. 22 December")
+            self.assertEqual(response[0]["labels"][5], "22-Dec-2019")
             self.assertEqual(response[0]["data"][5], 1.0)
-            self.assertEqual(response[0]["labels"][6], "Sun. 29 December")
+            self.assertEqual(response[0]["labels"][6], "29-Dec-2019")
             self.assertEqual(response[0]["data"][6], 4.0)
 
             # test month
@@ -1893,9 +1873,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][3], "Sun. 1 December")
+            self.assertEqual(response[0]["labels"][3], "1-Dec-2019")
             self.assertEqual(response[0]["data"][3], 1.0)
-            self.assertEqual(response[0]["labels"][4], "Wed. 1 January")
+            self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
             self.assertEqual(response[0]["data"][4], 4.0)
 
             with freeze_time("2020-01-02 23:30"):
@@ -1915,7 +1895,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][23], "Thu. 2 January, 23:00")
+            self.assertEqual(response[0]["labels"][23], "2-Jan-2020 23:00")
             self.assertEqual(response[0]["data"][23], 1.0)
 
         def test_breakdown_by_person_property(self):

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -195,12 +195,5 @@ class TestUpdateCache(APIBaseTest):
         )
         self.assertEqual(
             get_safe_cache(item_key)["result"][0]["labels"],
-            [
-                "Tue. 10 January",
-                "Wed. 11 January",
-                "Thu. 12 January",
-                "Fri. 13 January",
-                "Sat. 14 January",
-                "Sun. 15 January",
-            ],
+            ["10-Jan-2012", "11-Jan-2012", "12-Jan-2012", "13-Jan-2012", "14-Jan-2012", "15-Jan-2012",],
         )

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -56,10 +56,10 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 
 def format_label_date(date: datetime.datetime, interval: str) -> str:
-    labels_format = "%a. {day} %B"
+    labels_format = "%-d-%b-%Y"
     if interval == "hour" or interval == "minute":
-        labels_format += ", %H:%M"
-    return date.strftime(labels_format.format(day=date.day))
+        labels_format += " %H:%M"
+    return date.strftime(labels_format)
 
 
 def absolute_uri(url: Optional[str] = None) -> str:


### PR DESCRIPTION
## Changes

Closes #5328.

- [x] Added a util function to generate colon delimited time duration strings (+ test)
- [x] Change date formatting in line graph derived visualizations to `DD-MMM-YYYY` which is more concise and informative than today's `%a. %-d %B`.
- [x] singularify (? is that a word) labels. See #5328 for @clarkus's legend.
- [x] Change time duration formatting in session recording context
- [x] Simplify times in funnels context

### After Pics

<img width="1146" alt="Screen Shot 2021-07-26 at 2 14 54 PM" src="https://user-images.githubusercontent.com/13460330/127067858-9d93b08d-ac60-4cfb-8b43-5ad5b1f02354.png">
<img width="904" alt="Screen Shot 2021-07-26 at 3 20 35 PM" src="https://user-images.githubusercontent.com/13460330/127067851-71f05cc9-54b4-4330-88e7-9df4e24c24aa.png">
<img width="1139" alt="Screen Shot 2021-07-26 at 3 20 58 PM" src="https://user-images.githubusercontent.com/13460330/127067814-dd9aa9de-c5ba-4ffa-a783-002288d97f57.png">
<img width="817" alt="Screen Shot 2021-07-26 at 3 21 48 PM" src="https://user-images.githubusercontent.com/13460330/127067818-62a5362f-d36d-4244-a05c-2c9d136cc102.png">
<img width="802" alt="Screen Shot 2021-07-26 at 3 21 54 PM" src="https://user-images.githubusercontent.com/13460330/127067819-b22e1b19-1735-41a3-b397-1b3cf68ddb0e.png">
<img width="344" alt="Screen Shot 2021-07-26 at 3 21 59 PM" src="https://user-images.githubusercontent.com/13460330/127067821-724f8f0a-3ee8-46a0-82b9-b1f27d000c09.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
