### PR TITLE
fix bug with undefined date on plugin jobs UI

### DIFF
--- a/frontend/src/scenes/plugins/edit/interface-jobs/interfaceJobsLogic.ts
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/interfaceJobsLogic.ts
@@ -60,7 +60,11 @@ export const interfaceJobsLogic = kea<interfaceJobsLogicType>({
 
             for (const [fieldKey, fieldValue] of Object.entries(formValues)) {
                 if (props.jobSpecPayload?.[fieldKey].type === 'date') {
-                    formValues[fieldKey] = (fieldValue as moment.Moment).toISOString()
+                    if (!!formValues[fieldKey]) {
+                        formValues[fieldKey] = (fieldValue as moment.Moment).toISOString()
+                    } else {
+                        formValues[fieldKey] = null
+                    }
                 }
             }
             try {


### PR DESCRIPTION
## Changes

If a date value was not required and left undefined, we'd fail trying to convert it to an ISO string.

Fix for #5996 

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
