### PR TITLE
Put toolbar in storybook

### DIFF
--- a/frontend/src/toolbar/Toolbar.stories.tsx
+++ b/frontend/src/toolbar/Toolbar.stories.tsx
@@ -1,0 +1,40 @@
+import 'react-toastify/dist/ReactToastify.css'
+import '~/styles'
+import '~/toolbar/styles.scss'
+
+import React, { useEffect } from 'react'
+import { Meta } from '@storybook/react'
+import { keaStory } from 'lib/storybook/kea-story'
+
+import { ToolbarApp } from '~/toolbar/ToolbarApp'
+import toolbarJson from './__stories__/toolbar.json'
+
+import { EditorProps } from '~/types'
+
+export default {
+    title: 'Toolbar/Authenticated',
+} as Meta
+
+const toolbarStory = (json: Record<string, any>): (() => JSX.Element) => {
+    const { rawApiURL, rawJsUrl, buttonVisible, ...rest } = json?.toolbar?.toolbarLogic || {}
+    const editorParams: EditorProps = { ...rest, apiURL: rawApiURL, jsURL: rawJsUrl, userEmail: 'foobar@posthog.com' }
+    return keaStory(() => {
+        useEffect(() => {
+            const styleTags: HTMLStyleElement[] = Array.from(document.getElementsByTagName('style'))
+            ;(window as any)['__PHGTLB_STYLES__'] = styleTags.map((tag) => {
+                const style = document.createElement('style')
+                style.appendChild(document.createTextNode(tag.innerText))
+                return style
+            })
+        }, [])
+        return (
+            <div>
+                <div>The toolbar should show up now!</div>
+                <button>Click Me</button>
+                <ToolbarApp {...editorParams} />
+            </div>
+        )
+    }, json)
+}
+
+export const Open = toolbarStory(toolbarJson)

--- a/frontend/src/toolbar/__stories__/toolbar.json
+++ b/frontend/src/toolbar/__stories__/toolbar.json
@@ -1,0 +1,296 @@
+{
+    "kea": {
+        "router": {
+            "location": {
+                "pathname": "/feature_flags/new",
+                "search": "",
+                "hash": "#backTo=Feature%20Flags&backToURL=%2Ffeature_flags"
+            },
+            "searchParams": {},
+            "hashParams": {
+                "backTo": "Feature Flags",
+                "backToURL": "/feature_flags"
+            }
+        }
+    },
+    "toolbar": {
+        "toolbarLogic": {
+            "rawApiURL": "http://localhost:8000",
+            "rawJsURL": "http://localhost:8234/",
+            "temporaryToken": "UExb1dCsoqBtrhrZYxzmxXQ7XdjVH5Ea_zbQjTFuJqk",
+            "actionId": null,
+            "userIntent": null,
+            "buttonVisible": true,
+            "dataAttributes": ["data-attr"]
+        },
+        "stats": {
+            "currentPageLogic": {
+                "href": "http://localhost:8000/feature_flags/new#backTo=Feature%20Flags&backToURL=%2Ffeature_flags"
+            }
+        },
+        "elements": {
+            "heatmapLogic": {
+                "events": [],
+                "eventsLoading": false,
+                "heatmapEnabled": false,
+                "heatmapLoading": false,
+                "showHeatmapTooltip": false,
+                "heatmapFilter": {}
+            },
+            "elementsLogic": {
+                "inspectEnabledRaw": false,
+                "rectUpdateCounter": 6,
+                "hoverElement": null,
+                "highlightElement": null,
+                "selectedElement": null,
+                "enabledLast": null
+            }
+        },
+        "actions": {
+            "actionsLogic": {
+                "allActions": [
+                    {
+                        "id": 8,
+                        "name": "Entered Free Trial",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "8",
+                                "event": "entered_free_trial",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": null,
+                                "url": null,
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.742431Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.196274Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 7,
+                        "name": "Purchase",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "7",
+                                "event": "purchase",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": null,
+                                "url": null,
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.736545Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.181461Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 6,
+                        "name": "Watched Movie",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "6",
+                                "event": "watched_movie",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": null,
+                                "url": null,
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.506289Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.080960Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 5,
+                        "name": "Rated App",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "5",
+                                "event": "rated_app",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": null,
+                                "url": null,
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.498637Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.129927Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 4,
+                        "name": "Installed App",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "4",
+                                "event": "installed_app",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": null,
+                                "url": null,
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.493475Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.142609Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 3,
+                        "name": "HogFlix paid",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "3",
+                                "event": "$autocapture",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": "button",
+                                "url": "http://hogflix.com/2",
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.043829Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.174216Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 2,
+                        "name": "HogFlix signed up",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "2",
+                                "event": "$autocapture",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": "button",
+                                "url": "http://hogflix.com/1",
+                                "name": null,
+                                "url_matching": "contains",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:38.019025Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.166619Z",
+                        "created_by": null,
+                        "team_id": 2
+                    },
+                    {
+                        "id": 1,
+                        "name": "HogFlix homepage view",
+                        "post_to_slack": false,
+                        "slack_message_format": "",
+                        "steps": [
+                            {
+                                "id": "1",
+                                "event": "$pageview",
+                                "tag_name": null,
+                                "text": null,
+                                "href": null,
+                                "selector": null,
+                                "url": "http://hogflix.com",
+                                "name": null,
+                                "url_matching": "exact",
+                                "properties": []
+                            }
+                        ],
+                        "created_at": "2021-09-10T16:24:37.986574Z",
+                        "deleted": false,
+                        "is_calculating": false,
+                        "last_calculated_at": "2021-09-13T08:51:00.157574Z",
+                        "created_by": null,
+                        "team_id": 2
+                    }
+                ],
+                "allActionsLoading": false
+            },
+            "actionsTabLogic": {
+                "buttonActionsVisible": false,
+                "selectedActionId": null,
+                "newActionForElement": null,
+                "inspectingElement": null,
+                "editingFields": null,
+                "form": null,
+                "counter": 0,
+                "showActionsTooltip": false
+            }
+        },
+        "button": {
+            "toolbarButtonLogic": {
+                "windowHeight": 796,
+                "windowWidth": 890,
+                "heatmapInfoVisible": false,
+                "actionsInfoVisible": false,
+                "extensionPercentage": 1,
+                "lastDragPosition": {
+                    "x": 270,
+                    "y": 236
+                },
+                "heatmapPosition": {
+                    "x": 100,
+                    "y": 100
+                },
+                "actionsPosition": {
+                    "x": 120,
+                    "y": 100
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -30,3 +30,13 @@ initKea()
         container
     )
 }
+
+// Expose `window.getToolbarReduxState()` to make snapshots to storybook easy
+if (typeof window !== 'undefined') {
+    // Disabled in production to prevent leaking secret data, personal API keys, etc
+    if (process.env.NODE_ENV === 'development') {
+        ;(window as any).getToolbarReduxState = () => getContext().store.getState()
+    } else {
+        ;(window as any).getToolbarReduxState = () => 'Disabled outside development!'
+    }
+}

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -36,7 +36,5 @@ if (typeof window !== 'undefined') {
     // Disabled in production to prevent leaking secret data, personal API keys, etc
     if (process.env.NODE_ENV === 'development') {
         ;(window as any).getToolbarReduxState = () => getContext().store.getState()
-    } else {
-        ;(window as any).getToolbarReduxState = () => 'Disabled outside development!'
     }
 }


### PR DESCRIPTION
## Changes

- Adds a basic toolbar into the storybook
![2021-09-13 11 41 08](https://user-images.githubusercontent.com/53387/133061760-a8537823-4858-4877-bb32-a5b3ee75dde9.gif)

- Goal: use it to also showcase the toolbar feature flags frontend work: https://github.com/PostHog/posthog/pull/5866 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
