### PR TITLE
Cohort UI fixes: type type and deletion bug

### DIFF
--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -70,7 +70,7 @@ export function Cohort(props: { cohort: CohortType }): JSX.Element {
         },
     ]
 
-    const COHORT_TYPE_DROPDOWN = (
+    const cohortTypeDropdown = (): JSX.Element => (
         <DropdownSelector
             options={COHORT_TYPE_OPTIONS}
             disabled={cohort.id !== 'new'}
@@ -92,10 +92,10 @@ export function Cohort(props: { cohort: CohortType }): JSX.Element {
                 </Col>
                 <Col md={10}>
                     {cohort.id === 'new' ? (
-                        COHORT_TYPE_DROPDOWN
+                        cohortTypeDropdown()
                     ) : (
                         <Tooltip title="Create a new cohort to use a different type of cohort.">
-                            <div>{COHORT_TYPE_DROPDOWN}</div>
+                            <div>{cohortTypeDropdown()}</div>
                         </Tooltip>
                     )}
                 </Col>

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -130,7 +130,7 @@ class CohortSerializer(serializers.ModelSerializer):
         cohort.is_static = validated_data.get("is_static", cohort.is_static)
         deleted_state = validated_data.get("deleted", None)
 
-        is_deletion_change = deleted_state is not None
+        is_deletion_change = deleted_state is not None and cohort.deleted != deleted_state
         if is_deletion_change:
             cohort.deleted = deleted_state
 


### PR DESCRIPTION
## Changes

*Please describe.*  
- cohort type dropdown doesn't work right now because the component wasn't defined as a function
- deletion handling was faulty because the deleted field was being passed to the api but we don't want to handle it unless it's an actual deletion change. This was preventing the calculating field to be set and render the loading box on the frontend when someone updates a cohort

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
