### PR TITLE
Display 0% instead of NaN when 0 out of 0 people complete a step

### DIFF
--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -6,6 +6,9 @@ import { FunnelStep, FunnelsTimeConversionBins } from '~/types'
 const PERCENTAGE_DISPLAY_PRECISION = 1 // Number of decimals to show in percentages
 
 export function formatDisplayPercentage(percentage: number): string {
+    if (Number.isNaN(percentage)) {
+        percentage = 0
+    }
     // Returns a formatted string properly rounded to ensure consistent results
     return (percentage * 100).toFixed(PERCENTAGE_DISPLAY_PRECISION)
 }


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5633

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
