### PR TITLE
Fix cloud-specific override logic

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -54,6 +54,7 @@ def make_ch_pool(**overrides) -> ChPool:
         connections_min=CLICKHOUSE_CONN_POOL_MIN,
         connections_max=CLICKHOUSE_CONN_POOL_MAX,
         settings={"mutations_sync": "1"} if TEST else {},
+        **overrides,
     )
 
 


### PR DESCRIPTION
:sweat_smile: rebasing fail

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
