### PR TITLE
Split person asynchronously

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -198,9 +198,7 @@ export function Person(): JSX.Element {
             {mergeModalOpen && person && (
                 <MergePerson person={person} onPersonChange={setPerson} closeModal={() => setMergeModalOpen(false)} />
             )}
-            {splitModalOpen && person && (
-                <SplitPerson person={person} onPersonChange={setPerson} closeModal={() => setSplitModalOpen(false)} />
-            )}
+            {splitModalOpen && person && <SplitPerson person={person} closeModal={() => setSplitModalOpen(false)} />}
         </div>
     )
 }

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -304,13 +304,14 @@ def factory_test_person(event_factory, person_factory, get_events):
                 team=self.team, distinct_ids=["1", "2", "3"], properties={"$browser": "whatever", "$os": "Mac OS X"}
             )
 
-            self.client.post("/api/person/%s/split/" % person1.pk,)
+            response = self.client.post("/api/person/%s/split/" % person1.pk,)
             people = Person.objects.all().order_by("id")
             self.assertEqual(len(people), 3)
             self.assertEqual(people[0].distinct_ids, ["1"])
             self.assertEqual(people[0].properties, {})
             self.assertEqual(people[1].distinct_ids, ["2"])
             self.assertEqual(people[2].distinct_ids, ["3"])
+            self.assertTrue(response.json()["success"])
 
         def test_return_non_anonymous_name(self) -> None:
             person_factory(

--- a/posthog/models/person.py
+++ b/posthog/models/person.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Optional
 
 from django.apps import apps
 from django.db import models, transaction
@@ -50,17 +50,17 @@ class Person(models.Model):
 
             capture_internal(event, self.distinct_ids[-1], None, None, now, now, self.team.id)
 
-    def split_person(self, main_distinct_id: str):
-        with transaction.atomic():
-            distinct_ids = Person.objects.get(pk=self.pk).distinct_ids
-            if not main_distinct_id:
-                self.properties = {}
-                self.save()
-                main_distinct_id = distinct_ids[0]
+    def split_person(self, main_distinct_id: Optional[str]):
+        distinct_ids = Person.objects.get(pk=self.pk).distinct_ids
+        if not main_distinct_id:
+            self.properties = {}
+            self.save()
+            main_distinct_id = distinct_ids[0]
 
-            PersonDistinctId.objects.filter(person=self).exclude(distinct_id=main_distinct_id).delete()
-            for distinct_id in distinct_ids:
-                if not distinct_id == main_distinct_id:
+        for distinct_id in distinct_ids:
+            if not distinct_id == main_distinct_id:
+                with transaction.atomic():
+                    PersonDistinctId.objects.filter(person=self, distinct_id=distinct_id).delete()
                     Person.objects.create(team_id=self.team_id, distinct_ids=[distinct_id])
 
     objects = PersonManager()

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -5,6 +5,7 @@ import posthog.tasks.calculate_event_property_usage
 import posthog.tasks.delete_old_plugin_logs
 import posthog.tasks.email
 import posthog.tasks.session_recording_retention
+import posthog.tasks.split_person
 import posthog.tasks.status_report
 import posthog.tasks.sync_all_organization_available_features
 import posthog.tasks.update_cache

--- a/posthog/tasks/split_person.py
+++ b/posthog/tasks/split_person.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from posthog.celery import app
+from posthog.models import Person
+
+
+@app.task(ignore_result=True, max_retries=1)
+def split_person(person_id: int, main_distinct_id: Optional[str]) -> None:
+    """
+    Split all distinct ids into separate persons
+    """
+    person = Person.objects.get(pk=person_id)
+    person.split_person(main_distinct_id)


### PR DESCRIPTION
## Changes

@mariusandra was right, this didn't finish in time on app. Made it async and each distinct_id is now it's own transaction

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
