### PR TITLE
Fix edit actions losing focus on each keystroke

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -14,6 +14,9 @@ describe('Actions', () => {
         cy.get('[data-attr=edit-action-input]').type(name)
         cy.get('.ant-radio-group > :nth-child(3)').click()
         cy.get('[data-attr=edit-action-url-input]').type(Cypress.config().baseUrl)
+        cy.wait(300)
+        cy.focused().should('have.attr', 'data-attr', 'edit-action-url-input')
+
         cy.get('[data-attr=save-action-button]').click()
 
         cy.contains('Action saved').should('exist')

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -75,7 +75,7 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                                     step={step}
                                     sendStep={sendStep}
                                     item="url"
-                                    extra_options={<URLMatching step={step} />}
+                                    extra_options={<URLMatching step={step} sendStep={sendStep} />}
                                     label="URL"
                                 />
                                 {step.url_matching && step.url_matching in URL_MATCHING_HINTS && (
@@ -235,7 +235,7 @@ function AutocaptureFields({
                 step={step}
                 sendStep={sendStep}
                 item="url"
-                extra_options={<URLMatching step={step} />}
+                extra_options={<URLMatching step={step} sendStep={sendStep} />}
                 label="Page URL"
                 caption="Elements will match only when triggered from the URL (particularly useful if you have non-unique elements in different pages)."
             />

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -5,9 +5,10 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { Tooltip } from 'lib/components/Tooltip'
 import { URL_MATCHING_HINTS } from 'scenes/actions/hints'
 import { Card, Col, Input, Radio, Typography, Space, RadioChangeEvent } from 'antd'
-const { Text } = Typography
 import { ExportOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { ActionStepType } from '~/types'
+
+const { Text } = Typography
 
 const learnMoreLink = 'https://posthog.com/docs/user-guides/actions?utm_medium=in-product&utm_campaign=action-page'
 
@@ -26,175 +27,6 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
         onChange(stepToSend)
     }
 
-    function Option(props: {
-        item: keyof ActionStepType
-        label: JSX.Element | string
-        placeholder?: string
-        caption?: JSX.Element | string
-        extra_options?: JSX.Element | string
-    }): JSX.Element {
-        const onOptionChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void =>
-            sendStep({
-                ...step,
-                [props.item]: e.target.value,
-            })
-
-        return (
-            <div className="mb">
-                <label style={{ fontWeight: 'bold' }}>
-                    {props.label} {props.extra_options}
-                </label>
-                {props.caption && <div className="action-step-caption">{props.caption}</div>}
-                {props.item === 'selector' ? (
-                    <Input.TextArea
-                        allowClear
-                        onChange={onOptionChange}
-                        value={step[props.item] || ''}
-                        placeholder={props.placeholder}
-                    />
-                ) : (
-                    <Input
-                        data-attr="edit-action-url-input"
-                        allowClear
-                        onChange={onOptionChange}
-                        value={step[props.item] || ''}
-                        placeholder={props.placeholder}
-                    />
-                )}
-            </div>
-        )
-    }
-
-    function TypeSwitcher(): JSX.Element {
-        const handleChange = (e: RadioChangeEvent): void => {
-            const type = e.target.value
-            if (type === '$autocapture') {
-                sendStep({ ...step, event: '$autocapture' })
-            } else if (type === 'event') {
-                sendStep({ ...step, event: '' })
-            } else if (type === '$pageview') {
-                sendStep({
-                    ...step,
-                    event: '$pageview',
-                    url: step.url,
-                })
-            }
-        }
-
-        return (
-            <div className={`type-switcher${step.event === undefined ? ' unselected' : ''}`}>
-                <Radio.Group
-                    buttonStyle="solid"
-                    onChange={handleChange}
-                    value={
-                        step.event === '$autocapture' || step.event === '$pageview' || step.event === undefined
-                            ? step.event
-                            : 'event'
-                    }
-                >
-                    <Radio.Button value="$autocapture">Autocapture</Radio.Button>
-                    <Radio.Button value="event">Custom event</Radio.Button>
-                    <Radio.Button value="$pageview">Page view</Radio.Button>
-                </Radio.Group>
-            </div>
-        )
-    }
-
-    function AutocaptureFields(props: { step: ActionStepType; actionId: number }): JSX.Element {
-        const { step: _step, actionId: _actionId } = props
-
-        const AndC = (): JSX.Element => {
-            return (
-                <div className="text-center">
-                    <span className="stateful-badge and">AND</span>
-                </div>
-            )
-        }
-        return (
-            <div>
-                <span>
-                    <AppEditorLink actionId={_actionId} style={{ margin: '1rem 0' }}>
-                        Select element on site <ExportOutlined />
-                    </AppEditorLink>
-                    <a
-                        href={`${learnMoreLink}#autocapture-based-actions`}
-                        target="_blank"
-                        rel="noopener"
-                        style={{ marginLeft: 8 }}
-                    >
-                        See documentation.
-                    </a>{' '}
-                </span>
-                <Option
-                    item="href"
-                    label="Link target equals"
-                    caption={
-                        <>
-                            If your element is a link, the location that the link opens (<code>href</code> tag)
-                        </>
-                    }
-                />
-                <AndC />
-                <Option item="text" label="Text equals" caption="Text content inside your element" />
-                <AndC />
-                <Option
-                    item="selector"
-                    label={
-                        <>
-                            HTML selector matches
-                            <Tooltip title="Click here to learn more about supported selectors">
-                                <a href={`${learnMoreLink}#matching-selectors`} target="_blank" rel="noopener">
-                                    <InfoCircleOutlined style={{ marginLeft: 4 }} />
-                                </a>
-                            </Tooltip>
-                        </>
-                    }
-                    placeholder='button[data-attr="my-id"]'
-                    caption={
-                        <Space direction="vertical">
-                            <Text style={{ color: 'var(--muted)' }}>
-                                CSS selector or an HTML attribute that ideally uniquely identifies your element.
-                                Example: <Text code>[data-attr="signup"]</Text>
-                            </Text>
-                        </Space>
-                    }
-                />
-                <div style={{ marginBottom: 18 }}>
-                    <AndC />
-                </div>
-                <Option
-                    item="url"
-                    extra_options={<URLMatching step={_step} />}
-                    label="Page URL"
-                    caption="Elements will match only when triggered from the URL (particularly useful if you have non-unique elements in different pages)."
-                />
-                {_step?.url_matching && _step.url_matching in URL_MATCHING_HINTS && (
-                    <small style={{ display: 'block', marginTop: -12 }}>{URL_MATCHING_HINTS[_step.url_matching]}</small>
-                )}
-            </div>
-        )
-    }
-
-    function URLMatching(props: { step: ActionStepType }): JSX.Element {
-        const { step: _step } = props
-
-        const handleURLMatchChange = (e: RadioChangeEvent): void => {
-            sendStep({ ..._step, url_matching: e.target.value })
-        }
-        return (
-            <Radio.Group
-                buttonStyle="solid"
-                onChange={handleURLMatchChange}
-                value={_step.url_matching || 'contains'}
-                size="small"
-            >
-                <Radio.Button value="contains">contains</Radio.Button>
-                <Radio.Button value="regex">matches regex</Radio.Button>
-                <Radio.Button value="exact">matches exactly</Radio.Button>
-            </Radio.Group>
-        )
-    }
-
     return (
         <Col span={24} md={12}>
             <Card className="action-step" style={{ overflow: 'visible' }}>
@@ -210,14 +42,16 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                     <div className="mb">
                         <b>Match Group #{index + 1}</b>
                     </div>
-                    {<TypeSwitcher />}
+                    {<TypeSwitcher step={step} sendStep={sendStep} />}
                     <div
                         style={{
                             marginTop: step.event === '$pageview' ? 20 : 8,
                             paddingBottom: 0,
                         }}
                     >
-                        {step.event === '$autocapture' && <AutocaptureFields step={step} actionId={actionId} />}
+                        {step.event === '$autocapture' && (
+                            <AutocaptureFields step={step} sendStep={sendStep} actionId={actionId} />
+                        )}
                         {step.event != null && step.event !== '$autocapture' && step.event !== '$pageview' && (
                             <div style={{ marginTop: '2rem' }}>
                                 <label>
@@ -237,7 +71,13 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                         )}
                         {step.event === '$pageview' && (
                             <div>
-                                <Option item="url" extra_options={<URLMatching step={step} />} label="URL" />
+                                <Option
+                                    step={step}
+                                    sendStep={sendStep}
+                                    item="url"
+                                    extra_options={<URLMatching step={step} />}
+                                    label="URL"
+                                />
                                 {step.url_matching && step.url_matching in URL_MATCHING_HINTS && (
                                     <small style={{ display: 'block', marginTop: -12 }}>
                                         {URL_MATCHING_HINTS[step.url_matching]}
@@ -269,5 +109,204 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                 </div>
             </Card>
         </Col>
+    )
+}
+
+function Option(props: {
+    step: ActionStepType
+    sendStep: (stepToSend: ActionStepType) => void
+    item: keyof ActionStepType
+    label: JSX.Element | string
+    placeholder?: string
+    caption?: JSX.Element | string
+    extra_options?: JSX.Element | string
+}): JSX.Element {
+    const onOptionChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void =>
+        props.sendStep({
+            ...props.step,
+            [props.item]: e.target.value,
+        })
+
+    return (
+        <div className="mb">
+            <label style={{ fontWeight: 'bold' }}>
+                {props.label} {props.extra_options}
+            </label>
+            {props.caption && <div className="action-step-caption">{props.caption}</div>}
+            {props.item === 'selector' ? (
+                <Input.TextArea
+                    allowClear
+                    onChange={onOptionChange}
+                    value={props.step[props.item] || ''}
+                    placeholder={props.placeholder}
+                />
+            ) : (
+                <Input
+                    data-attr="edit-action-url-input"
+                    allowClear
+                    onChange={onOptionChange}
+                    value={props.step[props.item] || ''}
+                    placeholder={props.placeholder}
+                />
+            )}
+        </div>
+    )
+}
+
+function AutocaptureFields({
+    step,
+    actionId,
+    sendStep,
+}: {
+    step: ActionStepType
+    sendStep: (stepToSend: ActionStepType) => void
+    actionId: number
+}): JSX.Element {
+    const AndC = (): JSX.Element => {
+        return (
+            <div className="text-center">
+                <span className="stateful-badge and">AND</span>
+            </div>
+        )
+    }
+    return (
+        <div>
+            <span>
+                <AppEditorLink actionId={actionId} style={{ margin: '1rem 0' }}>
+                    Select element on site <ExportOutlined />
+                </AppEditorLink>
+                <a
+                    href={`${learnMoreLink}#autocapture-based-actions`}
+                    target="_blank"
+                    rel="noopener"
+                    style={{ marginLeft: 8 }}
+                >
+                    See documentation.
+                </a>{' '}
+            </span>
+            <Option
+                step={step}
+                sendStep={sendStep}
+                item="href"
+                label="Link target equals"
+                caption={
+                    <>
+                        If your element is a link, the location that the link opens (<code>href</code> tag)
+                    </>
+                }
+            />
+            <AndC />
+            <Option
+                step={step}
+                sendStep={sendStep}
+                item="text"
+                label="Text equals"
+                caption="Text content inside your element"
+            />
+            <AndC />
+            <Option
+                step={step}
+                sendStep={sendStep}
+                item="selector"
+                label={
+                    <>
+                        HTML selector matches
+                        <Tooltip title="Click here to learn more about supported selectors">
+                            <a href={`${learnMoreLink}#matching-selectors`} target="_blank" rel="noopener">
+                                <InfoCircleOutlined style={{ marginLeft: 4 }} />
+                            </a>
+                        </Tooltip>
+                    </>
+                }
+                placeholder='button[data-attr="my-id"]'
+                caption={
+                    <Space direction="vertical">
+                        <Text style={{ color: 'var(--muted)' }}>
+                            CSS selector or an HTML attribute that ideally uniquely identifies your element. Example:{' '}
+                            <Text code>[data-attr="signup"]</Text>
+                        </Text>
+                    </Space>
+                }
+            />
+            <div style={{ marginBottom: 18 }}>
+                <AndC />
+            </div>
+            <Option
+                step={step}
+                sendStep={sendStep}
+                item="url"
+                extra_options={<URLMatching step={step} />}
+                label="Page URL"
+                caption="Elements will match only when triggered from the URL (particularly useful if you have non-unique elements in different pages)."
+            />
+            {step?.url_matching && step.url_matching in URL_MATCHING_HINTS && (
+                <small style={{ display: 'block', marginTop: -12 }}>{URL_MATCHING_HINTS[step.url_matching]}</small>
+            )}
+        </div>
+    )
+}
+
+function TypeSwitcher({
+    step,
+    sendStep,
+}: {
+    step: ActionStepType
+    sendStep: (stepToSend: ActionStepType) => void
+}): JSX.Element {
+    const handleChange = (e: RadioChangeEvent): void => {
+        const type = e.target.value
+        if (type === '$autocapture') {
+            sendStep({ ...step, event: '$autocapture' })
+        } else if (type === 'event') {
+            sendStep({ ...step, event: '' })
+        } else if (type === '$pageview') {
+            sendStep({
+                ...step,
+                event: '$pageview',
+                url: step.url,
+            })
+        }
+    }
+
+    return (
+        <div className={`type-switcher${step.event === undefined ? ' unselected' : ''}`}>
+            <Radio.Group
+                buttonStyle="solid"
+                onChange={handleChange}
+                value={
+                    step.event === '$autocapture' || step.event === '$pageview' || step.event === undefined
+                        ? step.event
+                        : 'event'
+                }
+            >
+                <Radio.Button value="$autocapture">Autocapture</Radio.Button>
+                <Radio.Button value="event">Custom event</Radio.Button>
+                <Radio.Button value="$pageview">Page view</Radio.Button>
+            </Radio.Group>
+        </div>
+    )
+}
+
+function URLMatching({
+    step,
+    sendStep,
+}: {
+    step: ActionStepType
+    sendStep: (stepToSend: ActionStepType) => void
+}): JSX.Element {
+    const handleURLMatchChange = (e: RadioChangeEvent): void => {
+        sendStep({ ...step, url_matching: e.target.value })
+    }
+    return (
+        <Radio.Group
+            buttonStyle="solid"
+            onChange={handleURLMatchChange}
+            value={step.url_matching || 'contains'}
+            size="small"
+        >
+            <Radio.Button value="contains">contains</Radio.Button>
+            <Radio.Button value="regex">matches regex</Radio.Button>
+            <Radio.Button value="exact">matches exactly</Radio.Button>
+        </Radio.Group>
     )
 }


### PR DESCRIPTION
## Changes

Fixes #5627

Turns out React doesn't honor unique key re-rendering if components are nested and share states.

![image](https://user-images.githubusercontent.com/13460330/129809506-c7cd2fca-8dec-4c26-8240-274dc456da1e.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
