### PR TITLE
Handle materialized properties in more cases

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.materialized_columns.columns import ColumnName, get_materialized_columns
+from ee.clickhouse.materialized_columns.columns import ColumnName, PropertyName, get_materialized_columns
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
@@ -85,37 +85,30 @@ def prop_filter_json_extract(
     prop: Property, idx: int, prepend: str = "", prop_var: str = "properties", allow_denormalized_props: bool = False
 ) -> Tuple[str, Dict[str, Any]]:
     # Once all queries are migrated over we can get rid of allow_denormalized_props
-    json_extract = "trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, %(k{prepend}_{idx})s))".format(
-        idx=idx, prepend=prepend, prop_var=prop_var
+    property_expr, is_denormalized = get_property_string_expr(
+        property_table(prop), prop.key, f"%(k{prepend}_{idx})s", prop_var, allow_denormalized_props
     )
-    denormalized_column = get_denormalized_property_column(prop, allow_denormalized_props)
     operator = prop.operator
     params: Dict[str, Any] = {}
 
     if operator == "is_not":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): box_value(prop.value)}
         return (
-            "AND NOT has(%(v{prepend}_{idx})s, {left})".format(
-                idx=idx, prepend=prepend, left=denormalized_column or json_extract
-            ),
+            "AND NOT has(%(v{prepend}_{idx})s, {left})".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator == "icontains":
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND {left} LIKE %(v{prepend}_{idx})s".format(
-                idx=idx, prepend=prepend, left=denormalized_column or json_extract
-            ),
+            "AND {left} LIKE %(v{prepend}_{idx})s".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator == "not_icontains":
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND NOT ({left} LIKE %(v{prepend}_{idx})s)".format(
-                idx=idx, prepend=prepend, left=denormalized_column or json_extract
-            ),
+            "AND NOT ({left} LIKE %(v{prepend}_{idx})s)".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator in ("regex", "not_regex"):
@@ -129,15 +122,15 @@ def prop_filter_json_extract(
                 regex_function="match" if operator == "regex" else "NOT match",
                 idx=idx,
                 prepend=prepend,
-                left=denormalized_column or json_extract,
+                left=property_expr,
             ),
             params,
         )
     elif operator == "is_set":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
-        if denormalized_column:
+        if is_denormalized:
             return (
-                "AND NOT isNull({left})".format(left=denormalized_column),
+                "AND NOT isNull({left})".format(left=property_expr),
                 params,
             )
         return (
@@ -146,14 +139,14 @@ def prop_filter_json_extract(
         )
     elif operator == "is_not_set":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
-        if denormalized_column:
+        if is_denormalized:
             return (
-                "AND isNull({left})".format(left=denormalized_column),
+                "AND isNull({left})".format(left=property_expr),
                 params,
             )
         return (
             "AND (isNull({left}) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
-                idx=idx, prepend=prepend, prop_var=prop_var, left=json_extract
+                idx=idx, prepend=prepend, prop_var=prop_var, left=property_expr
             ),
             params,
         )
@@ -161,13 +154,7 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
             "AND toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) > %(v{prepend}_{idx})s".format(
-                idx=idx,
-                prepend=prepend,
-                left=denormalized_column
-                if denormalized_column
-                else "visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s)".format(
-                    idx=idx, prepend=prepend, prop_var=prop_var,
-                ),
+                idx=idx, prepend=prepend, left=property_expr,
             ),
             params,
         )
@@ -175,18 +162,12 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         return (
             "AND toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) < %(v{prepend}_{idx})s".format(
-                idx=idx,
-                prepend=prepend,
-                left=denormalized_column
-                if denormalized_column
-                else "visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s)".format(
-                    idx=idx, prepend=prepend, prop_var=prop_var,
-                ),
+                idx=idx, prepend=prepend, left=property_expr,
             ),
             params,
         )
     else:
-        if is_json(prop.value) and not denormalized_column:
+        if is_json(prop.value) and not is_denormalized:
             clause = "AND has(%(v{prepend}_{idx})s, replaceRegexpAll(visitParamExtractRaw({prop_var}, %(k{prepend}_{idx})s),' ', ''))"
             params = {
                 "k{}_{}".format(prepend, idx): prop.key,
@@ -196,9 +177,30 @@ def prop_filter_json_extract(
             clause = "AND has(%(v{prepend}_{idx})s, {left})"
             params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): box_value(prop.value)}
         return (
-            clause.format(left=denormalized_column or json_extract, idx=idx, prepend=prepend, prop_var=prop_var),
+            clause.format(left=property_expr, idx=idx, prepend=prepend, prop_var=prop_var),
             params,
         )
+
+
+def property_table(property: Property) -> str:
+    if property.type == "event":
+        return "events"
+    elif property.type == "person":
+        return "person"
+    else:
+        raise ValueError(f"Property type does not have a table: {property.type}")
+
+
+def get_property_string_expr(
+    table: str, property_name: PropertyName, var: str, prop_var: str, allow_denormalized_props: bool
+) -> Tuple[str, bool]:
+    materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
+
+    # :TODO: Handle denormalized properties in person table
+    if allow_denormalized_props and property_name in materialized_columns and table == "events":
+        return materialized_columns[property_name], True
+
+    return f"trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, {var}))", False
 
 
 def box_value(value: Any, remove_spaces=False) -> List[Any]:
@@ -221,15 +223,6 @@ def get_property_values_for_key(key: str, team: Team, value: Optional[str] = Non
         SELECT_PROP_VALUES_SQL.format(parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to),
         {"team_id": team.pk, "key": key},
     )
-
-
-def get_denormalized_property_column(prop, allow_denormalized_props: bool) -> Optional[ColumnName]:
-    columns = {}
-    # :TODO: Handle denormalized properties in person table
-    if allow_denormalized_props and prop.type == "event":
-        columns = get_materialized_columns("events")
-
-    return columns.get(prop.key)
 
 
 def filter_element(filters: Dict, prepend: str = "") -> Tuple[str, Dict]:

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -46,6 +46,8 @@ class ClickhouseFunnelBase(ABC, Funnel):
             self._filter = self._filter.with_data(new_limit)
             self.params.update(new_limit)
 
+        self._update_filters()
+
     def run(self, *args, **kwargs):
         if len(self._filter.entities) == 0:
             return []
@@ -120,8 +122,6 @@ class ClickhouseFunnelBase(ABC, Funnel):
             return self._format_single_funnel(results[0])
 
     def _exec_query(self) -> List[Tuple]:
-        self.update_filters()
-
         query = self.get_query()
         return sync_execute(query, self.params)
 

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.materialized_columns import get_materialized_columns
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.breakdown_props import (
@@ -378,11 +379,15 @@ class ClickhouseFunnelBase(ABC, Funnel):
         if self._filter.breakdown:
             self.params.update({"breakdown": self._filter.breakdown})
             if self._filter.breakdown_type == "person":
-                return f", trim(BOTH '\"' FROM JSONExtractRaw(person_props, %(breakdown)s)) as prop"
+                return f", trim(BOTH '\"' FROM JSONExtractRaw(person_props, %(breakdown)s)) AS prop"
             elif self._filter.breakdown_type == "event":
-                return f", trim(BOTH '\"' FROM JSONExtractRaw(properties, %(breakdown)s)) as prop"
+                column_name = get_materialized_columns("events").get(self._filter.breakdown)
+                if column_name is not None:
+                    return f", {column_name} AS prop"
+                else:
+                    return f", trim(BOTH '\"' FROM JSONExtractRaw(properties, %(breakdown)s)) AS prop"
             elif self._filter.breakdown_type == "cohort":
-                return ", value as prop"
+                return ", value AS prop"
 
         return ""
 

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -1004,26 +1004,22 @@ class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _cre
             "exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 1},],
         }
         filter = Filter(data=filters)
-        funnel = ClickhouseFunnel(filter, self.team)
-        self.assertRaises(ValidationError, funnel.run)
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnel(filter, self.team))
 
         filter = filter.with_data(
             {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 2}]}
         )
-        funnel = ClickhouseFunnel(filter, self.team)
-        self.assertRaises(ValidationError, funnel.run)
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnel(filter, self.team))
 
         filter = filter.with_data(
             {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 2, "funnel_to_step": 1}]}
         )
-        funnel = ClickhouseFunnel(filter, self.team)
-        self.assertRaises(ValidationError, funnel.run)
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnel(filter, self.team))
 
         filter = filter.with_data(
             {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 2}]}
         )
-        funnel = ClickhouseFunnel(filter, self.team)
-        self.assertRaises(ValidationError, funnel.run)
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnel(filter, self.team))
 
     def test_funnel_exclusion_no_end_event(self):
         filters = {

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -43,27 +43,7 @@ def _create_event(**kwargs):
 
 class TestFunnelBreakdown(ClickhouseTestMixin, funnel_breakdown_test_factory(ClickhouseFunnel, ClickhouseFunnelPersons, _create_event, _create_person)):  # type: ignore
     maxDiff = None
-
-    def test_funnel_query_with_denormalized_breakdown(self):
-        filter = Filter(
-            data={
-                "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": "some_breakdown_val",
-                "breakdown_limit": 5,
-            }
-        )
-
-        materialize("events", "some_breakdown_val")
-
-        funnel = ClickhouseFunnel(filter, self.team)
-
-        self.assertNotIn("json", funnel.get_query().lower())
-        funnel.run()
+    pass
 
 
 class TestFunnelConversionTime(ClickhouseTestMixin, funnel_conversion_time_test_factory(ClickhouseFunnel, ClickhouseFunnelPersons, _create_event, _create_person)):  # type: ignore

--- a/ee/clickhouse/queries/funnels/test/test_funnel_unordered.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_unordered.py
@@ -520,15 +520,13 @@ class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
             "exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 1},],
         }
         filter = Filter(data=filters)
-        funnel = ClickhouseFunnelUnordered(filter, self.team)
-        self.assertRaises(ValidationError, funnel.run)
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team))
 
         # partial windows not allowed for unordered
         filter = filter.with_data(
             {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1}]}
         )
-        funnel = ClickhouseFunnelUnordered(filter, self.team)
-        self.assertRaises(ValidationError, funnel.run)
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team))
 
     def test_funnel_exclusions_full_window(self):
         filters = {

--- a/ee/clickhouse/queries/funnels/test/test_funnel_unordered.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_unordered.py
@@ -520,13 +520,13 @@ class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
             "exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 1},],
         }
         filter = Filter(data=filters)
-        self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team))
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team).run())
 
         # partial windows not allowed for unordered
         filter = filter.with_data(
             {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1}]}
         )
-        self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team))
+        self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team).run())
 
     def test_funnel_exclusions_full_window(self):
         filters = {

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1,8 +1,11 @@
 from uuid import uuid4
 
+from ee.clickhouse.materialized_columns.columns import materialize
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.queries.clickhouse_paths import ClickhousePaths
 from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.constants import PAGEVIEW_EVENT, SCREEN_EVENT
+from posthog.models.filters.path_filter import PathFilter
 from posthog.models.person import Person
 from posthog.queries.test.test_paths import paths_test_factory
 
@@ -13,4 +16,14 @@ def _create_event(**kwargs):
 
 
 class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePaths, _create_event, Person.objects.create)):  # type: ignore
-    pass
+    def test_denormalized_properties(self):
+        materialize("events", "$current_url")
+        materialize("events", "$screen_name")
+
+        query, _ = ClickhousePaths().get_query(team=self.team, filter=PathFilter(data={"path_type": PAGEVIEW_EVENT}))
+        self.assertNotIn("json", query.lower())
+
+        query, _ = ClickhousePaths().get_query(team=self.team, filter=PathFilter(data={"path_type": SCREEN_EVENT}))
+        self.assertNotIn("json", query.lower())
+
+        self.test_current_url_paths_and_logic()

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -261,7 +261,7 @@ def insight_test_factory(event_factory, person_factory):
 
         def test_nonexistent_cohort_is_handled(self):
             response_nonexistent_property = self.client.get(
-                f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'property','key':'foo','value':'barabarab'}])}"
+                f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'event','key':'foo','value':'barabarab'}])}"
             )
             response_nonexistent_cohort = self.client.get(
                 f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':2137}])}"
@@ -279,7 +279,7 @@ def insight_test_factory(event_factory, person_factory):
             whatever_cohort_without_match_groups = Cohort.objects.create(team=self.team)
 
             response_nonexistent_property = self.client.get(
-                f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'property','key':'foo','value':'barabarab'}])}"
+                f"/api/insight/trend/?events={json.dumps([{'id': '$pageview'}])}&properties={json.dumps([{'type':'event','key':'foo','value':'barabarab'}])}"
             )
             response_cohort_without_match_groups = self.client.get(
                 f"/api/insight/trend/?events={json.dumps([{'id':'$pageview'}])}&properties={json.dumps([{'type':'cohort','key':'id','value':whatever_cohort_without_match_groups.pk}])}"

--- a/posthog/queries/paths.py
+++ b/posthog/queries/paths.py
@@ -1,12 +1,11 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from django.db import connection
 from django.db.models import F, OuterRef, Q
 from django.db.models.expressions import Window
 from django.db.models.functions import Lag
 
-from posthog.constants import FILTER_TEST_ACCOUNTS
-from posthog.models import Event, Filter, Team
+from posthog.models import Event, Team
 from posthog.models.filters.path_filter import PathFilter
 from posthog.queries.base import properties_to_Q
 from posthog.utils import request_to_date_query


### PR DESCRIPTION
Part of (but not all of)  https://github.com/PostHog/posthog/issues/5463

## Commits


- Extract method from funnels code
- Add failing test case for using denormalized property in a funnel breakdown
- Handle materialized event properties in funnel breakdown
- Refactor property lookups
- Use denormalized properties in paths

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
