### PR TITLE
Fix `icontains` in ClickHouse

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -101,14 +101,14 @@ def prop_filter_json_extract(
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND {left} LIKE %(v{prepend}_{idx})s".format(idx=idx, prepend=prepend, left=property_expr),
+            "AND {left} ILIKE %(v{prepend}_{idx})s".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator == "not_icontains":
         value = "%{}%".format(prop.value)
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): value}
         return (
-            "AND NOT ({left} LIKE %(v{prepend}_{idx})s)".format(idx=idx, prepend=prepend, left=property_expr),
+            "AND NOT ({left} ILIKE %(v{prepend}_{idx})s)".format(idx=idx, prepend=prepend, left=property_expr),
             params,
         )
     elif operator in ("regex", "not_regex"):

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -60,8 +60,19 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
             event="$pageview", team=self.team, distinct_id="whatever", properties={"attr": "some_val"},
         )
 
-        filter = Filter(data={"properties": [{"key": "attr", "value": "some_val"}],})
-        self.assertEqual(len(self._run_query(filter)), 1)
+        filter_exact = Filter(data={"properties": [{"key": "attr", "value": "some_val"}],})
+        self.assertEqual(len(self._run_query(filter_exact)), 1)
+
+        filter_regex = Filter(data={"properties": [{"key": "attr", "value": "some_.+_val", "operator": "regex"}],})
+        self.assertEqual(len(self._run_query(filter_regex)), 1)
+
+        filter_icontains = Filter(data={"properties": [{"key": "attr", "value": "Some_Val", "operator": "icontains"}],})
+        self.assertEqual(len(self._run_query(filter_icontains)), 1)
+
+        filter_not_icontains = Filter(
+            data={"properties": [{"key": "attr", "value": "other", "operator": "not_icontains"}],}
+        )
+        self.assertEqual(len(self._run_query(filter_not_icontains)), 1)
 
     def test_prop_selector_tag_name(self):
         _create_event(


### PR DESCRIPTION
## Changes

Small fix for "contains"/"doesn't contain" matching in ClickHouse: it was case-sensitive, which wasn't the intention. After this fix it's case-insensitive just like in Postgres from the beginning.

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User
- [x] Django backend tests