### PR TITLE
Error out on exclusion event being same as funnel step

### DIFF
--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -82,6 +82,10 @@ class ClickhouseFunnelBase(ABC, Funnel):
             if exclusion.funnel_to_step > len(self._filter.entities) - 1:
                 raise ValidationError("Exclusion event range is invalid. End of range is greater than number of steps.")
 
+            for entity in self._filter.entities[exclusion.funnel_from_step : exclusion.funnel_to_step + 1]:
+                if entity.equals(exclusion) or exclusion.is_superset(entity):
+                    raise ValidationError("Exclusion event can't be the same as funnel step")
+
         self._filter = self._filter.with_data(data)
 
     def _format_single_funnel(self, results, with_breakdown=False):

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+import pytest
+
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.api.test.test_insight import insight_test_factory
@@ -408,3 +410,50 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response["result"][1]["name"], "step two")
         self.assertEqual(response["result"][0]["count"], 1)
         self.assertEqual(response["result"][1]["count"], 1)
+
+    def test_funnel_invalid_exclusions(self):
+        _create_person(distinct_ids=["1"], team=self.team)
+        _create_event(team=self.team, event="step one", distinct_id="1")
+        _create_event(team=self.team, event="step x", distinct_id="1")
+        _create_event(team=self.team, event="step two", distinct_id="1")
+
+        _create_person(distinct_ids=["2"], team=self.team)
+        _create_event(team=self.team, event="step one", distinct_id="2")
+        _create_event(team=self.team, event="step two", distinct_id="2")
+
+        for exclusion_id, exclusion_from_step, exclusion_to_step, error in [
+            ("step one", 0, 1, True),
+            ("step two", 0, 1, True),
+            ("step two", 0, 2, True),
+            ("step one", 0, 2, True),
+            ("step three", 0, 2, True),
+            ("step three", 0, 1, False),
+        ]:
+            response = self.client.post(
+                "/api/insight/funnel/",
+                {
+                    "events": [
+                        {"id": "step one", "type": "events", "order": 0},
+                        {"id": "step two", "type": "events", "order": 1},
+                        {"id": "step three", "type": "events", "order": 2},
+                    ],
+                    "exclusions": [
+                        {
+                            "id": exclusion_id,
+                            "type": "events",
+                            "funnel_from_step": exclusion_from_step,
+                            "funnel_to_step": exclusion_to_step,
+                        },
+                    ],
+                    "funnel_window_days": 14,
+                    "insight": "funnels",
+                },
+            )
+
+            if error:
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.json(), self.validation_error_response("Exclusion event can't be the same as funnel step")
+                )
+            else:
+                self.assertEqual(response.status_code, 200)

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -1,7 +1,5 @@
 from uuid import uuid4
 
-import pytest
-
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.api.test.test_insight import insight_test_factory


### PR DESCRIPTION
## Changes

Concern raised here: https://github.com/PostHog/posthog/pull/5607#pullrequestreview-734773669

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
