### PR TITLE
Split out funnel apis and fix histogram paint order bug

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -14,12 +14,14 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
         self, filter: Filter, team: Team, funnel_order_class: Type[ClickhouseFunnelBase] = ClickhouseFunnel
     ) -> None:
         super().__init__(filter, team)
+        self._funnel_order_class = funnel_order_class
         self.funnel_order = funnel_order_class(filter, team)
 
     def _format_results(self, results: list) -> dict:
         return {
             "bins": [(bin_from_seconds, person_count) for bin_from_seconds, person_count, _ in results],
             "average_conversion_time": results[0][2],
+            "steps": self._funnel_order_class(team=self._team, filter=self._filter).run(),
         }
 
     def get_query(self) -> str:

--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -66,6 +66,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         results = funnel_trends.run()
 
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
+        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         self.assertEqual(
             results,
             {
@@ -174,6 +175,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
         results = funnel_trends.run()
 
+        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         # 7 bins, autoscaled to work best with minimum time to convert and maximum time to convert at hand
         self.assertEqual(
             results,
@@ -226,6 +228,8 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
         results = funnel_trends.run()
 
+        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+
         self.assertEqual(
             results,
             {
@@ -244,6 +248,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             Filter(data={**filter._data, "funnel_from_step": 0, "funnel_to_step": 2,}), self.team, ClickhouseFunnel
         )
         results_steps_specified = funnel_trends_steps_specified.run()
+        results_steps_specified.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
 
         self.assertEqual(results, results_steps_specified)
 
@@ -286,6 +291,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnelUnordered)
         results = funnel_trends.run()
 
+        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,
@@ -347,6 +353,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnelStrict)
         results = funnel_trends.run()
 
+        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,

--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -66,7 +66,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         results = funnel_trends.run()
 
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
-        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+        results.pop("steps")  # steps are already tested in ClickhouseFunnelTrends
         self.assertEqual(
             results,
             {
@@ -175,7 +175,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
         results = funnel_trends.run()
 
-        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+        results.pop("steps")  # steps are already tested in ClickhouseFunnelTrends
         # 7 bins, autoscaled to work best with minimum time to convert and maximum time to convert at hand
         self.assertEqual(
             results,
@@ -228,7 +228,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
         results = funnel_trends.run()
 
-        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+        results.pop("steps")  # steps are already tested in ClickhouseFunnelTrends
 
         self.assertEqual(
             results,
@@ -248,7 +248,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             Filter(data={**filter._data, "funnel_from_step": 0, "funnel_to_step": 2,}), self.team, ClickhouseFunnel
         )
         results_steps_specified = funnel_trends_steps_specified.run()
-        results_steps_specified.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+        results_steps_specified.pop("steps")  # steps are already tested in ClickhouseFunnelTrends
 
         self.assertEqual(results, results_steps_specified)
 
@@ -291,7 +291,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnelUnordered)
         results = funnel_trends.run()
 
-        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+        results.pop("steps")  # steps are already tested in ClickhouseFunnelTrends
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,
@@ -353,7 +353,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnelStrict)
         results = funnel_trends.run()
 
-        results.pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
+        results.pop("steps")  # steps are already tested in ClickhouseFunnelTrends
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
         self.assertEqual(
             results,

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -261,6 +261,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         response_data.pop("last_refresh")
+        response_data["result"].pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         self.assertEqual(
             response_data,
             {
@@ -312,6 +313,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         response_data.pop("last_refresh")
+        response_data["result"].pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         self.assertEqual(
             response_data,
             {
@@ -363,6 +365,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         response_data.pop("last_refresh")
+        response_data["result"].pop("steps", None)  # steps are already tested in ClickhouseFunnelTrends
         self.assertEqual(
             response_data,
             {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -157,6 +157,19 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
             success,
             error,
         }),
+        reportFunnelTimeConversionCalculated: (
+            eventCount: number,
+            actionCount: number,
+            interval: string,
+            success: boolean,
+            error?: string
+        ) => ({
+            eventCount,
+            actionCount,
+            interval,
+            success,
+            error,
+        }),
         reportPersonPropertyUpdated: (
             action: 'added' | 'updated' | 'removed',
             totalProperties: number,
@@ -428,6 +441,16 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
         },
         reportFunnelCalculated: async ({ eventCount, actionCount, interval, success, error }) => {
             posthog.capture('funnel result calculated', {
+                event_count: eventCount,
+                action_count: actionCount,
+                total_count_actions_events: eventCount + actionCount,
+                interval: interval,
+                success: success,
+                error: error,
+            })
+        },
+        reportFunnelTimeConversionCalculated: async ({ eventCount, actionCount, interval, success, error }) => {
+            posthog.capture('funnel time conversion result calculated', {
                 event_count: eventCount,
                 action_count: actionCount,
                 total_count_actions_events: eventCount + actionCount,

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -148,25 +148,14 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
             eventCount: number,
             actionCount: number,
             interval: string,
+            funnelVizType: string | undefined,
             success: boolean,
             error?: string
         ) => ({
             eventCount,
             actionCount,
             interval,
-            success,
-            error,
-        }),
-        reportFunnelTimeConversionCalculated: (
-            eventCount: number,
-            actionCount: number,
-            interval: string,
-            success: boolean,
-            error?: string
-        ) => ({
-            eventCount,
-            actionCount,
-            interval,
+            funnelVizType,
             success,
             error,
         }),
@@ -439,22 +428,13 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource>>({
                 instance_email_available: instanceEmailAvailable,
             })
         },
-        reportFunnelCalculated: async ({ eventCount, actionCount, interval, success, error }) => {
+        reportFunnelCalculated: async ({ eventCount, actionCount, interval, funnelVizType, success, error }) => {
             posthog.capture('funnel result calculated', {
                 event_count: eventCount,
                 action_count: actionCount,
                 total_count_actions_events: eventCount + actionCount,
                 interval: interval,
-                success: success,
-                error: error,
-            })
-        },
-        reportFunnelTimeConversionCalculated: async ({ eventCount, actionCount, interval, success, error }) => {
-            posthog.capture('funnel time conversion result calculated', {
-                event_count: eventCount,
-                action_count: actionCount,
-                total_count_actions_events: eventCount + actionCount,
-                interval: interval,
+                funnel_viz_type: funnelVizType,
                 success: success,
                 error: error,
             })

--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -202,6 +202,9 @@ export function Histogram({
                         })
                     })
 
+                // Always move bar above everything else
+                _svg.node().appendChild(_bars.node())
+
                 // text labels
                 if (!isDashboardItem) {
                     const _labels = getOrCreateEl(_svg, 'g#labels', () => _svg.append('svg:g').attr('id', 'labels'))
@@ -244,6 +247,9 @@ export function Histogram({
                             return y(d.count) + labelDy
                         })
                         .classed('outside', (d) => !d.shouldShowInBar)
+
+                    // Always move labels to top
+                    _svg.node().appendChild(_labels.node())
                 }
 
                 return _svg

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -816,7 +816,7 @@ export interface FunnelStepWithNestedBreakdown extends FunnelStep {
     nested_breakdown?: FunnelStep[]
 }
 
-export interface FunnelResult<ResultType = FunnelStep[]> {
+export interface FunnelResult<ResultType = FunnelStep[] | FunnelsTimeConversionBins> {
     is_cached: boolean
     last_refresh: string | null
     result: ResultType
@@ -826,13 +826,7 @@ export interface FunnelResult<ResultType = FunnelStep[]> {
 export interface FunnelsTimeConversionBins {
     bins: [number, number][]
     average_conversion_time: number
-}
-
-export interface FunnelsTimeConversionResult {
-    result: FunnelsTimeConversionBins
-    last_refresh: string | null
-    is_cached: boolean
-    type: 'Funnel'
+    steps: FunnelStep[] | FunnelStep[][]
 }
 
 export interface FunnelTimeConversionMetrics {
@@ -862,8 +856,7 @@ export interface FunnelRequestParams extends FilterType {
 }
 
 export interface LoadedRawFunnelResults {
-    results: FunnelStep[] | FunnelStep[][]
-    timeConversionResults: FunnelsTimeConversionBins
+    results: FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
     filters: Partial<FilterType>
 }
 


### PR DESCRIPTION
## Changes

Fixes #5878.

And while we're at it, also fixes #6001.

**Before:**

https://user-images.githubusercontent.com/13460330/133689929-ace7d595-4369-4c13-8c85-39eaa2f083b2.mov


**After:**

https://user-images.githubusercontent.com/13460330/133689842-aee7dd8f-f6c5-4e29-8ba9-462db9b77773.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)



