### PR TITLE
Dynamic materialized columns

### DIFF
--- a/ee/clickhouse/materialized_columns/__init__.py
+++ b/ee/clickhouse/materialized_columns/__init__.py
@@ -1,0 +1,1 @@
+from .columns import get_events_materialized_columns

--- a/ee/clickhouse/materialized_columns/__init__.py
+++ b/ee/clickhouse/materialized_columns/__init__.py
@@ -1,1 +1,1 @@
-from .columns import get_events_materialized_columns
+from .columns import get_materialized_columns

--- a/ee/clickhouse/materialized_columns/__init__.py
+++ b/ee/clickhouse/materialized_columns/__init__.py
@@ -1,1 +1,1 @@
-from .columns import get_materialized_columns
+from .columns import get_materialized_columns, materialize

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -16,7 +16,7 @@ def cache_for(cache_time: timedelta):
     def wrapper(fn):
         @wraps(fn)
         @no_type_check
-        def memoized_fn(*args, use_cache=TEST):
+        def memoized_fn(*args, use_cache=not TEST):
             current_time = now()
             if (
                 args not in memoized_fn.__cache

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -1,0 +1,49 @@
+from collections import defaultdict
+from functools import wraps
+from typing import Dict, no_type_check
+
+from dateutil.relativedelta import relativedelta
+from django.utils.timezone import now
+
+from ee.clickhouse.client import sync_execute
+from posthog.settings import CLICKHOUSE_DATABASE
+
+Property = str
+ColumnName = str
+
+
+def cache_for(cache_time: relativedelta):
+    def wrapper(fn):
+        @wraps(fn)
+        @no_type_check
+        def memoized_fn(*args):
+            current_time = now()
+            if args not in memoized_fn.__cache or current_time - memoized_fn.__cache[args][0] > cache_time:
+                memoized_fn.__cache[args] = (current_time, fn(*args))
+            return memoized_fn.__cache[args][1]
+
+        memoized_fn.__cache = {}
+        return memoized_fn
+
+    return wrapper
+
+
+@cache_for(relativedelta(minutes=15))
+def get_materialized_columns(table: str) -> Dict[Property, ColumnName]:
+    rows = sync_execute(
+        """
+        SELECT comment, name
+        FROM system.columns
+        WHERE database = %(database)s
+          AND table = 'events'
+          AND default_kind = 'MATERIALIZED'
+          AND comment LIKE '%column_materializer::%'
+    """,
+        {"database": CLICKHOUSE_DATABASE, "table": table},
+    )
+
+    return {extract_property(comment): column_name for comment, column_name in rows}
+
+
+def extract_property(comment: str) -> Property:
+    return comment.split("::", 1)[1]

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -6,11 +6,6 @@ from posthog.test.base import BaseTest
 
 
 class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
-    def tearDown(self):
-        super().tearDown()
-        # :TRICKY: Reset the fetch method cache after tests
-        get_materialized_columns.__cache = {}
-
     def test_get_columns_default(self):
         self.assertCountEqual(get_materialized_columns("events"), [])
         self.assertCountEqual(get_materialized_columns("person"), [])
@@ -21,12 +16,12 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             materialize("events", "$bar")
             materialize("person", "$zeta")
 
-            self.assertCountEqual(get_materialized_columns("events"), ["$foo", "$bar"])
-            self.assertCountEqual(get_materialized_columns("person"), ["$zeta"])
+            self.assertCountEqual(get_materialized_columns("events", use_cache=True), ["$foo", "$bar"])
+            self.assertCountEqual(get_materialized_columns("person", use_cache=True), ["$zeta"])
 
             materialize("events", "abc")
 
-            self.assertCountEqual(get_materialized_columns("events"), ["$foo", "$bar"])
+            self.assertCountEqual(get_materialized_columns("events", use_cache=True), ["$foo", "$bar"])
 
         with freeze_time("2020-01-04T14:00:01Z"):
-            self.assertCountEqual(get_materialized_columns("events"), ["$foo", "$bar", "abc"])
+            self.assertCountEqual(get_materialized_columns("events", use_cache=True), ["$foo", "$bar", "abc"])

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -1,0 +1,32 @@
+from freezegun import freeze_time
+
+from ee.clickhouse.materialized_columns.columns import get_materialized_columns, materialize
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.test.base import BaseTest
+
+
+class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
+    def tearDown(self):
+        super().tearDown()
+        # :TRICKY: Reset the fetch method cache after tests
+        get_materialized_columns.__cache = {}
+
+    def test_get_columns_default(self):
+        self.assertCountEqual(get_materialized_columns("events"), [])
+        self.assertCountEqual(get_materialized_columns("person"), [])
+
+    def test_caching_and_materializing(self):
+        with freeze_time("2020-01-04T13:01:01Z"):
+            materialize("events", "$foo")
+            materialize("events", "$bar")
+            materialize("person", "$zeta")
+
+            self.assertCountEqual(get_materialized_columns("events"), ["$foo", "$bar"])
+            self.assertCountEqual(get_materialized_columns("person"), ["$zeta"])
+
+            materialize("events", "abc")
+
+            self.assertCountEqual(get_materialized_columns("events"), ["$foo", "$bar"])
+
+        with freeze_time("2020-01-04T14:00:01Z"):
+            self.assertCountEqual(get_materialized_columns("events"), ["$foo", "$bar", "abc"])

--- a/ee/clickhouse/migrations/0015_materialized_column_comments.py
+++ b/ee/clickhouse/migrations/0015_materialized_column_comments.py
@@ -1,0 +1,15 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+already_materialized_columns = [
+    ("properties_issampledevent", "isSampledEvent"),
+    ("properties_currentscreen", "currentScreen"),
+    ("properties_objectname", "objectName"),
+]
+
+operations = []
+
+for column_name, property in already_materialized_columns:
+    statement = f"ALTER TABLE events ON CLUSTER {CLICKHOUSE_CLUSTER} COMMENT COLUMN {column_name} 'column_materializer::{property}'"
+    operations.append(migrations.RunSQL(statement))

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -1,10 +1,10 @@
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from django.conf import settings
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.materialized_columns.columns import ColumnName, get_materialized_columns
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
@@ -85,11 +85,10 @@ def prop_filter_json_extract(
     prop: Property, idx: int, prepend: str = "", prop_var: str = "properties", allow_denormalized_props: bool = False
 ) -> Tuple[str, Dict[str, Any]]:
     # Once all queries are migrated over we can get rid of allow_denormalized_props
-    is_denormalized = prop.key.lower() in settings.CLICKHOUSE_DENORMALIZED_PROPERTIES and allow_denormalized_props
     json_extract = "trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s))".format(
         idx=idx, prepend=prepend, prop_var=prop_var
     )
-    denormalized = "properties_{}".format(prop.key.lower())
+    denormalized_column = get_denormalized_property_column(prop, allow_denormalized_props)
     operator = prop.operator
     params: Dict[str, Any] = {}
 
@@ -97,7 +96,7 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): box_value(prop.value)}
         return (
             "AND NOT has(%(v{prepend}_{idx})s, {left})".format(
-                idx=idx, prepend=prepend, left=denormalized if is_denormalized else json_extract
+                idx=idx, prepend=prepend, left=denormalized_column or json_extract
             ),
             params,
         )
@@ -106,7 +105,7 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
             "AND {left} LIKE %(v{prepend}_{idx})s".format(
-                idx=idx, prepend=prepend, left=denormalized if is_denormalized else json_extract
+                idx=idx, prepend=prepend, left=denormalized_column or json_extract
             ),
             params,
         )
@@ -115,7 +114,7 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
             "AND NOT ({left} LIKE %(v{prepend}_{idx})s)".format(
-                idx=idx, prepend=prepend, left=denormalized if is_denormalized else json_extract
+                idx=idx, prepend=prepend, left=denormalized_column or json_extract
             ),
             params,
         )
@@ -130,15 +129,15 @@ def prop_filter_json_extract(
                 regex_function="match" if operator == "regex" else "NOT match",
                 idx=idx,
                 prepend=prepend,
-                left=denormalized if is_denormalized else json_extract,
+                left=denormalized_column or json_extract,
             ),
             params,
         )
     elif operator == "is_set":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
-        if is_denormalized:
+        if denormalized_column:
             return (
-                "AND NOT isNull({left})".format(left=denormalized),
+                "AND NOT isNull({left})".format(left=denormalized_column),
                 params,
             )
         return (
@@ -147,9 +146,9 @@ def prop_filter_json_extract(
         )
     elif operator == "is_not_set":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
-        if is_denormalized:
+        if denormalized_column:
             return (
-                "AND isNull({left})".format(left=denormalized),
+                "AND isNull({left})".format(left=denormalized_column),
                 params,
             )
         return (
@@ -164,8 +163,8 @@ def prop_filter_json_extract(
             "AND toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) > %(v{prepend}_{idx})s".format(
                 idx=idx,
                 prepend=prepend,
-                left=denormalized
-                if is_denormalized
+                left=denormalized_column
+                if denormalized_column
                 else "visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s)".format(
                     idx=idx, prepend=prepend, prop_var=prop_var,
                 ),
@@ -178,8 +177,8 @@ def prop_filter_json_extract(
             "AND toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) < %(v{prepend}_{idx})s".format(
                 idx=idx,
                 prepend=prepend,
-                left=denormalized
-                if is_denormalized
+                left=denormalized_column
+                if denormalized_column
                 else "visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s)".format(
                     idx=idx, prepend=prepend, prop_var=prop_var,
                 ),
@@ -187,7 +186,7 @@ def prop_filter_json_extract(
             params,
         )
     else:
-        if is_json(prop.value) and not is_denormalized:
+        if is_json(prop.value) and not denormalized_column:
             clause = "AND has(%(v{prepend}_{idx})s, replaceRegexpAll(visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s),' ', ''))"
             params = {
                 "k{}_{}".format(prepend, idx): prop.key,
@@ -197,9 +196,7 @@ def prop_filter_json_extract(
             clause = "AND has(%(v{prepend}_{idx})s, {left})"
             params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): box_value(prop.value)}
         return (
-            clause.format(
-                left=denormalized if is_denormalized else json_extract, idx=idx, prepend=prepend, prop_var=prop_var
-            ),
+            clause.format(left=denormalized_column or json_extract, idx=idx, prepend=prepend, prop_var=prop_var),
             params,
         )
 
@@ -224,6 +221,16 @@ def get_property_values_for_key(key: str, team: Team, value: Optional[str] = Non
         SELECT_PROP_VALUES_SQL.format(parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to),
         {"team_id": team.pk, "key": key},
     )
+
+
+def get_denormalized_property_column(prop, allow_denormalized_props: bool) -> Optional[ColumnName]:
+    columns = {}
+    if allow_denormalized_props and prop.type == "person":
+        columns = get_materialized_columns("person")
+    if allow_denormalized_props and prop.type == "event":
+        columns = get_materialized_columns("events")
+
+    return columns.get(prop.key)
 
 
 def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -225,8 +225,7 @@ def get_property_values_for_key(key: str, team: Team, value: Optional[str] = Non
 
 def get_denormalized_property_column(prop, allow_denormalized_props: bool) -> Optional[ColumnName]:
     columns = {}
-    if allow_denormalized_props and prop.type == "person":
-        columns = get_materialized_columns("person")
+    # :TODO: Handle denormalized properties in person table
     if allow_denormalized_props and prop.type == "event":
         columns = get_materialized_columns("events")
 

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -273,8 +273,7 @@ class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
         filter = Filter(data={"properties": [{"key": "test_prop", "value": "_other_", "operator": "not_icontains"}],})
         self.assertEqual(len(self._run_query(filter)), 1)
 
-    # Broken currently, denormalized person properties are not (yet) handled
-    @skip
+    @skip("denormalized person properties are not (yet) handled")
     def test_prop_person_denormalized(self):
         _create_person(distinct_ids=["some_id"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
         _create_event(event="$pageview", team=self.team, distinct_id="some_id")

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, Tuple
 
 from django.conf import settings
 
+from ee.clickhouse.materialized_columns import get_materialized_columns
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
-from ee.settings import CLICKHOUSE_DENORMALIZED_PROPERTIES
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 
 
@@ -16,8 +16,8 @@ class FunnelEventQuery(ClickhouseEventQuery):
             + (
                 " ".join(
                     [
-                        f", {self.EVENT_TABLE_ALIAS}.properties_{prop} as properties_{prop}"
-                        for prop in settings.CLICKHOUSE_DENORMALIZED_PROPERTIES
+                        f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
+                        for column_name in get_materialized_columns("events").values()
                     ]
                 )
             )

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from ee.settings import CLICKHOUSE_DENORMALIZED_PROPERTIES
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
-from posthog.models.action import Action
 
 
 class FunnelEventQuery(ClickhouseEventQuery):

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Tuple
 
-from django.conf import settings
-
+from ee.clickhouse.materialized_columns.columns import get_materialized_columns
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from ee.clickhouse.queries.trends.util import get_active_user_params, populate_entity_params
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
@@ -24,8 +23,8 @@ class TrendsEventQuery(ClickhouseEventQuery):
             + (
                 " ".join(
                     [
-                        f", {self.EVENT_TABLE_ALIAS}.properties_{prop} as properties_{prop}"
-                        for prop in settings.CLICKHOUSE_DENORMALIZED_PROPERTIES
+                        f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
+                        for column_name in get_materialized_columns("events").values()
                     ]
                 )
             )

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -26,9 +26,4 @@ if "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS" in os.environ:
     ].split(",")
 
 # ClickHouse and Kafka
-CLICKHOUSE_DENORMALIZED_PROPERTIES: list = (
-    os.getenv("CLICKHOUSE_DENORMALIZED_PROPERTIES", "").split(",")
-    if os.getenv("CLICKHOUSE_DENORMALIZED_PROPERTIES")
-    else []
-)
 KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -91,10 +91,6 @@
                     "value": "Posthog Cloud"
                 },
                 {
-                    "name": "CLICKHOUSE_DENORMALIZED_PROPERTIES",
-                    "value": "issampledevent,currentscreen,objectname"
-                },
-                {
                     "name": "BILLING_TRIAL_DAYS",
                     "value": "0"
                 },

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -85,10 +85,6 @@
                     "value": "Posthog Cloud"
                 },
                 {
-                    "name": "CLICKHOUSE_DENORMALIZED_PROPERTIES",
-                    "value": "issampledevent,currentscreen,objectname"
-                },
-                {
                     "name": "BILLING_TRIAL_DAYS",
                     "value": "0"
                 },


### PR DESCRIPTION
This PR:
- Introduces methods to materialize columns dynamically
- For fetching relevent materialized columns from clickhouse
- Removes the old setting + migrates old columns to conform

Restrictions:
- Analyzis code is still WIP - I've run this a few times in cloud + generated materialized columns using it 
- Person properties denormalization does not (yet) work as expected
- Since cloud is using a different schema from rest, `distributed` argument was added to the `materialize` function

## Commits

- Add migration marking existing columns as materialized with a comment
- Add method to allow looking up materialized columns
- Add test for fetching and creating materialized columns
- Disable caching in tests
- Remove some callsites to CLICKHOUSE_DENORMALIZED_PROPERTIES
- Fixup caching logic
- Add (currently broken) test for denormalizing person properties
- Update funnel event query to work with new functionality
- Update other tests/queries
- Remove now-unused setting

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
