### PR TITLE
Actually disable stale bot for issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,4 @@
-name: 'Handle stale issues and PRs'
+name: 'Handle stale PRs'
 on:
     schedule:
         - cron: '30 7 * * 1-5'
@@ -9,7 +9,7 @@ jobs:
         steps:
             - uses: actions/stale@v4
               with:
-                  only: pulls
+                  days-before-issue-stale: 9999
                   stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week."
                   close-pr-message: 'This PR was closed due to 2 weeks of inactivity. Feel free to reopen it if still relevant.'
                   days-before-pr-stale: 7


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog/pull/5324 didn't actually work, since `only` is not a valid parameter, so the bot kept closing issues.
