### PR TITLE
Storybook API connection toolbar

### DIFF
--- a/.storybook/ApiSelector/ApiForm.js
+++ b/.storybook/ApiSelector/ApiForm.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Button } from '@storybook/components'
-import { history } from './constants'
+import { ApiHistory } from './ApiHistory'
 
 export const ApiForm = ({ saveApi, selectedConnection }) => {
     const [apiHost, setApiHost] = useState(selectedConnection.apiHost)
@@ -23,25 +23,7 @@ export const ApiForm = ({ saveApi, selectedConnection }) => {
                     Save
                 </Button>
             </div>
-            <div style={{ margin: 10 }}>
-                <strong>History</strong>
-                {history.map(({ apiHost, apiKey }) => (
-                    <button
-                        onClick={() => saveApi(apiHost, apiKey)}
-                        style={{
-                            display: 'block',
-                            width: '100%',
-                            marginBottom: 3,
-                            textAlign: 'left',
-                            cursor: 'pointer',
-                        }}
-                    >
-                        Host: {apiHost}
-                        <br />
-                        Key: {apiKey}
-                    </button>
-                ))}
-            </div>
+            <ApiHistory saveApi={saveApi} />
         </div>
     )
 }

--- a/.storybook/ApiSelector/ApiForm.js
+++ b/.storybook/ApiSelector/ApiForm.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react'
+import { Button } from '@storybook/components'
+import { history } from './constants'
+
+export const ApiForm = ({ saveApi, selectedConnection }) => {
+    const [apiHost, setApiHost] = useState(selectedConnection.apiHost)
+    const [apiKey, setApiKey] = useState(selectedConnection.apiKey)
+
+    return (
+        <div>
+            <div style={{ margin: 10 }}>
+                API Host:
+                <br />
+                <input value={apiHost} onChange={(e) => setApiHost(e.target.value)} style={{ width: '100%' }} />
+            </div>
+            <div style={{ margin: 10 }}>
+                API Key:
+                <br />
+                <input value={apiKey} onChange={(e) => setApiKey(e.target.value)} style={{ width: '100%' }} />
+            </div>
+            <div style={{ margin: 10 }}>
+                <Button primary onClick={() => saveApi(apiHost, apiKey)}>
+                    Save
+                </Button>
+            </div>
+            <div style={{ margin: 10 }}>
+                <strong>History</strong>
+                {history.map(({ apiHost, apiKey }) => (
+                    <button
+                        onClick={() => saveApi(apiHost, apiKey)}
+                        style={{
+                            display: 'block',
+                            width: '100%',
+                            marginBottom: 3,
+                            textAlign: 'left',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Host: {apiHost}
+                        <br />
+                        Key: {apiKey}
+                    </button>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/.storybook/ApiSelector/ApiHistory.js
+++ b/.storybook/ApiSelector/ApiHistory.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { history, LOCALSTORAGE_HISTORY_KEY } from './constants'
+
+function uniques(arr) {
+    const obj = {}
+    for (const a of arr) {
+        obj[JSON.stringify(a)] = true
+    }
+    return Object.keys(obj).map((k) => JSON.parse(k))
+}
+
+export const ApiHistory = ({ saveApi }) => {
+    const localHistory = JSON.parse(window.localStorage.getItem(LOCALSTORAGE_HISTORY_KEY) || '[]')
+    const allOfHistory = uniques([...localHistory, ...history])
+
+    return (
+        <div style={{ margin: 10 }}>
+            <strong style={{ display: 'block', marginBottom: 5 }}>History</strong>
+            {allOfHistory.map(({ apiHost, apiKey }) => (
+                <button
+                    onClick={() => saveApi(apiHost, apiKey)}
+                    style={{
+                        display: 'block',
+                        width: '100%',
+                        marginBottom: 3,
+                        textAlign: 'left',
+                        cursor: 'pointer',
+                    }}
+                >
+                    <small style={{ opacity: 0.8 }}>Host:</small> {apiHost || ''}
+                    <br />
+                    <small style={{ opacity: 0.8 }}>Key:</small> {apiKey ? `${apiKey.substring(0, 10)}...` : ''}
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/.storybook/ApiSelector/ApiSelector.js
+++ b/.storybook/ApiSelector/ApiSelector.js
@@ -1,0 +1,39 @@
+import React, { useState, memo } from 'react'
+import { Icons, IconButton, WithTooltipPure } from '@storybook/components'
+import { useGlobals } from '@storybook/api'
+import { defaultConnection, GLOBAL_KEY, history } from './constants'
+import { ApiForm } from './ApiForm'
+
+export const ApiSelector = memo(() => {
+    const [globals, updateGlobals] = useGlobals()
+    const selectedConnection = globals[GLOBAL_KEY] || defaultConnection
+    const [tooltipShown, setTooltipShown] = useState(false)
+
+    const saveApi = (apiHost, apiKey) => {
+        updateGlobals({
+            [GLOBAL_KEY]: {
+                apiHost,
+                apiKey,
+            },
+        })
+        setTooltipShown(false)
+    }
+
+    return (
+        <WithTooltipPure
+            tooltipShown={tooltipShown}
+            placement="bottom"
+            tooltip={<ApiForm saveApi={saveApi} selectedConnection={selectedConnection} />}
+        >
+            <IconButton
+                key={GLOBAL_KEY}
+                title="Choose API connection"
+                style={!selectedConnection?.apiHost ? { color: 'red' } : {}}
+                onClick={() => setTooltipShown(!tooltipShown)}
+            >
+                <Icons icon="globe" style={{ marginRight: 5 }} />
+                {!selectedConnection?.apiHost ? 'offline' : selectedConnection?.apiHost}
+            </IconButton>
+        </WithTooltipPure>
+    )
+})

--- a/.storybook/ApiSelector/ApiSelector.js
+++ b/.storybook/ApiSelector/ApiSelector.js
@@ -1,15 +1,22 @@
 import React, { useState, memo } from 'react'
 import { Icons, IconButton, WithTooltipPure } from '@storybook/components'
 import { useGlobals } from '@storybook/api'
-import { defaultConnection, GLOBAL_KEY, history } from './constants'
+import { defaultConnection, GLOBAL_KEY, history, LOCALSTORAGE_HISTORY_KEY, LOCALSTORAGE_KEY } from './constants'
 import { ApiForm } from './ApiForm'
 
 export const ApiSelector = memo(() => {
     const [globals, updateGlobals] = useGlobals()
-    const selectedConnection = globals[GLOBAL_KEY] || defaultConnection
+    const selectedConnection =
+        globals[GLOBAL_KEY] || JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) || 'false') || defaultConnection
     const [tooltipShown, setTooltipShown] = useState(false)
 
     const saveApi = (apiHost, apiKey) => {
+        let localHistory = JSON.parse(window.localStorage.getItem(LOCALSTORAGE_HISTORY_KEY) || '[]')
+        if (![...history, ...localHistory].find((h) => h.apiHost === apiHost && h.apiKey === apiKey)) {
+            localHistory = [{ apiHost, apiKey }, ...localHistory]
+            window.localStorage.setItem(LOCALSTORAGE_HISTORY_KEY, JSON.stringify(localHistory))
+        }
+        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify({ apiHost, apiKey }))
         updateGlobals({
             [GLOBAL_KEY]: {
                 apiHost,

--- a/.storybook/ApiSelector/constants.js
+++ b/.storybook/ApiSelector/constants.js
@@ -1,5 +1,7 @@
 export const ADDON_ID = 'api-selector-v1'
 export const GLOBAL_KEY = 'connection'
+export const LOCALSTORAGE_KEY = 'api-storage'
+export const LOCALSTORAGE_HISTORY_KEY = 'api-storage-history'
 export const defaultConnection = { apiHost: '', apiKey: '' }
 
 export const history = [

--- a/.storybook/ApiSelector/constants.js
+++ b/.storybook/ApiSelector/constants.js
@@ -1,0 +1,9 @@
+export const ADDON_ID = 'api-selector-v1'
+export const GLOBAL_KEY = 'connection'
+export const defaultConnection = { apiHost: '', apiKey: '' }
+
+export const history = [
+    { apiHost: '', apiKey: '' },
+    { apiHost: 'http://localhost:8000', apiKey: '' },
+    { apiHost: 'https://app.posthog.com', apiKey: '' },
+]

--- a/.storybook/ApiSelector/register.js
+++ b/.storybook/ApiSelector/register.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { addons, types } from '@storybook/addons'
+
+import { ApiSelector } from './ApiSelector'
+import { ADDON_ID } from './constants'
+
+addons.register(ADDON_ID, () => {
+    addons.add(ADDON_ID, {
+        title: 'Api',
+        type: types.TOOL,
+        match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+        render: () => <ApiSelector />,
+    })
+})

--- a/.storybook/ApiSelector/withApi.js
+++ b/.storybook/ApiSelector/withApi.js
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react'
+import { GLOBAL_KEY } from './constants'
+
+export const withApi = (Story, context) => {
+    const connection = context.globals[GLOBAL_KEY]
+    const { apiKey, apiHost } = connection || {}
+
+    useEffect(() => {
+        const oldFetch = window.fetch
+        window.fetch = (url, ...args) => {
+            console.log('Intercepted Fetch', args)
+            if (url.startsWith('/api/')) {
+                if (!apiHost) {
+                    return Promise.resolve(new Error('Request Failed!'))
+                } else {
+                    let [opts, ...otherArgs] = args
+                    opts = {
+                        ...opts,
+                        headers: {
+                            ...opts.headers,
+                            Authorization: `Bearer ${apiKey}`,
+                        },
+                    }
+                    return oldFetch(`${apiHost}${url}`, opts || {}, ...otherArgs)
+                }
+            }
+            return oldFetch(url, ...args)
+        }
+        return () => {
+            window.fetch = oldFetch
+        }
+    }, [connection])
+
+    return <Story {...context} />
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ const babelConfig = require('../babel.config')
 
 module.exports = {
     stories: ['../frontend/src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-    addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+    addons: ['@storybook/addon-links', '@storybook/addon-essentials', './ApiSelector/register.js'],
     babel: async (options) => {
         // compile babel to "defaults" target (ES5)
         const envPreset = babelConfig.presets.find(

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { getContext } from 'kea'
 import { loadPostHogJS } from '~/loadPostHogJS'
 import '~/styles'
+import { withApi } from './ApiSelector/withApi'
 
 loadPostHogJS()
 window.getReduxState = () => getContext().store.getState()
@@ -21,4 +22,4 @@ export const parameters = {
     },
 }
 
-export const decorators = []
+export const decorators = [withApi]


### PR DESCRIPTION
## Changes

- Still definitely a WIP
- The need arose when creating a storybook for the "taxonomic property filter". I didn't want to mock the API with filters to make the infinite list work. Might as well skip the extra mocking step and just connect the storybook to a real API that comes with some test data.
- This idea came from Airbnb, who use a storybook that's always connected to a "story api" server, featuring random test data you can play with. They say it especially makes writing graphql connected widgets so much easier, as there's legit test data you can play with.
- Here's an attempt at trying the same for us. It's still very raw.
- I imagine we would have a shared storybook API, accessed with a public "personal" API key that's shared in a private slack message or repo.

![2021-09-09 10 45 48](https://user-images.githubusercontent.com/53387/132654065-b492b9d3-490f-4c40-a869-bf4da9cd29cd.gif)

Why am I spending so much time with storybook? 
- I believe there's something there. If we can properly integrate storybook into our frontend development flow, as so many other companies have done, we'll produce better and stabler interfaces.
- We can integrate this [directly with Cypress](https://www.cypress.io/blog/2021/05/19/cypress-x-storybook-2-0/), and have a test "every story renders".
- Visual regression tests sound nice, and this unlocks them.
- Having access to a real API makes it easier to write stories. You might not even need to capture the JSON anymore. Perhaps you will still want to... e.g. using captured redux state for "offline" renders, but an API without the state otherwise...

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
