### PR TITLE
Lower limit and pagination to fix property definitions from freezing 

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -25,7 +25,7 @@ export const propertyDefinitionsModel = kea<
             {
                 loadPropertyDefinitions: async (initial?: boolean) => {
                     const url = initial
-                        ? 'api/projects/@current/property_definitions/?limit=5000'
+                        ? 'api/projects/@current/property_definitions/?limit=500'
                         : values.propertyStorage.next
                     if (!url) {
                         throw new Error('Incorrect call to propertyDefinitionsLogic.loadPropertyDefinitions')

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -25,7 +25,7 @@ export const propertyDefinitionsModel = kea<
             {
                 loadPropertyDefinitions: async (initial?: boolean) => {
                     const url = initial
-                        ? 'api/projects/@current/property_definitions/?limit=500'
+                        ? 'api/projects/@current/property_definitions/?limit=5000'
                         : values.propertyStorage.next
                     if (!url) {
                         throw new Error('Incorrect call to propertyDefinitionsLogic.loadPropertyDefinitions')

--- a/frontend/src/scenes/events/VolumeTable.tsx
+++ b/frontend/src/scenes/events/VolumeTable.tsx
@@ -209,7 +209,7 @@ export function VolumeTable({
                 rowKey={(item) => item.eventOrProp.name}
                 size="small"
                 style={{ marginBottom: '4rem' }}
-                pagination={{ pageSize: 99999, hideOnSinglePage: true }}
+                pagination={{ pageSize: 100, hideOnSinglePage: true }}
                 onRow={(record) =>
                     hasTaxonomyFeatures && !isPosthogEvent(record.eventOrProp.name)
                         ? { onClick: () => openDrawer(type, record.eventOrProp.id), style: { cursor: 'pointer' } }


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Fix for #5376 

<img width="1008" alt="Screen Shot 2021-08-19 at 10 42 29 AM" src="https://user-images.githubusercontent.com/25164963/130089117-e25c1169-74af-408b-a3d2-6a552658c26c.png">


I think a couple culprits for ^ is that we're trying to load too many values at once in the backend and the frontend, so I've lowered the pagination limit on the API call and also the table because I doubt someone needs to see all 9999 property definitions at once?

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
