### PR TITLE
Fix colors if insights table is sorted

### DIFF
--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -32,7 +32,10 @@ export const tagColors = [
     'geekblue',
 ]
 
-const getColorVar = (variable: string): string => getComputedStyle(document.body).getPropertyValue('--' + variable)
+const getColorVar = (variable: string): string =>
+    getComputedStyle(document.body)
+        .getPropertyValue('--' + variable)
+        .trim()
 
 export const darkWhites = [
     'rgba(255,255,255,0.6)',

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -67,11 +67,10 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
     if (isLegend) {
         columns.push({
             title: '',
-            render: function RenderCheckbox({}, item: IndexedTrendResult, index: number) {
-                // legend will always be on insight page where the background is white
+            render: function RenderCheckbox({}, item: IndexedTrendResult) {
                 return (
                     <PHCheckbox
-                        color={colorList[index]}
+                        color={colorList[item.id]}
                         checked={visibilityMap[item.id]}
                         onChange={() => toggleVisibility(item.id)}
                         disabled={isSingleEntity}
@@ -107,11 +106,11 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
 
     columns.push({
         title: 'Event or Action',
-        render: function RenderLabel({}, item: IndexedTrendResult, index: number): JSX.Element {
+        render: function RenderLabel({}, item: IndexedTrendResult): JSX.Element {
             return (
                 <SeriesToggleWrapper id={item.id} toggleVisibility={toggleVisibility}>
                     <InsightLabel
-                        seriesColor={colorList[index]}
+                        seriesColor={colorList[item.id]}
                         action={item.action}
                         fallbackName={item.breakdown_value === '' ? 'None' : item.label}
                         hasMultipleSeries={indexedResults.length > 1}


### PR DESCRIPTION
## Changes

- The `indexedResults` value that feeds the insights table contains the index of the item in `item.id`. 
- The old code took the color of the row from the sortable table's row index, not the item's index.
- This caused a color mismatch between the chart and the table
- Flyby fix for removing a space from color property values (`" #000000"`)

![2021-09-16 14 01 59](https://user-images.githubusercontent.com/53387/133608668-c27e988f-511c-48f3-b7d4-4ca6f95f3679.gif)


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
