### PR TITLE
Add git sha to instance status page

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -37,6 +37,7 @@ jobs:
               if: github.repository == 'PostHog/posthog'
               uses: docker/build-push-action@v2
               with:
+                  context: .
                   push: true
                   tags: posthog/posthog:latest
 
@@ -45,6 +46,7 @@ jobs:
               if: github.repository == 'PostHog/posthog'
               uses: docker/build-push-action@v2
               with:
+                  context: .
                   file: dev.Dockerfile
                   push: true
                   tags: posthog/posthog:dev

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -14,6 +14,9 @@ jobs:
             - name: Checkout default branch
               uses: actions/checkout@v2
 
+            - name: Update git sha
+              run: echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
+
             - name: Set up QEMU
               if: github.repository == 'PostHog/posthog'
               uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -29,6 +29,13 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
 
+            - name: Login to DockerHub
+              if: github.repository == 'PostHog/posthog'
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
             - name: Build
               id: docker_build
               uses: docker/build-push-action@v2

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -12,6 +12,9 @@ jobs:
             - name: Checkout PR branch
               uses: actions/checkout@v2
 
+            - name: Update git sha
+              run: echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
+
             - name: Lint Dockerfiles with Hadolint
               run: |
                   # Install latest Hadolint binary from GitHub (not available via apt)

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -14,6 +14,7 @@ jobs:
 
             - name: Update git sha
               run: |
+                  git show
                   cat posthog/gitsha.py
                   echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
                   cat posthog/gitsha.py

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -12,13 +12,6 @@ jobs:
             - name: Checkout PR branch
               uses: actions/checkout@v2
 
-            - name: Update git sha
-              run: |
-                  git log -n 1
-                  cat posthog/gitsha.py
-                  echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
-                  cat posthog/gitsha.py
-
             - name: Lint Dockerfiles with Hadolint
               run: |
                   # Install latest Hadolint binary from GitHub (not available via apt)
@@ -33,19 +26,11 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
 
-            - name: Login to DockerHub
-              if: github.repository == 'PostHog/posthog'
-              uses: docker/login-action@v1
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
-
             - name: Build
               id: docker_build
               uses: docker/build-push-action@v2
               with:
-                  context: .
-                  push: true
+                  push: false
                   tags: posthog/posthog:testing
 
             - name: Image digest

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -13,7 +13,10 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Update git sha
-              run: echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
+              run: |
+                  cat posthog/gitsha.py
+                  echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
+                  cat posthog/gitsha.py
 
             - name: Lint Dockerfiles with Hadolint
               run: |
@@ -40,6 +43,7 @@ jobs:
               id: docker_build
               uses: docker/build-push-action@v2
               with:
+                  content: .
                   push: true
                   tags: posthog/posthog:testing
 

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -33,8 +33,8 @@ jobs:
               id: docker_build
               uses: docker/build-push-action@v2
               with:
-                  push: false
-                  tags: posthog/posthog:latest
+                  push: true
+                  tags: posthog/posthog:testing
 
             - name: Image digest
               run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -43,7 +43,7 @@ jobs:
               id: docker_build
               uses: docker/build-push-action@v2
               with:
-                  content: .
+                  context: .
                   push: true
                   tags: posthog/posthog:testing
 

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -14,7 +14,7 @@ jobs:
 
             - name: Update git sha
               run: |
-                  git show
+                  git log -n 1
                   cat posthog/gitsha.py
                   echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
                   cat posthog/gitsha.py

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -8,13 +8,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.ee import is_clickhouse_enabled
+from posthog.gitsha import GIT_SHA
 from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import Element, Event, SessionRecordingEvent
 from posthog.permissions import SingleTenancyOrAdmin
 from posthog.utils import (
     dict_from_cursor_fetchall,
-    get_git_branch,
-    get_git_commit,
     get_plugin_server_job_queues,
     get_plugin_server_version,
     get_redis_info,
@@ -43,13 +42,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
 
         metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
 
-        metrics.append(
-            {
-                "key": "posthog_git_branch_and_sha",
-                "metric": "PostHog Git branch:sha",
-                "value": f"{get_git_branch()}:{get_git_commit(short=False)}",
-            }
-        )
+        metrics.append({"key": "posthog_git_sha", "metric": "PostHog Git SHA", "value": GIT_SHA})
 
         metrics.append(
             {

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -13,6 +13,8 @@ from posthog.models import Element, Event, SessionRecordingEvent
 from posthog.permissions import SingleTenancyOrAdmin
 from posthog.utils import (
     dict_from_cursor_fetchall,
+    get_git_branch,
+    get_git_sha,
     get_plugin_server_job_queues,
     get_plugin_server_version,
     get_redis_info,
@@ -40,6 +42,14 @@ class InstanceStatusViewSet(viewsets.ViewSet):
         metrics: List[Dict[str, Union[str, bool, int, float]]] = []
 
         metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
+
+        metrics.append(
+            {
+                "key": "posthog_git_branch_and_sha",
+                "metric": "PostHog Git branch:sha",
+                "value": f"{get_git_branch()}:{get_git_sha()}",
+            }
+        )
 
         metrics.append(
             {

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -14,7 +14,7 @@ from posthog.permissions import SingleTenancyOrAdmin
 from posthog.utils import (
     dict_from_cursor_fetchall,
     get_git_branch,
-    get_git_sha,
+    get_git_commit,
     get_plugin_server_job_queues,
     get_plugin_server_version,
     get_redis_info,
@@ -47,7 +47,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
             {
                 "key": "posthog_git_branch_and_sha",
                 "metric": "PostHog Git branch:sha",
-                "value": f"{get_git_branch()}:{get_git_sha()}",
+                "value": f"{get_git_branch()}:{get_git_commit(short=False)}",
             }
         )
 

--- a/posthog/gitsha.py
+++ b/posthog/gitsha.py
@@ -1,0 +1,1 @@
+GIT_SHA = "Undefined"

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -174,7 +174,7 @@ def get_git_branch() -> Optional[str]:
         return None
 
 
-def get_git_commit(short: bool = True) -> Optional[str]:
+def get_git_commit() -> Optional[str]:
     """
     Returns the short hash of the last commit.
     Example: get_git_commit()
@@ -182,21 +182,7 @@ def get_git_commit(short: bool = True) -> Optional[str]:
     """
 
     try:
-        short_arg = ["--short"] if short else []
-        return subprocess.check_output(["git", "rev-parse"] + short_arg + ["HEAD"]).decode("utf-8").strip()
-    except Exception:
-        return None
-
-
-def get_git_sha() -> Optional[str]:
-    """
-    Returns the long hash of the last commit.
-    Example: get_git_sha()
-        => "a8731a3d00e7fdb9dc147035a62b891a00af82ea"
-    """
-
-    try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
+        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
     except Exception:
         return None
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -174,7 +174,7 @@ def get_git_branch() -> Optional[str]:
         return None
 
 
-def get_git_commit() -> Optional[str]:
+def get_git_commit(short: bool = True) -> Optional[str]:
     """
     Returns the short hash of the last commit.
     Example: get_git_commit()
@@ -182,7 +182,8 @@ def get_git_commit() -> Optional[str]:
     """
 
     try:
-        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
+        short_arg = ["--short"] if short else []
+        return subprocess.check_output(["git", "rev-parse"] + short_arg + ["HEAD"]).decode("utf-8").strip()
     except Exception:
         return None
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -187,6 +187,19 @@ def get_git_commit() -> Optional[str]:
         return None
 
 
+def get_git_sha() -> Optional[str]:
+    """
+    Returns the long hash of the last commit.
+    Example: get_git_sha()
+        => "a8731a3d00e7fdb9dc147035a62b891a00af82ea"
+    """
+
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
+    except Exception:
+        return None
+
+
 def render_template(template_name: str, request: HttpRequest, context: Dict = {}) -> HttpResponse:
     from loginas.utils import is_impersonated_session
 


### PR DESCRIPTION
## Changes

This would have been useful for me to see today. Based of https://github.com/PostHog/posthog/pull/5726 + comments there.

Note that `with.context: .` is needed so we build from local checkout instead (see https://github.com/docker/build-push-action#usage)

Verified that this works:
1. Built the package in with these temporary changes: https://github.com/PostHog/posthog/pull/5843/commits/315b14dc4e9e43d8e0d05fbb9b9b93de76a278d9 & https://github.com/PostHog/posthog/pull/5843/commits/d7084dad39182e66187485f3ee878773a5926896, which created https://hub.docker.com/r/posthog/posthog/tags?page=1&ordering=last_updated&name=testing
2. Deployed that to my Digital Ocean deployment via `helm upgrade -i -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/posthog/values.yml posthog posthog/posthog --create-namespace --namespace posthog --set image.tag=testing`
3. Checked the /instance/status page

<img width="1030" alt="Screen Shot 2021-09-07 at 23 58 30" src="https://user-images.githubusercontent.com/890921/132416293-b9e3a3cc-8f93-4d54-a2ce-2bcc780afd10.png">

Note that the sha is odd and doesn't match anything because I'm running this on top of a pull_request trigger, see docs: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit

Debug info in the check output
```
Run git log -n 1
commit a3f6a872eb16733eb9420e01933acefa321e65fc
Author: Tiina Turban <tiina303@gmail.com>
Date:   Tue Sep 7 22:06:45 2021 +0000

    Merge 4ebc15109c382bbb31e1509042d4753637ebbe9b into 37a355687d17761c60152866e4e671c510125826
GIT_SHA = "Undefined"
GIT_SHA = 'a3f6a872eb16733eb9420e01933acefa321e65fc'
```
Which makes me believe it will work fine on top of master/main.


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
