### PR TITLE
Display range in dropdown value if only start given

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -632,12 +632,29 @@ export function dateFilterToText(
     }
     dateFrom = (dateFrom || undefined) as string | undefined
     dateTo = (dateTo || undefined) as string | undefined
+
     if (isDate.test(dateFrom || '') && isDate.test(dateTo || '')) {
         return `${dateFrom} - ${dateTo}`
     }
+
     if (dateFrom === 'dStart') {
+        // Changed to "last 24 hours" but this is backwards compatibility
         return 'Today'
-    } // Changed to "last 24 hours" but this is backwards compatibility
+    }
+
+    if (isDate.test(dateFrom || '') && !isDate.test(dateTo || '')) {
+        const days = dayjs().diff(dayjs(dateFrom), 'days')
+        if (days > 366) {
+            return `${dateFrom} - Today`
+        } else if (days > 0) {
+            return `Last ${days} days`
+        } else if (days === 0) {
+            return `Today`
+        } else {
+            return `Starting from ${dateFrom}`
+        }
+    }
+
     let name = defaultValue
     Object.entries(dateMapping).map(([key, value]) => {
         if (value[0] === dateFrom && value[1] === dateTo && key !== 'Custom') {


### PR DESCRIPTION
## Changes

- Fixes parts of https://github.com/PostHog/posthog/issues/5358

- Before any date range specified as `date_from=2022-05-10&date_to&` in the filter was shown as "Last 7 days" (the default)
![image](https://user-images.githubusercontent.com/53387/129755211-86a19240-bd45-493e-8287-cca8d8805ef0.png)

- Now we show something real, even if it can't directly be selected:
![image](https://user-images.githubusercontent.com/53387/129755163-c5b75ff7-86a5-4077-ae97-4d1abd0a5b07.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
