### PR TITLE
Fix issue with person breakdowns and clashing params

### DIFF
--- a/ee/clickhouse/models/entity.py
+++ b/ee/clickhouse/models/entity.py
@@ -23,7 +23,7 @@ def get_entity_filtering_params(
             team_id,
             table_name=table_name,
             person_properties_column=person_properties_column,
-            prepend=f"e_{entity.index}",
+            prepend=f"entity",
         )
     if entity.type == TREND_FILTER_TYPE_ACTIONS:
         action = entity.get_action()

--- a/ee/clickhouse/models/entity.py
+++ b/ee/clickhouse/models/entity.py
@@ -19,7 +19,11 @@ def get_entity_filtering_params(
     prop_filters = ""
     if with_prop_filters:
         prop_filters, params = parse_prop_clauses(
-            entity.properties, team_id, table_name=table_name, person_properties_column=person_properties_column
+            entity.properties,
+            team_id,
+            table_name=table_name,
+            person_properties_column=person_properties_column,
+            prepend=f"e_{entity.index}",
         )
     if entity.type == TREND_FILTER_TYPE_ACTIONS:
         action = entity.get_action()

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -495,6 +495,7 @@ AUTH_PASSWORD_VALIDATORS = [
 SHELL_PLUS_PRINT_SQL = get_from_env("PRINT_SQL", False, type_cast=str_to_bool)
 SHELL_PLUS_POST_IMPORTS = [
     ("posthog.models.filters", ("Filter",)),
+    ("posthog.models.property", ("Property",)),
 ]
 
 if PRIMARY_DB == RDBMS.CLICKHOUSE:


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5814

Another PR https://github.com/PostHog/posthog/pull/5807 also fixes this
(incidentally) but this fix won't hurt it + adds a regression test.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
