### PR TITLE
Add HUBSPOT_API_KEY secrets manager arn

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -225,6 +225,10 @@
                 {
                     "name": "STRIPE_WEBHOOK_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
+                },
+                {
+                    "name": "HUBSPOT_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:HUBSPOT_API_KEY::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -243,6 +243,10 @@
                 {
                     "name": "STRIPE_WEBHOOK_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
+                },
+                {
+                    "name": "HUBSPOT_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:HUBSPOT_API_KEY::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -237,6 +237,10 @@
                 {
                     "name": "STRIPE_WEBHOOK_SECRET",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STRIPE_WEBHOOK_SECRET::"
+                },
+                {
+                    "name": "HUBSPOT_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:HUBSPOT_API_KEY::"
                 }
             ],
             "entryPoint": ["sh", "-c"],


### PR DESCRIPTION
## Changes

Adds a reference to HUBSPOT_API_KEY for use in `posthog-cloud` endpoints.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
