### PR TITLE
Random insights improvements

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -4,6 +4,23 @@ describe('Insights', () => {
         cy.visit('/insights')
     })
 
+    it('Opens insight with short URL', () => {
+        cy.visit('/i/TEST1234') // Insight `TEST1234` is created in demo data (revenue_data_generator.py)
+        cy.location('pathname').should('eq', '/insights') // User is taken to the insights page
+
+        cy.get('[data-attr=trend-element-subject-0]').contains('Entered Free Trial').should('exist') // Funnel is properly loaded
+        cy.get('[data-attr=trend-element-subject-1]').contains('Purchase').should('exist')
+
+        cy.get('[data-attr=funnel-viz]').should('exist')
+    })
+
+    it('Shows not found error with invalid short URL', () => {
+        cy.visit('/i/i_dont_exist')
+        cy.location('pathname').should('eq', '/i/i_dont_exist')
+        cy.get('h1.page-title').contains('Insight not found').should('exist')
+        cy.get('.not-found-component').get('.graphic').should('exist')
+    })
+
     it('Stickiness graph', () => {
         cy.get('.ant-tabs-tab').contains('Stickiness').click()
         cy.get('[data-attr=add-action-event-button]').click()

--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -11,7 +11,7 @@ describe('Insights', () => {
         cy.get('[data-attr=trend-element-subject-0]').contains('Entered Free Trial').should('exist') // Funnel is properly loaded
         cy.get('[data-attr=trend-element-subject-1]').contains('Purchase').should('exist')
 
-        cy.get('[data-attr=funnel-viz]').should('exist')
+        cy.get('[data-attr=funnel-bar-graph]').should('exist')
     })
 
     it('Shows not found error with invalid short URL', () => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -15,6 +15,7 @@ import {
     EntityType,
     DashboardItemType,
     ViewType,
+    InsightType,
 } from '~/types'
 import { Dayjs } from 'dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
@@ -131,6 +132,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
         reportInsightsTabReset: true,
         reportInsightsControlsCollapseToggle: (collapsed: boolean) => ({ collapsed }),
         reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
+        reportInsightShortUrlVisited: (valid: boolean, insight: InsightType | null) => ({ valid, insight }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -450,6 +452,9 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
         },
         reportInsightsTableCalcToggled: async (payload) => {
             posthog.capture('insights table calc toggled', payload)
+        },
+        reportInsightShortUrlVisited: (props) => {
+            posthog.capture('insight short url visited', props)
         },
     },
 })

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -64,7 +64,7 @@ function DashboardView(): JSX.Element {
                           ),
                       disabled: dashboardMode !== null && dashboardMode !== DashboardMode.Fullscreen,
                   },
-                  s: {
+                  k: {
                       action: () =>
                           setDashboardMode(
                               dashboardMode === DashboardMode.Sharing ? null : DashboardMode.Sharing,

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -124,7 +124,7 @@ export function DashboardHeader(): JSX.Element {
                 onClick={() => setDashboardMode(DashboardMode.Sharing, DashboardEventSource.DashboardHeader)}
                 data-attr="dashboard-share-button"
                 icon={<ShareAltOutlined />}
-                hotkey="s"
+                hotkey="k"
             >
                 Send or share
             </HotkeyButton>

--- a/frontend/src/scenes/insights/InsightRouter.tsx
+++ b/frontend/src/scenes/insights/InsightRouter.tsx
@@ -3,6 +3,7 @@ import { kea, useValues } from 'kea'
 import { router, combineUrl } from 'kea-router'
 import api from 'lib/api'
 import { NotFound } from 'lib/components/NotFound'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import React from 'react'
 import { DashboardItemType } from '~/types'
 import { insightRouterLogicType } from './InsightRouterType'
@@ -25,6 +26,7 @@ const insightRouterLogic = kea<insightRouterLogicType>({
             const response = await api.get(`api/insight/?short_id=${id}`)
             if (response.results.length) {
                 const item = response.results[0] as DashboardItemType
+                eventUsageLogic.actions.reportInsightShortUrlVisited(true, item.filters.insight)
                 router.actions.push(
                     combineUrl('/insights', item.filters, {
                         fromItem: item.id,
@@ -34,6 +36,7 @@ const insightRouterLogic = kea<insightRouterLogicType>({
                     }).url
                 )
             } else {
+                eventUsageLogic.actions.reportInsightShortUrlVisited(false, null)
                 actions.setError()
             }
         },

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -106,8 +106,8 @@ export function Insights(): JSX.Element {
         p: {
             action: () => handleHotkeyNavigation(ViewType.PATHS, 'p'),
         },
-        k: {
-            action: () => handleHotkeyNavigation(ViewType.STICKINESS, 'k'),
+        i: {
+            action: () => handleHotkeyNavigation(ViewType.STICKINESS, 'i'),
         },
         l: {
             action: () => handleHotkeyNavigation(ViewType.LIFECYCLE, 'l'),
@@ -219,7 +219,7 @@ export function Insights(): JSX.Element {
                                 data-attr="insight-stickiness-tab"
                             >
                                 Stickiness
-                                <InsightHotkey hotkey="k" />
+                                <InsightHotkey hotkey="i" />
                             </Tooltip>
                         }
                         key={ViewType.STICKINESS}

--- a/posthog/demo/revenue_data_generator.py
+++ b/posthog/demo/revenue_data_generator.py
@@ -65,13 +65,13 @@ class RevenueDataGenerator(DataGenerator):
                 "actions": [
                     {
                         "id": free_trial_action.id,
-                        "name": "Installed App",
+                        "name": "Entered Free Trial",
                         "order": 0,
                         "type": TREND_FILTER_TYPE_ACTIONS,
                     },
                     {
                         "id": purchase_action.id,
-                        "name": "Rated App",
+                        "name": "Purchase",
                         "order": 1,
                         "type": TREND_FILTER_TYPE_ACTIONS,
                         "properties": {"plan": "premium"},
@@ -80,4 +80,5 @@ class RevenueDataGenerator(DataGenerator):
                 "insight": "FUNNELS",
                 "date_from": "all",
             },
+            short_id="TEST1234",
         )

--- a/posthog/demo/web_data_generator.py
+++ b/posthog/demo/web_data_generator.py
@@ -10,7 +10,6 @@ from django.utils.timezone import now
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.demo.data_generator import DataGenerator
 from posthog.models import Action, ActionStep, Dashboard, DashboardItem, Person, PropertyDefinition
-from posthog.models.event_definition import EventDefinition
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.utils import UUIDT
 from posthog.utils import get_absolute_path


### PR DESCRIPTION
## Changes

This PR pulls some useful improvements from #4528 as we close that PR in favor of new work.
- This PR changes some hotkeys to free up the "S" hotkey to use as save in insights.
- Creates a custom event to report when an insight is accessed through its short ID.
- Adds E2E tests for opening insights using their short ID.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
