### PR TITLE
Move `is_clickhouse_enabled` from `posthog.ee` to `posthog.utils`

### DIFF
--- a/ee/clickhouse/middleware.py
+++ b/ee/clickhouse/middleware.py
@@ -3,8 +3,8 @@ from django.http import HttpRequest, HttpResponse
 from django.urls.base import resolve
 from loginas.utils import is_impersonated_session
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.internal_metrics import incr
+from posthog.utils import is_clickhouse_enabled
 
 
 class CHQueries(object):

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -19,9 +19,9 @@ from ee.clickhouse.sql.person import (
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
 from posthog import settings
-from posthog.ee import is_clickhouse_enabled
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.utils import UUIDT
+from posthog.utils import is_clickhouse_enabled
 
 if settings.EE_AVAILABLE and is_clickhouse_enabled():
 

--- a/ee/management/commands/setup_test_environment.py
+++ b/ee/management/commands/setup_test_environment.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from posthog.ee import is_clickhouse_enabled
+from posthog.utils import is_clickhouse_enabled
 
 
 class Command(BaseCommand):

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -1,7 +1,7 @@
 from rest_framework import decorators, exceptions
 
 from posthog.api.routing import DefaultRouterPlusPlus
-from posthog.ee import is_clickhouse_enabled
+from posthog.utils import is_clickhouse_enabled
 
 from . import (
     action,

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -15,13 +15,12 @@ from statshog.defaults.django import statsd
 from posthog.api.utils import get_token
 from posthog.celery import app as celery_app
 from posthog.constants import ENVIRONMENT_TEST
-from posthog.ee import is_clickhouse_enabled
 from posthog.exceptions import RequestParsingError, generate_exception_response
 from posthog.helpers.session_recording import preprocess_session_recording_events
 from posthog.models import Team, User
 from posthog.models.feature_flag import get_active_feature_flags
 from posthog.models.utils import UUIDT
-from posthog.utils import cors_response, get_ip_address, load_data_from_request
+from posthog.utils import cors_response, get_ip_address, is_clickhouse_enabled, load_data_from_request
 
 if is_clickhouse_enabled():
     from ee.kafka_client.client import KafkaProducer

--- a/posthog/api/instance_status.py
+++ b/posthog/api/instance_status.py
@@ -9,7 +9,6 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.gitsha import GIT_SHA
 from posthog.internal_metrics.team import get_internal_metrics_dashboards
 from posthog.models import Element, Event, SessionRecordingEvent
@@ -23,6 +22,7 @@ from posthog.utils import (
     get_redis_queue_depth,
     get_table_approx_count,
     get_table_size,
+    is_clickhouse_enabled,
     is_plugin_server_alive,
     is_postgres_alive,
     is_redis_alive,

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -306,7 +306,7 @@ def factory_test_event_api(event_factory, person_factory, _):
             self.assertIn("http://testserver/api/event/?distinct_id=1&before=", response["next"])
 
             page2 = self.client.get(response["next"]).json()
-            from posthog.ee import is_clickhouse_enabled
+            from posthog.utils import is_clickhouse_enabled
 
             if is_clickhouse_enabled():
                 from ee.clickhouse.client import sync_execute

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import (
     Cohort,
     Dashboard,
@@ -17,6 +16,7 @@ from posthog.models import (
     User,
 )
 from posthog.test.base import APIBaseTest
+from posthog.utils import is_clickhouse_enabled
 
 
 def insight_test_factory(event_factory, person_factory):

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -19,13 +19,12 @@ from rest_framework import mixins, permissions, serializers, viewsets
 from posthog.api.organization import OrganizationSerializer
 from posthog.api.shared import OrganizationBasicSerializer, TeamBasicSerializer
 from posthog.auth import authenticate_secondarily
-from posthog.ee import is_clickhouse_enabled
 from posthog.email import is_email_available
 from posthog.event_usage import report_user_updated
 from posthog.models import Team, User
 from posthog.models.organization import Organization
 from posthog.tasks import user_identify
-from posthog.utils import get_instance_realm
+from posthog.utils import get_instance_realm, is_clickhouse_enabled
 from posthog.version import VERSION
 
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -9,8 +9,8 @@ from django.db import connection
 from django.utils import timezone
 from sentry_sdk.api import capture_exception
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.redis import get_client
+from posthog.utils import is_clickhouse_enabled
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")

--- a/posthog/demo/__init__.py
+++ b/posthog/demo/__init__.py
@@ -5,10 +5,9 @@ from rest_framework.request import Request
 from posthog.demo.app_data_generator import AppDataGenerator
 from posthog.demo.revenue_data_generator import RevenueDataGenerator
 from posthog.demo.web_data_generator import WebDataGenerator
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import Organization, Team, User
 from posthog.models.event_definition import EventDefinition
-from posthog.utils import render_template
+from posthog.utils import is_clickhouse_enabled, render_template
 
 ORGANIZATION_NAME = "HogFlix"
 TEAM_NAME = "HogFlix Demo App"

--- a/posthog/demo/data_generator.py
+++ b/posthog/demo/data_generator.py
@@ -1,9 +1,9 @@
 from typing import Dict, List
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import Action, Event, Person, PersonDistinctId, Team
 from posthog.models.session_recording_event import SessionRecordingEvent
 from posthog.models.utils import UUIDT
+from posthog.utils import is_clickhouse_enabled
 
 
 class DataGenerator:

--- a/posthog/ee.py
+++ b/posthog/ee.py
@@ -1,7 +1,0 @@
-from django.conf import settings
-
-from posthog.constants import AnalyticsDBMS
-
-
-def is_clickhouse_enabled() -> bool:
-    return settings.EE_AVAILABLE and settings.PRIMARY_DB == AnalyticsDBMS.CLICKHOUSE

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -10,8 +10,8 @@ from django.db.models.expressions import F
 from django.utils import timezone
 from sentry_sdk import capture_exception
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.models.utils import sane_repr
+from posthog.utils import is_clickhouse_enabled
 
 from .action import Action
 from .event import Event

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -10,8 +10,8 @@ from posthog.constants import (
     INSIGHT_STICKINESS,
     INSIGHT_TRENDS,
 )
-from posthog.ee import is_clickhouse_enabled
 from posthog.models.filters.path_filter import PathFilter
+from posthog.utils import is_clickhouse_enabled
 
 
 def earliest_timestamp_func(team_id: int):

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -12,12 +12,12 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from semantic_version.base import SimpleSpec, Version
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.plugins.access import can_configure_plugins, can_install_plugins
 from posthog.plugins.reload import reload_plugins_on_workers
 from posthog.plugins.utils import download_plugin_archive, get_json_from_archive, load_json_file, parse_url
+from posthog.utils import is_clickhouse_enabled
 from posthog.version import VERSION
 
 from .utils import UUIDModel, sane_repr

--- a/posthog/tasks/calculate_action.py
+++ b/posthog/tasks/calculate_action.py
@@ -4,8 +4,8 @@ from typing import Sequence, cast
 
 from celery import shared_task
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import Action
+from posthog.utils import is_clickhouse_enabled
 
 logger = logging.getLogger(__name__)
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -10,8 +10,8 @@ from django.db.models import F
 from django.utils import timezone
 
 from posthog.constants import INSIGHT_STICKINESS
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import Cohort
+from posthog.utils import is_clickhouse_enabled
 
 logger = logging.getLogger(__name__)
 

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -5,12 +5,12 @@ from celery.app import shared_task
 from django.db.models import Count
 from django.utils.timezone import now
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import Team
 from posthog.models.dashboard_item import DashboardItem
 from posthog.models.event import Event
 from posthog.models.event_definition import EventDefinition
 from posthog.models.property_definition import PropertyDefinition
+from posthog.utils import is_clickhouse_enabled
 
 
 def calculate_event_property_usage() -> None:

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -25,13 +25,12 @@ from posthog.constants import (
     FunnelVizType,
 )
 from posthog.decorators import CacheType
-from posthog.ee import is_clickhouse_enabled
 from posthog.models import Dashboard, DashboardItem, Filter, Team
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import get_filter
 from posthog.settings import CACHED_RESULTS_TTL
 from posthog.types import FilterType
-from posthog.utils import generate_cache_key
+from posthog.utils import generate_cache_key, is_clickhouse_enabled
 
 PARALLEL_DASHBOARD_ITEM_CACHE = int(os.environ.get("PARALLEL_DASHBOARD_ITEM_CACHE", 5))
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -39,10 +39,10 @@ from django.utils import timezone
 from rest_framework.request import Request
 from sentry_sdk import push_scope
 
-from posthog.constants import AvailableFeature
-from posthog.ee import is_clickhouse_enabled
+from posthog.constants import AnalyticsDBMS, AvailableFeature
 from posthog.exceptions import RequestParsingError
 from posthog.redis import get_client
+from posthog.utils import is_clickhouse_enabled
 
 DATERANGE_MAP = {
     "minute": datetime.timedelta(minutes=1),
@@ -555,6 +555,10 @@ def queryset_to_named_query(qs: QuerySet, prepend: str = "") -> Tuple[str, dict]
     for idx, param in enumerate(params):
         named_params.update({f"{prepend}_arg_{idx}": param})
     return new_string, named_params
+
+
+def is_clickhouse_enabled() -> bool:
+    return settings.EE_AVAILABLE and settings.PRIMARY_DB == AnalyticsDBMS.CLICKHOUSE
 
 
 def get_instance_realm() -> str:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -42,7 +42,6 @@ from sentry_sdk import push_scope
 from posthog.constants import AnalyticsDBMS, AvailableFeature
 from posthog.exceptions import RequestParsingError
 from posthog.redis import get_client
-from posthog.utils import is_clickhouse_enabled
 
 DATERANGE_MAP = {
     "minute": datetime.timedelta(minutes=1),

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -12,7 +12,6 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
 
-from posthog.ee import is_clickhouse_enabled
 from posthog.email import is_email_available
 from posthog.models import Organization, User
 from posthog.utils import (
@@ -22,6 +21,7 @@ from posthog.utils import (
     get_celery_heartbeat,
     get_instance_realm,
     is_celery_alive,
+    is_clickhouse_enabled,
     is_plugin_server_alive,
     is_postgres_alive,
     is_redis_alive,


### PR DESCRIPTION
## Changes

`ee.py` only contained this one `is_clickhouse_enabled` function and was confusingly located in the `posthog` app. I moved the function to `utils` where it makes more sense and removed the file.