### PR TITLE
Beef up warning funnel empty state message

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -7,7 +7,7 @@ import { IllustrationDanger } from 'lib/components/icons'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { entityFilterLogic } from 'scenes/insights/ActionFilter/entityFilterLogic'
-import { Button } from 'antd'
+import { Button, Empty } from 'antd'
 
 export function LineGraphEmptyState({ color, isDashboard }: { color: string; isDashboard?: boolean }): JSX.Element {
     return (
@@ -208,10 +208,10 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
 
 export function FunnelEmptyState(): JSX.Element {
     return (
-        <div className="insight-empty-state funnels-empty-state timeout-message">
+        <div className="insight-empty-state funnels-empty-state info-message">
             <div className="insight-empty-state__wrapper">
                 <div className="illustration-main">
-                    <IllustrationDanger />
+                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
                 </div>
                 <h2 className="funnels-empty-state__title">There are no matching events for this query.</h2>
                 <p className="funnels-empty-state__description">

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -208,8 +208,16 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
 
 export function FunnelEmptyState(): JSX.Element {
     return (
-        <p style={{ textAlign: 'center', paddingTop: '2rem' }}>
-            We couldn't find any matching events. Try changing dates or pick another action, event, or breakdown.
-        </p>
+        <div className="insight-empty-state funnels-empty-state timeout-message">
+            <div className="insight-empty-state__wrapper">
+                <div className="illustration-main">
+                    <IllustrationDanger />
+                </div>
+                <h2 className="funnels-empty-state__title">There are no matching events for this query.</h2>
+                <p className="funnels-empty-state__description">
+                    Try changing dates or pick another action, event, or breakdown.
+                </p>
+            </div>
+        </div>
     )
 }

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -173,6 +173,17 @@
             line-height: 1em;
             text-align: center;
             margin-bottom: 1rem;
+
+            .ant-empty {
+                height: 6rem;
+                margin: 0;
+                .ant-empty-image {
+                    height: 100%;
+                    svg {
+                        width: 6rem;
+                    }
+                }
+            }
         }
 
         h2 {


### PR DESCRIPTION
## Changes

Related #5422.

Adds some styling to warning empty state so that it looks like other empty states.

<img width="698" alt="Screen Shot 2021-08-04 at 9 52 55 AM" src="https://user-images.githubusercontent.com/13460330/128222194-0db2d673-c93d-4cd0-821f-049404687396.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
