### PR TITLE
Execute merge_people in plugin server

### DIFF
--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -276,7 +276,8 @@ def factory_test_person(event_factory, person_factory, get_events, get_people):
                         unittest.mock.ANY,
                         self.team.id,
                     ),
-                ]
+                ],
+                any_order=True,
             )
 
         def test_return_non_anonymous_name(self) -> None:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1,6 +1,7 @@
 import json
+import unittest
+from unittest import mock
 
-from django.utils import timezone
 from rest_framework import status
 
 from posthog.models import Cohort, Event, Organization, Person, Team
@@ -243,7 +244,8 @@ def factory_test_person(event_factory, person_factory, get_events, get_people):
             self.assertEqual(response.json(), response_uuid.json())
             self.assertEqual(len(response.json()["results"]), 2)
 
-        def test_merge_people(self) -> None:
+        @mock.patch("posthog.api.capture.capture_internal")
+        def test_merge_people(self, mock_capture_internal) -> None:
             # created first
             person3 = person_factory(team=self.team, distinct_ids=["3"], properties={"oh": "hello"})
             person1 = person_factory(
@@ -251,17 +253,31 @@ def factory_test_person(event_factory, person_factory, get_events, get_people):
             )
             person2 = person_factory(team=self.team, distinct_ids=["2"], properties={"random_prop": "asdf"})
 
-            response = self.client.post("/api/person/%s/merge/" % person1.pk, {"ids": [person2.pk, person3.pk]},)
-            self.assertEqual(response.status_code, 201)
-            self.assertEqual(response.json()["created_at"].replace("Z", "+00:00"), person3.created_at.isoformat())
-            self.assertEqual(response.json()["distinct_ids"], ["3", "1", "2"])
-
-            person = get_people()
-            self.assertEqual(len(person), 1)
-            self.assertEqual(
-                person[0].properties, {"$browser": "whatever", "$os": "Mac OS X", "random_prop": "asdf", "oh": "hello"}
+            self.client.post(
+                "/api/person/%s/merge/" % person1.pk, {"ids": [person2.pk, person3.pk]},
             )
-            self.assertEqual(person[0].created_at, person3.created_at)
+            mock_capture_internal.assert_has_calls(
+                [
+                    mock.call(
+                        {"event": "$create_alias", "properties": {"alias": "3"}},
+                        "1",
+                        None,
+                        None,
+                        unittest.mock.ANY,
+                        unittest.mock.ANY,
+                        self.team.id,
+                    ),
+                    mock.call(
+                        {"event": "$create_alias", "properties": {"alias": "2"}},
+                        "1",
+                        None,
+                        None,
+                        unittest.mock.ANY,
+                        unittest.mock.ANY,
+                        self.team.id,
+                    ),
+                ]
+            )
 
         def test_return_non_anonymous_name(self) -> None:
             person_factory(


### PR DESCRIPTION
## Changes

Fixes #5145 

`merge_people` now delegates work to the plugin server by creating a `$create_alias` event.

Tests make sure that the event is created properly but tests for the merging logic are ofc in the plugin server code.


https://user-images.githubusercontent.com/38760734/128239716-b45eddf5-b665-4fee-a97c-6e92cd5172f1.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
