### PR TITLE
add alpha tag to mv test, make CTAs more obvious

### DIFF
--- a/frontend/src/scenes/experimentation/FeatureFlag.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlag.tsx
@@ -1,5 +1,19 @@
 import React, { useState } from 'react'
-import { Input, Button, Form, Switch, Slider, Card, Row, Col, Collapse, Radio, InputNumber, Popconfirm } from 'antd'
+import {
+    Input,
+    Button,
+    Form,
+    Switch,
+    Slider,
+    Card,
+    Row,
+    Col,
+    Collapse,
+    Radio,
+    InputNumber,
+    Popconfirm,
+    Tag,
+} from 'antd'
 import { useActions, useValues } from 'kea'
 import { SceneLoading } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -321,11 +335,21 @@ export function FeatureFlag(): JSX.Element {
                                     <Radio.Group
                                         options={[
                                             {
-                                                label: 'Boolean value',
+                                                label: 'Boolean value (A/B test)',
                                                 value: false,
                                             },
                                             {
-                                                label: 'a string variant',
+                                                label: (
+                                                    <div>
+                                                        String value (Multivariate test){' '}
+                                                        <Tag
+                                                            color={'orange'}
+                                                            style={{ fontSize: 12, fontWeight: 'bold' }}
+                                                        >
+                                                            ALPHA
+                                                        </Tag>
+                                                    </div>
+                                                ),
                                                 value: true,
                                             },
                                         ]}


### PR DESCRIPTION
## Changes
A couple of small tweaks-
- Added an alpha tag to the mv option
- Added test type associated with each option in the main CTA 

<img width="836" alt="Screen Shot 2021-09-16 at 7 23 49 PM" src="https://user-images.githubusercontent.com/5965891/133714324-67d7f0d0-d699-4129-acab-08fe09d34a7d.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
