### PR TITLE
Complete move to 4px border radius

### DIFF
--- a/frontend/src/styles/antd.less
+++ b/frontend/src/styles/antd.less
@@ -14,7 +14,7 @@ with SASS, leading to duplicated config. When changing any variable here, please
 @heading-color: @text-color;
 @text-color-secondary: rgba(0, 0, 0, 0.45);
 @disabled-color: @text-muted;
-@border-radius-base: 2px;
+@border-radius-base: 4px;
 @border-color-base: #d9d9d9;
 @body-background:  #fff;
 @layout-body-background: #fff;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -385,10 +385,6 @@ code.code {
 
 // Card styles
 
-.ant-card {
-    border-radius: $button_radius !important;
-}
-
 .ant-card-body > :first-child {
     margin-top: 0;
 }
@@ -441,29 +437,6 @@ code.code {
 }
 
 // Button styles
-
-.ant-btn,
-.ant-input,
-.ant-select:not(.ant-select-customize-input) .ant-select-selector {
-    border-radius: $button_radius !important;
-}
-
-.ant-radio-button-wrapper {
-    &:first-child {
-        border-radius: $button_radius 0 0 $button_radius !important;
-    }
-    &:last-child {
-        border-radius: 0 $button_radius $button_radius 0 !important;
-    }
-}
-
-.ant-input-search .ant-input-group .ant-input-affix-wrapper:not(:last-child) {
-    border-radius: $button_radius 0 0 $button_radius !important;
-}
-
-.ant-input-search > .ant-input-group > .ant-input-group-addon:last-child .ant-input-search-button {
-    border-radius: 0 $button_radius $button_radius 0 !important;
-}
 
 .btn-close {
     color: $text_muted;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -385,6 +385,10 @@ code.code {
 
 // Card styles
 
+.ant-card {
+    border-radius: $button_radius !important;
+}
+
 .ant-card-body > :first-child {
     margin-top: 0;
 }
@@ -440,6 +444,23 @@ code.code {
 
 button.ant-btn {
     border-radius: $button_radius;
+}
+
+.ant-radio-button-wrapper {
+    &:first-child {
+        border-radius: $button_radius 0 0 $button_radius !important;
+    }
+    &:last-child {
+        border-radius: 0 $button_radius $button_radius 0 !important;
+    }
+}
+
+.ant-input-search .ant-input-group .ant-input-affix-wrapper:not(:last-child) {
+    border-radius: 0 $button_radius $button_radius 0 !important;
+}
+
+.ant-input-search > .ant-input-group > .ant-input-group-addon:last-child .ant-input-search-button {
+    border-radius: 0 $button_radius $button_radius 0 !important;
 }
 
 .btn-close {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -442,8 +442,10 @@ code.code {
 
 // Button styles
 
-button.ant-btn {
-    border-radius: $button_radius;
+.ant-btn,
+.ant-input,
+.ant-select:not(.ant-select-customize-input) .ant-select-selector {
+    border-radius: $button_radius !important;
 }
 
 .ant-radio-button-wrapper {
@@ -456,7 +458,7 @@ button.ant-btn {
 }
 
 .ant-input-search .ant-input-group .ant-input-affix-wrapper:not(:last-child) {
-    border-radius: 0 $button_radius $button_radius 0 !important;
+    border-radius: $button_radius 0 0 $button_radius !important;
 }
 
 .ant-input-search > .ant-input-group > .ant-input-group-addon:last-child .ant-input-search-button {


### PR DESCRIPTION
## Changes

Follow-up to #5266 that completes move to 4px border radius.

Newly 4px elements:
![Zrzut ekranu 2021-08-2 o 20 45 25](https://user-images.githubusercontent.com/4550621/127909174-9bfcb56e-732f-4326-8f65-3cdf1c610b94.png)
![Zrzut ekranu 2021-08-2 o 20 45 53](https://user-images.githubusercontent.com/4550621/127909176-61d8cfd8-fc34-432c-97a1-f0b5922e40ce.png)
![Zrzut ekranu 2021-08-2 o 20 46 52](https://user-images.githubusercontent.com/4550621/127909397-0ed9b130-6080-4450-a043-c9ae803f618f.png)
![Zrzut ekranu 2021-08-2 o 20 43 06](https://user-images.githubusercontent.com/4550621/127909172-9a970712-13ed-43a6-acb0-261ca20ad1e4.png)

That last one was a bit weird because it _is_ an `.ant-button`, but an `a` tag instead of `button`, and the style only affected `button.ant-button` elements. I assume that was to avoid `!important` by increasing specificity instead, but it failed here, so I did resort to `!important`.