### PR TITLE
Hotfix crashing Home

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -43,7 +43,6 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Funnel } from 'scenes/funnels/Funnel'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 dayjs.extend(relativeTime)
 
@@ -187,7 +186,7 @@ export function DashboardItem({
     const [initialLoaded, setInitialLoaded] = useState(false)
     const [showSaveModal, setShowSaveModal] = useState(false)
     const { dashboards } = useValues(dashboardsModel)
-    const { refreshStatus } = useValues(dashboardLogic)
+    /* FIXME (see #5454): const { refreshStatus } = useValues(dashboardLogic) */
     const { renameDashboardItem } = useActions(dashboardItemsModel)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -499,23 +498,27 @@ export function DashboardItem({
                 )}
 
                 <div className={`dashboard-item-content ${_type}`} onClickCapture={onClick}>
-                    {!refreshStatus[item.id]?.loading && Element ? (
-                        <Alert.ErrorBoundary message="Error rendering graph!">
-                            {(dashboardMode === DashboardMode.Public || preventLoading) && !results && !item.result ? (
-                                <Skeleton />
-                            ) : (
-                                <Element
-                                    dashboardItemId={item.id}
-                                    filters={filters}
-                                    color={color}
-                                    theme={color === 'white' ? 'light' : 'dark'}
-                                    inSharedMode={dashboardMode === DashboardMode.Public}
-                                />
-                            )}
-                        </Alert.ErrorBoundary>
-                    ) : (
-                        <Loading />
-                    )}
+                    {
+                        /* FIXME (see #5454): !refreshStatus[item.id]?.loading && */ Element ? (
+                            <Alert.ErrorBoundary message="Error rendering graph!">
+                                {(dashboardMode === DashboardMode.Public || preventLoading) &&
+                                !results &&
+                                !item.result ? (
+                                    <Skeleton />
+                                ) : (
+                                    <Element
+                                        dashboardItemId={item.id}
+                                        filters={filters}
+                                        color={color}
+                                        theme={color === 'white' ? 'light' : 'dark'}
+                                        inSharedMode={dashboardMode === DashboardMode.Public}
+                                    />
+                                )}
+                            </Alert.ErrorBoundary>
+                        ) : (
+                            <Loading />
+                        )
+                    }
                 </div>
                 {footer}
             </div>


### PR DESCRIPTION
## Changes

I was notified by a user that our Home screen crashes the app. Confirmed on my own account. Looks like the bug was introduced in #5407 and is caused by `dashboardLogic` being `use`d  without `key` provided (via `props.id`). I'm not sure how that logic is supposed to be used, because it seems it only is invoked with a `key` in one place in our codebase and without in the rest. So for now only commenting out the offending code (UX regression but much more okay than the app crashing).

Learnings:
- Home should also be covered by at least one simple E2E test
- logics that depend on a key should be used with props in a consistent way

This should be fixed more solidly, but I don't have that much context on recent dashboard state work to do that right now (@alexkim205?).