### PR TITLE
Fix funnel saved insights don't take up the full width 

### DIFF
--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -101,7 +101,7 @@ export function Insights(): JSX.Element {
     })
 
     return (
-        <>
+        <div className="insights-page">
             {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && insightMode === ItemMode.View ? (
                 <>
                     <Row justify="space-between" align="middle" style={{ marginTop: 24 }}>
@@ -143,12 +143,12 @@ export function Insights(): JSX.Element {
                     <div className="mb" style={{ marginTop: 8 }} data-attr="insight-tags">
                         <ObjectTags tags={insight.tags || []} staticOnly />
                     </div>
-                    <Col span={24} xl={verticalLayout ? 16 : undefined}>
+                    <Col span={24}>
                         <InsightContainer loadResults={loadResults} resultsLoading={resultsLoading} />
                     </Col>
                 </>
             ) : (
-                <div className="insights-page">
+                <>
                     <PersonModal
                         visible={showingPeople && !cohortModalVisible}
                         view={ViewType.FUNNELS}
@@ -345,8 +345,8 @@ export function Insights(): JSX.Element {
                         )}
                     </Row>
                     <NPSPrompt />
-                </div>
+                </>
             )}
-        </>
+        </div>
     )
 }


### PR DESCRIPTION
## Changes

Part of #6036 saved insights initiative.

Before

<img width="1789" alt="Screen Shot 2021-09-20 at 11 49 05 AM" src="https://user-images.githubusercontent.com/13460330/134057705-1535f236-322c-4606-b350-7b1942582479.png">


After

<img width="1485" alt="Screen Shot 2021-09-20 at 11 39 02 AM" src="https://user-images.githubusercontent.com/13460330/134056619-1cce8dfb-ca30-44ca-88f4-d342e3bba270.png">

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
