### PR TITLE
Improvements to insights table & funnel logic cleanup

### DIFF
--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -120,6 +120,7 @@ describe('compactNumber()', () => {
         expect(compactNumber(5392)).toEqual('5.39K')
         expect(compactNumber(2833102)).toEqual('2.83M')
         expect(compactNumber(8283310234)).toEqual('8.28B')
+        expect(compactNumber(null)).toEqual('-')
     })
 })
 describe('pluralize()', () => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -13,17 +13,6 @@ import { FEATURE_FLAGS, WEBHOOK_SERVICES } from 'lib/constants'
 import { KeyMappingInterface } from 'lib/components/PropertyKeyInfo'
 import { AlignType } from 'rc-trigger/lib/interface'
 
-const SI_PREFIXES: { value: number; symbol: string }[] = [
-    { value: 1e18, symbol: 'E' },
-    { value: 1e15, symbol: 'P' },
-    { value: 1e12, symbol: 'T' },
-    { value: 1e9, symbol: 'G' },
-    { value: 1e6, symbol: 'M' },
-    { value: 1e3, symbol: 'k' },
-    { value: 1, symbol: '' },
-]
-const TRAILING_ZERO_REGEX = /\.0+$|(\.[0-9]*[1-9])0+$/
-
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
     // https://github.com/react-component/select/blob/dade915d81069b8d3b3b5679bb9daee7e992faba/src/SelectTrigger.jsx#L11-L28
@@ -633,24 +622,6 @@ export function dateFilterToText(
     return name
 }
 
-export function humanizeNumber(number: number | null, digits: number = 1): string {
-    if (number === null) {
-        return '-'
-    }
-    // adapted from https://stackoverflow.com/a/9462382/624476
-    let matchingPrefix = SI_PREFIXES[SI_PREFIXES.length - 1]
-    for (const currentPrefix of SI_PREFIXES) {
-        if (number >= currentPrefix.value) {
-            matchingPrefix = currentPrefix
-            break
-        }
-    }
-
-    const outputNumber = (number / matchingPrefix.value).toFixed(digits)
-    const formattedNumber = matchingPrefix.value !== 1 ? outputNumber.replace(TRAILING_ZERO_REGEX, '$1') : outputNumber
-    return formattedNumber + matchingPrefix.symbol
-}
-
 export function copyToClipboard(value: string, description?: string): boolean {
     if (!navigator.clipboard) {
         toast.info('Oops! Clipboard capabilities are only available over HTTPS or localhost.')
@@ -881,7 +852,11 @@ export function pluralize(count: number, singular: string, plural?: string, incl
 /** Return a number in a compact format, with a SI suffix if applicable.
  *  Server-side equivalent: utils.py#compact_number.
  */
-export function compactNumber(value: number): string {
+export function compactNumber(value: number | null): string {
+    if (value === null) {
+        return '-'
+    }
+
     value = parseFloat(value.toPrecision(3))
     let magnitude = 0
     while (Math.abs(value) >= 1000) {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -645,7 +645,10 @@ export function humanizeNumber(number: number | null, digits: number = 1): strin
             break
         }
     }
-    return (number / matchingPrefix.value).toFixed(digits).replace(TRAILING_ZERO_REGEX, '$1') + matchingPrefix.symbol
+
+    const outputNumber = (number / matchingPrefix.value).toFixed(digits)
+    const formattedNumber = matchingPrefix.value !== 1 ? outputNumber.replace(TRAILING_ZERO_REGEX, '$1') : outputNumber
+    return formattedNumber + matchingPrefix.symbol
 }
 
 export function copyToClipboard(value: string, description?: string): boolean {

--- a/frontend/src/scenes/events/VolumeTable.tsx
+++ b/frontend/src/scenes/events/VolumeTable.tsx
@@ -4,7 +4,7 @@ import Table, { ColumnsType } from 'antd/lib/table'
 import Fuse from 'fuse.js'
 import { useValues, useActions } from 'kea'
 import { keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { capitalizeFirstLetter, humanizeNumber } from 'lib/utils'
+import { capitalizeFirstLetter, compactNumber } from 'lib/utils'
 import React, { useState, useEffect } from 'react'
 import { userLogic } from 'scenes/userLogic'
 import { EventDefinition, EventOrPropType, PropertyDefinition } from '~/types'
@@ -124,7 +124,7 @@ export function VolumeTable({
                       )
                   },
                   render: function RenderVolume(_, record) {
-                      return <span className="ph-no-capture">{humanizeNumber(record.eventOrProp.volume_30_day)}</span>
+                      return <span className="ph-no-capture">{compactNumber(record.eventOrProp.volume_30_day)}</span>
                   },
                   sorter: (a, b) =>
                       a.eventOrProp.volume_30_day == b.eventOrProp.volume_30_day
@@ -145,7 +145,7 @@ export function VolumeTable({
                 )
             },
             render: function Render(_, item) {
-                return <span className="ph-no-capture">{humanizeNumber(item.eventOrProp.query_usage_30_day)}</span>
+                return <span className="ph-no-capture">{compactNumber(item.eventOrProp.query_usage_30_day)}</span>
             },
             sorter: (a, b) =>
                 a.eventOrProp.query_usage_30_day == b.eventOrProp.query_usage_30_day

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -1,5 +1,5 @@
 import React, { ForwardRefRenderFunction, useEffect, useRef, useState } from 'react'
-import { humanFriendlyDuration, humanizeNumber } from 'lib/utils'
+import { humanFriendlyDuration } from 'lib/utils'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { Button, ButtonProps, Popover, Tooltip } from 'antd'
 import { ArrowRightOutlined, InfoCircleOutlined } from '@ant-design/icons'
@@ -14,13 +14,13 @@ import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/Funne
 import { InsightTooltip } from 'scenes/insights/InsightTooltip'
 import { FunnelLayout } from 'lib/constants'
 import {
-    calcPercentage,
     getReferenceStep,
     humanizeOrder,
     getSeriesColor,
     getBreakdownMaxIndex,
     getSeriesPositionName,
     humanizeStepCount,
+    formatDisplayPercentage,
 } from './funnelUtils'
 import { ChartParams } from '~/types'
 
@@ -157,7 +157,7 @@ function Bar({
                 ref={barRef}
                 className={`funnel-bar ${getSeriesPositionName(breakdownIndex, breakdownMaxIndex)}`}
                 style={{
-                    flex: `${percentage} 100 0`,
+                    flex: `${percentage} 1 0`,
                     cursor: cursorType,
                     backgroundColor: getSeriesColor(breakdownIndex),
                 }}
@@ -175,9 +175,9 @@ function Bar({
                         role="progressbar"
                         aria-valuemin={0}
                         aria-valuemax={100}
-                        aria-valuenow={breakdownSumPercentage ?? percentage}
+                        aria-valuenow={(breakdownSumPercentage ?? percentage) * 100}
                     >
-                        {humanizeNumber(breakdownSumPercentage ?? percentage, 2)}%
+                        {formatDisplayPercentage(breakdownSumPercentage ?? percentage)}%
                     </div>
                 )}
             </div>
@@ -289,7 +289,7 @@ function MetricRow({ title, value }: { title: string; value: string | number }):
         <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
             <div>{title}</div>
             <div>
-                <strong>{value}</strong>
+                <strong style={{ paddingLeft: 6 }}>{value}</strong>
             </div>
         </div>
     )
@@ -354,7 +354,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                 {Array.isArray(step.nested_breakdown) && step.nested_breakdown?.length ? (
                                     <>
                                         {step.nested_breakdown.map((breakdown, index) => {
-                                            const barSizePercentage = calcPercentage(breakdown.count, basisStep.count)
+                                            const barSizePercentage = breakdown.count / basisStep.count
                                             return (
                                                 <Bar
                                                     key={`${breakdown.action_id}-${step.breakdown_value}-${index}`}
@@ -363,7 +363,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                     breakdownMaxIndex={breakdownMaxIndex}
                                                     breakdownSumPercentage={
                                                         index === breakdownMaxIndex && breakdownSum
-                                                            ? calcPercentage(breakdownSum, basisStep.count)
+                                                            ? breakdownSum / basisStep.count
                                                             : undefined
                                                     }
                                                     percentage={barSizePercentage}
@@ -388,17 +388,17 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                         {
                                                             title: 'Conversion rate (total)',
                                                             value:
-                                                                humanizeNumber(breakdown.conversionRates.total, 2) +
-                                                                '%',
+                                                                formatDisplayPercentage(
+                                                                    breakdown.conversionRates.total
+                                                                ) + '%',
                                                         },
                                                         {
                                                             title: `Conversion rate (from step ${humanizeOrder(
                                                                 previousStep.order
                                                             )})`,
                                                             value:
-                                                                humanizeNumber(
-                                                                    breakdown.conversionRates.fromPrevious,
-                                                                    2
+                                                                formatDisplayPercentage(
+                                                                    breakdown.conversionRates.fromPrevious
                                                                 ) + '%',
                                                             visible: step.order !== 0,
                                                         },
@@ -414,9 +414,8 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                                 previousStep.order
                                                             )})`,
                                                             value:
-                                                                humanizeNumber(
-                                                                    100 - breakdown.conversionRates.fromPrevious,
-                                                                    2
+                                                                formatDisplayPercentage(
+                                                                    1 - breakdown.conversionRates.fromPrevious
                                                                 ) + '%',
                                                             visible:
                                                                 step.order !== 0 &&
@@ -441,7 +440,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                 openPersonsModal(step, -(i + 1))
                                             } // dropoff value for steps is negative
                                             style={{
-                                                flex: `${100 - calcPercentage(breakdownSum, basisStep.count)} 100 0`,
+                                                flex: `${1 - breakdownSum / basisStep.count} 1 0`,
                                                 cursor: `${
                                                     clickhouseFeaturesEnabled && !dashboardItemId ? 'pointer' : ''
                                                 }`,
@@ -464,13 +463,15 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                 },
                                                 {
                                                     title: 'Conversion rate (total)',
-                                                    value: humanizeNumber(step.conversionRates.total, 2) + '%',
+                                                    value: formatDisplayPercentage(step.conversionRates.total) + '%',
                                                 },
                                                 {
                                                     title: `Conversion rate (from step ${humanizeOrder(
                                                         previousStep.order
                                                     )})`,
-                                                    value: humanizeNumber(step.conversionRates.fromPrevious, 2) + '%',
+                                                    value:
+                                                        formatDisplayPercentage(step.conversionRates.fromPrevious) +
+                                                        '%',
                                                     visible: step.order !== 0,
                                                 },
                                                 {
@@ -483,7 +484,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                         previousStep.order
                                                     )})`,
                                                     value:
-                                                        humanizeNumber(100 - step.conversionRates.fromPrevious, 2) +
+                                                        formatDisplayPercentage(1 - step.conversionRates.fromPrevious) +
                                                         '%',
                                                     visible: step.order !== 0 && step.droppedOffFromPrevious > 0,
                                                 },
@@ -502,7 +503,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                                 openPersonsModal(step, -(i + 1))
                                             } // dropoff value for steps is negative
                                             style={{
-                                                flex: `${100 - step.conversionRates.fromBasisStep} 100 0`,
+                                                flex: `${1 - step.conversionRates.fromBasisStep} 1 0`,
                                                 cursor: `${
                                                     clickhouseFeaturesEnabled && !dashboardItemId ? 'pointer' : ''
                                                 }`,
@@ -523,7 +524,7 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                         <b>{humanizeStepCount(step.count)}</b>
                                     </ValueInspectorButton>
                                     <span className="text-muted-alt">
-                                        ({step.order > 0 ? calcPercentage(step.count, steps[i - 1].count) : '100'}
+                                        ({formatDisplayPercentage(step.order > 0 ? step.count / steps[i - 1].count : 1)}
                                         %)
                                     </span>
                                 </div>
@@ -552,10 +553,9 @@ export function FunnelBarGraph({ filters, dashboardItemId, color = 'white' }: Om
                                     </ValueInspectorButton>
                                     <span className="text-muted-alt">
                                         (
-                                        {step.order > 0
-                                            ? Math.round((100 - calcPercentage(step.count, steps[i - 1].count)) * 100) /
-                                              100
-                                            : 0}
+                                        {formatDisplayPercentage(
+                                            step.order > 0 ? 1 - step.count / steps[i - 1].count : 0
+                                        )}
                                         %)
                                     </span>
                                 </div>

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -30,11 +30,11 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                         Total conversion rate:{' '}
                     </span>
                     <span>{conversionMetrics.totalRate}%</span>
-                    <span style={{ margin: '2px 8px', borderLeft: '1px solid var(--border)' }} />
                 </>
             )}
             {allFilters.funnel_viz_type !== FunnelVizType.Trends && !allFilters.breakdown && (
                 <>
+                    <span style={{ margin: '2px 8px', borderLeft: '1px solid var(--border)' }} />
                     <span className="text-muted-alt">
                         <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
                             <InfoCircleOutlined className="info-indicator left" />

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -9,6 +9,7 @@ import { funnelLogic } from './funnelLogic'
 import './FunnelCanvasLabel.scss'
 import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
 import { FunnelVizType } from '~/types'
+import { formatDisplayPercentage } from './funnelUtils'
 
 export function FunnelCanvasLabel(): JSX.Element | null {
     const { conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic)
@@ -29,7 +30,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                         </Tooltip>
                         Total conversion rate:{' '}
                     </span>
-                    <span>{conversionMetrics.totalRate}%</span>
+                    <span>{formatDisplayPercentage(conversionMetrics.totalRate)}%</span>
                 </>
             )}
             {allFilters.funnel_viz_type !== FunnelVizType.Trends && !allFilters.breakdown && (

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -3,8 +3,8 @@ import { Col, Row, Select } from 'antd'
 import { useActions, useValues } from 'kea'
 import clsx from 'clsx'
 import useSize from '@react-hook/size'
-import { ANTD_TOOLTIP_PLACEMENTS, hashCodeForString, humanFriendlyDuration, humanizeNumber } from 'lib/utils'
-import { calcPercentage, getReferenceStep } from './funnelUtils'
+import { ANTD_TOOLTIP_PLACEMENTS, hashCodeForString, humanFriendlyDuration } from 'lib/utils'
+import { formatDisplayPercentage, getReferenceStep } from './funnelUtils'
 import { funnelLogic } from './funnelLogic'
 import { Histogram } from 'scenes/insights/Histogram'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -48,8 +48,7 @@ export function FunnelHistogramHeader(): JSX.Element | null {
                                     </Row>
                                     <Row className="text-muted-alt">
                                         Total conversion rate:{' '}
-                                        {humanizeNumber(Math.round(calcPercentage(option.count ?? 0, basisStep.count)))}
-                                        %
+                                        {formatDisplayPercentage(option.count ?? 0 / basisStep.count)}%
                                     </Row>
                                 </Col>
                             </Select.Option>

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -3,9 +3,11 @@ import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/Funne
 import { getChartColors } from 'lib/colors'
 import { FunnelStep, FunnelsTimeConversionBins } from '~/types'
 
-export function calcPercentage(numerator: number, denominator: number): number {
-    // Rounds to two decimal places
-    return Math.round(((numerator / denominator) * 100 || 0) * 100) / 100
+const PERCENTAGE_DISPLAY_PRECISION = 1 // Number of decimals to show in percentages
+
+export function formatDisplayPercentage(percentage: number): string {
+    // Returns a formatted string properly rounded to ensure consistent results
+    return (percentage * 100).toFixed(PERCENTAGE_DISPLAY_PRECISION)
 }
 
 export function getReferenceStep<T>(steps: T[], stepReference: FunnelStepReference, index?: number): T {

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -1,4 +1,4 @@
-import { humanizeNumber } from 'lib/utils'
+import { compactNumber } from 'lib/utils'
 import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
 import { getChartColors } from 'lib/colors'
 import { FunnelStep, FunnelsTimeConversionBins } from '~/types'
@@ -76,7 +76,7 @@ export function humanizeStepCount(count?: number): string {
     if (typeof count === 'undefined') {
         return ''
     }
-    return count > 9999 ? humanizeNumber(count, 2) : count.toLocaleString()
+    return count > 9999 ? compactNumber(count) : count.toLocaleString()
 }
 
 export function cleanBinResult(binsResult: FunnelsTimeConversionBins): FunnelsTimeConversionBins {

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -8,9 +8,9 @@ import { formatBreakdownLabel } from 'scenes/insights/InsightsTable/InsightsTabl
 import { cohortsModel } from '~/models/cohortsModel'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { SeriesGlyph } from 'lib/components/SeriesGlyph'
-import { getSeriesColor, humanizeOrder } from 'scenes/funnels/funnelUtils'
+import { formatDisplayPercentage, getSeriesColor, humanizeOrder } from 'scenes/funnels/funnelUtils'
 import { ValueInspectorButton } from 'scenes/funnels/FunnelBarGraph'
-import { humanFriendlyDuration, humanizeNumber } from 'lib/utils'
+import { humanFriendlyDuration } from 'lib/utils'
 import { FlattenedFunnelStep } from '~/types'
 import { getBreakpoint } from 'lib/utils/responsiveUtils'
 
@@ -72,7 +72,6 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
         },
         fixed: 'left',
         width: 120,
-        align: 'center',
     })
 
     columns.push({
@@ -91,7 +90,7 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
     columns.push({
         title: 'Conversion',
         render: function RenderConversion({}, step: FlattenedFunnelStep): JSX.Element | null {
-            return step.order === 0 ? EmptyValue : <span>{step.conversionRates.total}%</span>
+            return step.order === 0 ? EmptyValue : <span>{formatDisplayPercentage(step.conversionRates.total)}%</span>
         },
         width: 80,
         align: 'center',
@@ -118,7 +117,7 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
             return step.order === 0 ? (
                 EmptyValue
             ) : (
-                <span>{humanizeNumber(100 - step.conversionRates.fromPrevious, 2)}%</span>
+                <span>{formatDisplayPercentage(1 - step.conversionRates.fromPrevious)}%</span>
             )
         },
         width: 80,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -33,6 +33,8 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
     const tableScrollBreakpoint = getBreakpoint('lg')
     const columns: ColumnsType<FlattenedFunnelStep> = []
 
+    const EmptyValue = <span className="text-muted-alt">-</span>
+
     columns.push({
         title: '',
         render: function RenderSeriesGlyph({}, step: FlattenedFunnelStep): JSX.Element | null {
@@ -44,6 +46,7 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
         },
         fixed: 'left',
         width: 30,
+        align: 'center',
     })
 
     columns.push({
@@ -69,6 +72,7 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
         },
         fixed: 'left',
         width: 120,
+        align: 'center',
     })
 
     columns.push({
@@ -81,42 +85,57 @@ export function FunnelStepTable({}: FunnelStepTableProps): JSX.Element | null {
             )
         },
         width: 80,
+        align: 'center',
     })
 
     columns.push({
         title: 'Conversion',
         render: function RenderConversion({}, step: FlattenedFunnelStep): JSX.Element | null {
-            return step.order === 0 ? null : <span>{step.conversionRates.total}%</span>
+            return step.order === 0 ? EmptyValue : <span>{step.conversionRates.total}%</span>
         },
         width: 80,
+        align: 'center',
     })
 
     columns.push({
         title: 'Dropped off',
         render: function RenderDropoff({}, step: FlattenedFunnelStep): JSX.Element | null {
-            return step.order === 0 ? null : (
+            return step.order === 0 ? (
+                EmptyValue
+            ) : (
                 <ValueInspectorButton onClick={() => openPersonsModal(step, -(step.order + 1), step.breakdown)}>
                     {step.droppedOffFromPrevious}
                 </ValueInspectorButton>
             )
         },
         width: 80,
+        align: 'center',
     })
 
     columns.push({
         title: 'From previous step',
         render: function RenderDropoffFromPrevious({}, step: FlattenedFunnelStep): JSX.Element | null {
-            return step.order === 0 ? null : <span>{humanizeNumber(100 - step.conversionRates.fromPrevious, 2)}%</span>
+            return step.order === 0 ? (
+                EmptyValue
+            ) : (
+                <span>{humanizeNumber(100 - step.conversionRates.fromPrevious, 2)}%</span>
+            )
         },
         width: 80,
+        align: 'center',
     })
 
     columns.push({
         title: 'Average time',
         render: function RenderAverageTime({}, step: FlattenedFunnelStep): JSX.Element {
-            return <span>{humanFriendlyDuration(step.average_conversion_time, 2)}</span>
+            return step.average_conversion_time ? (
+                <span>{humanFriendlyDuration(step.average_conversion_time, 2)}</span>
+            ) : (
+                EmptyValue
+            )
         },
         width: 80,
+        align: 'center',
     })
 
     return stepsWithCount.length > 1 ? (

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -172,7 +172,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
                 return (
                     <>
                         {count.toLocaleString()}
-                        {item.action && item.action.math === 'dau' && (
+                        {item.action && item.action?.math === 'dau' && (
                             <Tooltip title="Keep in mind this is just the sum of all values in the row, not the unique users across the entire time period (i.e. this number may contain duplicate users).">
                                 <InfoCircleOutlined style={{ marginLeft: 4, color: 'var(--primary-alt)' }} />
                             </Tooltip>

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -9,7 +9,7 @@ import { HeatmapElement } from '~/toolbar/elements/HeatmapElement'
 import { HeatmapLabel } from '~/toolbar/elements/HeatmapLabel'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { getBoxColors, getHeatMapHue } from '~/toolbar/utils'
-import { humanizeNumber } from 'lib/utils'
+import { compactNumber } from 'lib/utils'
 
 export function Elements(): JSX.Element {
     const {
@@ -118,7 +118,7 @@ export function Elements(): JSX.Element {
                                 onMouseOver={() => setHoverElement(element)}
                                 onMouseOut={() => setHoverElement(null)}
                             >
-                                {humanizeNumber(count || 0)}
+                                {compactNumber(count || 0)}
                             </HeatmapLabel>
                         </React.Fragment>
                     )


### PR DESCRIPTION
## Changes

This PR:
- Adds a clear empty state when values in the funnels table don’t make sense (e.g. conversion rate in step 1) to avoid confusion of missing values (i.e. thinking it's a bug)

**Before**
<img width="932" alt="" src="https://user-images.githubusercontent.com/5864173/128646854-541619b8-01fc-4090-932a-4c99278f7726.png">

**After**
<img width="918" alt="" src="https://user-images.githubusercontent.com/5864173/128646859-a08cbdee-0b4a-4915-a496-8893187a601e.png">


- Standardizes all percentages across funnels to have one decimal place (including trailing zero) for easy reading.
    <img width="911" alt="" src="https://user-images.githubusercontent.com/5864173/128646834-9d968338-e5e0-45b0-8525-f5189b8197d7.png">
    <img width="494" alt="" src="https://user-images.githubusercontent.com/5864173/128646848-36c7b478-2956-4588-ab57-8716211206f4.png">
- Cleans up all the logic related to percentages in funnels to delegate display logic to the components and keep only the data values in the data model.
- Removes `humanizeNumber` utility which has no tests and duplicates behavior from already existing `compactNumber`.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
