### PR TITLE
fix empty tooltip popup on dashboards

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -91,42 +91,43 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
         undefined,
         true
     )
-
+    const menuItem = (
+        <div className={`menu-item${isActive ? ' menu-item-active' : ''}`} data-attr={`menu-item-${identifier}`}>
+            {icon}
+            <span className="menu-title text-center">{title}</span>
+            {hotkey && (
+                <span className={`hotkey${hotkeyNavigationEngaged ? '' : ' hide'}`}>{hotkey.toUpperCase()}</span>
+            )}
+        </div>
+    )
     return (
         <Link to={to} onClick={handleClick}>
-            <Tooltip
-                title={
-                    tooltip && !isMobile() ? (
-                        <>
-                            <div className="mb-025">
-                                <b>{title}</b>
-                                {hotkey && (
-                                    <>
-                                        <span className="hotkey menu-tooltip-hotkey">G</span>
-                                        <span className="hotkey-plus" />
-                                        <span className="hotkey menu-tooltip-hotkey">{hotkey.toUpperCase()}</span>
-                                    </>
-                                )}
-                            </div>
-                            {tooltip}
-                        </>
-                    ) : undefined
-                }
-                placement="left"
-            >
-                <div
-                    className={`menu-item${isActive ? ' menu-item-active' : ''}`}
-                    data-attr={`menu-item-${identifier}`}
+            {tooltip ? (
+                <Tooltip
+                    title={
+                        !isMobile() ? (
+                            <>
+                                <div className="mb-025">
+                                    <b>{title}</b>
+                                    {hotkey && (
+                                        <>
+                                            <span className="hotkey menu-tooltip-hotkey">G</span>
+                                            <span className="hotkey-plus" />
+                                            <span className="hotkey menu-tooltip-hotkey">{hotkey.toUpperCase()}</span>
+                                        </>
+                                    )}
+                                </div>
+                                {tooltip}
+                            </>
+                        ) : undefined
+                    }
+                    placement="left"
                 >
-                    {icon}
-                    <span className="menu-title text-center">{title}</span>
-                    {hotkey && (
-                        <span className={`hotkey${hotkeyNavigationEngaged ? '' : ' hide'}`}>
-                            {hotkey.toUpperCase()}
-                        </span>
-                    )}
-                </div>
-            </Tooltip>
+                    {menuItem}
+                </Tooltip>
+            ) : (
+                menuItem
+            )}
         </Link>
     )
 }


### PR DESCRIPTION
## Changes
Noticed a bug on prod, an empty tooltip bubble when hovering over dashboards:
<img width="388" alt="Screen Shot 2021-08-17 at 7 00 48 PM" src="https://user-images.githubusercontent.com/5965891/129824688-444e3ad6-1427-4939-b60d-bbc34da9774b.png">
 
At first, I added tooltip text – then realized we likely purposefully omitted text, since we'd have two popups (the dashboard list and the tooltip which is hard to read).

Fix - only wrap a `<Tooltip>` around the menu item if one is provided.

<img width="306" alt="Screen Shot 2021-08-17 at 7 00 56 PM" src="https://user-images.githubusercontent.com/5965891/129824812-07a2a862-7c78-4602-926b-63be9716c618.png">
<img width="377" alt="Screen Shot 2021-08-17 at 7 01 02 PM" src="https://user-images.githubusercontent.com/5965891/129824817-ebecec02-7fe9-4352-9bd7-6f97d19efc0c.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
