### PR TITLE
Use materialized person properties in trends & funnels

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from django.forms.models import model_to_dict
 
@@ -9,7 +9,12 @@ from posthog.models.property import Property, PropertyName, PropertyType
 
 
 def format_action_filter(
-    action: Action, prepend: str = "action", use_loop: bool = False, filter_by_team=True, table_name: str = ""
+    action: Action,
+    prepend: str = "action",
+    use_loop: bool = False,
+    filter_by_team=True,
+    table_name: str = "",
+    person_properties_column: Optional[str] = None,
 ) -> Tuple[str, Dict]:
     # get action steps
     params = {"team_id": action.team.pk} if filter_by_team else {}
@@ -43,6 +48,7 @@ def format_action_filter(
                 team_id=action.team.pk if filter_by_team else None,
                 prepend=f"action_props_{action.pk}_{step.pk}",
                 table_name=table_name,
+                person_properties_column=person_properties_column,
             )
             conditions.append(prop_query.replace("AND", "", 1))
             params = {**params, **prop_params}

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -91,7 +91,10 @@ def get_properties_cohort_subquery(cohort: Cohort, cohort_group: Dict, group_idx
                 query_parts.append(f"AND person.id IN ({person_id_query})")
         else:
             filter_query, filter_params = prop_filter_json_extract(
-                prop=prop, idx=idx, prepend="{}_{}_{}_person".format(cohort.pk, group_idx, idx)
+                prop=prop,
+                idx=idx,
+                prepend="{}_{}_{}_person".format(cohort.pk, group_idx, idx),
+                allow_denormalized_props=True,
             )
             params.update(filter_params)
             query_parts.append(filter_query)

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -94,7 +94,7 @@ def get_properties_cohort_subquery(cohort: Cohort, cohort_group: Dict, group_idx
                 prop=prop,
                 idx=idx,
                 prepend="{}_{}_{}_person".format(cohort.pk, group_idx, idx),
-                allow_denormalized_props=True,
+                allow_denormalized_props=False,
             )
             params.update(filter_params)
             query_parts.append(filter_query)

--- a/ee/clickhouse/models/entity.py
+++ b/ee/clickhouse/models/entity.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.property import parse_prop_clauses
@@ -7,16 +7,25 @@ from posthog.models.entity import Entity
 
 
 def get_entity_filtering_params(
-    entity: Entity, team_id: int, table_name: str = "", *, with_prop_filters: bool = False
+    entity: Entity,
+    team_id: int,
+    table_name: str = "",
+    *,
+    with_prop_filters: bool = False,
+    person_properties_column: Optional[str] = None,
 ) -> Tuple[Dict, Dict]:
     params: Dict[str, Any] = {}
     content_sql_params: Dict[str, str]
     prop_filters = ""
     if with_prop_filters:
-        prop_filters, params = parse_prop_clauses(entity.properties, team_id)
+        prop_filters, params = parse_prop_clauses(
+            entity.properties, team_id, person_properties_column=person_properties_column
+        )
     if entity.type == TREND_FILTER_TYPE_ACTIONS:
         action = entity.get_action()
-        action_query, action_params = format_action_filter(action, table_name=table_name)
+        action_query, action_params = format_action_filter(
+            action, table_name=table_name, person_properties_column=person_properties_column
+        )
         params.update(action_params)
         content_sql_params = {"entity_query": f"AND {action_query} {prop_filters}"}
     else:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -51,14 +51,18 @@ def parse_prop_clauses(
                     "AND {table_name}distinct_id IN ({clause})".format(table_name=table_name, clause=person_id_query)
                 )
         elif prop.type == "person":
+            # :TODO: Clean this up by using ClickhousePersonQuery over GET_DISTINCT_IDS_BY_PROPERTY_SQL to have access
+            #   to materialized columns
+            # :TODO: (performance) Avoid subqueries whenever possible, use joins instead
+            is_direct_query = is_person_query or person_properties_column is not None
             filter_query, filter_params = prop_filter_json_extract(
                 prop,
                 idx,
                 "{}person".format(prepend),
-                prop_var=person_properties_column or "properties",
-                allow_denormalized_props=allow_denormalized_props,
+                prop_var=(person_properties_column or "properties") if is_direct_query else "properties",
+                allow_denormalized_props=allow_denormalized_props and is_direct_query,
             )
-            if is_person_query or person_properties_column is not None:
+            if is_direct_query:
                 final.append(filter_query)
                 params.update(filter_params)
             else:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -204,8 +204,7 @@ def get_property_string_expr(
 ) -> Tuple[str, bool]:
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
-    # :TODO: Handle denormalized properties in person table
-    if allow_denormalized_props and property_name in materialized_columns and table == "events":
+    if allow_denormalized_props and property_name in materialized_columns:
         return materialized_columns[property_name], True
 
     return f"trim(BOTH '\"' FROM JSONExtractRaw({prop_var}, {var}))", False

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -25,6 +25,7 @@ def parse_prop_clauses(
     allow_denormalized_props: bool = True,
     filter_test_accounts=False,
     is_person_query=False,
+    person_properties_column: Optional[str] = None,
 ) -> Tuple[str, Dict]:
     final = []
     params: Dict[str, Any] = {}
@@ -51,9 +52,13 @@ def parse_prop_clauses(
                 )
         elif prop.type == "person":
             filter_query, filter_params = prop_filter_json_extract(
-                prop, idx, "{}person".format(prepend), allow_denormalized_props=allow_denormalized_props
+                prop,
+                idx,
+                "{}person".format(prepend),
+                prop_var=person_properties_column or "properties",
+                allow_denormalized_props=allow_denormalized_props,
             )
-            if is_person_query:
+            if is_person_query or person_properties_column is not None:
                 final.append(filter_query)
                 params.update(filter_params)
             else:

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -4,6 +4,7 @@ from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.cohort import format_filter_query
 from ee.clickhouse.models.entity import get_entity_filtering_params
 from ee.clickhouse.models.property import get_property_string_expr, parse_prop_clauses
+from ee.clickhouse.queries.person_query import ClickhousePersonQuery
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.person import GET_LATEST_PERSON_SQL, GET_TEAM_PERSON_DISTINCT_IDS
 from ee.clickhouse.sql.trends.top_elements import TOP_ELEMENTS_ARRAY_OF_KEY_SQL
@@ -18,7 +19,6 @@ ALL_USERS_COHORT_ID = 0
 def _get_top_elements(filter: Filter, team_id: int, query: str, limit, params: Dict = {}) -> List:
     # use limit of 25 to determine if there are more than 20
     element_params = {
-        "key": filter.breakdown,
         "limit": limit,
         "team_id": team_id,
         "offset": filter.offset,
@@ -39,7 +39,8 @@ def get_breakdown_person_prop_values(
         team_id,
         table_name="e",
         filter_test_accounts=filter.filter_test_accounts,
-        allow_denormalized_props=False,
+        is_person_query=True,
+        allow_denormalized_props=True,
     )
     person_prop_filters, person_prop_params = parse_prop_clauses(
         [prop for prop in filter.properties if prop.type == "person"],
@@ -47,17 +48,20 @@ def get_breakdown_person_prop_values(
         filter_test_accounts=filter.filter_test_accounts,
         is_person_query=True,
         prepend="person",
-        allow_denormalized_props=False,
+        allow_denormalized_props=True,
     )
 
     entity_params, entity_format_params = get_entity_filtering_params(entity, team_id, with_prop_filters=True)
 
+    value_expression, _ = get_property_string_expr("person", cast(str, filter.breakdown), "%(key)s", "person_props")
+
     elements_query = TOP_PERSON_PROPS_ARRAY_OF_KEY_SQL.format(
+        value_expression=value_expression,
         parsed_date_from=parsed_date_from,
         parsed_date_to=parsed_date_to,
-        latest_person_sql=GET_LATEST_PERSON_SQL.format(query=""),
+        person_query=ClickhousePersonQuery(filter, team_id).get_query(),
         prop_filters=prop_filters,
-        person_prop_filters=person_prop_filters,
+        person_prop_filters=person_prop_filters or "1=1",
         aggregate_operation=aggregate_operation,
         GET_TEAM_PERSON_DISTINCT_IDS=GET_TEAM_PERSON_DISTINCT_IDS,
         **entity_format_params,
@@ -66,7 +70,7 @@ def get_breakdown_person_prop_values(
         filter=filter,
         team_id=team_id,
         query=elements_query,
-        params={**prop_filter_params, **person_prop_params, **entity_params, **extra_params},
+        params={**prop_filter_params, **person_prop_params, **entity_params, **extra_params, "key": filter.breakdown},
         limit=limit,
     )
 

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -61,7 +61,7 @@ def get_breakdown_person_prop_values(
         parsed_date_to=parsed_date_to,
         person_query=ClickhousePersonQuery(filter, team_id).get_query(),
         prop_filters=prop_filters,
-        person_prop_filters=person_prop_filters or "1=1",
+        person_prop_filters=person_prop_filters,
         aggregate_operation=aggregate_operation,
         GET_TEAM_PERSON_DISTINCT_IDS=GET_TEAM_PERSON_DISTINCT_IDS,
         **entity_format_params,

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -39,19 +39,21 @@ def get_breakdown_person_prop_values(
         team_id,
         table_name="e",
         filter_test_accounts=filter.filter_test_accounts,
-        is_person_query=True,
+        person_properties_column="person_props",
         allow_denormalized_props=True,
     )
     person_prop_filters, person_prop_params = parse_prop_clauses(
         [prop for prop in filter.properties if prop.type == "person"],
         team_id,
         filter_test_accounts=filter.filter_test_accounts,
-        is_person_query=True,
+        person_properties_column="person_props",
         prepend="person",
         allow_denormalized_props=True,
     )
 
-    entity_params, entity_format_params = get_entity_filtering_params(entity, team_id, with_prop_filters=True)
+    entity_params, entity_format_params = get_entity_filtering_params(
+        entity, team_id, with_prop_filters=True, person_properties_column="person_props"
+    )
 
     value_expression, _ = get_property_string_expr("person", cast(str, filter.breakdown), "%(key)s", "person_props")
 

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -35,8 +35,23 @@ class ColumnOptimizer:
         ]
 
     @cached_property
+    def materialized_person_columns_to_query(self) -> List[ColumnName]:
+        "Returns a list of person table columns containing materialized properties that this query needs"
+
+        materialized_columns = get_materialized_columns("person")
+        return [
+            materialized_columns[property_name]
+            for property_name, type in self._used_properties_with_type("person")
+            if property_name in materialized_columns
+        ]
+
+    @cached_property
     def should_query_event_properties_column(self) -> bool:
         return len(self.materialized_event_columns_to_query) != len(self._used_properties_with_type("event"))
+
+    @cached_property
+    def should_query_person_properties_column(self) -> bool:
+        return len(self.materialized_person_columns_to_query) != len(self._used_properties_with_type("person"))
 
     @cached_property
     def should_query_elements_chain_column(self) -> bool:

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Tuple, Union
 
 from ee.clickhouse.models.cohort import format_person_query, get_precalculated_query, is_precalculated_query
 from ee.clickhouse.models.property import filter_element, prop_filter_json_extract
+from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
+from ee.clickhouse.queries.person_query import ClickhousePersonQuery
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS
 from posthog.models import Cohort, Filter, Property, Team
@@ -17,6 +19,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
     _PERSON_PROPERTIES_ALIAS = "person_props"
     _filter: Union[Filter, PathFilter]
     _team_id: int
+    _column_optimizer: ColumnOptimizer
     _should_join_distinct_ids = False
     _should_join_persons = False
     _should_round_interval = False
@@ -32,6 +35,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
     ) -> None:
         self._filter = filter
         self._team_id = team_id
+        self._column_optimizer = ColumnOptimizer(self._filter, self._team_id)
         self.params: Dict[str, Any] = {
             "team_id": self._team_id,
         }
@@ -114,16 +118,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         if self._should_join_persons:
             return f"""
             INNER JOIN (
-                SELECT id, properties as {self._PERSON_PROPERTIES_ALIAS}
-                FROM (
-                    SELECT id,
-                        argMax(properties, person._timestamp) as properties,
-                        max(is_deleted) as is_deleted
-                    FROM person
-                    WHERE team_id = %(team_id)s
-                    GROUP BY id
-                    HAVING is_deleted = 0
-                )
+                {ClickhousePersonQuery(self._filter, self._team_id, self._column_optimizer).get_query()}
             ) {self.PERSON_TABLE_ALIAS}
             ON {self.PERSON_TABLE_ALIAS}.id = {self.DISTINCT_ID_TABLE_ALIAS}.person_id
             """
@@ -165,7 +160,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                     prop,
                     idx,
                     "{}person".format(prepend),
-                    allow_denormalized_props=False,
+                    allow_denormalized_props=True,
                     prop_var=self._PERSON_PROPERTIES_ALIAS,
                 )
                 final.append(filter_query)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -16,7 +16,6 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
     PERSON_TABLE_ALIAS = "person"
     EVENT_TABLE_ALIAS = "e"
 
-    _PERSON_PROPERTIES_ALIAS = "person_props"
     _filter: Union[Filter, PathFilter]
     _team_id: int
     _column_optimizer: ColumnOptimizer
@@ -161,7 +160,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
                     idx,
                     "{}person".format(prepend),
                     allow_denormalized_props=True,
-                    prop_var=self._PERSON_PROPERTIES_ALIAS,
+                    prop_var=ClickhousePersonQuery.PERSON_PROPERTIES_ALIAS,
                 )
                 final.append(filter_query)
                 params.update(filter_params)

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -295,7 +295,9 @@ class ClickhouseFunnelBase(ABC, Funnel):
         return content_sql
 
     def _build_filters(self, entity: Entity, index: int) -> str:
-        prop_filters, prop_filter_params = parse_prop_clauses(entity.properties, self._team.pk, prepend=str(index))
+        prop_filters, prop_filter_params = parse_prop_clauses(
+            entity.properties, self._team.pk, prepend=str(index), person_properties_column="person_props"
+        )
         self.params.update(prop_filter_params)
         if entity.properties:
             return prop_filters

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -385,11 +385,15 @@ class ClickhouseFunnelBase(ABC, Funnel):
         if self._filter.breakdown:
             self.params.update({"breakdown": self._filter.breakdown})
             if self._filter.breakdown_type == "person":
+                # :TRICKY: We only support string breakdown for event/person properties
+                assert isinstance(self._filter.breakdown, str)
                 expression, _ = get_property_string_expr(
                     "person", self._filter.breakdown, "%(breakdown)s", "person_props"
                 )
                 return f", {expression} AS prop"
             elif self._filter.breakdown_type == "event":
+                # :TRICKY: We only support string breakdown for event/person properties
+                assert isinstance(self._filter.breakdown, str)
                 expression, _ = get_property_string_expr(
                     "events", self._filter.breakdown, "%(breakdown)s", "properties"
                 )

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -391,8 +391,9 @@ class ClickhouseFunnelBase(ABC, Funnel):
                 return f", {expression} AS prop"
             elif self._filter.breakdown_type == "event":
                 expression, _ = get_property_string_expr(
-                    "person", self._filter.breakdown, "%(breakdown)s", "properties"
+                    "events", self._filter.breakdown, "%(breakdown)s", "properties"
                 )
+                return f", {expression} AS prop"
             elif self._filter.breakdown_type == "cohort":
                 return ", value AS prop"
 

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -24,7 +24,9 @@ class FunnelEventQuery(ClickhouseEventQuery):
                 else ""
             ),
             f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "",
-            f"{self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons and self._column_optimizer.should_query_person_properties_column else "",
+            f"{self.PERSON_TABLE_ALIAS}.person_props as person_props"
+            if self._should_join_persons and self._column_optimizer.should_query_person_properties_column
+            else "",
         ]
 
         _fields.extend(
@@ -34,7 +36,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
 
         if self._should_join_persons:
             _fields.extend(
-                f", {self.PERSON_TABLE_ALIAS}.{column_name} as {column_name}"
+                f"{self.PERSON_TABLE_ALIAS}.{column_name} as {column_name}"
                 for column_name in self._column_optimizer.materialized_person_columns_to_query
             )
 
@@ -56,7 +58,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
         self.params.update(entity_params)
 
         query = f"""
-            SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
+            SELECT {', '.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
             {self._get_disintct_id_query()}
             {self._get_person_query()}
             WHERE team_id = %(team_id)s

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -24,15 +24,19 @@ class FunnelEventQuery(ClickhouseEventQuery):
                 else ""
             ),
             f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "",
-            f"{self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons else "",
+            f"{self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons and self._column_optimizer.should_query_person_properties_column else "",
         ]
 
         _fields.extend(
-            [
-                f"{self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
-                for column_name in column_optimizer.materialized_event_columns_to_query
-            ]
+            f"{self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
+            for column_name in column_optimizer.materialized_event_columns_to_query
         )
+
+        if self._should_join_persons:
+            _fields.extend(
+                f", {self.PERSON_TABLE_ALIAS}.{column_name} as {column_name}"
+                for column_name in self._column_optimizer.materialized_person_columns_to_query
+            )
 
         _fields = list(filter(None, _fields))
 

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -512,6 +512,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_people_at_step(filter, 1, "Safari"), [person2.uuid, person3.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 2, "Safari"), [person2.uuid])
 
+        @test_with_materialized_columns(person_properties=["$browser"])
         def test_funnel_step_breakdown_person(self):
 
             filters = {

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -657,6 +657,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_people_at_step(filter, 1, "Safari"), [person2.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 3, "Safari"), [])
 
+        @test_with_materialized_columns(["some_breakdown_val"])
         def test_funnel_step_breakdown_limit(self):
 
             filters = {
@@ -704,6 +705,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             breakdown_vals = sorted([res[0]["breakdown"] for res in result])
             self.assertEqual(["5", "6", "7", "8", "9", "Other"], breakdown_vals)
 
+        @test_with_materialized_columns(["some_breakdown_val"])
         def test_funnel_step_custom_breakdown_limit_with_nulls(self):
 
             filters = {
@@ -776,6 +778,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             # skipped 1 and '' because the limit was 3.
             self.assertTrue(person0.uuid in self._get_people_at_step(filter, 1, "Other"))
 
+        @test_with_materialized_columns(["some_breakdown_val"])
         def test_funnel_step_custom_breakdown_limit_with_nulls_included(self):
 
             filters = {
@@ -853,6 +856,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertEqual([p_null.uuid], self._get_people_at_step(filter, 1, ""))
             self.assertEqual([p_null.uuid], self._get_people_at_step(filter, 3, ""))
 
+        @test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event_single_person_multiple_breakdowns(self):
 
             filters = {

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -1093,6 +1093,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_people_at_step(filter, 1, "Safari"), [person1.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 2, "Safari"), [person1.uuid])
 
+        @test_with_materialized_columns(person_properties=["key"], verify_no_jsonextract=False)
         def test_funnel_cohort_breakdown(self):
             # This caused some issues with SQL parsing
             person = _create_person(distinct_ids=[f"person1"], team_id=self.team.pk, properties={"key": "value"})
@@ -1104,7 +1105,9 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
                 timestamp="2020-01-02T12:00:00Z",
             )
             cohort = Cohort.objects.create(
-                team=self.team, name="test_cohort", groups=[{"properties": {"key": "value"}}]
+                team=self.team,
+                name="test_cohort",
+                groups=[{"properties": [{"key": "key", "value": "value", "type": "person"}]}],
             )
             filters = {
                 "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}, {"id": "buy", "order": 2},],
@@ -1149,118 +1152,98 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_people_at_step(filter, 1, cohort.pk), [person.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 2, cohort.pk), [])
 
-        def test_funnel_query_with_denormalized_breakdown(self):
-            filter = Filter(
-                data={
-                    "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}],
-                    "insight": INSIGHT_FUNNELS,
-                    "date_from": "2020-01-01",
-                    "date_to": "2020-01-08",
-                    "funnel_window_days": 7,
-                    "breakdown_type": "event",
-                    "breakdown": "some_breakdown_val",
-                    "breakdown_limit": 5,
-                }
+        def test_basic_funnel_default_funnel_days_breakdown_event(self):
+            person = _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id="user_1",
+                timestamp="2020-01-02T14:00:00Z",
+                properties={"$current_url": "https://posthog.com/docs/x"},
+            )
+            _create_event(
+                team=self.team,
+                event="paid",
+                distinct_id="user_1",
+                timestamp="2020-01-10T14:00:00Z",
+                properties={"$current_url": "https://posthog.com/docs/x"},
             )
 
-            materialize("events", "some_breakdown_val")
+            # Dummy events to make sure that breakdown is not confused
+            # It was confused before due to the nature of fetching breakdown values with a LIMIT based on value popularity
+            # See https://github.com/PostHog/posthog/pull/5496
+            for current_url_letter in ascii_lowercase[:20]:
+                # Twenty dummy breakdown values
+                for _ in range(2):
+                    # Each twice, so that the breakdown values from dummy events rank higher in raw order
+                    # This test makes sure that events are prefiltered properly to avoid problems with this raw order
+                    _create_event(
+                        team=self.team,
+                        event="user signed up",
+                        distinct_id="user_1",
+                        timestamp="2020-01-02T14:00:00Z",
+                        properties={"$current_url": f"https://posthog.com/blog/{current_url_letter}"},
+                    )
 
-            funnel = ClickhouseFunnel(filter, self.team)
-
-            self.assertNotIn("json", funnel.get_query().lower())
-            funnel.run()
-
-    def test_basic_funnel_default_funnel_days_breakdown_event(self):
-        person = _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
-        _create_event(
-            team=self.team,
-            event="user signed up",
-            distinct_id="user_1",
-            timestamp="2020-01-02T14:00:00Z",
-            properties={"$current_url": "https://posthog.com/docs/x"},
-        )
-        _create_event(
-            team=self.team,
-            event="paid",
-            distinct_id="user_1",
-            timestamp="2020-01-10T14:00:00Z",
-            properties={"$current_url": "https://posthog.com/docs/x"},
-        )
-
-        # Dummy events to make sure that breakdown is not confused
-        # It was confused before due to the nature of fetching breakdown values with a LIMIT based on value popularity
-        # See https://github.com/PostHog/posthog/pull/5496
-        for current_url_letter in ascii_lowercase[:20]:
-            # Twenty dummy breakdown values
-            for _ in range(2):
-                # Each twice, so that the breakdown values from dummy events rank higher in raw order
-                # This test makes sure that events are prefiltered properly to avoid problems with this raw order
-                _create_event(
-                    team=self.team,
-                    event="user signed up",
-                    distinct_id="user_1",
-                    timestamp="2020-01-02T14:00:00Z",
-                    properties={"$current_url": f"https://posthog.com/blog/{current_url_letter}"},
-                )
-
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [
-                        {
-                            "key": "$current_url",
-                            "operator": "icontains",
-                            "type": "event",
-                            "value": "https://posthog.com/docs",
-                        }
-                    ],
-                },
-                {"id": "paid", "type": "events", "order": 1},
-            ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "breakdown": "$current_url",
-            "breakdown_type": "event",
-        }
-
-        result = ClickhouseFunnel(Filter(data=filters), self.team).run()
-
-        self.assertEqual(
-            result,
-            [
-                [
+            filters = {
+                "events": [
                     {
-                        "action_id": "user signed up",
-                        "average_conversion_time": None,
-                        "breakdown": "https://posthog.com/docs/x",
-                        "breakdown_value": "https://posthog.com/docs/x",
-                        "count": 1,
-                        "median_conversion_time": None,
-                        "name": "user signed up",
+                        "id": "user signed up",
+                        "type": "events",
                         "order": 0,
-                        "people": [UUID(bytes=person.uuid.bytes)],
-                        "type": "events",
+                        "properties": [
+                            {
+                                "key": "$current_url",
+                                "operator": "icontains",
+                                "type": "event",
+                                "value": "https://posthog.com/docs",
+                            }
+                        ],
                     },
-                    {
-                        "action_id": "paid",
-                        "average_conversion_time": 691200.0,
-                        "breakdown": "https://posthog.com/docs/x",
-                        "breakdown_value": "https://posthog.com/docs/x",
-                        "count": 1,
-                        "median_conversion_time": 691200.0,
-                        "name": "paid",
-                        "order": 1,
-                        "people": [UUID(bytes=person.uuid.bytes)],
-                        "type": "events",
-                    },
-                ]
-            ],
-        )
+                    {"id": "paid", "type": "events", "order": 1},
+                ],
+                "insight": INSIGHT_FUNNELS,
+                "date_from": "2020-01-01",
+                "date_to": "2020-01-14",
+                "breakdown": "$current_url",
+                "breakdown_type": "event",
+            }
 
+            result = ClickhouseFunnel(Filter(data=filters), self.team).run()
+
+            self.assertEqual(
+                result,
+                [
+                    [
+                        {
+                            "action_id": "user signed up",
+                            "average_conversion_time": None,
+                            "breakdown": "https://posthog.com/docs/x",
+                            "breakdown_value": "https://posthog.com/docs/x",
+                            "count": 1,
+                            "median_conversion_time": None,
+                            "name": "user signed up",
+                            "order": 0,
+                            "people": [UUID(bytes=person.uuid.bytes)],
+                            "type": "events",
+                        },
+                        {
+                            "action_id": "paid",
+                            "average_conversion_time": 691200.0,
+                            "breakdown": "https://posthog.com/docs/x",
+                            "breakdown_value": "https://posthog.com/docs/x",
+                            "count": 1,
+                            "median_conversion_time": 691200.0,
+                            "name": "paid",
+                            "order": 1,
+                            "people": [UUID(bytes=person.uuid.bytes)],
+                            "type": "events",
+                        },
+                    ]
+                ],
+            )
+
+        @test_with_materialized_columns(["$current_url"])
         def test_basic_funnel_default_funnel_days_breakdown_action(self):
             # Same case as test_basic_funnel_default_funnel_days_breakdown_event but with an action
             user_signed_up_action = _create_action(name="user signed up", event="user signed up", team=self.team,)

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -7,7 +7,7 @@ from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
 from posthog.constants import INSIGHT_FUNNELS
 from posthog.models.cohort import Cohort
 from posthog.models.filters import Filter
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, test_with_materialized_columns
 
 
 def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_action, _create_person):
@@ -17,6 +17,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             result = FunnelPerson(person_filter, self.team)._exec_query()
             return [row[0] for row in result]
 
+        @test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event(self):
 
             filters = {
@@ -172,6 +173,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_people_at_step(filter, 1, "Safari"), [person2.uuid, person3.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 2, "Safari"), [person2.uuid])
 
+        @test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event_with_other(self):
 
             filters = {
@@ -355,6 +357,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_people_at_step(filter, 1, "Safari"), [person2.uuid, person3.uuid])
             self.assertCountEqual(self._get_people_at_step(filter, 2, "Safari"), [person2.uuid])
 
+        @test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event_no_type(self):
 
             filters = {

--- a/ee/clickhouse/queries/funnels/test/test_funnel_persons.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_persons.py
@@ -7,7 +7,7 @@ from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.constants import INSIGHT_FUNNELS
 from posthog.models import Cohort, Filter
 from posthog.models.person import Person
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, test_with_materialized_columns
 
 FORMAT_TIME = "%Y-%m-%d 00:00:00"
 MAX_STEP_COLUMN = 0
@@ -41,6 +41,47 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         for i in range(15, 35):
             _create_person(distinct_ids=[f"user_{i}"], team=self.team)
             _create_event(event="step one", distinct_id=f"user_{i}", team=self.team, timestamp="2021-05-01 00:00:00")
+
+    def _create_browser_breakdown_events(self):
+        person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk, properties={"$country": "PL"})
+        _create_event(
+            team=self.team,
+            event="sign up",
+            distinct_id="person1",
+            properties={"key": "val", "$browser": "Chrome"},
+            timestamp="2020-01-01T12:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="play movie",
+            distinct_id="person1",
+            properties={"key": "val", "$browser": "Chrome"},
+            timestamp="2020-01-01T13:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="buy",
+            distinct_id="person1",
+            properties={"key": "val", "$browser": "Chrome"},
+            timestamp="2020-01-01T15:00:00Z",
+        )
+
+        person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk, properties={"$country": "EE"})
+        _create_event(
+            team=self.team,
+            event="sign up",
+            distinct_id="person2",
+            properties={"key": "val", "$browser": "Safari"},
+            timestamp="2020-01-02T14:00:00Z",
+        )
+        _create_event(
+            team=self.team,
+            event="play movie",
+            distinct_id="person2",
+            properties={"key": "val", "$browser": "Safari"},
+            timestamp="2020-01-02T16:00:00Z",
+        )
+        return person1, person2
 
     def test_first_step(self):
         self._create_sample_data_multiple_dropoffs()
@@ -149,59 +190,22 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         results, _ = ClickhouseFunnelPersons(filter_offset, self.team).run()
         self.assertEqual(10, len(results))
 
+    @test_with_materialized_columns(["$browser"])
     def test_first_step_breakdowns(self):
-
-        person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
-        _create_event(
-            team=self.team,
-            event="sign up",
-            distinct_id="person1",
-            properties={"key": "val", "$browser": "Chrome"},
-            timestamp="2020-01-01T12:00:00Z",
+        person1, person2 = self._create_browser_breakdown_events()
+        filter = Filter(
+            data={
+                "insight": INSIGHT_FUNNELS,
+                "date_from": "2020-01-01",
+                "date_to": "2020-01-08",
+                "interval": "day",
+                "funnel_window_days": 7,
+                "funnel_step": 1,
+                "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}, {"id": "buy", "order": 2},],
+                "breakdown_type": "event",
+                "breakdown": "$browser",
+            }
         )
-        _create_event(
-            team=self.team,
-            event="play movie",
-            distinct_id="person1",
-            properties={"key": "val", "$browser": "Chrome"},
-            timestamp="2020-01-01T13:00:00Z",
-        )
-        _create_event(
-            team=self.team,
-            event="buy",
-            distinct_id="person1",
-            properties={"key": "val", "$browser": "Chrome"},
-            timestamp="2020-01-01T15:00:00Z",
-        )
-
-        person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
-        _create_event(
-            team=self.team,
-            event="sign up",
-            distinct_id="person2",
-            properties={"key": "val", "$browser": "Safari"},
-            timestamp="2020-01-02T14:00:00Z",
-        )
-        _create_event(
-            team=self.team,
-            event="play movie",
-            distinct_id="person2",
-            properties={"key": "val", "$browser": "Safari"},
-            timestamp="2020-01-02T16:00:00Z",
-        )
-
-        data = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-08",
-            "interval": "day",
-            "funnel_window_days": 7,
-            "funnel_step": 1,
-            "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}, {"id": "buy", "order": 2},],
-            "breakdown_type": "event",
-            "breakdown": "$browser",
-        }
-        filter = Filter(data=data)
         results = ClickhouseFunnelPersons(filter, self.team)._exec_query()
 
         self.assertCountEqual([val[0] for val in results], [person1.uuid, person2.uuid])
@@ -222,12 +226,43 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         )._exec_query()
         self.assertCountEqual([val[0] for val in results], [person2.uuid, person1.uuid])
 
+    @test_with_materialized_columns(person_properties=["$country"])
+    def test_first_step_breakdown_person(self):
+        person1, person2 = self._create_browser_breakdown_events()
+        filter = Filter(
+            data={
+                "insight": INSIGHT_FUNNELS,
+                "date_from": "2020-01-01",
+                "date_to": "2020-01-08",
+                "interval": "day",
+                "funnel_window_days": 7,
+                "funnel_step": 1,
+                "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}, {"id": "buy", "order": 2},],
+                "breakdown_type": "person",
+                "breakdown": "$country",
+            }
+        )
+
+        results = ClickhouseFunnelPersons(filter, self.team)._exec_query()
+        self.assertCountEqual([val[0] for val in results], [person1.uuid, person2.uuid])
+
+        results = ClickhouseFunnelPersons(filter.with_data({"funnel_step_breakdown": "EE"}), self.team)._exec_query()
+        self.assertCountEqual([val[0] for val in results], [person2.uuid])
+
+        results = ClickhouseFunnelPersons(filter.with_data({"funnel_step_breakdown": "PL"}), self.team)._exec_query()
+        self.assertCountEqual([val[0] for val in results], [person1.uuid])
+
+    @test_with_materialized_columns(["$browser"], verify_no_jsonextract=False)
     def test_funnel_cohort_breakdown_persons(self):
         person = _create_person(distinct_ids=[f"person1"], team_id=self.team.pk, properties={"key": "value"})
         _create_event(
             team=self.team, event="sign up", distinct_id=f"person1", properties={}, timestamp="2020-01-02T12:00:00Z",
         )
-        cohort = Cohort.objects.create(team=self.team, name="test_cohort", groups=[{"properties": {"key": "value"}}])
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="test_cohort",
+            groups=[{"properties": [{"key": "key", "value": "value", "type": "person"}]}],
+        )
         filters = {
             "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}, {"id": "buy", "order": 2},],
             "insight": INSIGHT_FUNNELS,

--- a/ee/clickhouse/queries/person_query.py
+++ b/ee/clickhouse/queries/person_query.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
+from posthog.models import Filter
+
+
+class ClickhousePersonQuery:
+    PERSON_PROPERTIES_ALIAS = "person_props"
+
+    _filter: Filter
+    _team_id: int
+    _column_optimizer: ColumnOptimizer
+
+    def __init__(self, filter: Filter, team_id: int, column_optimizer: Optional[ColumnOptimizer] = None) -> None:
+        self._filter = filter
+        self._team_id = team_id
+        self._column_optimizer = column_optimizer or ColumnOptimizer(self._filter, self._team_id)
+
+    def get_query(self) -> str:
+        fields = (
+            "id"
+            + (
+                f", argMax(properties, _timestamp) AS {self.PERSON_PROPERTIES_ALIAS}"
+                if self._column_optimizer.should_query_person_properties_column
+                else ""
+            )
+            + " ".join(
+                f", argMax({column_name}, _timestamp) as {column_name}"
+                for column_name in self._column_optimizer.materialized_person_columns_to_query
+            )
+        )
+
+        return f"""
+            SELECT {fields}
+            FROM person
+            WHERE team_id = %(team_id)s
+            GROUP BY id
+            HAVING max(is_deleted) = 0
+        """

--- a/ee/clickhouse/queries/person_query.py
+++ b/ee/clickhouse/queries/person_query.py
@@ -1,17 +1,20 @@
-from typing import Optional
+from typing import Optional, Union
 
 from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from posthog.models import Filter
+from posthog.models.filters.path_filter import PathFilter
 
 
 class ClickhousePersonQuery:
     PERSON_PROPERTIES_ALIAS = "person_props"
 
-    _filter: Filter
+    _filter: Union[Filter, PathFilter]
     _team_id: int
     _column_optimizer: ColumnOptimizer
 
-    def __init__(self, filter: Filter, team_id: int, column_optimizer: Optional[ColumnOptimizer] = None) -> None:
+    def __init__(
+        self, filter: Union[Filter, PathFilter], team_id: int, column_optimizer: Optional[ColumnOptimizer] = None
+    ) -> None:
         self._filter = filter
         self._team_id = team_id
         self._column_optimizer = column_optimizer or ColumnOptimizer(self._filter, self._team_id)

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -100,12 +100,19 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         optimizer = lambda: ColumnOptimizer(FILTER_WITH_PROPERTIES, self.team.id)
 
         self.assertEqual(optimizer().materialized_event_columns_to_query, [])
-        # self.assertEqual(optimizer().should_query_event_properties_column, True)
+        self.assertEqual(optimizer().should_query_event_properties_column, True)
+
+        self.assertEqual(optimizer().materialized_person_columns_to_query, [])
+        self.assertEqual(optimizer().should_query_person_properties_column, True)
 
         materialize("events", "event_prop")
+        materialize("person", "person_prop")
 
         self.assertEqual(optimizer().materialized_event_columns_to_query, ["mat_event_prop"])
-        # self.assertEqual(optimizer().should_query_event_properties_column, False)
+        self.assertEqual(optimizer().should_query_event_properties_column, False)
+
+        self.assertEqual(optimizer().materialized_person_columns_to_query, ["mat_person_prop"])
+        self.assertEqual(optimizer().should_query_person_properties_column, False)
 
     def test_should_query_element_chain_column(self):
         should_query_elements_chain_column = lambda filter: ColumnOptimizer(

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -111,7 +111,7 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(optimizer().materialized_event_columns_to_query, ["mat_event_prop"])
         self.assertEqual(optimizer().should_query_event_properties_column, False)
 
-        self.assertEqual(optimizer().materialized_person_columns_to_query, ["mat_person_prop"])
+        self.assertEqual(optimizer().materialized_person_columns_to_query, ["pmat_person_prop"])
         self.assertEqual(optimizer().should_query_person_properties_column, False)
 
     def test_should_query_element_chain_column(self):

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -93,14 +93,6 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         self._run_query(filter, entity)
 
-        filter = Filter(
-            data={
-                "date_from": "2021-05-01 00:00:00",
-                "date_to": "2021-05-07 00:00:00",
-                "events": [{"id": "viewed", "order": 0},],
-            }
-        )
-
         entity = Entity(
             {
                 "id": "viewed",
@@ -110,6 +102,10 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
                     {"key": "key", "value": "val"},
                 ],
             }
+        )
+
+        filter = Filter(
+            data={"date_from": "2021-05-01 00:00:00", "date_to": "2021-05-07 00:00:00", "events": [entity.to_dict()],}
         )
 
         self._run_query(filter, entity)

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -549,6 +549,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         result = ClickhouseTrends().run(filter, self.team,)
         self.assertEqual(result[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 0.0])
 
+    # @test_with_materialized_columns(person_properties=["name"])
     def test_filter_test_accounts(self):
         p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
         _create_event(

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 from django.utils import timezone
 from freezegun import freeze_time
 
-from ee.clickhouse.materialized_columns import materialize
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.person import create_person_distinct_id
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
@@ -127,6 +126,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             event_response, action_response,
         )
 
+    @test_with_materialized_columns(["$some_property"])
     def test_breakdown_filtering(self):
         self._create_events()
         # test breakdown filtering
@@ -155,6 +155,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         self.assertEqual(sum(response[2]["data"]), 1)
         self.assertEqual(sum(response[3]["data"]), 1)
 
+    @test_with_materialized_columns(person_properties=["email"])
     def test_breakdown_filtering_persons(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person1"], properties={"email": "test@posthog.com"})
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "test@gmail.com"})
@@ -183,6 +184,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         self.assertEqual(response[2]["count"], 1)
 
     # ensure that column names are properly handled when subqueries and person subquery share properties column
+    @test_with_materialized_columns(event_properties=["key"], person_properties=["email"])
     def test_breakdown_filtering_persons_with_action_props(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person1"], properties={"email": "test@posthog.com"})
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "test@gmail.com"})

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -44,6 +44,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
 
     maxDiff = None
 
+    @test_with_materialized_columns(["key"])
     def test_breakdown_with_filter(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person1"], properties={"email": "test@posthog.com"})
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "test@gmail.com"})

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -81,8 +81,9 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             )
         self.assertEqual(len(response), 25)  # We fetch 25 to see if there are more ethan 20 values
 
+    @test_with_materialized_columns(person_properties=["name"])
     def test_breakdown_by_person_property(self):
-        person1, person2, person3, person4 = self._create_multiple_people()
+        self._create_multiple_people()
         action = _create_action(name="watched movie", team=self.team)
 
         with freeze_time("2020-01-04T13:01:01Z"):

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -390,7 +390,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         )
         self.assertEqual(action_response[0]["count"], 0)
 
-    @test_with_materialized_columns(["key"], verify_no_jsonextract=False)
+    @test_with_materialized_columns(event_properties=["key"], person_properties=["email"])
     def test_breakdown_user_props_with_filter(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person1"], properties={"email": "test@posthog.com"})
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "test@gmail.com"})

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -46,7 +46,7 @@ class ClickhouseTrendsBreakdown:
             team_id,
             table_name="e",
             filter_test_accounts=filter.filter_test_accounts,
-            person_properties_column="person_props",
+            person_properties_column="person_props" if filter.breakdown_type == "person" else None,
         )
         aggregate_operation, _, math_params = process_math(entity)
 

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -10,10 +10,11 @@ from ee.clickhouse.queries.breakdown_props import (
     get_breakdown_event_prop_values,
     get_breakdown_person_prop_values,
 )
+from ee.clickhouse.queries.person_query import ClickhousePersonQuery
 from ee.clickhouse.queries.trends.util import enumerate_time_range, get_active_user_params, parse_response, process_math
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
 from ee.clickhouse.sql.events import EVENT_JOIN_PERSON_SQL
-from ee.clickhouse.sql.person import GET_LATEST_PERSON_SQL, GET_TEAM_PERSON_DISTINCT_IDS
+from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS
 from ee.clickhouse.sql.trends.breakdown import (
     BREAKDOWN_ACTIVE_USER_CONDITIONS_SQL,
     BREAKDOWN_ACTIVE_USER_INNER_SQL,
@@ -41,7 +42,11 @@ class ClickhouseTrendsBreakdown:
 
         props_to_filter = [*filter.properties, *entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, table_name="e", filter_test_accounts=filter.filter_test_accounts,
+            props_to_filter,
+            team_id,
+            table_name="e",
+            filter_test_accounts=filter.filter_test_accounts,
+            is_person_query=True,
         )
         aggregate_operation, _, math_params = process_math(entity)
 
@@ -171,18 +176,19 @@ class ClickhouseTrendsBreakdown:
         values_arr = get_breakdown_person_prop_values(
             filter, entity, aggregate_operation, team_id, extra_params=math_params
         )
-        breakdown_filter_params = {
-            "latest_person_sql": GET_LATEST_PERSON_SQL.format(query=""),
-        }
-        params = {
-            "values": values_arr,
-        }
+
+        # :TRICKY: We only support string breakdown for event/person properties
+        assert isinstance(filter.breakdown, str)
+        breakdown_value, _ = get_property_string_expr("person", filter.breakdown, "%(key)s", "person_props")
 
         return (
-            params,
+            {"values": values_arr},
             BREAKDOWN_PERSON_PROP_JOIN_SQL,
-            breakdown_filter_params,
-            "value",
+            {
+                "person_query": ClickhousePersonQuery(filter, team_id).get_query(),
+                "breakdown_value_expr": breakdown_value,
+            },
+            breakdown_value,
         )
 
     def _breakdown_prop_params(

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -46,7 +46,7 @@ class ClickhouseTrendsBreakdown:
             team_id,
             table_name="e",
             filter_test_accounts=filter.filter_test_accounts,
-            is_person_query=True,
+            person_properties_column="person_props",
         )
         aggregate_operation, _, math_params = process_math(entity)
 

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -95,7 +95,7 @@ class TrendsEventQuery(ClickhouseEventQuery):
 
     def _get_entity_query(self) -> Tuple[str, Dict]:
         entity_params, entity_format_params = get_entity_filtering_params(
-            self._entity, self._team_id, table_name=self.EVENT_TABLE_ALIAS
+            self._entity, self._team_id, table_name=self.EVENT_TABLE_ALIAS, person_properties_column="person_props"
         )
 
         return entity_format_params["entity_query"], entity_params

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Tuple
 
 from ee.clickhouse.models.entity import get_entity_filtering_params
-from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from ee.clickhouse.queries.trends.util import get_active_user_params
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
@@ -18,24 +17,20 @@ class TrendsEventQuery(ClickhouseEventQuery):
         super().__init__(*args, **kwargs)
 
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
-        column_optimizer = ColumnOptimizer(self._filter, self._team_id)
         _fields = (
             f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp"
             + (
                 f", {self.EVENT_TABLE_ALIAS}.properties as properties"
-                if column_optimizer.should_query_event_properties_column
+                if self._column_optimizer.should_query_event_properties_column
                 else ""
             )
-            + (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "")
-            + (f", {self.PERSON_TABLE_ALIAS}.person_props as person_props" if self._should_join_persons else "")
             + (
                 " ".join(
-                    [
-                        f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
-                        for column_name in column_optimizer.materialized_event_columns_to_query
-                    ]
+                    f", {self.EVENT_TABLE_ALIAS}.{column_name} as {column_name}"
+                    for column_name in self._column_optimizer.materialized_event_columns_to_query
                 )
             )
+            + (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "")
         )
 
         date_query, date_params = self._get_date_filter()

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -95,7 +95,10 @@ class TrendsEventQuery(ClickhouseEventQuery):
 
     def _get_entity_query(self) -> Tuple[str, Dict]:
         entity_params, entity_format_params = get_entity_filtering_params(
-            self._entity, self._team_id, table_name=self.EVENT_TABLE_ALIAS, person_properties_column="person_props"
+            self._entity,
+            self._team_id,
+            table_name=self.EVENT_TABLE_ALIAS,
+            person_properties_column=self._PERSON_PROPERTIES_ALIAS,
         )
 
         return entity_format_params["entity_query"], entity_params

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -2,11 +2,11 @@ from typing import Any, Dict, Tuple
 
 from ee.clickhouse.models.entity import get_entity_filtering_params
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
+from ee.clickhouse.queries.person_query import ClickhousePersonQuery
 from ee.clickhouse.queries.trends.util import get_active_user_params
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
 from posthog.constants import MONTHLY_ACTIVE, WEEKLY_ACTIVE
 from posthog.models import Entity
-from posthog.models.filters.filter import Filter
 
 
 class TrendsEventQuery(ClickhouseEventQuery):
@@ -98,7 +98,7 @@ class TrendsEventQuery(ClickhouseEventQuery):
             self._entity,
             self._team_id,
             table_name=self.EVENT_TABLE_ALIAS,
-            person_properties_column=self._PERSON_PROPERTIES_ALIAS,
+            person_properties_column=ClickhousePersonQuery.PERSON_PROPERTIES_ALIAS,
         )
 
         return entity_format_params["entity_query"], entity_params

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -68,16 +68,10 @@ WHERE e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from_prev_ra
 
 BREAKDOWN_PERSON_PROP_JOIN_SQL = """
 INNER JOIN (
-    SELECT *
-    from (
-        SELECT
-            id,
-            trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) as value
-        FROM ({latest_person_sql}) person WHERE team_id = %(team_id)s
-    )
+    {person_query}
 ) ep
 ON person_id = ep.id WHERE e.team_id = %(team_id)s {event_filter} {filters} {parsed_date_from} {parsed_date_to}
-AND breakdown_value in (%(values)s) {actions_query}
+AND {breakdown_value_expr} in (%(values)s) {actions_query}
 """
 
 BREAKDOWN_PROP_JOIN_SQL = """

--- a/ee/clickhouse/sql/trends/top_person_props.py
+++ b/ee/clickhouse/sql/trends/top_person_props.py
@@ -1,18 +1,12 @@
 TOP_PERSON_PROPS_ARRAY_OF_KEY_SQL = """
 SELECT groupArray(value) FROM (
-    SELECT value, {aggregate_operation} as count
+    SELECT {value_expression} as value, {aggregate_operation} as count
     FROM
     events e
     INNER JOIN ({GET_TEAM_PERSON_DISTINCT_IDS}) AS pdi ON e.distinct_id = pdi.distinct_id
     INNER JOIN
         (
-            SELECT *
-            from (
-                SELECT
-                    id,
-                    trim(BOTH '\"' FROM JSONExtractRaw(properties, %(key)s)) as value
-                FROM ({latest_person_sql}) person WHERE team_id = %(team_id)s {person_prop_filters}
-            )
+            {person_query} {person_prop_filters}
         ) ep ON person_id = ep.id
     WHERE
         e.team_id = %(team_id)s {entity_query} {parsed_date_from} {parsed_date_to} {prop_filters}

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -260,6 +260,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[1]["count"], 1)
             self.assertEqual(result[2]["count"], 0)
 
+        @test_with_materialized_columns(person_properties=["email"])
         def test_funnel_person_prop(self):
             action_credit_card = Action.objects.create(team_id=self.team.pk, name="paid")
             ActionStep.objects.create(
@@ -330,6 +331,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[1]["count"], 1)
             self.assertEqual(result[2]["count"], 0)
 
+        @test_with_materialized_columns(person_properties=["email"])
         def test_funnel_filter_test_accounts(self):
             person_factory(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
             person_factory(distinct_ids=["person2"], team_id=self.team.pk)

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -350,6 +350,36 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             ).run()
             self.assertEqual(result[0]["count"], 1)
 
+        @test_with_materialized_columns(person_properties=["email"])
+        def test_funnel_filter_by_action_with_person_properties(self):
+            person_factory(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
+            person_factory(distinct_ids=["person2"], team_id=self.team.pk, properties={"email": "another@example.com"})
+            person_factory(distinct_ids=["person3"], team_id=self.team.pk)
+            event_factory(distinct_id="person1", event="event1", team=self.team)
+            event_factory(distinct_id="person2", event="event1", team=self.team)
+            event_factory(distinct_id="person3", event="event1", team=self.team)
+
+            action = Action.objects.create(team_id=self.team.pk, name="event1")
+            ActionStep.objects.create(
+                action=action,
+                event="event2",
+                properties=[{"key": "email", "value": "is_set", "operator": "is_set", "type": "person"}],
+            )
+            action.calculate_events()
+
+            result = Funnel(
+                filter=Filter(
+                    data={
+                        "events": [{"id": "event1", "order": 0}],
+                        "insight": INSIGHT_FUNNELS,
+                        FILTER_TEST_ACCOUNTS: True,
+                        "funnel_window_days": 14,
+                    }
+                ),
+                team=self.team,
+            ).run()
+            self.assertEqual(result[0]["count"], 2)
+
     return TestGetFunnel
 
 

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -379,7 +379,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             ).run()
             self.assertEqual(result[0]["count"], 2)
 
-        @test_with_materialized_columns(person_properties=["email"])
+        @test_with_materialized_columns(person_properties=["email"], verify_no_jsonextract=False)
         def test_funnel_filter_by_action_with_person_properties(self):
             person_factory(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
             person_factory(distinct_ids=["person2"], team_id=self.team.pk, properties={"email": "another@example.com"})
@@ -391,22 +391,10 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             action = Action.objects.create(team_id=self.team.pk, name="event1")
             ActionStep.objects.create(
                 action=action,
-                event="event2",
+                event="event1",
                 properties=[{"key": "email", "value": "is_set", "operator": "is_set", "type": "person"}],
             )
             action.calculate_events()
-
-            result = Funnel(
-                filter=Filter(
-                    data={
-                        "events": [{"id": "event1", "order": 0}],
-                        "insight": INSIGHT_FUNNELS,
-                        "funnel_window_days": 14,
-                    }
-                ),
-                team=self.team,
-            ).run()
-            self.assertEqual(result[0]["count"], 2)
 
             result = Funnel(
                 filter=Filter(

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -372,12 +372,24 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                     data={
                         "events": [{"id": "event1", "order": 0}],
                         "insight": INSIGHT_FUNNELS,
-                        FILTER_TEST_ACCOUNTS: True,
                         "funnel_window_days": 14,
                     }
                 ),
                 team=self.team,
             ).run()
+            self.assertEqual(result[0]["count"], 2)
+
+            result = Funnel(
+                filter=Filter(
+                    data={
+                        "actions": [{"id": action.pk, "type": "actions", "order": 0}],
+                        "insight": INSIGHT_FUNNELS,
+                        "funnel_window_days": 14,
+                    }
+                ),
+                team=self.team,
+            ).run()
+
             self.assertEqual(result[0]["count"], 2)
 
     return TestGetFunnel

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -351,6 +351,35 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[0]["count"], 1)
 
         @test_with_materialized_columns(person_properties=["email"])
+        def test_funnel_with_entity_person_property_filters(self):
+            person_factory(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
+            person_factory(distinct_ids=["person2"], team_id=self.team.pk, properties={"email": "another@example.com"})
+            person_factory(distinct_ids=["person3"], team_id=self.team.pk)
+            event_factory(distinct_id="person1", event="event1", team=self.team)
+            event_factory(distinct_id="person2", event="event1", team=self.team)
+            event_factory(distinct_id="person3", event="event1", team=self.team)
+
+            result = Funnel(
+                filter=Filter(
+                    data={
+                        "events": [
+                            {
+                                "id": "event1",
+                                "order": 0,
+                                "properties": [
+                                    {"key": "email", "value": "is_set", "operator": "is_set", "type": "person"}
+                                ],
+                            }
+                        ],
+                        "insight": INSIGHT_FUNNELS,
+                        "funnel_window_days": 14,
+                    }
+                ),
+                team=self.team,
+            ).run()
+            self.assertEqual(result[0]["count"], 2)
+
+        @test_with_materialized_columns(person_properties=["email"])
         def test_funnel_filter_by_action_with_person_properties(self):
             person_factory(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
             person_factory(distinct_ids=["person2"], team_id=self.team.pk, properties={"email": "another@example.com"})

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -261,7 +261,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(daily_response[0]["aggregated_value"], 2.0)
             self.assertEqual(daily_response[0]["aggregated_value"], weekly_response[0]["aggregated_value"])
 
-        @test_with_materialized_columns(person_properties=["name"])
+        @test_with_materialized_columns(person_properties=["name"], verify_no_jsonextract=False)
         def test_trends_breakdown_single_aggregate_cohorts(self):
             person_1 = person_factory(team_id=self.team.pk, distinct_ids=["Jane"], properties={"name": "Jane"})
             person_2 = person_factory(team_id=self.team.pk, distinct_ids=["John"], properties={"name": "John"})
@@ -1281,7 +1281,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 0)
 
-        @test_with_materialized_columns(person_properties=["name"])
+        @test_with_materialized_columns(person_properties=["name"], verify_no_jsonextract=False)
         def test_filter_events_by_cohort(self):
             person1 = person_factory(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
             person2 = person_factory(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1550,6 +1550,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 response = trends().run(Filter(data={"events": [{"id": "DNE"}]}), self.team)
             self.assertEqual(response[0]["data"], [0, 0, 0, 0, 0, 0, 0, 0])
 
+        @test_with_materialized_columns(person_properties=["email", "bar"])
         def test_trends_regression_filtering_by_action_with_person_properties(self):
             person1 = person_factory(
                 team_id=self.team.pk, properties={"email": "foo@example.com", "bar": "aa"}, distinct_ids=["d1"]

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1774,6 +1774,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
 
             return (person1, person2, person3, person4)
 
+        @test_with_materialized_columns(person_properties=["name"])
         def test_person_property_filtering(self):
             self._create_multiple_people()
             with freeze_time("2020-01-04"):

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1281,6 +1281,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 0)
 
+        @test_with_materialized_columns(person_properties=["name"])
         def test_filter_events_by_cohort(self):
             person1 = person_factory(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
             person2 = person_factory(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
@@ -1295,7 +1296,11 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 event="event_name", team=self.team, distinct_id="person_2", properties={"$browser": "Safari"},
             )
 
-            cohort = cohort_factory(team=self.team, name="cohort1", groups=[{"properties": {"name": "Jane"}}])
+            cohort = cohort_factory(
+                team=self.team,
+                name="cohort1",
+                groups=[{"properties": [{"key": "name", "value": "Jane", "type": "person"}]}],
+            )
 
             response = trends().run(
                 Filter(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -204,6 +204,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(daily_response[0]["aggregated_value"], 1)
             self.assertEqual(daily_response[0]["aggregated_value"], weekly_response[0]["aggregated_value"])
 
+        @test_with_materialized_columns(["$math_prop"])
         def test_trends_single_aggregate_math(self):
             person = person_factory(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
@@ -260,13 +261,26 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(daily_response[0]["aggregated_value"], 2.0)
             self.assertEqual(daily_response[0]["aggregated_value"], weekly_response[0]["aggregated_value"])
 
+        @test_with_materialized_columns(person_properties=["name"])
         def test_trends_breakdown_single_aggregate_cohorts(self):
             person_1 = person_factory(team_id=self.team.pk, distinct_ids=["Jane"], properties={"name": "Jane"})
             person_2 = person_factory(team_id=self.team.pk, distinct_ids=["John"], properties={"name": "John"})
             person_3 = person_factory(team_id=self.team.pk, distinct_ids=["Jill"], properties={"name": "Jill"})
-            cohort1 = cohort_factory(team=self.team, name="cohort1", groups=[{"properties": {"name": "Jane"}}])
-            cohort2 = cohort_factory(team=self.team, name="cohort2", groups=[{"properties": {"name": "John"}}])
-            cohort3 = cohort_factory(team=self.team, name="cohort3", groups=[{"properties": {"name": "Jill"}}])
+            cohort1 = cohort_factory(
+                team=self.team,
+                name="cohort1",
+                groups=[{"properties": [{"key": "name", "value": "Jane", "type": "person"}]}],
+            )
+            cohort2 = cohort_factory(
+                team=self.team,
+                name="cohort2",
+                groups=[{"properties": [{"key": "name", "value": "John", "type": "person"}]}],
+            )
+            cohort3 = cohort_factory(
+                team=self.team,
+                name="cohort3",
+                groups=[{"properties": [{"key": "name", "value": "Jill", "type": "person"}]}],
+            )
             with freeze_time("2020-01-01 00:06:34"):
                 event_factory(
                     team=self.team,

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -2016,6 +2016,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 event_response, action_response,
             )
 
+        @test_with_materialized_columns(person_properties=["name"])
         def test_breakdown_by_person_property_pie(self):
             self._create_multiple_people()
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -130,7 +130,7 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
             self.client.force_login(self.user)
 
 
-def test_with_materialized_columns(event_properties=[], verify_no_jsonextract=True):
+def test_with_materialized_columns(event_properties=[], person_properties=[], verify_no_jsonextract=True):
     """
     Runs the test twice on clickhouse - once verifying it works normally, once with materialized columns.
 
@@ -152,6 +152,8 @@ def test_with_materialized_columns(event_properties=[], verify_no_jsonextract=Tr
 
             for prop in event_properties:
                 materialize("events", prop)
+            for prop in person_properties:
+                materialize("person", prop)
 
             with self.capture_select_queries() as sqls:
                 fn(self, *args, **kwargs)


### PR DESCRIPTION
The goal of this PR is to make sure we are able to use materialized person properties throughout Trends and Funnels.

Part of https://github.com/PostHog/posthog/issues/5461

This mostly achieves that, but there are some cases where JSONExtract is still used:
1. When filtering by cohorts. This is since a subselect against `person` table is used to find the people matching the cohort
2. When querying person properties in cases where the table was not joined with `person` table, resulting in a subselect
    - Example: Breaking down by event property but having a person property filter.
    - Example: Funnel filtering by action with person property filter

Both of these are left to be solved in subsequent PRs - this one is growing way too large :sweat_smile:. You can find these cases via `verify_no_jsonextract=False`

Working on this also highlighted some lower-level future performance optimizations we could be making:
1. By pushing person properties to be as "internal" as possible (e.g. when we select from person table)
2. Minimizing the number of subselects - not 100% sure on this
3. If we need to do subselects, avoid doing subselect-per-person-property as is happening currently in some places

Will document each of these under a separate issue.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
