### PR TITLE
Kill api/person/references method

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -150,26 +150,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             [{"name": convert_property_value(event[key]), "count": event["count"]} for event in people[:50]]
         )
 
-    @action(methods=["GET"], detail=False)
-    def references(self, request: request.Request, **kwargs) -> response.Response:
-        reference_id = request.GET.get("id", None)
-        offset = request.GET.get("offset", None)
-
-        if not reference_id or not offset:
-            return response.Response({})
-
-        offset_value = int(offset)
-        cached_result = get_safe_cache(reference_id)
-        if cached_result:
-            return response.Response(
-                {
-                    "result": cached_result[offset_value : offset_value + 100],
-                    "offset": offset_value + 100 if len(cached_result) > offset_value + 100 else None,
-                }
-            )
-        else:
-            return response.Response({})
-
     @action(methods=["POST"], detail=True)
     def merge(self, request: request.Request, pk=None, **kwargs) -> response.Response:
         people = Person.objects.filter(team_id=self.team_id, pk__in=request.data.get("ids"))


### PR DESCRIPTION
This was added in https://github.com/PostHog/posthog/pull/1202, but seems to be dead.

The frontend code seems to have been removed in https://github.com/PostHog/posthog/pull/2669

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
