### PR TITLE
Fix sessions to trends white screen death bug

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -29,7 +29,7 @@ export function ActionsLineGraph({
     const { loadPeople } = useActions(personsModalLogic)
     const [{ fromItem }] = useState(router.values.hashParams)
 
-    return indexedResults && !resultsLoading ? (
+    return indexedResults && indexedResults[0]?.data && !resultsLoading ? (
         indexedResults.filter((result) => result.count !== 0).length > 0 ? (
             <LineGraph
                 data-attr="trend-line-graph"


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

This was previously reverted because we thought it was causing insights not to load but that was due to different reasons, fixed in https://github.com/PostHog/posthog/pull/5612

I think adding this check to prevent incorrect `indexedResults` from passing into `ActionsLineGraph` temporarily when we switch insights tabs should still be correct

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
