### PR TITLE
Add support for CH for instance status reports

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -211,8 +211,7 @@ def get_event_count_for_team_and_period(
         SELECT count(1) as count
         FROM events
         WHERE team_id = %(team_id)s
-        AND timestamp > %(begin)s
-        AND timestamp < %(end)s
+        AND timestamp between %(begin)s AND %(end)s
     """,
         {"team_id": str(team_id), "begin": begin, "end": end},
     )[0][0]
@@ -247,7 +246,9 @@ def get_events_count_for_team_by_client_lib(
     results = sync_execute(
         """
         SELECT JSONExtractString(properties, '$lib') as lib, COUNT(1) as freq 
-        FROM events WHERE team_id = %(team_id)s AND timestamp >= %(begin)s AND timestamp <= %(end)s
+        FROM events
+        WHERE team_id = %(team_id)s 
+        AND timestamp between %(begin)s AND %(end)s
         GROUP BY lib
     """,
         {"team_id": str(team_id), "begin": begin, "end": end},
@@ -261,7 +262,9 @@ def get_events_count_for_team_by_event_type(
     results = sync_execute(
         """
         SELECT event, COUNT(1) as freq 
-        FROM events WHERE team_id = %(team_id)s AND timestamp >= %(begin)s AND timestamp <= %(end)s
+        FROM events
+        WHERE team_id = %(team_id)s
+        AND timestamp between %(begin)s AND %(end)s
         GROUP BY event 
     """,
         {"team_id": str(team_id), "begin": begin, "end": end},

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -18,12 +18,11 @@ from ee.clickhouse.sql.person import (
 )
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
-from posthog import settings
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.utils import UUIDT
 from posthog.utils import is_clickhouse_enabled
 
-if settings.EE_AVAILABLE and is_clickhouse_enabled():
+if is_clickhouse_enabled():
 
     @receiver(post_save, sender=Person)
     def person_created(sender, instance: Person, created, **kwargs):

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -74,7 +74,9 @@ _timestamp,
 _offset
 FROM {database}.kafka_{table_name}
 """.format(
-    table_name=EVENTS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE,
+    table_name=EVENTS_TABLE,
+    cluster=CLICKHOUSE_CLUSTER,
+    database=CLICKHOUSE_DATABASE,
 )
 
 INSERT_EVENT_SQL = """

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -74,9 +74,7 @@ _timestamp,
 _offset
 FROM {database}.kafka_{table_name}
 """.format(
-    table_name=EVENTS_TABLE,
-    cluster=CLICKHOUSE_CLUSTER,
-    database=CLICKHOUSE_DATABASE,
+    table_name=EVENTS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE,
 )
 
 INSERT_EVENT_SQL = """

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -98,8 +98,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
                 events_considered_total = Event.objects.filter(team_id=team.id)
                 instance_usage_summary["events_count_total"] += events_considered_total.count()
                 events_considered_new_in_period = events_considered_total.filter(
-                    timestamp__gte=period_start,
-                    timestamp__lte=period_end,
+                    timestamp__gte=period_start, timestamp__lte=period_end,
                 )
 
                 team_report["events_count_total"] = events_considered_total.count()
@@ -112,8 +111,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
             # pull person stats and the rest here from Postgres always
             persons_considered_total = Person.objects.filter(team_id=team.id)
             persons_considered_total_new_in_period = persons_considered_total.filter(
-                created_at__gte=period_start,
-                created_at__lte=period_end,
+                created_at__gte=period_start, created_at__lte=period_end,
             )
             team_report["persons_count_total"] = persons_considered_total.count()
             instance_usage_summary["persons_count_total"] += team_report["persons_count_total"]

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -14,7 +14,13 @@ from posthog.models.feature_flag import FeatureFlag
 from posthog.models.plugin import PluginConfig
 from posthog.models.utils import namedtuplefetchall
 from posthog.settings import EE_AVAILABLE
-from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_week
+from posthog.utils import (
+    get_helm_info_env,
+    get_instance_realm,
+    get_machine_id,
+    get_previous_week,
+    is_clickhouse_enabled,
+)
 from posthog.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -63,31 +69,59 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
 
     for team in Team.objects.exclude(organization__for_internal_metrics=True):
         try:
+            params = (team.id, report["period"]["start_inclusive"], report["period"]["end_inclusive"])
             team_report: Dict[str, Any] = {}
-            events_considered_total = Event.objects.filter(team_id=team.id)
-            instance_usage_summary["events_count_total"] += events_considered_total.count()
-            events_considered_new_in_period = events_considered_total.filter(
-                timestamp__gte=period_start, timestamp__lte=period_end,
-            )
+            if is_clickhouse_enabled():
+                # pull events stats from clickhouse
+                from ee.clickhouse.models.event import (
+                    get_event_count_for_team,
+                    get_event_count_for_team_and_period,
+                    get_events_count_for_team_by_client_lib,
+                    get_events_count_for_team_by_event_type,
+                )
+
+                team_event_count = get_event_count_for_team(team.id)
+                instance_usage_summary["events_count_total"] += team_event_count
+                team_report["events_count_total"] = team_event_count
+                team_events_in_period_count = get_event_count_for_team_and_period(team.id, period_start, period_end)
+                team_report["events_count_new_in_period"] = team_events_in_period_count
+                instance_usage_summary["events_count_new_in_period"] += team_report["events_count_new_in_period"]
+
+                team_report["events_count_by_lib"] = get_events_count_for_team_by_client_lib(
+                    team.id, period_start, period_end
+                )
+                team_report["events_count_by_name"] = get_events_count_for_team_by_event_type(
+                    team.id, period_start, period_end
+                )
+            else:
+                # pull events stats from postgres
+                events_considered_total = Event.objects.filter(team_id=team.id)
+                instance_usage_summary["events_count_total"] += events_considered_total.count()
+                events_considered_new_in_period = events_considered_total.filter(
+                    timestamp__gte=period_start,
+                    timestamp__lte=period_end,
+                )
+
+                team_report["events_count_total"] = events_considered_total.count()
+                team_report["events_count_new_in_period"] = events_considered_new_in_period.count()
+                instance_usage_summary["events_count_new_in_period"] += team_report["events_count_new_in_period"]
+
+                team_report["events_count_by_lib"] = fetch_event_counts_by_lib(params)
+                team_report["events_count_by_name"] = fetch_events_count_by_name(params)
+
+            # pull person stats and the rest here from Postgres always
             persons_considered_total = Person.objects.filter(team_id=team.id)
             persons_considered_total_new_in_period = persons_considered_total.filter(
-                created_at__gte=period_start, created_at__lte=period_end,
+                created_at__gte=period_start,
+                created_at__lte=period_end,
             )
-            team_report["events_count_total"] = events_considered_total.count()
-            team_report["events_count_new_in_period"] = events_considered_new_in_period.count()
-            instance_usage_summary["events_count_new_in_period"] += team_report["events_count_new_in_period"]
-
             team_report["persons_count_total"] = persons_considered_total.count()
             instance_usage_summary["persons_count_total"] += team_report["persons_count_total"]
 
             team_report["persons_count_new_in_period"] = persons_considered_total_new_in_period.count()
             instance_usage_summary["persons_count_new_in_period"] += team_report["persons_count_new_in_period"]
 
-            params = (team.id, report["period"]["start_inclusive"], report["period"]["end_inclusive"])
-
             team_report["persons_count_active_in_period"] = fetch_persons_count_active_in_period(params)
-            team_report["events_count_by_lib"] = fetch_event_counts_by_lib(params)
-            team_report["events_count_by_name"] = fetch_events_count_by_name(params)
 
             # Dashboards
             team_dashboards = Dashboard.objects.filter(team=team).exclude(deleted=True)


### PR DESCRIPTION
## Changes

This adds some signal for how many events clickhouse on prem instances have

Example payload:
```json
instance status report {"posthog_version": "1.28.0", "deployment": "unknown", "realm": "hosted-clickhouse", "period": {"start_inclusive": "2021-09-06T00:00:00+00:00", "end_inclusive": "2021-09-12T23:59:59.999999+00:00"}, "site_url": "unknown", "license_keys": [], "helm": {}, "users_who_logged_in": [{"id": 1, "distinct_id": "DJWPQYiUJydofPLrAKndnOiSWTwbVaM4XT6ldLxIAbj", "first_name": "test", "email": "test@test.com"}], "teams": {"1": {"events_count_total": 12, "events_count_new_in_period": 0, "events_count_by_lib": {}, "events_count_by_name": {}, "persons_count_total": 1, "persons_count_new_in_period": 0, "persons_count_active_in_period": 0, "dashboards_count": 1, "dashboards_template_count": 0, "dashboards_shared_count": 0, "dashboards_tagged_count": 0, "ff_count": 0, "ff_active_count": 0}, "2": {"events_count_total": 1876, "events_count_new_in_period": 694, "events_count_by_lib": {"": 588, "web": 106}, "events_count_by_name": {"purchase": 7, "$pageview": 347, "watched_movie": 97, "installed_app": 109, "rated_app": 81, "$autocapture": 53}, "persons_count_total": 321, "persons_count_new_in_period": 0, "persons_count_active_in_period": 0, "dashboards_count": 3, "dashboards_template_count": 0, "dashboards_shared_count": 0, "dashboards_tagged_count": 0, "ff_count": 0, "ff_active_count": 0}}, "table_sizes": {"posthog_event": 57344, "posthog_sessionrecordingevent": 49152}, "plugins_installed": {"GeoIP": 2}, "plugins_enabled": {"GeoIP": 2}, "instance_usage_summary": {"events_count_new_in_period": 694, "persons_count_new_in_period": 0, "persons_count_total": 322, "events_count_total": 1888, "dashboards_count": 4, "ff_count": 0}}
{'posthog_version': '1.28.0', 'deployment': 'unknown', 'realm': 'hosted-clickhouse', 'period': {'start_inclusive': '2021-09-06T00:00:00+00:00', 'end_inclusive': '2021-09-12T23:59:59.999999+00:00'}, 'site_url': 'unknown', 'license_keys': [], 'helm': {}, 'users_who_logged_in': [{'id': 1, 'distinct_id': 'DJWPQYiUJydofPLrAKndnOiSWTwbVaM4XT6ldLxIAbj', 'first_name': 'test', 'email': 'test@test.com'}], 'teams': {1: {'events_count_total': 12, 'events_count_new_in_period': 0, 'events_count_by_lib': {}, 'events_count_by_name': {}, 'persons_count_total': 1, 'persons_count_new_in_period': 0, 'persons_count_active_in_period': 0, 'dashboards_count': 1, 'dashboards_template_count': 0, 'dashboards_shared_count': 0, 'dashboards_tagged_count': 0, 'ff_count': 0, 'ff_active_count': 0}, 2: {'events_count_total': 1876, 'events_count_new_in_period': 694, 'events_count_by_lib': {'': 588, 'web': 106}, 'events_count_by_name': {'purchase': 7, '$pageview': 347, 'watched_movie': 97, 'installed_app': 109, 'rated_app': 81, '$autocapture': 53}, 'persons_count_total': 321, 'persons_count_new_in_period': 0, 'persons_count_active_in_period': 0, 'dashboards_count': 3, 'dashboards_template_count': 0, 'dashboards_shared_count': 0, 'dashboards_tagged_count': 0, 'ff_count': 0, 'ff_active_count': 0}}, 'table_sizes': {'posthog_event': 57344, 'posthog_sessionrecordingevent': 49152}, 'plugins_installed': Counter({'GeoIP': 2}), 'plugins_enabled': Counter({'GeoIP': 2}), 'instance_usage_summary': {'events_count_new_in_period': 694, 'persons_count_new_in_period': 0, 'persons_count_total': 322, 'events_count_total': 1888, 'dashboards_count': 4, 'ff_count': 0}}
```
## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
