### PR TITLE
make utility links block-level to increase clickability

### DIFF
--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -353,6 +353,10 @@
         display: flex;
         flex-direction: column;
 
+        a {
+            display: block;
+        }
+
         .organizations {
             padding-top: 4px;
             padding-bottom: 4px;


### PR DESCRIPTION
Inline anchor tags made a lot of the links in the utility menu not clickable. (Clicking outside the actual text would inadvertently close the menu. See red areas of screenshot which weren't previously clickable.)

This makes them block-level elements so there's more room to click.

![image](https://user-images.githubusercontent.com/154479/130123045-4880011f-6d3c-427c-9505-332eeea9f7d4.png)
