### PR TITLE
Increase # cohorts to calculate in parallel

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -77,6 +77,7 @@ if env_feature_flags != "0" and env_feature_flags.lower() != "false":
 
 SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG, type_cast=str_to_bool)
 USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
+CALCULATE_X_COHORTS_PARALLEL = get_from_env("CALCULATE_X_COHORTS_PARALLEL", 2)
 
 SITE_URL = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 from celery import shared_task
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from django.db.models import F
 from django.utils import timezone
 
@@ -15,7 +16,6 @@ from posthog.models import Cohort
 logger = logging.getLogger(__name__)
 
 MAX_AGE_MINUTES = 15
-PARALLEL_COHORTS = int(os.environ.get("PARALLEL_COHORTS", 2))
 
 
 def calculate_cohorts() -> None:
@@ -29,7 +29,7 @@ def calculate_cohorts() -> None:
             errors_calculating__lte=20,
         )
         .exclude(is_static=True)
-        .order_by(F("last_calculation").asc(nulls_first=True))[0:PARALLEL_COHORTS]
+        .order_by(F("last_calculation").asc(nulls_first=True))[0 : settings.CALCULATE_X_COHORTS_PARALLEL]
     ):
         calculate_cohort.delay(cohort.id)
         if is_clickhouse_enabled():

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -121,6 +121,10 @@
                 {
                     "name": "PERSISTED_FEATURE_FLAGS",
                     "value": "0"
+                },
+                {
+                    "name": "CALCULATE_X_COHORTS_PARALLEL",
+                    "value": "10"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -115,6 +115,10 @@
                 {
                     "name": "PERSISTED_FEATURE_FLAGS",
                     "value": "0"
+                },
+                {
+                    "name": "CALCULATE_X_COHORTS_PARALLEL",
+                    "value": "10"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Folks were complaining that their cohorts weren't calculating frequently enough (we say 15 minutes in a tooltip). Given the # of cohorts in app, right now it takes about 25 hours to recalculate every cohort. I've made this env a proper setting and set it to 10 as a test. It'll still take 5 hours for each cohort to calculate so i'll try to up that number.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
