### PR TITLE
Fix empty element filtering

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -25,9 +25,10 @@ def format_action_filter(
         if step.event == AUTOCAPTURE_EVENT:
             from ee.clickhouse.models.property import filter_element  # prevent circular import
 
-            el_conditions, element_params = filter_element(model_to_dict(step), f"{action.pk}_{index}{prepend}")
+            el_condition, element_params = filter_element(model_to_dict(step), f"{action.pk}_{index}{prepend}")
             params = {**params, **element_params}
-            conditions += el_conditions
+            if len(el_condition) > 0:
+                conditions.append(el_condition)
 
         # filter event conditions (ie URL)
         event_conditions, event_params = filter_event(step, f"{action.pk}_{index}{prepend}", index, table_name)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -64,8 +64,8 @@ def parse_prop_clauses(
                 )
                 params.update(filter_params)
         elif prop.type == "element":
-            query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
-            final.append("AND {}".format(query[0]))
+            queries, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
+            final.extend(f"AND {query}" for query in queries)
             params.update(filter_params)
         else:
             filter_query, filter_params = prop_filter_json_extract(

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -64,8 +64,8 @@ def parse_prop_clauses(
                 )
                 params.update(filter_params)
         elif prop.type == "element":
-            queries, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
-            final.extend(f"AND {query}" for query in queries)
+            query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
+            final.append(f" AND {query if len(query) > 0 else '1=2'}")
             params.update(filter_params)
         else:
             filter_query, filter_params = prop_filter_json_extract(
@@ -232,7 +232,7 @@ def get_denormalized_property_column(prop, allow_denormalized_props: bool) -> Op
     return columns.get(prop.key)
 
 
-def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
+def filter_element(filters: Dict, prepend: str = "") -> Tuple[str, Dict]:
     params = {}
     conditions = []
 
@@ -275,7 +275,7 @@ def filter_element(filters: Dict, prepend: str = "") -> Tuple[List[str], Dict]:
             if len(or_conditions) > 0:
                 conditions.append("(" + (" OR ".join(or_conditions)) + ")")
 
-    return (conditions, params)
+    return (" AND ".join(conditions), params)
 
 
 def _create_regex(selector: Selector) -> str:

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -145,6 +145,11 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter)), 2)
 
+        filter = Filter(
+            data={"properties": [{"key": "selector", "value": [], "operator": "exact", "type": "element",}]}
+        )
+        self.assertEqual(len(self._run_query(filter)), 0)
+
         # tag_name
 
         filter = Filter(

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -171,8 +171,8 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                 final.append(filter_query)
                 params.update(filter_params)
             elif prop.type == "element":
-                queries, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
-                final.extend(f"AND {query}" for query in queries)
+                query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
+                final.append(f" AND {query if len(query) > 0 else '1=2'}")
                 params.update(filter_params)
             else:
                 filter_query, filter_params = prop_filter_json_extract(

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -171,8 +171,8 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                 final.append(filter_query)
                 params.update(filter_params)
             elif prop.type == "element":
-                query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
-                final.append("AND {}".format(query[0]))
+                queries, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
+                final.extend(f"AND {query}" for query in queries)
                 params.update(filter_params)
             else:
                 filter_query, filter_params = prop_filter_json_extract(


### PR DESCRIPTION
- Refactor event_query class
- Don't error when filtering by empty elements array
- Solve same copy-pasted solution consistently
- Behave consistently with return values

Closes https://github.com/PostHog/posthog/issues/5501

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
