### PR TITLE
Allow mix-n-matching Funnel types in cache update

### DIFF
--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.utils.timezone import now
 from freezegun import freeze_time
 
+from ee.clickhouse.queries.funnels import funnel
 from posthog.constants import ENTITY_ID, ENTITY_TYPE, INSIGHT_STICKINESS
 from posthog.decorators import CacheType
 from posthog.models import Dashboard, DashboardItem, Event, Filter
@@ -119,6 +120,119 @@ class TestUpdateCache(APIBaseTest):
         updated_dashboard_item = DashboardItem.objects.get(pk=dashboard_item.pk)
         self.assertEqual(updated_dashboard_item.refreshing, False)
         self.assertEqual(updated_dashboard_item.last_refresh, now())
+
+    @freeze_time("2012-01-15")
+    @patch("posthog.tasks.update_cache.Funnel")
+    def test_update_cache_item_calls_right_funnel_class(self, funnel_mock: MagicMock) -> None:
+        #  basic funnel
+        filter = Filter(
+            data={
+                "insight": "FUNNELS",
+                "events": [
+                    {"id": "$pageview", "order": 0, "type": "events"},
+                    {"id": "$pageview", "order": 1, "type": "events"},
+                ],
+            }
+        )
+        dashboard_item = self._create_dashboard(filter)
+
+        funnel_mock.return_value.run.return_value = {}
+        with self.settings(EE_AVAILABLE=False):
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+
+        updated_dashboard_item = DashboardItem.objects.get(pk=dashboard_item.pk)
+        self.assertEqual(updated_dashboard_item.refreshing, False)
+        self.assertEqual(updated_dashboard_item.last_refresh, now())
+        funnel_mock.assert_called_once()
+
+    @freeze_time("2012-01-15")
+    @patch("posthog.tasks.update_cache.ClickhouseFunnelUnordered", create=True)
+    @patch("posthog.tasks.update_cache.ClickhouseFunnelStrict", create=True)
+    @patch("posthog.tasks.update_cache.ClickhouseFunnelTimeToConvert", create=True)
+    @patch("posthog.tasks.update_cache.ClickhouseFunnelTrends", create=True)
+    @patch("posthog.tasks.update_cache.ClickhouseFunnel", create=True)
+    def test_update_cache_item_calls_right_funnel_class_clickhouse(
+        self,
+        funnel_mock: MagicMock,
+        funnel_trends_mock: MagicMock,
+        funnel_time_to_convert_mock: MagicMock,
+        funnel_strict_mock: MagicMock,
+        funnel_unordered_mock: MagicMock,
+    ) -> None:
+        #  basic funnel
+        base_filter = Filter(
+            data={
+                "insight": "FUNNELS",
+                "events": [
+                    {"id": "$pageview", "order": 0, "type": "events"},
+                    {"id": "$pageview", "order": 1, "type": "events"},
+                ],
+            }
+        )
+
+        with self.settings(EE_AVAILABLE=True, PRIMARY_DB="clickhouse"):
+            filter = base_filter
+            funnel_mock.return_value.run.return_value = {}
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+            funnel_mock.assert_called_once()
+
+            # trends funnel
+            filter = base_filter.with_data({"funnel_viz_type": "trends"})
+            funnel_trends_mock.return_value.run.return_value = {}
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+
+            funnel_trends_mock.assert_called_once()
+            self.assertEqual(funnel_trends_mock.call_args[1]["funnel_order_class"], funnel_mock)
+            funnel_trends_mock.reset_mock()
+
+            # trends unordered funnel
+            filter = base_filter.with_data({"funnel_viz_type": "trends", "funnel_order_type": "unordered"})
+            funnel_trends_mock.return_value.run.return_value = {}
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+
+            funnel_trends_mock.assert_called_once()
+            self.assertEqual(funnel_trends_mock.call_args[1]["funnel_order_class"], funnel_unordered_mock)
+            funnel_trends_mock.reset_mock()
+
+            # time to convert strict funnel
+            filter = base_filter.with_data({"funnel_viz_type": "time_to_convert", "funnel_order_type": "strict"})
+            funnel_time_to_convert_mock.return_value.run.return_value = {}
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+
+            funnel_time_to_convert_mock.assert_called_once()
+            self.assertEqual(funnel_time_to_convert_mock.call_args[1]["funnel_order_class"], funnel_strict_mock)
+            funnel_time_to_convert_mock.reset_mock()
+
+            # strict funnel
+            filter = base_filter.with_data({"funnel_order_type": "strict"})
+            funnel_strict_mock.return_value.run.return_value = {}
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+
+            funnel_strict_mock.assert_called_once()
 
     def _test_refresh_dashboard_cache_types(
         self, filter: FilterType, cache_type: CacheType, patch_update_cache_item: MagicMock,

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from ee.clickhouse.queries.funnels import funnel
 from posthog.constants import ENTITY_ID, ENTITY_TYPE, INSIGHT_STICKINESS
 from posthog.decorators import CacheType
 from posthog.models import Dashboard, DashboardItem, Event, Filter

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -11,12 +11,6 @@ from django.db.models import Prefetch, Q
 from django.db.models.expressions import F, Subquery
 from django.utils import timezone
 
-from ee.clickhouse.queries.funnels import (
-    ClickhouseFunnelBase,
-    ClickhouseFunnelStrict,
-    ClickhouseFunnelTimeToConvert,
-    ClickhouseFunnelUnordered,
-)
 from posthog.celery import update_cache_item_task
 from posthog.constants import (
     INSIGHT_FUNNELS,
@@ -47,9 +41,14 @@ if is_clickhouse_enabled():
     from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
     from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
     from ee.clickhouse.queries.clickhouse_stickiness import ClickhouseStickiness
-    from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
-    from ee.clickhouse.queries.funnels.funnel_time_to_convert import ClickhouseFunnelTimeToConvert
-    from ee.clickhouse.queries.funnels.funnel_trends import ClickhouseFunnelTrends
+    from ee.clickhouse.queries.funnels import (
+        ClickhouseFunnel,
+        ClickhouseFunnelBase,
+        ClickhouseFunnelStrict,
+        ClickhouseFunnelTimeToConvert,
+        ClickhouseFunnelTrends,
+        ClickhouseFunnelUnordered,
+    )
     from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
     from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
 


### PR DESCRIPTION
## Changes

Follow up to https://github.com/PostHog/posthog/pull/5051 - it's not a problem yet, but would've been once support for different orderings is introduced.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
