### PR TITLE
Add Path timings

### DIFF
--- a/ee/clickhouse/queries/paths/paths.py
+++ b/ee/clickhouse/queries/paths/paths.py
@@ -39,9 +39,7 @@ class ClickhousePathsNew:
 
         resp = []
         for res in results:
-            resp.append(
-                {"source": res[0], "target": res[1], "value": res[2],}
-            )
+            resp.append({"source": res[0], "target": res[1], "value": res[2], "average_conversion_time": res[3]})
         return resp
 
     def _exec_query(self) -> List[Tuple]:

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -18,6 +18,9 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
+ONE_MINUTE = 60_000  # 1 minute in milliseconds
+
+
 class TestClickhousePathsOld(ClickhouseTestMixin, paths_test_factory(ClickhousePaths, _create_event, Person.objects.create)):  # type: ignore
     # remove when migrated to new Paths query
     def test_denormalized_properties(self):
@@ -47,6 +50,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
         self.test_current_url_paths_and_logic()
 
     def test_step_limit(self):
+
         with freeze_time("2012-01-01T03:21:34.000Z"):
             Person.objects.create(team_id=self.team.pk, distinct_ids=["fake"])
             _create_event(
@@ -56,11 +60,11 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             _create_event(
                 properties={"$current_url": "/2"}, distinct_id="fake", event="$pageview", team=self.team,
             )
-        with freeze_time("2012-01-01T03:23:34.000Z"):
+        with freeze_time("2012-01-01T03:24:34.000Z"):
             _create_event(
                 properties={"$current_url": "/3"}, distinct_id="fake", event="$pageview", team=self.team,
             )
-        with freeze_time("2012-01-01T03:24:34.000Z"):
+        with freeze_time("2012-01-01T03:27:34.000Z"):
             _create_event(
                 properties={"$current_url": "/4"}, distinct_id="fake", event="$pageview", team=self.team,
             )
@@ -69,7 +73,9 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             filter = PathFilter(data={"step_limit": 2})
             response = ClickhousePathsNew(team=self.team, filter=filter).run(team=self.team, filter=filter)
 
-        self.assertEqual(response, [{"source": "1_/1", "target": "2_/2", "value": 1}])
+        self.assertEqual(
+            response, [{"source": "1_/1", "target": "2_/2", "value": 1, "average_conversion_time": ONE_MINUTE}]
+        )
 
         with freeze_time("2012-01-7T03:21:34.000Z"):
             filter = PathFilter(data={"step_limit": 3})
@@ -77,7 +83,10 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
 
         self.assertEqual(
             response,
-            [{"source": "1_/1", "target": "2_/2", "value": 1}, {"source": "2_/2", "target": "3_/3", "value": 1}],
+            [
+                {"source": "1_/1", "target": "2_/2", "value": 1, "average_conversion_time": ONE_MINUTE},
+                {"source": "2_/2", "target": "3_/3", "value": 1, "average_conversion_time": 2 * ONE_MINUTE},
+            ],
         )
 
         with freeze_time("2012-01-7T03:21:34.000Z"):
@@ -87,8 +96,76 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
         self.assertEqual(
             response,
             [
-                {"source": "1_/1", "target": "2_/2", "value": 1},
-                {"source": "2_/2", "target": "3_/3", "value": 1},
-                {"source": "3_/3", "target": "4_/4", "value": 1},
+                {"source": "1_/1", "target": "2_/2", "value": 1, "average_conversion_time": ONE_MINUTE},
+                {"source": "2_/2", "target": "3_/3", "value": 1, "average_conversion_time": 2 * ONE_MINUTE},
+                {"source": "3_/3", "target": "4_/4", "value": 1, "average_conversion_time": 3 * ONE_MINUTE},
+            ],
+        )
+
+    def test_step_conversion_times(self):
+
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["fake"])
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:21:34.000Z",
+        )
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:22:34.000Z",
+        )
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:24:34.000Z",
+        )
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:27:34.000Z",
+        )
+
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["fake2"])
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:21:34.000Z",
+        )
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:23:34.000Z",
+        )
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01T03:27:34.000Z",
+        )
+
+        # with freeze_time("2012-01-7T03:21:34.000Z"):
+        filter = PathFilter(data={"step_limit": 4, "date_from": "2012-01-01"})
+        response = ClickhousePathsNew(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(
+            response,
+            [
+                {"source": "1_/1", "target": "2_/2", "value": 2, "average_conversion_time": 1.5 * ONE_MINUTE},
+                {"source": "2_/2", "target": "3_/3", "value": 2, "average_conversion_time": 3 * ONE_MINUTE},
+                {"source": "3_/3", "target": "4_/4", "value": 1, "average_conversion_time": 3 * ONE_MINUTE},
             ],
         )

--- a/ee/clickhouse/sql/paths/path.py
+++ b/ee/clickhouse/sql/paths/path.py
@@ -140,6 +140,7 @@ PATH_ARRAY_QUERY = """
 SELECT if(target_event LIKE %(autocapture_match)s, concat(arrayElement(splitByString('autocapture:', assumeNotNull(source_event)), 1), final_source_element), source_event) final_source_event,
        if(target_event LIKE %(autocapture_match)s, concat(arrayElement(splitByString('autocapture:', assumeNotNull(target_event)), 1), final_target_element), target_event) final_target_event,
        event_count,
+       average_conversion_time,
        if(target_event LIKE %(autocapture_match)s, arrayElement(splitByString('autocapture:', assumeNotNull(source_event)), 2), NULL) source_event_elements_chain,
        concat('<', extract(source_event_elements_chain, '^(.*?)[.|:]'), '> ', extract(source_event_elements_chain, 'text="(.*?)"')) final_source_element,
        if(target_event LIKE %(autocapture_match)s, arrayElement(splitByString('autocapture:', assumeNotNull(target_event)), 2), NULL) target_event_elements_chain,
@@ -147,16 +148,20 @@ SELECT if(target_event LIKE %(autocapture_match)s, concat(arrayElement(splitBySt
 FROM (
     SELECT last_path_key as source_event,
        path_key as target_event,
-       COUNT(*) AS event_count
+       COUNT(*) AS event_count,
+       avg(conversion_time) AS average_conversion_time
   FROM (
         SELECT person_id,
                path,
+               conversion_time,
                event_in_session_index,
                concat(toString(event_in_session_index), '_', path) as path_key,
                if(event_in_session_index > 1, neighbor(path_key, -1), null) AS last_path_key
           FROM (
           
-              SELECT person_id, joined_path_item as path
+              SELECT person_id
+                    , joined_path_tuple.1 as path
+                    , joined_path_tuple.2 as conversion_time
                     , event_in_session_index
                     , session_index
                     , arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0
@@ -168,6 +173,7 @@ FROM (
                     , if(start_index > 0, arraySlice(timings, start_index), timings) as filtered_timings
                     , arraySlice(filtered_path, 1, %(event_in_session_limit)s) as limited_path
                     , arraySlice(filtered_timings, 1, %(event_in_session_limit)s) as limited_timings
+                    , arrayZip(limited_path, limited_timings) as limited_path_timings
                 FROM (
                     SELECT person_id
                         , path_time_tuple.1 as path_basic
@@ -187,7 +193,7 @@ FROM (
                     /* this array join splits paths for a single personID per session */
                     ARRAY JOIN session_paths AS path_time_tuple, arrayEnumerate(session_paths) AS session_index
                 )
-                ARRAY JOIN limited_path AS joined_path_item, arrayEnumerate(limited_path) AS event_in_session_index
+                ARRAY JOIN limited_path_timings AS joined_path_tuple, arrayEnumerate(limited_path) AS event_in_session_index
                 {boundary_event_filter}
                 ORDER BY person_id, session_index
                )


### PR DESCRIPTION
## Changes

Allows returning and showing conversion times for paths

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
