### PR TITLE
View graph in dashboards is now a link

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -326,12 +326,10 @@ export function DashboardItem({
                                     trigger={['click']}
                                     overlay={
                                         <Menu data-attr={'dashboard-item-' + index + '-dropdown-menu'}>
-                                            <Menu.Item
-                                                data-attr={'dashboard-item-' + index + '-dropdown-view'}
-                                                icon={<Icon />}
-                                                onClick={() => router.actions.push(link)}
-                                            >
-                                                {viewText}
+                                            <Menu.Item data-attr={'dashboard-item-' + index + '-dropdown-view'}>
+                                                <a href={link}>
+                                                    <Icon /> {viewText}
+                                                </a>
                                             </Menu.Item>
                                             <Menu.Item
                                                 data-attr={'dashboard-item-' + index + '-dropdown-refresh'}

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -327,9 +327,9 @@ export function DashboardItem({
                                     overlay={
                                         <Menu data-attr={'dashboard-item-' + index + '-dropdown-menu'}>
                                             <Menu.Item data-attr={'dashboard-item-' + index + '-dropdown-view'}>
-                                                <a href={link}>
+                                                <Link to={link}>
                                                     <Icon /> {viewText}
-                                                </a>
+                                                </Link>
                                             </Menu.Item>
                                             <Menu.Item
                                                 data-attr={'dashboard-item-' + index + '-dropdown-refresh'}

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -141,7 +141,7 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
         className: 'retention',
         element: RetentionContainer,
         icon: TableOutlined,
-        viewText: 'View retention',
+        viewText: 'View graph',
         link: ({ id, dashboard, name, filters }: DashboardItemType): string => {
             return combineUrl(
                 `/insights`,

--- a/frontend/src/scenes/organization/Settings/index.tsx
+++ b/frontend/src/scenes/organization/Settings/index.tsx
@@ -56,7 +56,7 @@ function DomainWhitelist({ isRestricted }: RestrictedComponentProps): JSX.Elemen
 
     return (
         <div>
-            <h2 id="name" className="subtitle">
+            <h2 id="domain-whitelist" className="subtitle">
                 Domain Whitelist
             </h2>
             {socialAuthAvailable ? (
@@ -91,7 +91,7 @@ function DomainWhitelist({ isRestricted }: RestrictedComponentProps): JSX.Elemen
                 <div className="text-muted">
                     This feature is only available when social authentication is enabled.{' '}
                     <a
-                        href="https://posthog.com/docs/features/log-in-with-github-gitlab?utm_campaign=domain-whitelist&utm_medium=in-product"
+                        href="https://posthog.com/docs/features/sso?utm_campaign=domain-whitelist&utm_medium=in-product"
                         target="_blank"
                         rel="noopener"
                     >


### PR DESCRIPTION
## Changes

- Closes #4681 and adjusts a minor copy for retention graphs.
- Adjusts domain whitelist permalink, following https://github.com/PostHog/posthog.com/pull/1691

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
