### PR TITLE
Proposal: Set `mutations_sync` in client.py instead of docker config

### DIFF
--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -6,7 +6,6 @@
         <default>
             <!-- Maximum memory usage for processing single query, in bytes. -->
             <max_memory_usage>10000000000</max_memory_usage>
-            <mutations_sync>1</mutations_sync>
             <!-- How to choose between replicas during distributed query processing.
                  random - choose random replica from set of replicas with minimum number of errors
                  nearest_hostname - from set of replicas with minimum number of errors, choose replica

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -96,6 +96,7 @@ else:
             password=CLICKHOUSE_PASSWORD,
             ca_certs=CLICKHOUSE_CA,
             verify=CLICKHOUSE_VERIFY,
+            settings={"mutations_sync": "1"} if TEST else {},
         )
 
         ch_pool = ChPool(
@@ -108,6 +109,7 @@ else:
             verify=CLICKHOUSE_VERIFY,
             connections_min=CLICKHOUSE_CONN_POOL_MIN,
             connections_max=CLICKHOUSE_CONN_POOL_MAX,
+            settings={"mutations_sync": "1"} if TEST else {},
         )
 
         def async_execute(query, args=None, settings=None, with_column_types=False):


### PR DESCRIPTION
This avoids weird divergence with prod that we need in ee tests but don't
want in e.g. plugin server tests or while developing and could bite us down the line.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
