### PR TITLE
Include the set of organizations for an instance in a report

### DIFF
--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -8,7 +8,7 @@ import posthoganalytics
 from django.db import connection
 from psycopg2 import sql
 
-from posthog.models import Event, Person, Team, User
+from posthog.models import Event, Organization, Person, Team, User
 from posthog.models.dashboard import Dashboard
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.plugin import PluginConfig
@@ -27,6 +27,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         "realm": get_instance_realm(),
         "period": {"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
         "site_url": os.getenv("SITE_URL", "unknown"),
+        "organizations": get_instance_organizations(),
     }
 
     report["helm"] = get_helm_info_env()
@@ -65,11 +66,13 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
             events_considered_total = Event.objects.filter(team_id=team.id)
             instance_usage_summary["events_count_total"] += events_considered_total.count()
             events_considered_new_in_period = events_considered_total.filter(
-                timestamp__gte=period_start, timestamp__lte=period_end,
+                timestamp__gte=period_start,
+                timestamp__lte=period_end,
             )
             persons_considered_total = Person.objects.filter(team_id=team.id)
             persons_considered_total_new_in_period = persons_considered_total.filter(
-                created_at__gte=period_start, created_at__lte=period_end,
+                created_at__gte=period_start,
+                created_at__lte=period_end,
             )
             team_report["events_count_total"] = events_considered_total.count()
             team_report["events_count_new_in_period"] = events_considered_new_in_period.count()
@@ -170,3 +173,7 @@ def get_helm_info_env() -> dict:
         return json.loads(os.getenv("HELM_INSTALL_INFO", "{}"))
     except Exception:
         return {}
+
+
+def get_instance_organizations() -> List[str]:
+    return [org.name for org in Organization.objects.all()]

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -29,6 +29,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         "period": {"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
         "site_url": os.getenv("SITE_URL", "unknown"),
         "organizations": get_instance_organizations(),
+        "license_keys": get_instance_licenses(),
     }
 
     report["helm"] = get_helm_info_env()

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -66,13 +66,11 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
             events_considered_total = Event.objects.filter(team_id=team.id)
             instance_usage_summary["events_count_total"] += events_considered_total.count()
             events_considered_new_in_period = events_considered_total.filter(
-                timestamp__gte=period_start,
-                timestamp__lte=period_end,
+                timestamp__gte=period_start, timestamp__lte=period_end,
             )
             persons_considered_total = Person.objects.filter(team_id=team.id)
             persons_considered_total_new_in_period = persons_considered_total.filter(
-                created_at__gte=period_start,
-                created_at__lte=period_end,
+                created_at__gte=period_start, created_at__lte=period_end,
             )
             team_report["events_count_total"] = events_considered_total.count()
             team_report["events_count_new_in_period"] = events_considered_new_in_period.count()

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -13,6 +13,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.plugin import PluginConfig
 from posthog.models.utils import namedtuplefetchall
+from posthog.settings import EE_AVAILABLE
 from posthog.utils import get_instance_realm, get_machine_id, get_previous_week
 from posthog.version import VERSION
 
@@ -175,3 +176,12 @@ def get_helm_info_env() -> dict:
 
 def get_instance_organizations() -> List[str]:
     return [org.name for org in Organization.objects.all()]
+
+
+def get_instance_licenses() -> List[str]:
+    if EE_AVAILABLE:
+        from ee.models import License
+
+        return [license.key for license in License.objects.all()]
+    else:
+        return []

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -28,7 +28,6 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         "realm": get_instance_realm(),
         "period": {"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
         "site_url": os.getenv("SITE_URL", "unknown"),
-        "organizations": get_instance_organizations(),
         "license_keys": get_instance_licenses(),
     }
 
@@ -173,10 +172,6 @@ def get_helm_info_env() -> dict:
         return json.loads(os.getenv("HELM_INSTALL_INFO", "{}"))
     except Exception:
         return {}
-
-
-def get_instance_organizations() -> List[str]:
-    return [org.name for org in Organization.objects.all()]
 
 
 def get_instance_licenses() -> List[str]:


### PR DESCRIPTION
## Changes

We are currently segmenting on `SITE_URL` which is somewhat arbitrary and not always descriptive of the instance. Using organization names and seeing how many organizations are created on an instances should be much more informative

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
