### PR TITLE
Skip empty selectors in ClickHouse action matching

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -263,7 +263,8 @@ def filter_element(filters: Dict, *, operator: Optional[OperatorType] = None, pr
                 key = f"{prepend}_{idx}_selector_regex"
                 params[key] = build_selector_regex(selector)
                 combination_conditions.append(f"match(elements_chain, %({key})s)")
-            final_conditions.append(f"({' OR '.join(combination_conditions)})")
+            if combination_conditions:
+                final_conditions.append(f"({' OR '.join(combination_conditions)})")
         elif operator not in NEGATED_OPERATORS:
             # If a non-negated filter has an empty selector list provided, it can't match anything
             return "0 = 191", {}

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -257,6 +257,8 @@ def filter_element(filters: Dict, *, operator: Optional[OperatorType] = None, pr
         if selectors:
             combination_conditions = []
             for idx, query in enumerate(selectors):
+                if not query:  # Skip empty selectors
+                    continue
                 selector = Selector(query, escape_slashes=False)
                 key = f"{prepend}_{idx}_selector_regex"
                 params[key] = build_selector_regex(selector)

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -383,6 +383,26 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
             events = _get_events_for_action(action1)
             self.assertEqual(len(events), 0)
 
+        def test_empty_selector_same_as_null(self):
+            _create_person(distinct_ids=["whatever"], team=self.team)
+            action_null_selector = Action.objects.create(team=self.team)
+            ActionStep.objects.create(action=action_null_selector, selector=None)
+            action_empty_selector = Action.objects.create(team=self.team)
+            ActionStep.objects.create(action=action_empty_selector, selector="")
+            event1 = _create_event(
+                event="$autocapture",
+                team=self.team,
+                distinct_id="whatever",
+                elements=[Element(tag_name="span", attr_class=None)],
+            )
+
+            events_null_selector = _get_events_for_action(action_null_selector)
+            self.assertEqual(events_null_selector[0].pk, event1.pk)
+            self.assertEqual(len(events_null_selector), 1)
+
+            events_empty_selector = _get_events_for_action(action_empty_selector)
+            self.assertEqual(events_empty_selector, events_null_selector)
+
     return TestFilterByActions
 
 

--- a/posthog/test/test_event_model.py
+++ b/posthog/test/test_event_model.py
@@ -386,9 +386,9 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
         def test_empty_selector_same_as_null(self):
             _create_person(distinct_ids=["whatever"], team=self.team)
             action_null_selector = Action.objects.create(team=self.team)
-            ActionStep.objects.create(action=action_null_selector, selector=None)
+            ActionStep.objects.create(action=action_null_selector, event="$autocapture", selector=None)
             action_empty_selector = Action.objects.create(team=self.team)
-            ActionStep.objects.create(action=action_empty_selector, selector="")
+            ActionStep.objects.create(action=action_empty_selector, event="$autocapture", selector="")
             event1 = _create_event(
                 event="$autocapture",
                 team=self.team,


### PR DESCRIPTION
## Changes

This makes it so that empty (`""`) selectors are treated like null (`None`) ones – that is skipped. Solves a problem reported by a user, where the Toolbar was set as empty in the selector, resulting in no matches to be found for the action ([conversation](https://app.papercups.io/conversations/all?cid=48341d4d-3e96-48a7-8256-85d0058853b4))
 I figure there is no case where we want an empty selector to be taken into account, as it can't match anything, and no user is interested in always getting nothing.
Also, this already is the case for Postgres action matching and plugin server action matching, so aligning the ClickHouse query builder seems just sensible.

## Checklist

- [x] Django backend tests