### PR TITLE
Migrate person_distinct_id table to CollapsingMergeTree

### DIFF
--- a/ee/clickhouse/migrations/0016_collapsing_person_distinct_id.py
+++ b/ee/clickhouse/migrations/0016_collapsing_person_distinct_id.py
@@ -22,8 +22,6 @@ operations = [
         FROM {PERSONS_DISTINCT_ID_TABLE}
     """
     ),
-    migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
-    migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),
     migrations.RunSQL(
         f"""
         RENAME TABLE
@@ -32,4 +30,6 @@ operations = [
         ON CLUSTER {CLICKHOUSE_CLUSTER}
     """
     ),
+    migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
+    migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),
 ]

--- a/ee/clickhouse/migrations/0016_collapsing_person_distinct_id.py
+++ b/ee/clickhouse/migrations/0016_collapsing_person_distinct_id.py
@@ -1,0 +1,35 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.person import *
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+TEMPORARY_TABLE_NAME = "person_distinct_id_tmp_migration_0016"
+
+operations = [
+    migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_SQL.replace(PERSONS_DISTINCT_ID_TABLE, TEMPORARY_TABLE_NAME, 1)),
+    migrations.RunSQL(f"DROP TABLE person_distinct_id_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(f"DROP TABLE kafka_person_distinct_id ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(
+        f"""
+        INSERT INTO {TEMPORARY_TABLE_NAME} (distinct_id, person_id, team_id, _sign, _timestamp, _offset)
+        SELECT
+            distinct_id,
+            person_id,
+            team_id,
+            if(is_deleted==0, 1, -1) as _sign,
+            _timestamp,
+            _offset
+        FROM {PERSONS_DISTINCT_ID_TABLE}
+    """
+    ),
+    migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL),
+    migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),
+    migrations.RunSQL(
+        f"""
+        RENAME TABLE
+            {CLICKHOUSE_DATABASE}.{PERSONS_DISTINCT_ID_TABLE} to {CLICKHOUSE_DATABASE}.person_distinct_id_backup,
+            {CLICKHOUSE_DATABASE}.{TEMPORARY_TABLE_NAME} to {CLICKHOUSE_DATABASE}.{PERSONS_DISTINCT_ID_TABLE}
+        ON CLUSTER {CLICKHOUSE_CLUSTER}
+    """
+    ),
+]

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -48,7 +48,7 @@ def _create_person(**kwargs) -> Person:
     distinct_ids = kwargs.pop("distinct_ids")
     person = create_person(uuid=uuid, **kwargs)
     for id in distinct_ids:
-        create_person_distinct_id(0, kwargs["team_id"], id, str(person))
+        create_person_distinct_id(kwargs["team_id"], id, str(person))
     return Person(id=person, uuid=person)
 
 

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -73,23 +73,23 @@ class TestFiltering(
 
         prop_clause, prop_clause_params = parse_prop_clauses(filter.properties, self.team.pk)
         query = """
-        SELECT * FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
+        SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
         """.format(
             prop_clause=prop_clause
         )
         # get distinct_id column of result
-        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][1]
+        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][0]
         self.assertEqual(result, person1_distinct_id)
 
         # test cohort2 with negation
         filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],})
         prop_clause, prop_clause_params = parse_prop_clauses(filter.properties, self.team.pk)
         query = """
-        SELECT * FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
+        SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
         """.format(
             prop_clause=prop_clause
         )
         # get distinct_id column of result
-        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][1]
+        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][0]
 
         self.assertEqual(result, person2_distinct_id)

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -390,7 +390,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         person = Person.objects.create(
             team_id=self.team.pk, distinct_ids=["person3"], properties={"email": "test@gmail.com"}
         )
-        create_person_distinct_id(person.id, self.team.pk, "person1", str(person.uuid))
+        create_person_distinct_id(self.team.pk, "person1", str(person.uuid))
 
         _create_event(event="sign up", distinct_id="person1", team=self.team, properties={"key": "val"})
         _create_event(event="sign up", distinct_id="person2", team=self.team, properties={"key": "val"})

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -139,7 +139,6 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     table_name="kafka_" + PERSONS_DISTINCT_ID_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
     engine=kafka_engine(KAFKA_PERSON_UNIQUE_ID),
-    extra_fields="",
 )
 
 # You must include the database here because of a bug in clickhouse

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -227,7 +227,7 @@ INSERT INTO person (id, created_at, team_id, properties, is_identified, _timesta
 """
 
 INSERT_PERSON_DISTINCT_ID = """
-INSERT INTO person_distinct_id SELECT %(id)s, %(distinct_id)s, %(person_id)s, %(team_id)s, 0, now(), 0 VALUES
+INSERT INTO person_distinct_id SELECT%(distinct_id)s, %(person_id)s, %(team_id)s, %(sign)s, now(), 0 VALUES
 """
 
 DELETE_PERSON_BY_ID = """
@@ -240,10 +240,6 @@ WHERE distinct_id IN (
     SELECT distinct_id FROM person_distinct_id WHERE person_id=%(id)s AND team_id = %(team_id)s
 )
 AND team_id = %(team_id)s
-"""
-
-DELETE_PERSON_DISTINCT_ID_BY_PERSON_ID = """
-INSERT INTO person_distinct_id (id, distinct_id, person_id, team_id, is_deleted, _timestamp, _offset) SELECT %(id)s, %(distinct_id)s, %(person_id)s, %(team_id)s, 0, now(), 0
 """
 
 PERSON_TREND_SQL = """

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -124,6 +124,8 @@ PERSONS_DISTINCT_ID_TABLE_SQL = (
     storage_policy=STORAGE_POLICY,
 )
 
+# :KLUDGE: We default is_deleted to 0 for backwards compatibility for when we drop `is_deleted` from message schema.
+#    Can't make DEFAULT if(_sign==-1, 1, 0) because Cyclic aliases error.
 KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL = """
 CREATE TABLE {table_name} ON CLUSTER {cluster}
 (
@@ -131,7 +133,7 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     person_id UUID,
     team_id Int64,
     _sign Int8 DEFAULT if(is_deleted==0, 1, -1),
-    is_deleted Int8 DEFAULT if(_sign==-1, 1, 0)
+    is_deleted Int8 DEFAULT 0
 ) ENGINE = {engine}
 """.format(
     table_name="kafka_" + PERSONS_DISTINCT_ID_TABLE,
@@ -146,7 +148,6 @@ PERSONS_DISTINCT_ID_TABLE_MV_SQL = """
 CREATE MATERIALIZED VIEW {table_name}_mv ON CLUSTER {cluster}
 TO {database}.{table_name}
 AS SELECT
-id,
 distinct_id,
 person_id,
 team_id,

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -227,7 +227,7 @@ INSERT INTO person (id, created_at, team_id, properties, is_identified, _timesta
 """
 
 INSERT_PERSON_DISTINCT_ID = """
-INSERT INTO person_distinct_id SELECT%(distinct_id)s, %(person_id)s, %(team_id)s, %(sign)s, now(), 0 VALUES
+INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(sign)s, now(), 0 VALUES
 """
 
 DELETE_PERSON_BY_ID = """

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -132,8 +132,8 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     distinct_id VARCHAR,
     person_id UUID,
     team_id Int64,
-    _sign Int8 DEFAULT if(is_deleted==0, 1, -1),
-    is_deleted Int8 DEFAULT 0
+    _sign Nullable(Int8),
+    is_deleted Nullable(Int8)
 ) ENGINE = {engine}
 """.format(
     table_name="kafka_" + PERSONS_DISTINCT_ID_TABLE,
@@ -151,7 +151,7 @@ AS SELECT
 distinct_id,
 person_id,
 team_id,
-_sign,
+coalesce(_sign, if(is_deleted==0, 1, -1)) AS _sign,
 _timestamp,
 _offset
 FROM {database}.kafka_{table_name}

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_person.py
@@ -187,22 +187,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(0, len(people))
-        self.assertNotEqual(None, next)
-
-        response = self.client.get(next)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        j = response.json()
-        people = j["results"][0]["people"]
-        next = j["next"]
-        self.assertEqual(0, len(people))
-        self.assertNotEqual(None, next)
-
-        response = self.client.get(next)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        j = response.json()
-        people = j["results"][0]["people"]
-        self.assertEqual(0, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(next)
 
     def test_breakdowns(self):
         request_data = {

--- a/posthog/demo/data_generator.py
+++ b/posthog/demo/data_generator.py
@@ -45,9 +45,7 @@ class DataGenerator:
             for person in self.people:
                 create_person(team_id=person.team.pk, properties=person.properties, is_identified=person.is_identified)
             for pid in pids:
-                create_person_distinct_id(
-                    0, pid.team.pk, pid.distinct_id, str(pid.person.uuid)
-                )  # use dummy number for id
+                create_person_distinct_id(pid.team.pk, pid.distinct_id, str(pid.person.uuid))  # use dummy number for id
 
     def make_person(self, index):
         return Person(team=self.team, properties={"is_demo": True})


### PR DESCRIPTION
## Background

See https://github.com/PostHog/product-internal/issues/134 for a summary plaguing the current schema.

This fixes most of them relating to this table.

The fix is intended to be safe-to-deploy without races with e.g. plugin server - hence the added complexity in the table definitions.

## Testing plan

I tested this migration pretty extensively locally by:
- Resetting db on master
- Creating a few users, merging them via .identify calls
- Switching branches, running migration, verifying results
- Doing a few more .identify calls, verifying new data arrives and is correct

For getting this live, I propose _not_ merging and praying. Instead, I'd run all the SQL commands one-by-one in a live shell, leaving the old table around.

Once we're happy with things, we can remove the old data, mark the migration as done and merge.

## What next?

Use sign over is_deleted everywhere. :)

## What to review?

- Does this migration script make sense from a self-hosted perspective
- Does the rollout plan make sense for cloud?
- Are there other considerations (*cough*zookeeper paths*cough*)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
