### PR TITLE
Improve cached_property typing

### DIFF
--- a/ee/clickhouse/queries/clickhouse_session_recording.py
+++ b/ee/clickhouse/queries/clickhouse_session_recording.py
@@ -68,7 +68,7 @@ def query_sessions_in_range(
     filter_query, filter_params = "", {}
 
     if filter.recording_duration_filter:
-        filter_query = f"AND duration {OPERATORS[filter.recording_duration_filter.operator]} %(min_recording_duration)s"
+        filter_query = f"AND duration {OPERATORS[filter.recording_duration_filter.operator]} %(min_recording_duration)s"  # type: ignore
         filter_params = {
             "min_recording_duration": filter.recording_duration_filter.value,
         }

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union, cast
 
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -316,10 +316,10 @@ class ClickhouseFunnelBase(ABC, Funnel):
         return " AND ".join(conditions)
 
     def _parse_breakdown_prop_value(self):
-        prop_vals = (
+        prop_vals: List[Union[str, int]] = (
             [val.strip() for val in self._filter.funnel_step_breakdown.split(",")]
             if isinstance(self._filter.funnel_step_breakdown, str)
-            else [self._filter.funnel_step_breakdown]
+            else [cast(int, self._filter.funnel_step_breakdown)]
         )
         return prop_vals
 

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -64,11 +64,11 @@ class ClickhouseFunnelBase(ABC, Funnel):
                 total_people += results[step.order]
 
             serialized_result = self._serialize_step(step, total_people, [])
-            if step.order > 0:
+            if cast(int, step.order) > 0:
                 serialized_result.update(
                     {
-                        "average_conversion_time": results[step.order + len(self._filter.entities) - 1],
-                        "median_conversion_time": results[step.order + len(self._filter.entities) * 2 - 2],
+                        "average_conversion_time": results[cast(int, step.order) + len(self._filter.entities) - 1],
+                        "median_conversion_time": results[cast(int, step.order) + len(self._filter.entities) * 2 - 2],
                     }
                 )
             else:
@@ -140,7 +140,7 @@ class ClickhouseFunnelBase(ABC, Funnel):
             if i < level_index:
                 cols.append(f"latest_{i}")
                 for exclusion_id, exclusion in enumerate(self._filter.exclusions):
-                    if exclusion.funnel_from_step + 1 == i:
+                    if cast(int, exclusion.funnel_from_step) + 1 == i:
                         cols.append(f"exclusion_{exclusion_id}_latest_{exclusion.funnel_from_step}")
             else:
                 duplicate_event = 0
@@ -154,7 +154,7 @@ class ClickhouseFunnelBase(ABC, Funnel):
                 )
                 for exclusion_id, exclusion in enumerate(self._filter.exclusions):
                     # exclusion starting at step i follows semantics of step i+1 in the query (since we're looking for exclusions after step i)
-                    if exclusion.funnel_from_step + 1 == i:
+                    if cast(int, exclusion.funnel_from_step) + 1 == i:
                         cols.append(
                             f"min(exclusion_{exclusion_id}_latest_{exclusion.funnel_from_step}) over (PARTITION by person_id {self._get_breakdown_prop()} ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) exclusion_{exclusion_id}_latest_{exclusion.funnel_from_step}"
                         )

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -363,15 +363,14 @@ class ClickhouseFunnelBase(ABC, Funnel):
         formatted = ", ".join(conditions)
         return f", {formatted}" if formatted else ""
 
-    @abstractmethod
-    def get_query(self):
-        pass
+    def get_query(self) -> str:
+        raise NotImplementedError()
 
-    def get_step_counts_query(self):
-        pass
+    def get_step_counts_query(self) -> str:
+        raise NotImplementedError()
 
-    def get_step_counts_without_aggregation_query(self):
-        pass
+    def get_step_counts_without_aggregation_query(self) -> str:
+        raise NotImplementedError()
 
     def _get_breakdown_select_prop(self) -> str:
         if self._filter.breakdown:

--- a/ee/clickhouse/queries/funnels/funnel_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_persons.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
 from ee.clickhouse.sql.funnels.funnel import FUNNEL_PERSONS_BY_STEP_SQL
 from posthog.models import Person
@@ -16,4 +18,4 @@ class ClickhouseFunnelPersons(ClickhouseFunnel):
 
         from posthog.api.person import PersonSerializer
 
-        return PersonSerializer(people, many=True).data, len(results) > self._filter.limit - 1
+        return PersonSerializer(people, many=True).data, len(results) > cast(int, self._filter.limit) - 1

--- a/ee/clickhouse/queries/funnels/funnel_strict_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_strict_persons.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from ee.clickhouse.queries.funnels.funnel_strict import ClickhouseFunnelStrict
 from ee.clickhouse.sql.funnels.funnel import FUNNEL_PERSONS_BY_STEP_SQL
 from posthog.models import Person
@@ -16,4 +18,4 @@ class ClickhouseFunnelStrictPersons(ClickhouseFunnelStrict):
 
         from posthog.api.person import PersonSerializer
 
-        return PersonSerializer(people, many=True).data, len(results) > self._filter.limit - 1
+        return PersonSerializer(people, many=True).data, len(results) > cast(int, self._filter.limit) - 1

--- a/ee/clickhouse/queries/funnels/funnel_trends_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends_persons.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.queries.funnels.funnel_trends import TIMESTAMP_FORMAT, ClickhouseFunnelTrends
@@ -41,4 +43,4 @@ class ClickhouseFunnelTrendsPersons(ClickhouseFunnelTrends):
 
         from posthog.api.person import PersonSerializer
 
-        return PersonSerializer(people, many=True).data, len(results) > self._filter.limit - 1
+        return PersonSerializer(people, many=True).data, len(results) > cast(int, self._filter.limit) - 1

--- a/ee/clickhouse/queries/funnels/funnel_unordered.py
+++ b/ee/clickhouse/queries/funnels/funnel_unordered.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, cast
 
 from rest_framework.exceptions import ValidationError
 
@@ -16,7 +16,7 @@ class ClickhouseFunnelUnordered(ClickhouseFunnelBase):
     1. Given the first event is A, find the furthest everyone went starting from A.
        This finds any B's and C's that happen after A (without ordering them)
     2. Repeat the above, assuming first event to be B, and then C.
-    
+
     Then, the outer query unions the result of (2) and takes the maximum of these.
 
     ## Results
@@ -75,7 +75,7 @@ class ClickhouseFunnelUnordered(ClickhouseFunnelBase):
 
         for i in range(max_steps):
             inner_query = f"""
-                SELECT 
+                SELECT
                 person_id,
                 timestamp,
                 {partition_select}
@@ -144,7 +144,7 @@ class ClickhouseFunnelUnordered(ClickhouseFunnelBase):
         conditions = []
         for exclusion_id, exclusion in enumerate(self._filter.exclusions):
             from_time = f"latest_{exclusion.funnel_from_step}"
-            to_time = f"event_times[{exclusion.funnel_to_step + 1}]"
+            to_time = f"event_times[{cast(int, exclusion.funnel_to_step) + 1}]"
             exclusion_time = f"exclusion_{exclusion_id}_latest_{exclusion.funnel_from_step}"
             condition = (
                 f"if( {exclusion_time} > {from_time} AND {exclusion_time} < "

--- a/ee/clickhouse/queries/funnels/funnel_unordered_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_unordered_persons.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from ee.clickhouse.queries.funnels.funnel_unordered import ClickhouseFunnelUnordered
 from ee.clickhouse.sql.funnels.funnel import FUNNEL_PERSONS_BY_STEP_SQL
 from posthog.models import Person
@@ -16,4 +18,4 @@ class ClickhouseFunnelUnorderedPersons(ClickhouseFunnelUnordered):
 
         from posthog.api.person import PersonSerializer
 
-        return PersonSerializer(people, many=True).data, len(results) > self._filter.limit - 1
+        return PersonSerializer(people, many=True).data, len(results) > cast(int, self._filter.limit) - 1

--- a/ee/clickhouse/queries/sessions/clickhouse_sessions.py
+++ b/ee/clickhouse/queries/sessions/clickhouse_sessions.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Union
+from datetime import datetime
+from typing import Any, Dict, List, Union, cast
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -20,7 +21,7 @@ def set_default_dates(filter: SessionsFilter) -> SessionsFilter:
             date_from = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         data.update({"date_from": date_from})
         if not filter._date_to:
-            data.update({"date_to": date_from + relativedelta(days=1)})
+            data.update({"date_to": cast(datetime, date_from) + relativedelta(days=1)})
     else:
         if not filter._date_from:
             data.update({"date_from": relative_date_parse("-7d")})

--- a/ee/clickhouse/queries/sessions/events.py
+++ b/ee/clickhouse/queries/sessions/events.py
@@ -18,7 +18,7 @@ class SessionsListEvents(BaseQuery):
             {"team_id": team.pk, "distinct_id": filter.distinct_id},
         )
 
-        return self._serialize(raw_events, filter.distinct_id, team.pk)
+        return self._serialize(raw_events, cast(str, filter.distinct_id), team.pk)
 
     def _serialize(self, events: List[List[Any]], distinct_id: str, team_id: int) -> List[Dict]:
         data = []

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -120,7 +120,7 @@ class ClickhouseActionsViewSet(ActionViewSet):
 def _handle_date_interval(filter: Filter) -> Filter:
     # adhoc date handling. parsed differently with django orm
     date_from = filter.date_from or timezone.now()
-    data = {}
+    data: Dict = {}
     if filter.interval == "month":
         data.update(
             {"date_to": (date_from + relativedelta(months=1) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")}

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Union, cast
 
 import posthoganalytics
 from django.core.cache import cache
@@ -340,7 +340,7 @@ def _filter_cohort_breakdown(events: QuerySet, filter: Filter) -> QuerySet:
         events = events.filter(
             Exists(
                 CohortPeople.objects.filter(
-                    cohort_id=int(filter.breakdown_value), person_id=OuterRef("person_id"),
+                    cohort_id=int(cast(str, filter.breakdown_value)), person_id=OuterRef("person_id"),
                 ).only("id")
             )
         )

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -121,7 +121,7 @@ class BreakdownMixin(BaseParamMixin):
 
     @include_dict
     def breakdown_to_dict(self):
-        result = {}
+        result: Dict = {}
         if self.breakdown:
             result[BREAKDOWN] = self.breakdown
         if self._breakdown_limit:

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -73,11 +73,11 @@ class ShownAsMixin(BaseParamMixin):
 
 class FilterTestAccountsMixin(BaseParamMixin):
     @cached_property
-    def filter_test_accounts(self) -> Optional[bool]:
+    def filter_test_accounts(self) -> bool:
         setting = self._data.get(FILTER_TEST_ACCOUNTS, None)
         if setting == True or setting == "true":
             return True
-        return None
+        return False
 
     @include_dict
     def filter_out_team_members_to_dict(self):

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -90,7 +90,7 @@ class FunnelWindowMixin(BaseParamMixin):
 
     @include_dict
     def funnel_window_to_dict(self):
-        dict_part = {}
+        dict_part: Dict = {}
         if self.funnel_window_interval is not None:
             dict_part[FUNNEL_WINDOW_INTERVAL] = self.funnel_window_interval
         if self.funnel_window_interval_unit is not None:
@@ -170,7 +170,7 @@ class FunnelTypeMixin(BaseParamMixin):
 
     @include_dict
     def funnel_type_to_dict(self):
-        result = {}
+        result: Dict[str, str] = {}
         if self.funnel_order_type:
             result[FUNNEL_ORDER_TYPE] = self.funnel_order_type
         if self.funnel_viz_type:
@@ -202,7 +202,7 @@ class FunnelTrendsPersonsMixin(BaseParamMixin):
 
     @include_dict
     def funnel_trends_persons_to_dict(self):
-        result_dict = {}
+        result_dict: Dict = {}
         if self.entrance_period_start:
             result_dict[ENTRANCE_PERIOD_START] = self.entrance_period_start.isoformat()
         if self.drop_off is not None:

--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -54,6 +54,9 @@ class TotalIntervalsDerivedMixin(IntervalMixin, StickinessDateMixin):
 
     @cached_property
     def total_intervals(self) -> int:
+        assert self.date_from is not None
+        assert self.date_to is not None
+
         _num_intervals = 0
         _total_seconds = (self.date_to - self.date_from).total_seconds()
         if self.interval == "minute":

--- a/posthog/models/filters/mixins/utils.py
+++ b/posthog/models/filters/mixins/utils.py
@@ -1,9 +1,11 @@
 from functools import lru_cache
+from typing import Any, Callable, TypeVar
 
+T = TypeVar("T")
 
 # can't use cached_property directly from functools because of 3.7 compatibilty
-def cached_property(func):
-    return property(lru_cache(maxsize=1)(func))
+def cached_property(func: Callable[..., T]) -> T:
+    return property(lru_cache(maxsize=1)(func))  # type: ignore
 
 
 def include_dict(f):


### PR DESCRIPTION
Noticed that e.g. `filter.breakdown` was getting inferred to be `Any`
which is not correct. Added generics to fix it :)

EDIT: This caught a lot of issues. Fixed them all. We should perhaps change the data types though.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
