### PR TITLE
Better test coverage for materialized columns

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -43,7 +43,6 @@ def format_action_filter(
                 team_id=action.team.pk if filter_by_team else None,
                 prepend=f"action_props_{action.pk}_{step.pk}",
                 table_name=table_name,
-                allow_denormalized_props=True,
             )
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -228,9 +228,7 @@ def get_person_ids_by_cohort_id(team: Team, cohort_id: int):
     from ee.clickhouse.models.property import parse_prop_clauses
 
     filters = Filter(data={"properties": [{"key": "id", "value": cohort_id, "type": "cohort"}],})
-    filter_query, filter_params = parse_prop_clauses(
-        filters.properties, team.pk, table_name="pdi", allow_denormalized_props=True
-    )
+    filter_query, filter_params = parse_prop_clauses(filters.properties, team.pk, table_name="pdi")
 
     results = sync_execute(GET_PERSON_IDS_BY_FILTER.format(distinct_query=filter_query, query=""), filter_params,)
 

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -228,7 +228,9 @@ def get_person_ids_by_cohort_id(team: Team, cohort_id: int):
     from ee.clickhouse.models.property import parse_prop_clauses
 
     filters = Filter(data={"properties": [{"key": "id", "value": cohort_id, "type": "cohort"}],})
-    filter_query, filter_params = parse_prop_clauses(filters.properties, team.pk, table_name="pdi")
+    filter_query, filter_params = parse_prop_clauses(
+        filters.properties, team.pk, table_name="pdi", allow_denormalized_props=True
+    )
 
     results = sync_execute(GET_PERSON_IDS_BY_FILTER.format(distinct_query=filter_query, query=""), filter_params,)
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -22,7 +22,7 @@ def parse_prop_clauses(
     team_id: Optional[int],
     prepend: str = "global",
     table_name: str = "",
-    allow_denormalized_props: bool = False,
+    allow_denormalized_props: bool = True,
     filter_test_accounts=False,
     is_person_query=False,
 ) -> Tuple[str, Dict]:

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -78,7 +78,11 @@ def get_breakdown_event_prop_values(
 ):
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
+        filter.properties,
+        team_id,
+        table_name="e",
+        prepend="e_brkdwn",
+        filter_test_accounts=filter.filter_test_accounts,
     )
 
     entity_params, entity_format_params = get_entity_filtering_params(entity, team_id, with_prop_filters=True)

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -78,11 +78,7 @@ def get_breakdown_event_prop_values(
 ):
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties,
-        team_id,
-        table_name="e",
-        filter_test_accounts=filter.filter_test_accounts,
-        allow_denormalized_props=True,
+        filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
     )
 
     entity_params, entity_format_params = get_entity_filtering_params(entity, team_id, with_prop_filters=True)
@@ -120,7 +116,7 @@ def _format_all_query(team_id: int, filter: Filter, **kwargs) -> Tuple[str, Dict
         props_to_filter = [*props_to_filter, *entity.properties]
 
     prop_filters, prop_filter_params = parse_prop_clauses(
-        props_to_filter, team_id, prepend="all_cohort_", table_name="all_events", allow_denormalized_props=True
+        props_to_filter, team_id, prepend="all_cohort_", table_name="all_events"
     )
     query = f"""
             SELECT DISTINCT distinct_id, {ALL_USERS_COHORT_ID} as value

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -35,7 +35,11 @@ def get_breakdown_person_prop_values(
 ):
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
+        filter.properties,
+        team_id,
+        table_name="e",
+        filter_test_accounts=filter.filter_test_accounts,
+        allow_denormalized_props=False,
     )
     person_prop_filters, person_prop_params = parse_prop_clauses(
         [prop for prop in filter.properties if prop.type == "person"],
@@ -43,6 +47,7 @@ def get_breakdown_person_prop_values(
         filter_test_accounts=filter.filter_test_accounts,
         is_person_query=True,
         prepend="person",
+        allow_denormalized_props=False,
     )
 
     entity_params, entity_format_params = get_entity_filtering_params(entity, team_id, with_prop_filters=True)
@@ -73,7 +78,11 @@ def get_breakdown_event_prop_values(
 ):
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
+        filter.properties,
+        team_id,
+        table_name="e",
+        filter_test_accounts=filter.filter_test_accounts,
+        allow_denormalized_props=True,
     )
 
     entity_params, entity_format_params = get_entity_filtering_params(entity, team_id, with_prop_filters=True)
@@ -111,7 +120,7 @@ def _format_all_query(team_id: int, filter: Filter, **kwargs) -> Tuple[str, Dict
         props_to_filter = [*props_to_filter, *entity.properties]
 
     prop_filters, prop_filter_params = parse_prop_clauses(
-        props_to_filter, team_id, prepend="all_cohort_", table_name="all_events"
+        props_to_filter, team_id, prepend="all_cohort_", table_name="all_events", allow_denormalized_props=True
     )
     query = f"""
             SELECT DISTINCT distinct_id, {ALL_USERS_COHORT_ID} as value

--- a/ee/clickhouse/queries/clickhouse_paths.py
+++ b/ee/clickhouse/queries/clickhouse_paths.py
@@ -40,7 +40,7 @@ class ClickhousePaths(Paths):
         event, path_type, start_comparator = self._determine_path_type(filter.path_type if filter else None)
 
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
         )
 
         # Step 0. Event culling subexpression for step 1.

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -35,7 +35,7 @@ class ClickhouseRetention(Retention):
     def _execute_sql(self, filter: RetentionFilter, team: Team,) -> Dict[Tuple[int, int], Dict[str, Any]]:
         period = filter.period
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
         )
         target_entity = filter.target_entity
         returning_entity = filter.returning_entity
@@ -152,7 +152,7 @@ class ClickhouseRetention(Retention):
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
         )
 
         returning_entity = filter.returning_entity if filter.selected_interval > 0 else filter.target_entity
@@ -209,7 +209,7 @@ class ClickhouseRetention(Retention):
         period = filter.period
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk, allow_denormalized_props=True)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
 
         target_query, target_params = self._get_condition(filter.target_entity, table="e")
         target_query_formatted = "AND {target_query}".format(target_query=target_query)

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -36,10 +36,7 @@ class ClickhouseStickiness(Stickiness):
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
         prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties + entity.properties,
-            team_id,
-            filter_test_accounts=filter.filter_test_accounts,
-            allow_denormalized_props=True,
+            filter.properties + entity.properties, team_id, filter_test_accounts=filter.filter_test_accounts,
         )
         trunc_func = get_trunc_func_ch(filter.interval)
 
@@ -96,10 +93,7 @@ def _format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
 def _process_content_sql(target_entity: Entity, filter: StickinessFilter, team: Team) -> Tuple[str, Dict[str, Any]]:
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team.pk)
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties + target_entity.properties,
-        team.pk,
-        filter_test_accounts=filter.filter_test_accounts,
-        allow_denormalized_props=True,
+        filter.properties + target_entity.properties, team.pk, filter_test_accounts=filter.filter_test_accounts,
     )
     entity_sql, entity_params = _format_entity_filter(entity=target_entity)
     trunc_func = get_trunc_func_ch(filter.interval)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -114,7 +114,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         if self._should_join_persons:
             return f"""
             INNER JOIN (
-                SELECT id, properties as person_props
+                SELECT id, properties as {self._PERSON_PROPERTIES_ALIAS}
                 FROM (
                     SELECT id,
                         argMax(properties, person._timestamp) as properties,
@@ -141,11 +141,10 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
 
         return query, date_params
 
-    def _get_props(self, filters: List[Property], allow_denormalized_props: bool = False) -> Tuple[str, Dict]:
+    def _get_props(self, filters: List[Property]) -> Tuple[str, Dict]:
 
         filter_test_accounts = self._filter.filter_test_accounts
         team_id = self._team_id
-        table_name = f"{self.EVENT_TABLE_ALIAS}."
         prepend = "global"
 
         final = []
@@ -166,7 +165,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                     prop,
                     idx,
                     "{}person".format(prepend),
-                    allow_denormalized_props=allow_denormalized_props,
+                    allow_denormalized_props=False,
                     prop_var=self._PERSON_PROPERTIES_ALIAS,
                 )
                 final.append(filter_query)
@@ -180,7 +179,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                     params.update(filter_params)
             else:
                 filter_query, filter_params = prop_filter_json_extract(
-                    prop, idx, prepend, prop_var="properties", allow_denormalized_props=allow_denormalized_props,
+                    prop, idx, prepend, prop_var="properties", allow_denormalized_props=True,
                 )
 
                 final.append(filter_query)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -178,7 +178,9 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                     final.append(f" AND {query}")
                     params.update(filter_params)
             else:
-                filter_query, filter_params = prop_filter_json_extract(prop, idx, prepend, prop_var="properties")
+                filter_query, filter_params = prop_filter_json_extract(
+                    prop, idx, prepend, prop_var="properties", allow_denormalized_props=True
+                )
 
                 final.append(filter_query)
                 params.update(filter_params)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -178,9 +178,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                     final.append(f" AND {query}")
                     params.update(filter_params)
             else:
-                filter_query, filter_params = prop_filter_json_extract(
-                    prop, idx, prepend, prop_var="properties", allow_denormalized_props=True,
-                )
+                filter_query, filter_params = prop_filter_json_extract(prop, idx, prepend, prop_var="properties")
 
                 final.append(filter_query)
                 params.update(filter_params)

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -292,9 +292,7 @@ class ClickhouseFunnelBase(ABC, Funnel):
         return content_sql
 
     def _build_filters(self, entity: Entity, index: int) -> str:
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            entity.properties, self._team.pk, prepend=str(index), allow_denormalized_props=True
-        )
+        prop_filters, prop_filter_params = parse_prop_clauses(entity.properties, self._team.pk, prepend=str(index))
         self.params.update(prop_filter_params)
         if entity.properties:
             return prop_filters

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -39,7 +39,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
         self.params.update(date_params)
 
         prop_filters = self._filter.properties
-        prop_query, prop_params = self._get_props(prop_filters, allow_denormalized_props=True)
+        prop_query, prop_params = self._get_props(prop_filters)
         self.params.update(prop_params)
 
         if skip_entity_filter:

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -15,6 +15,7 @@ from posthog.models.action_step import ActionStep
 from posthog.models.filters import Filter
 from posthog.models.person import Person
 from posthog.queries.test.test_funnel import funnel_test_factory
+from posthog.test.base import test_with_materialized_columns
 
 FORMAT_TIME = "%Y-%m-%d 00:00:00"
 MAX_STEP_COLUMN = 0
@@ -51,7 +52,7 @@ class TestFunnelConversionTime(ClickhouseTestMixin, funnel_conversion_time_test_
     pass
 
 
-class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
+class TestClickhouseFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _create_event, _create_person)):  # type: ignore
 
     maxDiff = None
 
@@ -130,6 +131,7 @@ class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _cre
             self._get_people_at_step(filter, 2), [person1_stopped_after_two_signups.uuid],
         )
 
+    @test_with_materialized_columns(["key"])
     def test_basic_funnel_with_derivative_steps(self):
         filters = {
             "events": [
@@ -652,6 +654,7 @@ class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _cre
             self._get_people_at_step(filter, 5), [person5_stopped_after_many_pageview.uuid],
         )
 
+    @test_with_materialized_columns(["key"])
     def test_funnel_with_actions(self):
 
         sign_up_action = _create_action(
@@ -696,6 +699,7 @@ class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _cre
             self._get_people_at_step(filter, 2), [person1_stopped_after_two_signups.uuid],
         )
 
+    @test_with_materialized_columns(["key"])
     def test_funnel_with_actions_and_events(self):
 
         sign_up_action = _create_action(
@@ -772,6 +776,7 @@ class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _cre
 
         self.assertCountEqual(self._get_people_at_step(filter, 4), [person1_stopped_after_two_signups.uuid,])
 
+    @test_with_materialized_columns(["$current_url"])
     def test_funnel_with_matching_properties(self):
         filters = {
             "events": [
@@ -1053,6 +1058,7 @@ class TestFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFunnel, _cre
             self._get_people_at_step(filter, 2), [person1.uuid],
         )
 
+    @test_with_materialized_columns(["key"])
     def test_funnel_exclusions_with_actions(self):
 
         sign_up_action = _create_action(

--- a/ee/clickhouse/queries/paths/path_event_query.py
+++ b/ee/clickhouse/queries/paths/path_event_query.py
@@ -16,7 +16,7 @@ class PathEventQuery(ClickhouseEventQuery):
         self.params.update(date_params)
 
         prop_filters = self._filter.properties
-        prop_query, prop_params = self._get_props(prop_filters, allow_denormalized_props=True)
+        prop_query, prop_params = self._get_props(prop_filters)
         self.params.update(prop_params)
 
         query = f"""
@@ -43,13 +43,9 @@ class PathEventQuery(ClickhouseEventQuery):
         self._should_join_distinct_ids = True
 
     def _get_current_url_parsing(self):
-        path_type, _ = get_property_string_expr(
-            "events", "$current_url", "'$current_url'", "properties", allow_denormalized_props=True
-        )
+        path_type, _ = get_property_string_expr("events", "$current_url", "'$current_url'", "properties")
         return path_type
 
     def _get_screen_name_parsing(self):
-        path_type, _ = get_property_string_expr(
-            "events", "$screen_name", "'$screen_name'", "properties", allow_denormalized_props=True
-        )
+        path_type, _ = get_property_string_expr("events", "$screen_name", "'$screen_name'", "properties")
         return path_type

--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -27,7 +27,7 @@ class ClickhouseSessionsAvg:
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
         filters, params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
         )
 
         trunc_func = get_trunc_func_ch(filter.interval)

--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -13,7 +13,7 @@ class ClickhouseSessionsDist:
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
         filters, params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
         )
 
         entity_conditions, entity_params = entity_query_conditions(filter, team)

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -70,7 +70,9 @@ class ClickhouseSessionsList(SessionsList):
             persons = get_persons_by_distinct_ids(self.team.pk, [self.filter.distinct_id])
             return persons[0].distinct_ids if len(persons) > 0 else []
 
-        person_filters, person_filter_params = parse_prop_clauses(self.filter.person_filter_properties, self.team.pk)
+        person_filters, person_filter_params = parse_prop_clauses(
+            self.filter.person_filter_properties, self.team.pk, allow_denormalized_props=False
+        )
         return sync_execute(
             SESSIONS_DISTINCT_ID_SQL.format(
                 date_from=date_from,
@@ -154,7 +156,9 @@ def format_action_filters(filter: SessionsFilter) -> ActionFiltersSQL:
 def format_action_filter_aggregate(entity: Entity, prepend: str):
     filter_sql, params = format_entity_filter(entity, prepend=prepend, filter_by_team=False)
     if entity.properties:
-        filters, filter_params = parse_prop_clauses(entity.properties, prepend=prepend, team_id=None)
+        filters, filter_params = parse_prop_clauses(
+            entity.properties, prepend=prepend, team_id=None, allow_denormalized_props=False
+        )
         filter_sql += f" {filters}"
         params = {**params, **filter_params}
 

--- a/ee/clickhouse/queries/sessions/util.py
+++ b/ee/clickhouse/queries/sessions/util.py
@@ -13,7 +13,7 @@ def event_entity_to_query(entity: Entity, team: Team, prepend="event_entity") ->
         from ee.clickhouse.models.property import parse_prop_clauses
 
         prop_query, prop_params = parse_prop_clauses(
-            entity.properties, team_id=team.pk, prepend="{}_props".format(prepend),
+            entity.properties, team_id=team.pk, prepend="{}_props".format(prepend), allow_denormalized_props=False
         )
         event_query += prop_query
         params = {**params, **prop_params}

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -41,11 +41,7 @@ class ClickhouseTrendsBreakdown:
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter,
-            team_id,
-            table_name="e",
-            filter_test_accounts=filter.filter_test_accounts,
-            allow_denormalized_props=True,
+            props_to_filter, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
         )
         aggregate_operation, _, math_params = process_math(entity)
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -50,7 +50,7 @@ class ClickhouseLifecycle(LifecycleTrend):
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
         )
 
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
@@ -141,7 +141,7 @@ class ClickhouseLifecycle(LifecycleTrend):
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
         )
 
         result = sync_execute(

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -42,7 +42,7 @@ class TrendsEventQuery(ClickhouseEventQuery):
         self.params.update(date_params)
 
         prop_filters = [*self._filter.properties, *self._entity.properties]
-        prop_query, prop_params = self._get_props(prop_filters, allow_denormalized_props=True)
+        prop_query, prop_params = self._get_props(prop_filters)
         self.params.update(prop_params)
 
         entity_query, entity_params = self._get_entity_query()

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -23,6 +23,8 @@ from ee.clickhouse.sql.session_recording_events import (
 
 
 class ClickhouseTestMixin:
+    RUN_MATERIALIZED_COLUMN_TESTS = True
+
     def tearDown(self):
         try:
             self._destroy_event_tables()

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -155,7 +155,7 @@ def _process_content_sql(team: Team, entity: Entity, filter: Filter):
         filter.properties.append(breakdown_prop)
 
     prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts, allow_denormalized_props=True
+        filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
     )
     params: Dict = {"team_id": team.pk, **prop_filter_params, **entity_params, "offset": filter.offset}
 

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -17,9 +17,7 @@ class ClickhouseElementViewSet(ElementViewSet):
 
         date_from, date_to, _ = parse_timestamps(filter, team_id=self.team.pk)
 
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, self.team.pk, allow_denormalized_props=True
-        )
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, self.team.pk)
         result = sync_execute(
             GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters),
             {"team_id": self.team.pk, **prop_filter_params},

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -57,7 +57,7 @@ class ClickhouseEventsViewSet(EventViewSet):
             },
             long_date_from,
         )
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk, allow_denormalized_props=True)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
 
         if request.GET.get("action_id"):
             try:

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -8,7 +8,7 @@ from posthog.models.filters import Filter
 from posthog.queries.funnel import Funnel
 from posthog.tasks.calculate_action import calculate_actions_from_last_calculation
 from posthog.tasks.update_cache import update_cache_item
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, test_with_materialized_columns
 
 
 def funnel_test_factory(Funnel, event_factory, person_factory):
@@ -170,6 +170,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[1]["count"], 0)
             self.assertEqual(result[2]["count"], 0)
 
+        @test_with_materialized_columns(["$browser"])
         def test_funnel_prop_filters(self):
             funnel = self._basic_funnel(properties={"$browser": "Safari"})
 
@@ -194,6 +195,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[0]["count"], 2)
             self.assertEqual(result[1]["count"], 1)
 
+        @test_with_materialized_columns(["$browser"])
         def test_funnel_prop_filters_per_entity(self):
             action_credit_card = Action.objects.create(team_id=self.team.pk, name="paid")
             ActionStep.objects.create(
@@ -297,6 +299,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[1]["count"], 1)
             self.assertEqual(result[2]["count"], 1)
 
+        @test_with_materialized_columns(["test_prop"])
         def test_funnel_multiple_actions(self):
             # we had an issue on clickhouse where multiple actions with different property filters would incorrectly grab only the last
             # properties.

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -18,7 +18,7 @@ from posthog.queries.abstract_test.test_interval import AbstractIntervalTest
 from posthog.queries.abstract_test.test_timerange import AbstractTimerangeTest
 from posthog.queries.trends import Trends, breakdown_label
 from posthog.tasks.calculate_action import calculate_action, calculate_actions_from_last_calculation
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, test_with_materialized_columns
 from posthog.utils import generate_cache_key, relative_date_parse
 
 
@@ -1640,18 +1640,23 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertAlmostEqual(action_response[0]["data"][-1], expected_value, delta=0.5)
             self.assertEntityResponseEqual(action_response, event_response)
 
+        @test_with_materialized_columns(["some_number"])
         def test_sum_filtering(self):
             self._test_math_property_aggregation("sum", values=[2, 3, 5.5, 7.5], expected_value=18)
 
+        @test_with_materialized_columns(["some_number"])
         def test_avg_filtering(self):
             self._test_math_property_aggregation("avg", values=[2, 3, 5.5, 7.5], expected_value=4.5)
 
+        @test_with_materialized_columns(["some_number"])
         def test_min_filtering(self):
             self._test_math_property_aggregation("min", values=[2, 3, 5.5, 7.5], expected_value=2)
 
+        @test_with_materialized_columns(["some_number"])
         def test_max_filtering(self):
             self._test_math_property_aggregation("max", values=[2, 3, 5.5, 7.5], expected_value=7.5)
 
+        @test_with_materialized_columns(["some_number"])
         def test_median_filtering(self):
             self._test_math_property_aggregation("median", values=range(101, 201), expected_value=150)
 

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -476,6 +476,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(daily_response[0]["aggregated_value"], 2.0)
             self.assertEqual(daily_response[0]["aggregated_value"], weekly_response[0]["aggregated_value"])
 
+        @test_with_materialized_columns(["$math_prop", "$some_property"])
         def test_trends_breakdown_with_math_func(self):
 
             with freeze_time("2020-01-01 00:06:34"):
@@ -1248,6 +1249,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 ],
             )
 
+        @test_with_materialized_columns(["$some_property"])
         def test_property_filtering(self):
             self._create_events()
             with freeze_time("2020-01-04"):
@@ -1492,6 +1494,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(len(response), 1)
             self.assertEqual(response[0]["breakdown_value"], "test@gmail.com")
 
+        @test_with_materialized_columns(["key"])
         def test_breakdown_with_filter(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person1"], properties={"email": "test@posthog.com"})
             person_factory(team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "test@gmail.com"})
@@ -1584,6 +1587,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["data"][5], 2)
             self.assertEntityResponseEqual(action_response, response)
 
+        @test_with_materialized_columns(["$some_property"])
         def test_dau_with_breakdown_filtering(self):
             sign_up_action, _ = self._create_events()
             with freeze_time("2020-01-02"):
@@ -1660,15 +1664,19 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
         def test_median_filtering(self):
             self._test_math_property_aggregation("median", values=range(101, 201), expected_value=150)
 
+        @test_with_materialized_columns(["some_number"])
         def test_p90_filtering(self):
             self._test_math_property_aggregation("p90", values=range(101, 201), expected_value=190)
 
+        @test_with_materialized_columns(["some_number"])
         def test_p95_filtering(self):
             self._test_math_property_aggregation("p95", values=range(101, 201), expected_value=195)
 
+        @test_with_materialized_columns(["some_number"])
         def test_p99_filtering(self):
             self._test_math_property_aggregation("p99", values=range(101, 201), expected_value=199)
 
+        @test_with_materialized_columns(["some_number"])
         def test_avg_filtering_non_number_resiliency(self):
             sign_up_action, person = self._create_events()
             person_factory(team_id=self.team.pk, distinct_ids=["someone_else"])
@@ -1687,6 +1695,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(action_response[0]["data"][-1], 5)
             self.assertEntityResponseEqual(action_response, event_response)
 
+        @test_with_materialized_columns(["$some_property"])
         def test_per_entity_filtering(self):
             self._create_events()
             with freeze_time("2020-01-04T13:00:01Z"):
@@ -2103,6 +2112,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 ],
             )
 
+        @test_with_materialized_columns(["$some_property"])
         def test_breakdown_filtering_bar_chart_by_value(self):
             self._create_events()
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -147,7 +147,7 @@ def test_with_materialized_columns(event_properties=[], verify_no_jsonextract=Tr
         @pytest.mark.ee
         def fn_with_materialized(self, *args, **kwargs):
             # Don't run these tests under non-clickhouse classes even if decorated in base classes
-            if not getattr(self, "RUN_MATERIALIZED_COLUMN_TESTS"):
+            if not getattr(self, "RUN_MATERIALIZED_COLUMN_TESTS", False):
                 return
 
             for prop in event_properties:

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional
+import inspect
+from typing import Any, Dict, Optional
 
 from django.test import TestCase
 from rest_framework.test import APITestCase as DRFTestCase
@@ -111,7 +112,7 @@ class BaseTest(TestMixin, ErrorResponsesMixin, TestCase):
     """
     Base class for performing Postgres-based backend unit tests on.
     Each class and each test is wrapped inside an atomic block to rollback DB commits after each test.
-    Read more: https://docs.djangoproject.com/en/3.1/topics/testing/tools/#testcase 
+    Read more: https://docs.djangoproject.com/en/3.1/topics/testing/tools/#testcase
     """
 
     pass
@@ -126,3 +127,43 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
         super().setUp()
         if self.CONFIG_AUTO_LOGIN and self.user:
             self.client.force_login(self.user)
+
+
+def test_with_materialized_columns(event_properties=[], verify_no_jsonextract=True):
+    """
+    Runs the test twice on clickhouse - once verifying it works normally, once with materialized columns.
+
+    Requires a unittest class with ClickhouseTestMixin mixed in
+    """
+
+    try:
+        from ee.clickhouse.materialized_columns import materialize
+    except:
+        # EE not available? Just run the main test
+        return lambda fn: fn
+
+    def decorator(fn):
+        def fn_with_materialized(self, *args, **kwargs):
+            # Don't run these tests under non-clickhouse classes even if decorated in base classes
+            if not getattr(self, "RUN_MATERIALIZED_COLUMN_TESTS"):
+                # Noop!
+                return
+
+            for prop in event_properties:
+                materialize("events", prop)
+
+            with self.capture_select_queries() as sqls:
+                fn(self, *args, **kwargs)
+
+            if verify_no_jsonextract:
+                for sql in sqls:
+                    self.assertNotIn("JSONExtract", sql)
+                    self.assertNotIn("properties", sql)
+
+        # To add the test, we inspect the frame this function was called in and add the test there
+        frame_locals: Any = inspect.currentframe().f_back.f_locals  # type: ignore
+        frame_locals[f"{fn.__name__}_materialized"] = fn_with_materialized
+
+        return fn
+
+    return decorator

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Any, Dict, Optional
 
+import pytest
 from django.test import TestCase
 from rest_framework.test import APITestCase as DRFTestCase
 
@@ -143,10 +144,10 @@ def test_with_materialized_columns(event_properties=[], verify_no_jsonextract=Tr
         return lambda fn: fn
 
     def decorator(fn):
+        @pytest.mark.ee
         def fn_with_materialized(self, *args, **kwargs):
             # Don't run these tests under non-clickhouse classes even if decorated in base classes
             if not getattr(self, "RUN_MATERIALIZED_COLUMN_TESTS"):
-                # Noop!
                 return
 
             for prop in event_properties:


### PR DESCRIPTION
Adding tests for materialized columns was burdensome since we need to test all the same cases. 

Instead we now have a test decorator which materializes needed columns and generates tests.

Also cleans up some other related issues, e.g. defaulting to allowing denormalized props everywhere.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
