### PR TITLE
Add endpoint to trigger plugin jobs

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -335,12 +335,12 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             raise ValidationError("A job name must be specified!")
 
         # the plugin server uses "type" for job names but "name" makes for a more friendly API
-        job_type = job.get("name")
+        job_type = job.get("type")
         job_payload = job.get("payload", {})
         job_op = job.get("operation", "start")
 
         celery_app.send_task(
-            name=settings.CELERY_PLUGIN_JOBS_TASK,
+            name="posthog.tasks.plugins.plugin_job",
             queue=settings.PLUGINS_CELERY_QUEUE,
             args=[self.team.pk, plugin_config_id, job_type, job_op, job_payload],
         )

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -344,9 +344,7 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         task_name = CELERY_PLUGIN_JOBS_TASK
         celery_queue = settings.PLUGINS_CELERY_QUEUE
         celery_app.send_task(
-            name=task_name,
-            queue=celery_queue,
-            args=[self.team.pk, plugin_config_id, job_name, job_op, job_payload],
+            name=task_name, queue=celery_queue, args=[self.team.pk, plugin_config_id, job_name, job_op, job_payload],
         )
 
         return Response(status=200)

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Set, cast
 
 import requests
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile
 from django.db.models import Q
@@ -15,7 +16,8 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAuthentic
 from rest_framework.response import Response
 
 from posthog.api.routing import StructuredViewSetMixin
-from posthog.models import Plugin, PluginAttachment, PluginConfig, Team
+from posthog.celery import app as celery_app
+from posthog.models import Plugin, PluginAttachment, PluginConfig, Team, plugin
 from posthog.models.organization import Organization
 from posthog.models.plugin import update_validated_data_from_url
 from posthog.permissions import OrganizationMemberPermissions, ProjectMembershipNecessaryPermissions
@@ -24,6 +26,9 @@ from posthog.plugins.access import can_globally_manage_plugins
 
 # Keep this in sync with: frontend/scenes/plugins/utils.ts
 SECRET_FIELD_VALUE = "**************** POSTHOG SECRET FIELD ****************"
+
+
+CELERY_PLUGIN_JOBS_TASK = "posthog.tasks.plugins.plugin_job"
 
 
 def _update_plugin_attachments(request: request.Request, plugin_config: PluginConfig):
@@ -320,6 +325,31 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 plugin_config.save()
 
         return Response(PluginConfigSerializer(plugin_configs, many=True).data)
+
+    @action(methods=["POST"], detail=True)
+    def job(self, request: request.Request, **kwargs):
+        if not can_configure_plugins(self.team.organization_id):
+            raise ValidationError("Plugin configuration is not available for the current organization!")
+
+        plugin_config_id = self.get_object().id
+        job = request.data.get("job", {})
+
+        if "name" not in job:
+            raise ValidationError("A job name must be specified!")
+
+        job_name = job.get("name")
+        job_payload = job.get("payload", {})
+        job_op = job.get("operation", "start")
+
+        task_name = CELERY_PLUGIN_JOBS_TASK
+        celery_queue = settings.PLUGINS_CELERY_QUEUE
+        celery_app.send_task(
+            name=task_name,
+            queue=celery_queue,
+            args=[self.team.pk, plugin_config_id, job_name, job_op, job_payload],
+        )
+
+        return Response(status=200)
 
 
 def _get_secret_fields_for_plugin(plugin: Plugin) -> Set[str]:

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -331,8 +331,8 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         plugin_config_id = self.get_object().id
         job = request.data.get("job", {})
 
-        if "name" not in job:
-            raise ValidationError("A job name must be specified!")
+        if "type" not in job:
+            raise ValidationError("The job type must be specified!")
 
         # the plugin server uses "type" for job names but "name" makes for a more friendly API
         job_type = job.get("type")

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -459,11 +459,7 @@ class TestPluginAPI(APIBaseTest):
         self.assertEqual(mock_reload.call_count, 0)
         response = self.client.post(
             "/api/organizations/@current/plugins/",
-            {
-                "plugin_type": "source",
-                "name": "myplugin",
-                "source": "const processEvent = e => e",
-            },
+            {"plugin_type": "source", "name": "myplugin", "source": "const processEvent = e => e",},
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(
@@ -521,14 +517,12 @@ class TestPluginAPI(APIBaseTest):
             name="FooBar2", plugins_access_level=Organization.PluginsAccessLevel.INSTALL
         )
         response = self.client.post(
-            "/api/organizations/{}/plugins/".format(my_org.id),
-            {"url": "https://github.com/PostHog/helloworldplugin"},
+            "/api/organizations/{}/plugins/".format(my_org.id), {"url": "https://github.com/PostHog/helloworldplugin"},
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Plugin.objects.count(), 1)
         response = self.client.post(
-            "/api/organizations/{}/plugins/".format(my_org.id),
-            {"url": "https://github.com/PostHog/helloworldplugin"},
+            "/api/organizations/{}/plugins/".format(my_org.id), {"url": "https://github.com/PostHog/helloworldplugin"},
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(Plugin.objects.count(), 1)
@@ -762,9 +756,7 @@ class TestPluginAPI(APIBaseTest):
         )
 
         response = self.client.patch(
-            "/api/plugin_config/{}".format(plugin_config_id),
-            {"add_attachment[foodb]": tmp_file_2},
-            format="multipart",
+            "/api/plugin_config/{}".format(plugin_config_id), {"add_attachment[foodb]": tmp_file_2}, format="multipart",
         )
         self.assertEqual(PluginAttachment.objects.count(), 1)
 
@@ -783,9 +775,7 @@ class TestPluginAPI(APIBaseTest):
         )
 
         response = self.client.patch(
-            "/api/plugin_config/{}".format(plugin_config_id),
-            {"remove_attachment[foodb]": True},
-            format="multipart",
+            "/api/plugin_config/{}".format(plugin_config_id), {"remove_attachment[foodb]": True}, format="multipart",
         )
         self.assertEqual(response.json()["config"], {"bar": "moop"})
         self.assertEqual(PluginAttachment.objects.count(), 0)

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -876,7 +876,7 @@ class TestPluginAPI(APIBaseTest):
         plugin_config_id = response.json()["id"]
         response = self.client.post(
             "/api/plugin_config/{}/job".format(plugin_config_id),
-            {"job": {"name": "myJob", "payload": {"a": 1}, "operation": "stop"}},
+            {"job": {"type": "myJob", "payload": {"a": 1}, "operation": "stop"}},
             format="json",
         )
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -637,5 +637,3 @@ LOGGING = {
         "statsd": {"handlers": ["console"], "level": "WARNING", "propagate": True,},
     },
 }
-
-CELERY_PLUGIN_JOBS_TASK = "posthog.tasks.plugins.plugin_job"

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -637,3 +637,5 @@ LOGGING = {
         "statsd": {"handlers": ["console"], "level": "WARNING", "propagate": True,},
     },
 }
+
+CELERY_PLUGIN_JOBS_TASK = "posthog.tasks.plugins.plugin_job"


### PR DESCRIPTION
## Changes

Pair PR to https://github.com/PostHog/plugin-server/pull/537

Reasonably generic endpoint to allow us to expand its capabilities in the future. 

Purely backend change, nothing yet in the frontend to leverage this endpoint (coming soon).


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
