### PR TITLE
Make `EnterpriseFeatureException` more informational, with a CTA

### DIFF
--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -99,7 +99,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertEqual(response.json()["detail"], "This is an Enterprise feature.")
+        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
 
     def test_with_expired_license(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -110,4 +110,4 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertEqual(response.json()["detail"], "This is an Enterprise feature.")
+        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -99,7 +99,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])
 
     def test_with_expired_license(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -110,4 +110,4 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -99,7 +99,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
 
     def test_with_expired_license(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -110,4 +110,4 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")

--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -95,7 +95,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])
 
     def test_with_expired_license(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -106,7 +106,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])
 
     def test_filter_property_definitions(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(

--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -95,7 +95,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertEqual(response.json()["detail"], "This is an Enterprise feature.")
+        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
 
     def test_with_expired_license(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -106,7 +106,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertEqual(response.json()["detail"], "This is an Enterprise feature.")
+        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
 
     def test_filter_property_definitions(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(

--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -95,7 +95,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
 
     def test_with_expired_license(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -106,7 +106,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertContains(response.json()["detail"], "This feature is part of the premium PostHog offering.")
+        self.assertIn(response.json()["detail"], "This feature is part of the premium PostHog offering.")
 
     def test_filter_property_definitions(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -1,5 +1,6 @@
-from typing import Dict, Literal, Optional, TypedDict
+from typing import Optional, TypedDict
 
+from django.conf import settings
 from django.core.signals import got_request_exception
 from django.http.request import HttpRequest
 from django.http.response import JsonResponse
@@ -14,7 +15,18 @@ class RequestParsingError(Exception):
 
 class EnterpriseFeatureException(APIException):
     status_code = status.HTTP_402_PAYMENT_REQUIRED
-    default_detail = "This is an Enterprise feature."
+
+    def __init__(self) -> None:
+        super().__init__(
+            detail=(
+                "This feature is part of the premium PostHog offering. "
+                + (
+                    "To use it, subscribe to PostHog Cloud with a generous free tier: https://app.posthog.com/organization/billing"
+                    if settings.MULTI_TENANCY
+                    else "To use it, contact us for a self-hosted license: https://posthog.com/pricing"
+                )
+            )
+        )
 
 
 class EstimatedQueryExecutionTimeTooLong(APIException):


### PR DESCRIPTION
## Changes

Changes API error message for premium features from

> This is an Enterprise feature.

to (Cloud)

> This feature is part of the premium PostHog offering. To use it, subscribe to PostHog Cloud with a generous free tier: https://app.posthog.com/organization/billing

or (self-hosted)

> This feature is part of the premium PostHog offering. To use it, contact us for a self-hosted license: https://posthog.com/pricing

## Checklist

- [x] Django backend tests