### PR TITLE
Handle denormalized properties everywhere*

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -43,6 +43,7 @@ def format_action_filter(
                 team_id=action.team.pk if filter_by_team else None,
                 prepend=f"action_props_{action.pk}_{step.pk}",
                 table_name=table_name,
+                allow_denormalized_props=True,
             )
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -72,15 +72,16 @@ def filter_event(
 
     if step.url:
         value_expr, _ = get_property_string_expr("events", "$current_url", "'$current_url'", f"{table_name}properties")
+        prop_name = f"{prepend}_prop_val_{index}"
         if step.url_matching == ActionStep.EXACT:
-            conditions.append(f"{value_expr} = %({prepend}_prop_val_{index})s")
-            params.update({f"{prepend}_prop_val_{index}": step.url})
+            conditions.append(f"{value_expr} = %({prop_name})s")
+            params.update({prop_name: step.url})
         elif step.url_matching == ActionStep.REGEX:
-            conditions.append(f"match({value_expr}, %({prepend}_prop_val_{index})s)")
-            params.update({f"{prepend}_prop_val_{index}": step.url})
+            conditions.append(f"match({value_expr}, %({prop_name})s)")
+            params.update({prop_name: step.url})
         else:
-            conditions.append(f"{value_expr} LIKE %({prepend}_prop_val_{index})s")
-            params.update({f"{prepend}_prop_val_{index}": f"%{step.url}%"})
+            conditions.append(f"{value_expr} LIKE %({prop_name})s")
+            params.update({prop_name: f"%{step.url}%"})
 
     conditions.append(f"event = %({prepend}_{index})s")
 

--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -62,6 +62,8 @@ def format_action_filter(
 def filter_event(
     step: ActionStep, prepend: str = "event", index: int = 0, table_name: str = ""
 ) -> Tuple[List[str], Dict]:
+    from ee.clickhouse.models.property import get_property_string_expr
+
     params = {"{}_{}".format(prepend, index): step.event}
     conditions = []
 
@@ -69,20 +71,15 @@ def filter_event(
         table_name += "."
 
     if step.url:
+        value_expr, _ = get_property_string_expr("events", "$current_url", "'$current_url'", f"{table_name}properties")
         if step.url_matching == ActionStep.EXACT:
-            conditions.append(
-                f"JSONExtractString({table_name}properties, '$current_url') = %({prepend}_prop_val_{index})s"
-            )
+            conditions.append(f"{value_expr} = %({prepend}_prop_val_{index})s")
             params.update({f"{prepend}_prop_val_{index}": step.url})
         elif step.url_matching == ActionStep.REGEX:
-            conditions.append(
-                f"match(JSONExtractString({table_name}properties, '$current_url'), %({prepend}_prop_val_{index})s)"
-            )
+            conditions.append(f"match({value_expr}, %({prepend}_prop_val_{index})s)")
             params.update({f"{prepend}_prop_val_{index}": step.url})
         else:
-            conditions.append(
-                f"JSONExtractString({table_name}properties, '$current_url') LIKE %({prepend}_prop_val_{index})s"
-            )
+            conditions.append(f"{value_expr} LIKE %({prepend}_prop_val_{index})s")
             params.update({f"{prepend}_prop_val_{index}": f"%{step.url}%"})
 
     conditions.append(f"event = %({prepend}_{index})s")

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -197,7 +197,6 @@ def get_property_string_expr(
     var: str,
     prop_var: str,
     allow_denormalized_props: bool = True,
-    json_extract_expr="trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, {var}))",
 ) -> Tuple[str, bool]:
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
@@ -205,7 +204,7 @@ def get_property_string_expr(
     if allow_denormalized_props and property_name in materialized_columns and table == "events":
         return materialized_columns[property_name], True
 
-    return json_extract_expr.format(prop_var=prop_var, var=var), False
+    return f"trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, {var}))", False
 
 
 def box_value(value: Any, remove_spaces=False) -> List[Any]:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -192,7 +192,12 @@ def property_table(property: Property) -> TableWithProperties:
 
 
 def get_property_string_expr(
-    table: TableWithProperties, property_name: PropertyName, var: str, prop_var: str, allow_denormalized_props: bool
+    table: TableWithProperties,
+    property_name: PropertyName,
+    var: str,
+    prop_var: str,
+    allow_denormalized_props: bool = True,
+    json_extract_expr="trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, {var}))",
 ) -> Tuple[str, bool]:
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
@@ -200,7 +205,7 @@ def get_property_string_expr(
     if allow_denormalized_props and property_name in materialized_columns and table == "events":
         return materialized_columns[property_name], True
 
-    return f"trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, {var}))", False
+    return json_extract_expr.format(prop_var=prop_var, var=var), False
 
 
 def box_value(value: Any, remove_spaces=False) -> List[Any]:

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -82,9 +82,7 @@ def get_breakdown_event_prop_values(
 
     entity_params, entity_format_params = populate_entity_params(entity)
 
-    value_expression, _ = get_property_string_expr(
-        "events", cast(str, filter.breakdown), "%(key)s", "properties", allow_denormalized_props=True
-    )
+    value_expression, _ = get_property_string_expr("events", cast(str, filter.breakdown), "%(key)s", "properties")
 
     elements_query = TOP_ELEMENTS_ARRAY_OF_KEY_SQL.format(
         value_expression=value_expression,

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -40,7 +40,7 @@ class ClickhousePaths(Paths):
         event, path_type, start_comparator = self._determine_path_type(filter.path_type if filter else None)
 
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
 
         # Step 0. Event culling subexpression for step 1.

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -16,18 +16,14 @@ class ClickhousePaths(Paths):
     def _determine_path_type(self, requested_type=None):
         # Default
         event: Optional[str] = "$pageview"
-        path_type, _ = get_property_string_expr(
-            "events", "$current_url", "'$current_url'", "properties", allow_denormalized_props=True
-        )
+        path_type, _ = get_property_string_expr("events", "$current_url", "'$current_url'", "properties")
         start_comparator = "path_type"
 
         # determine requested type
         if requested_type:
             if requested_type == SCREEN_EVENT:
                 event = SCREEN_EVENT
-                path_type, _ = get_property_string_expr(
-                    "events", "$screen_name", "'$screen_name'", "properties", allow_denormalized_props=True
-                )
+                path_type, _ = get_property_string_expr("events", "$screen_name", "'$screen_name'", "properties")
             elif requested_type == AUTOCAPTURE_EVENT:
                 event = AUTOCAPTURE_EVENT
                 path_type = "concat('<', {tag_regex}, '> ', {text_regex})".format(

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -35,7 +35,7 @@ class ClickhouseRetention(Retention):
     def _execute_sql(self, filter: RetentionFilter, team: Team,) -> Dict[Tuple[int, int], Dict[str, Any]]:
         period = filter.period
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
         target_entity = filter.target_entity
         returning_entity = filter.returning_entity
@@ -152,7 +152,7 @@ class ClickhouseRetention(Retention):
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
 
         returning_entity = filter.returning_entity if filter.selected_interval > 0 else filter.target_entity
@@ -209,7 +209,7 @@ class ClickhouseRetention(Retention):
         period = filter.period
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk, allow_denormalized_props=True)
 
         target_query, target_params = self._get_condition(filter.target_entity, table="e")
         target_query_formatted = "AND {target_query}".format(target_query=target_query)

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -36,7 +36,10 @@ class ClickhouseStickiness(Stickiness):
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties + entity.properties, team_id, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            filter.properties + entity.properties,
+            team_id,
+            filter_test_accounts=filter.filter_test_accounts,
+            allow_denormalized_props=True,
         )
         trunc_func = get_trunc_func_ch(filter.interval)
 
@@ -93,7 +96,10 @@ def _format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
 def _process_content_sql(target_entity: Entity, filter: StickinessFilter, team: Team) -> Tuple[str, Dict[str, Any]]:
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team.pk)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties + target_entity.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+        filter.properties + target_entity.properties,
+        team.pk,
+        filter_test_accounts=filter.filter_test_accounts,
+        allow_denormalized_props=True,
     )
     entity_sql, entity_params = _format_entity_filter(entity=target_entity)
     trunc_func = get_trunc_func_ch(filter.interval)

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -36,7 +36,7 @@ class ClickhouseStickiness(Stickiness):
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties + entity.properties, team_id, filter_test_accounts=filter.filter_test_accounts
+            filter.properties + entity.properties, team_id, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
         trunc_func = get_trunc_func_ch(filter.interval)
 
@@ -93,7 +93,7 @@ def _format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
 def _process_content_sql(target_entity: Entity, filter: StickinessFilter, team: Team) -> Tuple[str, Dict[str, Any]]:
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team.pk)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties + target_entity.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+        filter.properties + target_entity.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
     )
     entity_sql, entity_params = _format_entity_filter(entity=target_entity)
     trunc_func = get_trunc_func_ch(filter.interval)

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -35,9 +35,7 @@ class ColumnOptimizer:
 
     @cached_property
     def should_query_event_properties_column(self) -> bool:
-        # :TODO: Once issue 5463 is solved (supporting materialized columns everywhere), uncomment this
-        # return len(self.materialized_event_columns_to_query) != len(self._used_properties_with_type("event"))
-        return True
+        return len(self.materialized_event_columns_to_query) != len(self._used_properties_with_type("event"))
 
     @cached_property
     def should_query_elements_chain_column(self) -> bool:

--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -27,7 +27,7 @@ class ClickhouseSessionsAvg:
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
         filters, params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
 
         trunc_func = get_trunc_func_ch(filter.interval)

--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -13,7 +13,7 @@ class ClickhouseSessionsDist:
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
         filters, params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
 
         entity_conditions, entity_params = entity_query_conditions(filter, team)

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -65,8 +65,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         )
 
         correct = """
-        SELECT e.timestamp as timestamp,
-               e.properties as properties
+        SELECT e.timestamp as timestamp
         FROM events e
         WHERE team_id = %(team_id)s
             AND event = %(event)s

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -736,7 +736,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             self.assertNotIn("JSONExtract", sql)
             self.assertNotIn("properties", sql)
 
-    @skip("breakdown queries don't yet use materialized properties properly")
+    # @skip("breakdown queries don't yet use materialized properties properly")
     def test_materialized_breakdown_queries_right_columns(self):
         materialize("events", "$some_property")
 

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -1,4 +1,3 @@
-from unittest.case import skip
 from uuid import uuid4
 
 from django.utils import timezone
@@ -736,7 +735,6 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             self.assertNotIn("JSONExtract", sql)
             self.assertNotIn("properties", sql)
 
-    # @skip("breakdown queries don't yet use materialized properties properly")
     def test_materialized_breakdown_queries_right_columns(self):
         materialize("events", "$some_property")
 

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -716,6 +716,26 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
 
         self.assertEqual(res[0]["count"], 1)
 
+    def test_materialized_property_filtering(self):
+        materialize("events", "$some_property")
+
+        with self.capture_select_queries() as sqls:
+            self.test_property_filtering()
+
+        for sql in sqls:
+            self.assertNotIn("JSONExtract", sql)
+            self.assertNotIn("properties", sql)
+
+    def test_materialized_per_entity_filtering(self):
+        materialize("events", "$some_property")
+
+        with self.capture_select_queries() as sqls:
+            self.test_per_entity_filtering()
+
+        for sql in sqls:
+            self.assertNotIn("JSONExtract", sql)
+            self.assertNotIn("properties", sql)
+
     @skip("breakdown queries don't yet use materialized properties properly")
     def test_materialized_breakdown_queries_right_columns(self):
         materialize("events", "$some_property")

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -757,7 +757,6 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             self.assertNotIn("JSONExtract", sql)
             self.assertNotIn("properties", sql)
 
-    @skip("action filters don't yet use materialized properties properly")
     def test_materialized_filtering_with_action_props(self):
         materialize("events", "key")
 

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -41,7 +41,11 @@ class ClickhouseTrendsBreakdown:
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts
+            props_to_filter,
+            team_id,
+            table_name="e",
+            filter_test_accounts=filter.filter_test_accounts,
+            allow_denormalized_props=True,
         )
         aggregate_operation, _, math_params = process_math(entity)
 

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
-from ee.clickhouse.models.property import parse_prop_clauses
+from ee.clickhouse.models.property import get_property_string_expr, parse_prop_clauses
 from ee.clickhouse.queries.breakdown_props import (
     ALL_USERS_COHORT_ID,
     format_breakdown_cohort_join_query,
@@ -183,14 +183,16 @@ class ClickhouseTrendsBreakdown:
         values_arr = get_breakdown_event_prop_values(
             filter, entity, aggregate_operation, team_id, extra_params=math_params
         )
-        params = {
-            "values": values_arr,
-        }
+
+        # :TRICKY: We only support string breakdown for event/person properties
+        assert isinstance(filter.breakdown, str)
+        breakdown_value, _ = get_property_string_expr("events", filter.breakdown, "%(key)s", "properties")
+
         return (
-            params,
+            {"values": values_arr, "key": filter.breakdown},
             BREAKDOWN_PROP_JOIN_SQL,
-            {},
-            "trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s))",
+            {"breakdown_value": breakdown_value},
+            breakdown_value,
         )
 
     def _parse_single_aggregate_result(

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -195,7 +195,7 @@ class ClickhouseTrendsBreakdown:
         return (
             {"values": values_arr, "key": filter.breakdown},
             BREAKDOWN_PROP_JOIN_SQL,
-            {"breakdown_value": breakdown_value},
+            {"breakdown_value_expr": breakdown_value},
             breakdown_value,
         )
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -50,7 +50,7 @@ class ClickhouseLifecycle(LifecycleTrend):
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
+            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
 
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
@@ -141,7 +141,7 @@ class ClickhouseLifecycle(LifecycleTrend):
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
+            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
         )
 
         result = sync_execute(

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -32,7 +32,7 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
         aggregate_operation = "count(DISTINCT person_id)"
     elif entity.math in MATH_FUNCTIONS:
         value, _ = get_property_string_expr(
-            "events", cast(str, entity.math_property), "", "", f"JSONExtractRaw(properties, %(e_{entity.index}_math))",
+            "events", cast(str, entity.math_property), f"%(e_{entity.index}_math))", "properties"
         )
         aggregate_operation = f"{MATH_FUNCTIONS[entity.math]}(toFloat64OrNull({value}))"
         params["join_property_key"] = entity.math_property

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -28,11 +28,7 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
 
     params = {f"e_{entity.index}_math": entity.math_property}
     value, _ = get_property_string_expr(
-        "events",
-        entity.math_property,
-        f"%({param_name})",
-        "properties",
-        "toFloat64OrNull(JSONExtractRaw({prop_var}, {var}))",
+        "events", entity.math_property, f"%({param_name})", "properties", "JSONExtractRaw({prop_var}, {var})",
     )
 
     aggregate_operation = "count(*)"
@@ -41,7 +37,7 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
         join_condition = EVENT_JOIN_PERSON_SQL
         aggregate_operation = "count(DISTINCT person_id)"
     elif entity.math in MATH_FUNCTIONS:
-        aggregate_operation = f"{MATH_FUNCTIONS[entity.math]}({value})"
+        aggregate_operation = f"{MATH_FUNCTIONS[entity.math]}(toFloat64OrNull({value}))"
         params["join_property_key"] = entity.math_property
 
     return aggregate_operation, join_condition, params

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -32,7 +32,7 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
         aggregate_operation = "count(DISTINCT person_id)"
     elif entity.math in MATH_FUNCTIONS:
         value, _ = get_property_string_expr(
-            "events", cast(str, entity.math_property), f"%(e_{entity.index}_math))", "properties"
+            "events", cast(str, entity.math_property), f"%(e_{entity.index}_math)s", "properties"
         )
         aggregate_operation = f"{MATH_FUNCTIONS[entity.math]}(toFloat64OrNull({value}))"
         params["join_property_key"] = entity.math_property

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -90,13 +90,13 @@ ON person_id = ep.id WHERE e.team_id = %(team_id)s {event_filter} {filters} {par
 
 BREAKDOWN_PROP_JOIN_SQL = """
 WHERE e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from} {parsed_date_to}
-  AND trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) in (%(values)s) 
+  AND {breakdown_value} in (%(values)s)
   {actions_query}
 """
 
 NONE_BREAKDOWN_PROP_JOIN_SQL = """
 WHERE e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from} {parsed_date_to}
-  AND NOT JSONHas(properties, %(key)s) 
+  AND NOT JSONHas(properties, %(key)s)
   {actions_query}
 """
 

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -90,7 +90,7 @@ ON person_id = ep.id WHERE e.team_id = %(team_id)s {event_filter} {filters} {par
 
 BREAKDOWN_PROP_JOIN_SQL = """
 WHERE e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from} {parsed_date_to}
-  AND {breakdown_value} in (%(values)s)
+  AND {breakdown_value_expr} in (%(values)s)
   {actions_query}
 """
 

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -1,4 +1,6 @@
 from contextlib import contextmanager
+from typing import List
+from unittest.mock import patch
 
 from clickhouse_driver.errors import ServerException
 from django.db import DEFAULT_DB_ALIAS
@@ -75,3 +77,16 @@ class ClickhouseTestMixin:
     # Ignore assertNumQueries in clickhouse tests
     def assertNumQueries(self, num, func=None, *args, using=DEFAULT_DB_ALIAS, **kwargs):
         return self._assertNumQueries(func)
+
+    @contextmanager
+    def capture_sql(self):
+        from ee.clickhouse.client import _annotate_tagged_query
+
+        sqls: List[str] = []
+
+        def wrapped_method(*args):
+            sqls.append(args[0])
+            return _annotate_tagged_query(*args)
+
+        with patch("ee.clickhouse.client._annotate_tagged_query", wraps=wrapped_method) as wrapped_annotate:
+            yield sqls

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -79,13 +79,14 @@ class ClickhouseTestMixin:
         return self._assertNumQueries(func)
 
     @contextmanager
-    def capture_sql(self):
+    def capture_select_queries(self):
         from ee.clickhouse.client import _annotate_tagged_query
 
         sqls: List[str] = []
 
         def wrapped_method(*args):
-            sqls.append(args[0])
+            if args[0].strip().startswith("SELECT"):
+                sqls.append(args[0])
             return _annotate_tagged_query(*args)
 
         with patch("ee.clickhouse.client._annotate_tagged_query", wraps=wrapped_method) as wrapped_annotate:

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -155,7 +155,7 @@ def _process_content_sql(team: Team, entity: Entity, filter: Filter):
         filter.properties.append(breakdown_prop)
 
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
+        filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
     )
     params: Dict = {"team_id": team.pk, **prop_filter_params, **entity_params, "offset": filter.offset}
 

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -17,7 +17,9 @@ class ClickhouseElementViewSet(ElementViewSet):
 
         date_from, date_to, _ = parse_timestamps(filter, team_id=self.team.pk)
 
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, self.team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(
+            filter.properties, self.team.pk, allow_denormalized_props=True
+        )
         result = sync_execute(
             GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters),
             {"team_id": self.team.pk, **prop_filter_params},

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -57,7 +57,7 @@ class ClickhouseEventsViewSet(EventViewSet):
             },
             long_date_from,
         )
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk, allow_denormalized_props=True)
 
         if request.GET.get("action_id"):
             try:


### PR DESCRIPTION
## Changes

After this PR we properly use materialized event properties 
throughout trends and funnels in a way that speeds up queries.

Closes https://github.com/PostHog/posthog/issues/5463

After this we only read `properties` column also only when needed.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
