### PR TITLE
Fix shared dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -12,7 +12,6 @@ import { DashboardLayoutSize, DashboardMode, DashboardType, FilterType, ViewType
 import { dashboardLogicType } from './dashboardLogicType'
 import React from 'react'
 import { Layout, Layouts } from 'react-grid-layout'
-import { sceneLogic } from 'scenes/sceneLogic'
 
 export const AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 300
 
@@ -53,6 +52,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
         setAutoRefresh: (enabled: boolean, interval: number) => ({ enabled, interval }),
         setRefreshStatus: (id: number, loading = false) => ({ id, loading }), // id represents dashboardItem id's
         setRefreshError: (id: number) => ({ id }),
+        setPageTitle: ({ title }) => {
+            document.title = title ? `${title} • PostHog` : 'PostHog'
+        },
     },
 
     loaders: ({ actions, props }) => ({
@@ -72,7 +74,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             })}`
                         )
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
-                        sceneLogic.actions.setPageTitle(dashboard.name ? `${dashboard.name} • Dashboard` : 'Dashboard')
+                        actions.setPageTitle(dashboard.name ? `${dashboard.name} • Dashboard` : 'Dashboard')
                         eventUsageLogic.actions.reportDashboardViewed(dashboard, !!props.shareToken)
                         return dashboard
                     } catch (error) {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -52,9 +52,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
         setAutoRefresh: (enabled: boolean, interval: number) => ({ enabled, interval }),
         setRefreshStatus: (id: number, loading = false) => ({ id, loading }), // id represents dashboardItem id's
         setRefreshError: (id: number) => ({ id }),
-        setPageTitle: ({ title }) => {
-            document.title = title ? `${title} • PostHog` : 'PostHog'
-        },
+        setPageTitle: (title: string) => ({ title }),
     },
 
     loaders: ({ actions, props }) => ({
@@ -564,6 +562,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     actions.refreshAllDashboardItems()
                 }, values.autoRefresh.interval * 1000)
             }
+        },
+        setPageTitle: ({ title }) => {
+            document.title = title ? `${title} • PostHog` : 'PostHog'
         },
     }),
 })


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/posthog/issues/5837
Fixes shared dashboard links, but I just duplicated the `setPageTitle` action from scenes.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
