### PR TITLE
Allow formulas for single graph series again

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -43,7 +43,7 @@ export function TrendTab({ view, annotationsToCreate }: TrendTabProps): JSX.Elem
         (!filters.insight || filters.insight === ViewType.TRENDS) &&
         featureFlags[FEATURE_FLAGS.FORMULAS] &&
         preflight?.is_clickhouse_enabled
-    const formulaEnabled = (filters.events?.length || 0) + (filters.actions?.length || 0) > 1
+    const formulaEnabled = (filters.events?.length || 0) + (filters.actions?.length || 0) > 0
 
     return (
         <>
@@ -152,7 +152,7 @@ export function TrendTab({ view, annotationsToCreate }: TrendTabProps): JSX.Elem
                                                 <Tooltip
                                                     title={
                                                         !formulaEnabled
-                                                            ? 'Please add at least two graph series to use formulas'
+                                                            ? 'Please add at least one graph series to use formulas'
                                                             : undefined
                                                     }
                                                 >

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -25,7 +25,7 @@ export interface TrendTabProps extends BaseTabProps {
 }
 
 export function TrendTab({ view, annotationsToCreate }: TrendTabProps): JSX.Element {
-    const { filters, filtersLoading, numberOfSeries } = useValues(trendsLogic({ dashboardItemId: null, view }))
+    const { filters, filtersLoading } = useValues(trendsLogic({ dashboardItemId: null, view }))
     const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
     const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
@@ -69,7 +69,7 @@ export function TrendTab({ view, annotationsToCreate }: TrendTabProps): JSX.Elem
                             setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
                             typeKey={'trends_' + view}
                             buttonCopy="Add graph series"
-                            showSeriesIndicator={numberOfSeries > 1}
+                            showSeriesIndicator
                             singleFilter={filters.insight === ViewType.LIFECYCLE}
                             hideMathSelector={filters.insight === ViewType.LIFECYCLE}
                             customRowPrefix={
@@ -126,7 +126,20 @@ export function TrendTab({ view, annotationsToCreate }: TrendTabProps): JSX.Elem
                                     {formulaAvailable && (
                                         <>
                                             <hr />
-                                            <h4 className="secondary">Formula</h4>
+                                            <h4 className="secondary">
+                                                Formula{' '}
+                                                <Tooltip
+                                                    title={
+                                                        <>
+                                                            Apply math operations to your series. You can do operations
+                                                            among series (e.g. <code>A / B</code>) or simple arithmetic
+                                                            operations on a single series (e.g. <code>A / 100</code>)
+                                                        </>
+                                                    }
+                                                >
+                                                    <InfoCircleOutlined />
+                                                </Tooltip>
+                                            </h4>
                                             {isUsingFormulas ? (
                                                 <Row align="middle" gutter={4}>
                                                     <Col>
@@ -160,6 +173,7 @@ export function TrendTab({ view, annotationsToCreate }: TrendTabProps): JSX.Elem
                                                         shape="round"
                                                         onClick={() => setIsUsingFormulas(true)}
                                                         disabled={!formulaEnabled}
+                                                        data-attr="btn-add-formula"
                                                     >
                                                         Add formula
                                                     </Button>


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Previously we were able to apply formulas for single graph series, re-enabling that 

![image](https://user-images.githubusercontent.com/25164963/127668926-f5614ac4-e97f-4ddb-ad63-84a6c9a5313d.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
