### PR TITLE
Wrap client err before sending to statsd

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -139,11 +139,12 @@ else:
             try:
                 result = client.execute(sql, args, settings=settings, with_column_types=with_column_types)
             except Exception as err:
+                err = wrap_query_error(err)
                 tags["failed"] = True
                 tags["reason"] = type(err).__name__
                 incr("clickhouse_sync_execution_failure", tags=tags)
 
-                raise wrap_query_error(err)
+                raise err
             finally:
                 execution_time = perf_counter() - start_time
 


### PR DESCRIPTION
This makes statsd stats more useful on query errors

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
