### PR TITLE
Deploy storybook.posthog.net

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -1,14 +1,14 @@
 # .github/workflows/chromatic.yml
 
 # Workflow name
-name: 'Chromatic'
+name: 'Storybook Chromatic'
 
 # Event for the workflow
 on: push
 
 # List of jobs
 jobs:
-    chromatic-deployment:
+    storybook-chromatic:
         # Operating System
         runs-on: ubuntu-latest
         # Job steps

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,0 +1,47 @@
+# .github/workflows/chromatic.yml
+
+# Workflow name
+name: 'Storybook Deployment'
+
+# Event for the workflow
+on:
+    push:
+        branches:
+            - master
+            - main
+            - storybook-build
+
+# List of jobs
+jobs:
+    storybook-deployment:
+        # Operating System
+        runs-on: ubuntu-latest
+        # Job steps
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v2
+              with:
+                  path: posthog
+                  fetch-depth: 0
+            - name: Check out storybook build repo
+              uses: actions/checkout@v2
+              with:
+                  path: storybook-build
+                  repository: PostHog/storybook-build
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+            - uses: actions/checkout@v1
+            - name: Install dependencies (yarn)
+              run: |
+                  cd posthog
+                  yarn
+            - name: Build storybook
+              run: |
+                  cd posthog
+                  yarn build-storybook
+            - name: Publish changes
+              run: |
+                  cp -a posthog/storybook-static storybook-build/docs
+                  cd storybook-build
+                  git add .
+                  git commit -m "Storybook build - $GITHUB_SHA"
+                  git push

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -21,34 +21,27 @@ jobs:
             - name: Check out PostHog/posthog repo
               uses: actions/checkout@v2
               with:
-                  path: posthog
                   fetch-depth: 0
             - name: Check out PostHog/storybook-build repo
               uses: actions/checkout@v2
               with:
-                  path: storybook-build
+                  path: ../storybook-build
                   repository: PostHog/storybook-build
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - uses: actions/checkout@v1
             - name: Install dependencies (yarn)
               run: |
-                  pwd
-                  cd posthog
-                  pwd
                   yarn
             - name: Build storybook
               run: |
-                  pwd
-                  cd posthog
-                  pwd
                   yarn build-storybook
             - name: Publish changes to PostHog/storybook-build repo
               run: |
                   pwd
-                  ls posthog
-                  ls posthog/storybook-static
-                  cp -a posthog/storybook-static storybook-build/docs
-                  cd storybook-build
+                  ls
+                  cp -a storybook-static ../storybook-build/docs
+                  cd ../storybook-build
+                  pwd
                   git add .
                   git commit -m "Storybook build - $GITHUB_SHA"
                   git push

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -32,14 +32,19 @@ jobs:
             - uses: actions/checkout@v1
             - name: Install dependencies (yarn)
               run: |
+                  pwd
                   cd posthog
+                  pwd
                   yarn
             - name: Build storybook
               run: |
+                  pwd
                   cd posthog
+                  pwd
                   yarn build-storybook
             - name: Publish changes
               run: |
+                  cd
                   pwd
                   ls
                   ls posthog

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -22,26 +22,21 @@ jobs:
               uses: actions/checkout@v2
               with:
                   fetch-depth: 0
+            - uses: actions/checkout@v1
+            - name: Install dependencies (yarn)
+              run: yarn
+            - name: Build storybook
+              run: yarn build-storybook
             - name: Check out PostHog/storybook-build repo
               uses: actions/checkout@v2
               with:
-                  path: ../storybook-build
+                  path: storybook-build
                   repository: PostHog/storybook-build
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
-            - uses: actions/checkout@v1
-            - name: Install dependencies (yarn)
-              run: |
-                  yarn
-            - name: Build storybook
-              run: |
-                  yarn build-storybook
             - name: Publish changes to PostHog/storybook-build repo
               run: |
-                  pwd
-                  ls
-                  cp -a storybook-static ../storybook-build/docs
-                  cd ../storybook-build
-                  pwd
+                  cp -a storybook-static storybook-build/docs
+                  cd storybook-build
                   git add .
                   git commit -m "Storybook build - $GITHUB_SHA"
                   git push

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -9,7 +9,6 @@ on:
         branches:
             - master
             - main
-            - storybook-build
 
 # List of jobs
 jobs:

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -33,10 +33,16 @@ jobs:
                   path: storybook-build
                   repository: PostHog/storybook-build
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
-            - name: Publish changes to PostHog/storybook-build repo
+            - name: Copy built changes to PostHog/storybook-build repo
               run: |
+                  rm -rf storybook-build/docs
                   cp -a storybook-static storybook-build/docs
-                  cd storybook-build
-                  git add .
-                  git commit -m "Storybook build - $GITHUB_SHA"
-                  git push
+            - name: Commit update
+              if: github.repository == 'PostHog/posthog'
+              uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                  repository: storybook-build
+                  commit_message: 'Storybook build - $GITHUB_SHA'
+                  commit_user_name: PostHog Bot
+                  commit_user_email: hey@posthog.com
+                  commit_author: PostHog Bot <hey@posthog.com>

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -9,6 +9,7 @@ on:
         branches:
             - master
             - main
+            - storybook-build
 
 # List of jobs
 jobs:
@@ -20,12 +21,12 @@ jobs:
             - name: Check out PostHog/posthog repo
               uses: actions/checkout@v2
               with:
+                  path: posthog
                   fetch-depth: 0
-            - uses: actions/checkout@v1
             - name: Install dependencies (yarn)
-              run: yarn
+              run: cd posthog && yarn
             - name: Build storybook
-              run: yarn build-storybook
+              run: cd posthog && yarn build-storybook
             - name: Check out PostHog/storybook-build repo
               uses: actions/checkout@v2
               with:
@@ -35,9 +36,9 @@ jobs:
             - name: Copy built changes to PostHog/storybook-build repo
               run: |
                   # keep the CNAME file, but discard all the rest
-                  cp storybook-build/docs/CNAME storybook-static/
+                  cp storybook-build/docs/CNAME posthog/storybook-static/
                   rm -rf storybook-build/docs
-                  cp -a storybook-static storybook-build/docs
+                  cp -a posthog/storybook-static storybook-build/docs
             - name: Commit update
               if: github.repository == 'PostHog/posthog'
               uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -18,12 +18,12 @@ jobs:
         runs-on: ubuntu-latest
         # Job steps
         steps:
-            - name: Check out the repo
+            - name: Check out PostHog/posthog repo
               uses: actions/checkout@v2
               with:
                   path: posthog
                   fetch-depth: 0
-            - name: Check out storybook build repo
+            - name: Check out PostHog/storybook-build repo
               uses: actions/checkout@v2
               with:
                   path: storybook-build
@@ -42,12 +42,11 @@ jobs:
                   cd posthog
                   pwd
                   yarn build-storybook
-            - name: Publish changes
+            - name: Publish changes to PostHog/storybook-build repo
               run: |
-                  cd
                   pwd
-                  ls
                   ls posthog
+                  ls posthog/storybook-static
                   cp -a posthog/storybook-static storybook-build/docs
                   cd storybook-build
                   git add .

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -9,6 +9,7 @@ on:
         branches:
             - master
             - main
+            - storybook-build
 
 # List of jobs
 jobs:
@@ -34,6 +35,8 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Copy built changes to PostHog/storybook-build repo
               run: |
+                  # keep the CNAME file, but discard all the rest
+                  cp storybook-build/docs/CNAME storybook-static/
                   rm -rf storybook-build/docs
                   cp -a storybook-static storybook-build/docs
             - name: Commit update
@@ -41,7 +44,7 @@ jobs:
               uses: stefanzweifel/git-auto-commit-action@v4
               with:
                   repository: storybook-build
-                  commit_message: 'Storybook build - $GITHUB_SHA'
+                  commit_message: 'Storybook build'
                   commit_user_name: PostHog Bot
                   commit_user_email: hey@posthog.com
                   commit_author: PostHog Bot <hey@posthog.com>

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -40,6 +40,9 @@ jobs:
                   yarn build-storybook
             - name: Publish changes
               run: |
+                  pwd
+                  ls
+                  ls posthog
                   cp -a posthog/storybook-static storybook-build/docs
                   cd storybook-build
                   git add .

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ docker-compose.prod.yml
 .python-version
 *.isorted
 build-storybook.log
+storybook-static

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ const { createEntry } = require('../webpack.config')
 const babelConfig = require('../babel.config')
 
 module.exports = {
-    stories: ['../frontend/src/**/*.stories.@(js|jsx|ts|tsx)'],
+    stories: ['../frontend/src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
     addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
     babel: async (options) => {
         // compile babel to "defaults" target (ES5)

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,6 +14,11 @@ export const parameters = {
             date: /Date$/,
         },
     },
+
+    options: {
+        // opt in to panels in your story by overridding `export const parameters`
+        showPanel: false,
+    },
 }
 
 export const decorators = []

--- a/frontend/src/Storybook.stories.mdx
+++ b/frontend/src/Storybook.stories.mdx
@@ -2,32 +2,40 @@ import { Meta } from '@storybook/addon-docs';
 
 <Meta title="Welcome" />
 
-<style>{`
-  .subheading {
-    --mediumdark: '#999999';
-    font-weight: 900;
-    font-size: 13px;
-    color: #999;
-    letter-spacing: 6px;
-    line-height: 24px;
-    text-transform: uppercase;
-    margin-bottom: 12px;
-    margin-top: 40px;
-  }
-
-`}</style>
-
 # Welcome to Storybook
 
 We'll be showcasing what the PostHog app can do inside this Storybook, and using it to track the difference between designed and
 implemented product decisions.
 
-<div className="subheading">How to create stories</div>
+## How to create stories
 
 While developing, run `getReduxState()` inside the JS console and save the object as a `.json` file. Then follow what
 the other `*.stories.tsx` files do.
 
-<div className="subheading">Fun story: PostHog Onboarding Story</div>
+```tsx
+// Signup.stories.tsx
+import React from 'react'
+import { ComponentMeta } from '@storybook/react'
+import { KeaStory } from 'lib/storybook/kea-story'
+
+import { Signup } from '../Signup'
+
+import signup from './signup.json'
+
+export default {
+    title: 'PostHog/Onboarding/2 Signup',
+    component: Signup,
+} as ComponentMeta<typeof Signup>
+
+export const Initial = (): JSX.Element => (
+    <KeaStory state={signup}>
+        <Signup />
+    </KeaStory>
+)
+
+```
+
+## Fun story: PostHog Onboarding Story
 
 For a fun story, check out [The Self-Hosted Onboarding Flow](/story/posthog-onboarding-1-preflight--initial), where a user
 has to go through three different designs before reaching the app they came for!

--- a/frontend/src/Storybook.stories.mdx
+++ b/frontend/src/Storybook.stories.mdx
@@ -1,0 +1,34 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Welcome" />
+
+<style>{`
+  .subheading {
+    --mediumdark: '#999999';
+    font-weight: 900;
+    font-size: 13px;
+    color: #999;
+    letter-spacing: 6px;
+    line-height: 24px;
+    text-transform: uppercase;
+    margin-bottom: 12px;
+    margin-top: 40px;
+  }
+
+`}</style>
+
+# Welcome to Storybook
+
+We'll be showcasing what the PostHog app can do inside this Storybook, and using it to track the difference between designed and
+implemented product decisions.
+
+<div className="subheading">How to create stories</div>
+
+While developing, run `getReduxState()` inside the JS console and save the object as a `.json` file. Then follow what
+the other `*.stories.tsx` files do.
+
+<div className="subheading">Fun story: PostHog Onboarding Story</div>
+
+For a fun story, check out [The Self-Hosted Onboarding Flow](/story/posthog-onboarding-1-preflight--initial), where a user
+has to go through three different designs before reaching the app they came for!
+

--- a/frontend/src/lib/components/NotFound/NotFound.stories.tsx
+++ b/frontend/src/lib/components/NotFound/NotFound.stories.tsx
@@ -6,6 +6,7 @@ import { NotFound } from './index'
 export default {
     title: 'PostHog/Components/NotFound',
     component: NotFound,
+    parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof NotFound>
 
 const Template: ComponentStory<typeof NotFound> = (args) => <NotFound {...args} />

--- a/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
@@ -6,6 +6,7 @@ import { PropertyKeyInfo } from './PropertyKeyInfo'
 export default {
     title: 'PostHog/Components/PropertyKeyInfo',
     component: PropertyKeyInfo,
+    parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof PropertyKeyInfo>
 
 const Template: ComponentStory<typeof PropertyKeyInfo> = (args) => {


### PR DESCRIPTION
## Changes

- Github Action to deploy changes on `master` to https://storybook.posthog.net/
- Adds a welcome page (`.mdx`) to storybook
- Hides the "add-ons" panel by default

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
