### PR TITLE
Fix IndexError in Retention endpoint: do not fail if there is more data than expected from clickhouse query

### DIFF
--- a/posthog/api/test/test_retention.py
+++ b/posthog/api/test/test_retention.py
@@ -1,0 +1,162 @@
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+from unittest.mock import ANY
+
+import pytest
+from django.test import Client
+from freezegun.api import freeze_time
+
+from posthog.api.test.test_event_definition import (
+    EventData,
+    capture_event,
+    create_organization,
+    create_team,
+    create_user,
+)
+from posthog.constants import TREND_FILTER_TYPE_EVENTS
+from posthog.models.person import Person, PersonDistinctId
+
+
+def identify(distinct_id: str, team_id: int):
+    """
+    Simulate what is being done in the plugin-server, so we end up with the
+    database in the right state
+    """
+    person = Person.objects.create(team_id=team_id)
+    PersonDistinctId.objects.create(distinct_id=distinct_id, team_id=team_id, person_id=person.id)
+    capture_event(
+        event=EventData(
+            event="$identify",
+            team_id=team_id,
+            distinct_id=distinct_id,
+            timestamp=datetime.now(),
+            properties={"distinct_id": distinct_id},
+        )
+    )
+
+
+def get_retention(
+    client: Client,
+    display: str,
+    events: List[Dict[str, Any]],
+    date_from: str,
+    date_to: str,
+    selected_interval: int,
+    total_intervals: int,
+    target_entity: Dict[str, Any],
+    returning_entity: Dict[str, Any],
+    insight: str,
+    period: str,
+    retention_type: str,
+    properties: Optional[List[Dict[str, Any]]] = None,
+    filter_test_accounts: bool = True,
+):
+    return client.get(
+        "/api/person/retention",
+        data={
+            "display": display,
+            "events": json.dumps(events),
+            "date_from": date_from,
+            "date_to": date_to,
+            "selected_interval": selected_interval,
+            "total_intervals": total_intervals,
+            "filter_test_accounts": filter_test_accounts,
+            "insight": insight,
+            "period": period,
+            "retention_type": retention_type,
+            "target_entity": json.dumps(target_entity),
+            "returning_entity": json.dumps(returning_entity),
+            "properties": json.dumps(properties or []),
+        },
+    )
+
+
+@pytest.mark.django_db
+@freeze_time("2021-08-03T18:46:15.579Z")
+def test_insight_retention_missing_persons_gh_5443(client: Client):
+    """
+    This is a regression test for GH-5443.
+
+    The scenario here is that, an api request is being made for person retention, specifically for:
+
+      1. a "Week" period is being requested
+      2. events just over a week from the first event for a user
+
+    """
+
+    organization = create_organization(name="test org")
+    team = create_team(organization=organization)
+    user = create_user("user", "pass", organization)
+
+    identify(distinct_id="abc", team_id=team.id)
+
+    #  This event will be the first event for the Person wrt the retention
+    #  period
+    capture_event(
+        event=EventData(
+            event="event_name", team_id=team.id, distinct_id="abc", timestamp=datetime(2021, 3, 29), properties={},
+        )
+    )
+
+    # Create an event for just over a week from the initial identify event
+    capture_event(
+        event=EventData(
+            event="event_name", team_id=team.id, distinct_id="abc", timestamp=datetime(2021, 4, 5), properties={},
+        )
+    )
+
+    client.force_login(user)
+
+    # These params are taken from
+    # https://sentry.io/organizations/posthog/issues/2516393859/events/df790b8837a54051a140aa1fee51adfc/?project=1899813
+    response = get_retention(
+        client=client,
+        events=[
+            {
+                "id": "$pageview",
+                "math": None,
+                "name": "$pageview",
+                "type": "events",
+                "order": 0,
+                "properties": [],
+                "math_property": None,
+            }
+        ],
+        date_from="-90d",
+        date_to="2021-03-31T18:22:50.579Z",
+        display="ActionsTable",
+        selected_interval=10,
+        total_intervals=11,
+        insight="RETENTION",
+        period="Week",
+        retention_type="retention_first_time",
+        target_entity={"id": "event_name", "name": "event_name", "type": "events", "order": 0},
+        returning_entity={
+            "id": "event_name",
+            "math": None,
+            "name": "event_name",
+            "type": "events",
+            "order": None,
+            "properties": [],
+            "math_property": None,
+        },
+    )
+
+    assert response.status_code == 200, response.content
+    data = response.json()
+
+    assert data["result"] == [
+        {
+            "appearances": [1],
+            "person": {
+                "created_at": "2020-01-02T00:00:00Z",
+                "distinct_ids": ["abc"],
+                "id": ANY,
+                "is_identified": False,
+                "name": "abc",
+                "properties": {},
+                "uuid": ANY,
+            },
+        },
+    ]

--- a/posthog/api/test/test_retention.py
+++ b/posthog/api/test/test_retention.py
@@ -73,7 +73,7 @@ def get_retention(
 
 
 @pytest.mark.django_db
-@freeze_time("2021-08-03T18:46:15.579Z")
+@freeze_time("2021-08-03")
 def test_insight_retention_missing_persons_gh_5443(client: Client):
     """
     This is a regression test for GH-5443.
@@ -146,11 +146,14 @@ def test_insight_retention_missing_persons_gh_5443(client: Client):
     assert response.status_code == 200, response.content
     data = response.json()
 
+    # NOTE: prior to the fix for GH-5443, this test would fail by returning an
+    # empty list. To "fix" I have make the generation of "appearances" more
+    # forgiving of getting too much data from the clickhouse query.
     assert data["result"] == [
         {
             "appearances": [1],
             "person": {
-                "created_at": "2020-01-02T00:00:00Z",
+                "created_at": "2021-08-03T00:00:00Z",
                 "distinct_ids": ["abc"],
                 "id": ANY,
                 "is_identified": False,

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -362,7 +362,4 @@ class Retention(BaseQuery):
 
 
 def appearance_to_markers(appearance_dates: List[float], num_intervals: int) -> List[int]:
-    markers = [0 for _ in range(num_intervals)]
-    for appearance in appearance_dates:
-        markers[int(appearance)] = 1
-    return markers
+    return [interval_number in appearance_dates for interval_number in range(num_intervals)]

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Tuple, Union
+import dataclasses
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Tuple, Union
 
 from django.db import connection
 from django.db.models import Min
@@ -17,6 +19,18 @@ from posthog.models.filters import RetentionFilter
 from posthog.models.person import Person
 from posthog.models.utils import namedtuplefetchall
 from posthog.queries.base import BaseQuery, properties_to_Q
+
+
+@dataclasses.dataclass
+class AppearanceRow:
+    """
+    Container for the rows of the "Appearance count" query.
+    """
+
+    person_id: str
+    appearance_count: int
+    # This is actually the number of days from first event to the current event.
+    appearances: List[int]
 
 
 class Retention(BaseQuery):
@@ -266,8 +280,6 @@ class Retention(BaseQuery):
             **format_fields
         )
 
-        result = []
-
         from posthog.api.person import PersonSerializer
 
         with connection.cursor() as cursor:
@@ -275,24 +287,30 @@ class Retention(BaseQuery):
                 final_query, params + (100, filter.offset),
             )
             raw_results = cursor.fetchall()
-            people_dict = {}
-            for person in Person.objects.filter(team_id=team.pk, id__in=[val[0] for val in raw_results]):
+            people_appearances = [AppearanceRow(*result) for result in raw_results]
+            people_dict: Dict[str, ReturnDict] = {}
+            for person in Person.objects.filter(
+                team_id=team.pk, id__in=[person.person_id for person in people_appearances]
+            ):
                 people_dict.update({person.pk: PersonSerializer(person).data})
 
-            result = self.process_people_in_period(filter, raw_results, people_dict)
+            result = self.process_people_in_period(filter, people_appearances, people_dict)
 
         return result
 
     def process_people_in_period(
-        self, filter: RetentionFilter, vals, people_dict: Dict[str, ReturnDict]
+        self, filter: RetentionFilter, people_appearances: List[AppearanceRow], people_dict: Dict[str, ReturnDict]
     ) -> List[Dict[str, Any]]:
         marker_length = filter.total_intervals
-        result = []
-        for val in vals:
+        result: List[Dict[Literal["person", "appearances"], Any]] = []
+        for person in people_appearances:
             # NOTE: This try/except shouldn't be necessary but there do seem to be a handful of missing persons that can't be looked up
             try:
                 result.append(
-                    {"person": people_dict[val[0]], "appearances": appearance_to_markers(sorted(val[2]), marker_length)}
+                    {
+                        "person": people_dict[person.person_id],
+                        "appearances": appearance_to_markers(sorted(person.appearances), marker_length),
+                    }
                 )
             except Exception as e:
                 capture_exception(e)
@@ -339,8 +357,8 @@ class Retention(BaseQuery):
             raise ValidationError(f"Period {period} is unsupported.")
 
 
-def appearance_to_markers(vals: List, num_intervals: int) -> List:
+def appearance_to_markers(appearance_dates: List[int], num_intervals: int) -> List[int]:
     markers = [0 for _ in range(num_intervals)]
-    for val in vals:
-        markers[int(val)] = 1
+    for appearance in appearance_dates:
+        markers[int(appearance)] = 1
     return markers


### PR DESCRIPTION
This just ensures that if more "appearances" are returned from clickhouse query than expected then we just silently drop the extra ones and return a response.

Prior to this we would silently drop the whole person from the retention response.

There is likely a better solution to this to make sure the query is retrieving what we expect, but it is at least an improvement and resolves the issue.

Fixes https://github.com/PostHog/posthog/issues/5443