### PR TITLE
Add "KEEP CLICKHOUSE-SERVER VERSION IN SYNC" comment

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -14,7 +14,9 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        image: yandex/clickhouse-server:21.6.5.37
+        # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
+        # https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/templates/clickhouse_instance.yaml#L88
+        image: yandex/clickhouse-server:21.6.5
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
## Changes

A comment added – https://github.com/PostHog/charts-clickhouse/pull/101 for the main repo.