### PR TITLE
Remove unused call to distutils which was deprecated in Python 3.10.

### DIFF
--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from typing import Optional, Type, TypeVar
 
 from django.db import connection, models


### PR DESCRIPTION
## Changes

Remove unused call to distutils which was deprecated in Python 3.10. This is a very minor code cleanup. Related https://github.com/PostHog/posthog/issues/4629

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
