### PR TITLE
Unify rounding to 4px everywhere

### DIFF
--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -347,7 +347,7 @@
 .navigation-top-dropdown-overlay {
     @extend %mixin-elevated;
     position: fixed;
-    border-radius: $button_radius;
+    border-radius: $radius;
     border: 1px solid var(--border);
     background-color: $bg_light;
     z-index: $z_top_navigation + 3 !important;
@@ -393,7 +393,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            border-radius: $button_radius;
+            border-radius: $radius;
             color: $primary;
             &:hover {
                 background-color: $border;

--- a/frontend/src/lib/components/Popup/Popup.scss
+++ b/frontend/src/lib/components/Popup/Popup.scss
@@ -5,6 +5,6 @@
     box-shadow: 0 3px 6px -4px rgb(0 0 0 / 12%), 0 6px 16px 0 rgb(0 0 0 / 8%), 0 9px 28px 8px rgb(0 0 0 / 5%);
     background: white;
     padding: 10px;
-    border-radius: $button_radius;
+    border-radius: $radius;
     border: 1px solid var(--border);
 }

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -116,8 +116,7 @@ $gosha_sans: 'GoshaSans-Bold', -apple-system, BlinkMacSystemFont, 'Segoe UI', Ro
 }
 
 $default_spacing: 16px;
-$radius: 2px;
-$button_radius: 4px;
+$radius: 4px;
 $top_nav_height: 50px;
 
 .text-ellipsis {


### PR DESCRIPTION
## Changes

Makes `$radius` 4px too, allowing for removal of separate `$button_radius`. Minimal change for the UI, since most rounding takes place at AntD level (`@border-radius-base`) anyway, which has been set at 4px last month.