### PR TITLE
fix(breakdown): resolve week rounding interval over shoot for trends

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -111,7 +111,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog/
+                  pytest -m "not ee" posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -168,7 +168,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog/
+                  pytest -m "not ee" posthog/
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -268,7 +268,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog --reuse-db -m "not skip_on_multitenancy"
+                  pytest posthog --reuse-db -m "not (skip_on_multitenancy or ee)"
 
             - name: Run cloud tests (posthog-cloud)
               env:

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -75,8 +75,14 @@ def get_time_diff(
     else:
         round_interval = diff.total_seconds() >= TIME_IN_SECONDS[interval] * 2
 
-    addition = 2 if interval == "week" else 1
-    return int(diff.total_seconds() / TIME_IN_SECONDS[interval]) + addition, TIME_IN_SECONDS[interval], round_interval
+    return (
+        # NOTE: `int` will simply strip the decimal part. Checking the
+        # extremities, if start_time, end_time are less than an interval apart,
+        # we'll get 0, then add 1, so we'll always get at least one interval
+        int(diff.total_seconds() / TIME_IN_SECONDS[interval]) + 1,
+        TIME_IN_SECONDS[interval],
+        round_interval,
+    )
 
 
 PERIOD_TO_TRUNC_FUNC: Dict[str, str] = {

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -2,10 +2,46 @@ BREAKDOWN_QUERY_SQL = """
 SELECT groupArray(day_start) as date, groupArray(count) as data, breakdown_value FROM (
     SELECT SUM(total) as count, day_start, breakdown_value FROM (
         SELECT * FROM (
+            -- Create a table with 1 row for each interval for the requested date range
+            -- This acts as a method of zero filling, i.e. when there are no data points
+            -- for a given interval, we'll still have a row for the group by interval with
+            -- a 0 value.
+            --
+            -- It's essentially a cross product of graph "ticks" and breakdown values.
+            --
+            -- TODO: we're relying on num_intervals, seconds_int_interval etc. being passed 
+            --       in as a parameter. To reduce the coupling between here and the 
+            --       calling code, we could perform calculations for these within the query
+            --       itself based on date_to/date_from. We could also pass in the intervals 
+            --       explicitly, although we'll be relying on the date handling between python 
+            --       and ClickHouse to be the same.
+            --
+            -- NOTE: there is the ORDER BY ... WITH FILL Expression but I'm not sure how we'd 
+            --       handle the edge cases:
+            --
+            --          https://clickhouse.com/docs/en/sql-reference/statements/select/order-by/#orderby-with-fill
+            --
+
             SELECT
-            toUInt16(0) AS total,
-            {interval}(toDateTime(%(date_to)s) - number * %(seconds_in_interval)s) as day_start,
-            breakdown_value from numbers(%(num_intervals)s) as main
+                toUInt16(0) AS total,
+                ticks.day_start as day_start,
+                breakdown_value 
+
+            FROM (
+                -- Generates all the intervals/ticks in the date range
+                -- NOTE: we build this range by including successive intervals back from the 
+                --       upper bound, then including the lower bound in the query also.
+
+                SELECT 
+                    {interval}(
+                        toDateTime(%(date_to)s) - number * %(seconds_in_interval)s
+                    ) as day_start
+                FROM numbers({num_intervals})
+                UNION ALL
+                SELECT {interval}(toDateTime(%(date_from)s)) as day_start
+            ) as ticks
+
+            -- Zero fill for all values for the specified breakdown
             CROSS JOIN
                 (
                     SELECT breakdown_value

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -1,6 +1,9 @@
+import json
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test.client import Client
 from rest_framework.test import APIClient
 
 from posthog.models import Person
@@ -160,3 +163,13 @@ email@example.org,
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(patch_calculate_cohort.call_count, 1)
+
+
+def create_cohort(client: Client, name: str, groups: List[Dict[str, Any]]):
+    return client.post("/api/cohort", {"name": name, "groups": json.dumps(groups)})
+
+
+def create_cohort_ok(client: Client, name: str, groups: List[Dict[str, Any]]):
+    response = create_cohort(client=client, name=name, groups=groups)
+    assert response.status_code == 201, response.content
+    return response.json()

--- a/posthog/api/test/test_trends.py
+++ b/posthog/api/test/test_trends.py
@@ -41,13 +41,13 @@ def test_includes_only_intervals_within_range(client: Client):
     #  this is what was used demonstrated in
     #  https://github.com/PostHog/posthog/issues/2675 but it might not be the
     #  simplest way to reproduce
-    cohort = create_cohort_ok(client=client, name="test cohort", groups=[{"properties": {"team_id": team.id}}])
+    cohort = create_cohort_ok(client=client, name="test cohort", groups=[{"properties": {"cohort_identifier": 1}}])
 
     # "2021-09-19" is a sunday, i.e. beginning of week
     with freeze_time("2021-09-20T16:00:00"):
         #  First identify as a member of the cohort
         distinct_id = "abc"
-        identify(distinct_id=distinct_id, team_id=team.id)
+        identify(distinct_id=distinct_id, team_id=team.id, properties={"cohort_identifier": 1})
 
         for date in ["2021-09-04", "2021-09-05", "2021-09-12", "2021-09-19"]:
             capture_event(

--- a/posthog/api/test/test_trends.py
+++ b/posthog/api/test/test_trends.py
@@ -1,0 +1,144 @@
+import dataclasses
+import json
+from datetime import datetime
+from typing import Any, Dict, List, TypedDict
+
+import pytest
+from django.test import Client
+from freezegun import freeze_time
+
+from posthog.api.test.test_cohort import create_cohort_ok
+from posthog.api.test.test_event_definition import (
+    EventData,
+    capture_event,
+    create_organization,
+    create_team,
+    create_user,
+)
+from posthog.api.test.test_retention import identify
+
+
+@pytest.mark.django_db
+@pytest.mark.ee
+def test_includes_only_intervals_within_range(client: Client):
+    """
+    This is the case highlighted by https://github.com/PostHog/posthog/issues/2675
+
+    Here the issue is that we request, for instance, 14 days as the
+    date_from, display at weekly intervals but previously we
+    were displaying 4 ticks on the date axis. If we were exactly on the
+    beginning of the week for two weeks then we'd want 2 ticks.
+    Otherwise we would have 3 ticks as the range would be intersecting
+    with three weeks. We should never need to display 4 ticks.
+    """
+    organization = create_organization(name="test org")
+    team = create_team(organization=organization)
+    user = create_user("user", "pass", organization)
+
+    client.force_login(user)
+
+    #  I'm creating a cohort here so that I can use as a breakdown, just because
+    #  this is what was used demonstrated in
+    #  https://github.com/PostHog/posthog/issues/2675 but it might not be the
+    #  simplest way to reproduce
+    cohort = create_cohort_ok(client=client, name="test cohort", groups=[{"properties": {"team_id": team.id}}])
+
+    # "2021-09-19" is a sunday, i.e. beginning of week
+    with freeze_time("2021-09-20T16:00:00"):
+        #  First identify as a member of the cohort
+        distinct_id = "abc"
+        identify(distinct_id=distinct_id, team_id=team.id)
+
+        for date in ["2021-09-04", "2021-09-05", "2021-09-12", "2021-09-19"]:
+            capture_event(
+                event=EventData(
+                    event="$pageview",
+                    team_id=team.id,
+                    distinct_id=distinct_id,
+                    timestamp=datetime.fromisoformat(date),
+                    properties={"distinct_id": "abc"},
+                )
+            )
+
+        trends = get_trends_ok(
+            client,
+            request=TrendsRequest(
+                date_from="-14days",
+                date_to="2021-09-21",
+                interval="week",
+                insight="TRENDS",
+                breakdown=[cohort["id"]],
+                breakdown_type="cohort",
+                display="ActionsLineGraph",
+                events=[
+                    {
+                        "id": "$pageview",
+                        "math": "dau",
+                        "name": "$pageview",
+                        "type": "events",
+                        "order": 0,
+                        "properties": [],
+                        "math_property": None,
+                    }
+                ],
+            ),
+        )
+        assert trends == {
+            "is_cached": False,
+            "last_refresh": "2021-09-20T16:00:00Z",
+            "next": None,
+            "result": [
+                {
+                    "action": {
+                        "id": "$pageview",
+                        "type": "events",
+                        "order": 0,
+                        "name": "$pageview",
+                        "math": "dau",
+                        "math_property": None,
+                        "properties": [],
+                    },
+                    "breakdown_value": cohort["id"],
+                    "label": "$pageview - test cohort",
+                    "count": 3.0,
+                    "data": [1.0, 1.0, 1.0],
+                    # Prior to the fix this would also include '29-Aug-2021'
+                    "labels": ["5-Sep-2021", "12-Sep-2021", "19-Sep-2021"],
+                    "days": ["2021-09-05", "2021-09-12", "2021-09-19"],
+                }
+            ],
+        }
+
+
+@dataclasses.dataclass
+class TrendsRequest:
+    date_from: str
+    date_to: str
+    interval: str
+    insight: str
+    breakdown: List[int]
+    breakdown_type: str
+    display: str
+    events: List[Dict[str, Any]]
+
+
+def get_trends(client, request: TrendsRequest):
+    return client.get(
+        "/api/insight/trend/",
+        data={
+            "date_from": request.date_from,
+            "date_to": request.date_to,
+            "interval": request.interval,
+            "insight": request.insight,
+            "breakdown": request.breakdown,
+            "breakdown_type": request.breakdown_type,
+            "display": request.display,
+            "events": json.dumps(request.events),
+        },
+    )
+
+
+def get_trends_ok(client: Client, request: TrendsRequest):
+    response = get_trends(client=client, request=request)
+    assert response.status_code == 200, response.content
+    return response.json()

--- a/posthog/queries/sessions/test/test_sessions.py
+++ b/posthog/queries/sessions/test/test_sessions.py
@@ -115,6 +115,7 @@ def sessions_test_factory(sessions, event_factory, person_factory):
             week_response = sessions().run(
                 SessionsFilter(
                     data={
+                        # 2012-01-01 is a Sunday
                         "date_from": "2012-01-01",
                         "date_to": "2012-02-01",
                         "interval": "week",
@@ -129,12 +130,12 @@ def sessions_test_factory(sessions, event_factory, person_factory):
                 ),
                 self.team,
             )
-            self.assertEqual(week_response[0]["data"][2], 4.0)
-            self.assertEqual(week_response[0]["data"][4], 2.0)
-            self.assertEqual(week_response[0]["labels"][0], "25-Dec-2011")
-            self.assertEqual(week_response[0]["labels"][2], "8-Jan-2012")
-            self.assertEqual(week_response[0]["days"][1], "2012-01-01")
-            self.assertEqual(week_response[0]["days"][2], "2012-01-08")
+            self.assertEqual(week_response[0]["data"][1], 4.0)
+            self.assertEqual(week_response[0]["data"][3], 2.0)
+            self.assertEqual(week_response[0]["labels"][0], "1-Jan-2012")
+            self.assertEqual(week_response[0]["labels"][1], "8-Jan-2012")
+            self.assertEqual(week_response[0]["days"][0], "2012-01-01")
+            self.assertEqual(week_response[0]["days"][1], "2012-01-08")
 
             # # # hour
             hour_response = sessions().run(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1962,6 +1962,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 response = trends().run(
                     Filter(
                         data={
+                            # 2019-11-24 is a Sunday
                             "date_from": "2019-11-24",
                             "interval": "week",
                             "events": [{"id": "sign up"}],
@@ -1971,10 +1972,11 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     ),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][5], "22-Dec-2019")
-            self.assertEqual(response[0]["data"][5], 1.0)
-            self.assertEqual(response[0]["labels"][6], "29-Dec-2019")
-            self.assertEqual(response[0]["data"][6], 4.0)
+
+            self.assertEqual(
+                response[0]["labels"][:5], ["24-Nov-2019", "1-Dec-2019", "8-Dec-2019", "15-Dec-2019", "22-Dec-2019"]
+            )
+            self.assertEqual(response[0]["data"][:5], [0.0, 0.0, 0.0, 0.0, 1.0])
 
             # test month
             with freeze_time("2020-01-02"):

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1349,10 +1349,10 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     Filter(data={"date_from": "2019-11-24", "interval": "week", "events": [{"id": "sign up"}]}),
                     self.team,
                 )
-            self.assertEqual(response[0]["labels"][5], "22-Dec-2019")
-            self.assertEqual(response[0]["data"][5], 1.0)
-            self.assertEqual(response[0]["labels"][6], "29-Dec-2019")
-            self.assertEqual(response[0]["data"][6], 4.0)
+            self.assertEqual(
+                response[0]["labels"][:5], ["24-Nov-2019", "1-Dec-2019", "8-Dec-2019", "15-Dec-2019", "22-Dec-2019"]
+            )
+            self.assertEqual(response[0]["data"][:5], [0.0, 0.0, 0.0, 0.0, 1.0])
 
             # test month
             with freeze_time("2020-01-02"):

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1346,7 +1346,14 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             # test week
             with freeze_time("2020-01-02"):
                 response = trends().run(
-                    Filter(data={"date_from": "2019-11-24", "interval": "week", "events": [{"id": "sign up"}]}),
+                    Filter(
+                        data={
+                            #  2019-11-24 is a Sunday, i.e. beginning of our week
+                            "date_from": "2019-11-24",
+                            "interval": "week",
+                            "events": [{"id": "sign up"}],
+                        }
+                    ),
                     self.team,
                 )
             self.assertEqual(

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -670,7 +670,7 @@ def get_daterange(
         start_date = start_date.replace(hour=0, minute=0, second=0, microsecond=0)
         end_date = end_date.replace(hour=0, minute=0, second=0, microsecond=0)
     if frequency == "week":
-        start_date -= datetime.timedelta(days=start_date.weekday() + 1)
+        start_date -= datetime.timedelta(days=(start_date.weekday() + 1) % 7)
     if frequency != "month":
         while start_date <= end_date:
             time_range.append(start_date)


### PR DESCRIPTION
Previously there was a fix for another issue with weekly intervals not
spanning a large enough range, see
https://github.com/PostHog/posthog/commit/69ba0b1d90826382bc9c414f02775fa277de4366
for details.

The issue that this was trying to resolve was consider a date range
date_from, date_to and a week interval. The range can cross two weeks,
but prior to the above commit it would only show one tick/week on the
graph. In this case we just added on another week to show.

This doesn't help however in the case where the range is less than a
week, in which case we'd end up showing a week/tick on the graph with
a zero value.

Instead, we remove the additional 1 week and simply ensure that both
lower and upper bounds are included in the clickhouse zero fill.

Closes https://github.com/PostHog/posthog/issues/2675

NOTE: this also ended up affecting:

 * the lifecycle query, as it uses the same `get_time_diff` function
 * some tests that look like they were incorrectly checking dates and expecting the sunday before to be included
 * `NULL_SQL` query was not using `def get_time_diff` but rather clickhouse's `dateDiff`, I've updated the logic here also and included @Twixes for review as he had previously touched this area