### PR TITLE
Add feature to copy dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -5,6 +5,7 @@ import { useActions, useValues } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { ShareModal } from './ShareModal'
 import {
+    CopyOutlined,
     PushpinFilled,
     PushpinOutlined,
     EllipsisOutlined,
@@ -36,7 +37,7 @@ export function DashboardHeader(): JSX.Element {
     )
     const { dashboardTags } = useValues(dashboardsLogic)
     const { dashboards, dashboardsLoading, dashboardLoading } = useValues(dashboardsModel)
-    const { pinDashboard, unpinDashboard, deleteDashboard } = useActions(dashboardsModel)
+    const { copyDashboard, pinDashboard, unpinDashboard, deleteDashboard } = useActions(dashboardsModel)
     const { user } = useValues(userLogic)
     const [newName, setNewName] = useState(dashboard?.name || null) // Used to update the input immediately, debouncing API calls
 
@@ -97,6 +98,9 @@ export function DashboardHeader(): JSX.Element {
                         )}
 
                         <Menu.Divider />
+                        <Menu.Item icon={<CopyOutlined />} onClick={() => copyDashboard(dashboard.id)}>
+                            Copy dashboard
+                        </Menu.Item>
                         <Menu.Item
                             icon={<DeleteOutlined />}
                             onClick={() => deleteDashboard({ id: dashboard.id, redirect: true })}

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -4,7 +4,14 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { Button, Card, Col, Drawer, Row, Spin, Table } from 'antd'
 import { dashboardsLogic } from 'scenes/dashboard/dashboardsLogic'
 import { Link } from 'lib/components/Link'
-import { AppstoreAddOutlined, DeleteOutlined, PlusOutlined, PushpinFilled, PushpinOutlined } from '@ant-design/icons'
+import {
+    AppstoreAddOutlined,
+    CopyOutlined,
+    DeleteOutlined,
+    PlusOutlined,
+    PushpinFilled,
+    PushpinOutlined,
+} from '@ant-design/icons'
 import { NewDashboard } from 'scenes/dashboard/NewDashboard'
 import { PageHeader } from 'lib/components/PageHeader'
 import { createdAtColumn, createdByColumn } from 'lib/components/Table/Table'
@@ -17,7 +24,7 @@ import { urls } from 'scenes/sceneLogic'
 
 export function Dashboards(): JSX.Element {
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard } = useActions(dashboardsModel)
+    const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard, copyDashboard } = useActions(dashboardsModel)
     const { setNewDashboardDrawer } = useActions(dashboardsLogic)
     const { dashboards, newDashboardDrawer, dashboardTags } = useValues(dashboardsLogic)
     const { user } = useValues(userLogic)
@@ -101,12 +108,17 @@ export function Dashboards(): JSX.Element {
             width: 120,
             render: function RenderActions({ id }: DashboardType) {
                 return (
-                    <span
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => deleteDashboard({ id, redirect: false })}
-                        className="text-danger"
-                    >
-                        <DeleteOutlined />
+                    <span>
+                        <span style={{ cursor: 'pointer', marginRight: 16 }} onClick={() => copyDashboard(id)}>
+                            <CopyOutlined />
+                        </span>
+                        <span
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => deleteDashboard({ id, redirect: false })}
+                            className="text-danger"
+                        >
+                            <DeleteOutlined />
+                        </span>
                     </span>
                 )
             },


### PR DESCRIPTION
First time working with OSS/this repo, thanks for your patience!

## Changes

Closes #1688 by adding ability to clone dashboards from list and dashboard view.

List view:
![image](https://user-images.githubusercontent.com/19638700/131950829-c42c5dd0-6e2d-4212-bb77-bc5854c04d0d.png)

Dashboard view:
![image](https://user-images.githubusercontent.com/19638700/131950823-db11bced-3294-4eeb-bfd3-564c63c2eded.png)

## Checklist

- [x] All querysets/queries filter by Organization, by Team, and by User (no modified queries)
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [x] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious (no modified migrations)
- [x] New/changed UI is decent on smartphones (viewport width around 360px)
![screencapture-localhost-8000-dashboard-2021-09-02-22_20_54](https://user-images.githubusercontent.com/19638700/131954525-3e95a0b5-ebad-4ebe-91ca-4d2999067e74.png)

## Help please!

Am having some trouble running `./bin/tests`... I'm getting:

```
(env) ➜  posthog git:(clone-dashboards) bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user

psql: error: could not connect to server: Connection refused
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
```

I think it's because I'm running postgres from Docker container? Any advice would be much appreciated!