### PR TITLE
Make breakdowns + formulas work

### DIFF
--- a/ee/clickhouse/queries/trends/formula.py
+++ b/ee/clickhouse/queries/trends/formula.py
@@ -10,23 +10,14 @@ from posthog.models.filters.filter import Filter
 
 
 class ClickhouseTrendsFormula:
-    def _label(self, filter: Filter, item: List, team_id: int) -> str:
-        if filter.breakdown:
-            if filter.breakdown_type == "cohort":
-                if item[2] == 0:
-                    return "all users"
-                return Cohort.objects.get(team=team_id, pk=item[2]).name
-            return item[2]
-        return "Formula ({})".format(filter.formula)
-
     def _run_formula_query(self, filter: Filter, team_id: int):
         letters = [chr(65 + i) for i in range(0, len(filter.entities))]
         queries = []
         params: Dict[str, Any] = {}
         for idx, entity in enumerate(filter.entities):
             sql, entity_params, _ = self._get_sql_for_entity(filter, entity, team_id)  # type: ignore
-            sql = sql.replace("%(", "%({}_".format(idx))
-            entity_params = {"{}_{}".format(idx, key): value for key, value in entity_params.items()}
+            sql = sql.replace("%(", f"%({idx}_")
+            entity_params = {f"{idx}_{key}": value for key, value in entity_params.items()}
             queries.append(sql)
             params = {**params, **entity_params}
 
@@ -49,10 +40,7 @@ class ClickhouseTrendsFormula:
             formula=filter.formula,  # formula is properly escaped in the filter
             # Need to wrap aggregates in arrays so we can still use arrayMap
             selects=", ".join(
-                [
-                    ("[sub_{}.data]" if is_aggregate else "sub_{}.data").format(letters[i])
-                    for i in range(0, len(filter.entities))
-                ]
+                [(f"[sub_{letter}.data]" if is_aggregate else f"sub_{letter}.data") for letter in letters]
             ),
             breakdown_value=breakdown_value if filter.breakdown else "",
             first_query=queries[0],
@@ -87,3 +75,12 @@ class ClickhouseTrendsFormula:
             additional_values["count"] = float(sum(additional_values["data"]))
             response.append(parse_response(item, filter, additional_values))
         return response
+
+    def _label(self, filter: Filter, item: List, team_id: int) -> str:
+        if filter.breakdown:
+            if filter.breakdown_type == "cohort":
+                if item[2] == 0:
+                    return "all users"
+                return Cohort.objects.get(team=team_id, pk=item[2]).name
+            return item[2]
+        return "Formula ({})".format(filter.formula)


### PR DESCRIPTION
Make formulas and breakdowns work
    
Closes https://github.com/PostHog/posthog/issues/5390
    
Previously the query returned a 500 for some breakdowns, with the error
`Arrays passed to arrayMap must have equal size: while executing 'FUNCTION arrayMap`
    
The issue came from the different subqueries having different breakdowns - some would break down with values A and B and other would have B and C
    
After the full outer join, arrays for breakdown values A and C would be empty in some cases. Filling them with zeroes fixes the issue.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
