### PR TITLE
Dashboard View and Dive buttons (Hackathon)

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -242,6 +242,7 @@ export const FEATURE_FLAGS = {
     SAVED_INSIGHTS: '3408-saved-insights',
     MULTIVARIATE_SUPPORT: '5440-multivariate-support',
     FUNNEL_HORIZONTAL_UI: '5730-funnel-horizontal-ui',
+    DIVE_DASHBOARDS: 'hackathon-dive-dashboards',
 }
 
 export const ENVIRONMENT_LOCAL_STORAGE_KEY = '$environment'

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -9,7 +9,7 @@ import { ActionsLineGraph } from 'scenes/trends/viz/ActionsLineGraph'
 import { ActionsTable } from 'scenes/trends/viz/ActionsTable'
 import { ActionsPie } from 'scenes/trends/viz/ActionsPie'
 import { Paths } from 'scenes/paths/Paths'
-import { EllipsisOutlined, SaveOutlined } from '@ant-design/icons'
+import { EllipsisOutlined, SaveOutlined, EyeOutlined, MacCommandOutlined } from '@ant-design/icons'
 import { dashboardColorNames, dashboardColors } from 'lib/colors'
 import { useLongPress } from 'lib/hooks/useLongPress'
 import { usePrevious } from 'lib/hooks/usePrevious'
@@ -34,6 +34,8 @@ import {
 } from 'scenes/insights/EmptyStates'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 dayjs.extend(relativeTime)
 
@@ -146,6 +148,10 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
     },
 }
 
+const dashboardDiveLink = (dive_dashboard: number, dive_source_id: number): string => {
+    return combineUrl(`/dashboard/${dive_dashboard}`, { dive_source_id: dive_source_id.toString() }).url
+}
+
 export function DashboardItem({
     item,
     dashboardId,
@@ -168,6 +174,7 @@ export function DashboardItem({
     const [showSaveModal, setShowSaveModal] = useState(false)
     const { dashboards } = useValues(dashboardsModel)
     const { renameDashboardItem } = useActions(dashboardItemsModel)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const _type: DisplayedType =
         item.filters.insight === ViewType.RETENTION
@@ -333,66 +340,118 @@ export function DashboardItem({
                                     </Tooltip>
                                 ))}
                             {dashboardMode !== DashboardMode.Internal && (
-                                <Dropdown
-                                    overlayStyle={{ minWidth: 240, border: '1px solid var(--primary)' }}
-                                    placement="bottomRight"
-                                    trigger={['click']}
-                                    overlay={
-                                        <Menu
-                                            data-attr={'dashboard-item-' + index + '-dropdown-menu'}
-                                            style={{ padding: '12px 4px' }}
-                                        >
-                                            <Menu.Item data-attr={'dashboard-item-' + index + '-dropdown-view'}>
-                                                <Link to={link}>{viewText}</Link>
-                                            </Menu.Item>
-                                            <Menu.Item
-                                                data-attr={'dashboard-item-' + index + '-dropdown-refresh'}
-                                                onClick={() => {
-                                                    loadResults(true)
-                                                    reportDashboardItemRefreshed(item)
-                                                }}
+                                <>
+                                    {featureFlags[FEATURE_FLAGS.DIVE_DASHBOARDS] && (
+                                        <>
+                                            <Link to={link}>
+                                                <EyeOutlined /> View
+                                            </Link>
+                                            {typeof item.dive_dashboard === 'number' && (
+                                                <Link to={dashboardDiveLink(item.dive_dashboard, item.id)}>
+                                                    <MacCommandOutlined /> Dive
+                                                </Link>
+                                            )}
+                                        </>
+                                    )}
+                                    <Dropdown
+                                        overlayStyle={{ minWidth: 240, border: '1px solid var(--primary)' }}
+                                        placement="bottomRight"
+                                        trigger={['click']}
+                                        overlay={
+                                            <Menu
+                                                data-attr={'dashboard-item-' + index + '-dropdown-menu'}
+                                                style={{ padding: '12px 4px' }}
                                             >
-                                                <Tooltip
-                                                    placement="left"
-                                                    title={
-                                                        <i>
-                                                            Last updated:{' '}
-                                                            {item.last_refresh
-                                                                ? dayjs(item.last_refresh).fromNow()
-                                                                : 'recently'}
-                                                        </i>
-                                                    }
+                                                <Menu.Item data-attr={'dashboard-item-' + index + '-dropdown-view'}>
+                                                    <Link to={link}>{viewText}</Link>
+                                                </Menu.Item>
+                                                <Menu.Item
+                                                    data-attr={'dashboard-item-' + index + '-dropdown-refresh'}
+                                                    onClick={() => {
+                                                        loadResults(true)
+                                                        reportDashboardItemRefreshed(item)
+                                                    }}
                                                 >
-                                                    Refresh
-                                                </Tooltip>
-                                            </Menu.Item>
-                                            <Menu.Item
-                                                data-attr={'dashboard-item-' + index + '-dropdown-rename'}
-                                                onClick={() => renameDashboardItem(item)}
-                                            >
-                                                Rename
-                                            </Menu.Item>
-                                            {updateItemColor && (
-                                                <Menu.SubMenu
-                                                    data-attr={'dashboard-item-' + index + '-dropdown-color'}
-                                                    key="colors"
-                                                    title="Set Color"
+                                                    <Tooltip
+                                                        placement="left"
+                                                        title={
+                                                            <i>
+                                                                Last updated:{' '}
+                                                                {item.last_refresh
+                                                                    ? dayjs(item.last_refresh).fromNow()
+                                                                    : 'recently'}
+                                                            </i>
+                                                        }
+                                                    >
+                                                        Refresh
+                                                    </Tooltip>
+                                                </Menu.Item>
+                                                <Menu.Item
+                                                    data-attr={'dashboard-item-' + index + '-dropdown-rename'}
+                                                    onClick={() => renameDashboardItem(item)}
                                                 >
-                                                    {Object.entries(dashboardColorNames).map(
-                                                        ([itemClassName, itemColor], colorIndex) => (
+                                                    Rename
+                                                </Menu.Item>
+                                                {updateItemColor && (
+                                                    <Menu.SubMenu
+                                                        data-attr={'dashboard-item-' + index + '-dropdown-color'}
+                                                        key="colors"
+                                                        title="Set Color"
+                                                    >
+                                                        {Object.entries(dashboardColorNames).map(
+                                                            ([itemClassName, itemColor], colorIndex) => (
+                                                                <Menu.Item
+                                                                    key={itemClassName}
+                                                                    onClick={() =>
+                                                                        updateItemColor(item.id, itemClassName)
+                                                                    }
+                                                                    data-attr={
+                                                                        'dashboard-item-' +
+                                                                        index +
+                                                                        '-dropdown-color-' +
+                                                                        colorIndex
+                                                                    }
+                                                                >
+                                                                    <span
+                                                                        style={{
+                                                                            background: dashboardColors[itemClassName],
+                                                                            border: '1px solid #eee',
+                                                                            display: 'inline-block',
+                                                                            width: 13,
+                                                                            height: 13,
+                                                                            verticalAlign: 'middle',
+                                                                            marginRight: 5,
+                                                                            marginBottom: 1,
+                                                                        }}
+                                                                    />
+                                                                    {itemColor}
+                                                                </Menu.Item>
+                                                            )
+                                                        )}
+                                                    </Menu.SubMenu>
+                                                )}
+                                                {duplicateDashboardItem && otherDashboards.length > 0 && (
+                                                    <Menu.SubMenu
+                                                        data-attr={'dashboard-item-' + index + '-dropdown-copy'}
+                                                        key="copy"
+                                                        title="Copy to"
+                                                    >
+                                                        {otherDashboards.map((dashboard, copyIndex) => (
                                                             <Menu.Item
-                                                                key={itemClassName}
-                                                                onClick={() => updateItemColor(item.id, itemClassName)}
                                                                 data-attr={
                                                                     'dashboard-item-' +
                                                                     index +
-                                                                    '-dropdown-color-' +
-                                                                    colorIndex
+                                                                    '-dropdown-copy-' +
+                                                                    copyIndex
+                                                                }
+                                                                key={dashboard.id}
+                                                                onClick={() =>
+                                                                    duplicateDashboardItem(item, dashboard.id)
                                                                 }
                                                             >
                                                                 <span
                                                                     style={{
-                                                                        background: dashboardColors[itemClassName],
+                                                                        background: dashboardColors[className],
                                                                         border: '1px solid #eee',
                                                                         display: 'inline-block',
                                                                         width: 13,
@@ -402,100 +461,68 @@ export function DashboardItem({
                                                                         marginBottom: 1,
                                                                     }}
                                                                 />
-                                                                {itemColor}
-                                                            </Menu.Item>
-                                                        )
-                                                    )}
-                                                </Menu.SubMenu>
-                                            )}
-                                            {duplicateDashboardItem && otherDashboards.length > 0 && (
-                                                <Menu.SubMenu
-                                                    data-attr={'dashboard-item-' + index + '-dropdown-copy'}
-                                                    key="copy"
-                                                    title="Copy to"
-                                                >
-                                                    {otherDashboards.map((dashboard, copyIndex) => (
-                                                        <Menu.Item
-                                                            data-attr={
-                                                                'dashboard-item-' +
-                                                                index +
-                                                                '-dropdown-copy-' +
-                                                                copyIndex
-                                                            }
-                                                            key={dashboard.id}
-                                                            onClick={() => duplicateDashboardItem(item, dashboard.id)}
-                                                        >
-                                                            <span
-                                                                style={{
-                                                                    background: dashboardColors[className],
-                                                                    border: '1px solid #eee',
-                                                                    display: 'inline-block',
-                                                                    width: 13,
-                                                                    height: 13,
-                                                                    verticalAlign: 'middle',
-                                                                    marginRight: 5,
-                                                                    marginBottom: 1,
-                                                                }}
-                                                            />
-                                                            {dashboard.name}
-                                                        </Menu.Item>
-                                                    ))}
-                                                </Menu.SubMenu>
-                                            )}
-                                            {moveDashboardItem &&
-                                                (otherDashboards.length > 0 ? (
-                                                    <Menu.SubMenu
-                                                        data-attr={'dashboard-item-' + index + '-dropdown-move'}
-                                                        key="move"
-                                                        title="Move to"
-                                                    >
-                                                        {otherDashboards.map((dashboard, moveIndex) => (
-                                                            <Menu.Item
-                                                                data-attr={
-                                                                    'dashboard-item-' +
-                                                                    index +
-                                                                    '-dropdown-move-' +
-                                                                    moveIndex
-                                                                }
-                                                                key={dashboard.id}
-                                                                onClick={() => moveDashboardItem(item, dashboard.id)}
-                                                            >
                                                                 {dashboard.name}
                                                             </Menu.Item>
                                                         ))}
                                                     </Menu.SubMenu>
-                                                ) : null)}
-                                            {duplicateDashboardItem && (
+                                                )}
+                                                {moveDashboardItem &&
+                                                    (otherDashboards.length > 0 ? (
+                                                        <Menu.SubMenu
+                                                            data-attr={'dashboard-item-' + index + '-dropdown-move'}
+                                                            key="move"
+                                                            title="Move to"
+                                                        >
+                                                            {otherDashboards.map((dashboard, moveIndex) => (
+                                                                <Menu.Item
+                                                                    data-attr={
+                                                                        'dashboard-item-' +
+                                                                        index +
+                                                                        '-dropdown-move-' +
+                                                                        moveIndex
+                                                                    }
+                                                                    key={dashboard.id}
+                                                                    onClick={() =>
+                                                                        moveDashboardItem(item, dashboard.id)
+                                                                    }
+                                                                >
+                                                                    {dashboard.name}
+                                                                </Menu.Item>
+                                                            ))}
+                                                        </Menu.SubMenu>
+                                                    ) : null)}
+                                                {duplicateDashboardItem && (
+                                                    <Menu.Item
+                                                        data-attr={'dashboard-item-' + index + '-dropdown-duplicate'}
+                                                        onClick={() => duplicateDashboardItem(item)}
+                                                    >
+                                                        Duplicate
+                                                    </Menu.Item>
+                                                )}
                                                 <Menu.Item
-                                                    data-attr={'dashboard-item-' + index + '-dropdown-duplicate'}
-                                                    onClick={() => duplicateDashboardItem(item)}
+                                                    data-attr={'dashboard-item-' + index + '-dropdown-delete'}
+                                                    onClick={() =>
+                                                        deleteWithUndo({
+                                                            object: item,
+                                                            endpoint: 'insight',
+                                                            callback: loadDashboardItems,
+                                                        })
+                                                    }
+                                                    className="text-danger"
                                                 >
-                                                    Duplicate
+                                                    Delete
                                                 </Menu.Item>
-                                            )}
-                                            <Menu.Item
-                                                data-attr={'dashboard-item-' + index + '-dropdown-delete'}
-                                                onClick={() =>
-                                                    deleteWithUndo({
-                                                        object: item,
-                                                        endpoint: 'insight',
-                                                        callback: loadDashboardItems,
-                                                    })
-                                                }
-                                                className="text-danger"
-                                            >
-                                                Delete
-                                            </Menu.Item>
-                                        </Menu>
-                                    }
-                                >
-                                    <span
-                                        data-attr={'dashboard-item-' + index + '-dropdown'}
-                                        style={{ cursor: 'pointer', marginTop: -3 }}
+                                            </Menu>
+                                        }
                                     >
-                                        <EllipsisOutlined />
-                                    </span>
-                                </Dropdown>
+                                        <span
+                                            data-attr={'dashboard-item-' + index + '-dropdown'}
+                                            style={{ cursor: 'pointer', marginTop: -3 }}
+                                        >
+                                            <EllipsisOutlined />
+                                        </span>
+                                    </Dropdown>
+                                </>
                             )}
                         </div>
                     )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -495,6 +495,7 @@ export interface DashboardItemType {
     created_by: UserBasicType | null
     is_sample: boolean
     dashboard: number
+    dive_dashboard?: number
     result: any | null
     updated_at: string
     tags: string[]


### PR DESCRIPTION
## Changes

All flagged behind `hackathon-dive-dashboards`.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
