### PR TITLE
Auth updates & fix login as

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -26,10 +26,10 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.9
+            - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: 3.8
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
@@ -240,10 +240,10 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.9
+            - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: 3.8
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -26,10 +26,10 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.8
+            - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
@@ -240,10 +240,10 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.8
+            - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -5,7 +5,7 @@ import os
 from typing import Dict, List
 
 from posthog.constants import RDBMS
-from posthog.settings import PRIMARY_DB, TEST
+from posthog.settings import AUTHENTICATION_BACKENDS, PRIMARY_DB, TEST
 
 # Zapier REST hooks
 HOOK_EVENTS: Dict[str, str] = {
@@ -24,6 +24,11 @@ if "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS" in os.environ:
     SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS: List[str] = os.environ[
         "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS"
     ].split(",")
+
+AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + (
+    "social_core.backends.google.GoogleOAuth2",
+    "ee.api.authentication.OIDC",
+)
 
 # ClickHouse and Kafka
 KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -25,7 +25,9 @@ if "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS" in os.environ:
         "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS"
     ].split(",")
 
-AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + ("social_core.backends.google.GoogleOAuth2",)
+AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
+    "social_core.backends.google.GoogleOAuth2",
+]
 
 # ClickHouse and Kafka
 KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -25,10 +25,7 @@ if "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS" in os.environ:
         "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS"
     ].split(",")
 
-AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + (
-    "social_core.backends.google.GoogleOAuth2",
-    "ee.api.authentication.OIDC",
-)
+AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + ("social_core.backends.google.GoogleOAuth2",)
 
 # ClickHouse and Kafka
 KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -2,7 +2,11 @@ from typing import Any, Dict, Optional, cast
 
 from django.conf import settings
 from django.contrib.auth import authenticate, login
+from django.contrib.auth import views as auth_views
 from django.http import JsonResponse
+from django.shortcuts import redirect
+from django.views.decorators.csrf import csrf_protect
+from loginas.utils import is_impersonated_session, restore_original_login
 from rest_framework import mixins, permissions, serializers, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,7 +15,23 @@ from posthog.event_usage import report_user_logged_in
 from posthog.models import User
 
 
-def axess_logout(*args, **kwargs):
+@csrf_protect
+def logout(request):
+    if request.user.is_authenticated:
+        request.user.temporary_token = None
+        request.user.save()
+
+    if is_impersonated_session(request):
+        restore_original_login(request)
+        return redirect("/admin/")
+
+    response = auth_views.logout_then_login(request)
+    response.delete_cookie(settings.TOOLBAR_COOKIE_NAME, "/")
+
+    return response
+
+
+def axess_locked_out(*args, **kwargs):
     return JsonResponse(
         {
             "type": "authentication_error",

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -393,7 +393,7 @@ class TestSignupAPI(APIBaseTest):
         )
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    def test_social_signup_is_disabled_in_cloud(self, mock_request):
+    def test_social_signup_to_existing_org_with_whitelisted_domains_is_disabled_in_cloud(self, mock_request):
         Organization.objects.create(name="Hogflix Movies", domain_whitelist=["hogflix.posthog.com"])
         user_count = User.objects.count()
         org_count = Organization.objects.count()

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -335,6 +335,7 @@ class TestSignupAPI(APIBaseTest):
         )  # show the user an error; operation not permitted
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
+    @pytest.mark.ee
     def test_api_social_login_to_create_organization(self, mock_request):
         response = self.client.get(reverse("social:begin", kwargs={"backend": "google-oauth2"}))
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
@@ -349,6 +350,7 @@ class TestSignupAPI(APIBaseTest):
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @pytest.mark.skip_on_multitenancy
+    @pytest.mark.ee
     def test_api_social_login_cannot_create_second_organization(self, mock_request):
         Organization.objects.create(name="Test org")
         response = self.client.get(reverse("social:begin", kwargs={"backend": "google-oauth2"}))
@@ -366,6 +368,7 @@ class TestSignupAPI(APIBaseTest):
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @pytest.mark.skip_on_multitenancy
+    @pytest.mark.ee
     def test_social_signup_with_whitelisted_domain(self, mock_request):
         new_org = Organization.objects.create(name="Hogflix Movies", domain_whitelist=["hogflix.posthog.com"])
         new_project = Team.objects.create(organization=new_org, name="My First Project")
@@ -393,6 +396,7 @@ class TestSignupAPI(APIBaseTest):
         )
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
+    @pytest.mark.ee
     def test_social_signup_to_existing_org_with_whitelisted_domains_is_disabled_in_cloud(self, mock_request):
         Organization.objects.create(name="Hogflix Movies", domain_whitelist=["hogflix.posthog.com"])
         user_count = User.objects.count()
@@ -415,6 +419,7 @@ class TestSignupAPI(APIBaseTest):
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @pytest.mark.skip_on_multitenancy
+    @pytest.mark.ee
     def test_api_cannot_use_whitelist_for_different_domain(self, mock_request):
         Organization.objects.create(name="Test org", domain_whitelist=["good.com"])
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -235,7 +235,7 @@ AXES_ENABLED = get_from_env("AXES_ENABLED", not TEST, type_cast=str_to_bool)
 AXES_HANDLER = "axes.handlers.cache.AxesCacheHandler"
 AXES_FAILURE_LIMIT = int(os.getenv("AXES_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=15)
-AXES_LOCKOUT_CALLABLE = "posthog.api.authentication.axess_logout"
+AXES_LOCKOUT_CALLABLE = "posthog.api.authentication.axess_locked_out"
 AXES_META_PRECEDENCE_ORDER = [
     "HTTP_X_FORWARDED_FOR",
     "REMOTE_ADDR",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -329,16 +329,16 @@ WSGI_APPLICATION = "posthog.wsgi.application"
 
 # Social Auth
 
-SOCIAL_AUTH_POSTGRES_JSONFIELD = True
+SOCIAL_AUTH_JSONFIELD_ENABLED = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", not DEBUG, type_cast=str_to_bool)
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
     "social_core.backends.github.GithubOAuth2",
     "social_core.backends.gitlab.GitLabOAuth2",
     "django.contrib.auth.backends.ModelBackend",
-)
+]
 
 SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.social_details",

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -337,7 +337,6 @@ AUTHENTICATION_BACKENDS = (
     "axes.backends.AxesBackend",
     "social_core.backends.github.GithubOAuth2",
     "social_core.backends.gitlab.GitLabOAuth2",
-    "social_core.backends.google.GoogleOAuth2",
     "django.contrib.auth.backends.ModelBackend",
 )
 

--- a/requirements.in
+++ b/requirements.in
@@ -47,7 +47,7 @@ requests==2.25.1
 requests-oauthlib==1.3.0
 sentry-sdk==0.19.2
 semantic_version==2.8.5
-social-auth-app-django==4.0.0
-social-auth-core==4.0.2
+social-auth-app-django==5.0.0
+social-auth-core==4.1.0
 toronado==0.0.11
 whitenoise==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ ptyprocess==0.6.0
     # via pexpect
 pycparser==2.20
     # via cffi
-pyjwt==1.7.1
+pyjwt==2.1.0
     # via social-auth-core
 python-dateutil==2.8.1
     # via
@@ -196,12 +196,10 @@ six==1.14.0
     #   posthoganalytics
     #   protobuf
     #   python-dateutil
-    #   social-auth-app-django
-    #   social-auth-core
     #   tenacity
-social-auth-app-django==4.0.0
+social-auth-app-django==5.0.0
     # via -r requirements.in
-social-auth-core==4.0.2
+social-auth-core==4.1.0
     # via
     #   -r requirements.in
     #   social-auth-app-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ ptyprocess==0.6.0
     # via pexpect
 pycparser==2.20
     # via cffi
-pyjwt==2.1.0
+pyjwt==1.7.0
     # via social-auth-core
 python-dateutil==2.8.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ ptyprocess==0.6.0
     # via pexpect
 pycparser==2.20
     # via cffi
-pyjwt==1.7.0
+pyjwt==2.1.0
     # via social-auth-core
 python-dateutil==2.8.1
     # via


### PR DESCRIPTION
## Changes

This PR grabs some useful code from #5606 and a couple of other fixes related to authentication.
- Moves Google auth to EE (as it's a premium feature)
- Fixes a typo in Axes locked out view to clarify what view is for
- Moves logout view to views.py & removes extra unnecessary line
- Fixes logging as user (currently broken in production)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
