### PR TITLE
Proposal: Make funnel entity list unique

### DIFF
--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -278,7 +278,8 @@ class ClickhouseFunnelBase(ABC, Funnel):
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = entity.get_action()
             for action_step in action.steps.all():
-                self.params[entity_name].append(action_step.event)
+                if entity_name not in self.params[entity_name]:
+                    self.params[entity_name].append(action_step.event)
             action_query, action_params = format_action_filter(action, f"{entity_name}_{step_prefix}step_{index}")
             if action_query == "":
                 return ""
@@ -286,7 +287,8 @@ class ClickhouseFunnelBase(ABC, Funnel):
             self.params.update(action_params)
             content_sql = "{actions_query} {filters}".format(actions_query=action_query, filters=filters,)
         else:
-            self.params[entity_name].append(entity.id)
+            if entity.id not in self.params[entity_name]:
+                self.params[entity_name].append(entity.id)
             event_param_key = f"{entity_name}_{step_prefix}event_{index}"
             self.params[event_param_key] = entity.id
             content_sql = f"event = %({event_param_key})s {filters}"

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -66,15 +66,15 @@ class FunnelEventQuery(ClickhouseEventQuery):
         self._should_join_distinct_ids = True
 
     def _get_entity_query(self, entities=None, entity_name="events") -> Tuple[str, Dict[str, Any]]:
-        events = []
+        events = set()
         entities_to_use = entities or self._filter.entities
 
         for entity in entities_to_use:
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
                 for action_step in action.steps.all():
-                    events.append(action_step.event)
+                    events.add(action_step.event)
             else:
-                events.append(entity.id)
+                events.add(entity.id)
 
-        return f"AND event IN %({entity_name})s", {entity_name: events}
+        return f"AND event IN %({entity_name})s", {entity_name: list(events)}


### PR DESCRIPTION
Looking at the generated SQL it has bothered me that the list of entity
names is not unique for funnels in queries like `event IN [somearray]`

This tries to fix that.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
