### PR TITLE
Only query event columns that are needed

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -1,7 +1,7 @@
 import re
 from datetime import timedelta
 from functools import wraps
-from typing import Dict, no_type_check
+from typing import Dict, Literal, Tuple, no_type_check
 
 from django.utils.timezone import now
 
@@ -10,6 +10,8 @@ from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, TEST
 
 PropertyName = str
 ColumnName = str
+TableWithProperties = Literal["events", "person"]
+TableAndProperty = Tuple[TableWithProperties, str]
 
 
 def cache_for(cache_time: timedelta):

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -1,18 +1,16 @@
 import re
 from datetime import timedelta
 from functools import wraps
-from typing import Dict, Literal, Tuple, no_type_check
+from typing import Dict, Literal, no_type_check
 
 from django.utils.timezone import now
 
 from ee.clickhouse.client import sync_execute
-from posthog.models.property import PropertyType
+from posthog.models.property import PropertyName
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, TEST
 
-PropertyName = str
 ColumnName = str
 TableWithProperties = Literal["events", "person"]
-PropertyAndType = Tuple[str, PropertyType]
 
 
 def cache_for(cache_time: timedelta):

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -6,12 +6,13 @@ from typing import Dict, Literal, Tuple, no_type_check
 from django.utils.timezone import now
 
 from ee.clickhouse.client import sync_execute
+from posthog.models.property import PropertyType
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, TEST
 
 PropertyName = str
 ColumnName = str
 TableWithProperties = Literal["events", "person"]
-TableAndProperty = Tuple[TableWithProperties, str]
+PropertyAndType = Tuple[str, PropertyType]
 
 
 def cache_for(cache_time: timedelta):

--- a/ee/clickhouse/materialized_columns/filter.py
+++ b/ee/clickhouse/materialized_columns/filter.py
@@ -1,0 +1,61 @@
+from typing import List, Set
+
+from ee.clickhouse.materialized_columns import get_materialized_columns
+from ee.clickhouse.materialized_columns.columns import ColumnName, PropertyName
+from ee.clickhouse.models.action import get_action_tables_and_properties
+from ee.clickhouse.models.property import TableAndProperty, extract_tables_and_properties
+from posthog.constants import TREND_FILTER_TYPE_ACTIONS
+from posthog.models.filters import Filter
+from posthog.models.filters.mixins.utils import cached_property
+from posthog.models.property import Property
+from posthog.models.team import Team
+
+
+class MaterializedColumnFilter:
+    """
+    This class is responsible for figuring out what columns can and should be materialized based on the query filter.
+
+    This speeds
+    """
+
+    def __init__(self, filter: Filter, team_id: int):
+        self.filter = filter
+        self.team_id = team_id
+
+    @cached_property
+    def event_columns_to_query(self) -> List[ColumnName]:
+        materialized_columns = get_materialized_columns("events")
+        return [
+            materialized_columns[property_name]
+            for table, property_name in self.properties_used_in_filter
+            if table == "events" and property_name in materialized_columns
+        ]
+
+    @cached_property
+    def should_query_event_properties_column(self) -> bool:
+        return len(self.event_columns_to_query) != len(self.properties_used_in_filter)
+
+    @cached_property
+    def properties_used_in_filter(self) -> Set[TableAndProperty]:
+        result: Set[TableAndProperty] = set()
+
+        result.extend(extract_tables_and_properties(self._filter.properties))
+        if self._filter.filter_test_accounts:
+            test_account_filters = Team.objects.only("test_account_filters").get(id=self.team_id).test_account_filters
+            result.extend(extract_tables_and_properties([Property(**prop) for prop in test_account_filters]))
+
+        if self._filter.breakdown_type == "person":
+            result.add(("person", self._filter.breakdown))
+        elif self._filter.breakdown_type == "event":
+            result.add(("events", self._filter.breakdown))
+
+        for entity in self._filter.entities:
+            result.extend(extract_tables_and_properties(entity.properties))
+
+            if entity.math_property:
+                result.add(("events", entity.math_property))
+
+            if entity.type == TREND_FILTER_TYPE_ACTIONS:
+                result.extend(get_action_tables_and_properties(entity.get_action()))
+
+        return result

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -2,10 +2,10 @@ from typing import Dict, List, Set, Tuple
 
 from django.forms.models import model_to_dict
 
-from ee.clickhouse.materialized_columns.columns import PropertyAndType
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Action, Entity, Filter
 from posthog.models.action_step import ActionStep
+from posthog.models.property import PropertyName, PropertyType
 
 
 def format_action_filter(
@@ -101,10 +101,10 @@ def format_entity_filter(entity: Entity, prepend: str = "action", filter_by_team
     return entity_filter, params
 
 
-def get_action_tables_and_properties(action: Action) -> Set[PropertyAndType]:
+def get_action_tables_and_properties(action: Action) -> Set[Tuple[PropertyName, PropertyType]]:
     from ee.clickhouse.models.property import extract_tables_and_properties
 
-    result: Set[PropertyAndType] = set()
+    result: Set[Tuple[PropertyName, PropertyType]] = set()
 
     for action_step in action.steps.all():
         if action_step.url:

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -1,9 +1,8 @@
-from typing import Dict, List, Literal, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 from django.forms.models import model_to_dict
-from rest_framework.exceptions import ValidationError
 
-from ee.clickhouse.models.property import TableAndProperty, extract_tables_and_properties
+from ee.clickhouse.materialized_columns.columns import TableAndProperty
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Action, Entity, Filter
 from posthog.models.action_step import ActionStep
@@ -103,6 +102,8 @@ def format_entity_filter(entity: Entity, prepend: str = "action", filter_by_team
 
 
 def get_action_tables_and_properties(action: Action) -> Set[TableAndProperty]:
+    from ee.clickhouse.models.property import extract_tables_and_properties
+
     result = set()
 
     for step in action.steps():

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -5,8 +5,8 @@ from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.materialized_columns.columns import (
+    PropertyAndType,
     PropertyName,
-    TableAndProperty,
     TableWithProperties,
     get_materialized_columns,
 )
@@ -187,7 +187,7 @@ def prop_filter_json_extract(
         )
 
 
-def property_table(property: Property) -> str:
+def property_table(property: Property) -> TableWithProperties:
     if property.type == "event":
         return "events"
     elif property.type == "person":
@@ -296,11 +296,5 @@ def _create_regex(selector: Selector) -> str:
     return regex
 
 
-def extract_tables_and_properties(props: List[Property]) -> Set[TableAndProperty]:
-    result: Set[TableAndProperty] = set()
-    for prop in props:
-        if prop.type == "person":
-            result.add(("person", prop.key))
-        elif prop.type == "event":
-            result.add(("events", prop.key))
-    return result
+def extract_tables_and_properties(props: List[Property]) -> Set[PropertyAndType]:
+    return set((prop.key, prop.type) for prop in props)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -1,10 +1,15 @@
 import re
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.materialized_columns.columns import PropertyName, TableAndProperty, get_materialized_columns
+from ee.clickhouse.materialized_columns.columns import (
+    PropertyName,
+    TableAndProperty,
+    TableWithProperties,
+    get_materialized_columns,
+)
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
@@ -192,7 +197,7 @@ def property_table(property: Property) -> str:
 
 
 def get_property_string_expr(
-    table: TableAndProperty, property_name: PropertyName, var: str, prop_var: str, allow_denormalized_props: bool
+    table: TableWithProperties, property_name: PropertyName, var: str, prop_var: str, allow_denormalized_props: bool
 ) -> Tuple[str, bool]:
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -1,10 +1,10 @@
 import re
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.materialized_columns.columns import ColumnName, PropertyName, get_materialized_columns
+from ee.clickhouse.materialized_columns.columns import PropertyName, TableAndProperty, get_materialized_columns
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
@@ -14,9 +14,6 @@ from posthog.models.event import Selector
 from posthog.models.property import Property
 from posthog.models.team import Team
 from posthog.utils import is_valid_regex, relative_date_parse
-
-TableWithProperties = Literal["events", "person"]
-TableAndProperty = Tuple[TableWithProperties, str]
 
 
 def parse_prop_clauses(

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -1,22 +1,17 @@
 import re
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from django.utils import timezone
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.materialized_columns.columns import (
-    PropertyAndType,
-    PropertyName,
-    TableWithProperties,
-    get_materialized_columns,
-)
+from ee.clickhouse.materialized_columns.columns import TableWithProperties, get_materialized_columns
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
 from ee.clickhouse.sql.person import GET_DISTINCT_IDS_BY_PROPERTY_SQL
 from posthog.models.cohort import Cohort
 from posthog.models.event import Selector
-from posthog.models.property import Property
+from posthog.models.property import Property, PropertyName, PropertyType
 from posthog.models.team import Team
 from posthog.utils import is_valid_regex, relative_date_parse
 
@@ -296,5 +291,5 @@ def _create_regex(selector: Selector) -> str:
     return regex
 
 
-def extract_tables_and_properties(props: List[Property]) -> Set[PropertyAndType]:
+def extract_tables_and_properties(props: List[Property]) -> Set[Tuple[PropertyName, PropertyType]]:
     return set((prop.key, prop.type) for prop in props)

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, cast
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.cohort import format_filter_query
@@ -81,7 +81,7 @@ def get_breakdown_event_prop_values(
     entity_params, entity_format_params = populate_entity_params(entity)
 
     value_expression, _ = get_property_string_expr(
-        "events", filter.breakdown, "%(key)s", "properties", allow_denormalized_props=True
+        "events", cast(str, filter.breakdown), "%(key)s", "properties", allow_denormalized_props=True
     )
 
     elements_query = TOP_ELEMENTS_ARRAY_OF_KEY_SQL.format(

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Tuple
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.cohort import format_filter_query
-from ee.clickhouse.models.property import parse_prop_clauses
+from ee.clickhouse.models.property import get_property_string_expr, parse_prop_clauses
 from ee.clickhouse.queries.trends.util import populate_entity_params
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.person import GET_LATEST_PERSON_SQL, GET_TEAM_PERSON_DISTINCT_IDS
@@ -80,7 +80,12 @@ def get_breakdown_event_prop_values(
 
     entity_params, entity_format_params = populate_entity_params(entity)
 
+    value_expression, _ = get_property_string_expr(
+        "events", filter.breakdown, "%(key)s", "properties", allow_denormalized_props=True
+    )
+
     elements_query = TOP_ELEMENTS_ARRAY_OF_KEY_SQL.format(
+        value_expression=value_expression,
         parsed_date_from=parsed_date_from,
         parsed_date_to=parsed_date_to,
         prop_filters=prop_filters,
@@ -91,7 +96,7 @@ def get_breakdown_event_prop_values(
         filter=filter,
         team_id=team_id,
         query=elements_query,
-        params={**prop_filter_params, **entity_params, **extra_params},
+        params={**prop_filter_params, **entity_params, **extra_params, "key": filter.breakdown},
         limit=limit,
     )
 
@@ -115,9 +120,9 @@ def _format_all_query(team_id: int, filter: Filter, **kwargs) -> Tuple[str, Dict
     query = f"""
             SELECT DISTINCT distinct_id, 0 as value
             FROM events all_events
-            WHERE team_id = {team_id} 
-            {parsed_date_from} 
-            {parsed_date_to} 
+            WHERE team_id = {team_id}
+            {parsed_date_from}
+            {parsed_date_to}
             {prop_filters}
             """
     return query, {**date_params, **prop_filter_params}

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -26,15 +26,13 @@ class ColumnOptimizer:
         materialized_columns = get_materialized_columns("events")
         return [
             materialized_columns[property_name]
-            for property_name, type in self.properties_used_in_filter
-            if type == "event" and property_name in materialized_columns
+            for property_name, type in self._used_properties_with_type("event")
+            if property_name in materialized_columns
         ]
 
     @cached_property
     def should_query_event_properties_column(self) -> bool:
-        return len(self.materialized_event_columns_to_query) != len(
-            [1 for _, type in self.properties_used_in_filter if type == "event"]
-        )
+        return len(self.materialized_event_columns_to_query) != len(self._used_properties_with_type("event"))
 
     @cached_property
     def properties_used_in_filter(self) -> Set[Tuple[PropertyName, PropertyType]]:
@@ -60,3 +58,6 @@ class ColumnOptimizer:
                 result |= get_action_tables_and_properties(entity.get_action())
 
         return result
+
+    def _used_properties_with_type(self, property_type: PropertyType) -> Set[Tuple[PropertyName, PropertyType]]:
+        return set((name, type) for name, type in self.properties_used_in_filter if type == property_type)

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -22,7 +22,7 @@ class ColumnOptimizer:
         self.team_id = team_id
 
     @cached_property
-    def event_columns_to_query(self) -> List[ColumnName]:
+    def materialized_event_columns_to_query(self) -> List[ColumnName]:
         materialized_columns = get_materialized_columns("events")
         return [
             materialized_columns[property_name]
@@ -32,7 +32,9 @@ class ColumnOptimizer:
 
     @cached_property
     def should_query_event_properties_column(self) -> bool:
-        return len(self.event_columns_to_query) != len(self.properties_used_in_filter)
+        return len(self.materialized_event_columns_to_query) != len(
+            [1 for _, type in self.properties_used_in_filter if type == "event"]
+        )
 
     @cached_property
     def properties_used_in_filter(self) -> Set[Tuple[PropertyName, PropertyType]]:

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -1,9 +1,8 @@
 from typing import List, Set
 
-from ee.clickhouse.materialized_columns import get_materialized_columns
-from ee.clickhouse.materialized_columns.columns import ColumnName
+from ee.clickhouse.materialized_columns.columns import ColumnName, TableAndProperty, get_materialized_columns
 from ee.clickhouse.models.action import get_action_tables_and_properties
-from ee.clickhouse.models.property import TableAndProperty, extract_tables_and_properties
+from ee.clickhouse.models.property import extract_tables_and_properties
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters import Filter
 from posthog.models.filters.mixins.utils import cached_property

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -1,7 +1,7 @@
 from typing import List, Set
 
 from ee.clickhouse.materialized_columns import get_materialized_columns
-from ee.clickhouse.materialized_columns.columns import ColumnName, PropertyName
+from ee.clickhouse.materialized_columns.columns import ColumnName
 from ee.clickhouse.models.action import get_action_tables_and_properties
 from ee.clickhouse.models.property import TableAndProperty, extract_tables_and_properties
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
@@ -11,11 +11,11 @@ from posthog.models.property import Property
 from posthog.models.team import Team
 
 
-class MaterializedColumnFilter:
+class ColumnOptimizer:
     """
     This class is responsible for figuring out what columns can and should be materialized based on the query filter.
 
-    This speeds
+    This speeds up queries since clickhouse ends up selecting less data.
     """
 
     def __init__(self, filter: Filter, team_id: int):

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -38,23 +38,23 @@ class ColumnOptimizer:
     def properties_used_in_filter(self) -> Set[TableAndProperty]:
         result: Set[TableAndProperty] = set()
 
-        result.extend(extract_tables_and_properties(self._filter.properties))
-        if self._filter.filter_test_accounts:
+        result |= extract_tables_and_properties(self.filter.properties)
+        if self.filter.filter_test_accounts:
             test_account_filters = Team.objects.only("test_account_filters").get(id=self.team_id).test_account_filters
-            result.extend(extract_tables_and_properties([Property(**prop) for prop in test_account_filters]))
+            result |= extract_tables_and_properties([Property(**prop) for prop in test_account_filters])
 
-        if self._filter.breakdown_type == "person":
-            result.add(("person", self._filter.breakdown))
-        elif self._filter.breakdown_type == "event":
-            result.add(("events", self._filter.breakdown))
+        if self.filter.breakdown_type == "person":
+            result.add(("person", self.filter.breakdown))
+        elif self.filter.breakdown_type == "event":
+            result.add(("events", self.filter.breakdown))
 
-        for entity in self._filter.entities:
-            result.extend(extract_tables_and_properties(entity.properties))
+        for entity in self.filter.entities:
+            result |= extract_tables_and_properties(entity.properties)
 
             if entity.math_property:
                 result.add(("events", entity.math_property))
 
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
-                result.extend(get_action_tables_and_properties(entity.get_action()))
+                result |= get_action_tables_and_properties(entity.get_action())
 
         return result

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -1,13 +1,12 @@
-from typing import List, Set
+from typing import List, Set, Tuple
 
-from ee.clickhouse.materialized_columns.columns import ColumnName, PropertyAndType, get_materialized_columns
+from ee.clickhouse.materialized_columns.columns import ColumnName, get_materialized_columns
 from ee.clickhouse.models.action import get_action_tables_and_properties
 from ee.clickhouse.models.property import extract_tables_and_properties
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters import Filter
-from posthog.models.filters.mixins.base import BreakdownType
 from posthog.models.filters.mixins.utils import cached_property
-from posthog.models.property import Property
+from posthog.models.property import Property, PropertyName, PropertyType
 from posthog.models.team import Team
 
 
@@ -36,8 +35,8 @@ class ColumnOptimizer:
         return len(self.event_columns_to_query) != len(self.properties_used_in_filter)
 
     @cached_property
-    def properties_used_in_filter(self) -> Set[PropertyAndType]:
-        result: Set[PropertyAndType] = set()
+    def properties_used_in_filter(self) -> Set[Tuple[PropertyName, PropertyType]]:
+        result: Set[Tuple[PropertyName, PropertyType]] = set()
 
         result |= extract_tables_and_properties(self.filter.properties)
         if self.filter.filter_test_accounts:

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -1,7 +1,7 @@
 from typing import List, Set, Tuple
 
 from ee.clickhouse.materialized_columns.columns import ColumnName, get_materialized_columns
-from ee.clickhouse.models.action import get_action_tables_and_properties
+from ee.clickhouse.models.action import get_action_tables_and_properties, uses_elements_chain
 from ee.clickhouse.models.property import extract_tables_and_properties
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters import Filter
@@ -52,10 +52,7 @@ class ColumnOptimizer:
                 return True
 
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
-                properties = list(
-                    Property(**prop) for step in entity.get_action().steps.all() for prop in step.properties
-                )
-                if has_element_type_property(properties):
+                if uses_elements_chain(entity.get_action()):
                     return True
 
         return False

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -35,7 +35,9 @@ class ColumnOptimizer:
 
     @cached_property
     def should_query_event_properties_column(self) -> bool:
-        return len(self.materialized_event_columns_to_query) != len(self._used_properties_with_type("event"))
+        # :TODO: Once issue 5463 is solved (supporting materialized columns everywhere), uncomment this
+        # return len(self.materialized_event_columns_to_query) != len(self._used_properties_with_type("event"))
+        return True
 
     @cached_property
     def should_query_elements_chain_column(self) -> bool:

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -1,9 +1,10 @@
-from typing import List, Set, Tuple
+from typing import List, Set, Tuple, cast
 
 from ee.clickhouse.materialized_columns.columns import ColumnName, get_materialized_columns
 from ee.clickhouse.models.action import get_action_tables_and_properties, uses_elements_chain
 from ee.clickhouse.models.property import extract_tables_and_properties
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
+from posthog.models.entity import Entity
 from posthog.models.filters import Filter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.property import Property, PropertyName, PropertyType
@@ -47,7 +48,7 @@ class ColumnOptimizer:
             if has_element_type_property(properties):
                 return True
 
-        for entity in self.filter.entities:
+        for entity in self.filter.entities + cast(List[Entity], self.filter.exclusions):
             if has_element_type_property(entity.properties):
                 return True
 
@@ -71,7 +72,7 @@ class ColumnOptimizer:
             assert isinstance(self.filter.breakdown, str)
             result.add((self.filter.breakdown, self.filter.breakdown_type))
 
-        for entity in self.filter.entities:
+        for entity in self.filter.entities + cast(List[Entity], self.filter.exclusions):
             result |= extract_tables_and_properties(entity.properties)
 
             if entity.math_property:

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -152,7 +152,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
 
         if filter_test_accounts:
             test_account_filters = Team.objects.only("test_account_filters").get(id=team_id).test_account_filters
-            filters.extend([Property(**prop) for prop in test_account_filters])
+            filters += [Property(**prop) for prop in test_account_filters]
 
         for idx, prop in enumerate(filters):
             if prop.type == "cohort":

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -12,14 +12,14 @@ class FunnelEventQuery(ClickhouseEventQuery):
             f"{self.EVENT_TABLE_ALIAS}.event as event, "
             + f"{self.EVENT_TABLE_ALIAS}.team_id as team_id, "
             + f"{self.EVENT_TABLE_ALIAS}.distinct_id as distinct_id, "
-            + f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp, "
+            + f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp"
             + (
-                f"{self.EVENT_TABLE_ALIAS}.properties as properties, "
+                f", {self.EVENT_TABLE_ALIAS}.properties as properties"
                 if column_optimizer.should_query_event_properties_column
                 else ""
             )
             + (
-                f"{self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
+                f", {self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
                 if column_optimizer.should_query_elements_chain_column
                 else ""
             )

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -7,7 +7,7 @@ from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 
 class FunnelEventQuery(ClickhouseEventQuery):
     def get_query(self, entities=None, entity_name="events", skip_entity_filter=False) -> Tuple[str, Dict[str, Any]]:
-        column_filter = ColumnOptimizer(self._filter, self._team_id)
+        column_optimizer = ColumnOptimizer(self._filter, self._team_id)
         _fields = (
             f"{self.EVENT_TABLE_ALIAS}.event as event, "
             + f"{self.EVENT_TABLE_ALIAS}.team_id as team_id, "
@@ -15,7 +15,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
             + f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp, "
             + (
                 f"{self.EVENT_TABLE_ALIAS}.properties as properties, "
-                if column_filter.should_query_event_properties_column
+                if column_optimizer.should_query_event_properties_column
                 else ""
             )
             + f"{self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
@@ -25,7 +25,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
                 " ".join(
                     [
                         f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
-                        for column_name in column_filter.event_columns_to_query
+                        for column_name in column_optimizer.event_columns_to_query
                     ]
                 )
             )

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -25,7 +25,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
                 " ".join(
                     [
                         f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
-                        for column_name in column_optimizer.event_columns_to_query
+                        for column_name in column_optimizer.materialized_event_columns_to_query
                     ]
                 )
             )

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -10,7 +10,12 @@ from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 class FunnelEventQuery(ClickhouseEventQuery):
     def get_query(self, entities=None, entity_name="events", skip_entity_filter=False) -> Tuple[str, Dict[str, Any]]:
         _fields = (
-            f"{self.EVENT_TABLE_ALIAS}.event as event, {self.EVENT_TABLE_ALIAS}.team_id as team_id, {self.EVENT_TABLE_ALIAS}.distinct_id as distinct_id, {self.EVENT_TABLE_ALIAS}.timestamp as timestamp, {self.EVENT_TABLE_ALIAS}.properties as properties, {self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
+            f"{self.EVENT_TABLE_ALIAS}.event as event, "
+            + f"{self.EVENT_TABLE_ALIAS}.team_id as team_id, "
+            + f"{self.EVENT_TABLE_ALIAS}.distinct_id as distinct_id, "
+            + f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp, "
+            + f"{self.EVENT_TABLE_ALIAS}.properties as properties, "
+            + f"{self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
             + (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "")
             + (f", {self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons else "")
             + (

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -18,7 +18,11 @@ class FunnelEventQuery(ClickhouseEventQuery):
                 if column_optimizer.should_query_event_properties_column
                 else ""
             )
-            + f"{self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
+            + (
+                f"{self.EVENT_TABLE_ALIAS}.elements_chain as elements_chain"
+                if column_optimizer.should_query_elements_chain_column
+                else ""
+            )
             + (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "")
             + (f", {self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons else "")
             + (

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, Tuple
 
-from ee.clickhouse.materialized_columns.filter import MaterializedColumnFilter
+from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 
 
 class FunnelEventQuery(ClickhouseEventQuery):
     def get_query(self, entities=None, entity_name="events", skip_entity_filter=False) -> Tuple[str, Dict[str, Any]]:
-        column_filter = MaterializedColumnFilter(self._filter, self._team_id)
+        column_filter = ColumnOptimizer(self._filter, self._team_id)
         _fields = (
             f"{self.EVENT_TABLE_ALIAS}.event as event, "
             + f"{self.EVENT_TABLE_ALIAS}.team_id as team_id, "

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -100,12 +100,12 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         optimizer = lambda: ColumnOptimizer(FILTER_WITH_PROPERTIES, self.team.id)
 
         self.assertEqual(optimizer().materialized_event_columns_to_query, [])
-        self.assertEqual(optimizer().should_query_event_properties_column, True)
+        # self.assertEqual(optimizer().should_query_event_properties_column, True)
 
         materialize("events", "event_prop")
 
         self.assertEqual(optimizer().materialized_event_columns_to_query, ["mat_event_prop"])
-        self.assertEqual(optimizer().should_query_event_properties_column, False)
+        # self.assertEqual(optimizer().should_query_event_properties_column, False)
 
     def test_should_query_element_chain_column(self):
         should_query_elements_chain_column = lambda filter: ColumnOptimizer(

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -5,38 +5,23 @@ from posthog.models import Action, ActionStep
 from posthog.models.filters import Filter
 from posthog.test.base import APIBaseTest
 
-BASE_FILTER = Filter({"events": [{"id": "$pageview", "type": "events", "order": 0}]})
+PROPERTIES_OF_ALL_TYPES = [
+    {"key": "event_prop", "value": ["foo", "bar"], "type": "event"},
+    {"key": "person_prop", "value": "efg", "type": "person"},
+    {"key": "id", "value": 1, "type": "cohort"},
+    {"key": "tag_name", "value": ["label"], "operator": "exact", "type": "element"},
+]
 
+BASE_FILTER = Filter({"events": [{"id": "$pageview", "type": "events", "order": 0}]})
 FILTER_BY_TEST_ACCOUNTS = BASE_FILTER.with_data({"filter_test_accounts": True})
-FILTER_WITH_PROPERTIES = BASE_FILTER.with_data(
-    {
-        "properties": [
-            {"key": "event_prop", "value": ["foo", "bar"], "type": "event"},
-            {"key": "person_prop", "value": "efg", "type": "person"},
-            {"key": "id", "value": 1, "type": "cohort"},
-            {"key": "tag_name", "value": ["label"], "operator": "exact", "type": "element"},
-        ]
-    }
-)
+FILTER_WITH_PROPERTIES = BASE_FILTER.with_data({"properties": PROPERTIES_OF_ALL_TYPES})
 
 
 class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
     def setUp(self):
         super().setUp()
-        self.team.test_account_filters = [
-            {"key": "email", "type": "person", "value": "posthog.com", "operator": "not_icontains"},
-            {
-                "key": "$host",
-                "type": "event",
-                "value": ["127.0.0.1:3000", "127.0.0.1:5000", "localhost:5000", "localhost:8000"],
-                "operator": "is_not",
-            },
-            {"key": "distinct_id", "type": "event", "value": "posthog.com", "operator": "not_icontains"},
-        ]
+        self.team.test_account_filters = PROPERTIES_OF_ALL_TYPES
         self.team.save()
-
-    def column_optimizer(self, filter: Filter):
-        return ColumnOptimizer(filter, self.team.id)
 
     def test_properties_used_in_filter(self):
         properties_used_in_filter = lambda filter: ColumnOptimizer(filter, self.team.id).properties_used_in_filter
@@ -44,7 +29,7 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(properties_used_in_filter(BASE_FILTER), set())
         self.assertEqual(
             properties_used_in_filter(FILTER_BY_TEST_ACCOUNTS),
-            {("$host", "event"), ("distinct_id", "event"), ("email", "person")},
+            {("event_prop", "event"), ("person_prop", "person"), ("id", "cohort"), ("tag_name", "element")},
         )
         self.assertEqual(
             properties_used_in_filter(FILTER_WITH_PROPERTIES),
@@ -70,12 +55,7 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
                         "order": 0,
                         "math": "sum",
                         "math_property": "numeric_prop",
-                        "properties": [
-                            {"key": "event_prop", "value": ["foo", "bar"], "type": "event"},
-                            {"key": "person_prop", "value": "efg", "type": "person"},
-                            {"key": "id", "value": 1, "type": "cohort"},
-                            {"key": "tag_name", "value": ["label"], "operator": "exact", "type": "element"},
-                        ],
+                        "properties": PROPERTIES_OF_ALL_TYPES,
                     }
                 ]
             }
@@ -120,3 +100,24 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(optimizer().materialized_event_columns_to_query, ["mat_event_prop"])
         self.assertEqual(optimizer().should_query_event_properties_column, False)
+
+    def test_should_query_element_chain_column(self):
+        should_query_elements_chain_column = lambda filter: ColumnOptimizer(
+            filter, self.team.id
+        ).should_query_elements_chain_column
+
+        self.assertEqual(should_query_elements_chain_column(BASE_FILTER), False)
+
+        self.assertEqual(should_query_elements_chain_column(FILTER_BY_TEST_ACCOUNTS), True)
+
+        self.team.test_account_filters = PROPERTIES_OF_ALL_TYPES[:2]  # Without the element filter
+        self.team.save()
+
+        self.assertEqual(should_query_elements_chain_column(FILTER_BY_TEST_ACCOUNTS), False)
+
+        self.assertEqual(should_query_elements_chain_column(FILTER_WITH_PROPERTIES), True)
+
+        filter = Filter(
+            data={"events": [{"id": "$pageview", "type": "events", "order": 0, "properties": PROPERTIES_OF_ALL_TYPES,}]}
+        )
+        self.assertEqual(should_query_elements_chain_column(filter), True)

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -90,6 +90,12 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
             {("$current_url", "event"), ("$browser", "person")},
         )
 
+        filter = BASE_FILTER.with_data({"exclusions": [{"id": action.id, "type": "actions"}]})
+        self.assertEqual(
+            ColumnOptimizer(filter, self.team.id).properties_used_in_filter,
+            {("$current_url", "event"), ("$browser", "person")},
+        )
+
     def test_materialized_columns_checks(self):
         optimizer = lambda: ColumnOptimizer(FILTER_WITH_PROPERTIES, self.team.id)
 
@@ -137,6 +143,11 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
             action=action, event="$autocapture", tag_name="button", text="Pay $10",
         )
 
+        self.assertEqual(
+            ColumnOptimizer(filter, self.team.id).should_query_elements_chain_column, True,
+        )
+
+        filter = BASE_FILTER.with_data({"exclusions": [{"id": action.id, "type": "actions"}]})
         self.assertEqual(
             ColumnOptimizer(filter, self.team.id).should_query_elements_chain_column, True,
         )

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -1,0 +1,122 @@
+from ee.clickhouse.materialized_columns import materialize
+from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.models import Action, ActionStep
+from posthog.models.filters import Filter
+from posthog.test.base import APIBaseTest
+
+BASE_FILTER = Filter({"events": [{"id": "$pageview", "type": "events", "order": 0}]})
+
+FILTER_BY_TEST_ACCOUNTS = BASE_FILTER.with_data({"filter_test_accounts": True})
+FILTER_WITH_PROPERTIES = BASE_FILTER.with_data(
+    {
+        "properties": [
+            {"key": "event_prop", "value": ["foo", "bar"], "type": "event"},
+            {"key": "person_prop", "value": "efg", "type": "person"},
+            {"key": "id", "value": 1, "type": "cohort"},
+            {"key": "tag_name", "value": ["label"], "operator": "exact", "type": "element"},
+        ]
+    }
+)
+
+
+class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.test_account_filters = [
+            {"key": "email", "type": "person", "value": "posthog.com", "operator": "not_icontains"},
+            {
+                "key": "$host",
+                "type": "event",
+                "value": ["127.0.0.1:3000", "127.0.0.1:5000", "localhost:5000", "localhost:8000"],
+                "operator": "is_not",
+            },
+            {"key": "distinct_id", "type": "event", "value": "posthog.com", "operator": "not_icontains"},
+        ]
+        self.team.save()
+
+    def column_optimizer(self, filter: Filter):
+        return ColumnOptimizer(filter, self.team.id)
+
+    def test_properties_used_in_filter(self):
+        properties_used_in_filter = lambda filter: ColumnOptimizer(filter, self.team.id).properties_used_in_filter
+
+        self.assertEqual(properties_used_in_filter(BASE_FILTER), set())
+        self.assertEqual(
+            properties_used_in_filter(FILTER_BY_TEST_ACCOUNTS),
+            {("$host", "event"), ("distinct_id", "event"), ("email", "person")},
+        )
+        self.assertEqual(
+            properties_used_in_filter(FILTER_WITH_PROPERTIES),
+            {("event_prop", "event"), ("person_prop", "person"), ("id", "cohort"), ("tag_name", "element")},
+        )
+
+        # Breakdown cases
+        filter = BASE_FILTER.with_data({"breakdown": "some_prop", "breakdown_type": "person"})
+        self.assertEqual(properties_used_in_filter(filter), {("some_prop", "person")})
+
+        filter = BASE_FILTER.with_data({"breakdown": "some_prop", "breakdown_type": "event"})
+        self.assertEqual(properties_used_in_filter(filter), {("some_prop", "event")})
+
+        filter = BASE_FILTER.with_data({"breakdown": [11], "breakdown_type": "cohort"})
+        self.assertEqual(properties_used_in_filter(filter), set())
+
+        filter = Filter(
+            data={
+                "events": [
+                    {
+                        "id": "$pageview",
+                        "type": "events",
+                        "order": 0,
+                        "math": "sum",
+                        "math_property": "numeric_prop",
+                        "properties": [
+                            {"key": "event_prop", "value": ["foo", "bar"], "type": "event"},
+                            {"key": "person_prop", "value": "efg", "type": "person"},
+                            {"key": "id", "value": 1, "type": "cohort"},
+                            {"key": "tag_name", "value": ["label"], "operator": "exact", "type": "element"},
+                        ],
+                    }
+                ]
+            }
+        )
+        self.assertEqual(
+            properties_used_in_filter(filter),
+            {
+                ("numeric_prop", "event"),
+                ("event_prop", "event"),
+                ("person_prop", "person"),
+                ("id", "cohort"),
+                ("tag_name", "element"),
+            },
+        )
+
+    def test_properties_used_in_filter_with_actions(self):
+        action = Action.objects.create(team=self.team)
+        ActionStep.objects.create(
+            event="$autocapture", action=action, url="https://example.com/donate", url_matching=ActionStep.EXACT,
+        )
+        ActionStep.objects.create(
+            action=action,
+            event="$autocapture",
+            tag_name="button",
+            text="Pay $10",
+            properties=[{"key": "$browser", "value": "Chrome", "type": "person"}],
+        )
+
+        filter = Filter(data={"actions": [{"id": action.id, "math": "dau"}]})
+        self.assertEqual(
+            ColumnOptimizer(filter, self.team.id).properties_used_in_filter,
+            {("$current_url", "event"), ("$browser", "person")},
+        )
+
+    def test_materialized_columns_checks(self):
+        optimizer = lambda: ColumnOptimizer(FILTER_WITH_PROPERTIES, self.team.id)
+
+        self.assertEqual(optimizer().materialized_event_columns_to_query, [])
+        self.assertEqual(optimizer().should_query_event_properties_column, True)
+
+        materialize("events", "event_prop")
+
+        self.assertEqual(optimizer().materialized_event_columns_to_query, ["mat_event_prop"])
+        self.assertEqual(optimizer().should_query_event_properties_column, False)

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -65,8 +65,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         )
 
         correct = """
-        SELECT e.timestamp as timestamp,
-        e.properties as properties
+        SELECT e.timestamp as timestamp
         FROM events e
         WHERE team_id = %(team_id)s
             AND event = %(event)s
@@ -91,10 +90,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         entity = Entity({"id": "viewed", "type": "events"})
 
-        global_prop_query, global_prop_query_params = TrendsEventQuery(
-            filter=filter, entity=entity, team_id=self.team.pk
-        ).get_query()
-        sync_execute(global_prop_query, global_prop_query_params)
+        self._run_query(filter, entity)
 
         filter = Filter(
             data={
@@ -115,12 +111,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        entity_prop_query = self._run_query(filter, entity)
-
-        # global queries and enttiy queries should be the same
-        self.assertEqual(
-            sqlparse.format(global_prop_query, reindent=True), sqlparse.format(entity_prop_query, reindent=True)
-        )
+        self._run_query(filter, entity)
 
     def test_event_properties_filter(self):
         filter = Filter(
@@ -134,10 +125,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         entity = Entity({"id": "viewed", "type": "events"})
 
-        global_prop_query, global_prop_query_params = TrendsEventQuery(
-            filter=filter, entity=entity, team_id=self.team.pk
-        ).get_query()
-        sync_execute(global_prop_query, global_prop_query_params)
+        self._run_query(filter, entity)
 
         filter = Filter(
             data={
@@ -155,12 +143,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        entity_prop_query = self._run_query(filter, entity)
-
-        # global queries and enttiy queries should be the same
-        self.assertEqual(
-            sqlparse.format(global_prop_query, reindent=True), sqlparse.format(entity_prop_query, reindent=True)
-        )
+        self._run_query(filter, entity)
 
     # just smoke test making sure query runs because no new functions are used here
     def test_cohort_filter(self):

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -65,7 +65,8 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         )
 
         correct = """
-        SELECT e.timestamp as timestamp
+        SELECT e.timestamp as timestamp,
+               e.properties as properties
         FROM events e
         WHERE team_id = %(team_id)s
             AND event = %(event)s

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -21,7 +21,7 @@ class TrendsEventQuery(ClickhouseEventQuery):
         _fields = (
             f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp"
             + (
-                f"{self.EVENT_TABLE_ALIAS}.properties as properties, "
+                f", {self.EVENT_TABLE_ALIAS}.properties as properties"
                 if column_optimizer.should_query_event_properties_column
                 else ""
             )

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Tuple
 
 from ee.clickhouse.materialized_columns.columns import get_materialized_columns
+from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from ee.clickhouse.queries.trends.util import get_active_user_params, populate_entity_params
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
@@ -16,15 +17,21 @@ class TrendsEventQuery(ClickhouseEventQuery):
         super().__init__(*args, **kwargs)
 
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
+        column_optimizer = ColumnOptimizer(self._filter, self._team_id)
         _fields = (
-            f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp, {self.EVENT_TABLE_ALIAS}.properties as properties"
+            f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp"
+            + (
+                f"{self.EVENT_TABLE_ALIAS}.properties as properties, "
+                if column_optimizer.should_query_event_properties_column
+                else ""
+            )
             + (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "")
             + (f", {self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons else "")
             + (
                 " ".join(
                     [
                         f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
-                        for column_name in get_materialized_columns("events").values()
+                        for column_name in column_optimizer.materialized_event_columns_to_query
                     ]
                 )
             )

--- a/ee/clickhouse/sql/trends/top_elements.py
+++ b/ee/clickhouse/sql/trends/top_elements.py
@@ -1,7 +1,7 @@
 TOP_ELEMENTS_ARRAY_OF_KEY_SQL = """
 SELECT groupArray(value) FROM (
     SELECT
-        trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) as value,
+        {value_expression} AS value,
         {aggregate_operation} as count
     FROM events e
     WHERE

--- a/posthog/models/entity.py
+++ b/posthog/models/entity.py
@@ -44,6 +44,7 @@ class Entity(PropertyMixin):
         self.math = data.get("math")
         self.math_property = data.get("math_property")
 
+        self._action: Optional[Action] = None
         self._data = data  # push data to instance object so mixins are handled properly
         if self.type == TREND_FILTER_TYPE_EVENTS and not self.name:
             # It won't be an int if it's an event, but mypy...
@@ -92,8 +93,13 @@ class Entity(PropertyMixin):
             raise ValueError(
                 f"Action can only be fetched for entities of type {TREND_FILTER_TYPE_ACTIONS}, not {self.type}!"
             )
+
+        if self._action:
+            return self._action
+
         try:
-            return Action.objects.get(id=self.id)
+            self._action = Action.objects.get(id=self.id)
+            return self._action
         except:
             raise ValidationError(f"Action ID {self.id} does not exist!")
 

--- a/posthog/models/entity.py
+++ b/posthog/models/entity.py
@@ -7,6 +7,7 @@ from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENT
 from posthog.models.action import Action
 from posthog.models.filters.mixins.funnel import FunnelFromToStepsMixin
 from posthog.models.filters.mixins.property import PropertyMixin
+from posthog.settings import TEST
 
 
 class Entity(PropertyMixin):
@@ -94,7 +95,7 @@ class Entity(PropertyMixin):
                 f"Action can only be fetched for entities of type {TREND_FILTER_TYPE_ACTIONS}, not {self.type}!"
             )
 
-        if self._action:
+        if self._action and not TEST:
             return self._action
 
         try:

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -7,6 +7,7 @@ from posthog.utils import is_valid_regex
 
 ValueT = Union[str, int, List[str]]
 PropertyType = Literal["event", "person", "cohort", "element"]
+PropertyName = str
 OperatorType = Literal[
     "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
 ]


### PR DESCRIPTION
## Changes

Ticket: https://github.com/PostHog/posthog/issues/5593

This PR introduces a new class `ColumnOptimizer` and uses it to minimize the number of `events` table columns we read in queries. This can significantly speed up queries.

Internally, the class figures out what properties and if element_chain is used based on the `Filter` object. While seemingly straight-forward, it really isn't due to the amount of corner-cases.

Reviewers, let me know if you think I've missed something - e.g. some property being included in some queries via filter attribute X or Y.

Also needs more testing before merging, cases around https://github.com/PostHog/posthog/issues/5463 might be breaking some queries.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
