### PR TITLE
Test before cancelling timeout task

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -149,7 +149,8 @@ else:
             finally:
                 execution_time = perf_counter() - start_time
 
-                QUERY_TIMEOUT_THREAD.cancel(timeout_task)
+                if not timeout_task.done:
+                    QUERY_TIMEOUT_THREAD.cancel(timeout_task)
                 timing("clickhouse_sync_execution_time", execution_time * 1000.0, tags=tags)
 
                 if app_settings.SHELL_PLUS_PRINT_SQL:


### PR DESCRIPTION
## Changes

ref: https://github.com/PostHog/posthog/pull/5460/files#r683385181

and https://sentry.io/organizations/posthog/issues/2555715604/?project=1899813&referrer=slack

This ensures cancel is called only when the task isn't done, and timing is recorded regardless.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
