### PR TITLE
Fix lingering tooltips in Line Graphs

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -61,6 +61,7 @@ export function LineGraph({
     const [boundaryInterval, setBoundaryInterval] = useState(0)
     const [topExtent, setTopExtent] = useState(0)
     const [annotationInRange, setInRange] = useState(false)
+    const [tooltipVisible, setTooltipVisible] = useState(false)
     const size = useWindowSize()
 
     const annotationsCondition =
@@ -77,6 +78,16 @@ export function LineGraph({
     useEffect(() => {
         buildChart()
     }, [datasets, color, visibilityMap])
+
+    // Hacky! - Chartjs doesn't internally call tooltip callback on mouseout from right border. Let's manually remove tooltips
+    // when the chart is being hovered over. #5061
+    useEffect(() => {
+        const tooltipEl = document.getElementById('ph-graph-tooltip')
+
+        if (tooltipEl && !tooltipVisible) {
+            tooltipEl.style.opacity = 0
+        }
+    }, [tooltipVisible])
 
     // annotation related effects
 
@@ -377,6 +388,11 @@ export function LineGraph({
                         } else {
                             evt.target.style.cursor = 'default'
                         }
+                    }
+                    if (evt.type === 'mouseout') {
+                        setTooltipVisible(false)
+                    } else {
+                        setTooltipVisible(true)
                     }
                 },
             },

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -79,14 +79,18 @@ export function LineGraph({
         buildChart()
     }, [datasets, color, visibilityMap])
 
-    // Hacky! - Chartjs doesn't internally call tooltip callback on mouseout from right border. Let's manually remove tooltips
-    // when the chart is being hovered over. #5061
+    // Hacky! - Chartjs doesn't internally call tooltip callback on mouseout from right border.
+    // Let's manually remove tooltips when the chart is being hovered over. #5061
     useEffect(() => {
-        const tooltipEl = document.getElementById('ph-graph-tooltip')
+        const removeTooltip = () => {
+            const tooltipEl = document.getElementById('ph-graph-tooltip')
 
-        if (tooltipEl && !tooltipVisible) {
-            tooltipEl.style.opacity = 0
+            if (tooltipEl && !tooltipVisible) {
+                tooltipEl.style.opacity = 0
+            }
         }
+        removeTooltip()
+        return removeTooltip // remove tooltip on component unmount
     }, [tooltipVisible])
 
     // annotation related effects


### PR DESCRIPTION
## Changes

Fixes #5061.

There's a bug in `posthog/Chart.js` where the custom tooltip callback isn't being called on `mouseout` event. This PR implements a somewhat hacky solution to manually remove our tooltips when the user isn't hovering over the chart area.

Before

https://user-images.githubusercontent.com/38760734/125440301-0dc2eef2-e953-4bdc-bffd-9b89066eae1f.mov

After

https://user-images.githubusercontent.com/13460330/130127781-b31f6d4b-1896-4fa5-b547-5e04838fc089.mov



## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
