### PR TITLE
Reset new events when changing events page filter

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.js
+++ b/frontend/src/scenes/events/eventsTableLogic.js
@@ -123,6 +123,7 @@ export const eventsTableLogic = kea({
         newEvents: [
             [],
             {
+                setProperties: () => [],
                 pollEventsSuccess: (_, { events }) => events,
                 prependNewEvents: () => [],
             },


### PR DESCRIPTION
## Changes

Removes the "there are new events" bar when you change the filter.

![image](https://user-images.githubusercontent.com/53387/133393976-c4cdec2b-4500-40ab-882d-7fa7c0bc6f12.png)

It used to stay there and give old prefetched events when clicked after changing a filter.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
