### PR TITLE
Humanize `$feature/*` key labels in PropertyKeyInfo

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
@@ -18,6 +18,9 @@ const Template: ComponentStory<typeof PropertyKeyInfo> = (args) => {
                 <PropertyKeyInfo {...args} value="$current_url" />
             </div>
             <div>
+                <PropertyKeyInfo {...args} value="$feature/some-feature-key" />
+            </div>
+            <div>
                 <PropertyKeyInfo {...args} value="$country" />
             </div>
             <div>

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -571,7 +571,7 @@ export function getKeyMapping(value: string | PropertyFilterValue, type: 'event'
         if (featureFlagKey) {
             return {
                 label: `Feature: ${featureFlagKey}`,
-                description: `Value for the feature flag "${featureFlagKey}" that was active when this event was sent.`,
+                description: `Value for the feature flag "${featureFlagKey}" when this event was sent.`,
                 examples: ['true', 'variant-1a'],
             }
         }

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -566,6 +566,15 @@ export function getKeyMapping(value: string | PropertyFilterValue, type: 'event'
             data.description = `${data.description} Data from the first time this user was seen.`
         }
         return data
+    } else if (value.startsWith('$feature/')) {
+        const featureFlagKey = value.replace(/^\$feature\//, '')
+        if (featureFlagKey) {
+            return {
+                label: `Feature: ${featureFlagKey}`,
+                description: `Value for the feature flag "${featureFlagKey}" that was active when this event was sent.`,
+                examples: ['true', 'variant-1a'],
+            }
+        }
     }
     return null
 }

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -549,7 +549,7 @@ export function PropertyKeyDescription({ data, value }: { data: KeyMapping; valu
                 data.description
             )}
             <hr />
-            Sent as <pre style={{ display: 'inline', padding: '2px 3px' }}>{value}</pre>
+            Sent as <code style={{ padding: '2px 3px' }}>{value}</code>
         </span>
     )
 }


### PR DESCRIPTION
## Changes

Parses property key names as specified in https://github.com/PostHog/posthog-js/pull/278 so that they look acceptable on the frontend.

Because of the work we've already done on searching/filtering properties, the user can just start typing the name of the flag they care about:

<img width="867" alt="Screen Shot 2021-09-10 at 5 05 06 PM" src="https://user-images.githubusercontent.com/4645779/132918191-7ac8fd3b-daae-4cfc-b7ba-b6ae505a8e14.png">

### Additional minor change

`<pre>` tag here with `inline` has been replaced by `<code>`, to avoid this unsightly overflow:

<img width="314" alt="Screen Shot 2021-09-10 at 5 05 12 PM" src="https://user-images.githubusercontent.com/4645779/132918193-0c3d6b9b-a80e-4aab-9e5e-b756f7b36af6.png">

With `<code>` tag:

<img width="311" alt="Screen Shot 2021-09-10 at 5 06 13 PM" src="https://user-images.githubusercontent.com/4645779/132918194-79582ac3-6360-49b4-b41d-cd8845ab116c.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
