### PR TITLE
Management command to create feature flags from constants.tsx

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -1,0 +1,39 @@
+import re
+from typing import List
+
+from django.core.management.base import BaseCommand
+
+from posthog.models import FeatureFlag, Team, User
+
+
+class Command(BaseCommand):
+    help = "Add and enable all feature flags in frontend/src/lib/constants.tsx for all teams"
+
+    def handle(self, *args, **options):
+        flags: List[str] = []
+        with open("frontend/src/lib/constants.tsx") as f:
+            lines = f.readlines()
+            parsing_flags = False
+            for line in lines:
+                if parsing_flags:
+                    if "}" in line:
+                        parsing_flags = False
+                    else:
+                        try:
+                            flag = line.split("'")[1]
+                            flags.append(flag)
+                        except IndexError:
+                            pass
+
+                elif "export const FEATURE_FLAGS" in line:
+                    parsing_flags = True
+
+        first_user = User.objects.first()
+        for team in Team.objects.all():
+            existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
+            for flag in flags:
+                if flag not in existing_flags:
+                    FeatureFlag.objects.create(
+                        team=team, rollout_percentage=100, name=flag, key=flag, created_by=first_user
+                    )
+                    print(f"Created feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")


### PR DESCRIPTION
## Changes

- Run `python manage.py sync_feature_flags` and you'll see something like this:

```
Created feature flag 'test-environment-3149 for team 2  - HogFlix Demo App
Created feature flag 'papercups-enabled for team 2  - HogFlix Demo App
Created feature flag 'ingestion-grid-exp-3 for team 2  - HogFlix Demo App
Created feature flag 'project-home-exp-5 for team 2  - HogFlix Demo App
Created feature flag '3638-trailing-wau-mau for team 2  - HogFlix Demo App
Created feature flag '4141-event-columns for team 2  - HogFlix Demo App
Created feature flag '4562-nps for team 2  - HogFlix Demo App
Created feature flag '4267-event-property-taxonomy for team 2  - HogFlix Demo App
Created feature flag '4871-plugin-metrics for team 2  - HogFlix Demo App
Created feature flag '4964-sessions-table for team 2  - HogFlix Demo App
Created feature flag '112-ingestion-help-button for team 2  - HogFlix Demo App
Created feature flag '3408-saved-insights for team 2  - HogFlix Demo App
Created feature flag '5440-multivariate-support for team 2  - HogFlix Demo App
Created feature flag '5730-funnel-horizontal-ui for team 2  - HogFlix Demo App
Created feature flag '5720-plugins-ui-jobs for team 2  - HogFlix Demo App
Created feature flag 'hackathon-dive-dashboards for team 2  - HogFlix Demo App
Created feature flag 'test-environment-3149 for team 1  - Default Project
Created feature flag 'papercups-enabled for team 1  - Default Project
Created feature flag 'ingestion-grid-exp-3 for team 1  - Default Project
Created feature flag 'project-home-exp-5 for team 1  - Default Project
Created feature flag '3638-trailing-wau-mau for team 1  - Default Project
Created feature flag '4141-event-columns for team 1  - Default Project
Created feature flag '4562-nps for team 1  - Default Project
Created feature flag '4267-event-property-taxonomy for team 1  - Default Project
Created feature flag '4871-plugin-metrics for team 1  - Default Project
Created feature flag '4964-sessions-table for team 1  - Default Project
Created feature flag '112-ingestion-help-button for team 1  - Default Project
Created feature flag '3408-saved-insights for team 1  - Default Project
Created feature flag '5440-multivariate-support for team 1  - Default Project
Created feature flag '5730-funnel-horizontal-ui for team 1  - Default Project
Created feature flag '5720-plugins-ui-jobs for team 1  - Default Project
Created feature flag 'hackathon-dive-dashboards for team 1  - Default Project
```

It takes the data from `constants.tsx`, so not all flags are created, but enough to make this really useful. No multivariate support either.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
