### PR TITLE
Show search bar for plugin config choice field

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -39,7 +39,7 @@ export function PluginField({
     ) : fieldConfig.type === 'string' ? (
         <Input value={value} onChange={onChange} autoFocus={editingSecret} className="ph-ignore-input" />
     ) : fieldConfig.type === 'choice' ? (
-        <Select dropdownMatchSelectWidth={false} value={value} onChange={onChange}>
+        <Select dropdownMatchSelectWidth={false} value={value} onChange={onChange} showSearch>
             {fieldConfig.choices.map((choice) => (
                 <Select.Option value={choice} key={choice}>
                     {choice}


### PR DESCRIPTION
## Changes

Allows searching through a plugin's config options. This will be important for plugins with a lot of choices available 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
