### PR TITLE
Sync `SUPPORTED_INTERVAL_TYPES` with rest of query-building

### DIFF
--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -44,7 +44,7 @@ ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
 class IntervalMixin(BaseParamMixin):
     """See https://clickhouse.tech/docs/en/sql-reference/data-types/special-data-types/interval/."""
 
-    SUPPORTED_INTERVAL_TYPES = ["second", "minute", "hour", "day", "week", "month", "quarter", "year"]
+    SUPPORTED_INTERVAL_TYPES = ["minute", "hour", "day", "week", "month"]
 
     @cached_property
     def interval(self) -> str:


### PR DESCRIPTION
## Changes

Query-building validation fix for a discrepancy noticed in https://github.com/PostHog/posthog/pull/5467#discussion_r684094463.