### PR TITLE
Hide time-to-convert when using breakdown

### DIFF
--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -33,7 +33,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                     <span style={{ margin: '2px 8px', borderLeft: '1px solid var(--border)' }} />
                 </>
             )}
-            {allFilters.funnel_viz_type !== FunnelVizType.Trends && (
+            {allFilters.funnel_viz_type !== FunnelVizType.Trends && !allFilters.breakdown && (
                 <>
                     <span className="text-muted-alt">
                         <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5472

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
