### PR TITLE
Fix filtering actions by people

### DIFF
--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -1,3 +1,5 @@
+import json
+
 from freezegun import freeze_time
 
 from posthog.constants import ENTITY_ID, ENTITY_MATH, ENTITY_TYPE
@@ -517,6 +519,23 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
             self.assertEqual(len(people["results"][0]["people"]), 2)
             ordered_people = sorted([p["id"] for p in people["results"][0]["people"]])
             self.assertEqual(ordered_people, sorted([person1.pk, person2.pk]))
+
+        def test_filtering_by_person_properties(self):
+            person1, person2, person3, person4 = self._create_multiple_people()
+
+            people = self.client.get(
+                "/api/action/people/",
+                data={
+                    "date_from": "2020-01-01",
+                    "date_to": "2020-01-07",
+                    ENTITY_TYPE: "events",
+                    ENTITY_ID: "watched movie",
+                    "properties": json.dumps([{"key": "name", "value": "person2", "type": "person"}]),
+                },
+            ).json()
+
+            self.assertEqual(len(people["results"][0]["people"]), 1)
+            self.assertEqual(people["results"][0]["people"][0]["id"], person2.pk)
 
     return TestActionPeople
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -221,7 +221,7 @@ def filter_persons(team_id: int, request: request.Request, queryset: QuerySet) -
         queryset = queryset.filter(cohort__id=request.GET["cohort"])
     if request.GET.get("properties"):
         filter = Filter(data={"properties": json.loads(request.GET["properties"])})
-        queryset = queryset.filter(properties_to_Q(filter.properties, team_id=team_id))
+        queryset = queryset.filter(properties_to_Q(filter.properties, team_id=team_id, is_person_query=True))
 
     queryset = queryset.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
     return queryset


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5477

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
