### PR TITLE
Sort insights table total sum

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -163,7 +163,6 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
                         filters.display === ACTIONS_TABLE ||
                         filters.display === ACTIONS_PIE_CHART)
                 ) {
-                    // Special handling because `count` will contain the last amount, instead of the cumulative sum.
                     return (item.count || item.aggregated_value).toLocaleString()
                 }
                 return (

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -164,10 +164,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
                         filters.display === ACTIONS_PIE_CHART)
                 ) {
                     // Special handling because `count` will contain the last amount, instead of the cumulative sum.
-                    return (
-                        item.aggregated_value?.toLocaleString() ||
-                        item.data.reduce((acc, val) => acc + val, 0).toLocaleString()
-                    )
+                    return (item.count || item.aggregated_value).toLocaleString()
                 }
                 return (
                     <>
@@ -180,6 +177,8 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
                     </>
                 )
             },
+            defaultSortOrder: 'descend',
+            sorter: (a, b) => a.count - b.count,
             dataIndex: 'count',
             fixed: 'right',
             width: 100,

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -146,7 +146,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
     if (showTotalCount) {
         columns.push({
             title: (
-                <Dropdown overlay={calcColumnMenu} trigger={['click']}>
+                <Dropdown overlay={calcColumnMenu}>
                     <span className="cursor-pointer">
                         {CALC_COLUMN_LABELS[calcColumnState]} <DownOutlined />
                     </span>
@@ -181,7 +181,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
             sorter: (a, b) => a.count - b.count,
             dataIndex: 'count',
             fixed: 'right',
-            width: 100,
+            width: 120,
             align: 'center',
         })
     }


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Adds default sort order and sorting to insights table breakdown
Addresses #5383 


https://user-images.githubusercontent.com/25164963/128783977-1f32d3ce-97a5-46d9-a74a-e02a29bb46f3.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
