### PR TITLE
Funnel Step Ordering

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -124,6 +124,7 @@ export const cleanFunnelParams = (filters: Partial<FilterType>, discardFiltersNo
             ? { funnel_step_breakdown: filters.funnel_step_breakdown }
             : {}),
         ...(filters.bin_count && filters.bin_count !== BinCountAuto ? { bin_count: filters.bin_count } : {}),
+        ...(filters.funnel_order_type ? { funnel_order_type: filters.funnel_order_type } : {}),
         interval: autocorrectInterval(filters),
         breakdown: breakdownEnabled ? filters.breakdown || undefined : undefined,
         breakdown_type: breakdownEnabled ? filters.breakdown_type || undefined : undefined,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
@@ -41,14 +41,7 @@ export function FunnelStepOrderPicker(): JSX.Element {
             dropdownMatchSelectWidth={false}
             dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
             optionLabelProp="label"
-        >
-            {options.map((option) => {
-                return (
-                    <Select.Option key={option.value} value={option.value} label={option.label}>
-                        {option.label}
-                    </Select.Option>
-                )
-            })}
-        </Select>
+            options={options}
+        />
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
@@ -4,30 +4,25 @@ import { Select } from 'antd'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
-import { Tooltip } from 'lib/components/Tooltip'
 
 interface StepOption {
     key?: string
     label: string
     value: StepOrderValue
-    copy: string
 }
 
 const options: StepOption[] = [
     {
         label: 'Sequential',
         value: StepOrderValue.ORDERED,
-        copy: "Step B must happen after Step A, but the previous step doesn't have to be step A.",
     },
     {
         label: 'Strict Order',
         value: StepOrderValue.STRICT,
-        copy: 'Step B must happen directly after Step A.',
     },
     {
         label: 'Any Order',
         value: StepOrderValue.UNORDERED,
-        copy: 'Steps can be completed in any sequence.',
     },
 ]
 
@@ -43,20 +38,17 @@ export function FunnelStepOrderPicker(): JSX.Element {
             value={filters.funnel_order_type || StepOrderValue.ORDERED}
             onSelect={(stepOrder) => setFilters({ funnel_order_type: stepOrder })}
             listHeight={440}
-            bordered={false}
             dropdownMatchSelectWidth={false}
             dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
             optionLabelProp="label"
         >
-            <Select.OptGroup label="Step Order">
-                {options.map((option) => {
-                    return (
-                        <Select.Option key={option.value} value={option.value}>
-                            <Tooltip title={option.copy}>{option.label}</Tooltip>
-                        </Select.Option>
-                    )
-                })}
-            </Select.OptGroup>
+            {options.map((option) => {
+                return (
+                    <Select.Option key={option.value} value={option.value} label={option.label}>
+                        {option.label}
+                    </Select.Option>
+                )
+            })}
         </Select>
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { StepOrderValue } from '~/types'
+import { Select } from 'antd'
+import { useActions, useValues } from 'kea'
+import { funnelLogic } from 'scenes/funnels/funnelLogic'
+import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
+import { Tooltip } from 'lib/components/Tooltip'
+
+interface StepOption {
+    key?: string
+    label: string
+    value: StepOrderValue
+    copy: string
+}
+
+const options: StepOption[] = [
+    {
+        label: 'Sequential',
+        value: StepOrderValue.ORDERED,
+        copy: "Step B must happen after Step A, but the previous step doesn't have to be step A.",
+    },
+    {
+        label: 'Strict Order',
+        value: StepOrderValue.STRICT,
+        copy: 'Step B must happen directly after Step A.',
+    },
+    {
+        label: 'Any Order',
+        value: StepOrderValue.UNORDERED,
+        copy: 'Steps can be completed in any sequence.',
+    },
+]
+
+export function FunnelStepOrderPicker(): JSX.Element {
+    const { filters } = useValues(funnelLogic)
+    const { setFilters } = useActions(funnelLogic)
+
+    return (
+        <Select
+            id="funnel-step-order-filter"
+            data-attr="funnel-step-order-filter"
+            defaultValue={StepOrderValue.ORDERED}
+            value={filters.funnel_order_type || StepOrderValue.ORDERED}
+            onSelect={(stepOrder) => setFilters({ funnel_order_type: stepOrder })}
+            listHeight={440}
+            bordered={false}
+            dropdownMatchSelectWidth={false}
+            dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
+            optionLabelProp="label"
+        >
+            <Select.OptGroup label="Step Order">
+                {options.map((option) => {
+                    return (
+                        <Select.Option key={option.value} value={option.value}>
+                            <Tooltip title={option.copy}>{option.label}</Tooltip>
+                        </Select.Option>
+                    )
+                })}
+            </Select.OptGroup>
+        </Select>
+    )
+}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -54,7 +54,9 @@ export function FunnelTab(): JSX.Element {
                         Steps
                     </h4>
                     <Row align="middle">
-                        <span className="l5 text-muted-alt mr-025">
+                        <span className="l5 text-muted-alt">
+                            <span style={{ marginRight: 5 }}>Step Order</span>
+                            <FunnelStepOrderPicker />
                             <Tooltip
                                 title={
                                     <ul style={{ paddingLeft: '1.2rem' }}>
@@ -72,11 +74,9 @@ export function FunnelTab(): JSX.Element {
                                     </ul>
                                 }
                             >
-                                <InfoCircleOutlined className="info-indicator left" />
+                                <InfoCircleOutlined className="info-indicator" />
                             </Tooltip>
-                            Step Order
                         </span>
-                        <FunnelStepOrderPicker />
                     </Row>
                 </Row>
                 <ActionFilter

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -53,31 +53,33 @@ export function FunnelTab(): JSX.Element {
                     <h4 className="secondary" style={{ marginBottom: 0 }}>
                         Steps
                     </h4>
-                    <Row align="middle">
-                        <span className="l5 text-muted-alt">
-                            <span style={{ marginRight: 5 }}>Step Order</span>
-                            <FunnelStepOrderPicker />
-                            <Tooltip
-                                title={
-                                    <ul style={{ paddingLeft: '1.2rem' }}>
-                                        <li>
-                                            <b>Sequential</b> - Step B must happen after Step A, but any number events
-                                            can happen between A and B.
-                                        </li>
-                                        <li>
-                                            <b>Strict Order</b> - Step B must happen directly after Step B without any
-                                            events in between.
-                                        </li>
-                                        <li>
-                                            <b>Any Order</b> - Steps can be completed in any sequence.
-                                        </li>
-                                    </ul>
-                                }
-                            >
-                                <InfoCircleOutlined className="info-indicator" />
-                            </Tooltip>
-                        </span>
-                    </Row>
+                    {clickhouseFeaturesEnabled && (
+                        <Row align="middle">
+                            <span className="l5 text-muted-alt">
+                                <span style={{ marginRight: 5 }}>Step Order</span>
+                                <FunnelStepOrderPicker />
+                                <Tooltip
+                                    title={
+                                        <ul style={{ paddingLeft: '1.2rem' }}>
+                                            <li>
+                                                <b>Sequential</b> - Step B must happen after Step A, but any number
+                                                events can happen between A and B.
+                                            </li>
+                                            <li>
+                                                <b>Strict Order</b> - Step B must happen directly after Step A without
+                                                any events in between.
+                                            </li>
+                                            <li>
+                                                <b>Any Order</b> - Steps can be completed in any sequence.
+                                            </li>
+                                        </ul>
+                                    }
+                                >
+                                    <InfoCircleOutlined className="info-indicator" />
+                                </Tooltip>
+                            </span>
+                        </Row>
+                    )}
                 </Row>
                 <ActionFilter
                     filters={filters}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -12,6 +12,7 @@ import { SaveOutlined } from '@ant-design/icons'
 import { ToggleButtonChartFilter } from './ToggleButtonChartFilter'
 import { InsightActionBar } from '../InsightActionBar'
 import { Tooltip } from 'lib/components/Tooltip'
+import { FunnelStepOrderPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker'
 
 export function FunnelTab(): JSX.Element {
     useMountedLogic(funnelCommandLogic)
@@ -50,6 +51,7 @@ export function FunnelTab(): JSX.Element {
             >
                 <Row justify="space-between" align="middle">
                     <h4 className="secondary">Steps</h4>
+                    <FunnelStepOrderPicker />
                 </Row>
                 <ActionFilter
                     filters={filters}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react'
 import { SaveModal } from '../../SaveModal'
 import { funnelCommandLogic } from './funnelCommandLogic'
 import { InsightTitle } from '../InsightTitle'
-import { SaveOutlined } from '@ant-design/icons'
+import { InfoCircleOutlined, SaveOutlined } from '@ant-design/icons'
 import { ToggleButtonChartFilter } from './ToggleButtonChartFilter'
 import { InsightActionBar } from '../InsightActionBar'
 import { Tooltip } from 'lib/components/Tooltip'
@@ -50,8 +50,33 @@ export function FunnelTab(): JSX.Element {
                 }}
             >
                 <Row justify="space-between" align="middle">
-                    <h4 className="secondary">Steps</h4>
-                    <FunnelStepOrderPicker />
+                    <h4 className="secondary" style={{ marginBottom: 0 }}>
+                        Steps
+                    </h4>
+                    <Row align="middle">
+                        <span className="l5 text-muted-alt mr-025">
+                            <Tooltip
+                                title={
+                                    <ul style={{ paddingLeft: '1.2rem' }}>
+                                        <li>
+                                            <b>Sequential</b> - Step B must happen after Step A, but the previous step
+                                            doesn't have to be step A.
+                                        </li>
+                                        <li>
+                                            <b>Strict Order</b> - Step B must happen directly after Step A.
+                                        </li>
+                                        <li>
+                                            <b>Any Order</b> - Steps can be completed in any sequence.
+                                        </li>
+                                    </ul>
+                                }
+                            >
+                                <InfoCircleOutlined className="info-indicator left" />
+                            </Tooltip>
+                            Step Order
+                        </span>
+                        <FunnelStepOrderPicker />
+                    </Row>
                 </Row>
                 <ActionFilter
                     filters={filters}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -59,11 +59,12 @@ export function FunnelTab(): JSX.Element {
                                 title={
                                     <ul style={{ paddingLeft: '1.2rem' }}>
                                         <li>
-                                            <b>Sequential</b> - Step B must happen after Step A, but the previous step
-                                            doesn't have to be step A.
+                                            <b>Sequential</b> - Step B must happen after Step A, but any number events
+                                            can happen between A and B.
                                         </li>
                                         <li>
-                                            <b>Strict Order</b> - Step B must happen directly after Step A.
+                                            <b>Strict Order</b> - Step B must happen directly after Step B without any
+                                            events in between.
                                         </li>
                                         <li>
                                             <b>Any Order</b> - Steps can be completed in any sequence.

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -48,7 +48,9 @@ export function FunnelTab(): JSX.Element {
                     loadResults()
                 }}
             >
-                <h4 className="secondary">Steps</h4>
+                <Row justify="space-between" align="middle">
+                    <h4 className="secondary">Steps</h4>
+                </Row>
                 <ActionFilter
                     filters={filters}
                     setFilters={(newFilters: Record<string, any>): void => setFilters(newFilters, false)}

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -244,7 +244,7 @@ export function Insights(): JSX.Element {
                     </Col>
                 ) : (
                     <>
-                        <Col span={24} lg={verticalLayout ? 7 : undefined}>
+                        <Col span={24} lg={verticalLayout ? 8 : undefined}>
                             <Card
                                 className={`insight-controls${controlsCollapsed ? ' collapsed' : ''}`}
                                 onClick={() => controlsCollapsed && toggleControlsCollapsed()}
@@ -303,7 +303,7 @@ export function Insights(): JSX.Element {
                             </Card>
                             {activeView === ViewType.FUNNELS && <FunnelSecondaryTabs />}
                         </Col>
-                        <Col span={24} lg={verticalLayout ? 17 : undefined}>
+                        <Col span={24} lg={verticalLayout ? 16 : undefined}>
                             {/* TODO: extract to own file. Props: activeView, allFilters, showDateFilter, dateFilterDisabled, annotationsToCreate; lastRefresh, showErrorMessage, showTimeoutMessage, isLoading; ... */}
                             {/* These are filters that are reused between insight features. They
                                 each have generic logic that updates the url

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -126,6 +126,11 @@ style files without adding already imported styles. */
     font-weight: 700;
 }
 
+.l5 {
+    font-size: 13px;
+    font-weight: 700;
+}
+
 .text-right {
     text-align: right;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -388,6 +388,13 @@ export interface SavedFunnel extends InsightHistory {
 
 export type BinCountValue = number | typeof BinCountAuto
 
+// https://github.com/PostHog/posthog/blob/master/posthog/constants.py#L106
+export enum StepOrderValue {
+    STRICT = 'strict',
+    UNORDERED = 'unordered',
+    ORDERED = 'ordered',
+}
+
 export enum PersonsTabType {
     EVENTS = 'events',
     SESSIONS = 'sessions',
@@ -662,6 +669,7 @@ export interface FilterType {
     funnel_step_breakdown?: string | number[] | number | null // used in steps breakdown: persons modal
     compare?: boolean
     bin_count?: BinCountValue // used in time to convert: number of bins to show in histogram
+    funnel_order_type?: StepOrderValue
 }
 
 export interface SystemStatusSubrows {


### PR DESCRIPTION
## Changes

Closes #5552.
Addresses part of #5367.

<img width="471" alt="Screen Shot 2021-08-18 at 2 43 36 PM" src="https://user-images.githubusercontent.com/13460330/129976220-c4b0556c-7b30-4ec9-bda4-2e1b321774b5.png">


- [ ] Adds new `<FunnelStepOrderPicker/>`
- [ ] Makes funnel's left query sidebar a tad bigger since we're adding a lot of filters/options/pickers there

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
