### PR TITLE
Cumulative person bug

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -30,7 +30,7 @@ from ee.clickhouse.sql.person import (
 from ee.clickhouse.sql.trends.volume import PERSONS_ACTIVE_USER_SQL
 from posthog.api.action import ActionSerializer, ActionViewSet
 from posthog.api.utils import get_target_entity
-from posthog.constants import MONTHLY_ACTIVE, WEEKLY_ACTIVE
+from posthog.constants import MONTHLY_ACTIVE, TRENDS_CUMULATIVE, WEEKLY_ACTIVE
 from posthog.models.action import Action
 from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
@@ -127,6 +127,8 @@ def _handle_date_interval(filter: Filter) -> Filter:
         )
     elif filter.interval == "week":
         data.update({"date_to": (date_from + relativedelta(weeks=1)).strftime("%Y-%m-%d %H:%M:%S")})
+    elif filter.interval == "day":
+        data.update({"date_to": (date_from + timedelta(days=1))})
     elif filter.interval == "hour":
         data.update({"date_to": date_from + timedelta(hours=1)})
     elif filter.interval == "minute":
@@ -136,7 +138,8 @@ def _handle_date_interval(filter: Filter) -> Filter:
 
 def _process_content_sql(team: Team, entity: Entity, filter: Filter):
 
-    filter = _handle_date_interval(filter)
+    if filter.display != TRENDS_CUMULATIVE:
+        filter = _handle_date_interval(filter)
 
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team.pk)
     entity_sql, entity_params = format_entity_filter(entity=entity)

--- a/ee/clickhouse/views/test/test_clickhouse_action.py
+++ b/ee/clickhouse/views/test/test_clickhouse_action.py
@@ -7,7 +7,7 @@ from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.api.test.test_action import factory_test_action_api
 from posthog.api.test.test_action_people import action_people_test_factory
-from posthog.constants import ENTITY_ID, ENTITY_MATH, ENTITY_TYPE
+from posthog.constants import ENTITY_ID, ENTITY_MATH, ENTITY_TYPE, TRENDS_CUMULATIVE
 from posthog.models import Action, ActionStep, Cohort, Organization, Person
 
 
@@ -235,6 +235,7 @@ class TestActionPeople(
                 "date_to": "2020-01-12",
                 ENTITY_TYPE: "events",
                 ENTITY_ID: "$pageview",
+                "display": TRENDS_CUMULATIVE,  # ensure that the date range is used as is
                 "breakdown_type": "event",
                 "breakdown_value": "val",
                 "breakdown": "key",
@@ -249,6 +250,7 @@ class TestActionPeople(
                 "date_to": "2020-01-12",
                 ENTITY_TYPE: "events",
                 ENTITY_ID: "$pageview",
+                "display": TRENDS_CUMULATIVE,  # ensure that the date range is used as is
                 "breakdown_type": "event",
                 "breakdown_value": "",
                 "breakdown": "key",

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -2,7 +2,7 @@ import json
 
 from freezegun import freeze_time
 
-from posthog.constants import ENTITY_ID, ENTITY_MATH, ENTITY_TYPE
+from posthog.constants import ENTITY_ID, ENTITY_MATH, ENTITY_TYPE, TRENDS_CUMULATIVE
 from posthog.models import Action, ActionStep, Cohort, Event, Organization, Person
 from posthog.queries.abstract_test.test_interval import AbstractIntervalTest
 from posthog.tasks.calculate_action import calculate_actions_from_last_calculation
@@ -508,6 +508,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "date_from": "2020-01-01",
                     "date_to": "2020-01-07",
+                    "display": TRENDS_CUMULATIVE,  # ensure date range is used as is
                     ENTITY_TYPE: "events",
                     ENTITY_ID: "watched movie",
                     "breakdown_type": "cohort",
@@ -526,6 +527,7 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
                 data={
                     "date_from": "2020-01-01",
                     "date_to": "2020-01-07",
+                    "display": TRENDS_CUMULATIVE,  # ensure date range is used as is
                     ENTITY_TYPE: "events",
                     ENTITY_ID: "watched movie",
                     "breakdown_type": "cohort",


### PR DESCRIPTION
## Changes

*Please describe.*  
- cumulative persons was spotty because of interval handling overriding the date range
- added test
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
