### PR TITLE
Dont identify users as null

### DIFF
--- a/frontend/src/toolbar/toolbarLogic.ts
+++ b/frontend/src/toolbar/toolbarLogic.ts
@@ -63,7 +63,10 @@ export const toolbarLogic = kea<toolbarLogicType>({
     events: ({ props, actions, values }) => ({
         async afterMount() {
             if (props.instrument) {
-                posthog.identify((props as EditorProps).distinctId || null, { email: props.userEmail })
+                const distinctId = props.distinctId
+                if (distinctId) {
+                    posthog.identify(distinctId, props.userEmail ? { email: props.userEmail } : {})
+                }
                 posthog.optIn()
             }
             if (props.userIntent) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -202,7 +202,7 @@ export type EditorProps = {
     userIntent?: ToolbarUserIntent
     instrument?: boolean
     distinctId?: string
-    userEmail?: boolean
+    userEmail?: string
     dataAttributes?: string[]
     featureFlags?: Record<string, string | boolean>
 }


### PR DESCRIPTION
## Changes

So turns out we were f'ing this up too huh

Plus posthog-js-lite doesn't have the guard against this behavior.

I believe @timgl realized this issue a while back but not sure why we didn't change this logic.

Even though the backend now handles this appropriately, this can actually lead to problems given posthog-js-lite will update the ID under the hood even if we won't merge the user into a massively merged `null` user (cc @marcushyett-ph)

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
