### PR TITLE
Percentages to Time Conversion + Better Y-Axis Labels + Misc. Fixes

### DIFF
--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -129,3 +129,17 @@ export function getBarColorFromStatus(status: string, hover?: boolean): string {
             return 'black'
     }
 }
+
+export function getGraphColors(isLightTheme: boolean = true): Record<string, string | null> {
+    return {
+        axisLabel: isLightTheme ? '#333' : 'rgba(255,255,255,0.8)',
+        axisLine: isLightTheme ? '#ddd' : 'rgba(255,255,255,0.2)',
+        axis: isLightTheme ? '#999' : 'rgba(255,255,255,0.6)',
+        crosshair: 'rgba(0,0,0,0.2)',
+        tooltipBackground: '#1dc9b7',
+        tooltipTitle: '#fff',
+        tooltipBody: '#fff',
+        annotationColor: isLightTheme ? null : 'white',
+        annotationAccessoryColor: isLightTheme ? null : 'black',
+    }
+}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1032,3 +1032,7 @@ export function median(input: number[]): number {
     }
     return average([sorted[half - 1], sorted[half]])
 }
+
+export function sum(input: number[]): number {
+    return input.reduce((a, b) => a + b, 0)
+}

--- a/frontend/src/lib/utils/d3Utils.ts
+++ b/frontend/src/lib/utils/d3Utils.ts
@@ -29,7 +29,9 @@ export const animate = (
 export const wrap = (
     text: D3Selector,
     width: number,
-    lineHeight: number = INITIAL_CONFIG.spacing.labelLineHeight
+    lineHeight: number = INITIAL_CONFIG.spacing.labelLineHeight,
+    isVertical: boolean = true,
+    dx: number = INITIAL_CONFIG.spacing.xLabel
 ): D3Selector => {
     const maxWidth = width - 6 // same as padding-{left|right}: 3px;
     text.each(function () {
@@ -45,6 +47,7 @@ export const wrap = (
                 .append('tspan')
                 .attr('x', 0)
                 .attr('y', y)
+                .attr('dx', isVertical ? 0 : -dx + 'px')
                 .attr('dy', dy + 'em')
 
         words.forEach((word) => {
@@ -59,6 +62,7 @@ export const wrap = (
                     .append('tspan')
                     .attr('x', 0)
                     .attr('y', y)
+                    .attr('dx', isVertical ? 0 : -dx + 'px')
                     .attr('dy', ++lineNumber * lineHeight + dy + 'em')
                     .text(word)
             }

--- a/frontend/src/scenes/funnels/FunnelHistogram.scss
+++ b/frontend/src/scenes/funnels/FunnelHistogram.scss
@@ -15,7 +15,13 @@
         display: none;
     }
     .funnel-histogram-outer-container {
-        height: 100%;
+        height: calc(100% - 1em);
         width: 100%;
+    }
+}
+
+.funnel-histogram-outer-container {
+    &.scrollable {
+        overflow-x: auto;
     }
 }

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import { Col, Row, Select } from 'antd'
 import { useActions, useValues } from 'kea'
+import clsx from 'clsx'
 import useSize from '@react-hook/size'
 import { ANTD_TOOLTIP_PLACEMENTS, hashCodeForString, humanFriendlyDuration, humanizeNumber } from 'lib/utils'
 import { calcPercentage, getReferenceStep } from './funnelUtils'
@@ -72,8 +73,7 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
 
     return (
         <div
-            className="funnel-histogram-outer-container"
-            style={dashboardItemId ? {} : { maxHeight: 500 }}
+            className={clsx('funnel-histogram-outer-container', { scrollable: !dashboardItemId })}
             ref={ref}
             data-attr="funnel-histogram"
         >
@@ -82,7 +82,8 @@ export function FunnelHistogram({ filters, dashboardItemId }: Omit<ChartParams, 
                     key={key}
                     data={histogramGraphData}
                     width={width}
-                    height={height}
+                    isDashboardItem={!!dashboardItemId}
+                    height={dashboardItemId ? height : undefined}
                     formatXTickLabel={(v) => humanFriendlyDuration(v, 2)}
                 />
             ) : null}

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -7,10 +7,9 @@ import { calcPercentage, getReferenceStep } from './funnelUtils'
 import { funnelLogic } from './funnelLogic'
 import { Histogram } from 'scenes/insights/Histogram'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { ChartParams, FunnelVizType } from '~/types'
 
 import './FunnelHistogram.scss'
-import { FunnelVizType } from '~/types'
-import { ChartParams } from '~/types'
 
 export function FunnelHistogramHeader(): JSX.Element | null {
     const { stepsWithCount, stepReference, histogramStepsDropdown, areFiltersValid } = useValues(funnelLogic)

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -6,6 +6,7 @@
 
     svg {
         width: 100%;
+        height: 100%;
         position: relative;
         top: 0;
         left: 0;
@@ -16,19 +17,49 @@
             fill: $funnel_alt;
         }
 
-        g#y-gridlines,
+        g#y-gridlines {
+            g.tick:not(:first-child) {
+                color: $funnel_axis;
+            }
+
+            .domain,
+            g:first-child {
+                display: none; // hide axis line
+            }
+        }
+
         g#y-axis {
             .domain {
-                display: none; // hide axis line
+                stroke: $funnel_axis;
+            }
+        }
+
+        g#x-axis {
+            .domain {
+                stroke: $funnel_axis_zero;
             }
         }
 
         g#x-axis,
         g#y-axis {
-            font-size: 14px;
+            text {
+                font-size: 13px;
+                fill: $funnel_axis_zero;
 
-            @media (max-width: $md) {
-                font-size: 12px;
+                @media (max-width: $md) {
+                    font-size: 11px;
+                }
+            }
+        }
+
+        g#labels {
+            text.bar-label {
+                font-size: 14px;
+                font-weight: bold;
+                fill: $text_light;
+                &.outside {
+                    fill: $funnel_alt;
+                }
             }
         }
     }

--- a/frontend/src/scenes/insights/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/Histogram/Histogram.scss
@@ -23,7 +23,7 @@
             }
 
             .domain,
-            g:first-child {
+            g.tick:nth-of-type(1) {
                 display: none; // hide axis line
             }
         }

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -70,7 +70,7 @@ export function Histogram({
         .y(y)
         .tickSize(0)
         .tickFormat((v: number) => {
-            const count = formatYTickLabel(v) * 10000
+            const count = formatYTickLabel(v)
             // SI-prefix with trailing zeroes trimmed off
             return d3.format('~s')(count)
         })

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import * as d3 from 'd3'
 import { D3Selector, D3Transition, useD3 } from 'lib/hooks/useD3'
 import { FunnelLayout } from 'lib/constants'
-import { createRoundedRectPath, getConfig, INITIAL_CONFIG } from './histogramUtils'
+import { createRoundedRectPath, getConfig, INITIAL_CONFIG, D3HistogramDatum } from './histogramUtils'
 import { getOrCreateEl, animate, wrap } from 'lib/utils/d3Utils'
 
 import './Histogram.scss'
@@ -14,6 +14,7 @@ export interface HistogramDatum {
     bin0: number
     bin1: number
     count: number
+    label: string | number
 }
 
 interface HistogramProps {
@@ -23,6 +24,7 @@ interface HistogramProps {
     width?: number
     height?: number
     formatXTickLabel?: (value: number) => number | string
+    formatYTickLabel?: (value: number) => number
 }
 
 export function Histogram({
@@ -32,17 +34,15 @@ export function Histogram({
     height = INITIAL_CONFIG.height,
     isAnimated = false,
     formatXTickLabel = (value: number) => value,
+    formatYTickLabel = (value: number) => value,
 }: HistogramProps): JSX.Element {
     const { config } = useValues(histogramLogic)
     const { setConfig } = useActions(histogramLogic)
     const isEmpty = data.length === 0 || d3.sum(data.map((d) => d.count)) === 0
 
-    // TODO: All D3 state outside of useD3 hook will be moved into separate kea histogramLogic
-
     // Initialize x-axis and y-axis scales
     const xMin = data?.[0]?.bin0 || 0
     const xMax = data?.[data.length - 1]?.bin1 || 1
-    const xSecond = data?.[0]?.bin1 || xMax
     const x = d3.scaleLinear().domain([xMin, xMax]).range(config.ranges.x).nice()
     const xAxis = config.axisFn
         .x(x)
@@ -66,7 +66,14 @@ export function Histogram({
         .domain([0, d3.max(data, (d: HistogramDatum) => d.count) as number])
         .range(config.ranges.y)
         .nice()
-    const yAxis = config.axisFn.y(y).tickSize(0)
+    const yAxis = config.axisFn
+        .y(y)
+        .tickSize(0)
+        .tickFormat((v: number) => {
+            const count = formatYTickLabel(v) * 10000
+            // SI-prefix with trailing zeroes trimmed off
+            return d3.format('~s')(count)
+        })
 
     // y-axis gridline scale
     const yAxisGrid = config.axisFn.y(y).tickSize(-config.gridlineTickSize).tickFormat('').ticks(y.ticks().length)
@@ -78,6 +85,8 @@ export function Histogram({
 
     const ref = useD3(
         (container) => {
+            const isVertical = config.layout === FunnelLayout.vertical
+
             const renderCanvas = (parentNode: D3Selector): D3Selector => {
                 // Update config to reflect dimension changes
                 x.range(config.ranges.x)
@@ -91,15 +100,15 @@ export function Histogram({
                         .attr('viewBox', `0 0 ${config.inner.width} ${config.inner.height}`)
                         .attr('width', '100%')
                         .append('svg:g')
-                        .classed(layout, true)
+                        .classed(config.layout, true)
                 )
                 // update dimensions
                 parentNode.select('svg').attr('viewBox', `0 0 ${config.width} ${config.height}`)
 
                 // if class doesn't exist on svg>g, layout has changed. after we learn this, reset
                 // the layout
-                const layoutChanged = !_svg.classed(layout)
-                _svg.attr('class', null).classed(layout, true)
+                const layoutChanged = !_svg.classed(config.layout)
+                _svg.attr('class', null).classed(config.layout, true)
 
                 // if layout changes, redraw axes from scratch
                 if (layoutChanged) {
@@ -113,7 +122,16 @@ export function Histogram({
                 _xAxis.call(animate, !layoutChanged ? config.transitionDuration : 0, isAnimated, (it: D3Transition) =>
                     it.call(xAxis).attr('transform', config.transforms.x)
                 )
-                _xAxis.selectAll('.tick text').call(wrap, x(xSecond) - x(0), config.spacing.labelLineHeight)
+                const binWidth = x(data?.[0]?.bin1 || data?.[data.length - 1]?.bin1 || 1) - x(data?.[0]?.bin0 || 0)
+                _xAxis
+                    .selectAll('.tick text')
+                    .call(
+                        wrap,
+                        isVertical ? binWidth : config.margin.left,
+                        config.spacing.labelLineHeight,
+                        isVertical,
+                        config.spacing.xLabel
+                    )
 
                 // Don't draw y-axis or y-gridline if the data is empty
                 if (!isEmpty) {
@@ -129,7 +147,9 @@ export function Histogram({
                             it
                                 .call(yAxis)
                                 .attr('transform', config.transforms.y)
-                                .call((g) => g.selectAll('.tick text').attr('dy', `-${config.spacing.yLabel}`))
+                                .call((g) =>
+                                    g.selectAll('.tick text').attr('dx', isVertical ? `-${config.spacing.yLabel}` : 0)
+                                )
                     )
 
                     // y-gridlines
@@ -140,55 +160,90 @@ export function Histogram({
                         animate,
                         !layoutChanged ? config.transitionDuration : 0,
                         isAnimated,
-                        (it: D3Transition) =>
-                            it
-                                .call(yAxisGrid)
-                                .call((g) =>
-                                    g
-                                        .selectAll('.tick:not(:first-of-type) line')
-                                        .attr('stroke-opacity', 0.5)
-                                        .attr('stroke-dasharray', '2,2')
-                                )
-                                .attr('transform', config.transforms.yGrid)
+                        (it: D3Transition) => it.call(yAxisGrid).attr('transform', config.transforms.yGrid)
                     )
                 }
+
+                const d3Data = data as D3HistogramDatum[]
 
                 // bars
                 const _bars = getOrCreateEl(_svg, 'g#bars', () => _svg.append('svg:g').attr('id', 'bars'))
                 _bars
                     .selectAll('path')
-                    .data(data)
+                    .data(d3Data)
                     .join('path')
                     .call(animate, config.transitionDuration, isAnimated, (it: D3Transition) => {
                         return it.attr('d', (d: HistogramDatum) => {
-                            if (layout === FunnelLayout.vertical) {
+                            if (!isVertical) {
+                                // is horizontal
                                 return createRoundedRectPath(
+                                    y(0),
                                     x(d.bin0) + config.spacing.btwnBins / 2,
-                                    y(d.count),
+                                    y(d.count) - y(0),
                                     Math.max(0, x(d.bin1) - x(d.bin0) - config.spacing.btwnBins),
-                                    y(0) - y(d.count),
                                     config.borderRadius,
-                                    'top'
+                                    'right'
                                 )
                             }
-                            // is horizontal
                             return createRoundedRectPath(
-                                y(0),
                                 x(d.bin0) + config.spacing.btwnBins / 2,
-                                y(d.count) - y(0),
+                                y(d.count),
                                 Math.max(0, x(d.bin1) - x(d.bin0) - config.spacing.btwnBins),
+                                y(0) - y(d.count),
                                 config.borderRadius,
-                                'right'
+                                'top'
                             )
                         })
                     })
+
+                // text labels
+                const _labels = getOrCreateEl(_svg, 'g#labels', () => _svg.append('svg:g').attr('id', 'labels'))
+                _labels
+                    .selectAll('text')
+                    .data(d3Data)
+                    .join('text')
+                    .text((d) => d.label)
+                    .classed('bar-label', true)
+                    .each(function (this: any, d) {
+                        const { width: labelWidth, height: labelHeight } = this.getBBox()
+                        d.labelWidth = labelWidth
+                        d.labelHeight = labelHeight
+                        d.shouldShowInBar = false
+                    })
+                    .attr('x', (d) => {
+                        if (!isVertical) {
+                            const labelWidth = (d.labelWidth || 0) + 2 * config.spacing.barLabelPadding
+                            const shouldShowInBar = labelWidth <= y(d.count) - y(0)
+                            const labelDx = shouldShowInBar
+                                ? -(labelWidth - config.spacing.barLabelPadding)
+                                : config.spacing.barLabelPadding
+                            d.shouldShowInBar = shouldShowInBar
+                            return y(d.count) + labelDx
+                        }
+                        // x + bin width + dx + dy
+                        return x(d.bin0) + binWidth / 2 - (d.labelWidth || 0) / 2
+                    })
+                    .attr('y', (d) => {
+                        if (!isVertical) {
+                            return x(d.bin0) + binWidth / 2
+                        }
+                        // determine if label should be in the bar or above it.
+                        const labelHeight = (d.labelHeight || 0) + 2 * config.spacing.barLabelPadding
+                        const shouldShowInBar = labelHeight <= y(0) - y(d.count)
+                        const labelDy = shouldShowInBar
+                            ? labelHeight - config.spacing.barLabelPadding
+                            : -config.spacing.barLabelPadding
+                        d.shouldShowInBar = shouldShowInBar
+                        return y(d.count) + labelDy
+                    })
+                    .classed('outside', (d) => !d.shouldShowInBar)
 
                 return _svg
             }
 
             renderCanvas(container)
         },
-        [data, layout, config]
+        [data, config]
     )
 
     return <div className="histogram-container" ref={ref} />

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -88,15 +88,6 @@ export function Histogram({
                 config.margin.left +
                 config.margin.right
         )
-        console.log(
-            'widths',
-            minWidth,
-            width,
-            data.length * (config.spacing.minBarWidth + config.spacing.btwnBins) +
-                config.margin.left +
-                config.margin.right,
-            data.length
-        )
         setConfig(getConfig(layout, isDashboardItem ? width : minWidth, height))
     }, [data.length, layout, width, height])
 

--- a/frontend/src/scenes/insights/Histogram/__snapshots__/histogramLogic.test.ts.snap
+++ b/frontend/src/scenes/insights/Histogram/__snapshots__/histogramLogic.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`histogramLogic values has proper defaults 1`] = `
+Object {
+  "config": Object {
+    "axisFn": Object {
+      "x": [Function],
+      "y": [Function],
+    },
+    "borderRadius": 4,
+    "gridlineTickSize": 445,
+    "height": 500,
+    "inner": Object {
+      "height": 460,
+      "width": 440,
+    },
+    "layout": "vertical",
+    "margin": Object {
+      "bottom": 20,
+      "left": 40,
+      "right": 20,
+      "top": 20,
+    },
+    "ranges": Object {
+      "x": Array [
+        40,
+        480,
+      ],
+      "y": Array [
+        480,
+        20,
+      ],
+    },
+    "spacing": Object {
+      "barLabelPadding": 8,
+      "btwnBins": 6,
+      "labelLineHeight": 1.2,
+      "xLabel": 8,
+      "yLabel": 5,
+    },
+    "transforms": Object {
+      "x": "translate(0,480)",
+      "y": "translate(40,0)",
+      "yGrid": "translate(35,0)",
+    },
+    "transitionDuration": 200,
+    "width": 500,
+  },
+}
+`;

--- a/frontend/src/scenes/insights/Histogram/__snapshots__/histogramLogic.test.ts.snap
+++ b/frontend/src/scenes/insights/Histogram/__snapshots__/histogramLogic.test.ts.snap
@@ -35,6 +35,7 @@ Object {
       "barLabelPadding": 8,
       "btwnBins": 6,
       "labelLineHeight": 1.2,
+      "minBarWidth": 95,
       "xLabel": 8,
       "yLabel": 5,
     },

--- a/frontend/src/scenes/insights/Histogram/histogramLogic.test.ts
+++ b/frontend/src/scenes/insights/Histogram/histogramLogic.test.ts
@@ -1,0 +1,32 @@
+import { histogramLogic } from './histogramLogic'
+import { BuiltLogic } from 'kea'
+import { histogramLogicType } from 'scenes/insights/Histogram/histogramLogicType'
+import { initKeaTestLogic } from '~/test/utils'
+import { getConfig } from 'scenes/insights/Histogram/histogramUtils'
+import { FunnelLayout } from 'lib/constants'
+
+describe('histogramLogic', () => {
+    let logic: BuiltLogic<histogramLogicType>
+
+    initKeaTestLogic({
+        logic: histogramLogic,
+        onLogic: (l) => (logic = l),
+    })
+
+    describe('values', () => {
+        it('has proper defaults', () => {
+            expect(logic.values).toMatchSnapshot()
+        })
+    })
+
+    describe('reducers', () => {
+        describe('config', () => {
+            it('is set via setConfig', async () => {
+                const newConfig = getConfig(FunnelLayout.vertical, 1000, 3000)
+                expect(logic.values.config).toEqual(getConfig(FunnelLayout.vertical))
+                logic.actions.setConfig(newConfig)
+                expect(logic.values.config).toEqual(newConfig)
+            })
+        })
+    })
+})

--- a/frontend/src/scenes/insights/Histogram/histogramUtils.ts
+++ b/frontend/src/scenes/insights/Histogram/histogramUtils.ts
@@ -14,7 +14,14 @@ export interface HistogramConfig {
     transforms: { x: string; y: string; yGrid: string }
     axisFn: { x: any; y: any }
     transitionDuration: number
-    spacing: { btwnBins: number; yLabel: number; xLabel: number; labelLineHeight: number; barLabelPadding: number }
+    spacing: {
+        btwnBins: number
+        yLabel: number
+        xLabel: number
+        labelLineHeight: number
+        barLabelPadding: number
+        minBarWidth: number
+    }
 }
 
 export const INITIAL_CONFIG = {
@@ -29,7 +36,8 @@ export const INITIAL_CONFIG = {
         yLabel: 5, // y-axis label xOffset in vertical position
         xLabel: 8, // x-axis label xOffset in horizontal position
         labelLineHeight: 1.2, // line height of wrapped label text in em's,
-        barLabelPadding: 8, // padding between bar and bar label
+        barLabelPadding: 8, // padding between bar and bar label,
+        minBarWidth: 95, // minimum bar width
     },
 }
 

--- a/frontend/src/scenes/insights/Histogram/histogramUtils.ts
+++ b/frontend/src/scenes/insights/Histogram/histogramUtils.ts
@@ -1,7 +1,9 @@
 import * as d3 from 'd3'
 import { FunnelLayout } from 'lib/constants'
+import { HistogramDatum } from 'scenes/insights/Histogram/Histogram'
 
 export interface HistogramConfig {
+    layout: FunnelLayout
     height: number
     width: number
     inner: { height: number; width: number }
@@ -12,19 +14,22 @@ export interface HistogramConfig {
     transforms: { x: string; y: string; yGrid: string }
     axisFn: { x: any; y: any }
     transitionDuration: number
-    spacing: { btwnBins: number; yLabel: number; labelLineHeight: number }
+    spacing: { btwnBins: number; yLabel: number; xLabel: number; labelLineHeight: number; barLabelPadding: number }
 }
 
 export const INITIAL_CONFIG = {
+    layout: FunnelLayout.vertical,
     height: 500,
     width: 500,
-    margin: { top: 40, right: 20, bottom: 40, left: 40 },
+    margin: { top: 20, right: 20, bottom: 20, left: 40 },
     borderRadius: 4, // same as funnel bar graph,
     transitionDuration: 200, // in ms; same as in funnel bar graph
     spacing: {
         btwnBins: 6, // spacing between bins
         yLabel: 5, // y-axis label xOffset in vertical position
-        labelLineHeight: 1.2, // line height of wrapped label text in em's
+        xLabel: 8, // x-axis label xOffset in horizontal position
+        labelLineHeight: 1.2, // line height of wrapped label text in em's,
+        barLabelPadding: 8, // padding between bar and bar label
     },
 }
 
@@ -35,6 +40,7 @@ export const getConfig = (layout: FunnelLayout, width?: number, height?: number)
 
     return {
         ...INITIAL_CONFIG,
+        layout,
         height: _height,
         width: _width,
         inner: {
@@ -50,7 +56,7 @@ export const getConfig = (layout: FunnelLayout, width?: number, height?: number)
                 : [INITIAL_CONFIG.margin.left, _width - INITIAL_CONFIG.margin.right],
         },
         gridlineTickSize: isVertical
-            ? _width - INITIAL_CONFIG.margin.left + INITIAL_CONFIG.spacing.yLabel * 2.5 - INITIAL_CONFIG.margin.right
+            ? _width - INITIAL_CONFIG.margin.left + INITIAL_CONFIG.spacing.yLabel - INITIAL_CONFIG.margin.right
             : _height - INITIAL_CONFIG.margin.bottom - INITIAL_CONFIG.margin.top,
         transforms: {
             x: isVertical
@@ -58,7 +64,7 @@ export const getConfig = (layout: FunnelLayout, width?: number, height?: number)
                 : `translate(${INITIAL_CONFIG.margin.left},0)`,
             y: isVertical ? `translate(${INITIAL_CONFIG.margin.left},0)` : `translate(0,${INITIAL_CONFIG.margin.top})`,
             yGrid: isVertical
-                ? `translate(${INITIAL_CONFIG.margin.left - INITIAL_CONFIG.spacing.yLabel * 2.5},0)`
+                ? `translate(${INITIAL_CONFIG.margin.left - INITIAL_CONFIG.spacing.yLabel},0)`
                 : `translate(0,${INITIAL_CONFIG.margin.top})`,
         },
         axisFn: {
@@ -142,4 +148,10 @@ export const createRoundedRectPath = (
         // Close the shape
         'z'
     )
+}
+
+export interface D3HistogramDatum extends HistogramDatum {
+    labelWidth?: number
+    labelHeight?: number
+    shouldShowInBar?: boolean
 }

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -5,7 +5,7 @@ import Chart from '@posthog/chart.js'
 import 'chartjs-adapter-dayjs'
 import PropTypes from 'prop-types'
 import { compactNumber, lightenDarkenColor } from '~/lib/utils'
-import { getBarColorFromStatus, getChartColors } from 'lib/colors'
+import { getBarColorFromStatus, getChartColors, getGraphColors } from 'lib/colors'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
 import { toast } from 'react-toastify'
 import { Annotations, annotationsLogic, AnnotationMarker } from 'lib/components/Annotations'
@@ -22,6 +22,7 @@ Chart.defaults.global.elements.line.tension = 0
 //--Chart Style Options--//
 
 const noop = () => {}
+
 export function LineGraph({
     datasets,
     visibilityMap = null,
@@ -69,18 +70,7 @@ export function LineGraph({
         !inSharedMode &&
         datasets[0].labels?.[0] !== '1 day' // stickiness graphs
 
-    const isLightTheme = color === 'white'
-    const colors = {
-        axisLabel: isLightTheme ? '#333' : 'rgba(255,255,255,0.8)',
-        axisLine: isLightTheme ? '#ddd' : 'rgba(255,255,255,0.2)',
-        axis: isLightTheme ? '#999' : 'rgba(255,255,255,0.6)',
-        crosshair: 'rgba(0,0,0,0.2)',
-        tooltipBackground: '#1dc9b7',
-        tooltipTitle: '#fff',
-        tooltipBody: '#fff',
-        annotationColor: isLightTheme ? null : 'white',
-        annotationAccessoryColor: isLightTheme ? null : 'black',
-    }
+    const colors = getGraphColors(color === 'white')
 
     useEscapeKey(() => setFocused(false), [focused])
 

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -45,6 +45,9 @@ $lifecycle_dormant: #f86234;
 $funnel_default: $primary;
 $funnel_alt: $primary_alt;
 $funnel_background: #e7e8ee;
+$funnel_axis_zero: $bg_depth;
+$funnel_axis: $border_dark;
+$funnel_axis_label: $text_muted;
 
 .bg-mid {
     background-color: $bg_mid !important;


### PR DESCRIPTION
## Changes

Fixes a bunch of time conversion quality bugs, refactors it a bunch, and adds a few features. See below for a detailed breakdown.

- [X] Abbreviate y labels to use SI units (k, M, etc.). Fixes #5302.
- [X] Hide step 1-2 if only two steps
- [X] Standardize axis colors with existing LineGraph colors
- [X] Shift y labels to align
- [X] Fix squished height bug in Safari. Fixes #5339
- [X] Add absolute percentages above/below bar. Closes #5327.
- [X] Add kea logic tests for `histogramLogic`
- [X] Scrolling for many bins, adds min width to each bar so labels don't get squished

**Before**

<img width="706" alt="Screen Shot 2021-07-27 at 5 24 21 PM" src="https://user-images.githubusercontent.com/13460330/127244190-6d42ea4e-5a35-472a-ae7d-d7049f4f8934.png">

**After**

<img width="684" alt="Screen Shot 2021-07-27 at 5 23 29 PM" src="https://user-images.githubusercontent.com/13460330/127244196-30181e8d-cd82-4510-9cdd-97fb2861d736.png">

<img width="706" alt="Screen Shot 2021-07-27 at 5 24 59 PM" src="https://user-images.githubusercontent.com/13460330/127244241-8748e30b-eb4c-4d41-b880-61f5d87dcf1e.png">

<img width="546" alt="Screen Shot 2021-07-28 at 12 11 43 PM" src="https://user-images.githubusercontent.com/13460330/127382069-e294f147-acd7-459a-a2d9-d07c406f41e7.png">


Safari:

<img width="1563" alt="Screen Shot 2021-07-27 at 5 25 31 PM" src="https://user-images.githubusercontent.com/13460330/127244266-2d024ee3-b5f2-40da-b31e-44a05cd5e3e0.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [X]  Kea logic tests
- [X] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
