### PR TITLE
Match docker compose file clickhouse version to cloud prod version

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -14,7 +14,7 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        image: yandex/clickhouse-server
+        image: yandex/clickhouse-server:21.6.5.37
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
## Changes

*Please describe.*  
- our docker-compose ch follows latest rather than production which might have unintended and hard to track side effects. This [run](https://github.com/PostHog/posthog/runs/3314680462) is failing due to extra checks in a query clause that clickhouse added in the latest version
- explicitly set the version to cloud version 21.6.5.37
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
