### PR TITLE
Have migration task bypass pgbouncer and connect direct to pg for session stickiness

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -128,7 +128,7 @@
                 },
                 {
                     "name": "DATABASE_URL",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:DATABASE_URL::"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:PG_DATABASE_URL::"
                 },
                 {
                     "name": "EMAIL_HOST",

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -18,7 +18,7 @@
             "environment": [
                 {
                     "name": "USING_PGBOUNCER",
-                    "value": "True"
+                    "value": "False"
                 },
                 {
                     "name": "DISABLE_SERVER_SIDE_CURSORS",
@@ -99,10 +99,6 @@
                 {
                     "name": "PLUGIN_SERVER_ACTION_MATCHING",
                     "value": "1"
-                },
-                {
-                    "name": "USING_PGBOUNCER",
-                    "value": "True"
                 },
                 {
                     "name": "PERSISTED_FEATURE_FLAGS",


### PR DESCRIPTION
This is in preparation for issue #4941 where we want to create an index concurrently that will exceed our statement_timeout time.
