### PR TITLE
Make organization members lookup UUID-based + remove pagination

### DIFF
--- a/frontend/src/scenes/events/definitions/DefinitionOwnerDropdown.tsx
+++ b/frontend/src/scenes/events/definitions/DefinitionOwnerDropdown.tsx
@@ -18,10 +18,15 @@ export function DefinitionOwnerDropdown({ owner }: { owner: UserBasicType | null
                 placeholder={<Owner user={owner} />}
                 style={{ minWidth: 200 }}
                 dropdownClassName="owner-option"
-                onChange={(val) => changeOwner(members.find((mem) => mem.user.id === val))}
+                onChange={(val) => {
+                    const newOwner = members.find((mem) => mem.user.id === val)?.user
+                    if (newOwner) {
+                        changeOwner(newOwner)
+                    }
+                }}
             >
                 {members.map((member) => (
-                    <Select.Option key={member.user_id} value={member.user.id}>
+                    <Select.Option key={member.user.id} value={member.user.id}>
                         <Owner user={member.user} />
                     </Select.Option>
                 ))}

--- a/frontend/src/scenes/organization/Settings/Members.tsx
+++ b/frontend/src/scenes/organization/Settings/Members.tsx
@@ -258,7 +258,7 @@ export function Members({ user }: { user: UserType }): JSX.Element {
             <Table
                 dataSource={members}
                 columns={columns}
-                rowKey="membership_id"
+                rowKey="id"
                 pagination={false}
                 style={{ marginTop: '1rem' }}
                 loading={membersLoading}

--- a/frontend/src/scenes/organization/Settings/Members.tsx
+++ b/frontend/src/scenes/organization/Settings/Members.tsx
@@ -203,41 +203,35 @@ function ActionsComponent(member: OrganizationMemberType): JSX.Element | null {
 export function Members({ user }: { user: UserType }): JSX.Element {
     const { members, membersLoading } = useValues(membersLogic)
 
-    const columns: ColumnsType<Record<string, any>> = [
+    const columns: ColumnsType<OrganizationMemberType> = [
         {
-            dataIndex: 'user_email',
-            key: 'user_email',
+            key: 'user_profile_picture',
             render: function ProfilePictureRender(_, member) {
-                return <ProfilePicture name={member.user_first_name} email={member.user_email} />
+                return <ProfilePicture name={member.user.first_name} email={member.user.email} />
             },
             width: 32,
         },
         {
             title: 'Name',
-            dataIndex: 'user_first_name',
             key: 'user_first_name',
-            render: (firstName: string, member: Record<string, any>) =>
-                member.user_id == user.uuid ? `${firstName} (me)` : firstName,
-            sorter: (a, b) =>
-                (a as OrganizationMemberType).user.first_name.localeCompare(
-                    (b as OrganizationMemberType).user.first_name
-                ),
+            render: (_, member) =>
+                member.user.uuid == user.uuid ? `${member.user.first_name} (me)` : member.user.first_name,
+            sorter: (a, b) => a.user.first_name.localeCompare(b.user.first_name),
         },
         {
             title: 'Email',
-            dataIndex: 'user_email',
             key: 'user_email',
-            sorter: (a, b) =>
-                (a as OrganizationMemberType).user.email.localeCompare((b as OrganizationMemberType).user.email),
+            render: (_, member) => member.user.email,
+            sorter: (a, b) => a.user.email.localeCompare(b.user.email),
         },
         {
             title: 'Level',
             dataIndex: 'level',
             key: 'level',
             render: function LevelRender(_, member) {
-                return LevelComponent(member as OrganizationMemberType)
+                return LevelComponent(member)
             },
-            sorter: (a, b) => (a as OrganizationMemberType).level - (b as OrganizationMemberType).level,
+            sorter: (a, b) => a.level - b.level,
             defaultSortOrder: 'descend',
         },
         {
@@ -245,8 +239,7 @@ export function Members({ user }: { user: UserType }): JSX.Element {
             dataIndex: 'joined_at',
             key: 'joined_at',
             render: (joinedAt: string) => humanFriendlyDetailedTime(joinedAt),
-            sorter: (a, b) =>
-                (a as OrganizationMemberType).joined_at.localeCompare((b as OrganizationMemberType).joined_at),
+            sorter: (a, b) => a.joined_at.localeCompare(b.joined_at),
             defaultSortOrder: 'ascend',
         },
         {
@@ -254,7 +247,7 @@ export function Members({ user }: { user: UserType }): JSX.Element {
             key: 'actions',
             align: 'center',
             render: function ActionsRender(_, member) {
-                return ActionsComponent(member as OrganizationMemberType)
+                return ActionsComponent(member)
             },
         },
     ]

--- a/frontend/src/scenes/organization/Settings/membersLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/membersLogic.tsx
@@ -15,37 +15,31 @@ export const membersLogic = kea<membersLogicType>({
             member,
             level,
         }),
-        postRemoveMember: (memberUuid: string) => ({ memberUuid }),
+        postRemoveMember: (userUuid: string) => ({ userUuid }),
     },
     loaders: ({ values, actions }) => ({
         members: {
-            __default: [],
+            __default: [] as OrganizationMemberType[],
             loadMembers: async () => {
-                return (await api.get('api/organizations/@current/members/')).results
+                return await api.get('api/organizations/@current/members/')
             },
-            removeMember: async (member) => {
-                await api.delete(`api/organizations/@current/members/${member.user_id}/`)
+            removeMember: async (member: OrganizationMemberType) => {
+                await api.delete(`api/organizations/@current/members/${member.user.uuid}/`)
                 toast(
                     <div>
                         <h1 className="text-success">
-                            <CheckCircleOutlined /> Removed <b>{member.user_first_name}</b> from organization.
+                            <CheckCircleOutlined /> Removed <b>{member.user.first_name}</b> from organization.
                         </h1>
                     </div>
                 )
                 actions.postRemoveMember(member.user.uuid)
-                return values.members.filter((thisMember) => thisMember.user_id !== member.user_id)
+                return values.members.filter((thisMember) => thisMember.user.id !== member.user.id)
             },
         },
     }),
     listeners: ({ actions }) => ({
-        changeMemberAccessLevel: async ({
-            member,
-            level,
-        }: {
-            member: OrganizationMemberType
-            level: OrganizationMembershipLevel
-        }) => {
-            await api.update(`api/organizations/@current/members/${member.user.id}/`, { level })
+        changeMemberAccessLevel: async ({ member, level }) => {
+            await api.update(`api/organizations/@current/members/${member.user.uuid}/`, { level })
             toast(
                 <div>
                     <h1 className="text-success">
@@ -60,8 +54,8 @@ export const membersLogic = kea<membersLogicType>({
             }
             actions.loadMembers()
         },
-        postRemoveMember: async ({ memberUuid }) => {
-            if (memberUuid === userLogic.values.user?.uuid) {
+        postRemoveMember: async ({ userUuid }) => {
+            if (userUuid === userLogic.values.user?.uuid) {
                 location.reload()
             }
         },

--- a/frontend/src/scenes/organization/Settings/membersLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/membersLogic.tsx
@@ -21,7 +21,7 @@ export const membersLogic = kea<membersLogicType>({
         members: {
             __default: [] as OrganizationMemberType[],
             loadMembers: async () => {
-                return await api.get('api/organizations/@current/members/')
+                return (await api.get('api/organizations/@current/members/?limit=200')).results
             },
             removeMember: async (member: OrganizationMemberType) => {
                 await api.delete(`api/organizations/@current/members/${member.user.uuid}/`)

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -282,8 +282,8 @@ export function SavedInsights(): JSX.Element {
                     >
                         <Select.Option value={'All users'}>All users</Select.Option>
                         {members.map((member) => (
-                            <Select.Option key={member.user_id} value={member.user_id}>
-                                {member.user_first_name}
+                            <Select.Option key={member.user.id} value={member.user.id}>
+                                {member.user.first_name}
                             </Select.Option>
                         ))}
                     </Select>

--- a/frontend/src/scenes/saved-insights/__stories__/saved-insights-card.json
+++ b/frontend/src/scenes/saved-insights/__stories__/saved-insights-card.json
@@ -1818,10 +1818,6 @@
                                 "first_name": "Marius",
                                 "email": "marius@posthog.com"
                             },
-                            "membership_id": "01778ae6-ad1a-0000-2024-9c7fae441f44",
-                            "user_id": 1,
-                            "user_first_name": "Marius",
-                            "user_email": "marius@posthog.com",
                             "level": 15,
                             "joined_at": "2021-02-10T07:45:09.403253Z",
                             "updated_at": "2021-02-10T07:45:09.403362Z"
@@ -1835,10 +1831,6 @@
                                 "first_name": "Test",
                                 "email": "test@hot.ee"
                             },
-                            "membership_id": "017a519e-12de-0000-6888-df2a58b3ab43",
-                            "user_id": 2,
-                            "user_first_name": "Test",
-                            "user_email": "test@hot.ee",
                             "level": 1,
                             "joined_at": "2021-06-28T07:55:51.902703Z",
                             "updated_at": "2021-06-28T07:55:51.902733Z"

--- a/frontend/src/scenes/saved-insights/__stories__/saved-insights-list.json
+++ b/frontend/src/scenes/saved-insights/__stories__/saved-insights-list.json
@@ -1818,10 +1818,6 @@
                                 "first_name": "Marius",
                                 "email": "marius@posthog.com"
                             },
-                            "membership_id": "01778ae6-ad1a-0000-2024-9c7fae441f44",
-                            "user_id": 1,
-                            "user_first_name": "Marius",
-                            "user_email": "marius@posthog.com",
                             "level": 15,
                             "joined_at": "2021-02-10T07:45:09.403253Z",
                             "updated_at": "2021-02-10T07:45:09.403362Z"
@@ -1835,10 +1831,6 @@
                                 "first_name": "Test",
                                 "email": "test@hot.ee"
                             },
-                            "membership_id": "017a519e-12de-0000-6888-df2a58b3ab43",
-                            "user_id": 2,
-                            "user_first_name": "Test",
-                            "user_email": "test@hot.ee",
                             "level": 1,
                             "joined_at": "2021-06-28T07:55:51.902703Z",
                             "updated_at": "2021-06-28T07:55:51.902733Z"

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -71,7 +71,6 @@ class OrganizationMemberViewSet(
 ):
     serializer_class = OrganizationMemberSerializer
     permission_classes = [IsAuthenticated, OrganizationMemberPermissions, OrganizationMemberObjectPermissions]
-    pagination_class = None
     queryset = OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
     lookup_field = "user__uuid"
     ordering = ["level", "-joined_at"]

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -35,9 +35,6 @@ class OrganizationMemberObjectPermissions(BasePermission):
 
 
 class OrganizationMemberSerializer(serializers.ModelSerializer):
-    user_first_name = serializers.CharField(source="user.first_name", read_only=True)
-    user_email = serializers.CharField(source="user.email", read_only=True)
-    membership_id = serializers.CharField(source="id", read_only=True)
     user = UserBasicSerializer(read_only=True)
 
     class Meta:
@@ -45,15 +42,11 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "user",
-            "membership_id",  # TODO: DEPRECATED in favor of `id` (for consistency)
-            "user_id",  # TODO: DEPRECATED in favor of `user`
-            "user_first_name",  # TODO: DEPRECATED in favor of `user`
-            "user_email",  # TODO: DEPRECATED in favor of `user`
             "level",
             "joined_at",
             "updated_at",
         ]
-        read_only_fields = ["user_id", "joined_at", "updated_at"]
+        read_only_fields = ["id", "joined_at", "updated_at"]
 
     def update(self, updated_membership, validated_data, **kwargs):
         updated_membership = cast(OrganizationMembership, updated_membership)

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -9,6 +9,7 @@ from rest_framework.serializers import raise_errors_on_nested_writes
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.constants import INTERNAL_BOT_EMAIL_SUFFIX
 from posthog.models import OrganizationMembership
 from posthog.models.user import User
 from posthog.permissions import OrganizationMemberPermissions, extract_organization
@@ -77,8 +78,9 @@ class OrganizationMemberViewSet(
 ):
     serializer_class = OrganizationMemberSerializer
     permission_classes = [IsAuthenticated, OrganizationMemberPermissions, OrganizationMemberObjectPermissions]
-    queryset = OrganizationMembership.objects.exclude(user__email__endswith="@posthogbot.user")
-    lookup_field = "user_id"
+    pagination_class = None
+    queryset = OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
+    lookup_field = "user__uuid"
     ordering = ["level", "-joined_at"]
 
     def get_object(self):

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -11,7 +11,7 @@ class TestOrganizationMembersAPI(APIBaseTest):
         response = self.client.get("/api/organizations/@current/members/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response_data = response.json()
+        response_data = response.json()["results"]
         self.assertEqual(len(response_data), self.organization.members.count())
         instance = OrganizationMembership.objects.get(id=response_data[0]["id"])
         self.assertEqual(response_data[0]["user"]["uuid"], str(instance.user.uuid))

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -75,7 +75,6 @@ class TestOrganizationMembersAPI(APIBaseTest):
             response_data,
             {
                 "id": str(updated_membership.id),
-                "membership_id": str(updated_membership.id),
                 "user": {
                     "id": user.id,
                     "uuid": str(user.uuid),
@@ -83,9 +82,6 @@ class TestOrganizationMembersAPI(APIBaseTest):
                     "first_name": user.first_name,
                     "email": user.email,
                 },
-                "user_id": user.id,
-                "user_first_name": user.first_name,
-                "user_email": user.email,
                 "level": OrganizationMembership.Level.ADMIN.value,
             },
         )

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -17,9 +17,6 @@ class TestOrganizationMembersAPI(APIBaseTest):
         self.assertEqual(response_data[0]["user"]["uuid"], str(instance.user.uuid))
         self.assertEqual(response_data[0]["user"]["first_name"], instance.user.first_name)
 
-        # Backwards compatibility
-        self.assertEqual(response_data[0]["id"], response_data[0]["membership_id"])
-
     def test_cant_list_members_for_an_alien_organization(self):
         org = Organization.objects.create(name="Alien Org")
         user = User.objects.create(email="another_user@posthog.com")

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+INTERNAL_BOT_EMAIL_SUFFIX = "@posthogbot.user"
+
 
 class AvailableFeature(str, Enum):
     ZAPIER = "zapier"


### PR DESCRIPTION
## Changes

Removes dependency on `User.id` which we'd like to avoid, by using `User.uuid` instead.
Also removes deprecated fields (including `user_id`) from `OrganizationMemberSerializer`.
Closes #5968.