### PR TITLE
Add link to ingestion docs to helper dropdown

### DIFF
--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -5,7 +5,7 @@ import { useInterval } from 'lib/hooks/useInterval'
 import { CardContainer } from 'scenes/ingestion/CardContainer'
 import { Button, Row, Spin, Space, Popconfirm, Dropdown, Menu, Typography } from 'antd'
 import { ingestionLogic } from 'scenes/ingestion/ingestionLogic'
-import { DownOutlined, SlackSquareOutlined } from '@ant-design/icons'
+import { DownOutlined, SlackSquareOutlined, ReadOutlined } from '@ant-design/icons'
 import { CreateInviteModalWithButton } from 'scenes/organization/Settings/CreateInviteModal'
 
 const { Text } = Typography
@@ -31,19 +31,28 @@ export function VerificationPanel(): JSX.Element {
         function HelpButton(): JSX.Element {
             const menu = (
                 <Menu selectable>
+                    <Menu.Item key="0" data-attr="ingestion-help-item-docs">
+                        <a
+                            href="https://posthog.com/docs/integrate/ingest-live-data"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <Button type="link">
+                                <ReadOutlined />
+                                Read the docs
+                            </Button>
+                        </a>
+                    </Menu.Item>
                     <Menu.Item key="1" data-attr="ingestion-help-item-invite">
                         <CreateInviteModalWithButton type="link" />
                     </Menu.Item>
                     <Menu.Item key="2" data-attr="ingestion-help-item-slack">
-                        <Button
-                            type="link"
-                            onClick={() => {
-                                window.open('https://posthog.com/slack?s=app', '_blank')
-                            }}
-                        >
-                            <SlackSquareOutlined />
-                            Ask in Slack
-                        </Button>
+                        <a href="https://posthog.com/slack?s=app" target="_blank" rel="noopener noreferrer">
+                            <Button type="link">
+                                <SlackSquareOutlined />
+                                Ask us in Slack
+                            </Button>
+                        </a>
                     </Menu.Item>
                 </Menu>
             )

--- a/frontend/src/scenes/organization/Settings/CreateInviteModal.tsx
+++ b/frontend/src/scenes/organization/Settings/CreateInviteModal.tsx
@@ -56,7 +56,7 @@ export function CreateInviteModalWithButton(buttonProps: ButtonProps): JSX.Eleme
                 icon={<UserAddOutlined />}
                 {...buttonProps}
             >
-                Invite team member
+                Invite teammate
             </Button>
             <Modal
                 title={`Inviting Team Member${user?.organization ? ' to ' + user?.organization?.name : ''}`}

--- a/frontend/src/scenes/organization/Settings/CreateInviteModal.tsx
+++ b/frontend/src/scenes/organization/Settings/CreateInviteModal.tsx
@@ -56,7 +56,7 @@ export function CreateInviteModalWithButton(buttonProps: ButtonProps): JSX.Eleme
                 icon={<UserAddOutlined />}
                 {...buttonProps}
             >
-                Invite Team Member
+                Invite team member
             </Button>
             <Modal
                 title={`Inviting Team Member${user?.organization ? ' to ' + user?.organization?.name : ''}`}


### PR DESCRIPTION
## Changes

Adds a link to the new [ingestion docs](https://posthog.com/docs/integrate/ingest-live-data) to the helper options in the ingestion wizard.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
