### PR TITLE
Fix behavior for is_set/is_not_set operator behavior on materialized columns

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -134,7 +134,7 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         if is_denormalized:
             return (
-                "AND NOT isNull({left})".format(left=property_expr),
+                "AND notEmpty({left})".format(left=property_expr),
                 params,
             )
         return (
@@ -145,7 +145,7 @@ def prop_filter_json_extract(
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         if is_denormalized:
             return (
-                "AND isNull({left})".format(left=property_expr),
+                "AND empty({left})".format(left=property_expr),
                 params,
             )
         return (

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -417,21 +417,38 @@ def test_events(db, team) -> List[UUID]:
     ]
 
 
-@pytest.mark.parametrize(
-    "property,expected_event_indexes",
-    [
-        (Property(key="email", value="test@posthog.com"), [0]),
-        (Property(key="email", value="test@posthog.com", operator="exact"), [0]),
-        (Property(key="email", value=["pineapple@pizza.com", "mongo@example.com"], operator="exact"), [1]),
-        (Property(key="attr", value="5"), [4]),
-        (Property(key="email", value="test@posthog.com", operator="is_not"), range(1, 5)),
-        (Property(key="email", value=["test@posthog.com", "mongo@example.com"], operator="is_not"), range(2, 5)),
-        (Property(key="email", value=r".*est@.*", operator="regex"), [0]),
-        (Property(key="email", value=r"?.", operator="regex"), []),
-    ],
-)
+TEST_PROPERTIES = [
+    (Property(key="email", value="test@posthog.com"), [0]),
+    (Property(key="email", value="test@posthog.com", operator="exact"), [0]),
+    (Property(key="email", value=["pineapple@pizza.com", "mongo@example.com"], operator="exact"), [1]),
+    (Property(key="attr", value="5"), [4]),
+    (Property(key="email", value="test@posthog.com", operator="is_not"), range(1, 5)),
+    (Property(key="email", value=["test@posthog.com", "mongo@example.com"], operator="is_not"), range(2, 5)),
+    (Property(key="email", value=r".*est@.*", operator="regex"), [0]),
+    (Property(key="email", value=r"?.", operator="regex"), []),
+    (Property(key="email", operator="is_set", value="is_set"), [0, 1]),
+    (Property(key="email", operator="is_not_set", value="is_not_set"), range(2, 5)),
+]
+
+
+@pytest.mark.parametrize("property,expected_event_indexes", TEST_PROPERTIES)
 def test_prop_filter_json_extract(test_events, property, expected_event_indexes):
     query, params = prop_filter_json_extract(property, 0)
+    uuids = list(sorted([uuid for (uuid,) in sync_execute(f"SELECT uuid FROM events WHERE 111 = 111 {query}", params)]))
+    expected = list(sorted([test_events[index] for index in expected_event_indexes]))
+
+    assert uuids == expected
+
+
+@pytest.mark.parametrize("property,expected_event_indexes", TEST_PROPERTIES)
+def test_prop_filter_json_extract_materialized(test_events, property, expected_event_indexes):
+    materialize("events", "attr")
+    materialize("events", "email")
+
+    query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=True)
+
+    assert "JSONExtract" not in query
+
     uuids = list(sorted([uuid for (uuid,) in sync_execute(f"SELECT uuid FROM events WHERE 111 = 111 {query}", params)]))
     expected = list(sorted([test_events[index] for index in expected_event_indexes]))
 


### PR DESCRIPTION
Given that the extracted value is '' if value is not present we need to
leverage that.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
