### PR TITLE
Make us write the linked dashboard to the db too

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -80,6 +80,7 @@ class InsightSerializer(InsightBasicSerializer):
             "order",
             "deleted",
             "dashboard",
+            "dive_dashboard",
             "layouts",
             "color",
             "last_refresh",


### PR DESCRIPTION
## Changes

Tested by refreshing after setting the dive dashboard, before it didn't persist, now it does.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
