### PR TITLE
Hide "date" in stickiness graph

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -11,7 +11,7 @@ import { useThrottledCallback } from 'use-debounce'
 import './FunnelBarGraph.scss'
 import { useActions, useValues } from 'kea'
 import { FunnelStepReference } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker'
-import { InsightTooltip } from 'scenes/insights/InsightTooltip'
+import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { FunnelLayout } from 'lib/constants'
 import {
     getReferenceStep,
@@ -147,7 +147,7 @@ function Bar({
             trigger="hover"
             placement="right"
             content={
-                <InsightTooltip chartType="funnel" altTitle={popoverTitle}>
+                <InsightTooltip altTitle={popoverTitle}>
                     {popoverMetrics.map(({ title, value, visible }, index) =>
                         visible !== false ? <MetricRow key={index} title={title} value={value} /> : null
                     )}

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -10,32 +10,35 @@ interface BodyLine {
 }
 
 interface InsightTooltipProps {
-    chartType: string
     altTitle?: string | JSX.Element | null // Alternate string to display as title (in case date reference is not available or not desired)
     referenceDate?: string
     interval?: IntervalType
     bodyLines?: BodyLine[] // bodyLines is in here for its similarity to LineChart's built-in tooltips, but children is easier to use in other React components
     inspectUsersLabel?: boolean
     children?: React.ReactNode
-    hideDate?: boolean
+    preferAltTitle?: boolean // Whether `altTitle` should be prefered over the default DateDisplay to show as header of the tooltip
+    hideHeader?: boolean
 }
 
 export function InsightTooltip({
-    chartType,
     altTitle,
     referenceDate,
     interval,
     bodyLines = [],
     inspectUsersLabel,
     children,
-    hideDate,
+    preferAltTitle,
+    hideHeader,
 }: InsightTooltipProps): JSX.Element {
-    console.log({ chartType })
     return (
         <div className={`inner-tooltip${bodyLines.length > 1 ? ' multiple' : ''}`} style={{ maxWidth: 300 }}>
-            {chartType !== 'horizontalBar' && !hideDate && (
+            {!hideHeader && (
                 <header>
-                    {referenceDate && interval ? <DateDisplay interval={interval} date={referenceDate} /> : altTitle}
+                    {referenceDate && interval && !preferAltTitle ? (
+                        <DateDisplay interval={interval} date={referenceDate} />
+                    ) : (
+                        altTitle
+                    )}
                 </header>
             )}
             {bodyLines?.length > 0 && (

--- a/frontend/src/scenes/insights/InsightTooltip/index.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/index.tsx
@@ -17,6 +17,7 @@ interface InsightTooltipProps {
     bodyLines?: BodyLine[] // bodyLines is in here for its similarity to LineChart's built-in tooltips, but children is easier to use in other React components
     inspectUsersLabel?: boolean
     children?: React.ReactNode
+    hideDate?: boolean
 }
 
 export function InsightTooltip({
@@ -27,10 +28,12 @@ export function InsightTooltip({
     bodyLines = [],
     inspectUsersLabel,
     children,
+    hideDate,
 }: InsightTooltipProps): JSX.Element {
+    console.log({ chartType })
     return (
         <div className={`inner-tooltip${bodyLines.length > 1 ? ' multiple' : ''}`} style={{ maxWidth: 300 }}>
-            {chartType !== 'horizontalBar' && (
+            {chartType !== 'horizontalBar' && !hideDate && (
                 <header>
                     {referenceDate && interval ? <DateDisplay interval={interval} date={referenceDate} /> : altTitle}
                 </header>

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -38,6 +38,7 @@ export function LineGraph({
     interval = undefined,
     totalValue,
     showPersonsModal = true,
+    showDatesInTooltip = true,
 }) {
     const chartRef = useRef()
     const myLineChart = useRef()
@@ -317,6 +318,7 @@ export function LineGraph({
                             bodyLines={bodyLines}
                             inspectUsersLabel={inspectUsersLabel}
                             chartType={type}
+                            hideDate={!showDatesInTooltip}
                         />,
                         tooltipEl
                     )

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -13,7 +13,7 @@ import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import dayjs from 'dayjs'
 import './LineGraph.scss'
 import { InsightLabel } from 'lib/components/InsightLabel'
-import { InsightTooltip } from '../InsightTooltip'
+import { InsightTooltip } from '../InsightTooltip/InsightTooltip'
 
 //--Chart Style Options--//
 Chart.defaults.global.legend.display = false
@@ -38,7 +38,7 @@ export function LineGraph({
     interval = undefined,
     totalValue,
     showPersonsModal = true,
-    showDatesInTooltip = true,
+    tooltipPreferAltTitle = false,
 }) {
     const chartRef = useRef()
     const myLineChart = useRef()
@@ -298,11 +298,11 @@ export function LineGraph({
 
                 if (tooltipModel.body) {
                     const referenceDataPoint = tooltipModel.dataPoints[0] // Use this point as reference to get the date
-                    const comparing = datasets[referenceDataPoint.datasetIndex].compare
-                    const altTitle = tooltipModel.title && comparing ? tooltipModel.title[0] : ''
-                    const referenceDate = !comparing
-                        ? datasets[referenceDataPoint.datasetIndex].days[referenceDataPoint.index]
-                        : undefined
+                    const dataset = datasets[referenceDataPoint.datasetIndex]
+
+                    const altTitle =
+                        tooltipModel.title && (dataset.compare || tooltipPreferAltTitle) ? tooltipModel.title[0] : '' // When comparing we show the whole range for clarity; when on stickiness we show the relative timeframe (e.g. `5 days`)
+                    const referenceDate = !dataset.compare ? dataset.days[referenceDataPoint.index] : undefined
                     const bodyLines = tooltipModel.body
                         .flatMap(({ lines }) => lines)
                         .map((component, idx) => ({
@@ -317,8 +317,8 @@ export function LineGraph({
                             interval={interval}
                             bodyLines={bodyLines}
                             inspectUsersLabel={inspectUsersLabel}
-                            chartType={type}
-                            hideDate={!showDatesInTooltip}
+                            preferAltTitle={tooltipPreferAltTitle}
+                            hideHeader={type === 'horizontalBar'}
                         />,
                         tooltipEl
                     )

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -43,6 +43,7 @@ export function ActionsLineGraph({
                 inSharedMode={inSharedMode}
                 interval={filters.interval}
                 showPersonsModal={showPersonsModal}
+                showDatesInTooltip={filters.insight !== ViewType.STICKINESS}
                 onClick={
                     dashboardItemId
                         ? null

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -43,7 +43,7 @@ export function ActionsLineGraph({
                 inSharedMode={inSharedMode}
                 interval={filters.interval}
                 showPersonsModal={showPersonsModal}
-                showDatesInTooltip={filters.insight !== ViewType.STICKINESS}
+                tooltipPreferAltTitle={filters.insight === ViewType.STICKINESS}
                 onClick={
                     dashboardItemId
                         ? null


### PR DESCRIPTION
The date is not actually a date but rather a day count in this view.

Probably not the best solution but PRs > issues

![image](https://user-images.githubusercontent.com/148820/130051792-81d8d9ab-e3d8-499b-930f-70bbbfacd831.png)

Closes https://github.com/PostHog/posthog/issues/5585

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
