### PR TITLE
Fix uses_elements_chain

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -113,14 +113,14 @@ def get_action_tables_and_properties(action: Action) -> Set[Tuple[PropertyName, 
     for action_step in action.steps.all():
         if action_step.url:
             result.add(("$current_url", "event"))
-        result |= extract_tables_and_properties(Filter(data={"properties": action_step.properties}).properties)
+        result |= extract_tables_and_properties(Filter(data={"properties": action_step.properties or []}).properties)
 
     return result
 
 
 def uses_elements_chain(action: Action) -> bool:
     for action_step in action.steps.all():
-        if any(Property(**prop).type == "element" for prop in action_step.properties):
+        if any(Property(**prop).type == "element" for prop in (action_step.properties or [])):
             return True
         if any(getattr(action_step, attribute) is not None for attribute in ["selector", "tag_name", "href", "text"]):
             return True


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5808

I'd love to fix this at the schema level but looked into it for ~20
minutes and it didn't seem like there's a pretty solution that allows to
pass `None` to .objects.create and for the default to be used.

Other solutions would be even more invasive and require manipulating
serializers.

Best leave this to when we refactor all of out `properties` JSONFields
since they all have this issue

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
