### PR TITLE
Count query as failed if it takes > 15s

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -2,7 +2,7 @@ import asyncio
 import hashlib
 import json
 import re
-from time import time
+from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple
 
 import sqlparse
@@ -129,7 +129,7 @@ else:
 
     def sync_execute(query, args=None, settings=None, with_column_types=False):
         with ch_pool.get_client() as client:
-            start_time = time()
+            start_time = perf_counter()
             tags = {}
             if app_settings.SHELL_PLUS_PRINT_SQL:
                 print()
@@ -147,7 +147,7 @@ else:
 
                 raise _wrap_api_error(err)
             finally:
-                execution_time = time() - start_time
+                execution_time = perf_counter() - start_time
 
                 if not timeout_task.done:
                     QUERY_TIMEOUT_THREAD.cancel(timeout_task)

--- a/ee/clickhouse/timer.py
+++ b/ee/clickhouse/timer.py
@@ -1,0 +1,105 @@
+import logging
+import uuid
+from collections import OrderedDict
+from functools import partial
+from threading import Condition, Thread
+from time import time
+from typing import Callable, Dict, Optional, Tuple
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class TimerTask:
+    id: str
+    done: bool
+
+    def __init__(self, callback: Callable, *args, **kwargs):
+        self.callback = partial(callback, *args, **kwargs)
+        self.id = str(uuid.uuid4())
+        self.done = False
+
+    def run(self):
+        self.done = True
+        try:
+            self.callback()
+        except Exception as err:
+            logger.warn("TimerTask failed, ignoring error", err)
+
+
+class SingleThreadedTimer(Thread):
+    def __init__(self, timeout_ms: int, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setDaemon(True)
+
+        self.timeout_ms = timeout_ms
+        self.started = False
+        self.lock = Condition()
+        self.tasks: OrderedDict = OrderedDict()
+
+    def schedule(self, callback: Callable, *args, **kwargs) -> TimerTask:
+        self.start()
+
+        with self.lock:
+            task = TimerTask(callback, *args, **kwargs)
+            self.tasks[task.id] = (task, time())
+            self.lock.notify()
+
+            return task
+
+    def cancel(self, task: TimerTask) -> None:
+        with self.lock:
+            del self.tasks[task.id]
+            self.lock.notify()
+
+    def start(self):
+        if not self.started:
+            self.started = True
+            super().start()
+
+    def run(self):
+        while True:
+            job = None
+            with self.lock:
+                sleep = self._sleep_time()
+                if len(self.tasks) == 0:
+                    self.lock.wait()
+                elif sleep > 0:
+                    self.lock.wait(sleep)
+                else:
+                    _, (job, _) = self.tasks.popitem(last=False)
+
+            if job is not None:
+                job.run()
+
+    def _next_task(self) -> Optional[Tuple[TimerTask, float]]:
+        for _, task_and_time in self.tasks.items():
+            return task_and_time
+        return None
+
+    def _sleep_time(self) -> float:
+        next_task = self._next_task()
+        if next_task is None:
+            return 0
+        else:
+            _, start_time = next_task
+            return start_time + self.timeout_ms / 1000.0 - time()
+
+
+class TestSingleThreadedTimer(SingleThreadedTimer):
+    def run(self):
+        pass
+
+
+_threads: Dict[str, SingleThreadedTimer] = {}
+
+
+def get_timer_thread(name: str, timeout_ms: int) -> SingleThreadedTimer:
+    if settings.TEST:
+        return TestSingleThreadedTimer(timeout_ms=timeout_ms)
+
+    if name not in _threads:
+        _threads[name] = SingleThreadedTimer(timeout_ms=timeout_ms)
+
+    return _threads[name]

--- a/ee/clickhouse/timer.py
+++ b/ee/clickhouse/timer.py
@@ -69,7 +69,7 @@ class SingleThreadedTimer(Thread):
         while True:
             job = None
             with self.lock:
-                sleep = self._sleep_time()
+                sleep = self._sleep_time_until_next_task()
                 if len(self.tasks) == 0:
                     # Wait until a task is scheduled
                     self.lock.wait()
@@ -86,7 +86,7 @@ class SingleThreadedTimer(Thread):
             return task_and_time
         return None
 
-    def _sleep_time(self) -> float:
+    def _sleep_time_until_next_task(self) -> float:
         "Return time until the next task should be executed, if any task is scheduled"
         next_task = self._next_task()
         if next_task is None:

--- a/ee/clickhouse/timer.py
+++ b/ee/clickhouse/timer.py
@@ -3,7 +3,7 @@ import uuid
 from collections import OrderedDict
 from functools import partial
 from threading import Condition, Thread
-from time import time
+from time import perf_counter
 from typing import Callable, Dict, Optional, Tuple
 
 from django.conf import settings
@@ -43,7 +43,7 @@ class SingleThreadedTimer(Thread):
 
         with self.lock:
             task = TimerTask(callback, *args, **kwargs)
-            self.tasks[task.id] = (task, time())
+            self.tasks[task.id] = (task, perf_counter())
             self.lock.notify()
 
             return task
@@ -84,7 +84,7 @@ class SingleThreadedTimer(Thread):
             return 0
         else:
             _, start_time = next_task
-            return start_time + self.timeout_ms / 1000.0 - time()
+            return start_time + self.timeout_ms / 1000.0 - perf_counter()
 
 
 class TestSingleThreadedTimer(SingleThreadedTimer):


### PR DESCRIPTION
## Changes

This affects query stats. Read about the reasoning here: https://github.com/PostHog/product-internal/issues/119

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
