### PR TITLE
Fix Refresh button Tooltip

### DIFF
--- a/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
@@ -2,7 +2,7 @@ import { Button } from 'antd'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import React, { useEffect, useState } from 'react'
-import { Tooltip } from 'lib/components/Tooltip'
+import { Tooltip } from 'antd'
 
 dayjs.extend(relativeTime)
 
@@ -26,7 +26,7 @@ export function ComputationTimeWithRefresh({ lastRefresh, loadResults }: Computa
     return (
         <div className="text-muted-alt" style={{ marginLeft: 'auto' }}>
             Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
-            {' • '}
+            <span style={{ padding: '0 4px' }}>•</span>
             <Tooltip
                 title={
                     <>

--- a/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
@@ -6,12 +6,12 @@ import { Tooltip } from 'antd'
 
 dayjs.extend(relativeTime)
 
-export interface ComputationTimeWithRefresh {
+export interface ComputationTimeWithRefreshProps {
     lastRefresh: string
     loadResults: (refresh: boolean) => void
 }
 
-export function ComputationTimeWithRefresh({ lastRefresh, loadResults }: ComputationTimeWithRefresh): JSX.Element {
+export function ComputationTimeWithRefresh({ lastRefresh, loadResults }: ComputationTimeWithRefreshProps): JSX.Element {
     const [, setRerenderCounter] = useState(0)
 
     useEffect(() => {


### PR DESCRIPTION
## Changes

Unfortunately our modified Tooltip component doesn't work with disabled components. I refactored it a bit, but also ended up just using the Ant Design one in `ComputationTimeWithRefresh` to fix the issue without having to replicate the slightly hacky stuff Ant does behind the scenes.

 

| Before | After |
| --- | --- |
 | <img width="299" alt="Screen Shot 2021-08-24 at 11 50 23" src="https://user-images.githubusercontent.com/4550621/130596949-a7bea1e0-50bf-48d1-90e0-0c6d6cd97997.png"> | <img width="334" alt="Screen Shot 2021-08-24 at 11 49 54" src="https://user-images.githubusercontent.com/4550621/130596954-20f41682-a792-455d-b0f1-0783a54d1e9e.png"> |
