### PR TITLE
Ingestion - add confirmation to skip + help button

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -240,6 +240,7 @@ export const FEATURE_FLAGS = {
     FUNNEL_BAR_VIZ: '4535-funnel-bar-viz', // Nail Funnels #4785
     SESSIONS_TABLE: '4964-sessions-table', // Expand/collapse all in sessions table (performance consideration)
     TAXONOMIC_PROPERTY_FILTER: '4267-taxonomic-property-filter',
+    INGESTION_HELP_BUTTON: '112-ingestion-help-button',
 }
 
 export const ENVIRONMENT_LOCAL_STORAGE_KEY = '$environment'

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -1,20 +1,109 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { useInterval } from 'lib/hooks/useInterval'
 import { CardContainer } from 'scenes/ingestion/CardContainer'
-import { Button, Row, Spin } from 'antd'
+import { Button, Row, Spin, Space, Popconfirm, Dropdown, Menu, Typography } from 'antd'
 import { ingestionLogic } from 'scenes/ingestion/ingestionLogic'
+import { DownOutlined, SlackSquareOutlined } from '@ant-design/icons'
+import { CreateInviteModalWithButton } from 'scenes/organization/Settings/CreateInviteModal'
+
+const { Text } = Typography
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function VerificationPanel(): JSX.Element {
     const { loadUser } = useActions(userLogic)
     const { user } = useValues(userLogic)
     const { setVerify, completeOnboarding } = useActions(ingestionLogic)
     const { index, totalSteps } = useValues(ingestionLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const [isMenuOpen, setIsMenuOpen] = useState(false)
 
     useInterval(() => {
-        !user?.team?.ingested_event && loadUser()
+        if (!user?.team?.ingested_event) {
+            if (!isMenuOpen) {
+                loadUser()
+            }
+        }
     }, 1500)
+
+    function HelperButtonRow(): JSX.Element {
+        function HelpButton(): JSX.Element {
+            const menu = (
+                <Menu selectable>
+                    <Menu.Item key="1">
+                        <CreateInviteModalWithButton type="link" />
+                    </Menu.Item>
+                    <Menu.Item key="2">
+                        <Button
+                            type="link"
+                            onClick={() => {
+                                window.open('https://posthog.com/slack?s=app', '_blank')
+                            }}
+                        >
+                            <SlackSquareOutlined />
+                            Ask in Slack
+                        </Button>
+                    </Menu.Item>
+                </Menu>
+            )
+            return (
+                <div
+                    onMouseLeave={() => {
+                        setIsMenuOpen(false)
+                    }}
+                >
+                    <Dropdown overlay={menu} trigger={['click']}>
+                        <Button type="primary" onMouseEnter={() => setIsMenuOpen(true)}>
+                            Need help? <DownOutlined />
+                        </Button>
+                    </Dropdown>
+                </div>
+            )
+        }
+
+        const popoverTitle = (
+            <Space direction="vertical">
+                <Text strong>Are you sure you want to continue without event data?</Text>
+                <Text>For the best experience, we strongly recommend adding event data before continuing.</Text>
+            </Space>
+        )
+        return (
+            <Space style={{ float: 'right' }}>
+                <Popconfirm
+                    title={popoverTitle}
+                    okText="Yes, I know what I'm doing."
+                    okType="danger"
+                    cancelText="No, go back."
+                    onVisibleChange={(v) => {
+                        setIsMenuOpen(v)
+                    }}
+                    onCancel={() => {
+                        setIsMenuOpen(false)
+                    }}
+                    onConfirm={completeOnboarding}
+                    cancelButtonProps={{ type: 'primary' }}
+                >
+                    <Button type="dashed">Continue without verifying</Button>
+                </Popconfirm>
+                <HelpButton />
+            </Space>
+        )
+    }
+
+    function DefaultSkipCta(): JSX.Element {
+        return (
+            <b
+                data-attr="wizard-complete-button"
+                style={{ float: 'right' }}
+                className="button-border clickable"
+                onClick={completeOnboarding}
+            >
+                Continue without verifying
+            </b>
+        )
+    }
 
     return (
         <CardContainer index={index} totalSteps={totalSteps} onBack={() => setVerify(false)}>
@@ -29,14 +118,7 @@ export function VerificationPanel(): JSX.Element {
                         Once you have integrated the snippet and sent an event, we will verify it sent properly and
                         continue
                     </p>
-                    <b
-                        data-attr="wizard-complete-button"
-                        style={{ float: 'right' }}
-                        className="button-border clickable"
-                        onClick={completeOnboarding}
-                    >
-                        Continue without verifying
-                    </b>
+                    {featureFlags[FEATURE_FLAGS.INGESTION_HELPER_ROW] ? <HelperButtonRow /> : <DefaultSkipCta />}
                 </>
             ) : (
                 <>

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -18,13 +18,14 @@ export function VerificationPanel(): JSX.Element {
     const { setVerify, completeOnboarding } = useActions(ingestionLogic)
     const { index, totalSteps } = useValues(ingestionLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const [isMenuOpen, setIsMenuOpen] = useState(false)
+    const [isPopConfirmShowing, setPopConfirmShowing] = useState(false)
+    const [isHelpMenuShowing, setHelpMenuShowing] = useState(false)
 
     useInterval(() => {
-        if (!user?.team?.ingested_event && !isMenuOpen) {
+        if (!user?.team?.ingested_event && !isPopConfirmShowing && !isHelpMenuShowing) {
             loadUser()
         }
-    }, 1500)
+    }, 2000)
 
     function HelperButtonRow(): JSX.Element {
         function HelpButton(): JSX.Element {
@@ -47,21 +48,18 @@ export function VerificationPanel(): JSX.Element {
                 </Menu>
             )
             return (
-                <div
-                    onMouseLeave={() => {
-                        setIsMenuOpen(false)
+                <Dropdown
+                    overlay={menu}
+                    trigger={['click']}
+                    visible={isHelpMenuShowing}
+                    onVisibleChange={(v) => {
+                        setHelpMenuShowing(v)
                     }}
                 >
-                    <Dropdown overlay={menu} trigger={['click']}>
-                        <Button
-                            type="primary"
-                            data-attr="ingestion-help-button"
-                            onMouseEnter={() => setIsMenuOpen(true)}
-                        >
-                            Need help? <DownOutlined />
-                        </Button>
-                    </Dropdown>
-                </div>
+                    <Button type="primary" data-attr="ingestion-help-button" onClick={() => setHelpMenuShowing(true)}>
+                        Need help? <DownOutlined />
+                    </Button>
+                </Dropdown>
             )
         }
 
@@ -80,15 +78,22 @@ export function VerificationPanel(): JSX.Element {
                     okType="danger"
                     cancelText="No, go back."
                     onVisibleChange={(v) => {
-                        setIsMenuOpen(v)
+                        setPopConfirmShowing(v)
                     }}
                     onCancel={() => {
-                        setIsMenuOpen(false)
+                        setPopConfirmShowing(false)
                     }}
+                    visible={isPopConfirmShowing}
                     onConfirm={completeOnboarding}
                     cancelButtonProps={{ type: 'primary' }}
                 >
-                    <Button type="dashed" data-attr="ingestion-continue-anyway">
+                    <Button
+                        type="dashed"
+                        data-attr="ingestion-continue-anyway"
+                        onClick={() => {
+                            setPopConfirmShowing(true)
+                        }}
+                    >
                         Continue without verifying
                     </Button>
                 </Popconfirm>

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -32,10 +32,10 @@ export function VerificationPanel(): JSX.Element {
         function HelpButton(): JSX.Element {
             const menu = (
                 <Menu selectable>
-                    <Menu.Item key="1">
+                    <Menu.Item key="1" data-attr="ingestion-help-item-invite">
                         <CreateInviteModalWithButton type="link" />
                     </Menu.Item>
-                    <Menu.Item key="2">
+                    <Menu.Item key="2" data-attr="ingestion-help-item-slack">
                         <Button
                             type="link"
                             onClick={() => {
@@ -55,7 +55,11 @@ export function VerificationPanel(): JSX.Element {
                     }}
                 >
                     <Dropdown overlay={menu} trigger={['click']}>
-                        <Button type="primary" onMouseEnter={() => setIsMenuOpen(true)}>
+                        <Button
+                            type="primary"
+                            data-attr="ingestion-help-button"
+                            onMouseEnter={() => setIsMenuOpen(true)}
+                        >
                             Need help? <DownOutlined />
                         </Button>
                     </Dropdown>
@@ -65,8 +69,9 @@ export function VerificationPanel(): JSX.Element {
 
         const popoverTitle = (
             <Space direction="vertical">
-                <Text strong>Are you sure you want to continue without event data?</Text>
-                <Text>For the best experience, we strongly recommend adding event data before continuing.</Text>
+                <Text strong>Are you sure you want to continue without data?</Text>
+                <Text>You won't be able to conduct analysis or use most tools without event data.</Text>
+                <Text>For the best experience, we recommend adding event data before continuing.</Text>
             </Space>
         )
         return (
@@ -85,7 +90,9 @@ export function VerificationPanel(): JSX.Element {
                     onConfirm={completeOnboarding}
                     cancelButtonProps={{ type: 'primary' }}
                 >
-                    <Button type="dashed">Continue without verifying</Button>
+                    <Button type="dashed" data-attr="ingestion-continue-anyway">
+                        Continue without verifying
+                    </Button>
                 </Popconfirm>
                 <HelpButton />
             </Space>
@@ -116,7 +123,7 @@ export function VerificationPanel(): JSX.Element {
                     <p className="prompt-text">
                         {' '}
                         Once you have integrated the snippet and sent an event, we will verify it sent properly and
-                        continue
+                        continue.
                     </p>
                     {featureFlags[FEATURE_FLAGS.INGESTION_HELP_BUTTON] ? <HelperButtonRow /> : <DefaultSkipCta />}
                 </>

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -21,10 +21,8 @@ export function VerificationPanel(): JSX.Element {
     const [isMenuOpen, setIsMenuOpen] = useState(false)
 
     useInterval(() => {
-        if (!user?.team?.ingested_event) {
-            if (!isMenuOpen) {
-                loadUser()
-            }
+        if (!user?.team?.ingested_event && !isMenuOpen) {
+            loadUser()
         }
     }, 1500)
 

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -118,7 +118,7 @@ export function VerificationPanel(): JSX.Element {
                         Once you have integrated the snippet and sent an event, we will verify it sent properly and
                         continue
                     </p>
-                    {featureFlags[FEATURE_FLAGS.INGESTION_HELPER_ROW] ? <HelperButtonRow /> : <DefaultSkipCta />}
+                    {featureFlags[FEATURE_FLAGS.INGESTION_HELP_BUTTON] ? <HelperButtonRow /> : <DefaultSkipCta />}
                 </>
             ) : (
                 <>

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -71,7 +71,7 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) or 
     "4535-funnel-bar-viz",
 ]
 
-SELF_CAPTURE = False
+SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG, type_cast=str_to_bool)
 SHELL_PLUS_PRINT_SQL = get_from_env("PRINT_SQL", False, type_cast=str_to_bool)
 USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -71,7 +71,7 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) or 
     "4535-funnel-bar-viz",
 ]
 
-SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG, type_cast=str_to_bool)
+SELF_CAPTURE = False
 SHELL_PLUS_PRINT_SQL = get_from_env("PRINT_SQL", False, type_cast=str_to_bool)
 USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
 


### PR DESCRIPTION
## Changes
[Ticket](https://github.com/PostHog/product-internal/issues/112?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDIyMDM5NTY4NDM6NTk2NTg5MQ%3D%3D&notifications_query=is%3Adone#issuecomment-888507292)
- Add confirmation dialog before skipping without events
- Add escape valve helper links (invite a teammate, ask in slack)

State management was a little tricky - we re-render this component every 1.5 sec to check for new events, so that's why there's code taking component state to determine whether to load a user or not. 

Open to feedback here if there's a better way to have done it!

<img width="929" alt="Screen Shot 2021-07-27 at 6 41 51 PM" src="https://user-images.githubusercontent.com/5965891/127250974-ce243d96-4d72-4fbc-86b6-864d10844730.png">
<img width="983" alt="Screen Shot 2021-07-27 at 6 41 39 PM" src="https://user-images.githubusercontent.com/5965891/127250971-31981993-0942-4afd-b5ba-d4a1ab75e5b3.png">
<img width="965" alt="Screen Shot 2021-07-27 at 6 41 46 PM" src="https://user-images.githubusercontent.com/5965891/127250973-f1ffebb5-b71f-47de-b97b-a5a64b2cb409.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
