### PR TITLE
Center aligned person uuids in modals

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -229,7 +229,7 @@ export function PersonRow({ person, people, filters }: PersonRowProps): JSX.Elem
             <Row style={{ justifyContent: 'space-between' }}>
                 <Row>
                     <ExpandIcon {...expandProps}>{undefined}</ExpandIcon>
-                    <Col>
+                    <Col style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
                         <span className="text-default">
                             <strong>{person.properties.email}</strong>
                         </span>


### PR DESCRIPTION
## Changes

Fixes #5412.

Before

<img width="590" alt="Screen Shot 2021-08-02 at 11 26 29 AM" src="https://user-images.githubusercontent.com/13460330/127908570-8502a3fa-7281-4859-9133-cd239995e7fa.png">


After

<img width="719" alt="Screen Shot 2021-08-02 at 11 40 29 AM" src="https://user-images.githubusercontent.com/13460330/127908562-68b59b77-10bb-465c-97e5-e91bc16ff3bf.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
