### PR TITLE
Fix broken back button on saved insights

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -20,7 +20,7 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { SaveModal } from 'scenes/insights/SaveModal'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
-import { DashboardItemType, DashboardMode, DashboardType, ChartDisplayType, ViewType } from '~/types'
+import { DashboardItemType, DashboardMode, DashboardType, ChartDisplayType, ViewType, FilterType } from '~/types'
 import { ActionsBarValueGraph } from 'scenes/trends/viz'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
@@ -152,6 +152,16 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
     },
 }
 
+export function getDisplayedType(filters: Partial<FilterType>): DisplayedType {
+    return (filters.insight === ViewType.RETENTION
+        ? 'RetentionContainer'
+        : filters.insight === ViewType.PATHS
+        ? 'PathsViz'
+        : filters.insight === ViewType.FUNNELS
+        ? 'FunnelViz'
+        : filters.display || 'ActionsLineGraph') as DisplayedType
+}
+
 const dashboardDiveLink = (dive_dashboard: number, dive_source_id: number): string => {
     return combineUrl(`/dashboard/${dive_dashboard}`, { dive_source_id: dive_source_id.toString() }).url
 }
@@ -182,14 +192,7 @@ export function DashboardItem({
     const { renameDashboardItem } = useActions(dashboardItemsModel)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const _type: DisplayedType =
-        item.filters.insight === ViewType.RETENTION
-            ? 'RetentionContainer'
-            : item.filters.insight === ViewType.PATHS
-            ? 'PathsViz'
-            : item.filters.insight === ViewType.FUNNELS
-            ? 'FunnelViz'
-            : item.filters.display || 'ActionsLineGraph'
+    const _type: DisplayedType = getDisplayedType(item.filters)
 
     const insightTypeDisplayName =
         item.filters.insight === ViewType.RETENTION

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -4,7 +4,7 @@ import { Link } from 'lib/components/Link'
 import { ObjectTags } from 'lib/components/ObjectTags'
 import { deleteWithUndo, humanFriendlyDetailedTime } from 'lib/utils'
 import React from 'react'
-import { DashboardItemType, LayoutView, SavedInsightsTabs, ViewType } from '~/types'
+import { DashboardItemType, LayoutView, SavedInsightsTabs } from '~/types'
 import { savedInsightsLogic } from './savedInsightsLogic'
 import {
     StarOutlined,
@@ -25,7 +25,7 @@ import {
 } from '@ant-design/icons'
 import './SavedInsights.scss'
 import { organizationLogic } from 'scenes/organizationLogic'
-import { DashboardItem, DisplayedType, displayMap } from 'scenes/dashboard/DashboardItem'
+import { DashboardItem, displayMap, getDisplayedType } from 'scenes/dashboard/DashboardItem'
 import { membersLogic } from 'scenes/organization/Settings/membersLogic'
 import { normalizeColumnTitle } from 'lib/components/Table/utils'
 import { dashboardsModel } from '~/models/dashboardsModel'
@@ -106,26 +106,22 @@ export function SavedInsights(): JSX.Element {
             title: 'Name',
             dataIndex: 'name',
             key: 'name',
-            render: function renderName(
-                name: string,
-                {
-                    short_id,
-                    id,
-                    description,
-                    favorited,
-                }: { short_id: string; id: number; description?: string; favorited?: boolean }
-            ) {
+            render: function renderName(name: string, insight: DashboardItemType) {
+                const link = displayMap[getDisplayedType(insight.filters)].link(insight)
+
                 return (
                     <Col>
                         <Row>
-                            <Link to={`/i/${short_id}`} style={{ marginRight: 12 }}>
-                                <strong>{name || `Insight #${id}`}</strong>
+                            <Link to={link} style={{ marginRight: 12 }}>
+                                <strong>{name || `Insight #${insight.id}`}</strong>
                             </Link>
                             <div
                                 style={{ cursor: 'pointer', width: 'fit-content' }}
-                                onClick={() => updateFavoritedInsight({ id, favorited: !favorited })}
+                                onClick={() =>
+                                    updateFavoritedInsight({ id: insight.id, favorited: !insight.favorited })
+                                }
                             >
-                                {favorited ? (
+                                {insight.favorited ? (
                                     <StarFilled className="text-warning" />
                                 ) : (
                                     <StarOutlined className="star-outlined" />
@@ -133,7 +129,7 @@ export function SavedInsights(): JSX.Element {
                             </div>
                         </Row>
                         {hasDashboardCollaboration && (
-                            <div className="text-muted-alt">{description || 'No description provided'}</div>
+                            <div className="text-muted-alt">{insight.description || 'No description provided'}</div>
                         )}
                     </Col>
                 )
@@ -418,11 +414,7 @@ export function SavedInsights(): JSX.Element {
                                             }}
                                             dashboardMode={null}
                                             onClick={() => {
-                                                const _type: DisplayedType =
-                                                    insight.filters.insight === ViewType.RETENTION
-                                                        ? 'RetentionContainer'
-                                                        : insight.filters.display
-                                                window.open(displayMap[_type].link(insight))
+                                                window.open(displayMap[getDisplayedType(insight.filters)].link(insight))
                                             }}
                                             preventLoading={true}
                                             index={index}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -484,6 +484,7 @@ export interface DashboardItemType {
     name: string
     short_id: string
     description?: string
+    favorited?: boolean
     filters: Record<string, any>
     filters_hash: string
     order: number


### PR DESCRIPTION
## Changes

Part of #6036 saved insights initiative.

The back button doesn't work on saved insights because clicking on the insight name takes you to a shortened url that django resolves by replacing the router's entire history. This PR changes this behavior to use the long url instead of the shortened one so that the back button works. 

I took inspiration from `DashboardItem.tsx` where the same thing is being done.

Before

https://user-images.githubusercontent.com/13460330/134087564-e5a36c20-37ab-4ec5-aa38-bb43ec772035.mov

After

https://user-images.githubusercontent.com/13460330/134087571-ce85285a-1a0e-49da-98af-4a22ad6e7065.mov

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
