### PR TITLE
Fix cohort logic saving bug

### DIFF
--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -230,7 +230,7 @@ AND team_id = %(team_id)s
 """
 
 INSERT_COHORT_ALL_PEOPLE_THROUGH_PERSON_ID = """
-INSERT INTO {cohort_table} SELECT generateUUIDv4(), id, %(cohort_id)s, %(team_id)s, %(_timestamp)s, 0 FROM (
+INSERT INTO {cohort_table} SELECT generateUUIDv4(), person_id, %(cohort_id)s, %(team_id)s, %(_timestamp)s, 0 FROM (
     SELECT person_id FROM ({query})
 )
 """

--- a/frontend/src/scenes/cohorts/cohortLogic.tsx
+++ b/frontend/src/scenes/cohorts/cohortLogic.tsx
@@ -109,7 +109,6 @@ export const cohortLogic = kea<cohortLogicType>({
 
             for (const [itemKey, value] of Object.entries(cohort as CohortType)) {
                 if (itemKey === 'groups') {
-                    debugger
                     if (cohort.is_static) {
                         if (!cohort.csv && isNewCohort) {
                             actions.setSubmitted(true)


### PR DESCRIPTION
## Changes

- Fixed an issue where `id === "personModalNew"` was used when making API calls
- Because it's a `for` loop and not `.forEach`, this `return` here exited the reducer and hence no API calls to save the cohort were made.
- Fixed this return in two other cases.
- Also had a broken SQL query

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
