### PR TITLE
[Proposal] use latest version of 3.9

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -70,7 +70,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8.5', '3.9']
+                python-version: ['3.8.5', '3.9.0']
         steps:
             - uses: actions/checkout@v1
               with:
@@ -86,6 +86,7 @@ jobs:
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
+              if: matrix.python-version != '3.9.0' # avoid using dependencies of 3.8.5
             - uses: syphar/restore-pip-download-cache@v1
               if: steps.cache-backend-tests.outputs.cache-hit != 'true'
             - name: Install python dependencies

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -70,7 +70,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8.5', '3.9.0']
+                python-version: ['3.8.5', '3.9']
         steps:
             - uses: actions/checkout@v1
               with:


### PR DESCRIPTION
## Changes

*Please describe.*  
- Suggestion to change the 3.9.0 test to 3.9 for now to suppress cache flakiness
- Context: Sometimes when you [run 3.9.0 test](https://github.com/PostHog/posthog/runs/3569128054), it's trying to use modules from a cached python 3.9.6 environment. 
- TODO: figure out why cache modules are wrong version and add back 3.9.0 separately
*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
