### PR TITLE
Increase parallel cohorts to 50

### DIFF
--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -124,7 +124,7 @@
                 },
                 {
                     "name": "CALCULATE_X_COHORTS_PARALLEL",
-                    "value": "10"
+                    "value": "50"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -118,7 +118,7 @@
                 },
                 {
                     "name": "CALCULATE_X_COHORTS_PARALLEL",
-                    "value": "10"
+                    "value": "50"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Should bring the refresh rate of cohorts down to under an hour. This will increase load on clickhouse quite a bit I suspect.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
