### PR TITLE
Fix "ambigious column distinct_id"

### DIFF
--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -92,6 +92,6 @@ class TrendsEventQuery(ClickhouseEventQuery):
         return date_filter, date_params
 
     def _get_entity_query(self) -> Tuple[str, Dict]:
-        entity_params, entity_format_params = populate_entity_params(self._entity)
+        entity_params, entity_format_params = populate_entity_params(self._entity, table_name=self.EVENT_TABLE_ALIAS)
 
         return entity_format_params["entity_query"], entity_params

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -92,11 +92,11 @@ def get_active_user_params(filter: Filter, entity: Entity, team_id: int) -> Dict
     return params
 
 
-def populate_entity_params(entity: Entity) -> Tuple[Dict, Dict]:
+def populate_entity_params(entity: Entity, table_name: str = "") -> Tuple[Dict, Dict]:
     params, content_sql_params = {}, {}
     if entity.type == TREND_FILTER_TYPE_ACTIONS:
         action = entity.get_action()
-        action_query, action_params = format_action_filter(action)
+        action_query, action_params = format_action_filter(action, table_name=table_name)
         params = {**action_params}
         content_sql_params = {"entity_query": "AND {action_query}".format(action_query=action_query)}
     else:

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1552,6 +1552,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 event="$pageview",
                 properties=[{"key": "bar", "type": "person", "value": "a", "operator": "icontains"}],
             )
+            event_filtering_action.calculate_events()
             filter = Filter(
                 {
                     "actions": [{"id": event_filtering_action.id}],


### PR DESCRIPTION
The problem came in a trends query:
1. Which filters by action having person property filters
2. The overall query having a person property filter

See also the regression test

Closes https://github.com/PostHog/posthog/issues/5388

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
