### PR TITLE
Use new histogram for sessions distribution insight

### DIFF
--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -36,6 +36,14 @@ class ClickhouseSessionsDist:
 
         result = sync_execute(dist_query, params)
 
-        res = [{"label": DIST_LABELS[index], "count": result[0][index]} for index in range(len(DIST_LABELS))]
+        res = [
+            {
+                "label": DIST_LABELS[index].label,
+                "bin0": DIST_LABELS[index].bin0,
+                "bin1": DIST_LABELS[index].bin1,
+                "count": result[0][index],
+            }
+            for index in range(len(DIST_LABELS))
+        ]
 
         return res

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -30,9 +30,12 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
     const tableDisabled = false
     const pieDisabled =
         !!filters.session || filters.insight === ViewType.RETENTION || filters.insight === ViewType.STICKINESS
-    const barDisabled = !!filters.session || filters.insight === ViewType.RETENTION
+    const barDisabled = (!!filters.session && filters.session === 'avg') || filters.insight === ViewType.RETENTION
     const barValueDisabled =
-        barDisabled || filters.insight === ViewType.STICKINESS || filters.insight === ViewType.RETENTION
+        barDisabled ||
+        filters.insight === ViewType.STICKINESS ||
+        filters.insight === ViewType.RETENTION ||
+        (!!filters.session && filters.session === 'dist')
     const defaultDisplay: ChartDisplayType =
         filters.insight === ViewType.RETENTION
             ? ChartDisplayType.ActionsTable
@@ -128,6 +131,7 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
             defaultValue={filters.display || defaultDisplay}
             value={chartFilter || defaultDisplay}
             onChange={(value: ChartDisplayType | FunnelVizType) => {
+                console.log('value', value)
                 setChartFilter(value)
                 onChange(value)
             }}

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -42,6 +42,29 @@ export function Histogram({
     const { setConfig } = useActions(histogramLogic)
     const isEmpty = data.length === 0 || d3.sum(data.map((d) => d.count)) === 0
 
+    console.log('width', width)
+
+    // Check if there are -inf and +inf values and normalize data
+    let _data = data
+    const hasLeftInf = data[0].bin0 === -2
+    const hasRightInf = data[0].bin1 === -1
+    const binValueWidth =
+        hasLeftInf && hasRightInf && data.length === 2
+            ? 5 /* default bin width */
+            : hasLeftInf
+            ? data[1].bin1 - data[1].bin0
+            : data[0].bin1 - data[0].bin0
+    if (hasLeftInf) {
+        _data = [{ ..._data[0], bin0: _data[0].bin1 - binValueWidth }, ..._data.slice(1)]
+    }
+    if (hasRightInf) {
+        _data = [
+            ..._data.slice(0, -1),
+            { ..._data[_data.length - 1], bin1: _data[_data.length - 1].bin0 + binValueWidth },
+        ]
+    }
+    console.log('NEW DATA', _data)
+
     // Initialize x-axis and y-axis scales
     const xMin = data?.[0]?.bin0 || 0
     const xMax = data?.[data.length - 1]?.bin1 || 1

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -17,6 +17,7 @@ import { ViewType } from '~/types'
 import { InsightsTable } from 'scenes/insights/InsightsTable'
 import { Button } from 'antd'
 import { personsModalLogic } from './personsModalLogic'
+import { ActionsBarTimeGraph } from 'scenes/trends/viz/ActionsBarTimeGraph'
 
 interface Props {
     view: ViewType
@@ -31,6 +32,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
     const { loadMoreBreakdownValues } = useActions(trendsLogic({ dashboardItemId: null, view, filters: null }))
     const { showingPeople } = useValues(personsModalLogic)
     const { saveCohortWithFilters, refreshCohort } = useActions(personsModalLogic)
+    console.log('render viz', _filters)
     const renderViz = (): JSX.Element | undefined => {
         if (
             !_filters.display ||
@@ -38,6 +40,11 @@ export function TrendInsight({ view }: Props): JSX.Element {
             _filters.display === ACTIONS_LINE_GRAPH_CUMULATIVE ||
             _filters.display === ACTIONS_BAR_CHART
         ) {
+            console.log('triggered')
+            if (view === ViewType.SESSIONS && _filters.session === 'dist' && _filters.display === ACTIONS_BAR_CHART) {
+                console.log('triggered 2')
+                return <ActionsBarTimeGraph filters={_filters} view={view} />
+            }
             return <ActionsLineGraph filters={_filters} view={view} />
         }
         if (_filters.display === ACTIONS_TABLE) {

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -61,10 +61,7 @@ function cleanFilters(filters: Partial<FilterType>): Partial<FilterType> {
         insight: ViewType.TRENDS,
         ...filters,
         interval: autocorrectInterval(filters),
-        display:
-            filters.session && filters.session === 'dist'
-                ? ChartDisplayType.ActionsTable
-                : filters.display || ChartDisplayType.ActionsLineGraphLinear,
+        display: filters.display || ChartDisplayType.ActionsLineGraphLinear,
         actions: Array.isArray(filters.actions) ? filters.actions : undefined,
         events: Array.isArray(filters.events) ? filters.events : undefined,
         properties: filters.properties || [],

--- a/frontend/src/scenes/trends/viz/ActionsBarTimeGraph.scss
+++ b/frontend/src/scenes/trends/viz/ActionsBarTimeGraph.scss
@@ -1,0 +1,5 @@
+.action-bar-time-graph-container {
+    &.scrollable {
+        overflow-x: auto;
+    }
+}

--- a/frontend/src/scenes/trends/viz/ActionsBarTimeGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsBarTimeGraph.tsx
@@ -1,0 +1,54 @@
+import React, { useRef } from 'react'
+import { useValues } from 'kea'
+import useSize from '@react-hook/size'
+import clsx from 'clsx'
+import { ChartParams } from '~/types'
+import { trendsLogic } from 'scenes/trends/trendsLogic'
+import { hashCodeForString, humanFriendlyDuration, Loading } from 'lib/utils'
+import { Histogram, HistogramDatum } from 'scenes/insights/Histogram'
+import './ActionsBarTimeGraph.scss'
+
+export function ActionsBarTimeGraph({
+    dashboardItemId,
+    view,
+    filters: filtersParam,
+    cachedResults,
+}: ChartParams): JSX.Element {
+    const logic = trendsLogic({ dashboardItemId, view, filters: filtersParam, cachedResults })
+    const { filters, indexedResults, resultsLoading } = useValues(logic)
+    const ref = useRef(null)
+    const [width, height] = useSize(ref)
+
+    console.log('results', indexedResults, filters)
+
+    // const histogramGraphData: HistogramDatum[] = indexedResults
+
+    // Must reload the entire graph on a dashboard when values change, otherwise will run into random d3 bugs
+    // See: https://github.com/PostHog/posthog/pull/5259
+    const key = dashboardItemId ? hashCodeForString(JSON.stringify(indexedResults)) : 'staticGraph'
+
+    return (
+        <div
+            className={clsx('action-bar-time-graph-container', { scrollable: !dashboardItemId })}
+            ref={ref}
+            data-attr="action-bar-time-graph"
+        >
+            {indexedResults && !resultsLoading ? (
+                indexedResults[0] ? (
+                    <Histogram
+                        key={key}
+                        data={indexedResults as HistogramDatum[]}
+                        width={width}
+                        isDashboardItem={!!dashboardItemId}
+                        height={dashboardItemId ? height : undefined}
+                        formatXTickLabel={(v) => humanFriendlyDuration(v, 2)}
+                    />
+                ) : (
+                    <p style={{ textAlign: 'center', marginTop: '4rem' }}>We couldn't find any matching actions.</p>
+                )
+            ) : (
+                <Loading />
+            )}
+        </div>
+    )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -719,6 +719,8 @@ export interface TrendResult {
     breakdown_value?: string | number
     aggregated_value: number
     status?: string
+    bin0?: number // histogram
+    bin1?: number // histogram
 }
 
 export interface TrendResultWithAggregate extends TrendResult {

--- a/posthog/queries/sessions/sessions.py
+++ b/posthog/queries/sessions/sessions.py
@@ -20,17 +20,27 @@ from posthog.queries.base import (
 )
 from posthog.utils import append_data, friendly_time, get_daterange
 
+
+class DistDatum(object):
+    def __init__(self, _id, bin0, bin1, label):
+        self.id = _id
+        self.bin0 = bin0
+        self.bin1 = bin1
+        self.label = label
+
+
+# bin (-2, -1) === (-inf, +inf)
 DIST_LABELS = [
-    "0 seconds (1 event)",
-    "0-3 seconds",
-    "3-10 seconds",
-    "10-30 seconds",
-    "30-60 seconds",
-    "1-3 minutes",
-    "3-10 minutes",
-    "10-30 minutes",
-    "30-60 minutes",
-    "1+ hours",
+    DistDatum(0, -2, 0, "0 seconds (1 event)"),
+    DistDatum(1, 0, 3, "0-3 seconds"),
+    DistDatum(2, 3, 10, "3-10 seconds"),
+    DistDatum(3, 10, 30, "10-30 seconds"),
+    DistDatum(4, 30, 60, "30-60 seconds"),
+    DistDatum(5, 60, 180, "1-3 minutes"),
+    DistDatum(6, 180, 600, "3-10 minutes"),
+    DistDatum(7, 600, 1800, "10-30 minutes"),
+    DistDatum(8, 1800, 3600, "30-60 minutes"),
+    DistDatum(9, 3600, -1, "1+ hours"),
 ]
 
 Query = str
@@ -215,7 +225,13 @@ class Sessions(BaseQuery):
         cursor.execute(distribution, params)
         calculated = cursor.fetchall()
         result = [
-            {"label": DIST_LABELS[index], "count": calculated[0][index], "aggregated_value": calculated[0][index]}
+            {
+                "label": DIST_LABELS[index].label,
+                "bin0": DIST_LABELS[index].bin0,
+                "bin1": DIST_LABELS[index].bin1,
+                "count": calculated[0][index],
+                "aggregated_value": calculated[0][index],
+            }
             for index in range(len(DIST_LABELS))
         ]
         return result


### PR DESCRIPTION
## Changes

Preliminary draft for using our new d3 histogram for session distribution insights!

Distribution graph for our session distribution table.

<img width="1013" alt="Screen Shot 2021-08-03 at 2 59 25 PM" src="https://user-images.githubusercontent.com/13460330/128091894-1844255f-d9c3-4eee-ad5e-4ff3a3b5ee9d.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
