### PR TITLE
SAML auto provisioning

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -10,6 +10,7 @@ from django.shortcuts import redirect, render
 from django.urls.base import reverse
 from rest_framework import exceptions, generics, permissions, response, serializers, validators
 from sentry_sdk import capture_exception
+from social_core.backends.base import BaseAuth
 from social_core.pipeline.partial import partial
 from social_django.strategy import DjangoStrategy
 
@@ -279,6 +280,73 @@ def finish_social_signup(request):
     return render(request, "signup_to_organization_company.html", {"user_name": request.session["user_name"]})
 
 
+def process_social_invite_signup(strategy: DjangoStrategy, invite_id: str, email: str, full_name: str) -> User:
+    try:
+        invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
+            "organization",
+        ).get(id=invite_id)
+    except (OrganizationInvite.DoesNotExist, ValidationError):
+        try:
+            invite = TeamInviteSurrogate(invite_id)
+        except Team.DoesNotExist:
+            return redirect(f"/signup/{invite_id}?error_code=invalid_invite&source=social_create_user")
+
+    try:
+        invite.validate(user=None, email=email)
+    except exceptions.ValidationError as e:
+        return redirect(
+            f"/signup/{invite_id}?error_code={e.get_codes()[0]}&error_detail={e.args[0]}&source=social_create_user"
+        )
+
+    try:
+        user = strategy.create_user(email=email, first_name=full_name, password=None)
+    except Exception as e:
+        capture_exception(e)
+        message = "Account unable to be created. This account may already exist. Please try again"
+        " or use different credentials."
+        return redirect(f"/signup/{invite_id}?error_code=unknown&error_detail={message}&source=social_create_user")
+
+    invite.use(user, prevalidated=True)
+
+    return user
+
+
+def process_social_domain_whitelist_signup(email: str, full_name: str) -> Optional[User]:
+    domain_organization: Optional[Organization] = None
+    user: Optional[User] = None
+
+    # TODO: This feature is currently available only in self-hosted
+    if not settings.MULTI_TENANCY:
+        # Check if the user is on a whitelisted domain
+        domain = email.split("@")[-1]
+        # TODO: Handle multiple organizations with the same whitelisted domain
+        domain_organization = Organization.objects.filter(domain_whitelist__contains=[domain]).first()
+
+    if domain_organization:
+        user = User.objects.create_and_join(
+            organization=domain_organization, email=email, password=None, first_name=full_name
+        )
+
+    return user
+
+
+def process_social_saml_signup(backend: BaseAuth, email: str, full_name: str) -> Optional[User]:
+    """
+    With SAML we have automatic provisioning because the IdP should already handle the logic of which users to allow to
+    login.
+    """
+
+    if backend.name != "saml":
+        return None
+
+    return User.objects.create_and_join(
+        organization=Organization.objects.filter(for_internal_metrics=False).first(),
+        email=email,
+        password=None,
+        first_name=full_name,
+    )
+
+
 @partial
 def social_create_user(strategy: DjangoStrategy, details, backend, request, user=None, *args, **kwargs):
     if user:
@@ -301,24 +369,24 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
             {missing_attr: "This field is required and was not provided by the IdP."}, code="required"
         )
 
-    if not invite_id:
+    if invite_id:
+        from_invite = True
+        user = process_social_invite_signup(strategy, invite_id, user_email, user_name)
 
-        domain_organization: Optional[Organization] = None
-
-        # TODO: This feature is currently available only in self-hosted
-        if not settings.MULTI_TENANCY:
-            # Check if the user is on a whitelisted domain
-            domain = user_email.split("@")[-1]
-            # TODO: Handle multiple organizations with the same whitelisted domain
-            domain_organization = Organization.objects.filter(domain_whitelist__contains=[domain]).first()
-
-        if domain_organization:
+    else:
+        # Domain whitelist?
+        user = process_social_domain_whitelist_signup(user_email, user_name)
+        if user:
             backend_processor = "domain_whitelist"
-            user = User.objects.create_and_join(
-                organization=domain_organization, email=user_email, password=None, first_name=user_name
-            )
 
-        else:
+        # SAML
+        if not user:
+            # Domain whitelist?
+            user = process_social_saml_signup(backend, user_email, user_name)
+            if user:
+                backend_processor = "saml"
+
+        if not user:
             organization_name = strategy.session_get("organization_name", None)
             email_opt_in = strategy.session_get("email_opt_in", None)
             if not organization_name or email_opt_in is None:
@@ -337,34 +405,6 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
 
             serializer.is_valid(raise_exception=True)
             user = serializer.save()
-    else:
-        from_invite = True
-        try:
-            invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
-                "organization",
-            ).get(id=invite_id)
-        except (OrganizationInvite.DoesNotExist, ValidationError):
-            try:
-                invite = TeamInviteSurrogate(invite_id)
-            except Team.DoesNotExist:
-                return redirect(f"/signup/{invite_id}?error_code=invalid_invite&source=social_create_user")
-
-        try:
-            invite.validate(user=None, email=user_email)
-        except exceptions.ValidationError as e:
-            return redirect(
-                f"/signup/{invite_id}?error_code={e.get_codes()[0]}&error_detail={e.args[0]}&source=social_create_user"
-            )
-
-        try:
-            user = strategy.create_user(email=user_email, first_name=user_name, password=None)
-        except Exception as e:
-            capture_exception(e)
-            message = "Account unable to be created. This account may already exist. Please try again"
-            " or use different credentials."
-            return redirect(f"/signup/{invite_id}?error_code=unknown&error_detail={message}&source=social_create_user")
-
-        invite.use(user, prevalidated=True)
 
     report_user_signed_up(
         distinct_id=user.distinct_id,

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -340,7 +340,7 @@ def process_social_saml_signup(backend: BaseAuth, email: str, full_name: str) ->
         return None
 
     return User.objects.create_and_join(
-        organization=Organization.objects.filter(for_internal_metrics=False).first(),
+        organization=Organization.objects.filter(for_internal_metrics=False).order_by("created_at").first(),
         email=email,
         password=None,
         first_name=full_name,

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth import login, password_validation
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
+from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls.base import reverse
 from rest_framework import exceptions, generics, permissions, response, serializers, validators
@@ -280,7 +281,9 @@ def finish_social_signup(request):
     return render(request, "signup_to_organization_company.html", {"user_name": request.session["user_name"]})
 
 
-def process_social_invite_signup(strategy: DjangoStrategy, invite_id: str, email: str, full_name: str) -> User:
+def process_social_invite_signup(
+    strategy: DjangoStrategy, invite_id: str, email: str, full_name: str
+) -> Union[HttpResponse, User]:
     try:
         invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
             "organization",
@@ -340,7 +343,7 @@ def process_social_saml_signup(backend: BaseAuth, email: str, full_name: str) ->
         return None
 
     return User.objects.create_and_join(
-        organization=Organization.objects.filter(for_internal_metrics=False).order_by("created_at").first(),
+        organization=Organization.objects.filter(for_internal_metrics=False).order_by("created_at").first(),  # type: ignore
         email=email,
         password=None,
         first_name=full_name,


### PR DESCRIPTION
## Changes

Closes #5853. Any new user who logs in through SAML will now get an account created automatically **every time**.  See issue for rationale. New users can be provisioned to specific organizations either by setting a domain whitelist in the org to match their email address (takes priority) or by creating/sending an invite for the specific user (#5839 pending).

User will be provisioned in the default org otherwise.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
