### PR TITLE
Hide funnel step table when graphs are errored

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -396,6 +396,7 @@ export function Insights(): JSX.Element {
                             {featureFlags[FEATURE_FLAGS.FUNNEL_BAR_VIZ] &&
                                 preflight?.is_clickhouse_enabled &&
                                 activeView === ViewType.FUNNELS &&
+                                !showErrorMessage &&
                                 allFilters.funnel_viz_type === FunnelVizType.Steps && <FunnelStepTable />}
                             {(!allFilters.display ||
                                 (allFilters.display !== ACTIONS_TABLE &&


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Closes #5540 

<img width="1301" alt="Screen Shot 2021-08-11 at 1 18 25 PM" src="https://user-images.githubusercontent.com/25164963/129074384-946331a0-c99f-4b47-b5f4-5f959d77ea96.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
