### PR TITLE
Retention event query cleanup

### DIFF
--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -23,7 +23,13 @@ from ee.clickhouse.sql.retention.retention import (
     RETENTION_PEOPLE_SQL,
     RETENTION_SQL,
 )
-from posthog.constants import RETENTION_FIRST_TIME, TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, TRENDS_LINEAR
+from posthog.constants import (
+    RETENTION_FIRST_TIME,
+    TREND_FILTER_TYPE_ACTIONS,
+    TREND_FILTER_TYPE_EVENTS,
+    TRENDS_LINEAR,
+    RetentionQueryType,
+)
 from posthog.models.action import Action
 from posthog.models.entity import Entity
 from posthog.models.filters import RetentionFilter
@@ -40,12 +46,14 @@ class ClickhouseRetention(Retention):
         trunc_func = get_trunc_func_ch(period)
 
         returning_event_query, returning_event_params = RetentionEventsQuery(
-            filter=filter, team_id=team.pk, event_query_type="returning"
+            filter=filter, team_id=team.pk, event_query_type=RetentionQueryType.RETURNING
         ).get_query()
         target_event_query, target_event_params = RetentionEventsQuery(
             filter=filter,
             team_id=team.pk,
-            event_query_type="target_first_time" if is_first_time_retention else "target",
+            event_query_type=RetentionQueryType.TARGET_FIRST_TIME
+            if is_first_time_retention
+            else RetentionQueryType.TARGET,
         ).get_query()
 
         all_params = {

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -8,6 +8,7 @@ from posthog.models.entity import Entity
 from posthog.models.filters import Filter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.path_filter import PathFilter
+from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.property import Property, PropertyName, PropertyType
 from posthog.models.team import Team
 
@@ -19,7 +20,7 @@ class ColumnOptimizer:
     This speeds up queries since clickhouse ends up selecting less data.
     """
 
-    def __init__(self, filter: Union[Filter, PathFilter], team_id: int):
+    def __init__(self, filter: Union[Filter, PathFilter, RetentionFilter], team_id: int):
         self.filter = filter
         self.team_id = team_id
 

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -10,6 +10,7 @@ from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS
 from posthog.models import Cohort, Filter, Property, Team
 from posthog.models.filters.path_filter import PathFilter
+from posthog.models.filters.retention_filter import RetentionFilter
 
 
 class ClickhouseEventQuery(metaclass=ABCMeta):
@@ -17,7 +18,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
     PERSON_TABLE_ALIAS = "person"
     EVENT_TABLE_ALIAS = "e"
 
-    _filter: Union[Filter, PathFilter]
+    _filter: Union[Filter, PathFilter, RetentionFilter]
     _team_id: int
     _column_optimizer: ColumnOptimizer
     _should_join_distinct_ids = False
@@ -28,7 +29,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
 
     def __init__(
         self,
-        filter: Union[Filter, PathFilter],
+        filter: Union[Filter, PathFilter, RetentionFilter],
         team_id: int,
         round_interval=False,
         should_join_distinct_ids=False,

--- a/ee/clickhouse/queries/person_query.py
+++ b/ee/clickhouse/queries/person_query.py
@@ -4,20 +4,21 @@ from ee.clickhouse.materialized_columns.columns import ColumnName
 from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from posthog.models import Filter
 from posthog.models.filters.path_filter import PathFilter
+from posthog.models.filters.retention_filter import RetentionFilter
 
 
 class ClickhousePersonQuery:
     PERSON_PROPERTIES_ALIAS = "person_props"
     ALIASES = {"properties": "person_props"}
 
-    _filter: Union[Filter, PathFilter]
+    _filter: Union[Filter, PathFilter, RetentionFilter]
     _team_id: int
     _column_optimizer: ColumnOptimizer
     _extra_fields: List[ColumnName]
 
     def __init__(
         self,
-        filter: Union[Filter, PathFilter],
+        filter: Union[Filter, PathFilter, RetentionFilter],
         team_id: int,
         column_optimizer: Optional[ColumnOptimizer] = None,
         extra_fields: List[ColumnName] = [],

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -29,16 +29,16 @@ class RetentionEventsQuery(ClickhouseEventQuery):
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         _fields = [
             self.get_timestamp_field(),
-            (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else ""),
+            (f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else ""),
             (
-                f", argMin(e.uuid, {self._trunc_func}(e.timestamp)) as min_uuid"
+                f"argMin(e.uuid, {self._trunc_func}(e.timestamp)) as min_uuid"
                 if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
-                else f", {self.EVENT_TABLE_ALIAS}.uuid AS uuid"
+                else f"{self.EVENT_TABLE_ALIAS}.uuid AS uuid"
             ),
             (
-                f", argMin(e.event, {self._trunc_func}(e.timestamp)) as min_event"
+                f"argMin(e.event, {self._trunc_func}(e.timestamp)) as min_event"
                 if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
-                else f", {self.EVENT_TABLE_ALIAS}.event AS event"
+                else f"{self.EVENT_TABLE_ALIAS}.event AS event"
             ),
         ]
         _fields = list(filter(None, _fields))

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -1,0 +1,80 @@
+from typing import Any, Dict, Literal, Tuple
+
+from ee.clickhouse.models.action import format_action_filter
+from ee.clickhouse.queries.event_query import ClickhouseEventQuery
+from posthog.constants import PAGEVIEW_EVENT, TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, TRENDS_LINEAR
+from posthog.models import Entity
+from posthog.models.action import Action
+from posthog.models.filters.retention_filter import RetentionFilter
+
+
+class RetentionEventsQuery(ClickhouseEventQuery):
+    _filter: RetentionFilter
+    _event_query_type: Literal["returning", "target"]
+
+    def __init__(self, event_query_type: Literal["returning", "target"], *args, **kwargs):
+        self._event_query_type = event_query_type
+        super().__init__(*args, **kwargs)
+
+    def get_query(self) -> Tuple[str, Dict[str, Any]]:
+        _fields = (
+            f"{self.EVENT_TABLE_ALIAS}.timestamp AS event_date"
+            + (f", {self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else "")
+            + f", {self.EVENT_TABLE_ALIAS}.uuid AS uuid"
+            + f", {self.EVENT_TABLE_ALIAS}.event AS event"
+        )
+
+        date_query, date_params = self._get_date_filter()
+        self.params.update(date_params)
+
+        prop_filters = [*self._filter.properties]
+        prop_query, prop_params = self._get_props(prop_filters)
+        self.params.update(prop_params)
+
+        entity_query, entity_params = self._get_entity_query(
+            entity=self._filter.target_entity if self._event_query_type == "target" else self._filter.returning_entity
+        )
+        self.params.update(entity_params)
+
+        query = f"""
+            SELECT {_fields} FROM events {self.EVENT_TABLE_ALIAS}
+            {self._get_disintct_id_query()}
+            {self._get_person_query()}
+            WHERE team_id = %(team_id)s
+            {entity_query}
+            {date_query}
+            {prop_query}
+        """
+
+        return query, self.params
+
+    def _determine_should_join_distinct_ids(self) -> None:
+        self._should_join_distinct_ids = True
+
+    def _get_entity_query(self, entity: Entity):
+        prepend = self._event_query_type
+        if entity.type == TREND_FILTER_TYPE_ACTIONS:
+            action = Action.objects.get(pk=entity.id)
+            action_query, params = format_action_filter(action, prepend=prepend, use_loop=False)
+            condition = action_query
+        elif entity.type == TREND_FILTER_TYPE_EVENTS:
+            condition = f"{self.EVENT_TABLE_ALIAS}.event = %({prepend}_event)s"
+            params = {f"{prepend}_event": entity.id}
+        else:
+            condition = f"{self.EVENT_TABLE_ALIAS}.event = %({prepend}_event)s"
+            params = {f"{prepend}_event": PAGEVIEW_EVENT}
+        return f"AND {condition}", params
+
+    def _get_date_filter(self):
+        query = f"toDateTime({self.EVENT_TABLE_ALIAS}.timestamp) >= toDateTime(%({self._event_query_type}_start_date)s) AND toDateTime({self.EVENT_TABLE_ALIAS}.timestamp) <= toDateTime(%({self._event_query_type}_end_date)s)"
+        params = {
+            f"{self._event_query_type}_start_date": self._filter.date_from.strftime(
+                "%Y-%m-%d{}".format(" %H:%M:%S" if self._filter.period == "Hour" else " 00:00:00")
+            ),
+            f"{self._event_query_type}_end_date": (
+                (self._filter.date_from + self._filter.period_increment)
+                if self._filter.display == TRENDS_LINEAR
+                else self._filter.date_to
+            ).strftime("%Y-%m-%d{}".format(" %H:%M:%S" if self._filter.period == "Hour" else " 00:00:00")),
+        }
+        return f"AND {query}", params

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -7,10 +7,12 @@ from ee.clickhouse.queries.trends.util import get_active_user_params
 from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trunc_func_ch, parse_timestamps
 from posthog.constants import MONTHLY_ACTIVE, WEEKLY_ACTIVE
 from posthog.models import Entity
+from posthog.models.filters.filter import Filter
 
 
 class TrendsEventQuery(ClickhouseEventQuery):
     _entity: Entity
+    _filter: Filter
 
     def __init__(self, entity: Entity, *args, **kwargs):
         self._entity = entity

--- a/ee/clickhouse/sql/retention/retention.py
+++ b/ee/clickhouse/sql/retention/retention.py
@@ -4,14 +4,7 @@ SELECT
     datediff(%(period)s, reference_event.event_date, {trunc_func}(toDateTime(event_date))) as intervals_from_base,
     COUNT(DISTINCT event.person_id) count
 FROM (
-    SELECT
-    timestamp AS event_date,
-    pdi.person_id as person_id,
-    e.uuid as uuid,
-    e.event as event
-    FROM events e join ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on e.distinct_id = pdi.distinct_id
-    where toDateTime(e.timestamp) >= toDateTime(%(start_date)s) AND toDateTime(e.timestamp) <= toDateTime(%(end_date)s)
-    AND e.team_id = %(team_id)s {returning_query} {filters}
+    {returning_event_queyr}
 ) event
 JOIN (
     {reference_event_sql}

--- a/ee/clickhouse/sql/retention/retention.py
+++ b/ee/clickhouse/sql/retention/retention.py
@@ -4,10 +4,10 @@ SELECT
     datediff(%(period)s, reference_event.event_date, {trunc_func}(toDateTime(event_date))) as intervals_from_base,
     COUNT(DISTINCT event.person_id) count
 FROM (
-    {returning_event_queyr}
+    {returning_event_query}
 ) event
 JOIN (
-    {reference_event_sql}
+    {target_event_query}
 ) reference_event
     ON (event.person_id = reference_event.person_id)
 WHERE {trunc_func}(event.event_date) > {trunc_func}(reference_event.event_date)

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -95,21 +95,6 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
         renderPaths()
     }, [paths, !pathsLoading, size, color])
 
-    function calculatePercentages(nodes) {
-        let newNodes = []
-        nodes.forEach((n) => {
-            let parentTotal = 0
-            n.targetLinks.forEach((link) => {
-                parentTotal += link.value
-            })
-            newNodes.push({
-                ...n,
-                perctange: parentTotal > 0 ? n.value / parentTotal : 0,
-            })
-        })
-        return newNodes
-    }
-
     function renderPaths() {
         const elements = document
             .getElementById(`'${dashboardItemId || DEFAULT_PATHS_ID}'`)
@@ -140,9 +125,6 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
             nodes: paths.nodes.map((d) => ({ ...d })),
             links: paths.links.map((d) => ({ ...d })),
         })
-
-        const newNodes = calculatePercentages(nodes)
-        console.log(newNodes)
 
         svg.append('g')
             .selectAll('rect')
@@ -259,13 +241,11 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
             .text(loadedFilter?.path_type === PAGEVIEW ? pageUrl : pathText)
             .style('cursor', 'auto')
             .style('fill', color === 'white' ? '#000' : '#fff')
-        console.log(nodes, links)
+
         textSelection
             .append('tspan')
             .attr('fill-opacity', 0.8)
-            .text((d) => {
-                return ` ${d.value.toLocaleString()}`
-            })
+            .text((d) => ` ${d.value.toLocaleString()}`)
 
         textSelection.append('title').text((d) => stripHTTP(d.name))
 

--- a/frontend/src/scenes/paths/Paths.js
+++ b/frontend/src/scenes/paths/Paths.js
@@ -95,6 +95,21 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
         renderPaths()
     }, [paths, !pathsLoading, size, color])
 
+    function calculatePercentages(nodes) {
+        let newNodes = []
+        nodes.forEach((n) => {
+            let parentTotal = 0
+            n.targetLinks.forEach((link) => {
+                parentTotal += link.value
+            })
+            newNodes.push({
+                ...n,
+                perctange: parentTotal > 0 ? n.value / parentTotal : 0,
+            })
+        })
+        return newNodes
+    }
+
     function renderPaths() {
         const elements = document
             .getElementById(`'${dashboardItemId || DEFAULT_PATHS_ID}'`)
@@ -125,6 +140,9 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
             nodes: paths.nodes.map((d) => ({ ...d })),
             links: paths.links.map((d) => ({ ...d })),
         })
+
+        const newNodes = calculatePercentages(nodes)
+        console.log(newNodes)
 
         svg.append('g')
             .selectAll('rect')
@@ -241,11 +259,13 @@ export function Paths({ dashboardItemId = null, filters = null, color = 'white' 
             .text(loadedFilter?.path_type === PAGEVIEW ? pageUrl : pathText)
             .style('cursor', 'auto')
             .style('fill', color === 'white' ? '#000' : '#fff')
-
+        console.log(nodes, links)
         textSelection
             .append('tspan')
             .attr('fill-opacity', 0.8)
-            .text((d) => ` ${d.value.toLocaleString()}`)
+            .text((d) => {
+                return ` ${d.value.toLocaleString()}`
+            })
 
         textSelection.append('title').text((d) => stripHTTP(d.name))
 

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -152,3 +152,9 @@ MONTHLY_ACTIVE = "monthly_active"
 
 ENVIRONMENT_TEST = "test"
 ENVIRONMENT_PRODUCTION = "production"
+
+
+class RetentionQueryType(str, Enum):
+    RETURNING = "returning"
+    TARGET = "target"
+    TARGET_FIRST_TIME = "target"

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -157,4 +157,4 @@ ENVIRONMENT_PRODUCTION = "production"
 class RetentionQueryType(str, Enum):
     RETURNING = "returning"
     TARGET = "target"
-    TARGET_FIRST_TIME = "target"
+    TARGET_FIRST_TIME = "target_first_time"

--- a/posthog/models/filters/retention_filter.py
+++ b/posthog/models/filters/retention_filter.py
@@ -20,6 +20,7 @@ from posthog.models.entity import Entity
 from posthog.models.filters.base_filter import BaseFilter
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.mixins.common import (
+    BreakdownTypeMixin,
     DisplayDerivedMixin,
     FilterTestAccountsMixin,
     InsightMixin,
@@ -46,6 +47,7 @@ class RetentionFilter(
     PropertyMixin,
     DisplayDerivedMixin,
     FilterTestAccountsMixin,
+    BreakdownTypeMixin,
     InsightMixin,
     OffsetMixin,
     BaseFilter,

--- a/posthog/models/filters/retention_filter.py
+++ b/posthog/models/filters/retention_filter.py
@@ -20,6 +20,7 @@ from posthog.models.entity import Entity
 from posthog.models.filters.base_filter import BaseFilter
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.mixins.common import (
+    BreakdownMixin,
     BreakdownTypeMixin,
     DisplayDerivedMixin,
     FilterTestAccountsMixin,
@@ -47,6 +48,7 @@ class RetentionFilter(
     PropertyMixin,
     DisplayDerivedMixin,
     FilterTestAccountsMixin,
+    BreakdownMixin,
     BreakdownTypeMixin,
     InsightMixin,
     OffsetMixin,


### PR DESCRIPTION
## Changes

*Please describe.*  
- a part of #5888. refactoring retention so that person prop filtering performance improvements are utilized
- Create a retentioneventsquery class as we have done for funnels, paths, and trends
- Refactor main retention query to use the query class

Followup
- refactor persons queries to use query classes

**Note: there's possibly even more performance improvement opportunity here for refactoring the query to not require a join
