### PR TITLE
Fix sessions -> trends whitescreen bug

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -132,7 +132,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
         },
     })
 
-    if (indexedResults?.length > 0) {
+    if (indexedResults?.length > 0 && indexedResults[0].data) {
         const valueColumns: ColumnsType<IndexedTrendResult> = indexedResults[0].data.map(({}, index: number) => ({
             title: (
                 <DateDisplay
@@ -204,7 +204,11 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
             rowKey="id"
             pagination={{ pageSize: 100, hideOnSinglePage: true }}
             style={{ marginTop: '1rem' }}
-            scroll={indexedResults && indexedResults.length > 0 ? { x: indexedResults[0].data.length * 160 } : {}}
+            scroll={
+                indexedResults && indexedResults.length > 0 && indexedResults[0].data
+                    ? { x: indexedResults[0].data.length * 160 }
+                    : {}
+            }
             data-attr="insights-table-graph"
         />
     )


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

The results shape for distribution of session lengths is not compatible with what trends receives so during the temporary switch, indexedResults[0].data does not exist 


https://user-images.githubusercontent.com/25164963/133006892-7c056b86-7643-40a3-ae58-7a79134fbea0.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
