### PR TITLE
Fix refreshing funnels

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -188,6 +188,7 @@ export const funnelLogic = kea<funnelLogicType>({
 
                     // Don't load results if layout was the only thing changed
                     if (
+                        !refresh &&
                         equal(
                             Object.assign({}, values.filters, { layout: undefined }),
                             Object.assign({}, values.lastAppliedFilters, { layout: undefined })


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/5576 broke funnels refreshing
due to an added equality check

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
