### PR TITLE
Fix missing navigation item tooltips

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -58,9 +58,19 @@ interface MenuItemProps {
     hotkey?: HotKeys
     tooltip?: string
     onClick?: () => void
+    hideTooltip?: boolean
 }
 
-const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: MenuItemProps): JSX.Element => {
+const MenuItem = ({
+    title,
+    icon,
+    identifier,
+    to,
+    hotkey,
+    tooltip,
+    onClick,
+    hideTooltip = false,
+}: MenuItemProps): JSX.Element => {
     const { activeScene } = useValues(sceneLogic)
     const { hotkeyNavigationEngaged } = useValues(navigationLogic)
     const { collapseMenu, setHotkeyNavigationEngaged } = useActions(navigationLogic)
@@ -103,7 +113,7 @@ const MenuItem = ({ title, icon, identifier, to, hotkey, tooltip, onClick }: Men
     )
     return (
         <Link to={to} onClick={handleClick}>
-            {tooltip ? (
+            {!hideTooltip && (tooltip || hotkey) ? (
                 <Tooltip
                     title={
                         !isMobile() ? (
@@ -309,6 +319,7 @@ export function MainNavigation(): JSX.Element {
                                 to={urls.dashboards()}
                                 onClick={() => setPinnedDashboardsVisible(false)}
                                 hotkey="d"
+                                hideTooltip
                             />
                         </div>
                     </Popover>


### PR DESCRIPTION
## Changes

Before


https://user-images.githubusercontent.com/13460330/134212559-45bf95da-5493-4ee0-9c0b-962e47917897.mov


After

https://user-images.githubusercontent.com/13460330/134212581-767b5936-7ef3-4d15-827c-338e692e4e9e.mov


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
