### PR TITLE
`PersonModal` refactor

### DIFF
--- a/frontend/src/lib/components/CopyToClipboard.tsx
+++ b/frontend/src/lib/components/CopyToClipboard.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { HTMLProps } from 'react'
 import { Input } from 'antd'
 import { CopyOutlined } from '@ant-design/icons'
 import { copyToClipboard } from 'lib/utils'
 import { Tooltip } from 'lib/components/Tooltip'
 
-interface InlineProps {
+interface InlineProps extends HTMLProps<HTMLSpanElement> {
     children?: JSX.Element | string
     explicitValue?: string
     description?: string

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -145,7 +145,7 @@ export function PropertiesTable({
     sortProperties = false,
     nestingLevel = 0,
     onDelete,
-    className = '',
+    className,
 }: PropertiesTableType): JSX.Element {
     const objectProperties = useMemo(() => {
         if (!(properties instanceof Object)) {

--- a/frontend/src/scenes/trends/PersonModal.scss
+++ b/frontend/src/scenes/trends/PersonModal.scss
@@ -1,14 +1,6 @@
 .person-modal {
-    .ant-modal-body {
-        padding: 0;
-        max-height: 60vh;
-        overflow-y: scroll;
-    }
-
-    .ant-btn {
-        a {
-            color: var(--primary);
-        }
+    .ant-modal-header {
+        padding: 16px;
     }
 
     .ant-modal-title {
@@ -16,14 +8,38 @@
         text-overflow: ellipsis;
     }
 
-    .ant-modal-header {
-        padding: 16px 16px;
-        width: 575px;
+    .ant-modal-content {
+        overflow: hidden;
     }
-}
 
-.person-modal-properties {
+    .ant-modal-body {
+        padding: 0;
+        max-height: 60vh;
+        overflow-y: scroll;
+    }
+
+    .ant-input-search {
+        padding: 16px;
+    }
+
     .ant-table-wrapper {
         width: 100%;
+        padding: 0 16px;
+    }
+
+    .person-row-container {
+        border-top: 1px solid var(--border-light);
+    }
+
+    .person-row {
+        display: flex;
+        align-items: center;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-light);
+    }
+
+    .person-ids {
+        display: flex;
+        flex-direction: column;
     }
 }

--- a/frontend/src/scenes/trends/PersonModal.scss
+++ b/frontend/src/scenes/trends/PersonModal.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .person-modal {
     .ant-modal-header {
         padding: 16px;
@@ -16,6 +18,10 @@
         padding: 0;
         max-height: 60vh;
         overflow-y: scroll;
+    }
+
+    .ant-modal-footer .ant-btn {
+        color: $primary;
     }
 
     .ant-input-search {

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -62,7 +62,8 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModa
         [filters, people, isInitialLoad]
     )
 
-    const showModalActions = clickhouseFeaturesEnabled && (view === ViewType.TRENDS || view === ViewType.STICKINESS)
+    const isDownloadCsvAvailable = view === ViewType.TRENDS
+    const isSaveAsCohortAvailable = clickhouseFeaturesEnabled
 
     return (
         <Modal
@@ -73,32 +74,36 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModa
             footer={
                 people &&
                 people.count > 0 &&
-                showModalActions && (
+                (isDownloadCsvAvailable || isSaveAsCohortAvailable) && (
                     <>
-                        <Button
-                            icon={<DownloadOutlined />}
-                            href={`/api/action/people.csv?${parsePeopleParams(
-                                {
-                                    label: people.label,
-                                    action: people.action,
-                                    date_from: people.day,
-                                    date_to: people.day,
-                                    breakdown_value: people.breakdown_value,
-                                },
-                                filters
-                            )}`}
-                            style={{ marginRight: 8 }}
-                            data-attr="person-modal-download-csv"
-                        >
-                            Download CSV
-                        </Button>
-                        <Button
-                            onClick={onSaveCohort}
-                            icon={<UsergroupAddOutlined />}
-                            data-attr="person-modal-save-as-cohort"
-                        >
-                            Save as cohort
-                        </Button>
+                        {isDownloadCsvAvailable && (
+                            <Button
+                                icon={<DownloadOutlined />}
+                                href={`/api/action/people.csv?${parsePeopleParams(
+                                    {
+                                        label: people.label,
+                                        action: people.action,
+                                        date_from: people.day,
+                                        date_to: people.day,
+                                        breakdown_value: people.breakdown_value,
+                                    },
+                                    filters
+                                )}`}
+                                style={{ marginRight: 8 }}
+                                data-attr="person-modal-download-csv"
+                            >
+                                Download CSV
+                            </Button>
+                        )}
+                        {isSaveAsCohortAvailable && (
+                            <Button
+                                onClick={onSaveCohort}
+                                icon={<UsergroupAddOutlined />}
+                                data-attr="person-modal-save-as-cohort"
+                            >
+                                Save as cohort
+                            </Button>
+                        )}
                     </>
                 )
             }
@@ -132,7 +137,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModa
                             />
                         )}
                         <div style={{ background: '#FAFAFA' }}>
-                            {people?.people.length > 0 ? (
+                            {people.count > 0 ? (
                                 people?.people.map((person) => (
                                     <div key={person.id}>
                                         <PersonRow person={person} people={people} filters={filters} />

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -140,7 +140,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModa
                             {people.count > 0 ? (
                                 people?.people.map((person) => (
                                     <div key={person.id}>
-                                        <PersonRow person={person} people={people} filters={filters} />
+                                        <PersonRow person={person} />
                                     </div>
                                 ))
                             ) : (
@@ -170,12 +170,9 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModa
 
 interface PersonRowProps {
     person: PersonType
-    people: any
-    filters: any
 }
 
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-export function PersonRow({ person, people, filters }: PersonRowProps): JSX.Element {
+export function PersonRow({ person }: PersonRowProps): JSX.Element {
     const [showProperties, setShowProperties] = useState(false)
     const expandProps = {
         record: '',

--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -1,12 +1,9 @@
 import React, { useMemo, useState } from 'react'
 import { useActions, useValues } from 'kea'
-import dayjs from 'dayjs'
-import { TrendPeople, parsePeopleParams } from 'scenes/trends/trendsLogic'
+import { parsePeopleParams } from 'scenes/trends/trendsLogic'
 import { DownloadOutlined, UsergroupAddOutlined } from '@ant-design/icons'
-import { Modal, Button, Spin, Input, Row, Col, Skeleton } from 'antd'
-import { deepLinkToPersonSessions } from 'scenes/persons/PersonsTable'
-import { ActionFilter, EntityTypes, EventPropertyFilter, FilterType, SessionsPropertyFilter, ViewType } from '~/types'
-import { ACTION_TYPE, EVENT_TYPE } from 'lib/constants'
+import { Modal, Button, Spin, Input, Skeleton } from 'antd'
+import { FilterType, PersonType, ViewType } from '~/types'
 import { personsModalLogic } from './personsModalLogic'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { midEllipsis } from 'lib/utils'
@@ -17,29 +14,16 @@ import { ExpandIcon, ExpandIconProps } from 'lib/components/ExpandIcon'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
-// Utility function to handle filter conversion required for deeplinking to person -> sessions
-const convertToSessionFilters = (people: TrendPeople, filters: Partial<FilterType>): SessionsPropertyFilter[] => {
-    if (!people?.action) {
-        return []
-    }
-    const actions: ActionFilter[] = people.action === 'session' ? (filters.events as ActionFilter[]) : [people.action]
-    return actions.map((a) => ({
-        key: 'id',
-        value: a.id,
-        label: a.name as string,
-        type: a.type === EntityTypes.ACTIONS ? ACTION_TYPE : EVENT_TYPE,
-        properties: [...(a.properties || []), ...(filters.properties || [])] as EventPropertyFilter[], // combine global properties into action/event filter
-    }))
-}
+import { urls } from '../sceneLogic'
 
-interface Props {
+export interface PersonModalProps {
     visible: boolean
     view: ViewType
     filters: Partial<FilterType>
     onSaveCohort: () => void
 }
 
-export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JSX.Element {
+export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModalProps): JSX.Element {
     const {
         people,
         loadingMorePeople,
@@ -55,21 +39,20 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
     const title = useMemo(
         () =>
             isInitialLoad ? (
-                'Loading persons list...'
+                'Loading users…'
             ) : filters.shown_as === 'Stickiness' ? (
-                `"${people?.label}" stickiness ${people?.day} day${people?.day === 1 ? '' : 's'}`
+                <>
+                    <PropertyKeyInfo value={people?.label || ''} disablePopover /> stickiness on day {people?.day}
+                </>
             ) : filters.display === 'ActionsBarValue' || filters.display === 'ActionsPie' ? (
-                `"${people?.label}"`
+                <PropertyKeyInfo value={people?.label || ''} disablePopover />
             ) : filters.insight === ViewType.FUNNELS ? (
-                <span style={{ whiteSpace: 'nowrap' }}>
-                    <strong>
-                        Persons who {(people?.funnelStep ?? 0) >= 0 ? 'completed' : 'dropped off at'} step #
-                        {Math.abs(people?.funnelStep ?? 0)} -{' '}
-                        <PropertyKeyInfo value={people?.label || ''} disablePopover />{' '}
-                        {people?.breakdown_value !== undefined &&
-                            `- ${people.breakdown_value ? people.breakdown_value : 'None'}`}
-                    </strong>
-                </span>
+                <>
+                    Persons who {(people?.funnelStep ?? 0) >= 0 ? 'completed' : 'dropped off at'} step #
+                    {Math.abs(people?.funnelStep ?? 0)} - <PropertyKeyInfo value={people?.label || ''} disablePopover />{' '}
+                    {people?.breakdown_value !== undefined &&
+                        `- ${people.breakdown_value ? people.breakdown_value : 'None'}`}
+                </>
             ) : (
                 <>
                     <PropertyKeyInfo value={people?.label || ''} disablePopover /> on{' '}
@@ -88,118 +71,105 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: Props): JS
             onOk={hidePeople}
             onCancel={hidePeople}
             footer={
-                <Row style={{ justifyContent: 'space-between', alignItems: 'center', padding: '6px 0px' }}>
-                    <Row style={{ alignItems: 'center' }}>
-                        {people && people.count > 0 && showModalActions && (
-                            <>
-                                <div style={{ paddingRight: 8 }}>
-                                    <Button onClick={onSaveCohort} data-attr="person-modal-save-as-cohort">
-                                        <UsergroupAddOutlined />
-                                        Save as cohort
-                                    </Button>
-                                </div>
-                                <Button
-                                    icon={<DownloadOutlined />}
-                                    href={`/api/action/people.csv?/?${parsePeopleParams(
-                                        {
-                                            label: people.label,
-                                            action: people.action,
-                                            date_from: people.day,
-                                            date_to: people.day,
-                                            breakdown_value: people.breakdown_value,
-                                        },
-                                        filters
-                                    )})}`}
-                                    title="Download CSV"
-                                >
-                                    Download CSV
-                                </Button>
-                            </>
-                        )}
-                    </Row>
-                    <Button onClick={hidePeople}>Close</Button>
-                </Row>
+                people &&
+                people.count > 0 &&
+                showModalActions && (
+                    <>
+                        <Button
+                            icon={<DownloadOutlined />}
+                            href={`/api/action/people.csv?${parsePeopleParams(
+                                {
+                                    label: people.label,
+                                    action: people.action,
+                                    date_from: people.day,
+                                    date_to: people.day,
+                                    breakdown_value: people.breakdown_value,
+                                },
+                                filters
+                            )}`}
+                            style={{ marginRight: 8 }}
+                            data-attr="person-modal-download-csv"
+                        >
+                            Download CSV
+                        </Button>
+                        <Button
+                            onClick={onSaveCohort}
+                            icon={<UsergroupAddOutlined />}
+                            data-attr="person-modal-save-as-cohort"
+                        >
+                            Save as cohort
+                        </Button>
+                    </>
+                )
             }
             width={600}
             className="person-modal"
         >
-            {isInitialLoad && (
+            {isInitialLoad ? (
                 <div style={{ padding: 16 }}>
                     <Skeleton active />
                 </div>
-            )}
-            {!isInitialLoad && people && (
-                <>
-                    <div
-                        style={{
-                            marginBottom: 16,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'space-between',
-                        }}
-                    >
-                        <div
-                            style={{
-                                display: 'flex',
-                                flexDirection: 'column',
-                                width: '100%',
-                                alignItems: 'flex-start',
-                                padding: '0px 16px',
-                            }}
-                        >
-                            {!preflight?.is_clickhouse_enabled && (
-                                <Input.Search
-                                    allowClear
-                                    enterButton
-                                    placeholder="Search person by email, name, or ID"
-                                    style={{ width: '100%', flexGrow: 1 }}
-                                    onChange={(e) => {
-                                        setSearchTerm(e.target.value)
-                                        if (!e.target.value) {
-                                            setFirstLoadedPeople(firstLoadedPeople)
-                                        }
-                                    }}
-                                    value={searchTerm}
-                                    onSearch={(term) =>
-                                        term
-                                            ? setPersonsModalFilters(term, people, filters)
-                                            : setFirstLoadedPeople(firstLoadedPeople)
+            ) : (
+                people && (
+                    <>
+                        {!preflight?.is_clickhouse_enabled && (
+                            <Input.Search
+                                allowClear
+                                enterButton
+                                placeholder="Search person by email, name, or ID"
+                                onChange={(e) => {
+                                    setSearchTerm(e.target.value)
+                                    if (!e.target.value) {
+                                        setFirstLoadedPeople(firstLoadedPeople)
                                     }
-                                />
+                                }}
+                                value={searchTerm}
+                                onSearch={(term) =>
+                                    term
+                                        ? setPersonsModalFilters(term, people, filters)
+                                        : setFirstLoadedPeople(firstLoadedPeople)
+                                }
+                            />
+                        )}
+                        <div style={{ background: '#FAFAFA' }}>
+                            {people?.people.length > 0 ? (
+                                people?.people.map((person) => (
+                                    <div key={person.id}>
+                                        <PersonRow person={person} people={people} filters={filters} />
+                                    </div>
+                                ))
+                            ) : (
+                                <div className="person-row-container person-row">
+                                    We couldn't find any matching users for this datapoint.
+                                </div>
                             )}
                         </div>
-                    </div>
-                    <Col style={{ background: '#FAFAFA' }}>
-                        {people?.people.map((person) => (
-                            <div key={person.id}>
-                                <PersonRow person={person} people={people} filters={filters} />
-                            </div>
-                        ))}
-                    </Col>
-                    <div
-                        style={{
-                            margin: '1rem',
-                            textAlign: 'center',
-                        }}
-                    >
                         {people?.next && (
-                            <Button type="primary" style={{ color: 'white' }} onClick={loadMorePeople}>
-                                {loadingMorePeople ? <Spin /> : 'Load more people'}
-                            </Button>
+                            <div
+                                style={{
+                                    margin: '1rem',
+                                    textAlign: 'center',
+                                }}
+                            >
+                                <Button type="primary" style={{ color: 'white' }} onClick={loadMorePeople}>
+                                    {loadingMorePeople ? <Spin /> : 'Load more people'}
+                                </Button>
+                            </div>
                         )}
-                    </div>
-                </>
+                    </>
+                )
             )}
         </Modal>
     )
 }
 
 interface PersonRowProps {
-    person: any
+    person: PersonType
     people: any
     filters: any
 }
 
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 export function PersonRow({ person, people, filters }: PersonRowProps): JSX.Element {
     const [showProperties, setShowProperties] = useState(false)
     const expandProps = {
@@ -211,51 +181,24 @@ export function PersonRow({ person, people, filters }: PersonRowProps): JSX.Elem
     } as ExpandIconProps
 
     return (
-        <Col
-            key={person.id}
-            style={{
-                alignItems: 'center',
-                padding: '14px 8px',
-                borderBottom: '1px solid #D9D9D9',
-            }}
-        >
-            <Row style={{ justifyContent: 'space-between' }}>
-                <Row>
-                    <ExpandIcon {...expandProps}>{undefined}</ExpandIcon>
-                    <Col style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-                        <span className="text-default">
-                            <strong>{person.properties.email}</strong>
-                        </span>
-                        <div className="text-small text-muted-alt">
-                            <CopyToClipboardInline
-                                explicitValue={person.distinct_ids[0]}
-                                tooltipMessage=""
-                                iconStyle={{ color: 'var(--primary)' }}
-                                iconPosition="end"
-                            >
-                                {midEllipsis(person.distinct_ids[0], 32)}
-                            </CopyToClipboardInline>
-                        </div>
-                    </Col>
-                </Row>
-                <Button>
-                    <Link
-                        to={deepLinkToPersonSessions(
-                            person,
-                            convertToSessionFilters(people, filters),
-                            people?.day ? dayjs(people.day).format('YYYY-MM-DD') : '',
-                            'Insights'
-                        )}
-                    >
-                        View details
+        <div key={person.id} className="person-row-container">
+            <div className="person-row">
+                <ExpandIcon {...expandProps} />
+                <div className="person-ids">
+                    <Link to={urls.person(person.distinct_ids[0])} className="text-default">
+                        <strong>{person.properties.email}</strong>
                     </Link>
-                </Button>
-            </Row>
-            {showProperties && (
-                <Row className="person-modal-properties" style={{ paddingTop: 16 }}>
-                    <PropertiesTable properties={person.properties} />
-                </Row>
-            )}
-        </Col>
+                    <CopyToClipboardInline
+                        explicitValue={person.distinct_ids[0]}
+                        iconStyle={{ color: 'var(--primary)' }}
+                        iconPosition="end"
+                        className="text-small text-muted-alt"
+                    >
+                        {midEllipsis(person.distinct_ids[0], 32)}
+                    </CopyToClipboardInline>
+                </div>
+            </div>
+            {showProperties && <PropertiesTable properties={person.properties} className="person-modal-properties" />}
+        </div>
     )
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -25,7 +25,9 @@ style files without adding already imported styles. */
     --text-light: #{$text_light};
     --muted: #{$text_muted};
     --muted-alt: #{$text_muted_alt};
+    --border-light: #{$border_light};
     --border: #{$border};
+    --border-dark: #{$border_dark};
     // Used for graph series
     --blue: #{$blue_500};
     --purple: #{$purple_500};

--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -138,8 +138,8 @@ label.disabled {
 }
 
 .property-key-info {
+    display: inline-block;
     line-height: 19px;
-    width: 100%;
 }
 
 .property-key-info-logo {


### PR DESCRIPTION
## Changes

`PersonModal` was quite messy, so I refactored it in preparation for new session recordings linking. It's still far from ideal (most importantly the logic for handling various people endpoints is kind of hard to reason about), but at least the UX is significantly more polished.
Closes #5600.

| | Before | After |
| --- | --- | --- |
| Trends empty state | ![Zrzut ekranu 2021-08-24 o 22 08 41](https://user-images.githubusercontent.com/4550621/130684355-173f586a-fcb7-4b26-bbda-0d6ebe919345.png) | ![Zrzut ekranu 2021-08-24 o 22 09 07](https://user-images.githubusercontent.com/4550621/130684358-ae555e71-235b-44e8-b104-8ccededcbadd.png) |
| Trends | <img width="616" alt="Screen Shot 2021-08-24 at 20 50 56" src="https://user-images.githubusercontent.com/4550621/130684342-5d04a60e-9144-4ce8-b34f-60b98b5000a9.png"> | <img width="622" alt="Screen Shot 2021-08-24 at 20 44 00" src="https://user-images.githubusercontent.com/4550621/130684346-fbfdb622-4431-4f8c-b5cc-77488d15bf36.png"> |
| Stickiness | <img width="613" alt="Screen Shot 2021-08-24 at 20 52 59" src="https://user-images.githubusercontent.com/4550621/130684349-22118f07-a4b6-4b4c-932f-f2f2cac2ab94.png"> |  <img width="621" alt="Screen Shot 2021-08-24 at 20 54 30" src="https://user-images.githubusercontent.com/4550621/130684350-32295f3a-d5c8-4b12-9573-a60b3e7ff480.png">  |
| Funnel | <img width="619" alt="Screen Shot 2021-08-24 at 20 50 27" src="https://user-images.githubusercontent.com/4550621/130684353-8a254694-4181-45b6-9040-b6e9a7ba0c1d.png"> | <img width="621" alt="Screen Shot 2021-08-24 at 20 49 29" src="https://user-images.githubusercontent.com/4550621/130684335-bed0b2e0-38ca-4121-b795-d2a793e64e1f.png"> |




