### PR TITLE
Pass `dive_source_id` to the dashboard item api call

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -12,6 +12,7 @@ import { urls } from 'scenes/sceneLogic'
 export const dashboardsModel = kea<dashboardsModelType>({
     actions: () => ({
         delayedDeleteDashboard: (id: number) => ({ id }),
+        setDiveSourceId: (id: number | null) => ({ id }),
         setLastDashboardId: (id: number) => ({ id }),
         // this is moved out of dashboardLogic, so that you can click "undo" on a item move when already
         // on another dashboard - both dashboards can listen to and share this event, even if one is not yet mounted
@@ -139,6 +140,13 @@ export const dashboardsModel = kea<dashboardsModelType>({
                 setLastDashboardId: (_, { id }) => id,
             },
         ],
+        diveSourceId: [
+            null as null | number,
+            { persist: true },
+            {
+                setDiveSourceId: (_, { id }) => id,
+            },
+        ],
     },
 
     selectors: ({ selectors }) => ({
@@ -211,9 +219,14 @@ export const dashboardsModel = kea<dashboardsModelType>({
     }),
 
     urlToAction: ({ actions }) => ({
-        '/dashboard/:id': ({ id }) => {
+        '/dashboard/:id': ({ id }, { dive_source_id: diveSourceId }) => {
             if (id) {
                 actions.setLastDashboardId(parseInt(id))
+            }
+            if (diveSourceId !== undefined && diveSourceId !== null) {
+                actions.setDiveSourceId(diveSourceId)
+            } else {
+                actions.setDiveSourceId(null)
             }
         },
     }),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -24,7 +24,10 @@ export const dashboardLogic = kea<dashboardLogicType>({
 
     actions: {
         addNewDashboard: true,
-        loadDashboardItems: ({ refresh }: { refresh?: boolean } = {}) => ({ refresh }),
+        loadDashboardItems: ({ refresh, dive_source_id }: { refresh?: boolean; dive_source_id?: number } = {}) => ({
+            refresh,
+            dive_source_id,
+        }),
         triggerDashboardUpdate: (payload) => ({ payload }),
         setIsSharedDashboard: (id: number, isShared: boolean) => ({ id, isShared }), // whether the dashboard is shared or not
         // dashboardMode represents the current state in which the dashboard is being viewed (:TODO: move definitions to TS)
@@ -55,10 +58,17 @@ export const dashboardLogic = kea<dashboardLogicType>({
         allItems: [
             null as DashboardType | null,
             {
-                loadDashboardItems: async ({ refresh }: { refresh?: boolean } = {}) => {
+                loadDashboardItems: async ({
+                    refresh,
+                    dive_source_id,
+                }: { refresh?: boolean; dive_source_id?: number } = {}) => {
                     try {
                         const dashboard = await api.get(
-                            `api/dashboard/${props.id}/?${toParams({ share_token: props.shareToken, refresh })}`
+                            `api/dashboard/${props.id}/?${toParams({
+                                share_token: props.shareToken,
+                                refresh,
+                                dive_source_id,
+                            })}`
                         )
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
                         eventUsageLogic.actions.reportDashboardViewed(dashboard, !!props.shareToken)
@@ -368,7 +378,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
     }),
     events: ({ actions, cache, props }) => ({
         afterMount: () => {
-            actions.loadDashboardItems({ refresh: props.internal })
+            actions.loadDashboardItems({ refresh: props.internal, dive_source_id: dashboardsModel.values.diveSourceId })
             if (props.shareToken) {
                 actions.setDashboardMode(
                     props.internal ? DashboardMode.Internal : DashboardMode.Public,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -378,7 +378,10 @@ export const dashboardLogic = kea<dashboardLogicType>({
     }),
     events: ({ actions, cache, props }) => ({
         afterMount: () => {
-            actions.loadDashboardItems({ refresh: props.internal, dive_source_id: dashboardsModel.values.diveSourceId })
+            actions.loadDashboardItems({
+                refresh: props.internal,
+                dive_source_id: dashboardsModel.values.diveSourceId ?? undefined,
+            })
             if (props.shareToken) {
                 actions.setDashboardMode(
                     props.internal ? DashboardMode.Internal : DashboardMode.Public,


### PR DESCRIPTION
## Changes

Pass the dive source dashboard item id to the appropriate API call.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
