### PR TITLE
chore(tests): make clickhouse calls raise if PRIMARY_DB not set to clickhouse

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -63,14 +63,18 @@ def make_ch_pool(**overrides) -> ChPool:
 if PRIMARY_DB != AnalyticsDBMS.CLICKHOUSE:
     ch_client = None  # type: Client
 
+    class ClickHouseNotConfigured(NotImplementedError):
+        def __init__(self, msg='This function only works if PRIMARY_DB is set to indicate ClickHouse!"', *args):
+            super().__init__(msg, *args)
+
     def async_execute(query, args=None, settings=None, with_column_types=False):
-        return
+        raise ClickHouseNotConfigured()
 
     def sync_execute(query, args=None, settings=None, with_column_types=False):
-        return
+        raise ClickHouseNotConfigured()
 
     def cache_sync_execute(query, args=None, redis_client=None, ttl=None, settings=None, with_column_types=False):
-        return
+        raise ClickHouseNotConfigured()
 
 
 else:


### PR DESCRIPTION
This is an attempt to make the tests louder if things are incorrectly configured. I've had a few times when I've tried to run tests and got "`None` is not iterable" due to having PRIMARY_DB=postgres when running clickhouse tests. I'd rather it told me that things are not configured correctly.