### PR TITLE
Disable browser translators in PostHog

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html lang="en" class="notranslate" translate="no">
+<html lang="en">
     <head>
         {% include "head.html" %}
     </head>
     <body>
         {% include "overlays.html" %}
         <script>
-            if (typeof Object.entries === 'undefined' || typeof Object.fromEntries === 'undefined' || typeof Array.prototype.flatMap === 'undefined') {
+            if (
+                typeof Object.entries === 'undefined' ||
+                typeof Object.fromEntries === 'undefined' ||
+                typeof Array.prototype.flatMap === 'undefined'
+            ) {
                 var div = document.createElement('div')
                 div.style.color = '#fef6f6'
                 div.style.background = '#920c0c'

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en" class="notranslate" translate="no">
     <head>
         {% include "head.html" %}
     </head>

--- a/frontend/src/layout.ejs
+++ b/frontend/src/layout.ejs
@@ -1,6 +1,6 @@
 <%/* DJANGO login/signup form layout! */%>
 <!doctype html>
-<html lang="en" class="notranslate" translate="no">
+<html lang="en">
   <head>
     <meta name="robots" content="noindex">
     <title>PostHog</title>

--- a/frontend/src/layout.ejs
+++ b/frontend/src/layout.ejs
@@ -1,6 +1,6 @@
 <%/* DJANGO login/signup form layout! */%>
 <!doctype html>
-<html>
+<html lang="en" class="notranslate" translate="no">
   <head>
     <meta name="robots" content="noindex">
     <title>PostHog</title>

--- a/posthog/templates/demo.html
+++ b/posthog/templates/demo.html
@@ -1,4 +1,4 @@
-<html lang="en" class="notranslate" translate="no">
+<html lang="en">
 
 <head>
     <title>HogFlix</title>

--- a/posthog/templates/demo.html
+++ b/posthog/templates/demo.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en" class="notranslate" translate="no">
 
 <head>
     <title>HogFlix</title>


### PR DESCRIPTION
## Changes

Small addition to top-level `html` tags that will prevent browser translators from trying to translate PostHog (which caused weird wording in at least one case for @liyiy).