### PR TITLE
Only replace top level distinct_id when formatting cohort subquery

### DIFF
--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -148,6 +148,8 @@ def _parse_breakdown_cohorts(cohorts: BaseManager) -> Tuple[List[str], Dict]:
     for idx, cohort in enumerate(cohorts):
         person_id_query, cohort_filter_params = format_filter_query(cohort, idx)
         params = {**params, **cohort_filter_params}
-        cohort_query = person_id_query.replace("SELECT distinct_id", f"SELECT distinct_id, {cohort.pk} as value")
+        cohort_query = person_id_query.replace(
+            "SELECT distinct_id", f"SELECT distinct_id, {cohort.pk} as value", 1
+        )  # only replace the first top level occurrence
         queries.append(cohort_query)
     return queries, params

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -1,6 +1,4 @@
-from typing import Any, Dict, List, Tuple, Union
-
-from django.db.models.manager import BaseManager
+from typing import Any, Dict, List, Tuple
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.cohort import format_filter_query
@@ -132,7 +130,7 @@ def format_breakdown_cohort_join_query(team_id: int, filter: Filter, **kwargs) -
         if isinstance(filter.breakdown, list)
         else Cohort.objects.filter(team_id=team_id, pk=filter.breakdown)
     )
-    cohort_queries, params = _parse_breakdown_cohorts(cohorts)
+    cohort_queries, params = _parse_breakdown_cohorts(list(cohorts))
     ids = [cohort.pk for cohort in cohorts]
     if isinstance(filter.breakdown, list) and "all" in filter.breakdown:
         all_query, all_params = _format_all_query(team_id, filter, entity=entity)
@@ -142,7 +140,7 @@ def format_breakdown_cohort_join_query(team_id: int, filter: Filter, **kwargs) -
     return " UNION ALL ".join(cohort_queries), ids, params
 
 
-def _parse_breakdown_cohorts(cohorts: Union[BaseManager, List[Cohort]]) -> Tuple[List[str], Dict]:
+def _parse_breakdown_cohorts(cohorts: List[Cohort]) -> Tuple[List[str], Dict]:
     queries = []
     params: Dict[str, Any] = {}
     for idx, cohort in enumerate(cohorts):

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from django.db.models.manager import BaseManager
 
@@ -142,7 +142,7 @@ def format_breakdown_cohort_join_query(team_id: int, filter: Filter, **kwargs) -
     return " UNION ALL ".join(cohort_queries), ids, params
 
 
-def _parse_breakdown_cohorts(cohorts: BaseManager) -> Tuple[List[str], Dict]:
+def _parse_breakdown_cohorts(cohorts: Union[BaseManager, List[Cohort]]) -> Tuple[List[str], Dict]:
     queries = []
     params: Dict[str, Any] = {}
     for idx, cohort in enumerate(cohorts):

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -4,8 +4,13 @@ from uuid import uuid4
 import pytz
 from freezegun.api import freeze_time
 
+from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.event import create_event
+from ee.clickhouse.queries.breakdown_props import _parse_breakdown_cohorts
 from ee.clickhouse.queries.util import get_earliest_timestamp
+from posthog.models.action import Action
+from posthog.models.action_step import ActionStep
+from posthog.models.cohort import Cohort
 
 
 def _create_event(**kwargs):
@@ -25,3 +30,14 @@ def test_get_earliest_timestamp(db, team):
 @freeze_time("2021-01-21")
 def test_get_earliest_timestamp_with_no_events(db, team):
     assert get_earliest_timestamp(team.id) == datetime(2021, 1, 14, tzinfo=pytz.UTC)
+
+
+def test_parse_breakdown_cohort_query(db, team):
+    action = Action.objects.create(team=team, name="$pageview")
+    ActionStep.objects.create(action=action, event="$pageview")
+    cohort1 = Cohort.objects.create(
+        team=team, groups=[{"action_id": action.pk, "start_date": datetime(2020, 1, 8, 12, 0, 1)}], name="cohort1",
+    )
+    query, params = _parse_breakdown_cohorts([cohort1])
+    assert len(query) == 1
+    sync_execute(query[0], params)

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -38,6 +38,6 @@ def test_parse_breakdown_cohort_query(db, team):
     cohort1 = Cohort.objects.create(
         team=team, groups=[{"action_id": action.pk, "start_date": datetime(2020, 1, 8, 12, 0, 1)}], name="cohort1",
     )
-    query, params = _parse_breakdown_cohorts([cohort1])
-    assert len(query) == 1
-    sync_execute(query[0], params)
+    queries, params = _parse_breakdown_cohorts([cohort1])
+    assert len(queries) == 1
+    sync_execute(queries[0], params)


### PR DESCRIPTION
## Changes

*Please describe.*  
- cohort subquery contains multiple "select distinct_id" which caused error when replacing. Only replace the first one to include breakdown value
- addresses the second query in #5487
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
