### PR TITLE
Hide bot users from org members

### DIFF
--- a/frontend/src/scenes/organization/Settings/membersLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/membersLogic.tsx
@@ -21,10 +21,7 @@ export const membersLogic = kea<membersLogicType>({
         members: {
             __default: [],
             loadMembers: async () => {
-                const allMembers = (await api.get('api/organizations/@current/members/')).results
-                return allMembers.filter(
-                    (member: OrganizationMemberType) => !member.user.email.endsWith('posthogbot.user')
-                )
+                return (await api.get('api/organizations/@current/members/')).results
             },
             removeMember: async (member) => {
                 await api.delete(`api/organizations/@current/members/${member.user_id}/`)

--- a/frontend/src/scenes/organization/Settings/membersLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/membersLogic.tsx
@@ -21,7 +21,10 @@ export const membersLogic = kea<membersLogicType>({
         members: {
             __default: [],
             loadMembers: async () => {
-                return (await api.get('api/organizations/@current/members/')).results
+                const allMembers = (await api.get('api/organizations/@current/members/')).results
+                return allMembers.filter(
+                    (member: OrganizationMemberType) => !member.user.email.endsWith('posthogbot.user')
+                )
             },
             removeMember: async (member) => {
                 await api.delete(`api/organizations/@current/members/${member.user_id}/`)

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -77,7 +77,7 @@ class OrganizationMemberViewSet(
 ):
     serializer_class = OrganizationMemberSerializer
     permission_classes = [IsAuthenticated, OrganizationMemberPermissions, OrganizationMemberObjectPermissions]
-    queryset = OrganizationMembership.objects.all()
+    queryset = OrganizationMembership.objects.exclude(user__email__endswith="@posthogbot.user")
     lookup_field = "user_id"
     ordering = ["level", "-joined_at"]
 


### PR DESCRIPTION
## Changes

Will update https://github.com/PostHog/plugin-server/pull/519 so that bot users get a "valid" email with domain `posthogbot.user`.

We can then hide these users in the UI.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
