### PR TITLE
Raise ValidationError if "math" without "math_property" passed to BE from FE

### DIFF
--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from django.utils import timezone
 from freezegun import freeze_time
+from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.person import create_person_distinct_id
@@ -852,3 +853,9 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         )
 
         self.assertEqual(response[0]["count"], 2)
+
+    def test_trends_math_without_math_property(self):
+        with self.assertRaises(ValidationError):
+            ClickhouseTrends().run(
+                Filter(data={"events": [{"id": "sign up", "math": "sum"}]}), self.team,
+            )

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -22,7 +22,7 @@ MATH_FUNCTIONS = {
 }
 
 
-def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
+def process_math(entity: Entity) -> Tuple[str, str, Dict[str, str]]:
     aggregate_operation = "count(*)"
     join_condition = ""
     params = {}

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -30,9 +30,10 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
         join_condition = EVENT_JOIN_PERSON_SQL
         aggregate_operation = "count(DISTINCT person_id)"
     elif entity.math in MATH_FUNCTIONS:
-        value, _ = get_property_string_expr(
-            "events", cast(str, entity.math_property), f"%(e_{entity.index}_math)s", "properties"
-        )
+        if entity.math_property is None:
+            raise ValidationError(f"Math without math_property passed")
+
+        value, _ = get_property_string_expr("events", entity.math_property, f"%(e_{entity.index}_math)s", "properties")
         aggregate_operation = f"{MATH_FUNCTIONS[entity.math]}(toFloat64OrNull({value}))"
         params["join_property_key"] = entity.math_property
         params[f"e_{entity.index}_math"] = entity.math_property

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -31,7 +31,7 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Optional[str]]]:
         aggregate_operation = "count(DISTINCT person_id)"
     elif entity.math in MATH_FUNCTIONS:
         if entity.math_property is None:
-            raise ValidationError(f"Math without math_property passed")
+            raise ValidationError({"math_property": "This field is required when `math` is set."}, code="required")
 
         value, _ = get_property_string_expr("events", entity.math_property, f"%(e_{entity.index}_math)s", "properties")
         aggregate_operation = f"{MATH_FUNCTIONS[entity.math]}(toFloat64OrNull({value}))"


### PR DESCRIPTION
BE side fix for https://github.com/PostHog/posthog/issues/5756

I'm not really happy with the experience side of this though, but it's unchanged from current:

https://user-images.githubusercontent.com/148820/132831008-a07234e3-5640-489c-b210-991ed364f83b.mp4

Worth showing a different screen on validation errors (400)?

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
