### PR TITLE
Bring back top sessions link in persons modal

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import dayjs from 'dayjs'
 import { TrendPeople, parsePeopleParams } from 'scenes/trends/trendsLogic'
-import { DownloadOutlined, UsergroupAddOutlined } from '@ant-design/icons'
+import { DownloadOutlined, UsergroupAddOutlined, ClockCircleOutlined, ArrowRightOutlined } from '@ant-design/icons'
 import { Modal, Button, Spin, Input, Row, Col, Skeleton } from 'antd'
 import { deepLinkToPersonSessions } from 'scenes/persons/PersonsTable'
 import { ActionFilter, EntityTypes, EventPropertyFilter, FilterType, SessionsPropertyFilter, ViewType } from '~/types'
@@ -47,6 +47,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
         searchTerm,
         isInitialLoad,
         clickhouseFeaturesEnabled,
+        peopleModalURL,
     } = useValues(personsModalLogic)
     const { hidePeople, loadMorePeople, setFirstLoadedPeople, setPersonsModalFilters, setSearchTerm } = useActions(
         personsModalLogic
@@ -143,7 +144,6 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                                 display: 'flex',
                                 flexDirection: 'column',
                                 width: '100%',
-                                alignItems: 'flex-start',
                                 padding: '0px 16px',
                             }}
                         >
@@ -167,6 +167,29 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
                                     }
                                 />
                             )}
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    paddingTop: 16,
+                                    flexDirection: 'column',
+                                    alignItems: 'flex-end',
+                                }}
+                            >
+                                <Link
+                                    to={peopleModalURL.sessions}
+                                    style={{ marginLeft: 8 }}
+                                    data-attr="persons-modal-sessions"
+                                >
+                                    <ClockCircleOutlined /> View related sessions <ArrowRightOutlined />
+                                </Link>
+                                <Link
+                                    to={peopleModalURL.recordings}
+                                    type="primary"
+                                    data-attr="persons-modal-recordings"
+                                >
+                                    View related recordings <ArrowRightOutlined />
+                                </Link>
+                            </div>
                             <span style={{ paddingTop: 9 }}>
                                 Found{' '}
                                 <b>

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -119,7 +119,7 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 ]
                 if (peopleParams?.filters.breakdown && peopleParams.filters.breakdown_type && breakdown_value) {
                     properties.push({
-                        key: peopleParams?.filters.breakdown,
+                        key: peopleParams?.filters.breakdown.toString(),
                         value: breakdown_value,
                         type: peopleParams?.filters.breakdown_type,
                         operator: null,


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Bring back sessions links on the top of the persons modal

<img width="808" alt="Screen Shot 2021-08-09 at 10 17 47 AM" src="https://user-images.githubusercontent.com/25164963/128721557-23d74acf-e991-41a5-a36c-de8299123651.png">
<img width="711" alt="Screen Shot 2021-08-09 at 10 18 04 AM" src="https://user-images.githubusercontent.com/25164963/128721561-81e7f241-23ef-4163-bf23-eb8353d549ad.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
