### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -66,7 +66,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.7.8', '3.8.5', '3.9.0']
+                python-version: ['3.8.5', '3.9.0']
         steps:
             - uses: actions/checkout@v1
               with:


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5482

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
