### PR TITLE
Respect disabled toolbar

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -67,7 +67,7 @@ def get_decide(request: HttpRequest):
 
     if request.COOKIES.get(settings.TOOLBAR_COOKIE_NAME) and request.user.is_authenticated:
         response["isAuthenticated"] = True
-        if settings.JS_URL and request.user.toolbar_mode != "disabled":
+        if settings.JS_URL and request.user.toolbar_mode == User.TOOLBAR:
             response["editorParams"] = {"jsURL": settings.JS_URL, "toolbarVersion": "toolbar"}
 
     if request.user.is_authenticated:

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -65,7 +65,7 @@ def get_decide(request: HttpRequest):
         "supportedCompression": ["gzip", "gzip-js", "lz64"],
     }
 
-    if request.COOKIES.get(settings.TOOLBAR_COOKIE_NAME):
+    if request.COOKIES.get(settings.TOOLBAR_COOKIE_NAME) and request.user.is_authenticated:
         response["isAuthenticated"] = True
         if settings.JS_URL and request.user.toolbar_mode != "disabled":
             response["editorParams"] = {"jsURL": settings.JS_URL, "toolbarVersion": "toolbar"}

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -67,7 +67,7 @@ def get_decide(request: HttpRequest):
 
     if request.COOKIES.get(settings.TOOLBAR_COOKIE_NAME):
         response["isAuthenticated"] = True
-        if settings.JS_URL:
+        if settings.JS_URL and request.user.toolbar_mode != "disabled":
             response["editorParams"] = {"jsURL": settings.JS_URL, "toolbarVersion": "toolbar"}
 
     if request.user.is_authenticated:

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -52,7 +52,7 @@ class TestDecide(BaseTest):
         # Make sure the endpoint works with and without the trailing slash
         response = self.client.get("/decide", HTTP_ORIGIN="https://example.com").json()
         self.assertEqual(response["isAuthenticated"], True)
-        self.assertIsNone(response.get("toolbarVersion", None))
+        self.assertIsNone(response["editorParams"].get("toolbarVersion"))
 
     def test_user_on_evil_site(self):
         user = self.organization.members.first()

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -223,7 +223,6 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     # Set the frontend app context
     if not request.GET.get("no-preloaded-app-context"):
         from posthog.api.user import UserSerializer
-        from posthog.models import EventDefinition
         from posthog.views import preflight_check
 
         posthog_app_context: Dict = {


### PR DESCRIPTION
## Changes

Pair PR to https://github.com/PostHog/posthog-js/pull/264

Fixes an issue reported by a user on Slack where the toolbar actually loads even when it's disabled from Project Settings

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
