### PR TITLE
Add warning for locally set feature flags

### DIFF
--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -9,7 +9,9 @@ import { PostHog } from 'posthog-js'
 
 export function FeatureFlags(): JSX.Element {
     const { userFlagsWithCalculatedInfo, showLocalFeatureFlagWarning } = useValues(featureFlagsLogic)
-    const { setOverriddenUserFlag, deleteOverriddenUserFlag } = useActions(featureFlagsLogic)
+    const { setOverriddenUserFlag, deleteOverriddenUserFlag, setShowLocalFeatureFlagWarning } = useActions(
+        featureFlagsLogic
+    )
     return (
         <div className="toolbar-block">
             {showLocalFeatureFlagWarning ? (
@@ -19,17 +21,17 @@ export function FeatureFlags(): JSX.Element {
                             Warning:
                         </Typography.Text>{' '}
                         It looks like you've previously used the developer console to set local feature flags. To use
-                        feature flags in the toolbar, please{' '}
-                        <Typography.Text strong>clear them below and refresh the page.</Typography.Text>
+                        feature flags in the toolbar, please clear them below.
                     </Typography.Text>
                     <div>
                         <Button
                             type="primary"
                             onClick={() => {
                                 ;(window['posthog'] as PostHog).feature_flags.override(false)
+                                setShowLocalFeatureFlagWarning(false)
                             }}
                         >
-                            Clear Local Feature Flags
+                            Clear locally set feature flags
                         </Button>
                     </div>
                 </div>

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -3,74 +3,101 @@ import './featureFlags.scss'
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
-import { Radio, Switch, Row, Typography, List } from 'antd'
+import { Radio, Switch, Row, Typography, List, Button } from 'antd'
 import { AnimatedCollapsible } from './AnimatedCollapsible'
+import { PostHog } from 'posthog-js'
 
 export function FeatureFlags(): JSX.Element {
-    const { userFlagsWithCalculatedInfo } = useValues(featureFlagsLogic)
+    const { userFlagsWithCalculatedInfo, showLocalFeatureFlagWarning } = useValues(featureFlagsLogic)
     const { setOverriddenUserFlag, deleteOverriddenUserFlag } = useActions(featureFlagsLogic)
-
     return (
         <div className="toolbar-block">
-            <List
-                dataSource={userFlagsWithCalculatedInfo}
-                renderItem={({
-                    feature_flag,
-                    value_for_user_without_override,
-                    override,
-                    hasVariants,
-                    currentValue,
-                }) => {
-                    return (
-                        <div className="feature-flag-row">
-                            <Row
-                                className={override ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'}
-                            >
-                                <Typography.Text ellipsis className="feature-flag-title">
-                                    {feature_flag.key}
-                                </Typography.Text>
-                                <Switch
-                                    checked={!!currentValue}
-                                    onChange={(checked) => {
-                                        const newValue =
-                                            hasVariants && checked
-                                                ? (feature_flag.filters?.multivariate?.variants[0]?.key as string)
-                                                : checked
-                                        if (newValue === value_for_user_without_override && override) {
-                                            deleteOverriddenUserFlag(override.id as number)
-                                        } else {
-                                            setOverriddenUserFlag(feature_flag.id as number, newValue)
-                                        }
-                                    }}
-                                />
-                            </Row>
-
-                            <AnimatedCollapsible collapsed={!hasVariants || !currentValue}>
-                                <Row className={override ? 'variant-radio-group overridden' : 'variant-radio-group'}>
-                                    <Radio.Group
-                                        disabled={!currentValue}
-                                        value={currentValue}
-                                        onChange={(event) => {
-                                            const newValue = event.target.value
+            {showLocalFeatureFlagWarning ? (
+                <div className="local-feature-flag-override-warning">
+                    <Typography.Text>
+                        <Typography.Text type="warning" strong>
+                            Warning:
+                        </Typography.Text>{' '}
+                        It looks like you've previously used the developer console to set local feature flags. To use
+                        feature flags in the toolbar, please{' '}
+                        <Typography.Text strong>clear them below and refresh the page.</Typography.Text>
+                    </Typography.Text>
+                    <div>
+                        <Button
+                            type="primary"
+                            onClick={() => {
+                                ;(window['posthog'] as PostHog).feature_flags.override(false)
+                            }}
+                        >
+                            Clear Local Feature Flags
+                        </Button>
+                    </div>
+                </div>
+            ) : (
+                <List
+                    dataSource={userFlagsWithCalculatedInfo}
+                    renderItem={({
+                        feature_flag,
+                        value_for_user_without_override,
+                        override,
+                        hasVariants,
+                        currentValue,
+                    }) => {
+                        return (
+                            <div className="feature-flag-row">
+                                <Row
+                                    className={
+                                        override ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'
+                                    }
+                                >
+                                    <Typography.Text ellipsis className="feature-flag-title">
+                                        {feature_flag.key}
+                                    </Typography.Text>
+                                    <Switch
+                                        checked={!!currentValue}
+                                        onChange={(checked) => {
+                                            const newValue =
+                                                hasVariants && checked
+                                                    ? (feature_flag.filters?.multivariate?.variants[0]?.key as string)
+                                                    : checked
                                             if (newValue === value_for_user_without_override && override) {
                                                 deleteOverriddenUserFlag(override.id as number)
                                             } else {
                                                 setOverriddenUserFlag(feature_flag.id as number, newValue)
                                             }
                                         }}
-                                    >
-                                        {feature_flag.filters?.multivariate?.variants.map((variant) => (
-                                            <Radio key={variant.key} value={variant.key}>
-                                                {`${variant.key} - ${variant.name} (${variant.rollout_percentage}%)`}
-                                            </Radio>
-                                        ))}
-                                    </Radio.Group>
+                                    />
                                 </Row>
-                            </AnimatedCollapsible>
-                        </div>
-                    )
-                }}
-            />
+
+                                <AnimatedCollapsible collapsed={!hasVariants || !currentValue}>
+                                    <Row
+                                        className={override ? 'variant-radio-group overridden' : 'variant-radio-group'}
+                                    >
+                                        <Radio.Group
+                                            disabled={!currentValue}
+                                            value={currentValue}
+                                            onChange={(event) => {
+                                                const newValue = event.target.value
+                                                if (newValue === value_for_user_without_override && override) {
+                                                    deleteOverriddenUserFlag(override.id as number)
+                                                } else {
+                                                    setOverriddenUserFlag(feature_flag.id as number, newValue)
+                                                }
+                                            }}
+                                        >
+                                            {feature_flag.filters?.multivariate?.variants.map((variant) => (
+                                                <Radio key={variant.key} value={variant.key}>
+                                                    {`${variant.key} - ${variant.name} (${variant.rollout_percentage}%)`}
+                                                </Radio>
+                                            ))}
+                                        </Radio.Group>
+                                    </Row>
+                                </AnimatedCollapsible>
+                            </div>
+                        )
+                    }}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/toolbar/flags/featureFlags.scss
+++ b/frontend/src/toolbar/flags/featureFlags.scss
@@ -44,4 +44,10 @@
             border-left-color: #fdedc9;
         }
     }
+    .local-feature-flag-override-warning {
+        margin: 16px;
+        .ant-btn {
+            margin-top: 10px;
+        }
+    }
 }

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -10,7 +10,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         getUserFlags: true,
         setOverriddenUserFlag: (flagId: number, overrideValue: string | boolean) => ({ flagId, overrideValue }),
         deleteOverriddenUserFlag: (overrideId: number) => ({ overrideId }),
-        setShowLocalFeatureFlagWarning: (showWarning: bool) => ({ showWarning }),
+        setShowLocalFeatureFlagWarning: (showWarning: boolean) => ({ showWarning }),
     },
 
     loaders: ({ values }) => ({
@@ -105,9 +105,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             ;(window['posthog'] as PostHog).onFeatureFlags((_, variants) => {
                 toolbarLogic.actions.updateFeatureFlags(variants)
             })
-            const locallyOverrideFeatureFlags = (window['posthog'] as PostHog).feature_flags.instance.get_property(
-                '$override_feature_flags'
-            )
+            const locallyOverrideFeatureFlags = (window['posthog'] as PostHog).get_property('$override_feature_flags')
             if (locallyOverrideFeatureFlags) {
                 actions.setShowLocalFeatureFlagWarning(true)
             }


### PR DESCRIPTION
## Changes

If a user has added local feature flag overrides in the developer console, they won't work with the feature flag overrides in the Toolbar. This change prompts the user to clear their local overrides before using this feature.

<img src="https://user-images.githubusercontent.com/4813045/133541936-0aea5b56-c106-4615-9bfa-a364c94bcaaf.png" width=300/>


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
