### PR TITLE
Revert person.distinct_ids column

### DIFF
--- a/ee/clickhouse/migrations/0014_persons_distinct_ids_column_remove.py
+++ b/ee/clickhouse/migrations/0014_persons_distinct_ids_column_remove.py
@@ -1,0 +1,12 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.person import KAFKA_PERSONS_TABLE_SQL, PERSONS_TABLE_MV_SQL
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(f"ALTER TABLE person ON CLUSTER {CLICKHOUSE_CLUSTER} DROP COLUMN IF NOT EXISTS distinct_ids"),
+    migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
+    migrations.RunSQL(PERSONS_TABLE_MV_SQL),
+]

--- a/ee/clickhouse/migrations/0014_persons_distinct_ids_column_remove.py
+++ b/ee/clickhouse/migrations/0014_persons_distinct_ids_column_remove.py
@@ -6,7 +6,7 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 operations = [
     migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
     migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER {CLICKHOUSE_CLUSTER}"),
-    migrations.RunSQL(f"ALTER TABLE person ON CLUSTER {CLICKHOUSE_CLUSTER} DROP COLUMN IF NOT EXISTS distinct_ids"),
+    migrations.RunSQL(f"ALTER TABLE person ON CLUSTER {CLICKHOUSE_CLUSTER} DROP COLUMN IF EXISTS distinct_ids"),
     migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
     migrations.RunSQL(PERSONS_TABLE_MV_SQL),
 ]

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -17,7 +17,6 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     team_id Int64,
     properties VARCHAR,
     is_identified Boolean,
-    distinct_ids Array(VARCHAR),
     is_deleted Boolean DEFAULT 0
     {extra_fields}
 ) ENGINE = {engine}
@@ -51,7 +50,6 @@ created_at,
 team_id,
 properties,
 is_identified,
-distinct_ids,
 is_deleted,
 _timestamp,
 _offset


### PR DESCRIPTION
## Changes

Reverts https://github.com/PostHog/posthog/pull/5276

This seems to be causing this sentry issue: https://sentry.io/organizations/posthog/issues/2279241522/?project=5592816&query=&statsPeriod=24h
Related discussion: PostHog/product-internal#114

Additionally we got most of the measurements we wanted out of this.

Needs to be deployed together with https://github.com/PostHog/plugin-server/pull/510

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
