### PR TITLE
Refactor organization members component

### DIFF
--- a/frontend/src/lib/utils/permissioning.ts
+++ b/frontend/src/lib/utils/permissioning.ts
@@ -38,5 +38,5 @@ export function getReasonForAccessLevelChangeProhibition(
     if (currentMembershipLevel < memberChanged.level) {
         return 'You can only change access level of members with level lower or equal to you.'
     }
-    return false
+    return null
 }

--- a/frontend/src/lib/utils/permissioning.ts
+++ b/frontend/src/lib/utils/permissioning.ts
@@ -1,0 +1,41 @@
+import { OrganizationMemberType, UserType } from '../../types'
+import { OrganizationMembershipLevel } from '../constants'
+
+export function getReasonForAccessLevelChangeProhibition(
+    currentMembershipLevel: OrganizationMembershipLevel | null,
+    currentUser: UserType,
+    memberChanged: OrganizationMemberType,
+    newLevelOrAllowedLevels: OrganizationMembershipLevel | OrganizationMembershipLevel[]
+): false | string {
+    if (memberChanged.user.uuid === currentUser.uuid) {
+        return "You can't change your own access level."
+    }
+    if (!currentMembershipLevel) {
+        return 'Your membership level is unknown.'
+    }
+    if (Array.isArray(newLevelOrAllowedLevels)) {
+        if (currentMembershipLevel === OrganizationMembershipLevel.Owner) {
+            return false
+        }
+        if (!newLevelOrAllowedLevels.length) {
+            return "You don't have permission to change this member's access level."
+        }
+    } else {
+        if (newLevelOrAllowedLevels === memberChanged.level) {
+            return "It doesn't make sense to set the same level as before."
+        }
+        if (currentMembershipLevel === OrganizationMembershipLevel.Owner) {
+            return false
+        }
+        if (newLevelOrAllowedLevels > currentMembershipLevel) {
+            return 'You can only change access level of others to lower or equal to your current one.'
+        }
+    }
+    if (currentMembershipLevel < OrganizationMembershipLevel.Admin) {
+        return "You don't have permission to change access levels."
+    }
+    if (currentMembershipLevel < memberChanged.level) {
+        return 'You can only change access level of members with level lower or equal to you.'
+    }
+    return false
+}

--- a/frontend/src/lib/utils/permissioning.ts
+++ b/frontend/src/lib/utils/permissioning.ts
@@ -1,12 +1,13 @@
 import { OrganizationMemberType, UserType } from '../../types'
 import { OrganizationMembershipLevel } from '../constants'
 
+/** If access level change is disallowed given the circumstances, returns a reason why so. Otherwise returns null. */
 export function getReasonForAccessLevelChangeProhibition(
     currentMembershipLevel: OrganizationMembershipLevel | null,
     currentUser: UserType,
     memberChanged: OrganizationMemberType,
     newLevelOrAllowedLevels: OrganizationMembershipLevel | OrganizationMembershipLevel[]
-): false | string {
+): null | string {
     if (memberChanged.user.uuid === currentUser.uuid) {
         return "You can't change your own access level."
     }
@@ -15,7 +16,7 @@ export function getReasonForAccessLevelChangeProhibition(
     }
     if (Array.isArray(newLevelOrAllowedLevels)) {
         if (currentMembershipLevel === OrganizationMembershipLevel.Owner) {
-            return false
+            return null
         }
         if (!newLevelOrAllowedLevels.length) {
             return "You don't have permission to change this member's access level."
@@ -25,7 +26,7 @@ export function getReasonForAccessLevelChangeProhibition(
             return "It doesn't make sense to set the same level as before."
         }
         if (currentMembershipLevel === OrganizationMembershipLevel.Owner) {
-            return false
+            return null
         }
         if (newLevelOrAllowedLevels > currentMembershipLevel) {
             return 'You can only change access level of others to lower or equal to your current one.'


### PR DESCRIPTION
## Changes

A bit of a refactor of the organization members component spun out of https://github.com/PostHog/posthog/pull/5976.
`getReasonForAccessLevelChangeProhibition` is now in `frontend/src/lib/utils/permissioning.ts` in preparation of sharing it between org and project membership management.
