### PR TITLE
Show error instead of timeout message when query fails with non-500

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -90,7 +90,7 @@ export const insightLogic = kea<insightLogicType>({
         maybeShowErrorMessage: [
             false,
             {
-                endQuery: (_, { exception }) => exception?.status === 500 || false,
+                endQuery: (_, { exception }) => exception?.status >= 400,
                 startQuery: () => false,
                 setActiveView: () => false,
             },


### PR DESCRIPTION
Currently our frontend shows a "timeout" error message when the api
query resolves with a 400 or other non-500 error. This creates the
impression that things are "slow" when they are "broken" instead and we
should fix it in code.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
