### PR TITLE
Add test for defining both a start and end point for path

### DIFF
--- a/ee/clickhouse/queries/paths/paths.py
+++ b/ee/clickhouse/queries/paths/paths.py
@@ -91,8 +91,10 @@ class ClickhousePathsNew:
     def get_target_point_filter(self) -> str:
         if self._filter.end_point and self._filter.start_point:
             return "WHERE start_target_index > 0 AND end_target_index > 0"
-        else:
+        elif self._filter.end_point or self._filter.start_point:
             return f"WHERE target_index > 0"
+        else:
+            return ""
 
     def get_target_clause(self) -> Tuple[str, Dict]:
         params: Dict[str, Union[str, None]] = {"target_point": None, "secondary_target_point": None}

--- a/ee/clickhouse/queries/paths/paths.py
+++ b/ee/clickhouse/queries/paths/paths.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -90,7 +90,7 @@ class ClickhousePathsNew:
 
     def get_target_point_filter(self) -> Tuple[str, Dict]:
         conditions = []
-        params = {"target_point": None}
+        params: Dict[str, Union[str, None]] = {"target_point": None}
 
         if self._filter.end_point and self._filter.start_point:
             conditions.append("arrayElement(limited_path, -1) = %(target_point)s")

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -879,7 +879,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
         filter = PathFilter(
             data={
                 "path_type": "$pageview",
-                "start_point": "/2",
+                "start_point": "/5",
                 "end_point": "/about",
                 "date_from": "2021-05-01 00:00:00",
                 "date_to": "2021-05-07 00:00:00",
@@ -887,14 +887,5 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
         )
         response = ClickhousePathsNew(team=self.team, filter=filter).run(team=self.team, filter=filter,)
         self.assertEqual(
-            response,
-            [
-                {"source": "1_/2", "target": "2_/3", "value": 1, "average_conversion_time": 60000.0},
-                {"source": "1_/3", "target": "2_/4", "value": 1, "average_conversion_time": 60000.0},
-                {"source": "1_/5", "target": "2_/about", "value": 1, "average_conversion_time": 60000.0},
-                {"source": "2_/3", "target": "3_/4", "value": 1, "average_conversion_time": 60000.0},
-                {"source": "2_/4", "target": "3_/about", "value": 1, "average_conversion_time": 60000.0},
-                {"source": "3_/4", "target": "4_/5", "value": 1, "average_conversion_time": 60000.0},
-                {"source": "4_/5", "target": "5_/about", "value": 1, "average_conversion_time": 60000.0},
-            ],
+            response, [{"source": "1_/5", "target": "2_/about", "value": 2, "average_conversion_time": 60000.0}]
         )

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -776,3 +776,125 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
                 {"source": "2_/2", "target": "3_/3", "value": 2, "average_conversion_time": 3 * ONE_MINUTE},
             ],
         )
+
+    @test_with_materialized_columns(["$current_url"])
+    def test_paths_start_and_end(self):
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"])
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:01:00",
+        )
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:02:00",
+        )
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:03:00",
+        )
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:04:00",
+        )
+        _create_event(
+            properties={"$current_url": "/5"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:05:00",
+        )
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:06:00",
+        )
+        _create_event(
+            properties={"$current_url": "/after"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:07:00",
+        )
+
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_2"])
+        _create_event(
+            properties={"$current_url": "/5"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:01:00",
+        )
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:02:00",
+        )
+
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_3"])
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:01:00",
+        )
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:02:00",
+        )
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:03:00",
+        )
+        _create_event(
+            properties={"$current_url": "/after"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:04:00",
+        )
+
+        filter = PathFilter(
+            data={
+                "path_type": "$pageview",
+                "start_point": "/2",
+                "end_point": "/about",
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+            }
+        )
+        response = ClickhousePathsNew(team=self.team, filter=filter).run(team=self.team, filter=filter,)
+        self.assertEqual(
+            response,
+            [
+                {"source": "1_/2", "target": "2_/3", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "1_/3", "target": "2_/4", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "1_/5", "target": "2_/about", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "2_/3", "target": "3_/4", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "2_/4", "target": "3_/about", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "3_/4", "target": "4_/5", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "4_/5", "target": "5_/about", "value": 1, "average_conversion_time": 60000.0},
+            ],
+        )

--- a/ee/clickhouse/sql/paths/path.py
+++ b/ee/clickhouse/sql/paths/path.py
@@ -168,11 +168,7 @@ FROM (
                     , arrayMap((x,y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping
                     , arrayFilter((x,y) -> y, time, mapping) as timings
                     , arrayFilter((x,y)->y, path_basic, mapping) as compact_path
-                    , indexOf(compact_path, %(target_point)s) as target_index
-                    , if(target_index > 0, {compacting_function}(compact_path, target_index), compact_path) as filtered_path
-                    , if(target_index > 0, {compacting_function}(timings, target_index), timings) as filtered_timings
-                    , {path_limiting_clause} as limited_path
-                    , {time_limiting_clause} as limited_timings
+                    {target_clause}
                     , arrayDifference(limited_timings) as timings_diff
                     , arrayZip(limited_path, timings_diff) as limited_path_timings
                 FROM (


### PR DESCRIPTION
## Changes

*Please describe.*  
- start and endpoint already work together 
- add test to ensure that paths will work when start and end point are both provided
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
