### PR TITLE
Don't pin dashboards by default

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -51,6 +51,10 @@ describe('Dashboard', () => {
 
         cy.contains('New Dashboard').should('exist')
         cy.get('.empty-state').should('exist')
+
+        // Check that dashboard is not pinned by default
+        cy.get('[data-attr="dashboard-more"]').click()
+        cy.get('.ant-dropdown-menu-item span').contains('Pin dashboard').should('exist')
     })
 
     it('Create dashboard from a template', () => {

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -49,7 +49,6 @@ export const dashboardsModel = kea<dashboardsModelType>({
             addDashboard: async ({ name, show, useTemplate }) => {
                 const result = (await api.create('api/dashboard', {
                     name,
-                    pinned: true,
                     use_template: useTemplate,
                 })) as DashboardType
                 if (show) {


### PR DESCRIPTION
## Changes

- Closes #5377 & adds a cypress test for it.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
