### PR TITLE
Support `href`/`text` element filters

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -25,7 +25,7 @@ def format_action_filter(
         if step.event == AUTOCAPTURE_EVENT:
             from ee.clickhouse.models.property import filter_element  # prevent circular import
 
-            el_condition, element_params = filter_element(model_to_dict(step), f"{action.pk}_{index}{prepend}")
+            el_condition, element_params = filter_element(model_to_dict(step), prepend=f"{action.pk}_{index}{prepend}")
             params = {**params, **element_params}
             if len(el_condition) > 0:
                 conditions.append(el_condition)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -229,26 +229,6 @@ def get_property_values_for_key(key: str, team: Team, value: Optional[str] = Non
     )
 
 
-def process_ok_values(ok_values: Any, operator: OperatorType) -> List[str]:
-    if operator.endswith("_set"):
-        return [r'[^"]+']
-    else:
-        # Make sure ok_values is a list
-        ok_values = cast(List[str], [str(val) for val in ok_values]) if isinstance(ok_values, list) else [ok_values]
-        # Escape double quote characters, since e.g. text 'foo="bar"' is represented as text="foo=\"bar\""
-        # in the elements chain
-        ok_values = [text.replace('"', r"\"") for text in ok_values]
-        if operator.endswith("icontains"):
-            # Process values for case-insensitive-contains matching by way of regex,
-            # making sure matching scope is limited to between double quotes
-            return [rf'[^"]*{re.escape(text)}[^"]*' for text in ok_values]
-        if operator.endswith("regex"):
-            # Use values as-is in case of regex matching
-            return ok_values
-        # For all other operators escape regex-meaningful sequences
-        return [re.escape(text) for text in ok_values]
-
-
 def filter_element(filters: Dict, *, operator: Optional[OperatorType] = None, prepend: str = "") -> Tuple[str, Dict]:
     if not operator:
         operator = "exact"
@@ -312,6 +292,26 @@ def filter_element(filters: Dict, *, operator: Optional[OperatorType] = None, pr
         return f"{'NOT ' if operator in NEGATED_OPERATORS else ''}({' AND '.join(final_conditions)})", params
     else:
         return "", {}
+
+
+def process_ok_values(ok_values: Any, operator: OperatorType) -> List[str]:
+    if operator.endswith("_set"):
+        return [r'[^"]+']
+    else:
+        # Make sure ok_values is a list
+        ok_values = cast(List[str], [str(val) for val in ok_values]) if isinstance(ok_values, list) else [ok_values]
+        # Escape double quote characters, since e.g. text 'foo="bar"' is represented as text="foo=\"bar\""
+        # in the elements chain
+        ok_values = [text.replace('"', r"\"") for text in ok_values]
+        if operator.endswith("icontains"):
+            # Process values for case-insensitive-contains matching by way of regex,
+            # making sure matching scope is limited to between double quotes
+            return [rf'[^"]*{re.escape(text)}[^"]*' for text in ok_values]
+        if operator.endswith("regex"):
+            # Use values as-is in case of regex matching
+            return ok_values
+        # For all other operators escape regex-meaningful sequences
+        return [re.escape(text) for text in ok_values]
 
 
 def build_selector_regex(selector: Selector) -> str:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -105,14 +105,14 @@ def prop_filter_json_extract(
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND {left} ILIKE %(v{prepend}_{idx})s".format(idx=idx, prepend=prepend, left=property_expr),
+            "AND {left} LIKE %(v{prepend}_{idx})s".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator == "not_icontains":
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND NOT ({left} ILIKE %(v{prepend}_{idx})s)".format(idx=idx, prepend=prepend, left=property_expr),
+            "AND NOT ({left} LIKE %(v{prepend}_{idx})s)".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator in ("regex", "not_regex"):

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -70,15 +70,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
             distinct_id="whatever",
             properties={"attr": "some_other_val"},
             elements=[
-                Element(
-                    tag_name="a",
-                    href="/a-url",
-                    attr_class=["small"],
-                    text="bla bla",
-                    attributes={},
-                    nth_child=1,
-                    nth_of_type=0,
-                ),
+                Element(tag_name="a", href="/a-url", attr_class=["small"], text="bla bla", nth_child=1, nth_of_type=0,),
                 Element(tag_name="button", attr_class=["btn", "btn-primary"], nth_child=0, nth_of_type=0),
                 Element(tag_name="div", nth_child=0, nth_of_type=0),
                 Element(tag_name="label", nth_child=0, nth_of_type=0, attr_id="nested",),
@@ -250,10 +242,10 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter_href_not_regex)), 2)
 
-        filter_href_icontains_with_doublequote = Filter(
+        filter_text_icontains_with_doublequote = Filter(
             data={"properties": [{"key": "text", "value": 'bla"bla', "operator": "icontains", "type": "element"}]}
         )
-        self.assertEqual(len(self._run_query(filter_href_icontains_with_doublequote)), 1)
+        self.assertEqual(len(self._run_query(filter_text_icontains_with_doublequote)), 1)
 
         filter_text_is_set = Filter(
             data={"properties": [{"key": "text", "value": "is_set", "operator": "is_set", "type": "element"}]}

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -60,19 +60,8 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
             event="$pageview", team=self.team, distinct_id="whatever", properties={"attr": "some_val"},
         )
 
-        filter_exact = Filter(data={"properties": [{"key": "attr", "value": "some_val"}],})
-        self.assertEqual(len(self._run_query(filter_exact)), 1)
-
-        filter_regex = Filter(data={"properties": [{"key": "attr", "value": "some_.+_val", "operator": "regex"}],})
-        self.assertEqual(len(self._run_query(filter_regex)), 1)
-
-        filter_icontains = Filter(data={"properties": [{"key": "attr", "value": "Some_Val", "operator": "icontains"}],})
-        self.assertEqual(len(self._run_query(filter_icontains)), 1)
-
-        filter_not_icontains = Filter(
-            data={"properties": [{"key": "attr", "value": "other", "operator": "not_icontains"}],}
-        )
-        self.assertEqual(len(self._run_query(filter_not_icontains)), 1)
+        filter = Filter(data={"properties": [{"key": "attr", "value": "some_val"}],})
+        self.assertEqual(len(self._run_query(filter)), 1)
 
     def test_prop_element(self):
         _create_event(

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -74,7 +74,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter_not_icontains)), 1)
 
-    def test_prop_selector_tag_name(self):
+    def test_prop_element(self):
         _create_event(
             event="$autocapture",
             team=self.team,
@@ -199,7 +199,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter)), 2)
 
-        # href
+        # href/text
 
         filter_href_exact = Filter(
             data={"properties": [{"key": "href", "value": ["/a-url"], "operator": "exact", "type": "element"}]}
@@ -245,6 +245,16 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
             data={"properties": [{"key": "href", "value": r"/\d+", "operator": "not_regex", "type": "element"}]}
         )
         self.assertEqual(len(self._run_query(filter_href_not_regex)), 2)
+
+        filter_href_is_set = Filter(
+            data={"properties": [{"key": "text", "value": "is_set", "operator": "is_set", "type": "element"}]}
+        )
+        self.assertEqual(len(self._run_query(filter_href_is_set)), 2)
+
+        filter_href_is_not_set = Filter(
+            data={"properties": [{"key": "text", "value": "is_not_set", "operator": "is_not_set", "type": "element"}]}
+        )
+        self.assertEqual(len(self._run_query(filter_href_is_not_set)), 1)
 
     def test_prop_ints_saved_as_strings(self):
         _create_event(

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -105,7 +105,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
                     tag_name="a",
                     href="/a-url",
                     attr_class=["small"],
-                    text="bla bla",
+                    text='bla"bla',
                     attributes={},
                     nth_child=1,
                     nth_of_type=0,
@@ -165,10 +165,15 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter)), 2)
 
-        filter = Filter(
+        filter_selector_exact = Filter(
             data={"properties": [{"key": "selector", "value": [], "operator": "exact", "type": "element",}]}
         )
-        self.assertEqual(len(self._run_query(filter)), 0)
+        self.assertEqual(len(self._run_query(filter_selector_exact)), 0)
+
+        filter_selector_is_not = Filter(
+            data={"properties": [{"key": "selector", "value": [], "operator": "is_not", "type": "element",}]}
+        )
+        self.assertEqual(len(self._run_query(filter_selector_is_not)), 3)
 
         # tag_name
 
@@ -211,6 +216,11 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter_href_exact_double)), 3)
 
+        filter_href_exact_empty = Filter(
+            data={"properties": [{"key": "href", "value": [], "operator": "exact", "type": "element"}]}
+        )
+        self.assertEqual(len(self._run_query(filter_href_exact_empty)), 0)
+
         filter_href_is_not = Filter(
             data={"properties": [{"key": "href", "value": ["/a-url"], "operator": "is_not", "type": "element"}]}
         )
@@ -220,6 +230,11 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
             data={"properties": [{"key": "href", "value": ["/a-url", "/789"], "operator": "is_not", "type": "element"}]}
         )
         self.assertEqual(len(self._run_query(filter_href_is_not_double)), 0)
+
+        filter_href_is_not_empty = Filter(
+            data={"properties": [{"key": "href", "value": [], "operator": "is_not", "type": "element"}]}
+        )
+        self.assertEqual(len(self._run_query(filter_href_is_not_empty)), 3)
 
         filter_href_exact_with_tag_name_is_not = Filter(
             data={
@@ -246,15 +261,20 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter_href_not_regex)), 2)
 
-        filter_href_is_set = Filter(
+        filter_href_icontains_with_doublequote = Filter(
+            data={"properties": [{"key": "text", "value": 'bla"bla', "operator": "icontains", "type": "element"}]}
+        )
+        self.assertEqual(len(self._run_query(filter_href_icontains_with_doublequote)), 1)
+
+        filter_text_is_set = Filter(
             data={"properties": [{"key": "text", "value": "is_set", "operator": "is_set", "type": "element"}]}
         )
-        self.assertEqual(len(self._run_query(filter_href_is_set)), 2)
+        self.assertEqual(len(self._run_query(filter_text_is_set)), 2)
 
-        filter_href_is_not_set = Filter(
+        filter_text_is_not_set = Filter(
             data={"properties": [{"key": "text", "value": "is_not_set", "operator": "is_not_set", "type": "element"}]}
         )
-        self.assertEqual(len(self._run_query(filter_href_is_not_set)), 1)
+        self.assertEqual(len(self._run_query(filter_text_is_not_set)), 1)
 
     def test_prop_ints_saved_as_strings(self):
         _create_event(

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -165,15 +165,15 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter)), 2)
 
-        filter_selector_exact = Filter(
+        filter_selector_exact_empty = Filter(
             data={"properties": [{"key": "selector", "value": [], "operator": "exact", "type": "element",}]}
         )
-        self.assertEqual(len(self._run_query(filter_selector_exact)), 0)
+        self.assertEqual(len(self._run_query(filter_selector_exact_empty)), 0)
 
-        filter_selector_is_not = Filter(
+        filter_selector_is_not_empty = Filter(
             data={"properties": [{"key": "selector", "value": [], "operator": "is_not", "type": "element",}]}
         )
-        self.assertEqual(len(self._run_query(filter_selector_is_not)), 3)
+        self.assertEqual(len(self._run_query(filter_selector_is_not_empty)), 3)
 
         # tag_name
 

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -174,8 +174,9 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                 query, filter_params = filter_element(
                     {prop.key: prop.value}, operator=prop.operator, prepend="{}_".format(idx)
                 )
-                final.append(f" AND {query if len(query) > 0 else '1=2'}")
-                params.update(filter_params)
+                if query:
+                    final.append(f" AND {query}")
+                    params.update(filter_params)
             else:
                 filter_query, filter_params = prop_filter_json_extract(
                     prop, idx, prepend, prop_var="properties", allow_denormalized_props=allow_denormalized_props,

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -171,7 +171,9 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                 final.append(filter_query)
                 params.update(filter_params)
             elif prop.type == "element":
-                query, filter_params = filter_element({prop.key: prop.value}, prepend="{}_".format(idx))
+                query, filter_params = filter_element(
+                    {prop.key: prop.value}, operator=prop.operator, prepend="{}_".format(idx)
+                )
                 final.append(f" AND {query if len(query) > 0 else '1=2'}")
                 params.update(filter_params)
             else:

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -12,6 +12,8 @@ OperatorType = Literal[
     "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
 ]
 
+NEGATED_OPERATORS = ["is_not", "not_icontains", "not_regex", "is_not_set"]
+
 
 class Property:
     key: str

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@
 Django==3.1.12 # freeze version to the same as in production
 djangorestframework==3.12.2 # freeze version to the same as in production
 
-flake8>=3.9
+flake8>=3.8 # match minimum version to oldest Python version that PostHog currently supports
 flake8-bugbear
 flake8-colors
 flake8-commas

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@
 Django==3.1.12 # freeze version to the same as in production
 djangorestframework==3.12.2 # freeze version to the same as in production
 
-flake8
+flake8>=3.9
 flake8-bugbear
 flake8-colors
 flake8-commas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -43,8 +43,6 @@ djangorestframework-stubs==1.4.0
     # via -r requirements-dev.in
 djangorestframework==3.12.2
     # via -r requirements-dev.in
-entrypoints==0.3
-    # via flake8
 fakeredis==1.4.5
     # via -r requirements-dev.in
 flake8-bugbear==20.1.4
@@ -61,7 +59,7 @@ flake8-logging-format==0.6.0
     # via -r requirements-dev.in
 flake8-print==3.1.4
     # via -r requirements-dev.in
-flake8==3.7.9
+flake8==3.9.2
     # via
     #   -r requirements-dev.in
     #   flake8-bugbear
@@ -106,12 +104,12 @@ pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
-pycodestyle==2.5.0
+pycodestyle==2.7.0
     # via
     #   flake8
     #   flake8-import-order
     #   flake8-print
-pyflakes==2.1.1
+pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging


### PR DESCRIPTION
## Changes

Resolves #5598.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests