### PR TITLE
minor wording changes to plugin jobs interface

### DIFF
--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from 'lib/components/Tooltip'
 import React from 'react'
 import { PluginTypeWithConfig } from '../../types'
 import { PluginJobConfiguration } from './PluginJobConfiguration'
@@ -17,7 +18,7 @@ export function PluginJobOptions({ plugin, pluginConfigId }: PluginJobOptionsPro
     return (
         <>
             <h3 className="l3" style={{ marginTop: 32 }}>
-                Jobs
+                Jobs (Beta)
             </h3>
 
             {capabilities.jobs.map((jobName) => {
@@ -26,7 +27,13 @@ export function PluginJobOptions({ plugin, pluginConfigId }: PluginJobOptionsPro
                 }
                 return (
                     <div key={jobName}>
-                        <i>{jobName}</i>
+                        {jobName === 'Export events from the beginning' ? (
+                            <Tooltip title="Run this plugin on all historical events ingested until now">
+                                <i>Export events from the beginning</i>
+                            </Tooltip>
+                        ) : (
+                            <i>{jobName}</i>
+                        )}
                         <PluginJobConfiguration
                             jobName={jobName}
                             jobSpec={public_jobs[jobName]}


### PR DESCRIPTION
## Changes

Marking this explicitly as Beta so that we can release to some users while keeping expectations low.

Also added a little tooltip about export from the beginning

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
