### PR TITLE
Delete session recording events with one db query

### DIFF
--- a/posthog/tasks/test/test_session_recording_retention.py
+++ b/posthog/tasks/test/test_session_recording_retention.py
@@ -27,8 +27,8 @@ class TestSessionRecording(BaseTest):
 
             patched_session_recording_retention.assert_has_calls(
                 [
-                    call(team_id=team.id, time_threshold=now() - timedelta(days=5)),
-                    call(team_id=team3.id, time_threshold=now() - timedelta(days=6)),
+                    call(team_id=team.id, time_threshold=(now() - timedelta(days=5)).isoformat()),
+                    call(team_id=team3.id, time_threshold=(now() - timedelta(days=6)).isoformat()),
                 ],
                 any_order=True,
             )
@@ -45,18 +45,6 @@ class TestSessionRecording(BaseTest):
 
             self.assertEqual(SessionRecordingEvent.objects.count(), 1)
             self.assertEqual(SessionRecordingEvent.objects.last(), event_after_threshold)
-
-    def test_does_not_delete_session_near_threshold(self) -> None:
-        with freeze_time("2020-01-10"):
-            self.create_snapshot("1", threshold() - timedelta(minutes=60))
-            self.create_snapshot("1", threshold() - timedelta(minutes=50))
-            self.create_snapshot("1", threshold() - timedelta(minutes=40))
-            self.create_snapshot("1", threshold() - timedelta(minutes=30))
-            self.create_snapshot("1", threshold() - timedelta(minutes=20))
-
-            session_recording_retention(self.team.id, threshold().isoformat())
-
-            self.assertEqual(SessionRecordingEvent.objects.count(), 5)
 
     def create_snapshot(self, session_id: str, timestamp: datetime) -> SessionRecordingEvent:
         return SessionRecordingEvent.objects.create(


### PR DESCRIPTION
## Changes

- The previous code pretty much selected all events and then ran a `.delete()` in django for all of them.
```py
primary_keys = [event.pk for session_events in purged_sessions.values() for event in session_events]
SessionRecordingEvent.objects.filter(pk__in=primary_keys).delete()
```
- It failed if you had gigabytes of recordings to delete, but when it worked, it worked cleanly and didn't split sessions in half.
- This is a brute-force approach that deletes all old recording events, not taking into account if we might just delete the first half of a session or not. But it'll actually delete them! We should be able to handle broken recordings anyway, and we'll soon group recordings better anyway.
- I tried adding a `VACCUUM` here as well, but that shouldn't run in a transaction, and I couldn't find a [non-hacky way](https://stackoverflow.com/questions/1017463/postgresql-how-to-run-vacuum-from-code-outside-transaction-block) to get out from being in one, so I punted.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
