### PR TITLE
Fix docker build

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -8,7 +8,7 @@ COPY . /code/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.6' \
+    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.*' \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y --no-install-recommends 'nodejs=14.*' \
     && npm install -g yarn@1 \


### PR DESCRIPTION
## Changes

This broke due to an upstream change:

- We use `python:3.8-slim` as our base image
- https://github.com/docker-library/python/commit/f154e5d1c8f5b582aa2fd782df880b9cc96bb431 / https://github.com/docker-library/python/pull/633 updated the base image to use debian 11 (bullseye)
- Our builds started failing with `E: Version '12.6' for 'build-essential' was not found` since debian 11 has a newer version of the `build-essential` package available

Fun! Thanks @fuziontech for setting up docker image testing, glad we caught it quick :)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
