### PR TITLE
Improve clickhouse flamegraphs

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -43,19 +43,21 @@ _request_information: Optional[Dict] = None
 
 
 def make_ch_pool(**overrides) -> ChPool:
-    return ChPool(
-        host=CLICKHOUSE_HOST,
-        database=CLICKHOUSE_DATABASE,
-        secure=CLICKHOUSE_SECURE,
-        user=CLICKHOUSE_USER,
-        password=CLICKHOUSE_PASSWORD,
-        ca_certs=CLICKHOUSE_CA,
-        verify=CLICKHOUSE_VERIFY,
-        connections_min=CLICKHOUSE_CONN_POOL_MIN,
-        connections_max=CLICKHOUSE_CONN_POOL_MAX,
-        settings={"mutations_sync": "1"} if TEST else {},
+    kwargs = {
+        "host": CLICKHOUSE_HOST,
+        "database": CLICKHOUSE_DATABASE,
+        "secure": CLICKHOUSE_SECURE,
+        "user": CLICKHOUSE_USER,
+        "password": CLICKHOUSE_PASSWORD,
+        "ca_certs": CLICKHOUSE_CA,
+        "verify": CLICKHOUSE_VERIFY,
+        "connections_min": CLICKHOUSE_CONN_POOL_MIN,
+        "connections_max": CLICKHOUSE_CONN_POOL_MAX,
+        "settings": {"mutations_sync": "1"} if TEST else {},
         **overrides,
-    )
+    }
+
+    return ChPool(**kwargs)
 
 
 if PRIMARY_DB != AnalyticsDBMS.CLICKHOUSE:

--- a/frontend/src/scenes/instance/SystemStatus/AnalyzeQueryModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/AnalyzeQueryModal.tsx
@@ -47,9 +47,10 @@ export function AnalyzeQueryModal(): JSX.Element | null {
                         <div key={key}>
                             <h3>Flamegraph: {key}</h3>
 
-                            <img
-                                src={`data:image/svg+xml;utf8,${encodeURIComponent(value)}`}
-                                style={{ width: '100%' }}
+                            <a
+                                className="embedded-svg-wrapper"
+                                href={`data:image/svg+xml;utf8,${encodeURIComponent(value)}`}
+                                dangerouslySetInnerHTML={{ __html: value }}
                             />
                         </div>
                     ))}

--- a/frontend/src/scenes/instance/SystemStatus/index.scss
+++ b/frontend/src/scenes/instance/SystemStatus/index.scss
@@ -6,3 +6,12 @@
         }
     }
 }
+
+.embedded-svg-wrapper {
+    cursor: text;
+
+    svg {
+        width: 100%;
+        height: 100%;
+    }
+}


### PR DESCRIPTION
- Fix cloud-specific override logic
- Final fix for kwargs
- Make flamegraphs interactable, still allow opening in a new tab

Sorry for the many PRs. :sweat_smile:

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
