### PR TITLE
Use `Literal` type to type Filter/Property/Entity objects better

### DIFF
--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -36,7 +36,7 @@ class ClickhouseTrendsBreakdown:
         params: Dict[str, Any] = {"team_id": team_id}
         interval_annotation = get_trunc_func_ch(filter.interval)
         num_intervals, seconds_in_interval, round_interval = get_time_diff(
-            filter.interval or "day", filter.date_from, filter.date_to, team_id
+            filter.interval, filter.date_from, filter.date_to, team_id
         )
         _, parsed_date_to, date_params = parse_timestamps(filter=filter, team_id=team_id)
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -41,7 +41,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         if not date_from:
             date_from = get_earliest_timestamp(team_id)
 
-        interval = filter.interval or "day"
+        interval = filter.interval
         num_intervals, seconds_in_interval, _ = get_time_diff(interval, filter.date_from, filter.date_to, team_id)
         interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
         trunc_func = get_trunc_func_ch(interval)
@@ -118,7 +118,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         if not date_from:
             date_from = get_earliest_timestamp(team_id)
 
-        interval = filter.interval or "day"
+        interval = filter.interval
         num_intervals, seconds_in_interval, _ = get_time_diff(
             interval, filter.date_from, filter.date_to, team_id=team_id
         )

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -22,9 +22,7 @@ class ClickhouseTrendsTotalVolume:
 
         trunc_func = get_trunc_func_ch(filter.interval)
         interval_func = get_interval_func_ch(filter.interval)
-        _, seconds_in_interval, _ = get_time_diff(
-            filter.interval or "day", filter.date_from, filter.date_to, team_id=team_id
-        )
+        _, seconds_in_interval, _ = get_time_diff(filter.interval, filter.date_from, filter.date_to, team_id=team_id)
         aggregate_operation, join_condition, math_params = process_math(entity)
 
         trend_event_query = TrendsEventQuery(

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -69,7 +69,7 @@ class TrendsEventQuery(ClickhouseEventQuery):
         date_params: Dict[str, Any] = {}
         interval_annotation = get_trunc_func_ch(self._filter.interval)
         _, _, round_interval = get_time_diff(
-            self._filter.interval or "day", self._filter.date_from, self._filter.date_to, team_id=self._team_id
+            self._filter.interval, self._filter.date_from, self._filter.date_to, team_id=self._team_id
         )
         _, parsed_date_to, date_params = parse_timestamps(filter=self._filter, team_id=self._team_id)
         parsed_date_from = date_from_clause(interval_annotation, round_interval)

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -148,9 +148,7 @@ def _process_content_sql(team: Team, entity: Entity, filter: Filter):
         person_filter, person_filter_params = format_filter_query(cohort)
         person_filter = "AND distinct_id IN ({})".format(person_filter)
     elif filter.breakdown_type and isinstance(filter.breakdown, str) and isinstance(filter.breakdown_value, str):
-        breakdown_prop = Property(
-            **{"key": filter.breakdown, "value": filter.breakdown_value, "type": filter.breakdown_type}
-        )
+        breakdown_prop = Property(key=filter.breakdown, value=filter.breakdown_value, type=filter.breakdown_type)
         filter.properties.append(breakdown_prop)
 
     prop_filters, prop_filter_params = parse_prop_clauses(

--- a/posthog/models/entity.py
+++ b/posthog/models/entity.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -17,7 +17,7 @@ class Entity(PropertyMixin):
     """
 
     id: Union[int, str]
-    type: str
+    type: Literal["events", "actions"]
     order: Optional[int]
     name: Optional[str]
     math: Optional[str]

--- a/posthog/models/filters/mixins/base.py
+++ b/posthog/models/filters/mixins/base.py
@@ -1,4 +1,7 @@
-from typing import Dict
+from typing import Dict, Literal
+
+BreakdownType = Literal["event", "person", "cohort"]
+IntervalType = Literal["minute", "hour", "day", "week", "month"]
 
 
 class BaseParamMixin:

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -165,12 +165,12 @@ class BreakdownValueMixin(BaseParamMixin):
 
 class InsightMixin(BaseParamMixin):
     @cached_property
-    def insight(self) -> str:
+    def insight(self) -> Literal["TRENDS", "SESSIONS", "FUNNELS", "RETENTION", "PATHS", "LIFECYCLE", "STICKINESS"]:
         return self._data.get(INSIGHT, INSIGHT_TRENDS).upper()
 
     @include_dict
     def insight_to_dict(self):
-        return {"insight": self.insight} if self.insight else {}
+        return {"insight": self.insight}
 
 
 class DisplayDerivedMixin(InsightMixin):

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import re
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from dateutil.relativedelta import relativedelta
 from django.db.models.query_utils import Q
@@ -39,6 +39,7 @@ from posthog.models.filters.mixins.utils import cached_property, include_dict
 from posthog.utils import relative_date_parse, str_to_bool
 
 ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
+BreakdownType = Literal["event", "person", "cohort"]
 
 
 class IntervalMixin(BaseParamMixin):
@@ -144,7 +145,7 @@ class BreakdownMixin(BaseParamMixin):
 
 class BreakdownTypeMixin(BaseParamMixin):
     @cached_property
-    def breakdown_type(self) -> Optional[str]:
+    def breakdown_type(self) -> Optional[BreakdownType]:
         return self._data.get(BREAKDOWN_TYPE, None)
 
     @include_dict

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import re
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union, cast
 
 from dateutil.relativedelta import relativedelta
 from django.db.models.query_utils import Q
@@ -40,6 +40,7 @@ from posthog.utils import relative_date_parse, str_to_bool
 
 ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
 BreakdownType = Literal["event", "person", "cohort"]
+IntervalType = Literal["minute", "hour", "day", "week", "month"]
 
 
 class IntervalMixin(BaseParamMixin):
@@ -48,7 +49,7 @@ class IntervalMixin(BaseParamMixin):
     SUPPORTED_INTERVAL_TYPES = ["minute", "hour", "day", "week", "month"]
 
     @cached_property
-    def interval(self) -> str:
+    def interval(self) -> IntervalType:
         interval_candidate = self._data.get(INTERVAL)
         if not interval_candidate:
             return "day"
@@ -57,11 +58,11 @@ class IntervalMixin(BaseParamMixin):
         interval_candidate = interval_candidate.lower()
         if interval_candidate not in self.SUPPORTED_INTERVAL_TYPES:
             raise ValueError(f"Interval {interval_candidate} does not belong to SUPPORTED_INTERVAL_TYPES!")
-        return interval_candidate
+        return cast(IntervalType, interval_candidate)
 
     @include_dict
     def interval_to_dict(self):
-        return {"interval": self.interval} if self.interval else {}
+        return {"interval": self.interval}
 
 
 class SelectorMixin(BaseParamMixin):

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -175,12 +175,23 @@ class InsightMixin(BaseParamMixin):
 
 class DisplayDerivedMixin(InsightMixin):
     @cached_property
-    def display(self) -> str:
+    def display(
+        self,
+    ) -> Literal[
+        "ActionsLineGraphLinear",
+        "ActionsLineGraphCumulative",
+        "ActionsTable",
+        "ActionsPieChart",
+        "ActionsBarChart",
+        "ActionsBarChartValue",
+        "PathsViz",
+        "FunnelViz",
+    ]:
         return self._data.get(DISPLAY, INSIGHT_TO_DISPLAY[self.insight])
 
     @include_dict
     def display_to_dict(self):
-        return {"display": self.display} if self.display else {}
+        return {"display": self.display}
 
 
 class SessionMixin(BaseParamMixin):

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -34,13 +34,11 @@ from posthog.constants import (
     TREND_FILTER_TYPE_EVENTS,
 )
 from posthog.models.entity import Entity, ExclusionEntity
-from posthog.models.filters.mixins.base import BaseParamMixin
+from posthog.models.filters.mixins.base import BaseParamMixin, BreakdownType, IntervalType
 from posthog.models.filters.mixins.utils import cached_property, include_dict
 from posthog.utils import relative_date_parse, str_to_bool
 
 ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
-BreakdownType = Literal["event", "person", "cohort"]
-IntervalType = Literal["minute", "hour", "day", "week", "month"]
 
 
 class IntervalMixin(BaseParamMixin):

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -24,7 +24,7 @@ from posthog.constants import (
     FunnelOrderType,
     FunnelVizType,
 )
-from posthog.models.filters.mixins.base import BaseParamMixin
+from posthog.models.filters.mixins.base import BaseParamMixin, IntervalType
 from posthog.models.filters.mixins.utils import cached_property, include_dict
 from posthog.utils import relative_date_parse, str_to_bool
 
@@ -84,7 +84,7 @@ class FunnelWindowMixin(BaseParamMixin):
         return _amt
 
     @cached_property
-    def funnel_window_interval_unit(self) -> Optional[str]:
+    def funnel_window_interval_unit(self) -> Optional[IntervalType]:
         _unit = self._data.get(FUNNEL_WINDOW_INTERVAL_UNIT, None)
         return _unit.lower() if _unit is not None else _unit
 

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, Optional, Union
+from typing import Dict, Literal, Optional, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -142,7 +142,7 @@ class FunnelPersonsStepBreakdownMixin(BaseParamMixin):
 
 class FunnelLayoutMixin(BaseParamMixin):
     @cached_property
-    def layout(self) -> Optional[str]:
+    def layout(self) -> Optional[Literal["horizontal", "vertical"]]:
         return self._data.get(FUNNEL_LAYOUT)
 
     @include_dict

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -97,7 +97,7 @@ class FunnelWindowMixin(BaseParamMixin):
             dict_part[FUNNEL_WINDOW_INTERVAL_UNIT] = self.funnel_window_interval_unit
         return dict_part
 
-    def funnel_window_interval_unit_ch(self) -> str:
+    def funnel_window_interval_unit_ch(self) -> Literal["DAY", "MINUTE", "HOUR", "WEEK", "MONTH"]:
         if self.funnel_window_interval_unit is None:
             return "DAY"
 

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple
+from typing import Dict, Literal, Optional, Tuple
 
 from posthog.constants import AUTOCAPTURE_EVENT, CUSTOM_EVENT, PAGEVIEW_EVENT, PATH_TYPE, SCREEN_EVENT, START_POINT
 from posthog.models.filters.mixins.common import BaseParamMixin
@@ -7,7 +7,7 @@ from posthog.models.filters.mixins.utils import cached_property, include_dict
 
 class PathTypeMixin(BaseParamMixin):
     @cached_property
-    def path_type(self) -> Optional[str]:
+    def path_type(self) -> Optional[Literal["$pageview", "$autocapture", "$screen", "custom_event"]]:
         return self._data.get(PATH_TYPE, None)
 
     @include_dict

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -1,13 +1,15 @@
-from typing import Dict, Literal, Optional, Tuple
+from typing import Dict, Literal, Optional, Tuple, cast
 
 from posthog.constants import AUTOCAPTURE_EVENT, CUSTOM_EVENT, PAGEVIEW_EVENT, PATH_TYPE, SCREEN_EVENT, START_POINT
 from posthog.models.filters.mixins.common import BaseParamMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
 
+PathType = Literal["$pageview", "$autocapture", "$screen", "custom_event"]
+
 
 class PathTypeMixin(BaseParamMixin):
     @cached_property
-    def path_type(self) -> Optional[Literal["$pageview", "$autocapture", "$screen", "custom_event"]]:
+    def path_type(self) -> Optional[PathType]:
         return self._data.get(PATH_TYPE, None)
 
     @include_dict
@@ -53,12 +55,12 @@ class ComparatorDerivedMixin(PropTypeDerivedMixin):
 
 class TargetEventDerivedMixin(PropTypeDerivedMixin):
     @cached_property
-    def target_event(self) -> Tuple[Optional[str], Dict[str, str]]:
+    def target_event(self) -> Tuple[Optional[PathType], Dict[str, str]]:
         if self.path_type == SCREEN_EVENT:
-            return SCREEN_EVENT, {"event": SCREEN_EVENT}
+            return cast(PathType, SCREEN_EVENT), {"event": SCREEN_EVENT}
         elif self.path_type == AUTOCAPTURE_EVENT:
-            return AUTOCAPTURE_EVENT, {"event": AUTOCAPTURE_EVENT}
+            return cast(PathType, AUTOCAPTURE_EVENT), {"event": AUTOCAPTURE_EVENT}
         elif self.path_type == CUSTOM_EVENT:
             return None, {}
         else:
-            return PAGEVIEW_EVENT, {"event": PAGEVIEW_EVENT}
+            return cast(PathType, PAGEVIEW_EVENT), {"event": PAGEVIEW_EVENT}

--- a/posthog/models/filters/mixins/retention.py
+++ b/posthog/models/filters/mixins/retention.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Literal, Optional, Tuple, Union
 
 from dateutil.relativedelta import relativedelta
 from django.db.models.query_utils import Q
@@ -26,12 +26,12 @@ from posthog.utils import relative_date_parse
 
 class RetentionTypeMixin(BaseParamMixin):
     @cached_property
-    def retention_type(self) -> str:
+    def retention_type(self) -> Literal["retention_recurring", "retention_first_time"]:
         return self._data.get(RETENTION_TYPE, RETENTION_RECURRING)
 
     @include_dict
     def retention_type_to_dict(self):
-        return {"retention_type": self.retention_type} if self.retention_type else {}
+        return {"retention_type": self.retention_type}
 
 
 RETENTION_DEFAULT_INTERVALS = 11

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -7,16 +7,24 @@ from posthog.utils import is_valid_regex
 
 ValueT = Union[str, int, List[str]]
 PropertyType = Literal["event", "person", "cohort", "element"]
+OperatorType = Literal[
+    "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
+]
 
 
 class Property:
     key: str
-    operator: Optional[str]
+    operator: Optional[OperatorType]
     value: ValueT
     type: PropertyType
 
     def __init__(
-        self, key: str, value: ValueT, operator: Optional[str] = None, type: Optional[PropertyType] = None, **kwargs
+        self,
+        key: str,
+        value: ValueT,
+        operator: Optional[OperatorType] = None,
+        type: Optional[PropertyType] = None,
+        **kwargs,
     ) -> None:
         self.key = key
         self.value = value

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -1,21 +1,22 @@
 import json
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from django.db.models import Exists, OuterRef, Q
 
 from posthog.utils import is_valid_regex
 
 ValueT = Union[str, int, List[str]]
+PropertyType = Literal["event", "person", "cohort", "element"]
 
 
 class Property:
     key: str
     operator: Optional[str]
     value: ValueT
-    type: str
+    type: PropertyType
 
     def __init__(
-        self, key: str, value: ValueT, operator: Optional[str] = None, type: Optional[str] = None, **kwargs
+        self, key: str, value: ValueT, operator: Optional[str] = None, type: Optional[PropertyType] = None, **kwargs
     ) -> None:
         self.key = key
         self.value = value

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -380,7 +380,7 @@ def get_trunc_func(period: str) -> Tuple[str, str]:
 class LifecycleTrend:
     def _serialize_lifecycle(self, entity: Entity, filter: Filter, team_id: int) -> List[Dict[str, Any]]:
 
-        period = filter.interval or "day"
+        period = filter.interval
         num_intervals, prev_date_from, date_from, date_to, after_date_to = get_time_diff(
             period, filter.date_from, filter.date_to, team_id
         )
@@ -447,7 +447,7 @@ class LifecycleTrend:
         limit: int = 100,
     ):
         entity = filter.entities[0]
-        period = filter.interval or "day"
+        period = filter.interval
         num_intervals, prev_date_from, date_from, date_to, after_date_to = get_time_diff(
             period, filter.date_from, filter.date_to, team_id
         )

--- a/posthog/queries/trends.py
+++ b/posthog/queries/trends.py
@@ -180,12 +180,12 @@ def add_person_properties_annotations(team_id: int, breakdown: str) -> Dict[str,
 def aggregate_by_interval(
     events: QuerySet, team_id: int, entity: Entity, filter: Filter, breakdown: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], QuerySet]:
-    interval = filter.interval if filter.interval else "day"
+    interval = filter.interval
     interval_annotation = get_interval_annotation(interval)
     filtered_events = events.filter(
         filter_events(team_id, filter, entity, interval_annotation=interval_annotation[interval])
     )
-    values = [interval]
+    values: List[str] = [interval]
     if breakdown:
         if filter.breakdown_type == "cohort":
             cohort_annotations = add_cohort_annotations(


### PR DESCRIPTION
Python 3.8 introduced the new `Literal` type which makes it possible to typecheck static string types.

This syncs up some of our backend types with types.ts.

## Commits

- Type python Property.type
- Type Filter.breakdown_type in python
- Fix typing issue in actions view
- Type python Filter.insight
- Type python Filter.display
- Type python Filter.interval, fix resulting typing errors
- Type python funnel Filter.layout
- Type python funnel Filter.funnel_window_interval_unit
- Type python Filter.retention_type
- Type python funnel Filter.funnel_window_interval_unit_ch
- Type python path Filter.path_type
- Type python path Filter.target_event
- Type Entity.type
- Type python Property.operator

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
