### PR TITLE
Try using Vectorized Redpanda instead of Kafka

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -33,14 +33,26 @@ services:
     zookeeper:
         image: wurstmeister/zookeeper
     kafka:
-        image: wurstmeister/kafka
-        depends_on:
-            - zookeeper
+        command:
+            - redpanda
+            - start
+            - --smp
+            - '1'
+            - --reserve-memory
+            - 0M
+            - --overprovisioned
+            - --node-id
+            - '0'
+            - --kafka-addr
+            - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+            - --advertise-kafka-addr
+            - PLAINTEXT://kafka:29092,OUTSIDE://kafka:9092
+            # NOTE: Please use the latest version here!
+        image: docker.vectorized.io/vectorized/redpanda:v21.8.1
+        container_name: redpanda-1
         ports:
-            - '9092:9092'
-        environment:
-            KAFKA_ADVERTISED_HOST_NAME: kafka
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            - 9092:9092
+            - 29092:29092
     worker: &worker
         build:
             context: ../


### PR DESCRIPTION
## Changes

A few reasons why this may be interesting
- [x] More performant both in dev and in prod
- [x] One less dependency on ZK
- [x] M1 support out of the box!
- [x] Supports over 2 million partitions per topic
- [x] Lossless by default 🏦 
- [x] Inline WASM transformations 🤔 
- [x] Native C++ instead of JVM Scala for Kafka
- [x] Data archiving to S3 or GCS https://vectorized.io/docs/data-archiving/ 💰 

Further reading if you are interested:
https://vectorized.io/redpanda

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
