### PR TITLE
Add missing ordering clause to path query

### DIFF
--- a/ee/clickhouse/sql/paths/path.py
+++ b/ee/clickhouse/sql/paths/path.py
@@ -195,7 +195,7 @@ FROM (
                 )
                 ARRAY JOIN limited_path_timings AS joined_path_tuple, arrayEnumerate(limited_path) AS event_in_session_index
                 {boundary_event_filter}
-                ORDER BY person_id, session_index
+                ORDER BY person_id, session_index, event_in_session_index
                )
        )
  WHERE source_event IS NOT NULL


### PR DESCRIPTION
## Changes

*Please describe.*  
- event ordering within a session in the path query wasn't guaranteed so sometimes the paths would be scrambled
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
