### PR TITLE
Automatically create materialized properties

### DIFF
--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -58,6 +58,7 @@ class Query:
 
     def properties(self, team_manager: TeamManager) -> Generator[Tuple[TableWithProperties, PropertyName], None, None]:
         # Reverse-engineer whether a property is an "event" or "person" property by getting their event definitions.
+        # :KLUDGE: Note that the same property will be found on both tables if both are used.
         person_props = team_manager.person_properties(self.team_id)
         event_props = team_manager.event_properties(self.team_id)
         for property in self._all_properties:

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -1,0 +1,98 @@
+import re
+from collections import defaultdict
+from typing import Dict, Generator, List, Optional, Set, Tuple
+
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.materialized_columns.util import instance_memoize
+from ee.clickhouse.sql.person import GET_PERSON_PROPERTIES_COUNT
+from posthog.models.filters.mixins.utils import cached_property
+from posthog.models.property import PropertyName, TableWithProperties
+from posthog.models.property_definition import PropertyDefinition
+from posthog.models.team import Team
+
+Suggestion = Dict
+
+INSPECT_QUERY_THRESHOLD_MS = 5000
+
+
+class TeamManager:
+    @instance_memoize
+    def person_properties(self, team_id: str) -> Set[str]:
+        rows = sync_execute(GET_PERSON_PROPERTIES_COUNT, {"team_id": team_id})
+        return set(name for name, _ in rows)
+
+    @instance_memoize
+    def event_properties(self, team_id: str) -> Set[str]:
+        return set(PropertyDefinition.objects.filter(team_id=team_id).values_list("name", flat=True))
+
+
+class Query:
+    def __init__(self, query_string: str, query_time_ms: float):
+        self.query_string = query_string
+        self.query_time_ms = query_time_ms
+
+    @property
+    def cost(self) -> int:
+        return int((self.query_time_ms - INSPECT_QUERY_THRESHOLD_MS) / 1000) + 1
+
+    @cached_property
+    def is_valid(self):
+        return self.team_id is not None and Team.objects.filter(pk=self.team_id).exists()
+
+    @cached_property
+    def team_id(self) -> Optional[str]:
+        matches = re.findall(r"team_id = (\d+)", self.query_string)
+        return matches[0] if matches else None
+
+    @cached_property
+    def _all_properties(self) -> List[PropertyName]:
+        return re.findall(r"JSONExtract\w+\(\S+, '([^']+)'\)", self.query_string)
+
+    def properties(self, team_manager: TeamManager) -> Generator[Tuple[TableWithProperties, PropertyName], None, None]:
+        # Reverse-engineer whether a property is an "event" or "person" property by getting their event definitions.
+        person_props = team_manager.person_properties(self.team_id)
+        event_props = team_manager.event_properties(self.team_id)
+        for property in self._all_properties:
+            if property in person_props:
+                yield "person", property
+            if property in event_props:
+                yield "events", property
+
+
+def get_queries(since_hours_ago):
+    raw_queries = sync_execute(
+        f"""
+        SELECT
+            query,
+            query_duration_ms
+        FROM system.query_log
+        WHERE
+            query NOT LIKE '%%query_log%%'
+            AND query LIKE '/* request:%%'
+            AND query NOT LIKE '%%INSERT%%'
+            AND type = 'QueryFinish'
+            AND query_start_time > now() - toIntervalHour(%(since)s)
+            AND query_duration_ms > {INSPECT_QUERY_THRESHOLD_MS}
+        ORDER BY query_duration_ms desc
+        """,
+        {"since": since_hours_ago},
+    )
+    return [Query(query, query_duration_ms) for query, query_duration_ms in raw_queries]
+
+
+def analyze(queries: List[Query]) -> List[Suggestion]:
+    team_manager = TeamManager()
+    costs: defaultdict = defaultdict(int)
+
+    for query in queries:
+        if not query.is_valid:
+            continue
+
+        for table, property in query.properties(team_manager):
+            costs[(table, property)] += query.cost
+
+    return list(sorted(costs.items(), key=lambda kv: -kv[1]))  # type: ignore
+
+
+if __name__ == "__main__":
+    print(analyze(get_queries(120)))

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import Dict, Generator, List, Optional, Set, Tuple
+from typing import Generator, List, Optional, Set, Tuple
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.materialized_columns.columns import get_materialized_columns

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -13,7 +13,7 @@ from posthog.models.team import Team
 
 Suggestion = Tuple[TableWithProperties, PropertyName, int]
 
-INSPECT_QUERY_THRESHOLD_MS = 50
+INSPECT_QUERY_THRESHOLD_MS = 3000
 
 
 class TeamManager:
@@ -114,7 +114,3 @@ def suggested_columns_to_materialize(since_hours_ago: int, maximum: int = 10) ->
             result.append(suggestion)
 
     return result[:maximum]
-
-
-if __name__ == "__main__":
-    print(analyze(get_queries(120)))

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -101,14 +101,14 @@ def backfill_materialized_events_column(properties: List[PropertyName], backfill
     assignments = ", ".join(
         f"{materialized_columns[property]} = {materialized_columns[property]}" for property in properties
     )
-    cutoff = (now() - backfill_period).strftime("%Y-%m-%d")
     sync_execute(
         f"""
         ALTER TABLE {table}
         ON CLUSTER {CLICKHOUSE_CLUSTER}
         UPDATE {assignments}
-        WHERE timestamp > {cutoff}
-        """
+        WHERE timestamp > %(cutoff)s
+        """,
+        {"cutoff": (now() - backfill_period).strftime("%Y-%m-%d")},
     )
 
     # Update the schema back even though updates are ongoing - no validations against this at least.

--- a/ee/clickhouse/materialized_columns/test/test_analyze.py
+++ b/ee/clickhouse/materialized_columns/test/test_analyze.py
@@ -27,7 +27,7 @@ class TestMaterializedColumnsAnalyze(ClickhouseTestMixin, BaseTest):
         )
 
     def test_query_class(self):
-        with self.settings(MATERIALIZED_COLUMNS_MINIMUM_QUERY_TIME=3000):
+        with self.settings(MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME=3000):
             event_query = Query(*self.DUMMY_QUERIES[0])
             person_query = Query(*self.DUMMY_QUERIES[1])
 

--- a/ee/clickhouse/materialized_columns/test/test_analyze.py
+++ b/ee/clickhouse/materialized_columns/test/test_analyze.py
@@ -1,0 +1,55 @@
+from ee.clickhouse.materialized_columns import materialize
+from ee.clickhouse.materialized_columns.analyze import Query, TeamManager, analyze
+from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.models import Person, PropertyDefinition
+from posthog.test.base import BaseTest
+
+
+class TestMaterializedColumnsAnalyze(ClickhouseTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.DUMMY_QUERIES = [
+            (
+                f"SELECT JSONExtractString(properties, 'event_prop') FROM events WHERE team_id = {self.team.pk} AND trim(BOTH '\"' FROM JSONExtractRaw(properties, 'another_prop')",
+                6723,
+            ),
+            (f"SELECT JSONExtractString(properties, 'person_prop') FROM person WHERE team_id = {self.team.pk}", 9723),
+        ]
+
+        # Create property definitions
+        PropertyDefinition.objects.create(team=self.team, name="event_prop")
+        PropertyDefinition.objects.create(team=self.team, name="another_prop")
+
+        Person.objects.create(
+            team_id=self.team.pk,
+            distinct_ids=["2"],
+            properties={"person_prop": "something", "$another_prop": "something"},
+        )
+
+    def test_query_class(self):
+        with self.settings(MATERIALIZED_COLUMNS_MINIMUM_QUERY_TIME=3000):
+            event_query = Query(*self.DUMMY_QUERIES[0])
+            person_query = Query(*self.DUMMY_QUERIES[1])
+
+            self.assertTrue(event_query.is_valid)
+            self.assertTrue(person_query.is_valid)
+
+            self.assertEqual(event_query.team_id, str(self.team.pk))
+            self.assertEqual(person_query.team_id, str(self.team.pk))
+
+            self.assertEqual(
+                list(event_query.properties(TeamManager())), [("events", "event_prop"), ("events", "another_prop")]
+            )
+            self.assertEqual(list(person_query.properties(TeamManager())), [("person", "person_prop")])
+            self.assertEqual(event_query.cost, 4)
+            self.assertEqual(person_query.cost, 7)
+
+    def test_query_class_edge_cases(self):
+        invalid_query = Query("SELECT * FROM events WHERE team_id = -1", 100)
+        self.assertFalse(invalid_query.is_valid)
+        self.assertIsNone(invalid_query.team_id)
+
+        query_with_unknown_property = Query(
+            f"SELECT JSONExtractString(properties, '$unknown_prop') FROM events WHERE team_id = {self.team.pk}", 0
+        )
+        self.assertEqual(list(query_with_unknown_property.properties(TeamManager())), [])

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -11,9 +11,9 @@ from ee.clickhouse.materialized_columns.columns import (
     get_materialized_columns,
     materialize,
 )
+from ee.clickhouse.models.event import create_event
 from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
 from ee.clickhouse.sql.person import DROP_PERSON_TABLE_SQL, PERSONS_TABLE_SQL
-from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.settings import CLICKHOUSE_DATABASE
 from posthog.test.base import BaseTest

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -1,3 +1,5 @@
+import random
+
 from freezegun import freeze_time
 
 from ee.clickhouse.client import sync_execute
@@ -33,12 +35,31 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             materialize("events", "$bar")
             materialize("person", "$zeta")
 
-            self.assertCountEqual(get_materialized_columns("events", use_cache=True), ["$foo", "$bar"])
-            self.assertCountEqual(get_materialized_columns("person", use_cache=True), ["$zeta"])
+            self.assertCountEqual(get_materialized_columns("events", use_cache=True).keys(), ["$foo", "$bar"])
+            self.assertCountEqual(get_materialized_columns("person", use_cache=True).keys(), ["$zeta"])
 
             materialize("events", "abc")
 
-            self.assertCountEqual(get_materialized_columns("events", use_cache=True), ["$foo", "$bar"])
+            self.assertCountEqual(get_materialized_columns("events", use_cache=True).keys(), ["$foo", "$bar"])
 
         with freeze_time("2020-01-04T14:00:01Z"):
-            self.assertCountEqual(get_materialized_columns("events", use_cache=True), ["$foo", "$bar", "abc"])
+            self.assertCountEqual(get_materialized_columns("events", use_cache=True).keys(), ["$foo", "$bar", "abc"])
+
+    def test_materialized_column_naming(self):
+        random.seed(0)
+
+        materialize("events", "$foO();--sqlinject")
+        materialize("events", "$foO();ääsqlinject")
+        materialize("events", "$foO_____sqlinject")
+        materialize("person", "SoMePrOp")
+
+        self.assertEqual(
+            get_materialized_columns("events"),
+            {
+                "$foO();--sqlinject": "mat_$foO_____sqlinject",
+                "$foO();ääsqlinject": "mat_$foO_____sqlinject_yWAc",
+                "$foO_____sqlinject": "mat_$foO_____sqlinject_qGFz",
+            },
+        )
+
+        self.assertEqual(get_materialized_columns("person"), {"SoMePrOp": "pmat_SoMePrOp"})

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -120,7 +120,9 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         self.assertEqual(self._count_materialized_rows("mat_another"), 0)
 
         with freeze_time("2021-05-10T14:00:01Z"):
-            backfill_materialized_events_column(["prop", "another"], timedelta(days=50))
+            backfill_materialized_events_column(
+                ["prop", "another"], timedelta(days=50), test_settings={"mutations_sync": "0"}
+            )
 
         _create_event(
             event="fifth_event",

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -1,13 +1,29 @@
 import random
+from datetime import timedelta
+from time import sleep
+from uuid import uuid4
 
 from freezegun import freeze_time
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.materialized_columns.columns import get_materialized_columns, materialize
+from ee.clickhouse.materialized_columns.columns import (
+    backfill_materialized_events_column,
+    get_materialized_columns,
+    materialize,
+)
 from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
 from ee.clickhouse.sql.person import DROP_PERSON_TABLE_SQL, PERSONS_TABLE_SQL
+from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.settings import CLICKHOUSE_DATABASE
 from posthog.test.base import BaseTest
+
+
+def _create_event(**kwargs):
+    pk = uuid4()
+    kwargs.update({"event_uuid": pk})
+    create_event(**kwargs)
+    return pk
 
 
 class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
@@ -63,3 +79,87 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         )
 
         self.assertEqual(get_materialized_columns("person"), {"SoMePrOp": "pmat_SoMePrOp"})
+
+    def test_backfilling_data(self):
+        sync_execute("ALTER TABLE events DROP COLUMN IF EXISTS mat_prop")
+        sync_execute("ALTER TABLE events DROP COLUMN IF EXISTS mat_another")
+
+        _create_event(
+            event="some_event", distinct_id="1", team=self.team, timestamp="2020-01-01 00:00:00", properties={"prop": 1}
+        )
+        _create_event(
+            event="some_event",
+            distinct_id="1",
+            team=self.team,
+            timestamp="2021-05-02 00:00:00",
+            properties={"prop": 2, "another": 5},
+        )
+        _create_event(
+            event="some_event", distinct_id="1", team=self.team, timestamp="2021-05-03 00:00:00", properties={"prop": 3}
+        )
+        _create_event(event="another_event", distinct_id="1", team=self.team, timestamp="2021-05-04 00:00:00")
+        _create_event(
+            event="third_event",
+            distinct_id="1",
+            team=self.team,
+            timestamp="2021-05-05 00:00:00",
+            properties={"prop": 4},
+        )
+        _create_event(
+            event="fourth_event",
+            distinct_id="1",
+            team=self.team,
+            timestamp="2021-05-06 00:00:00",
+            properties={"another": 6},
+        )
+
+        materialize("events", "prop")
+        materialize("events", "another")
+
+        self.assertEqual(self._count_materialized_rows("mat_prop"), 0)
+        self.assertEqual(self._count_materialized_rows("mat_another"), 0)
+
+        with freeze_time("2021-05-10T14:00:01Z"):
+            backfill_materialized_events_column(["prop", "another"], timedelta(days=50))
+
+        _create_event(
+            event="fifth_event",
+            distinct_id="1",
+            team=self.team,
+            timestamp="2021-05-07 00:00:00",
+            properties={"another": 7},
+        )
+
+        iterations = 0
+        while self._get_count_of_mutations_running() > 0 and iterations < 100:
+            sleep(0.1)
+            iterations += 1
+
+        self.assertGreaterEqual(self._count_materialized_rows("mat_prop"), 4)
+        self.assertGreaterEqual(self._count_materialized_rows("mat_another"), 4)
+
+        self.assertEqual(
+            sync_execute("SELECT mat_prop, mat_another FROM events ORDER BY timestamp"),
+            [("1", ""), ("2", "5"), ("3", ""), ("", ""), ("4", ""), ("", "6"), ("", "7")],
+        )
+
+    def _count_materialized_rows(self, column):
+        return sync_execute(
+            """
+            SELECT sum(rows)
+            FROM system.parts_columns
+            WHERE table = 'events'
+              AND database = %(database)s
+              AND column = %(column)s
+        """,
+            {"database": CLICKHOUSE_DATABASE, "column": column},
+        )[0][0]
+
+    def _get_count_of_mutations_running(self) -> int:
+        return sync_execute(
+            """
+            SELECT count(*)
+            FROM system.mutations
+            WHERE is_done = 0
+        """
+        )[0][0]

--- a/ee/clickhouse/materialized_columns/util.py
+++ b/ee/clickhouse/materialized_columns/util.py
@@ -1,0 +1,41 @@
+from datetime import timedelta
+from functools import wraps
+from typing import no_type_check
+
+from django.utils.timezone import now
+
+from posthog.settings import TEST
+
+
+def cache_for(cache_time: timedelta):
+    def wrapper(fn):
+        @wraps(fn)
+        @no_type_check
+        def memoized_fn(*args, use_cache=not TEST):
+            if not use_cache:
+                return fn(*args)
+
+            current_time = now()
+            if args not in memoized_fn.__cache or current_time - memoized_fn.__cache[args][0] > cache_time:
+                memoized_fn.__cache[args] = (current_time, fn(*args))
+            return memoized_fn.__cache[args][1]
+
+        memoized_fn.__cache = {}
+        return memoized_fn
+
+    return wrapper
+
+
+def instance_memoize(callback):
+    name = f"_{callback.__name__}_memo"
+
+    def _inner(self, *args):
+        if not hasattr(self, name):
+            setattr(self, name, {})
+
+        memo = getattr(self, name)
+        if args not in memo:
+            memo[args] = callback(self, *args)
+        return memo[args]
+
+    return _inner

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -33,5 +33,9 @@ AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
 KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST
 
 # Settings specific for materialized columns
+
+# Schedule to run column materialization on. Follows crontab syntax.
+# Use empty string to prevent from materializing
+MATERIALIZE_COLUMNS_SCHEDULE_CRON = get_from_env("MATERIALIZE_COLUMNS_SCHEDULE_CRON", "0 5 * * SAT")
 # Minimum query time before a query if considered for optimization by adding materialized columns
-MATERIALIZED_COLUMNS_MINIMUM_QUERY_TIME = get_from_env("MATERIALIZED_COLUMNS_MINIMUM_QUERY_TIME", 3000, type_cast=int)
+MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME = get_from_env("MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME", 3000, type_cast=int)

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -5,7 +5,7 @@ import os
 from typing import Dict, List
 
 from posthog.constants import RDBMS
-from posthog.settings import AUTHENTICATION_BACKENDS, PRIMARY_DB, TEST
+from posthog.settings import AUTHENTICATION_BACKENDS, PRIMARY_DB, TEST, get_from_env
 
 # Zapier REST hooks
 HOOK_EVENTS: Dict[str, str] = {
@@ -31,3 +31,7 @@ AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
 
 # ClickHouse and Kafka
 KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST
+
+# Settings specific for materialized columns
+# Minimum query time before a query if considered for optimization by adding materialized columns
+MATERIALIZED_COLUMNS_MINIMUM_QUERY_TIME = get_from_env("MATERIALIZED_COLUMNS_MINIMUM_QUERY_TIME", 3000, type_cast=int)

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -39,3 +39,5 @@ KAFKA_ENABLED = PRIMARY_DB == RDBMS.CLICKHOUSE and not TEST
 MATERIALIZE_COLUMNS_SCHEDULE_CRON = get_from_env("MATERIALIZE_COLUMNS_SCHEDULE_CRON", "0 5 * * SAT")
 # Minimum query time before a query if considered for optimization by adding materialized columns
 MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME = get_from_env("MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME", 3000, type_cast=int)
+# How big of a timeframe to backfill when materializing event properties. 0 for no backfilling
+MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS = get_from_env("MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS", 180, type_cast=int)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -240,7 +240,8 @@ def clickhouse_materialize_columns():
     if is_clickhouse_enabled() and settings.EE_AVAILABLE:
         from ee.clickhouse.materialized_columns.analyze import materialize_properties_task
 
-        materialize_properties_task()
+        # :TODO: Noop until ready
+        # materialize_properties_task()
 
 
 @app.task(ignore_result=True)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -82,6 +82,27 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
         sender.add_periodic_task(120, clickhouse_part_count.s(), name="clickhouse table parts count")
         sender.add_periodic_task(120, clickhouse_mutation_count.s(), name="clickhouse table mutations count")
+
+        try:
+            from ee.settings import MATERIALIZE_COLUMNS_SCHEDULE_CRON
+
+            minute, hour, day_of_month, month_of_year, day_of_week = MATERIALIZE_COLUMNS_SCHEDULE_CRON.strip().split(
+                " "
+            )
+
+            sender.add_periodic_task(
+                crontab(
+                    minute=minute,
+                    hour=hour,
+                    day_of_month=day_of_month,
+                    month_of_year=month_of_year,
+                    day_of_week=day_of_week,
+                ),
+                clickhouse_materialize_columns.s(),
+                name="clickhouse materialize columns",
+            )
+        except:
+            pass
     elif settings.PLUGIN_SERVER_ACTION_MATCHING >= 2:
         sender.add_periodic_task(
             ACTION_EVENT_MAPPING_INTERVAL_SECONDS,
@@ -212,6 +233,14 @@ def clickhouse_mutation_count():
             gauge(f"posthog_celery_clickhouse_table_mutations_count", muts, tags={"table": table})
     else:
         pass
+
+
+@app.task(ignore_result=True)
+def clickhouse_materialize_columns():
+    if is_clickhouse_enabled() and settings.EE_AVAILABLE:
+        from ee.clickhouse.materialized_columns.analyze import materialize_properties_task
+
+        materialize_properties_task()
 
 
 @app.task(ignore_result=True)

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -8,6 +8,7 @@ from posthog.utils import is_valid_regex
 ValueT = Union[str, int, List[str]]
 PropertyType = Literal["event", "person", "cohort", "element"]
 PropertyName = str
+TableWithProperties = Literal["events", "person"]
 OperatorType = Literal[
     "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
 ]


### PR DESCRIPTION
## Changes

This adds most of the code for analyzing, creating and backfilling materialized columns. https://github.com/PostHog/posthog/issues/5475

Blocked from fully deploying this by https://github.com/PostHog/posthog/issues/5735 and I want to hand-hold the first run on cloud just in case.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
