### PR TITLE
Setting the dive dashboard from dashboarditem

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -43,6 +43,7 @@ interface Props {
     item: DashboardItemType
     dashboardId?: number
     updateItemColor?: (id: number, itemClassName: string) => void
+    setDiveDashboard?: (id: number, dashboardId: number) => void
     loadDashboardItems?: () => void
     isDraggingRef?: RefObject<boolean>
     dashboardMode: DashboardMode | null
@@ -156,6 +157,7 @@ export function DashboardItem({
     item,
     dashboardId,
     updateItemColor,
+    setDiveDashboard,
     loadDashboardItems,
     isDraggingRef,
     dashboardMode,
@@ -428,6 +430,40 @@ export function DashboardItem({
                                                                 </Menu.Item>
                                                             )
                                                         )}
+                                                    </Menu.SubMenu>
+                                                )}
+                                                {featureFlags[FEATURE_FLAGS.DIVE_DASHBOARDS] && setDiveDashboard && (
+                                                    <Menu.SubMenu
+                                                        data-attr={'dashboard-item-' + index + '-dive-dashboard'}
+                                                        key="dive"
+                                                        title="Set Dive Dashboard"
+                                                    >
+                                                        {otherDashboards.map((dashboard, diveIndex) => (
+                                                            <Menu.Item
+                                                                data-attr={
+                                                                    'dashboard-item-' +
+                                                                    index +
+                                                                    '-dive-dashboard-' +
+                                                                    diveIndex
+                                                                }
+                                                                key={dashboard.id}
+                                                                onClick={() => setDiveDashboard(item.id, dashboard.id)}
+                                                            >
+                                                                <span
+                                                                    style={{
+                                                                        background: dashboardColors[className],
+                                                                        border: '1px solid #eee',
+                                                                        display: 'inline-block',
+                                                                        width: 13,
+                                                                        height: 13,
+                                                                        verticalAlign: 'middle',
+                                                                        marginRight: 5,
+                                                                        marginBottom: 1,
+                                                                    }}
+                                                                />
+                                                                {dashboard.name}
+                                                            </Menu.Item>
+                                                        ))}
                                                     </Menu.SubMenu>
                                                 )}
                                                 {duplicateDashboardItem && otherDashboards.length > 0 && (

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -15,9 +15,14 @@ const ReactGridLayout = WidthProvider(Responsive)
 
 export function DashboardItems(): JSX.Element {
     const { dashboard, items, layouts, layoutForItem, breakpoints, cols, dashboardMode } = useValues(dashboardLogic)
-    const { loadDashboardItems, updateLayouts, updateContainerWidth, updateItemColor, setDashboardMode } = useActions(
-        dashboardLogic
-    )
+    const {
+        loadDashboardItems,
+        updateLayouts,
+        updateContainerWidth,
+        updateItemColor,
+        setDashboardMode,
+        setDiveDashboard,
+    } = useActions(dashboardLogic)
     const { duplicateDashboardItem } = useActions(dashboardItemsModel)
 
     // make sure the dashboard takes up the right size
@@ -93,6 +98,7 @@ export function DashboardItems(): JSX.Element {
                             resizingItem?.i?.toString() === item.id.toString() ? resizingItem : layoutForItem[item.id]
                         }
                         loadDashboardItems={loadDashboardItems}
+                        setDiveDashboard={setDiveDashboard}
                         duplicateDashboardItem={duplicateDashboardItem}
                         moveDashboardItem={(it: DashboardItemType, dashboardId: number) =>
                             duplicateDashboardItem(it, dashboardId, true)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -33,6 +33,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
         updateContainerWidth: (containerWidth: number, columns: number) => ({ containerWidth, columns }),
         saveLayouts: true,
         updateItemColor: (id: number, color: string) => ({ id, color }),
+        setDiveDashboard: (id: number, dive_dashboard: number) => ({ id, dive_dashboard }),
         refreshAllDashboardItems: true,
         refreshAllDashboardItemsManual: true,
         resetInterval: true,
@@ -151,6 +152,12 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     return {
                         ...state,
                         items: state?.items.map((i) => (i.id === id ? { ...i, color } : i)),
+                    } as DashboardType
+                },
+                setDiveDashboard: (state, { id, dive_dashboard }) => {
+                    return {
+                        ...state,
+                        items: state?.items.map((i) => (i.id === id ? { ...i, dive_dashboard } : i)),
                     } as DashboardType
                 },
                 [dashboardItemsModel.actionTypes.duplicateDashboardItemSuccess]: (state, { item }): DashboardType => {
@@ -423,6 +430,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
         },
         updateItemColor: ({ id, color }) => {
             api.update(`api/insight/${id}`, { color })
+        },
+        setDiveDashboard: ({ id, dive_dashboard }) => {
+            api.update(`api/insight/${id}`, { dive_dashboard })
         },
         refreshAllDashboardItemsManual: () => {
             // reset auto refresh interval


### PR DESCRIPTION
Depends on https://github.com/PostHog/posthog/pull/5785

## Changes

Setting the dive dashboard similarly as dashboard color gets updated. There's currently no way to remove the dive dashboard (lower priority).

Tested that it works (notice the dive icon that appears in the end and didn't exist earlier that also went to the right dashboard as expected):
<img width="427" alt="Screen Shot 2021-09-02 at 04 16 18" src="https://user-images.githubusercontent.com/890921/131776109-0212a649-9f8a-4ba3-8b59-1f398d5e6f22.png">
<img width="466" alt="Screen Shot 2021-09-02 at 04 16 26" src="https://user-images.githubusercontent.com/890921/131776125-69c7552e-7387-4f2f-aa1e-96e6227c75ae.png">
<img width="415" alt="Screen Shot 2021-09-02 at 04 16 44" src="https://user-images.githubusercontent.com/890921/131776139-8d140d80-c47f-495c-8b0f-14fd69093b7a.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
