### PR TITLE
Revert "Fix white screen bug for sessions table navigation to trends"

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -28,7 +28,8 @@ export function ActionsLineGraph({
     const { filters, indexedResults, resultsLoading, visibilityMap } = useValues(logic)
     const { loadPeople } = useActions(personsModalLogic)
     const [{ fromItem }] = useState(router.values.hashParams)
-    return indexedResults && !resultsLoading && indexedResults[0]?.data ? (
+
+    return indexedResults && !resultsLoading ? (
         indexedResults.filter((result) => result.count !== 0).length > 0 ? (
             <LineGraph
                 data-attr="trend-line-graph"


### PR DESCRIPTION
Reverts PostHog/posthog#5569

This was causing some action line graphs to be stuck in perpetual loading states.

https://posthog.slack.com/archives/C01G8S5T08Z/p1628893937075400

