### PR TITLE
Fix events table SAMPLE BY

### DIFF
--- a/ee/clickhouse/migrations/0017_cityHash64_events_sample_by.py
+++ b/ee/clickhouse/migrations/0017_cityHash64_events_sample_by.py
@@ -1,0 +1,7 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"ALTER TABLE events ON CLUSTER {CLICKHOUSE_CLUSTER} MODIFY SAMPLE BY cityHash64(uuid)"),
+]

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -21,7 +21,7 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     created_at DateTime64(6, 'UTC')
     {materialized_columns}
     {extra_fields}
-) ENGINE = {engine} 
+) ENGINE = {engine}
 """
 
 EVENTS_TABLE_MATERIALIZED_COLUMNS = """
@@ -35,7 +35,7 @@ EVENTS_TABLE_SQL = (
     EVENTS_TABLE_BASE_SQL
     + """PARTITION BY toYYYYMM(timestamp)
 ORDER BY (team_id, toDate(timestamp), distinct_id, uuid)
-SAMPLE BY uuid 
+SAMPLE BY cityHash64(uuid)
 {storage_policy}
 """
 ).format(
@@ -59,7 +59,7 @@ KAFKA_EVENTS_TABLE_SQL = EVENTS_TABLE_BASE_SQL.format(
 # related to https://github.com/ClickHouse/ClickHouse/issues/10471
 EVENTS_TABLE_MV_SQL = """
 CREATE MATERIALIZED VIEW {table_name}_mv ON CLUSTER {cluster}
-TO {database}.{table_name} 
+TO {database}.{table_name}
 AS SELECT
 uuid,
 event,
@@ -71,7 +71,7 @@ elements_chain,
 created_at,
 _timestamp,
 _offset
-FROM {database}.kafka_{table_name} 
+FROM {database}.kafka_{table_name}
 """.format(
     table_name=EVENTS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE,
 )
@@ -142,7 +142,7 @@ SELECT
     elements_chain,
     created_at
 FROM events
-WHERE 
+WHERE
 team_id = %(team_id)s
 {conditions}
 {filters}
@@ -176,7 +176,7 @@ INNER JOIN ({GET_TEAM_PERSON_DISTINCT_IDS}) as pdi ON events.distinct_id = pdi.d
 """
 
 GET_EVENTS_WITH_PROPERTIES = """
-SELECT * FROM events WHERE 
+SELECT * FROM events WHERE
 team_id = %(team_id)s
 {filters}
 {order_by}


### PR DESCRIPTION
This was "broken" upsteam in 21.7 in
https://github.com/ClickHouse/ClickHouse/issues/822 /
https://github.com/ClickHouse/ClickHouse/pull/26256

Needed if we ever upgrade.

In reality if we ever tried to use SAMPLE BY it would just have failed
due to the wrong column.

Fixed by hashing the UUID for sampling.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
