### PR TITLE
Show only spinner when loading for funnels

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -442,7 +442,7 @@ function FunnelInsight(): JSX.Element {
         if (!areFiltersValid) {
             return <FunnelInvalidFiltersEmptyState />
         }
-        return <FunnelEmptyState />
+        return isLoading ? <></> : <FunnelEmptyState />
     }
 
     return (

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -442,7 +442,7 @@ function FunnelInsight(): JSX.Element {
         if (!areFiltersValid) {
             return <FunnelInvalidFiltersEmptyState />
         }
-        return isLoading ? <></> : <FunnelEmptyState />
+        return isLoading ? <div style={{ height: 50 }} /> : <FunnelEmptyState />
     }
 
     return (


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

<img width="763" alt="Screen Shot 2021-08-04 at 11 39 11 AM" src="https://user-images.githubusercontent.com/25164963/128211160-031e3e3e-56c1-43d7-9b0c-42fee9b72e0f.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
