### PR TITLE
Materialize person columns automatically

### DIFF
--- a/ee/clickhouse/materialized_columns/__init__.py
+++ b/ee/clickhouse/materialized_columns/__init__.py
@@ -1,1 +1,2 @@
-from .columns import get_materialized_columns, materialize
+from .analyze import analyze, get_queries, materialize_properties_task
+from .columns import backfill_materialized_columns, get_materialized_columns, materialize

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -24,7 +24,6 @@ def get_materialized_columns(table: TableWithProperties) -> Dict[PropertyName, C
         FROM system.columns
         WHERE database = %(database)s
           AND table = %(table)s
-          AND default_kind = 'MATERIALIZED'
           AND comment LIKE '%%column_materializer::%%'
     """,
         {"database": CLICKHOUSE_DATABASE, "table": table},

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -71,13 +71,14 @@ elements_chain,
 created_at,
 _timestamp,
 _offset
-FROM {database}.kafka_{table_name} 
+FROM {database}.kafka_{table_name}
 """.format(
     table_name=EVENTS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE,
 )
 
 INSERT_EVENT_SQL = """
-INSERT INTO events SELECT %(uuid)s, %(event)s, %(properties)s, %(timestamp)s, %(team_id)s, %(distinct_id)s, %(elements_chain)s, %(created_at)s, now(), 0
+INSERT INTO events (uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, _timestamp, _offset)
+SELECT %(uuid)s, %(event)s, %(properties)s, %(timestamp)s, %(team_id)s, %(distinct_id)s, %(elements_chain)s, %(created_at)s, now(), 0
 """
 
 GET_EVENTS_SQL = """

--- a/ee/tasks/materialized_column_backfill.py
+++ b/ee/tasks/materialized_column_backfill.py
@@ -1,0 +1,43 @@
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.materialized_columns.columns import TRIM_AND_EXTRACT_PROPERTY, get_materialized_columns
+from posthog.celery import app
+from posthog.models.property import PropertyName, TableWithProperties
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_REPLICATION
+
+DELAY_SECONDS = 4 * 60 * 60
+
+
+@app.task(ignore_result=True, max_retries=3)
+def check_backfill_done(table: TableWithProperties, property: PropertyName) -> None:
+    should_retry = True
+
+    try:
+        updated_table = "sharded_events" if CLICKHOUSE_REPLICATION and table == "events" else table
+        # :TRICKY: On cloud, we ON CLUSTER updates to events/sharded_events but not to persons. Why? ¯\_(ツ)_/¯
+        execute_on_cluster = f"ON CLUSTER {CLICKHOUSE_CLUSTER}" if table == "events" else ""
+        column_name = get_materialized_columns(table, use_cache=False)[property]
+
+        results = sync_execute(
+            f"""
+            SELECT count(*)
+            FROM system.mutations
+            WHERE table = '{table}'
+              AND command LIKE '%UPDATE%'
+              AND command LIKE '%{column_name} = {column_name}%'
+        """
+        )
+
+        if results[0][0] == 0:
+            sync_execute(
+                f"""
+                ALTER TABLE {updated_table}
+                {execute_on_cluster}
+                MODIFY COLUMN
+                {column_name} VARCHAR MATERIALIZED {TRIM_AND_EXTRACT_PROPERTY}
+                """,
+                {"property": property},
+            )
+            should_retry = False
+    finally:
+        if should_retry:
+            check_backfill_done.apply_async((table, property,), countdown=DELAY_SECONDS)

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -470,6 +470,7 @@ if PRIMARY_DB == RDBMS.CLICKHOUSE:
         pass
     else:
         CELERY_IMPORTS.append("ee.tasks.webhooks_ee")
+        CELERY_IMPORTS.append("ee.tasks.materialized_column_backfill")
 
 CELERY_BROKER_URL = REDIS_URL  # celery connects to redis
 CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # sleep max 30sec before checking for new periodic events


### PR DESCRIPTION
## Changes

Learnings from yesterdays jam session with @fuziontech.

1. We can't ON CLUSTER person columns
2. We can't immediately revert the column after backfill
3. Minor aesthetic fixes

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
