### PR TITLE
Fix userFlags type if response is error

### DIFF
--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -19,7 +19,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                 getUserFlags: async (_, breakpoint) => {
                     const response = await toolbarFetch('api/feature_flag/my_flags')
                     breakpoint()
-                    if (response.status === 403) {
+                    if (!response.ok) {
                         return []
                     }
                     const results = await response.json()
@@ -35,7 +35,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                         }
                     )
                     breakpoint()
-                    if (response.status === 403) {
+                    if (!response.ok) {
                         return []
                     }
                     const results = await response.json()
@@ -53,7 +53,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                         'DELETE'
                     )
                     breakpoint()
-                    if (response.status === 403) {
+                    if (!response.ok) {
                         return []
                     }
                     ;(window['posthog'] as PostHog).featureFlags.reloadFeatureFlags()


### PR DESCRIPTION
## Changes

- With a status `401`, an error was stored as the flags 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
