### PR TITLE
Encode insight url in toolbar

### DIFF
--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -180,9 +180,9 @@ export const actionsTabLogic = kea<actionsTabLogicType<ActionFormInstance>>({
             actionsLogic.actions.updateAction({ action: response })
             actions.selectAction(null)
 
-            const insightsUrl = `insights?insight=TRENDS&interval=day&actions=${JSON.stringify([
-                { type: 'actions', id: response.id, order: 0, name: response.name },
-            ])}`
+            const insightsUrl = `insights?insight=TRENDS&interval=day&actions=${encodeURIComponent(
+                JSON.stringify([{ type: 'actions', id: response.id, order: 0, name: response.name }])
+            )}`
 
             toast(
                 <>


### PR DESCRIPTION
## Changes

This JSON wasn't encoded properly.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
