### PR TITLE
Better insights instrumentation

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -19,6 +19,7 @@ import {
 } from '~/types'
 import { Dayjs } from 'dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { PersonModalParams } from 'scenes/trends/personsModalLogic'
 
 const keyMappingKeys = Object.keys(keyMapping.event)
 
@@ -44,6 +45,11 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
             filters,
             isFirstLoad,
             fromDashboard,
+        }),
+        reportPersonModalViewed: (params: PersonModalParams, count: number, hasNext: boolean) => ({
+            params,
+            count,
+            hasNext,
         }),
         reportBookmarkletDragged: true,
         reportIngestionBookmarkletCollapsible: (activePanels: string[]) => ({ activePanels }),
@@ -115,7 +121,6 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
             itemType,
             displayLocation,
         }),
-
         reportEventSearched: (searchTerm: string, extraProps?: Record<string, number>) => ({
             searchTerm,
             extraProps,
@@ -257,6 +262,24 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
             }
 
             posthog.capture('insight viewed', properties)
+        },
+        reportPersonModalViewed: async ({ params, count, hasNext }) => {
+            const { funnelStep, filters, breakdown_value, saveOriginal, searchTerm, date_from, date_to } = params
+            const properties = {
+                insight: filters.insight,
+                display: filters.display,
+                funnel_viz_type: filters.funnel_viz_type,
+                interval: filters.interval,
+                date_from,
+                date_to,
+                funnel_step: funnelStep,
+                has_breakdown_value: Boolean(breakdown_value),
+                save_original: saveOriginal,
+                has_search_term: Boolean(searchTerm),
+                count, // Total count of persons
+                has_next: hasNext, // Whether there are other persons to be loaded (pagination)
+            }
+            posthog.capture('insight person modal viewed', properties)
         },
         reportDashboardViewed: async ({ dashboard, hasShareToken }, breakpoint) => {
             await breakpoint(500) // Debounce to avoid noisy events from continuous navigation

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -40,7 +40,11 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
-        reportInsightViewed: (filters: Partial<FilterType>, isFirstLoad: boolean) => ({ filters, isFirstLoad }),
+        reportInsightViewed: (filters: Partial<FilterType>, isFirstLoad: boolean, fromDashboard: boolean) => ({
+            filters,
+            isFirstLoad,
+            fromDashboard,
+        }),
         reportBookmarkletDragged: true,
         reportIngestionBookmarkletCollapsible: (activePanels: string[]) => ({ activePanels }),
         reportProjectCreationSubmitted: (projectCount: number, nameLength: number) => ({ projectCount, nameLength }),
@@ -191,7 +195,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
             }
             posthog.capture('person viewed', properties)
         },
-        reportInsightViewed: async ({ filters, isFirstLoad }, breakpoint) => {
+        reportInsightViewed: async ({ filters, isFirstLoad, fromDashboard }, breakpoint) => {
             await breakpoint(500) // Debounce to avoid noisy events from changing filters multiple times
 
             // Reports `insight viewed` event
@@ -209,6 +213,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
                 filters_count: filters.properties?.length || 0,
                 events_count: filters.events?.length || 0,
                 actions_count: filters.actions?.length || 0,
+                from_dashboard: fromDashboard, // Whether the insight is on a dashboard
             }
 
             properties.total_event_actions_count = (properties.events_count || 0) + (properties.actions_count || 0)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -294,7 +294,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
                 properties.stickiness_days = filters.stickiness_days
             }
 
-            const eventName = delay ? 'delayed insight viewed' : 'insight viewed'
+            const eventName = delay ? 'insight analyzed' : 'insight viewed'
 
             posthog.capture(eventName, properties)
         },

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -451,6 +451,10 @@ export const funnelLogic = kea<funnelLogicType>({
         apiParams: [
             (s) => [s.filters, s.conversionWindowInDays, featureFlagLogic.selectors.featureFlags],
             (filters, conversionWindowInDays, featureFlags) => {
+                /* TODO: Related to #4329. We're mixing `from_dashboard` as both which causes hard to manage code:
+                    a) a boolean-based hash param to determine if the insight is saved in a dashboard (when viewing insights page)
+                    b) dashboard ID passed as a filter in certain kind of insights when viewing in the dashboard page
+                */
                 const { from_dashboard } = filters
                 const cleanedParams = cleanFunnelParams(filters)
                 return {

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -80,6 +80,7 @@ export function Insights(): JSX.Element {
 
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
+    const { reportCohortCreatedFromPersonModal } = useActions(eventUsageLogic)
 
     const verticalLayout = activeView === ViewType.FUNNELS // Whether to display the control tab on the side instead of on top
 
@@ -130,6 +131,7 @@ export function Insights(): JSX.Element {
                 onOk={(title: string) => {
                     saveCohortWithFilters(title, allFilters)
                     setCohortModalVisible(false)
+                    reportCohortCreatedFromPersonModal(allFilters)
                 }}
                 onCancel={() => setCohortModalVisible(false)}
             />

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -11,6 +11,7 @@ import { Entity, FilterType, FunnelVizType, PropertyFilter, ViewType } from '~/t
 import { captureInternalMetric } from 'lib/internalMetrics'
 export const TRENDS_BASED_INSIGHTS = ['TRENDS', 'SESSIONS', 'STICKINESS', 'LIFECYCLE'] // Insights that are based on the same `Trends` components
 import { Scene, sceneLogic } from 'scenes/sceneLogic'
+import { router } from 'kea-router'
 
 /*
 InsightLogic maintains state for changing between insight features
@@ -153,7 +154,8 @@ export const insightLogic = kea<insightLogicType>({
     },
     listeners: ({ actions, values }) => ({
         setAllFilters: (filters) => {
-            eventUsageLogic.actions.reportInsightViewed(filters.filters, values.isFirstLoad)
+            const { fromDashboard } = router.values.hashParams
+            eventUsageLogic.actions.reportInsightViewed(filters.filters, values.isFirstLoad, Boolean(fromDashboard))
             actions.setNotFirstLoad()
         },
         startQuery: () => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -153,10 +153,13 @@ export const insightLogic = kea<insightLogicType>({
         ],
     },
     listeners: ({ actions, values }) => ({
-        setAllFilters: (filters) => {
+        setAllFilters: async (filters, breakpoint) => {
             const { fromDashboard } = router.values.hashParams
             eventUsageLogic.actions.reportInsightViewed(filters.filters, values.isFirstLoad, Boolean(fromDashboard))
             actions.setNotFirstLoad()
+
+            await breakpoint(10000)
+            eventUsageLogic.actions.reportInsightViewed(filters.filters, values.isFirstLoad, Boolean(fromDashboard), 10)
         },
         startQuery: () => {
             actions.setShowTimeoutMessage(false)

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -93,7 +93,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                         {people && people.count > 0 && showModalActions && (
                             <>
                                 <div style={{ paddingRight: 8 }}>
-                                    <Button onClick={onSaveCohort}>
+                                    <Button onClick={onSaveCohort} data-attr="person-modal-save-as-cohort">
                                         <UsergroupAddOutlined />
                                         Save as cohort
                                     </Button>

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -17,6 +17,7 @@ import { ViewType } from '~/types'
 import { InsightsTable } from 'scenes/insights/InsightsTable'
 import { Button } from 'antd'
 import { personsModalLogic } from './personsModalLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface Props {
     view: ViewType
@@ -31,6 +32,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
     const { loadMoreBreakdownValues } = useActions(trendsLogic({ dashboardItemId: null, view, filters: null }))
     const { showingPeople } = useValues(personsModalLogic)
     const { saveCohortWithFilters, refreshCohort } = useActions(personsModalLogic)
+    const { reportCohortCreatedFromPersonModal } = useActions(eventUsageLogic)
     const renderViz = (): JSX.Element | undefined => {
         if (
             !_filters.display ||
@@ -109,6 +111,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                 onOk={(title: string) => {
                     saveCohortWithFilters(title, _filters)
                     setCohortModalVisible(false)
+                    reportCohortCreatedFromPersonModal(_filters)
                 }}
                 onCancel={() => setCohortModalVisible(false)}
             />

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -9,8 +9,9 @@ import { ActionFilter, FilterType, ViewType, FunnelVizType } from '~/types'
 import { personsModalLogicType } from './personsModalLogicType'
 import { parsePeopleParams, TrendPeople } from './trendsLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
-interface PersonModalParams {
+export interface PersonModalParams {
     action: ActionFilter | 'session' // todo, refactor this session string param out
     label: string // Contains the step name
     date_from: string | number
@@ -171,9 +172,13 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                     next: people.next,
                     funnelStep,
                 } as TrendPeople
+
+                eventUsageLogic.actions.reportPersonModalViewed(peopleParams, peopleResult.count, !!people.next)
+
                 if (saveOriginal) {
                     actions.saveFirstLoadedPeople(peopleResult)
                 }
+
                 return peopleResult
             },
             loadMorePeople: async ({}, breakpoint) => {


### PR DESCRIPTION
## Changes

Few changes to improve instrumentation around insights:
- Send `from_dasbhoard` param to know if insight is saved to a dashboard.
- We now report `insight person modal viewed` event when a user opens the person modal from any of the insights pages.
- We abstract the filter sanitization method for reporting to PostHog to make it reusable and extra clear that it doesn't send any sensitive information. 
- Report when a cohort is created from the person modal.
- Report `insight analyzed` which happens after an insight has been viewed for 10s without navigating away (more context on https://github.com/PostHog/product-internal/issues/89)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
