### PR TITLE
Bugfix: cohort calculating race condition

### DIFF
--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -43,9 +43,9 @@ INSERT INTO cohortpeople
         SELECT id, argMax(properties, person._timestamp) as properties, sum(is_deleted) as is_deleted FROM person WHERE team_id = %(team_id)s GROUP BY id
     ) as person
     LEFT JOIN (
-        SELECT person_id FROM cohortpeople WHERE cohort_id = %(cohort_id)s AND team_id = %(team_id)s
+        SELECT person_id, sum(sign) AS sign FROM cohortpeople WHERE cohort_id = %(cohort_id)s AND team_id = %(team_id)s GROUP BY person_id
     ) as cohortpeople ON (person.id = cohortpeople.person_id)
-    WHERE cohortpeople.person_id = '00000000-0000-0000-0000-000000000000'
+    WHERE (cohortpeople.person_id = '00000000-0000-0000-0000-000000000000' OR sign = 0)
     AND person.is_deleted = 0
     AND id IN ({cohort_filter})
 """

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -149,7 +149,7 @@ class Cohort(models.Model):
 
             try:
                 recalculate_cohortpeople(self)
-                calculate_cohort.delay(self.id)
+                calculate_cohort(self.id)
                 self.last_calculation = timezone.now()
                 self.errors_calculating = 0
             except Exception as e:

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -145,9 +145,11 @@ class Cohort(models.Model):
     def calculate_people_ch(self):
         if is_clickhouse_enabled():
             from ee.clickhouse.models.cohort import recalculate_cohortpeople
+            from posthog.tasks.calculate_cohort import calculate_cohort
 
             try:
                 recalculate_cohortpeople(self)
+                calculate_cohort.delay(self.id)
                 self.last_calculation = timezone.now()
                 self.errors_calculating = 0
             except Exception as e:

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -31,9 +31,10 @@ def calculate_cohorts() -> None:
         .exclude(is_static=True)
         .order_by(F("last_calculation").asc(nulls_first=True))[0 : settings.CALCULATE_X_COHORTS_PARALLEL]
     ):
-        calculate_cohort.delay(cohort.id)
         if is_clickhouse_enabled():
             calculate_cohort_ch.delay(cohort.id)
+        else:
+            calculate_cohort.delay(cohort.id)
 
 
 @shared_task(ignore_result=True, max_retries=1)


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses #5927
- The issue was due to poor ordering of functions that caused a race condition.
- Cohort persons retrieves from our postgres store. Clickhouse backed instances update cohorts by (1) calculating from cohortpeople in clickhouse then (2) using the updated cohortpeople to populate the postgres store. The order of (1) and (2) wasn't consistent
- Additionally, when calculating the new cohort people to add to the cohort, the query wasn't considering the tombstoned persons in the cohortpeople table

https://user-images.githubusercontent.com/13127476/133151544-7bab94af-2d9d-4355-816e-05348be9184e.mov



Next steps:
- add tests
- clean up cohort queries. They seem very repetitive and can use our new patterns

** The next steps aren't blocking to get this merged for the release