### PR TITLE
Fix time conversion blanking

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -440,7 +440,7 @@ export const funnelLogic = kea<funnelLogicType>({
         interval: [() => [selectors.apiParams], (apiParams) => apiParams.interval || ''],
         stepsFromResult: [
             () => [selectors.results, selectors.timeConversionResults],
-            (trendResults, timeConversionResults) => timeConversionResults?.steps ?? trendResults ?? [],
+            (results, timeConversionResults) => (Array.isArray(results) ? results : timeConversionResults?.steps) ?? [],
         ],
         stepsWithNestedBreakdown: [
             () => [selectors.stepsFromResult, selectors.apiParams],

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -439,8 +439,16 @@ export const funnelLogic = kea<funnelLogicType>({
         actionCount: [() => [selectors.apiParams], (apiParams) => apiParams.actions?.length || 0],
         interval: [() => [selectors.apiParams], (apiParams) => apiParams.interval || ''],
         stepsFromResult: [
-            () => [selectors.results, selectors.timeConversionResults],
-            (results, timeConversionResults) => (Array.isArray(results) ? results : timeConversionResults?.steps) ?? [],
+            () => [selectors.filters, selectors.results, selectors.timeConversionResults],
+            (filters, results, timeConversionResults) => {
+                // In time to convert view, results is an object with shape FunnelsTimeConversionBins = {..., steps: FunnelStep[]}
+                // on the other hand, steps and trends results are arrays in the shape of FunnelStep[] | FunnelStep[][]
+                return (
+                    (filters.funnel_viz_type === FunnelVizType.TimeToConvert
+                        ? timeConversionResults?.steps
+                        : results) ?? []
+                )
+            },
         ],
         stepsWithNestedBreakdown: [
             () => [selectors.stepsFromResult, selectors.apiParams],


### PR DESCRIPTION
## Changes

Time conversion bug where the results selector for time conversion was always returning an empty array. Introduced here #6002.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
