### PR TITLE
Fix session recording navigation from persons page

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -201,10 +201,13 @@ export const personsLogic = kea<personsLogicType<PersonPaginatedResponse>>({
                 actions.loadPersons()
             }
         },
-        '/person/*': ({ _: person }, _searchParams, { activeTab }) => {
-            if (activeTab && values.activeTab !== activeTab) {
+        '/person/*': ({ _: person }, { sessionRecordingId }, { activeTab }) => {
+            if (sessionRecordingId) {
+                actions.navigateToTab(PersonsTabType.SESSIONS)
+            } else if (activeTab && values.activeTab !== activeTab) {
                 actions.navigateToTab(activeTab as PersonsTabType)
             }
+
             if (person) {
                 actions.loadPerson(person) // underscore contains the wildcard
             }

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -63,7 +63,7 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
             properties,
             selectedDate,
         }),
-        setSessionRecordingId: (sessionRecordingId: SessionRecordingId) => ({ sessionRecordingId }),
+        setSessionRecordingId: (sessionRecordingId: SessionRecordingId | null) => ({ sessionRecordingId }),
         closeSessionPlayer: true,
         loadSessionEvents: (session: SessionType) => ({ session }),
         addSessionEvents: (session: SessionType, events: EventType[]) => ({ session, events }),
@@ -290,8 +290,8 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
                 actions.loadSessions(true)
             }
 
-            if (params.sessionRecordingId && params.sessionRecordingId !== values.sessionRecordingId) {
-                actions.setSessionRecordingId(params.sessionRecordingId)
+            if (params.sessionRecordingId !== values.sessionRecordingId) {
+                actions.setSessionRecordingId(params.sessionRecordingId ?? null)
             }
 
             if (JSON.stringify(params.filters || {}) !== JSON.stringify(values.filters)) {


### PR DESCRIPTION
## Changes

- Fixes bug where clicking on "Back to persons" or the close button in the session recording player if you were in the Persons page, actually didn't do anything. Recording of expected behavior now working below:

![image](https://user-images.githubusercontent.com/5864173/127700805-4f358f56-09f4-4a78-ab6a-efae9ff34f5e.gif)

- Fixes a bug in which when you refreshed the page while playing a session from persons, the events tab would be open and then the recording would open if you switched tabs. Recording below shows what used to happen before the fix.

![image](https://user-images.githubusercontent.com/5864173/127700945-195dbabe-cbc6-4908-96d1-919a14440c70.gif)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
