### PR TITLE
Hotfix: Use materialized columns on cloud

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -24,7 +24,6 @@ def get_materialized_columns(table: TableWithProperties) -> Dict[PropertyName, C
         FROM system.columns
         WHERE database = %(database)s
           AND table = %(table)s
-          AND default_kind = 'MATERIALIZED'
           AND comment LIKE '%%column_materializer::%%'
     """,
         {"database": CLICKHOUSE_DATABASE, "table": table},


### PR DESCRIPTION
This was broken since default_kind was different on Distributed tables
on cloud


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
