### PR TITLE
Closes #4987 sets page title to dashboard name whenever a dashboard is visited

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -37,10 +37,7 @@ describe('Dashboard', () => {
             .then((link) => {
                 cy.wait(200)
                 cy.visit(link)
-                cy.get('[data-attr=dashboard-item-title]').should(
-                    'contain',
-                    'Installed App -> Rated App -> Rated App 5 Stars'
-                )
+                cy.get('[data-attr=dashboard-item-title]').should('contain', 'App Analytics')
             })
     })
 

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import { toast } from 'react-toastify'
 import { dashboardsModelType } from './dashboardsModelType'
 import { DashboardItemType, DashboardType } from '~/types'
-import { urls } from 'scenes/sceneLogic'
+import { sceneLogic, urls } from 'scenes/sceneLogic'
 
 export const dashboardsModel = kea<dashboardsModelType>({
     actions: () => ({
@@ -83,10 +83,7 @@ export const dashboardsModel = kea<dashboardsModelType>({
                         payload[updatedAttribute].length
                     )
                     if (updatedAttribute === 'name') {
-                        const title = payload[updatedAttribute]
-                        if (title !== '' || title !== undefined) {
-                            document.title = 'Dashboard : ' + title
-                        }
+                        sceneLogic.actions.setPageTitle(response.name ? `${response.name} • Dashboard` : 'Dashboard')
                     }
                 }
                 return response

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -82,6 +82,12 @@ export const dashboardsModel = kea<dashboardsModelType>({
                         values.rawDashboards[id]?.[updatedAttribute]?.length || 0,
                         payload[updatedAttribute].length
                     )
+                    if (updatedAttribute === 'name') {
+                        const title = payload[updatedAttribute]
+                        if (title !== '' || title !== undefined) {
+                            document.title = 'Dashboard : ' + title
+                        }
+                    }
                 }
                 return response
             },

--- a/frontend/src/scenes/dashboard/SharedDashboard.tsx
+++ b/frontend/src/scenes/dashboard/SharedDashboard.tsx
@@ -27,7 +27,9 @@ ReactDOM.render(
                     </a>
                 </Col>
                 <Col sm={10} xs={24} style={{ padding: '1rem' }}>
-                    <h1 style={{ textAlign: 'center' }}>{dashboard.name}</h1>
+                    <h1 style={{ textAlign: 'center' }} data-attr="dashboard-item-title">
+                        {dashboard.name}
+                    </h1>
                 </Col>
                 <Col sm={7} xs={0} style={{ padding: '1rem', textAlign: 'right' }}>
                     <span style={{ paddingTop: 15, display: 'inline-block' }}>{dashboard.team_name}</span>

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -52,6 +52,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
         setAutoRefresh: (enabled: boolean, interval: number) => ({ enabled, interval }),
         setRefreshStatus: (id: number, loading = false) => ({ id, loading }), // id represents dashboardItem id's
         setRefreshError: (id: number) => ({ id }),
+        setTitle: (title: string) => ({ title }),
     },
 
     loaders: ({ actions, props }) => ({
@@ -71,6 +72,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             })}`
                         )
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
+                        actions.setTitle(dashboard.name)
                         eventUsageLogic.actions.reportDashboardViewed(dashboard, !!props.shareToken)
                         return dashboard
                     } catch (error) {
@@ -559,6 +561,11 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 cache.autoRefreshInterval = window.setInterval(() => {
                     actions.refreshAllDashboardItems()
                 }, values.autoRefresh.interval * 1000)
+            }
+        },
+        setTitle: ({ title }) => {
+            if (title !== '' || title !== undefined) {
+                document.title = 'Dashboard : ' + title
             }
         },
     }),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -12,6 +12,7 @@ import { DashboardLayoutSize, DashboardMode, DashboardType, FilterType, ViewType
 import { dashboardLogicType } from './dashboardLogicType'
 import React from 'react'
 import { Layout, Layouts } from 'react-grid-layout'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 export const AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 300
 
@@ -52,7 +53,6 @@ export const dashboardLogic = kea<dashboardLogicType>({
         setAutoRefresh: (enabled: boolean, interval: number) => ({ enabled, interval }),
         setRefreshStatus: (id: number, loading = false) => ({ id, loading }), // id represents dashboardItem id's
         setRefreshError: (id: number) => ({ id }),
-        setTitle: (title: string) => ({ title }),
     },
 
     loaders: ({ actions, props }) => ({
@@ -72,7 +72,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             })}`
                         )
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
-                        actions.setTitle(dashboard.name)
+                        sceneLogic.actions.setPageTitle(dashboard.name ? `${dashboard.name} • Dashboard` : 'Dashboard')
                         eventUsageLogic.actions.reportDashboardViewed(dashboard, !!props.shareToken)
                         return dashboard
                     } catch (error) {
@@ -561,11 +561,6 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 cache.autoRefreshInterval = window.setInterval(() => {
                     actions.refreshAllDashboardItems()
                 }, values.autoRefresh.interval * 1000)
-            }
-        },
-        setTitle: ({ title }) => {
-            if (title !== '' || title !== undefined) {
-                document.title = 'Dashboard : ' + title
             }
         },
     }),

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -264,6 +264,7 @@ export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneCo
         showUpgradeModal: (featureName: string, featureCaption: string) => ({ featureName, featureCaption }),
         hideUpgradeModal: true,
         takeToPricing: true,
+        setPageTitle: (title: string) => ({ title }),
     },
     reducers: {
         scene: [
@@ -342,7 +343,7 @@ export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneCo
         },
         setScene: () => {
             posthog.capture('$pageview')
-            document.title = values.scene ? `${identifierToHuman(values.scene)} • PostHog` : 'PostHog'
+            actions.setPageTitle(identifierToHuman(values.scene || ''))
         },
         openScene: ({ scene, params }) => {
             const sceneConfig = sceneConfigurations[scene] || {}
@@ -480,6 +481,9 @@ export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneCo
                 await delay(500)
                 unmount()
             }
+        },
+        setPageTitle: ({ title }) => {
+            document.title = title ? `${title} • PostHog` : 'PostHog'
         },
     }),
 })


### PR DESCRIPTION
Fixes #4987 

Issue 4987 is among starter issues to tackle.
I believe this should take care of setting page title as the name of the dashboard.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

![Screenshot from 2021-09-07 04-07-03](https://user-images.githubusercontent.com/7192261/132263898-d8559ae4-2ec9-4a61-998b-c7b83c35737a.png)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
