### PR TITLE
Allow Taxonomic Property Filter Form Field Width to Expand to max width

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -3,7 +3,6 @@
 
     &.in-dropdown {
         min-width: 300px;
-        width: 550px;
         max-width: calc(100vw - 25px);
         background: white;
     }


### PR DESCRIPTION
This is my first PR on PostHog, please feel free to be harsh, but supportive to help me learn :)

## Changes
In order to resolve this issue: https://github.com/PostHog/posthog/issues/5349

Where the taxonomic Property filter value box was too narrow for an email address or URL, I removed the default width of the taxonomic property filter to allow each of the form elements to expand.

**Screenshots**

Funnels - Wide
![image](https://user-images.githubusercontent.com/85295485/127292851-47a628e1-e97d-451b-8cdb-51cbfb0d4c6b.png)

Funnels - Narrow
![image](https://user-images.githubusercontent.com/85295485/127292935-039cbe15-78fe-4c05-afe8-428ca30f38e8.png)

Funnels - Smartphone
![image](https://user-images.githubusercontent.com/85295485/127293321-8bf3cf20-5bc6-43c0-b1cb-1684f3a5777a.png)

Trends - Wide
![image](https://user-images.githubusercontent.com/85295485/127293442-02c3ed45-13f7-43b5-970b-aa920ac7e493.png)

Trends - Narrow
![image](https://user-images.githubusercontent.com/85295485/127293420-eb5cf2e9-783b-41d3-b301-6fc5f2a6f6f7.png)

Trends - Smartphone
![image](https://user-images.githubusercontent.com/85295485/127293377-7866bdc7-d704-43f2-b502-37544200ea3f.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [x] Jest frontend tests
- [x] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [x] New/changed UI is decent on smartphones (viewport width around 360px)
