### PR TITLE
Add removal for dive dashboard link

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -43,7 +43,7 @@ interface Props {
     item: DashboardItemType
     dashboardId?: number
     updateItemColor?: (id: number, itemClassName: string) => void
-    setDiveDashboard?: (id: number, dashboardId?: number) => void
+    setDiveDashboard?: (id: number, dashboardId: number | null) => void
     loadDashboardItems?: () => void
     isDraggingRef?: RefObject<boolean>
     dashboardMode: DashboardMode | null

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -43,7 +43,7 @@ interface Props {
     item: DashboardItemType
     dashboardId?: number
     updateItemColor?: (id: number, itemClassName: string) => void
-    setDiveDashboard?: (id: number, dashboardId: number) => void
+    setDiveDashboard?: (id: number, dashboardId?: number) => void
     loadDashboardItems?: () => void
     isDraggingRef?: RefObject<boolean>
     dashboardMode: DashboardMode | null
@@ -436,7 +436,9 @@ export function DashboardItem({
                                                     <Menu.SubMenu
                                                         data-attr={'dashboard-item-' + index + '-dive-dashboard'}
                                                         key="dive"
-                                                        title="Set Dive Dashboard"
+                                                        title={`${
+                                                            !item.dive_dashboard ? 'Set' : 'Update'
+                                                        } Dive Dashboard`}
                                                     >
                                                         {otherDashboards.map((dashboard, diveIndex) => (
                                                             <Menu.Item
@@ -464,6 +466,16 @@ export function DashboardItem({
                                                                 {dashboard.name}
                                                             </Menu.Item>
                                                         ))}
+                                                        <Menu.Item
+                                                            data-attr={
+                                                                'dashboard-item-' + index + '-dive-dashboard-remove'
+                                                            }
+                                                            key="remove"
+                                                            onClick={() => setDiveDashboard(item.id, null)}
+                                                            className="text-danger"
+                                                        >
+                                                            Remove
+                                                        </Menu.Item>
                                                     </Menu.SubMenu>
                                                 )}
                                                 {duplicateDashboardItem && otherDashboards.length > 0 && (

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -33,7 +33,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
         updateContainerWidth: (containerWidth: number, columns: number) => ({ containerWidth, columns }),
         saveLayouts: true,
         updateItemColor: (id: number, color: string) => ({ id, color }),
-        setDiveDashboard: (id: number, dive_dashboard?: number) => ({ id, dive_dashboard }),
+        setDiveDashboard: (id: number, dive_dashboard: number | null) => ({ id, dive_dashboard }),
         refreshAllDashboardItems: true,
         refreshAllDashboardItemsManual: true,
         resetInterval: true,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -33,7 +33,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
         updateContainerWidth: (containerWidth: number, columns: number) => ({ containerWidth, columns }),
         saveLayouts: true,
         updateItemColor: (id: number, color: string) => ({ id, color }),
-        setDiveDashboard: (id: number, dive_dashboard: number) => ({ id, dive_dashboard }),
+        setDiveDashboard: (id: number, dive_dashboard?: number) => ({ id, dive_dashboard }),
         refreshAllDashboardItems: true,
         refreshAllDashboardItemsManual: true,
         resetInterval: true,


### PR DESCRIPTION
## Changes

<img width="481" alt="Screen Shot 2021-09-02 at 11 18 56" src="https://user-images.githubusercontent.com/890921/131827022-ac7b174f-4d0d-4e7d-bfd2-82957cdc6f98.png">
 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
