### PR TITLE
Remove `AsyncActionMappingNotice`

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -15,10 +15,6 @@ import dayjs from 'dayjs'
 import { compactNumber } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
-function AsyncActionMappingNotice() {
-    return <p>Please note that actions may be delayed up to 5 minutes due to open-source PostHog configuration.</p>
-}
-
 export function ActionEdit({ action: loadedAction, actionId, apiURL, onSave, temporaryToken }) {
     let logic = actionEditLogic({
         id: actionId,
@@ -191,7 +187,6 @@ export function ActionEdit({ action: loadedAction, actionId, apiURL, onSave, tem
                                 {slackEnabled ? 'Configure' : 'Enable'} this integration in Setup.
                             </Link>
                         </p>
-                        {!preflight?.is_clickhouse_enabled && <AsyncActionMappingNotice />}
                         {action.post_to_slack && (
                             <>
                                 <Input


### PR DESCRIPTION
## Changes

Eliminates this notice, which is false since we started doing action matching in the plugin server on the fly:

![Fake news](https://user-images.githubusercontent.com/4550621/127911688-d764ef5b-f2fa-405a-99a9-2708bcd66ac9.png)
