### PR TITLE
Add descriptive headers to Saved Insights View/Edit/Create modes

### DIFF
--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -83,7 +83,6 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
 
     // Empty states that can coexist with the graph (e.g. Loading)
     const CoexistingEmptyState = (() => {
-        console.log('LOADING', isLoading || resultsLoading)
         if (isLoading || resultsLoading) {
             return <Loading />
         }

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -83,6 +83,7 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
 
     // Empty states that can coexist with the graph (e.g. Loading)
     const CoexistingEmptyState = (() => {
+        console.log('LOADING', isLoading || resultsLoading)
         if (isLoading || resultsLoading) {
             return <Loading />
         }

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -106,7 +106,7 @@ export function Insights(): JSX.Element {
                 <>
                     <Row justify="space-between" align="middle" style={{ marginTop: 24 }}>
                         <span style={{ fontSize: 28, fontWeight: 600 }}>
-                            {insight.name || `Insight #${insight.id}`}
+                            {insight.name || `Insight #${insight.id ?? '...'}`}
                         </span>
                         <div>
                             <SaveToDashboard
@@ -167,75 +167,96 @@ export function Insights(): JSX.Element {
                         onCancel={() => setCohortModalVisible(false)}
                     />
                     {insight.id && (
-                        <Row style={{ marginTop: 24, alignItems: 'baseline', justifyContent: 'space-between' }}>
-                            {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] ? (
-                                <Col>
-                                    <span>
-                                        <strong>Name</strong>
+                        <>
+                            <Row
+                                align="middle"
+                                style={{ marginTop: 24, justifyContent: 'space-between' }}
+                                className="mb-05"
+                            >
+                                {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] ? (
+                                    <Col>
+                                        <span style={{ fontSize: 28, fontWeight: 600 }}>
+                                            {insight.saved ? 'Edit' : 'Create'} Insight
+                                        </span>
+                                    </Col>
+                                ) : (
+                                    <span style={{ fontSize: 28, fontWeight: 600 }}>
+                                        {insight.name || `Insight #${insight.id}`}
                                     </span>
-                                    <div style={{ minWidth: 720 }}>
-                                        <Input
-                                            placeholder={insight.name || `Insight #${insight.id}`}
-                                            value={insight.name || ''}
-                                            size="large"
-                                            style={{ minWidth: 720, marginTop: 8 }}
-                                            onChange={(e) => setInsight({ ...insight, name: e.target.value })}
-                                            onKeyDown={(e) => {
-                                                if (e.key === 'Enter') {
-                                                    updateInsight(insight)
-                                                }
-                                            }}
-                                            tabIndex={0}
-                                        />
-                                    </div>
-                                </Col>
-                            ) : (
-                                <span style={{ fontSize: 28, fontWeight: 600 }}>
-                                    {insight.name || `Insight #${insight.id}`}
-                                </span>
-                            )}
+                                )}
 
-                            <Col>
-                                <>
-                                    <Popconfirm
-                                        title="Are you sure? This will clear all filters and any progress will be lost."
-                                        onConfirm={() => {
-                                            window.scrollTo({ top: 0 })
-                                            push(`/insights?insight=${insight?.filters?.insight}`)
-                                            reportInsightsTabReset()
-                                        }}
-                                    >
-                                        <Tooltip placement="top" title="Reset all filters">
-                                            <Button type="link" className="btn-reset">
-                                                {'Reset'}
+                                <Col>
+                                    <>
+                                        <Popconfirm
+                                            title="Are you sure? This will clear all filters and any progress will be lost."
+                                            onConfirm={() => {
+                                                window.scrollTo({ top: 0 })
+                                                push(`/insights?insight=${insight?.filters?.insight}`)
+                                                reportInsightsTabReset()
+                                            }}
+                                        >
+                                            <Tooltip placement="top" title="Reset all filters">
+                                                <Button type="link" className="btn-reset">
+                                                    {'Reset'}
+                                                </Button>
+                                            </Tooltip>
+                                        </Popconfirm>
+                                        <SaveToDashboard
+                                            displayComponent={
+                                                <Button style={{ color: 'var(--primary)' }} className="btn-save">
+                                                    {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS]
+                                                        ? 'Save & add to dashboard'
+                                                        : 'Add to dashboard'}
+                                                </Button>
+                                            }
+                                            tooltipOptions={{
+                                                placement: 'bottom',
+                                                title: 'Save to dashboard',
+                                            }}
+                                            item={{
+                                                entity: {
+                                                    filters: insight.filters || allFilters,
+                                                    annotations: annotationsToCreate,
+                                                },
+                                            }}
+                                        />
+                                        {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && (
+                                            <Button
+                                                style={{ marginLeft: 8 }}
+                                                type="primary"
+                                                onClick={() => saveInsight()}
+                                            >
+                                                Save
                                             </Button>
-                                        </Tooltip>
-                                    </Popconfirm>
-                                    <SaveToDashboard
-                                        displayComponent={
-                                            <Button style={{ color: 'var(--primary)' }} className="btn-save">
-                                                Add to dashboard
-                                            </Button>
-                                        }
-                                        tooltipOptions={{
-                                            placement: 'bottom',
-                                            title: 'Save to dashboard',
-                                        }}
-                                        item={{
-                                            entity: {
-                                                filters: insight.filters || allFilters,
-                                                annotations: annotationsToCreate,
-                                            },
-                                        }}
-                                    />
-                                    {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && (
-                                        <Button style={{ marginLeft: 8 }} type="primary" onClick={() => saveInsight()}>
-                                            Save
-                                        </Button>
-                                    )}
-                                </>
-                            </Col>
-                        </Row>
+                                        )}
+                                    </>
+                                </Col>
+                            </Row>
+                            {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && (
+                                <Row>
+                                    <Col className="mt-05 mb-05">
+                                        <span>
+                                            <strong>Name</strong>
+                                        </span>
+                                        <div style={{ minWidth: 720 }}>
+                                            <Input
+                                                placeholder={insight.name || `Insight #${insight.id}`}
+                                                value={insight.name || ''}
+                                                size="large"
+                                                style={{ minWidth: 720, marginTop: 8 }}
+                                                onChange={(e) => setInsight({ ...insight, name: e.target.value })}
+                                                onKeyDown={(e) => {
+                                                    if (e.key === 'Enter') {
+                                                        updateInsight(insight)
+                                                    }
+                                                }}
+                                                tabIndex={0}
+                                            />
+                                        </div>
+                                    </Col>
+                                </Row>
+                            )}
+                        </>
                     )}
 
                     {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && (

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -251,7 +251,7 @@ export function SavedInsights(): JSX.Element {
     return (
         <div className="saved-insights">
             <Row style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
-                <PageHeader style={{ marginTop: 0 }} title={'Insights'} />
+                <PageHeader title={'Insights'} />
                 <Dropdown
                     overlay={
                         <Menu style={{ maxWidth: 320, border: '1px solid var(--primary)' }}>


### PR DESCRIPTION
## Changes

Part of #6036 saved insights initiative.

Before

<img width="1331" alt="Screen Shot 2021-09-20 at 2 20 52 PM" src="https://user-images.githubusercontent.com/13460330/134077476-2516e2a1-77bf-4d98-b655-5848a9458fd2.png">

After

https://user-images.githubusercontent.com/13460330/134077381-4d8727ce-3171-424c-bdbd-e5958323e1df.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
