### PR TITLE
Random improvements

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -97,6 +97,11 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
             },
             fixed: 'left',
             width: 150,
+            sorter: (a, b) => {
+                const labelA = formatBreakdownLabel(a.breakdown_value, cohorts)
+                const labelB = formatBreakdownLabel(b.breakdown_value, cohorts)
+                return labelA.localeCompare(labelB)
+            },
         })
     }
 
@@ -120,6 +125,11 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
         },
         fixed: 'left',
         width: 200,
+        sorter: (a, b) => {
+            const labelA = a.action?.name || a.label || ''
+            const labelB = b.action?.name || b.label || ''
+            return labelA.localeCompare(labelB)
+        },
     })
 
     if (indexedResults?.length > 0) {

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -17,6 +17,7 @@ import utc from 'dayjs/plugin/utc'
 dayjs.extend(utc)
 
 import { ColumnsType } from 'antd/lib/table'
+import clsx from 'clsx'
 
 export function RetentionTable({
     dashboardItemId = null,
@@ -74,7 +75,8 @@ export function RetentionTable({
                     return renderPercentage(
                         row.values[dayIndex]['count'],
                         row.values[0]['count'],
-                        isLatestPeriod && dayIndex === row.values.length - 1
+                        isLatestPeriod && dayIndex === row.values.length - 1,
+                        dayIndex === 0
                     )
                 },
             })
@@ -209,13 +211,15 @@ export function RetentionTable({
     )
 }
 
-const renderPercentage = (value: number, total: number, latest = false): JSX.Element => {
+const renderPercentage = (value: number, total: number, latest = false, periodZero = false): JSX.Element => {
     const _percentage = total > 0 ? (100.0 * value) / total : 0
-    const backgroundColor = `hsl(212, 63%, ${30 + (100 - _percentage) * 0.65}%)`
-    const color = _percentage >= 65 ? 'hsl(0, 0%, 80%)' : undefined
+    const percentageBasisForColor = periodZero ? 100 : _percentage // So that Period 0 is always shown consistently
+    const backgroundColor = `hsl(212, 63%, ${30 + (100 - percentageBasisForColor) * 0.65}%)`
+    const color =
+        periodZero && value == 0 ? 'var(--warning)' : percentageBasisForColor >= 65 ? 'hsl(0, 0%, 80%)' : undefined
 
     const numberCell = (
-        <div style={{ backgroundColor, color }} className={`percentage-cell${latest ? ' period-in-progress' : ''}`}>
+        <div style={{ backgroundColor, color }} className={clsx('percentage-cell', { 'period-in-progress': latest })}>
             {_percentage.toFixed(1)}%{latest && '*'}
         </div>
     )

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -215,8 +215,7 @@ const renderPercentage = (value: number, total: number, latest = false, periodZe
     const _percentage = total > 0 ? (100.0 * value) / total : 0
     const percentageBasisForColor = periodZero ? 100 : _percentage // So that Period 0 is always shown consistently
     const backgroundColor = `hsl(212, 63%, ${30 + (100 - percentageBasisForColor) * 0.65}%)`
-    const color =
-        periodZero && value == 0 ? 'var(--warning)' : percentageBasisForColor >= 65 ? 'hsl(0, 0%, 80%)' : undefined
+    const color = percentageBasisForColor >= 65 ? 'hsl(0, 0%, 80%)' : undefined
 
     const numberCell = (
         <div style={{ backgroundColor, color }} className={clsx('percentage-cell', { 'period-in-progress': latest })}>


### PR DESCRIPTION
## Changes

1. The first period in the retention table now always shows the same dark background even if the cohort is empty. We also now show a different text color to highlight the cohort is empty. CC @clarkus 

<img width="957" alt="" src="https://user-images.githubusercontent.com/5864173/131030388-56b1cc8d-619c-43b8-925c-39e62b748320.png">

2. Adds sorting capabilities to the breakdown values and event/action names column on the insights table. This was requested by a user where they breakdown by email and need a way of visualizing each user together (to get a solid sense of their usage). This is just a patch, will open a separate issue to detail their full problem so we can find a better solution.

<img width="949" alt="" src="https://user-images.githubusercontent.com/5864173/131030508-193c746e-a572-4feb-acf5-05fcca328815.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
