### PR TITLE
perf(events): add index on distinct_id for postgres Event model

### DIFF
--- a/posthog/models/event.py
+++ b/posthog/models/event.py
@@ -288,6 +288,10 @@ class Event(models.Model):
             models.Index(fields=["timestamp", "team_id", "event"]),
             # Separately managed:
             # models.Index(fields=["created_at"]),
+            # NOTE: The below index has been added as a manual migration in
+            # `posthog/migrations/0024_add_event_distinct_id_index.py, but I'm
+            # adding this here to improve visibility.
+            # models.Index(fields=["distinct_id"], name="idx_distinct_id"),
         ]
 
     def _can_use_cached_query(self, last_updated_action_ts):


### PR DESCRIPTION
UPDATE: just add docs on the existing index added as a manual migration.

~~We're using this to join onto person distinct ids in lots of places so this really should be indexed. There is almost certainly a better composite index here however.~~

~~Of interest here also is that we create the index concurrently, so as not to block the `./manage.py migrate` command~~

~~Relates to https://github.com/PostHog/posthog/issues/5519 although I have yet to
look into if this is a resolution to the issue specifically.~~

~~There are likely other perf improvements here that I'll do as a followup pr, but this seems like a cross cutting improvement which doesn't require too much introspection into the querying logic.~~

~~The specific query for #5519 looks like this, from looking `pytest posthog/api/test/test_insight.py -k test_insight_funnels_basic_post`:~~

```
SELECT "posthog_person"."uuid",
    "posthog_person"."created_at",
    "posthog_person"."team_id",
    "posthog_person"."properties",
    "posthog_person"."is_user_id",
    MIN("step_0"."step_ts") as "step_0",
    MIN("step_1"."step_ts") as "step_1"
FROM (
        SELECT "pdi"."person_id",
            MIN("posthog_event"."timestamp") AS "step_ts"
        FROM posthog_event
            JOIN posthog_persondistinctid pdi ON pdi.distinct_id = posthog_event.distinct_id
        WHERE (
                "posthog_event"."timestamp" >= '2020-10-08T00:00:00+00:00'::timestamptz
                AND "posthog_event"."timestamp" <= '2020-11-15T13:10:40.739763+00:00'::timestamptz
                AND "posthog_event"."event" = 'user signed up'
                AND "posthog_event"."team_id" = 2
            )
        GROUP BY "pdi"."person_id"
    ) step_0
    LEFT JOIN LATERAL (
        SELECT "pdi"."person_id",
            MIN("posthog_event"."timestamp") AS "step_ts"
        FROM posthog_event
            JOIN posthog_persondistinctid pdi ON pdi.distinct_id = posthog_event.distinct_id
        WHERE (
                "posthog_event"."timestamp" >= '2020-10-08T00:00:00+00:00'::timestamptz
                AND "posthog_event"."timestamp" <= '2020-11-15T13:10:40.739763+00:00'::timestamptz
                AND "pdi"."person_id" = "step_0"."person_id"
                AND "posthog_event"."event" = 'user did things'
                AND "posthog_event"."team_id" = 2
                AND "posthog_event"."timestamp" >= "step_0"."step_ts"
            )
        GROUP BY "pdi"."person_id"
    ) step_1 ON TRUE
    JOIN posthog_person ON posthog_person.id = "step_0".person_id
WHERE "step_0".person_id IS NOT NULL
GROUP BY "posthog_person"."uuid",
    "posthog_person"."created_at",
    "posthog_person"."team_id",
    "posthog_person"."properties",
    "posthog_person"."is_user_id"
```
