### PR TITLE
Combine Layout button on saved insights

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Dropdown, Input, Menu, Row, Select, Table, Tabs } from 'antd'
+import { Col, Dropdown, Input, Menu, Row, Select, Table, Tabs, Radio } from 'antd'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/components/Link'
 import { ObjectTags } from 'lib/components/ObjectTags'
@@ -347,20 +347,20 @@ export function SavedInsights(): JSX.Element {
                 <Row className="list-or-card-layout">
                     Showing {paginationCount()} - {nextResult ? offset : count} of {count} insights
                     <div>
-                        <Button
-                            type={layoutView === LayoutView.List ? 'primary' : 'default'}
-                            onClick={() => setLayoutView(LayoutView.List)}
+                        <Radio.Group
+                            onChange={(e) => setLayoutView(e.target.value)}
+                            value={layoutView}
+                            buttonStyle="solid"
                         >
-                            <UnorderedListOutlined />
-                            List
-                        </Button>
-                        <Button
-                            type={layoutView === LayoutView.Card ? 'primary' : 'default'}
-                            onClick={() => setLayoutView(LayoutView.Card)}
-                        >
-                            <AppstoreFilled />
-                            Card
-                        </Button>
+                            <Radio.Button value={LayoutView.List}>
+                                <UnorderedListOutlined className="mr-05" />
+                                List
+                            </Radio.Button>
+                            <Radio.Button value={LayoutView.Card}>
+                                <AppstoreFilled className="mr-05" />
+                                Card
+                            </Radio.Button>
+                        </Radio.Group>
                     </div>
                 </Row>
             )}


### PR DESCRIPTION
## Changes

Part of #6036 saved insights initiative.

Before

<img width="206" alt="Screen Shot 2021-09-20 at 4 17 45 PM" src="https://user-images.githubusercontent.com/13460330/134088889-78ca1881-0b5f-4ed6-9a71-f7d37158959a.png">

After

<img width="229" alt="Screen Shot 2021-09-20 at 4 15 42 PM" src="https://user-images.githubusercontent.com/13460330/134088882-bda93950-0eb6-4175-b852-50d441c160aa.png">


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
