### PR TITLE
Funnels: support breaking down by "All users" pseudo-cohort

### DIFF
--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -12,6 +12,8 @@ from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filters.filter import Filter
 
+ALL_USERS_COHORT_ID = 0
+
 
 def _get_top_elements(filter: Filter, team_id: int, query: str, limit, params: Dict = {}) -> List:
     # use limit of 25 to determine if there are more than 20
@@ -118,7 +120,7 @@ def _format_all_query(team_id: int, filter: Filter, **kwargs) -> Tuple[str, Dict
         props_to_filter, team_id, prepend="all_cohort_", table_name="all_events"
     )
     query = f"""
-            SELECT DISTINCT distinct_id, 0 as value
+            SELECT DISTINCT distinct_id, {ALL_USERS_COHORT_ID} as value
             FROM events all_events
             WHERE team_id = {team_id}
             {parsed_date_from}
@@ -141,7 +143,7 @@ def format_breakdown_cohort_join_query(team_id: int, filter: Filter, **kwargs) -
         all_query, all_params = _format_all_query(team_id, filter, entity=entity)
         cohort_queries.append(all_query)
         params = {**params, **all_params}
-        ids.append(0)
+        ids.append(ALL_USERS_COHORT_ID)
     return " UNION ALL ".join(cohort_queries), ids, params
 
 
@@ -156,3 +158,10 @@ def _parse_breakdown_cohorts(cohorts: List[Cohort]) -> Tuple[List[str], Dict]:
         )  # only replace the first top level occurrence
         queries.append(cohort_query)
     return queries, params
+
+
+def get_breakdown_cohort_name(cohort_id: int) -> str:
+    if cohort_id == ALL_USERS_COHORT_ID:
+        return "all users"
+    else:
+        return Cohort.objects.get(pk=cohort_id).name

--- a/ee/clickhouse/queries/funnels/funnel.py
+++ b/ee/clickhouse/queries/funnels/funnel.py
@@ -1,5 +1,6 @@
 from typing import List, cast
 
+from ee.clickhouse.queries.breakdown_props import get_breakdown_cohort_name
 from ee.clickhouse.queries.funnels.base import ClickhouseFunnelBase
 from posthog.models.cohort import Cohort
 
@@ -101,7 +102,7 @@ class ClickhouseFunnel(ClickhouseFunnelBase):
                 # breakdown_value will return the underlying id if different from display ready value (ex: cohort id)
                 serialized_result.update(
                     {
-                        "breakdown": Cohort.objects.get(pk=result[-1]).name
+                        "breakdown": get_breakdown_cohort_name(result[-1])
                         if self._filter.breakdown_type == "cohort"
                         else result[-1],
                         "breakdown_value": result[-1],

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -1,4 +1,5 @@
 from ee.clickhouse.materialized_columns import materialize
+from ee.clickhouse.queries.breakdown_props import ALL_USERS_COHORT_ID
 from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
 from posthog.constants import INSIGHT_FUNNELS
 from posthog.models.cohort import Cohort
@@ -1101,16 +1102,21 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_p
                 "date_to": "2020-01-08",
                 "funnel_window_days": 7,
                 "breakdown_type": "cohort",
-                "breakdown": [cohort.pk],
+                "breakdown": ["all", cohort.pk],
             }
             filter = Filter(data=filters)
             funnel = ClickhouseFunnel(filter, self.team)
 
             result = funnel.run()
             self.assertEqual(len(result[0]), 3)
-            self.assertEqual(result[0][0]["breakdown"], "test_cohort")
+            self.assertEqual(result[0][0]["breakdown"], "all users")
+            self.assertEqual(len(result[1]), 3)
+            self.assertEqual(result[1][0]["breakdown"], "test_cohort")
             self.assertCountEqual(self._get_people_at_step(filter, 1, cohort.pk), [person.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 2, cohort.pk), [])
+
+            self.assertCountEqual(self._get_people_at_step(filter, 1, ALL_USERS_COHORT_ID), [person.uuid])
+            self.assertCountEqual(self._get_people_at_step(filter, 2, ALL_USERS_COHORT_ID), [])
 
             # non array
             filters = {

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -4,7 +4,9 @@ from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.breakdown_props import (
+    ALL_USERS_COHORT_ID,
     format_breakdown_cohort_join_query,
+    get_breakdown_cohort_name,
     get_breakdown_event_prop_values,
     get_breakdown_person_prop_values,
 )
@@ -21,11 +23,8 @@ from ee.clickhouse.sql.trends.breakdown import (
     BREAKDOWN_PERSON_PROP_JOIN_SQL,
     BREAKDOWN_PROP_JOIN_SQL,
     BREAKDOWN_QUERY_SQL,
-    NONE_BREAKDOWN_PERSON_PROP_JOIN_SQL,
-    NONE_BREAKDOWN_PROP_JOIN_SQL,
 )
 from posthog.constants import MONTHLY_ACTIVE, TREND_FILTER_TYPE_ACTIONS, TRENDS_DISPLAY_BY_VALUE, WEEKLY_ACTIVE
-from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filters import Filter
 
@@ -229,7 +228,7 @@ class ClickhouseTrendsBreakdown:
             "label": label,
         }
         if filter.breakdown_type == "cohort":
-            additional_values["breakdown_value"] = "all" if breakdown_value == 0 else breakdown_value
+            additional_values["breakdown_value"] = "all" if breakdown_value == ALL_USERS_COHORT_ID else breakdown_value
         else:
             additional_values["breakdown_value"] = breakdown_value
 
@@ -244,9 +243,6 @@ class ClickhouseTrendsBreakdown:
     ) -> str:
         breakdown = breakdown if breakdown and isinstance(breakdown, list) else []
         if breakdown_type == "cohort":
-            if breakdown_value == 0:
-                return "all users"
-            else:
-                return Cohort.objects.get(pk=breakdown_value).name
+            return get_breakdown_cohort_name(breakdown_value)
         else:
             return str(value) or "none"

--- a/ee/clickhouse/queries/trends/formula.py
+++ b/ee/clickhouse/queries/trends/formula.py
@@ -3,6 +3,7 @@ from itertools import accumulate
 from typing import Any, Dict, List
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.queries.breakdown_props import get_breakdown_cohort_name
 from ee.clickhouse.queries.trends.util import parse_response
 from posthog.constants import TRENDS_CUMULATIVE, TRENDS_DISPLAY_BY_VALUE
 from posthog.models.cohort import Cohort
@@ -86,8 +87,6 @@ class ClickhouseTrendsFormula:
     def _label(self, filter: Filter, item: List, team_id: int) -> str:
         if filter.breakdown:
             if filter.breakdown_type == "cohort":
-                if item[2] == 0:
-                    return "all users"
-                return Cohort.objects.get(team=team_id, pk=item[2]).name
+                return get_breakdown_cohort_name(item[2])
             return item[2]
         return "Formula ({})".format(filter.formula)


### PR DESCRIPTION
This already works in trends, but had a bug in funnels. Unified the
implementations as well.

Closes https://github.com/PostHog/posthog/issues/5566

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
