### PR TITLE
Set mutations_sync = 1 for testing clickhouse env

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -767,4 +767,9 @@
 
     <!-- Uncomment to disable ClickHouse internal DNS caching. -->
     <!-- <disable_internal_dns_cache>1</disable_internal_dns_cache> -->
+    <profiles>
+        <default>
+            <mutations_sync>1</mutations_sync>
+        </default>
+    </profiles>
 </yandex>


### PR DESCRIPTION
## Changes

Set `mutations_sync` to true in default profile

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
