### PR TITLE
WIP: Automatically Persist Filter Value on Blur

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -70,13 +70,6 @@ export function PropertyValue({
     useEffect(() => {
         if (!value) {
             setInput('')
-        } else if (value !== input) {
-            const valueObject = options[propertyKey]?.values?.find((v) => v.id === value)
-            if (valueObject) {
-                setInput(toString(valueObject.name))
-            } else {
-                setInput(toString(value))
-            }
         }
     }, [value])
 
@@ -120,6 +113,12 @@ export function PropertyValue({
         loadPropertyValues('')
     }, [propertyKey])
 
+    useEffect(() => {
+        if (input === '' && document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur()
+        }
+    }, [input])
+
     const displayOptions = (options[propertyKey]?.values || []).filter(
         (option) => input === '' || matchesLowerCase(input, toString(option?.name))
     )
@@ -142,7 +141,7 @@ export function PropertyValue({
         allowClear: Boolean(value),
         onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Escape' && e.target instanceof HTMLElement) {
-                e.target.blur()
+                setInput('')
             }
             if (!isMultiSelect && e.key === 'Enter') {
                 // We have not explicitly selected a dropdown item by pressing the up/down keys; or the ref is unavailable
@@ -152,6 +151,16 @@ export function PropertyValue({
                 ) {
                     setValue(input)
                 }
+            }
+        },
+        handleBlur: () => {
+            if (input != '') {
+                if (Array.isArray(value) && !value.includes(input)) {
+                    setValue([...value, ...[input]])
+                } else if (!Array.isArray(value)) {
+                    setValue(input)
+                }
+                setInput('')
             }
         },
     }

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -113,12 +113,6 @@ export function PropertyValue({
         loadPropertyValues('')
     }, [propertyKey])
 
-    useEffect(() => {
-        if (input === '' && document.activeElement instanceof HTMLElement) {
-            document.activeElement.blur()
-        }
-    }, [input])
-
     const displayOptions = (options[propertyKey]?.values || []).filter(
         (option) => input === '' || matchesLowerCase(input, toString(option?.name))
     )
@@ -142,6 +136,7 @@ export function PropertyValue({
         onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Escape' && e.target instanceof HTMLElement) {
                 setInput('')
+                e.target.blur()
             }
             if (!isMultiSelect && e.key === 'Enter') {
                 // We have not explicitly selected a dropdown item by pressing the up/down keys; or the ref is unavailable

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -63,6 +63,7 @@ export function PropertyValue({
 }: PropertyValueProps): JSX.Element {
     const isMultiSelect = operator && isOperatorMulti(operator)
     const [input, setInput] = useState(isMultiSelect ? '' : toString(value))
+    const [shouldBlur, setShouldBlur] = useState(false)
     const [options, setOptions] = useState({} as Record<string, Option>)
     const autoCompleteRef = useRef<HTMLElement>(null)
 
@@ -113,6 +114,13 @@ export function PropertyValue({
         loadPropertyValues('')
     }, [propertyKey])
 
+    useEffect(() => {
+        if (input === '' && shouldBlur && document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur()
+            setShouldBlur(false)
+        }
+    }, [input, shouldBlur])
+
     const displayOptions = (options[propertyKey]?.values || []).filter(
         (option) => input === '' || matchesLowerCase(input, toString(option?.name))
     )
@@ -136,7 +144,7 @@ export function PropertyValue({
         onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Escape' && e.target instanceof HTMLElement) {
                 setInput('')
-                e.target.blur()
+                setShouldBlur(true)
             }
             if (!isMultiSelect && e.key === 'Enter') {
                 // We have not explicitly selected a dropdown item by pressing the up/down keys; or the ref is unavailable

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -70,6 +70,11 @@ export function PropertyValue({
     useEffect(() => {
         if (!value) {
             setInput('')
+        } else if (value !== input) {
+            const valueObject = options[propertyKey]?.values?.find((v) => v.id === value)
+            if (valueObject) {
+                setInput(toString(valueObject.name))
+            }
         }
     }, [value])
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -120,8 +120,8 @@ export function PropertyValue({
     }, [propertyKey])
 
     useEffect(() => {
-        if (input === '' && shouldBlur && document.activeElement instanceof HTMLElement) {
-            document.activeElement.blur()
+        if (input === '' && shouldBlur) {
+            ;(document.activeElement as HTMLElement)?.blur()
             setShouldBlur(false)
         }
     }, [input, shouldBlur])
@@ -147,9 +147,10 @@ export function PropertyValue({
         placeholder,
         allowClear: Boolean(value),
         onKeyDown: (e: React.KeyboardEvent) => {
-            if (e.key === 'Escape' && e.target instanceof HTMLElement) {
+            if (e.key === 'Escape') {
                 setInput('')
                 setShouldBlur(true)
+                return
             }
             if (!isMultiSelect && e.key === 'Enter') {
                 // We have not explicitly selected a dropdown item by pressing the up/down keys; or the ref is unavailable

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -54,8 +54,8 @@ export function SelectGradientOverflow({
     defaultOpen = false,
     delayBeforeAutoOpen,
     dropdownMatchSelectWidth = true,
+    handleBlur = () => {},
     placement,
-    handleBlur,
     ...props
 }: SelectGradientOverflowProps): JSX.Element {
     const selectRef: React.RefObject<RefSelectProps> | null = useRef(null)
@@ -91,7 +91,7 @@ export function SelectGradientOverflow({
     const onBlur = (): void => {
         if (isOpen) {
             setOpen(false)
-            handleBlur?.()
+            handleBlur()
         }
     }
 

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -55,6 +55,7 @@ export function SelectGradientOverflow({
     delayBeforeAutoOpen,
     dropdownMatchSelectWidth = true,
     placement,
+    handleBlur,
     ...props
 }: SelectGradientOverflowProps): JSX.Element {
     const selectRef: React.RefObject<RefSelectProps> | null = useRef(null)
@@ -90,7 +91,7 @@ export function SelectGradientOverflow({
     const onBlur = (): void => {
         if (isOpen) {
             setOpen(false)
-            if (props.handleBlur) {props.handleBlur()}
+            handleBlur?.()
         }
     }
 

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -46,6 +46,7 @@ export type SelectGradientOverflowProps = SelectProps<any> & {
     delayBeforeAutoOpen?: number
     dropdownMatchSelectWidth?: boolean | number
     placement?: 'bottomLeft' | 'topLeft' // Dropdown placement (undefined = auto). See API at https://ant.design/components/dropdown
+    handleBlur?: () => void
 }
 
 export function SelectGradientOverflow({
@@ -89,6 +90,7 @@ export function SelectGradientOverflow({
     const onBlur = (): void => {
         if (isOpen) {
             setOpen(false)
+            if (props.handleBlur) {props.handleBlur()}
         }
     }
 

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -346,7 +346,7 @@ export const trendsLogic = kea<trendsLogicType<IndexedTrendResult, TrendResponse
 
             let indexedResults
             if (values.filters.insight !== ViewType.LIFECYCLE) {
-                indexedResults = values.results.map((element, index) => {
+                indexedResults = values.results?.map((element, index) => {
                     actions.setVisibilityById({ [`${index}`]: true })
                     return { ...element, id: index }
                 })


### PR DESCRIPTION
This is a work in progress - I'd like to get feedback on my approach as I'm not super confident it's correct. 

The following video shows adding a new value to a multi-value-field (equals) by: 
* Selecting a value
* Clicking outside of the edit area
* Pressing enter
* Pressing escape (where the most recent input is expect to be lost)

It also shows the same scenarios for a single value field (Contains)

https://user-images.githubusercontent.com/85295485/127501346-f997aa3b-a5a4-4a39-8e99-ad18d0f4d09e.mov

## Changes

* Added a handler to automatically persist the value of the input on blur
* Resolved bug where suggested value was a comma separated list of existing values
* Preserved escape key functionality to empty and blur the field

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
