### PR TITLE
Don't fetch team unless needed

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -187,16 +187,7 @@ def get_git_commit() -> Optional[str]:
 
 
 def render_template(template_name: str, request: HttpRequest, context: Dict = {}) -> HttpResponse:
-    from posthog.models import Team
-
     template = get_template(template_name)
-
-    # Get the current user's team (or first team in the instance) to set opt out capture & self capture configs
-    team: Optional[Team] = None
-    try:
-        team = request.user.team  # type: ignore
-    except (Team.DoesNotExist, AttributeError):
-        team = Team.objects.first()
 
     context["self_capture"] = False
     context["opt_out_capture"] = os.getenv("OPT_OUT_CAPTURE", False)
@@ -211,8 +202,10 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     if settings.SELF_CAPTURE:
         context["self_capture"] = True
-        if team:
-            context["js_posthog_api_key"] = f"'{team.api_token}'"
+        api_token = get_self_capture_api_token(request)
+
+        if api_token:
+            context["js_posthog_api_key"] = f"'{api_token}'"
             context["js_posthog_host"] = "window.location.origin"
     else:
         context["js_posthog_api_key"] = "'sTMFPsFhdP1Ssg'"
@@ -242,6 +235,21 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     html = template.render(context, request=request)
     return HttpResponse(html)
+
+
+def get_self_capture_api_token(request: HttpRequest) -> Optional[str]:
+    from posthog.models import Team
+
+    # Get the current user's team (or first team in the instance) to set self capture configs
+    team: Optional[Team] = None
+    try:
+        team = request.user.team  # type: ignore
+    except (Team.DoesNotExist, AttributeError):
+        team = Team.objects.only("api_token").first()
+
+    if team:
+        return team.api_token
+    return None
 
 
 def get_default_event_name():


### PR DESCRIPTION
Previously every login/shared dashboard/page load request loaded
team independent of whether it's needed or not.

This makes it so we only load the team here when SELF_CAPTURE is turned
on (i.e. only during dev)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
