### PR TITLE
Optimize UI around session recordings

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -142,7 +142,6 @@ export const commandPaletteLogic = kea<
         deregisterCommand: (commandKey: string) => ({ commandKey }),
         setCustomCommand: (commandKey: string) => ({ commandKey }),
         deregisterScope: (scope: string) => ({ scope }),
-        shareFeedbackCommand: (instruction?: string) => ({ instruction }),
     },
     reducers: {
         isPaletteShown: [
@@ -264,30 +263,6 @@ export const commandPaletteLogic = kea<
                     })
                 }
             }
-        },
-        shareFeedbackCommand: ({ instruction = "What's on your mind?" }) => {
-            actions.showPalette()
-            actions.activateFlow({
-                scope: 'Sharing Feedback',
-                instruction,
-                icon: CommentOutlined,
-                resolver: (argument) => ({
-                    icon: SendOutlined,
-                    display: 'Send',
-                    executor: !argument?.length
-                        ? undefined
-                        : () => {
-                              posthog.capture('palette feedback', { message: argument })
-                              return {
-                                  resolver: {
-                                      icon: CheckOutlined,
-                                      display: 'Message Sent!',
-                                      executor: true,
-                                  },
-                              }
-                          },
-                }),
-            })
         },
     }),
     selectors: {

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -22,6 +22,7 @@ export interface ResizableColumnType<RecordType> extends ColumnType<RecordType> 
         | ((value: any, record?: RecordType, ...rest: any) => JSX.Element | string | RenderedCell<RecordType> | null)
     ellipsis?: boolean
     span: number
+    defaultWidth?: number
     eventProperties?: string[]
     widthConstraints?: [number, number] // Override default min and max width (px). To specify no max, use Infinity.
 }
@@ -198,7 +199,7 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
                         ? column
                         : {
                               ...column,
-                              width: Math.max(columnSpanWidth * column.span, minColumnWidth),
+                              width: Math.max(column.defaultWidth || columnSpanWidth * column.span, minColumnWidth),
                           }
                 )
                 setHeaderColumns(nextColumns)

--- a/frontend/src/lib/components/Tooltip.tsx
+++ b/frontend/src/lib/components/Tooltip.tsx
@@ -8,6 +8,7 @@ const DEFAULT_DELAY_MS = 500
 export type TooltipProps = AntdTooltipProps & {
     /** Whether Ant Design's default Tooltip behavior should be used instead of PostHog's. */
     isDefaultTooltip?: boolean
+    delayMs?: number
 }
 
 /** Extension of Ant Design's Tooltip that enables a delay.
@@ -16,13 +17,19 @@ export type TooltipProps = AntdTooltipProps & {
  * See https://github.com/ant-design/ant-design/blob/master/components/tooltip/index.tsx#L82-L130.
  */
 // CAUTION: Any changes here will affect tooltips across the entire app.
-export function Tooltip({ children, visible, isDefaultTooltip = false, ...props }: TooltipProps): JSX.Element {
+export function Tooltip({
+    children,
+    visible,
+    isDefaultTooltip = false,
+    delayMs = DEFAULT_DELAY_MS,
+    ...props
+}: TooltipProps): JSX.Element {
     const [localVisible, setVisible] = useState(visible)
-    const [debouncedLocalVisible] = useDebounce(visible ?? localVisible, DEFAULT_DELAY_MS)
+    const [debouncedLocalVisible] = useDebounce(visible ?? localVisible, delayMs)
 
     if (!isDefaultTooltip && !('mouseEnterDelay' in props)) {
         // If not preserving default behavior and mouseEnterDelay is not already provided, we use a custom default here
-        props.mouseEnterDelay = DEFAULT_DELAY_MS
+        props.mouseEnterDelay = delayMs
     }
 
     // If child is not a valid element (string or string + ReactNode, Fragment), antd wraps children in a span.

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -196,6 +196,8 @@ describe('humanFriendlyDuration()', () => {
     it('returns correct value for <= 60', () => {
         expect(humanFriendlyDuration(60)).toEqual('1min')
         expect(humanFriendlyDuration(45)).toEqual('45s')
+        expect(humanFriendlyDuration(44.8)).toEqual('45s')
+        expect(humanFriendlyDuration(45.2)).toEqual('45s')
     })
     it('returns correct value for 60 < t < 120', () => {
         expect(humanFriendlyDuration(90)).toEqual('1min 30s')
@@ -207,9 +209,12 @@ describe('humanFriendlyDuration()', () => {
         expect(humanFriendlyDuration(3600)).toEqual('1h')
         expect(humanFriendlyDuration(3601)).toEqual('1h 1s')
         expect(humanFriendlyDuration(3961)).toEqual('1h 6min 1s')
+        expect(humanFriendlyDuration(3961.333)).toEqual('1h 6min 1s')
+        expect(humanFriendlyDuration(3961.666)).toEqual('1h 6min 2s')
     })
     it('returns correct value for t >= 86400', () => {
         expect(humanFriendlyDuration(86400)).toEqual('1d')
+        expect(humanFriendlyDuration(86400.12)).toEqual('1d')
     })
     it('truncates to specified # of units', () => {
         expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6min')
@@ -232,6 +237,8 @@ describe('colonDelimitedDuration()', () => {
     })
     it('returns correct value for t > 120', () => {
         expect(colonDelimitedDuration(360)).toEqual('00:06:00')
+        expect(colonDelimitedDuration(360.3233)).toEqual('00:06:00')
+        expect(colonDelimitedDuration(360.782)).toEqual('00:06:01')
     })
     it('returns correct value for t >= 3600', () => {
         expect(colonDelimitedDuration(3600)).toEqual('01:00:00')
@@ -252,6 +259,8 @@ describe('colonDelimitedDuration()', () => {
         expect(colonDelimitedDuration(90061, 4)).toEqual('01:01:01:01')
         expect(colonDelimitedDuration(604800, 5)).toEqual('01:00:00:00:00')
         expect(colonDelimitedDuration(604800, 6)).toEqual('01:00:00:00:00')
+        expect(colonDelimitedDuration(604800.222, 5)).toEqual('01:00:00:00:00')
+        expect(colonDelimitedDuration(604800.999, 6)).toEqual('01:00:00:00:01')
     })
     it('returns an empty string for nullish inputs', () => {
         expect(colonDelimitedDuration('')).toEqual('')

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -439,7 +439,7 @@ export function humanFriendlyDuration(d: string | number | null | undefined, max
     const days = Math.floor(d / 86400)
     const h = Math.floor((d % 86400) / 3600)
     const m = Math.floor((d % 3600) / 60)
-    const s = Math.floor((d % 3600) % 60)
+    const s = Math.round((d % 3600) % 60)
 
     const dayDisplay = days > 0 ? days + 'd' : ''
     const hDisplay = h > 0 ? h + 'h' : ''
@@ -517,6 +517,7 @@ export function colonDelimitedDuration(d: string | number | null | undefined, nu
         m = Math.floor(s / 60)
         s -= m * 60
     }
+    s = Math.round(s)
 
     const units = [zeroPad(weeks, 2), zeroPad(days, 2), zeroPad(h, 2), zeroPad(m, 2), zeroPad(s, 2)]
 

--- a/frontend/src/scenes/project/Settings/SessionRecording.tsx
+++ b/frontend/src/scenes/project/Settings/SessionRecording.tsx
@@ -52,10 +52,10 @@ export function SessionRecording(): JSX.Element {
                                 marginLeft: '10px',
                             }}
                         >
-                            Automatically delete old session recordings after
+                            Automatically delete old session recordings{period !== null && ' after'}
                         </label>
                     </div>
-                    {period != null && (
+                    {period !== null && (
                         <div style={{ maxWidth: '15rem', marginLeft: 54 }}>
                             <Input
                                 type="number"

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -16,7 +16,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { DangerZone } from './DangerZone'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Link } from 'lib/components/Link'
-import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { JSBookmarklet } from 'lib/components/JSBookmarklet'
 import { RestrictedArea } from '../../../lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from '../../../lib/constants'
@@ -67,8 +66,6 @@ export function ProjectSettings(): JSX.Element {
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const { resetToken } = useActions(teamLogic)
     const { location } = useValues(router)
-
-    const { shareFeedbackCommand } = useActions(commandPaletteLogic)
 
     useAnchor(location.hash)
 
@@ -225,11 +222,6 @@ export function ProjectSettings(): JSX.Element {
                     installed.
                 </p>
                 <SessionRecording />
-                <p>
-                    This is a new feature of PostHog. Please{' '}
-                    <a onClick={() => shareFeedbackCommand('How can we improve session recording?')}>share feedback</a>{' '}
-                    with us!
-                </p>
                 <Divider />
                 <RestrictedArea Component={DangerZone} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
             </Card>

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -62,9 +62,6 @@ function getSessionRecordingsDurationSum(session: SessionType): number {
 
 export const MATCHING_EVENT_ICON_SIZE = 26
 
-const enableSessionRecordingCTA =
-    'Session recording is turned off for this project. Go to the Project page using the sidebar to enable them.'
-
 export function SessionsView({ personIds, isPersonPage = false }: SessionsTableProps): JSX.Element {
     const logic = sessionsTableLogic({ personIds })
     const {
@@ -148,9 +145,10 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 <Tooltip
                     title={
                         currentTeam?.session_recording_opt_in
-                            ? 'Replay sessions as if you were right beside your users.'
-                            : enableSessionRecordingCTA
+                            ? 'Replay sessions as if you were right next to your users.'
+                            : 'Session recording is turned off for this project. Click to go to settings.'
                     }
+                    delayMs={0}
                 >
                     <span style={{ whiteSpace: 'nowrap' }}>
                         {currentTeam?.session_recording_opt_in ? (
@@ -159,9 +157,9 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                                 <QuestionCircleOutlined className="info-indicator" />
                             </>
                         ) : (
-                            <Link to={urls.projectSettings() + '#session-recording'}>
+                            <Link to={urls.projectSettings() + '#session-recording'} style={{ color: 'inherit' }}>
                                 Recordings
-                                <PoweroffOutlined className="info-indicator text-warning" />
+                                <PoweroffOutlined className="info-indicator" />
                             </Link>
                         )}
                     </span>
@@ -237,7 +235,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                                 ? 'No recordings found for this date.'
                                 : currentTeam?.session_recording_opt_in
                                 ? 'Play all recordings found for this date.'
-                                : enableSessionRecordingCTA
+                                : 'Session recording is turned off for this project. Enable in Project Settings.'
                         }
                     >
                         <LinkButton

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -159,7 +159,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                                 <QuestionCircleOutlined className="info-indicator" />
                             </>
                         ) : (
-                            <Link to={urls.projectSettings()}>
+                            <Link to={urls.projectSettings() + '#session-recording'}>
                                 Recordings
                                 <PoweroffOutlined className="info-indicator text-warning" />
                             </Link>
@@ -173,6 +173,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 ) : null
             },
             span: 4,
+            defaultWidth: 184,
         },
     ]
 


### PR DESCRIPTION
## Changes

Small fixes for session recordings UI (for instance links in `Tooltip`s don't work, because tooltip content can't be clicked, the hoverable element must be a link instead).

| Before | After |
| --- | --- |
| <img width="309" alt="Screen Shot 2021-08-28 at 01 55 18" src="https://user-images.githubusercontent.com/4550621/131248021-ba532d7d-3ff2-470e-95c0-a80da2fef505.png"> | <img width="311" alt="Screen Shot 2021-08-28 at 01 49 49" src="https://user-images.githubusercontent.com/4550621/131248019-93f15bf0-eb31-4561-a5e4-454db885e759.png"> |
| <img width="462" alt="Screen Shot 2021-08-28 at 01 36 24" src="https://user-images.githubusercontent.com/4550621/131248023-58e660d7-c9ae-4483-8d77-7930954ca8ea.png"> | <img width="457" alt="Screen Shot 2021-08-28 at 01 36 46" src="https://user-images.githubusercontent.com/4550621/131248022-867de882-ad5c-4d4e-88ac-0d29c9c0a0f9.png"> |
