### PR TITLE
Fix eventUsageLogic.ts error if properties is an object

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -78,14 +78,19 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
     } = filters
 
     let properties_local: string[] = []
-    for (const event of filters.events || []) {
+
+    const events = Array.isArray(filters.events) ? filters.events : []
+    for (const event of events || []) {
         properties_local = properties_local.concat(flattenProperties(event.properties || []))
     }
-    for (const action of filters.actions || []) {
+
+    const actions = Array.isArray(filters.actions) ? filters.actions : []
+    for (const action of actions || []) {
         properties_local = properties_local.concat(flattenProperties(action.properties || []))
     }
 
-    const properties_global = flattenProperties(filters.properties || [])
+    const properties = Array.isArray(filters.properties) ? filters.properties : []
+    const properties_global = flattenProperties(properties || [])
 
     return {
         insight,
@@ -95,9 +100,9 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
         date_to,
         filter_test_accounts,
         formula,
-        filters_count: filters.properties?.length || 0,
-        events_count: filters.events?.length || 0,
-        actions_count: filters.actions?.length || 0,
+        filters_count: properties?.length || 0,
+        events_count: events?.length || 0,
+        actions_count: actions?.length || 0,
         funnel_viz_type,
         funnel_from_step,
         funnel_to_step,

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -80,17 +80,17 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
     let properties_local: string[] = []
 
     const events = Array.isArray(filters.events) ? filters.events : []
-    for (const event of events || []) {
+    for (const event of events) {
         properties_local = properties_local.concat(flattenProperties(event.properties || []))
     }
 
     const actions = Array.isArray(filters.actions) ? filters.actions : []
-    for (const action of actions || []) {
+    for (const action of actions) {
         properties_local = properties_local.concat(flattenProperties(action.properties || []))
     }
 
     const properties = Array.isArray(filters.properties) ? filters.properties : []
-    const properties_global = flattenProperties(properties || [])
+    const properties_global = flattenProperties(properties)
 
     return {
         insight,


### PR DESCRIPTION
## Changes

- Very niche fix for `reportInsightViewed` in `eventUsageLogic` not crashing.
- Fix for https://sentry.io/organizations/posthog/issues/2647762958/?referrer=slack
- Not a fix for the root cause unfortunately. Not sure where these object properties came from.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
