### PR TITLE
Test and fix "filtering trends with action with person property" failure

### DIFF
--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -54,6 +54,10 @@ class ColumnOptimizer:
         return len(self.materialized_person_columns_to_query) != len(self._used_properties_with_type("person"))
 
     @cached_property
+    def is_using_person_properties(self) -> bool:
+        return len(self._used_properties_with_type("person")) > 0
+
+    @cached_property
     def should_query_elements_chain_column(self) -> bool:
         "Returns whether this query uses elements_chain"
         has_element_type_property = lambda properties: any(prop.type == "element" for prop in properties)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -76,6 +76,13 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
             return ""
 
     def _determine_should_join_persons(self) -> None:
+        if self._column_optimizer.is_using_person_properties:
+            self._should_join_distinct_ids = True
+            self._should_join_persons = True
+            return
+
+        # :KLUDGE: The following is mostly making sure if cohorts are included as well.
+        #   Can be simplified significantly after https://github.com/PostHog/posthog/issues/5854
         if any(self._should_property_join_persons(prop) for prop in self._filter.properties):
             self._should_join_distinct_ids = True
             self._should_join_persons = True

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -217,7 +217,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         self._run_query(filter)
 
-    def test_actions(self):
+    def test_action_with_person_property_filter(self):
         person1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
         person2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
 

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1576,17 +1576,24 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 properties=[{"key": "bar", "type": "person", "value": "a", "operator": "icontains"}],
             )
             event_filtering_action.calculate_events()
-            filter = Filter(
-                {
-                    "actions": [{"id": event_filtering_action.id}],
-                    "properties": [{"key": "email", "type": "person", "value": "is_set", "operator": "is_set"}],
-                }
-            )
 
             with freeze_time("2020-01-04T13:01:01Z"):
-                response = trends().run(filter, self.team)
+                response = trends().run(Filter({"actions": [{"id": event_filtering_action.id}],}), self.team)
             self.assertEqual(len(response), 1)
-            self.assertEqual(response[0]["count"], 2)
+            self.assertEqual(response[0]["count"], 3)
+
+            with freeze_time("2020-01-04T13:01:01Z"):
+                response_with_email_filter = trends().run(
+                    Filter(
+                        {
+                            "actions": [{"id": event_filtering_action.id}],
+                            "properties": [{"key": "email", "type": "person", "value": "is_set", "operator": "is_set"}],
+                        }
+                    ),
+                    self.team,
+                )
+            self.assertEqual(len(response_with_email_filter), 1)
+            self.assertEqual(response_with_email_filter[0]["count"], 2)
 
         def test_dau_filtering(self):
             sign_up_action, person = self._create_events()


### PR DESCRIPTION
Closes #5876

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
