### PR TITLE
Fix retention filters

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -24,7 +24,9 @@ import { GlobalFiltersTitle } from '../common'
 import { ActionFilter } from '../ActionFilter/ActionFilter'
 
 export function RetentionTab({ annotationsToCreate }: BaseTabProps): JSX.Element {
-    const { filters, filtersLoading } = useValues(retentionTableLogic({ dashboardItemId: null }))
+    const { filters, filtersLoading, actionFilterTargetEntity, actionFilterReturningEntity } = useValues(
+        retentionTableLogic({ dashboardItemId: null })
+    )
     const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: null }))
 
     const screens = useBreakpoint()
@@ -58,7 +60,7 @@ export function RetentionTab({ annotationsToCreate }: BaseTabProps): JSX.Element
                                 hideMathSelector
                                 hideFilter
                                 buttonCopy="Add graph series"
-                                filters={{ events: [filters.target_entity] }} // retention filters use target and returning entity instead of events
+                                filters={actionFilterTargetEntity} // retention filters use target and returning entity instead of events
                                 setFilters={(newFilters: FilterType) => {
                                     if (newFilters.events && newFilters.events.length > 0) {
                                         setFilters({ target_entity: newFilters.events[0] })
@@ -117,7 +119,7 @@ export function RetentionTab({ annotationsToCreate }: BaseTabProps): JSX.Element
                                 hideMathSelector
                                 hideFilter
                                 buttonCopy="Add graph series"
-                                filters={{ events: [filters.returning_entity] }}
+                                filters={actionFilterReturningEntity}
                                 setFilters={(newFilters: FilterType) => {
                                     if (newFilters.events && newFilters.events.length > 0) {
                                         setFilters({ returning_entity: newFilters.events[0] })

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -58,7 +58,7 @@ export function RetentionTab({ annotationsToCreate }: BaseTabProps): JSX.Element
                                 hideMathSelector
                                 hideFilter
                                 buttonCopy="Add graph series"
-                                filters={filters}
+                                filters={{ events: [filters.target_entity] }}
                                 setFilters={(newFilters: FilterType) => {
                                     if (newFilters.events && newFilters.events.length > 0) {
                                         setFilters({ target_entity: newFilters.events[0] })
@@ -117,14 +117,14 @@ export function RetentionTab({ annotationsToCreate }: BaseTabProps): JSX.Element
                                 hideMathSelector
                                 hideFilter
                                 buttonCopy="Add graph series"
-                                filters={filters}
+                                filters={{ events: [filters.returning_entity] }}
                                 setFilters={(newFilters: FilterType) => {
                                     if (newFilters.events && newFilters.events.length > 0) {
-                                        setFilters({ target_entity: newFilters.events[0] })
+                                        setFilters({ returning_entity: newFilters.events[0] })
                                     } else if (newFilters.actions && newFilters.actions.length > 0) {
-                                        setFilters({ target_entity: newFilters.actions[0] })
+                                        setFilters({ returning_entity: newFilters.actions[0] })
                                     } else {
-                                        setFilters({ target_entity: null })
+                                        setFilters({ returning_entity: null })
                                     }
                                 }}
                                 typeKey="retention-table-returning"

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -58,7 +58,7 @@ export function RetentionTab({ annotationsToCreate }: BaseTabProps): JSX.Element
                                 hideMathSelector
                                 hideFilter
                                 buttonCopy="Add graph series"
-                                filters={{ events: [filters.target_entity] }}
+                                filters={{ events: [filters.target_entity] }} // retention filters use target and returning entity instead of events
                                 setFilters={(newFilters: FilterType) => {
                                     if (newFilters.events && newFilters.events.length > 0) {
                                         setFilters({ target_entity: newFilters.events[0] })

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -150,6 +150,8 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
             (featureFlags, eventsLoaded, propertiesLoaded) =>
                 !featureFlags[FEATURE_FLAGS.TAXONOMIC_PROPERTY_FILTER] && (!eventsLoaded || !propertiesLoaded),
         ],
+        actionFilterTargetEntity: [(s) => [s.filters], (filters) => ({ events: [filters.target_entity] })],
+        actionFilterReturningEntity: [(s) => [s.filters], (filters) => ({ events: [filters.returning_entity] })],
     },
     events: ({ actions, props }) => ({
         afterMount: () => props.dashboardItemId && actions.loadResults(),


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

After switching retention to the new filters, a bug came up where the values weren't displaying properly, (the api call was correct though)

fixed:

https://user-images.githubusercontent.com/25164963/129416989-bd5cd727-76b8-4ff9-ac80-18cc07a5e422.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
