### PR TITLE
Give staff flamegraph access on cloud

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -8,6 +8,8 @@ import {
     SystemStatusQueriesResult,
     SystemStatusAnalyzeResult,
     OrganizationType,
+    UserType,
+    PreflightStatus,
 } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -94,9 +96,17 @@ export const systemStatusLogic = kea<systemStatusLogicType<TabName>>({
             (status: SystemStatus | null): SystemStatusRow[] => (status ? status.overview : []),
         ],
         showAnalyzeQueryButton: [
-            () => [organizationLogic.selectors.currentOrganization],
-            (org: OrganizationType | null): boolean =>
-                !!org?.membership_level && org.membership_level >= OrganizationMembershipLevel.Admin,
+            () => [
+                preflightLogic.selectors.preflight,
+                organizationLogic.selectors.currentOrganization,
+                userLogic.selectors.user,
+            ],
+            (preflight: PreflightStatus | null, org: OrganizationType | null, user: UserType | null): boolean => {
+                if (preflight?.cloud) {
+                    return !!user?.is_staff
+                }
+                return !!org?.membership_level && org.membership_level >= OrganizationMembershipLevel.Admin
+            },
         ],
     }),
 


### PR DESCRIPTION
## Changes

Follow-up to previous flamegraphs PR. Button is hidden on cloud but allowed on BE for non-admin staff.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
