### PR TITLE
Simplify timeframe options

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Select } from 'antd'
 import dayjs from 'dayjs'
 import { dateMapping, isDate, dateFilterToText } from 'lib/utils'
@@ -55,7 +55,7 @@ export function DateFilter({
                 setDateRangeOpen(true)
             }
         } else {
-            setDate(dateMapping[v][0], dateMapping[v][1])
+            setDate(dateMapping[v].values[0], dateMapping[v].values[1])
         }
     }
 
@@ -85,12 +85,18 @@ export function DateFilter({
         setDate(dayjs(rangeDateFrom).format('YYYY-MM-DD'), dayjs(rangeDateTo).format('YYYY-MM-DD'))
     }
 
+    const parsedValue = useMemo(() => dateFilterToText(dateFrom, dateTo, defaultValue), [
+        dateFrom,
+        dateTo,
+        defaultValue,
+    ])
+
     return (
         <Select
             data-attr="date-filter"
             bordered={bordered}
             id="daterange_selector"
-            value={dateFilterToText(dateFrom, dateTo, defaultValue)}
+            value={parsedValue}
             onChange={_onChange}
             style={{
                 marginRight: 4,
@@ -124,10 +130,15 @@ export function DateFilter({
             }}
         >
             {[
-                ...Object.entries(dateMapping).map(([key]) => {
+                ...Object.entries(dateMapping).map(([key, { inactive }]) => {
                     if (key === 'Custom' && !showCustom) {
                         return null
                     }
+
+                    if (inactive && parsedValue !== key) {
+                        return null
+                    }
+
                     return (
                         <Select.Option key={key} value={key} label={makeLabel ? makeLabel(key) : undefined}>
                             {key}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -606,23 +606,26 @@ export function determineDifferenceType(
     }
 }
 
-export const dateMapping: Record<string, string[]> = {
-    Custom: [],
-    Today: ['dStart'],
-    Yesterday: ['-1d', 'dStart'],
-    'Last 24 hours': ['-24h'],
-    'Last 7 days': ['-7d'],
-    'Last 14 days': ['-14d'],
-    'Last 30 days': ['-30d'],
-    'Last 90 days': ['-90d'],
-    //'This month': ['mStart'],
-    'Year to date': ['yStart'],
-    'All time': ['all'],
+interface dateMappingOption {
+    inactive?: boolean // Options removed due to low usage (see relevant PR); will not show up for new insights but will be kept for existing
+    values: string[]
 }
 
-// The following constants are also supported for dateMapping but where removed due to low usage (see relevant PR)
-//  'Previous month': ['-1mStart', '-1mEnd'],
-//  'Last 48 hours': ['-48h'],
+export const dateMapping: Record<string, dateMappingOption> = {
+    Custom: { values: [] },
+    Today: { values: ['dStart'] },
+    Yesterday: { values: ['-1d', 'dStart'] },
+    'Last 24 hours': { values: ['-24h'] },
+    'Last 48 hours': { values: ['-48h'], inactive: true },
+    'Last 7 days': { values: ['-7d'] },
+    'Last 14 days': { values: ['-14d'] },
+    'Last 30 days': { values: ['-30d'] },
+    'Last 90 days': { values: ['-90d'] },
+    'This month': { values: ['mStart'], inactive: true },
+    'Previous month': { values: ['-1mStart', '-1mEnd'], inactive: true },
+    'Year to date': { values: ['yStart'] },
+    'All time': { values: ['all'] },
+}
 
 export const isDate = /([0-9]{4}-[0-9]{2}-[0-9]{2})/
 
@@ -660,8 +663,8 @@ export function dateFilterToText(
     }
 
     let name = defaultValue
-    Object.entries(dateMapping).map(([key, value]) => {
-        if (value[0] === dateFrom && value[1] === dateTo && key !== 'Custom') {
+    Object.entries(dateMapping).map(([key, { values }]) => {
+        if (values[0] === dateFrom && values[1] === dateTo && key !== 'Custom') {
             name = key
         }
     })[0]

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -611,16 +611,18 @@ export const dateMapping: Record<string, string[]> = {
     Today: ['dStart'],
     Yesterday: ['-1d', 'dStart'],
     'Last 24 hours': ['-24h'],
-    'Last 48 hours': ['-48h'],
     'Last 7 days': ['-7d'],
     'Last 14 days': ['-14d'],
     'Last 30 days': ['-30d'],
     'Last 90 days': ['-90d'],
-    'This month': ['mStart'],
-    'Previous month': ['-1mStart', '-1mEnd'],
+    //'This month': ['mStart'],
     'Year to date': ['yStart'],
     'All time': ['all'],
 }
+
+// The following constants are also supported for dateMapping but where removed due to low usage (see relevant PR)
+//  'Previous month': ['-1mStart', '-1mEnd'],
+//  'Last 48 hours': ['-48h'],
 
 export const isDate = /([0-9]{4}-[0-9]{2}-[0-9]{2})/
 

--- a/frontend/src/scenes/insights/insightCommandLogic.ts
+++ b/frontend/src/scenes/insights/insightCommandLogic.ts
@@ -23,11 +23,11 @@ export const insightCommandLogic = kea<insightCommandLogicType>({
                                 compareFilterLogic.actions.toggleCompare()
                             },
                         },
-                        ...Object.entries(dateMapping).map(([key, value]) => ({
+                        ...Object.entries(dateMapping).map(([key, { values }]) => ({
                             icon: RiseOutlined,
                             display: `Set Time Range to ${key}`,
                             executor: () => {
-                                insightDateFilterLogic.actions.setDates(value[0], value[1])
+                                insightDateFilterLogic.actions.setDates(values[0], values[1])
                             },
                         })),
                     ],


### PR DESCRIPTION
## Changes

As discussed in https://github.com/PostHog/posthog/issues/5358#issuecomment-904982902, we're removing certain options from the time frame presets to simplify choices. Options we're removing are used less than 1% of the time. Saved insights with the newly deprecated options will still work properly.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
