### PR TITLE
Add missing interval value to unordered funnels

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_unordered.py
+++ b/ee/clickhouse/queries/funnels/funnel_unordered.py
@@ -148,7 +148,7 @@ class ClickhouseFunnelUnordered(ClickhouseFunnelBase):
             exclusion_time = f"exclusion_{exclusion_id}_latest_{exclusion.funnel_from_step}"
             condition = (
                 f"if( {exclusion_time} > {from_time} AND {exclusion_time} < "
-                f"if(isNull({to_time}), {from_time} + INTERVAL {self._filter.funnel_window_interval} DAY, {to_time}), 1, 0)"
+                f"if(isNull({to_time}), {from_time} + INTERVAL {self._filter.funnel_window_interval} {self._filter.funnel_window_interval_unit_ch()}, {to_time}), 1, 0)"
             )
             conditions.append(condition)
 


### PR DESCRIPTION
## Changes

Follow up to: https://github.com/PostHog/posthog/pull/5329

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
