### PR TITLE
Remove plugin configs polling

### DIFF
--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -144,17 +144,6 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection>>({
             {} as Record<string, PluginConfigType>,
             {
                 loadPluginConfigs: async () => {
-                    if (!!values.pluginConfigPollTimeout) {
-                        clearTimeout(values.pluginConfigPollTimeout)
-                    }
-                    // poll for plugin configs every 5s
-                    // needed for "live" erroring without web sockets
-                    actions.setPluginConfigPollTimeout(
-                        window.setTimeout(() => {
-                            actions.loadPluginConfigs()
-                        }, 5000)
-                    )
-
                     const pluginConfigs: Record<string, PluginConfigType> = {}
                     const { results } = await api.get('api/plugin_config')
 
@@ -415,12 +404,6 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection>>({
             null as string | null,
             {
                 setSearchTerm: (_, { term }) => term,
-            },
-        ],
-        pluginConfigPollTimeout: [
-            null as NodeJS.Timeout | null,
-            {
-                setPluginConfigPollTimeout: (_, { timeout }) => timeout,
             },
         ],
         sectionsOpen: [
@@ -703,17 +686,12 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection>>({
             }
         },
     }),
-    events: ({ actions, values }) => ({
+    events: ({ actions }) => ({
         afterMount: () => {
             actions.loadPlugins()
             actions.loadPluginConfigs()
             if (canGloballyManagePlugins(userLogic.values.user?.organization)) {
                 actions.loadRepository()
-            }
-        },
-        beforeUnmount: () => {
-            if (!!values.pluginConfigPollTimeout) {
-                clearTimeout(values.pluginConfigPollTimeout)
             }
         },
     }),


### PR DESCRIPTION
## Changes

For live erroring we're polling configs every 5s but this is causing instability on the plugins page as many components keep re-rendering. 

Removing this for now until I have time to devise a better solution.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
