### PR TITLE
perf(funnels): add filter on pdi.team_id to speed up query

### DIFF
--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -83,7 +83,9 @@ class Funnel(BaseQuery):
                 # not after `ON pdi.distinct_id = posthog_event.distinct_id`
                 r'FROM "posthog_event"( [A-Z][0-9])?',
                 r"FROM posthog_event\1 JOIN posthog_persondistinctid pdi "
-                r"ON pdi.distinct_id = posthog_event.distinct_id",
+                #  NOTE: here we are joining on the unique identifier of the
+                #  persondistinctid table, i.e. (team_id, distinct_id)
+                r"ON pdi.distinct_id = posthog_event.distinct_id AND pdi.team_id = posthog_event.team_id",
                 event_string,
             )
             query = sql.SQL(event_string)
@@ -106,7 +108,7 @@ class Funnel(BaseQuery):
 
     def _build_query(self, within_time: Optional[str] = None):
         """Build query using lateral joins using a combination of Django generated SQL
-           and sql built using psycopg2
+        and sql built using psycopg2
         """
         query_bodies = self._gen_lateral_bodies(within_time=within_time)
 
@@ -290,7 +292,7 @@ class Funnel(BaseQuery):
         Builds and runs a query to get all persons that have been in the funnel
         steps defined by `self._filter.entities`. For example, entities may be
         defined as:
-            
+
             1. event with event name "user signed up"
             2. event with event name "user looked at report"
 


### PR DESCRIPTION
Have tested on prod with team_id=2. Seems to work at making the query
complete in time. Quite quick there but not much data.

There's probably a lot more we could do here but I don't want to burn
too much time on this.

Future improvements could be:

 1. Remove the first subquery and just do a join
 2. Investigate if there's benefit in removing the group by and using
    distinct on. I don't know enough about this tbh.
 3. Remove all the string manipulations with re. Just write up the query
    by hand.
 4. Remove the implicit coupling between query_bodies gen and the `for step,
    qb` look. It's probably best to do this in one pass.

Closes https://github.com/PostHog/posthog/issues/5519