### PR TITLE
Add helm info to instance status page

### DIFF
--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Any, Dict, List, Union
 
@@ -45,9 +46,16 @@ class InstanceStatusViewSet(viewsets.ViewSet):
 
         metrics.append({"key": "posthog_git_sha", "metric": "PostHog Git SHA", "value": GIT_SHA})
 
-        metrics.append(
-            {"key": "chart_version", "metric": "Chart version", "value": os.getenv("CHART_VERSION", "Undefined"),}
-        )
+        helm_info = json.loads(os.getenv("HELM_INSTALL_INFO", "{}"))
+        if len(helm_info) > 0:
+            metrics.append(
+                {
+                    "key": "helm",
+                    "metric": "Helm Info",
+                    "value": "",
+                    "subrows": {"columns": ["key", "value"], "rows": list(helm_info.items())},
+                }
+            )
 
         metrics.append(
             {

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -40,7 +40,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
         redis_alive = is_redis_alive()
         postgres_alive = is_postgres_alive()
 
-        metrics: List[Dict[str, Union[str, bool, int, float]]] = []
+        metrics: List[Dict[str, Union[str, bool, int, float, Dict[str, Any]]]] = []
 
         metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
 

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -16,6 +16,7 @@ from posthog.models import Element, Event, SessionRecordingEvent
 from posthog.permissions import SingleTenancyOrAdmin
 from posthog.utils import (
     dict_from_cursor_fetchall,
+    get_helm_info_env,
     get_plugin_server_job_queues,
     get_plugin_server_version,
     get_redis_info,
@@ -46,7 +47,7 @@ class InstanceStatusViewSet(viewsets.ViewSet):
 
         metrics.append({"key": "posthog_git_sha", "metric": "PostHog Git SHA", "value": GIT_SHA})
 
-        helm_info = json.loads(os.getenv("HELM_INSTALL_INFO", "{}"))
+        helm_info = get_helm_info_env()
         if len(helm_info) > 0:
             metrics.append(
                 {

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, List, Union
 
 from django.db import connection
@@ -43,6 +44,10 @@ class InstanceStatusViewSet(viewsets.ViewSet):
         metrics.append({"key": "posthog_version", "metric": "PostHog version", "value": VERSION})
 
         metrics.append({"key": "posthog_git_sha", "metric": "PostHog Git SHA", "value": GIT_SHA})
+
+        metrics.append(
+            {"key": "chart_version", "metric": "Chart version", "value": os.getenv("CHART_VERSION", "Undefined"),}
+        )
 
         metrics.append(
             {

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -14,7 +14,7 @@ from posthog.models.feature_flag import FeatureFlag
 from posthog.models.plugin import PluginConfig
 from posthog.models.utils import namedtuplefetchall
 from posthog.settings import EE_AVAILABLE
-from posthog.utils import get_instance_realm, get_machine_id, get_previous_week
+from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_week
 from posthog.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -165,13 +165,6 @@ def fetch_sql(sql_: str, params: Tuple[Any, ...]) -> List[Any]:
     with connection.cursor() as cursor:
         cursor.execute(sql.SQL(sql_), params)
         return namedtuplefetchall(cursor)
-
-
-def get_helm_info_env() -> dict:
-    try:
-        return json.loads(os.getenv("HELM_INSTALL_INFO", "{}"))
-    except Exception:
-        return {}
 
 
 def get_instance_licenses() -> List[str]:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -774,3 +774,10 @@ def str_to_bool(value: Any) -> bool:
 def print_warning(warning_lines: Sequence[str]):
     highlight_length = min(max(map(len, warning_lines)) // 2, shutil.get_terminal_size().columns)
     print("\n".join(("", "🔻" * highlight_length, *warning_lines, "🔺" * highlight_length, "",)), file=sys.stderr)
+
+
+def get_helm_info_env() -> dict:
+    try:
+        return json.loads(os.getenv("HELM_INSTALL_INFO", "{}"))
+    except Exception:
+        return {}


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/charts-clickhouse/issues/97

if helm info env doesn't exist nothing changes.

if the env exists we see this: 

<img width="1242" alt="Screen Shot 2021-09-08 at 18 18 13" src="https://user-images.githubusercontent.com/890921/132547241-427333e1-90c9-4583-b9a2-687e8b9fb62e.png">

Note that I tested by defining it locally via `export HELM_INSTALL_INFO="{\"chart_version\":\"3.7.1\",\"cloud\":\"na\",\"deployment_type\":\"helm\",\"hostname\":null,\"ingress_type\":\"\",\"operation\":\"install\",\"release_name\":\"posthog\",\"release_revision\":1}"` before running `python manage.py runserver`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
