### PR TITLE
Handle person having no distinct_ids in events table

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -158,7 +158,7 @@ class ClickhouseEventSerializer(serializers.Serializer):
         person = self.context["people"][event[5]]
         return {
             "is_identified": person.is_identified,
-            "distinct_ids": [person.distinct_ids[0]],  # only send the first one to avoid a payload bloat
+            "distinct_ids": person.distinct_ids[:1],  # only send the first one to avoid a payload bloat
             "properties": {
                 key: person.properties[key] for key in ["email", "name", "username"] if key in person.properties
             },


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/2297864788/?project=1899813&referrer=github_integration
Closes https://github.com/PostHog/posthog/issues/5385

Not 100% sure how this happens (race condition with user getting
identified?) but the same guard exists in the postgresql-based codebase.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
