### PR TITLE
Don't show units less than 1 in graph counts

### DIFF
--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -63,13 +63,11 @@ export function Histogram({
         })
 
     // y-axis scale
-    const y = d3
-        .scaleLinear()
-        .domain([0, d3.max(data, (d: HistogramDatum) => d.count) as number])
-        .range(config.ranges.y)
-        .nice()
+    const yMax = d3.max(data, (d: HistogramDatum) => d.count) as number
+    const y = d3.scaleLinear().domain([0, yMax]).range(config.ranges.y).nice()
     const yAxis = config.axisFn
         .y(y)
+        .tickValues(y.ticks().filter((tick) => Number.isInteger(tick)))
         .tickSize(0)
         .tickFormat((v: number) => {
             const count = formatYTickLabel(v)


### PR DESCRIPTION
## Changes

Before

<img width="658" alt="Screenshot 2021-07-30 at 11 26 29 AM" src="https://user-images.githubusercontent.com/13460330/127698951-6615eac1-5276-4c01-bc8d-dd0fa75a4a68.png">


After

![Screen Shot 2021-07-30 at 11 50 39 AM](https://user-images.githubusercontent.com/13460330/127698898-7f2a2d2f-e95c-48f0-881e-a90783dbfefb.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
