### PR TITLE
Add more contrast between official and community plugins

### DIFF
--- a/frontend/src/scenes/plugins/Plugins.scss
+++ b/frontend/src/scenes/plugins/Plugins.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .plugins-scene {
     padding-bottom: 60px;
 }
@@ -76,4 +78,8 @@
             display: none;
         }
     }
+}
+
+.plugins-popconfirm {
+    z-index: $z_plugins-popconfirm;
 }

--- a/frontend/src/scenes/plugins/Plugins.scss
+++ b/frontend/src/scenes/plugins/Plugins.scss
@@ -1,9 +1,16 @@
 .plugins-scene {
     padding-bottom: 60px;
 }
-.plugins-installed-tab-section-header:hover {
+
+.plugins-installed-tab-section-header:hover,
+.plugins-repository-tab-section-header:hover {
     cursor: pointer;
 }
+
+.plugins-repository-tab-section-header {
+    margin-left: 5px;
+}
+
 .plugin-capabilities-tag {
     cursor: default;
 }

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -150,6 +150,7 @@ export function PluginDrawer(): JSX.Element {
                                         onConfirm={() => uninstallPlugin(editingPlugin.name)}
                                         okText="Uninstall"
                                         cancelText="Cancel"
+                                        className="plugins-popconfirm"
                                     >
                                         <Button
                                             style={{ color: 'var(--danger)', padding: 4 }}

--- a/frontend/src/scenes/plugins/plugin/CommunityPluginTag.tsx
+++ b/frontend/src/scenes/plugins/plugin/CommunityPluginTag.tsx
@@ -1,6 +1,16 @@
 import React from 'react'
-import { Tag } from 'antd'
+import { Tag, Tooltip } from 'antd'
 
 export function CommunityPluginTag({ isCommunity }: { isCommunity?: boolean }): JSX.Element {
-    return <Tag color={isCommunity ? 'green' : 'blue'}>{isCommunity ? 'Community' : 'Official'}</Tag>
+    return (
+        <Tooltip
+            title={
+                isCommunity
+                    ? 'This plugin was built by a community memeber, not the PostHog team.'
+                    : 'This plugin was built by the PostHog team.'
+            }
+        >
+            <Tag color={isCommunity ? 'cyan' : 'geekblue'}>{isCommunity ? 'Community' : 'Official'}</Tag>
+        </Tooltip>
+    )
 }

--- a/frontend/src/scenes/plugins/plugin/LocalPluginTag.tsx
+++ b/frontend/src/scenes/plugins/plugin/LocalPluginTag.tsx
@@ -13,7 +13,7 @@ export function LocalPluginTag({
 }): JSX.Element {
     return (
         <Tooltip title={url.substring(5)}>
-            <Tag color="geekblue" onClick={() => copyToClipboard(url.substring(5))} style={style}>
+            <Tag color="purple" onClick={() => copyToClipboard(url.substring(5))} style={style}>
                 {title || 'Local Plugin'}
             </Tag>
         </Tooltip>

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -91,10 +91,13 @@ export function PluginCard({
         showPluginLogs,
         showPluginMetrics,
     } = useActions(pluginsLogic)
-    const { loading, installingPluginUrl, checkingForUpdates } = useValues(pluginsLogic)
+    const { loading, installingPluginUrl, checkingForUpdates, pluginUrlToMaintainer } = useValues(pluginsLogic)
     const { user } = useValues(userLogic)
 
     const { featureFlags } = useValues(featureFlagLogic)
+
+    const hasSpecifiedMaintainer = maintainer || (plugin.url && pluginUrlToMaintainer[plugin.url])
+    const pluginMaintainer = maintainer || pluginUrlToMaintainer[plugin.url || '']
 
     return (
         <Col
@@ -152,7 +155,9 @@ export function PluginCard({
                     <Col style={{ flex: 1 }}>
                         <div>
                             <strong style={{ marginRight: 8 }}>{name}</strong>
-                            {maintainer && !pluginId && <CommunityPluginTag isCommunity={maintainer === 'community'} />}
+                            {hasSpecifiedMaintainer && (
+                                <CommunityPluginTag isCommunity={pluginMaintainer === 'community'} />
+                            )}
                             {pluginConfig?.error ? (
                                 <PluginError
                                     error={pluginConfig.error}

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -625,6 +625,16 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection>>({
                 )
             },
         ],
+        pluginUrlToMaintainer: [
+            (s) => [s.repository],
+            (repository) => {
+                const pluginNameToMaintainerMap: Record<string, string> = {}
+                for (const plugin of Object.values(repository)) {
+                    pluginNameToMaintainerMap[plugin.url] = plugin.maintainer || ''
+                }
+                return pluginNameToMaintainerMap
+            },
+        ],
     },
 
     listeners: ({ actions, values }) => ({

--- a/frontend/src/scenes/plugins/tabs/repository/RepositoryTab.tsx
+++ b/frontend/src/scenes/plugins/tabs/repository/RepositoryTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Col, Row } from 'antd'
 import { useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
@@ -6,38 +6,135 @@ import { PluginCard } from 'scenes/plugins/plugin/PluginCard'
 import { Subtitle } from 'lib/components/PageHeader'
 import { PluginLoading } from 'scenes/plugins/plugin/PluginLoading'
 import { PluginsSearch } from '../../PluginsSearch'
+import { CaretRightOutlined, CaretDownOutlined } from '@ant-design/icons'
+
+export enum RepositorySection {
+    Official = 'official',
+    Community = 'community',
+}
 
 export function RepositoryTab(): JSX.Element {
-    const { repositoryLoading, uninstalledPlugins, filteredUninstalledPlugins } = useValues(pluginsLogic)
+    const { repositoryLoading, filteredUninstalledPlugins } = useValues(pluginsLogic)
+    const [repositorySectionsOpen, setRepositorySectionsOpen] = useState([RepositorySection.Official])
+
+    const officialPlugins = filteredUninstalledPlugins.filter((plugin) => plugin.maintainer === 'official')
+    const communityPlugins = filteredUninstalledPlugins.filter((plugin) => plugin.maintainer === 'community')
+
+    const toggleRepositorySectionOpen = (section: RepositorySection): void => {
+        if (repositorySectionsOpen.includes(section)) {
+            setRepositorySectionsOpen(repositorySectionsOpen.filter((s) => section !== s))
+            return
+        }
+        setRepositorySectionsOpen([...repositorySectionsOpen, section])
+    }
 
     return (
         <div>
             <Subtitle subtitle="Plugin Repository" />
             <PluginsSearch />
-            <Row gutter={16} style={{ marginTop: 16 }}>
+            <div>
                 {(!repositoryLoading || filteredUninstalledPlugins.length > 0) && (
                     <>
-                        {filteredUninstalledPlugins.map((plugin) => {
-                            return (
-                                <PluginCard
-                                    key={plugin.url}
-                                    plugin={{
-                                        name: plugin.name,
-                                        url: plugin.url,
-                                        description: plugin.description,
-                                    }}
-                                    maintainer={plugin.maintainer}
+                        <Row gutter={16} style={{ marginTop: 16, display: 'block' }}>
+                            <div
+                                className="plugins-repository-tab-section-header"
+                                onClick={() => toggleRepositorySectionOpen(RepositorySection.Official)}
+                            >
+                                <Subtitle
+                                    subtitle={
+                                        <>
+                                            {repositorySectionsOpen.includes(RepositorySection.Official) ? (
+                                                <CaretDownOutlined />
+                                            ) : (
+                                                <CaretRightOutlined />
+                                            )}
+                                            {` Official Plugins (${officialPlugins.length})`}
+                                        </>
+                                    }
                                 />
-                            )
-                        })}
-                        {uninstalledPlugins.length == 0 && (
-                            <Col span={24}>
-                                You have already installed all available plugins from the official repository!
-                            </Col>
-                        )}
+                            </div>
+                            {repositorySectionsOpen.includes(RepositorySection.Official) && (
+                                <>
+                                    <Col span={24}>
+                                        {officialPlugins.length > 0
+                                            ? 'Official plugins are built and maintained by the PostHog team.'
+                                            : 'You have already installed all official plugins!'}
+                                    </Col>
+                                    <br />
+                                    {officialPlugins.map((plugin) => {
+                                        return (
+                                            <PluginCard
+                                                key={plugin.url}
+                                                plugin={{
+                                                    name: plugin.name,
+                                                    url: plugin.url,
+                                                    description: plugin.description,
+                                                }}
+                                                maintainer={plugin.maintainer}
+                                            />
+                                        )
+                                    })}
+                                </>
+                            )}
+                        </Row>
+                        <Row gutter={16} style={{ marginTop: 16, display: 'block' }}>
+                            <div
+                                className="plugins-repository-tab-section-header"
+                                onClick={() => toggleRepositorySectionOpen(RepositorySection.Community)}
+                            >
+                                <Subtitle
+                                    subtitle={
+                                        <>
+                                            {repositorySectionsOpen.includes(RepositorySection.Community) ? (
+                                                <CaretDownOutlined />
+                                            ) : (
+                                                <CaretRightOutlined />
+                                            )}
+                                            {` Community Plugins (${communityPlugins.length})`}
+                                        </>
+                                    }
+                                />
+                            </div>
+                            {repositorySectionsOpen.includes(RepositorySection.Community) && (
+                                <>
+                                    <Col span={24}>
+                                        {communityPlugins.length > 0 ? (
+                                            <span>
+                                                Community plugins are not built nor maintained by the PostHog team.
+                                                Anyone,{' '}
+                                                <a
+                                                    href="https://posthog.com/docs/plugins/build-your-own"
+                                                    target="_blank"
+                                                    rel="noreferrer noopener"
+                                                >
+                                                    including you
+                                                </a>
+                                                , can build a plugin.
+                                            </span>
+                                        ) : (
+                                            'You have already installed all community plugins!'
+                                        )}
+                                    </Col>
+                                    <br />
+                                    {communityPlugins.map((plugin) => {
+                                        return (
+                                            <PluginCard
+                                                key={plugin.url}
+                                                plugin={{
+                                                    name: plugin.name,
+                                                    url: plugin.url,
+                                                    description: plugin.description,
+                                                }}
+                                                maintainer={plugin.maintainer}
+                                            />
+                                        )
+                                    })}
+                                </>
+                            )}
+                        </Row>
                     </>
                 )}
-            </Row>
+            </div>
             {repositoryLoading && filteredUninstalledPlugins.length === 0 && (
                 <Row gutter={16}>
                     <PluginLoading />

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -135,6 +135,7 @@ $z_ant_message: 1070;
 $z_ant_modal_wrap: 1060;
 $z_ant_modal_mask: 1050;
 $z_popup: 1060;
+$z_plugins-popconfirm: 1001;
 $z_drawer: 1000;
 $z_pinned_dashboards_popup: 962;
 $z_graph_tooltip: 951;


### PR DESCRIPTION
## Changes

This was going to be a larger change but I settled for now given my updated priorities.

Import plugins got me thinking that we'll end up with a repository full of noise until we allow any plugins on Cloud. Someone will open the repository and see "Company A Redshift Import", "Company B Redshift Import", "Company C Redshift Import", etc, so I thought it'd make sense to give official plugins priority.

This is also important as it removes a bit of responsibility from us regarding community plugins.

For self-hosted, this works nicely:
<img width="1439" alt="Screenshot 2021-08-04 at 11 48 46" src="https://user-images.githubusercontent.com/38760734/128203260-495e5f00-4351-4b9b-acce-70df4677dc81.png">

On Cloud, however, there's no repository tab, there's just the installed tab. So for now I've settled for showing the official/community tags here too, just so that even if there's noise, there's an understanding of what's going on.
<img width="1437" alt="Screenshot 2021-08-04 at 11 48 59" src="https://user-images.githubusercontent.com/38760734/128203432-452ccf57-6e1c-4f41-abfd-54400f345a4d.png">

We could also send community plugins to the bottom?

This will become more important as I'm planning to introduce plugin templates that people can fork and tailor to their needs, as an alternative to https://github.com/PostHog/plugin-server/pull/504

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
