### PR TITLE
Allow codespaces container to connect to docker host

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,7 +25,7 @@ services:
             - .:/workspace:cached
 
             # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
-            # - /var/run/docker.sock:/var/run/docker.sock
+            - /var/run/docker.sock:/var/run/docker.sock
 
         # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
         # cap_add:


### PR DESCRIPTION
## Changes

This makes it much more feasible to work in codespaces

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
