### PR TITLE
Fix white screen bug for sessions table navigation to trends

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -28,8 +28,7 @@ export function ActionsLineGraph({
     const { filters, indexedResults, resultsLoading, visibilityMap } = useValues(logic)
     const { loadPeople } = useActions(personsModalLogic)
     const [{ fromItem }] = useState(router.values.hashParams)
-
-    return indexedResults && !resultsLoading ? (
+    return indexedResults && !resultsLoading && indexedResults[0].data ? (
         indexedResults.filter((result) => result.count !== 0).length > 0 ? (
             <LineGraph
                 data-attr="trend-line-graph"

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -28,7 +28,7 @@ export function ActionsLineGraph({
     const { filters, indexedResults, resultsLoading, visibilityMap } = useValues(logic)
     const { loadPeople } = useActions(personsModalLogic)
     const [{ fromItem }] = useState(router.values.hashParams)
-    return indexedResults && !resultsLoading && indexedResults[0].data ? (
+    return indexedResults && !resultsLoading && indexedResults[0]?.data ? (
         indexedResults.filter((result) => result.count !== 0).length > 0 ? (
             <LineGraph
                 data-attr="trend-line-graph"


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Fixes #5562 white screen of death that was happening because we were passing in wrong results to the line graph

Line graph always takes an input of [{ data: {} }] but after going to sessions table we were returning with [{}, {}, {}, ...]

<img width="404" alt="Screen Shot 2021-08-12 at 10 54 58 AM" src="https://user-images.githubusercontent.com/25164963/129219549-de90ca07-e3e5-4bf9-bb84-0e4af68ea58d.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
