### PR TITLE
Send license usage

### DIFF
--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -13,9 +13,7 @@ from ee.clickhouse.materialized_columns.columns import (
     materialize,
 )
 from ee.clickhouse.models.event import create_event
-from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
-from ee.clickhouse.sql.person import DROP_PERSON_TABLE_SQL, PERSONS_TABLE_SQL
-from ee.clickhouse.util import ClickhouseTestMixin
+from ee.clickhouse.util import ClickhouseDestroyTablesMixin, ClickhouseTestMixin
 from ee.tasks.materialized_columns import mark_all_materialized
 from posthog.settings import CLICKHOUSE_DATABASE
 from posthog.test.base import BaseTest
@@ -28,21 +26,7 @@ def _create_event(**kwargs):
     return pk
 
 
-class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
-    def setUp(self):
-        super().setUp()
-        sync_execute(DROP_EVENTS_TABLE_SQL)
-        sync_execute(EVENTS_TABLE_SQL)
-        sync_execute(DROP_PERSON_TABLE_SQL)
-        sync_execute(PERSONS_TABLE_SQL)
-
-    def tearDown(self):
-        super().tearDown()
-        sync_execute(DROP_EVENTS_TABLE_SQL)
-        sync_execute(EVENTS_TABLE_SQL)
-        sync_execute(DROP_PERSON_TABLE_SQL)
-        sync_execute(PERSONS_TABLE_SQL)
-
+class TestMaterializedColumns(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseTest):
     def test_get_columns_default(self):
         self.assertCountEqual(get_materialized_columns("events"), [])
         self.assertCountEqual(get_materialized_columns("person"), [])

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -7,6 +7,7 @@ from django.db import DEFAULT_DB_ALIAS
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
 from ee.clickhouse.sql.person import DROP_PERSON_TABLE_SQL, PERSONS_TABLE_SQL
+from posthog.test.base import BaseTest
 
 
 class ClickhouseTestMixin:
@@ -38,7 +39,7 @@ class ClickhouseTestMixin:
             yield sqls
 
 
-class ClickhouseDestroyTablesMixin:
+class ClickhouseDestroyTablesMixin(BaseTest):
     """
     To speed up tests we normally don't destroy the tables between tests, so clickhouse tables will have data from previous tests.
     Use this mixin to make sure you completely destroy the tables between tests.

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -4,6 +4,10 @@ from unittest.mock import patch
 
 from django.db import DEFAULT_DB_ALIAS
 
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
+from ee.clickhouse.sql.person import DROP_PERSON_TABLE_SQL, PERSONS_TABLE_SQL
+
 
 class ClickhouseTestMixin:
     RUN_MATERIALIZED_COLUMN_TESTS = True
@@ -32,3 +36,24 @@ class ClickhouseTestMixin:
 
         with patch("ee.clickhouse.client._annotate_tagged_query", wraps=wrapped_method) as wrapped_annotate:
             yield sqls
+
+
+class ClickhouseDestroyTablesMixin:
+    """
+    To speed up tests we normally don't destroy the tables between tests, so clickhouse tables will have data from previous tests.
+    Use this mixin to make sure you completely destroy the tables between tests.
+    """
+
+    def setUp(self):
+        super().setUp()
+        sync_execute(DROP_EVENTS_TABLE_SQL)
+        sync_execute(EVENTS_TABLE_SQL)
+        sync_execute(DROP_PERSON_TABLE_SQL)
+        sync_execute(PERSONS_TABLE_SQL)
+
+    def tearDown(self):
+        super().tearDown()
+        sync_execute(DROP_EVENTS_TABLE_SQL)
+        sync_execute(EVENTS_TABLE_SQL)
+        sync_execute(DROP_PERSON_TABLE_SQL)
+        sync_execute(PERSONS_TABLE_SQL)

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -12,17 +12,19 @@ def send_license_usage():
     license = License.objects.first_valid()
     if not license:
         return
-    date_from = (timezone.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    date_to = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
     try:
+        date_from = (timezone.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        date_to = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         events_count = sync_execute(
             "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s",
             {"date_from": date_from, "date_to": date_to},
         )[0][0]
         response = requests.post(
-            "https://license.posthog.com/license/usage",
+            "https://license.posthog.com/licenses/usage",
             data={"date": date_from.strftime("%Y-%m-%d"), "key": license.key, "events_count": events_count,},
         )
+
+        response.raise_for_status()
         if not response.ok:
             posthoganalytics.capture(
                 User.objects.first().distinct_id,  # type: ignore

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -25,7 +25,7 @@ def send_license_usage():
         )
         if not response.ok:
             posthoganalytics.capture(
-                User.objects.first().distinct_id,
+                User.objects.first().distinct_id,  # type: ignore
                 "send license usage data error",
                 {
                     "error": response.content,
@@ -36,7 +36,7 @@ def send_license_usage():
             )
     except Exception as err:
         posthoganalytics.capture(
-            User.objects.first().distinct_id,
+            User.objects.first().distinct_id,  # type: ignore
             "send license usage data error",
             {"error": str(err), "date": date_from.strftime("%Y-%m-%d")},
         )

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -1,0 +1,42 @@
+import posthoganalytics
+import requests
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+
+from ee.clickhouse.client import sync_execute
+from ee.models.license import License
+from posthog.models import User
+
+
+def send_license_usage():
+    license = License.objects.first_valid()
+    if not license:
+        return
+    date_from = (timezone.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    date_to = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    try:
+        events_count = sync_execute(
+            "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s",
+            {"date_from": date_from, "date_to": date_to},
+        )[0][0]
+        response = requests.post(
+            "https://license.posthog.com/license/usage",
+            data={"date": date_from.strftime("%Y-%m-%d"), "key": license.key, "events_count": events_count,},
+        )
+        if not response.ok:
+            posthoganalytics.capture(
+                User.objects.first().distinct_id,
+                "send license usage data error",
+                {
+                    "error": response.content,
+                    "status_code": response.status_code,
+                    "date": date_from.strftime("%Y-%m-%d"),
+                    "events_count": events_count,
+                },
+            )
+    except Exception as err:
+        posthoganalytics.capture(
+            User.objects.first().distinct_id,
+            "send license usage data error",
+            {"error": str(err), "date": date_from.strftime("%Y-%m-%d")},
+        )

--- a/ee/tasks/test/test_send_license_usage.py
+++ b/ee/tasks/test/test_send_license_usage.py
@@ -33,7 +33,7 @@ class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIB
         send_license_usage()
 
         mock_post.assert_called_once_with(
-            "https://license.posthog.com/license/usage",
+            "https://license.posthog.com/licenses/usage",
             data={"date": "2021-10-09", "key": self.license.key, "events_count": 3},
         )
 

--- a/ee/tasks/test/test_send_license_usage.py
+++ b/ee/tasks/test/test_send_license_usage.py
@@ -19,7 +19,7 @@ def _create_event(**kwargs):
     create_event(**kwargs)
 
 
-class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):  # type: ignore
+class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     @freeze_time("2021-10-10T23:01:00Z")
     @patch("requests.post")
     def test_send_license_usage(self, mock_post):
@@ -54,7 +54,7 @@ class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIB
         )
 
 
-class SendLicenseUsageNoLicenseTest(APIBaseTest):  # type: ignore
+class SendLicenseUsageNoLicenseTest(APIBaseTest):
     @freeze_time("2021-10-10T23:01:00Z")
     @patch("requests.post")
     def test_no_license(self, mock_post):

--- a/ee/tasks/test/test_send_license_usage.py
+++ b/ee/tasks/test/test_send_license_usage.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+import posthoganalytics
+from freezegun import freeze_time
+
+from ee.api.test.base import LicensedTestMixin
+from ee.clickhouse.models.event import create_event
+from ee.clickhouse.util import ClickhouseDestroyTablesMixin
+from ee.models.license import License
+from ee.tasks.send_license_usage import send_license_usage
+from posthog.models import organization
+from posthog.models.team import Team
+from posthog.test.base import APIBaseTest
+
+
+def _create_event(**kwargs):
+    kwargs.update({"event_uuid": uuid4()})
+    create_event(**kwargs)
+
+
+class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):  # type: ignore
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("requests.post")
+    def test_send_license_usage(self, mock_post):
+        team2 = Team.objects.create(organization=self.organization)
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+
+        send_license_usage()
+
+        mock_post.assert_called_once_with(
+            "https://license.posthog.com/license/usage",
+            data={"date": "2021-10-09", "key": self.license.key, "events_count": 3},
+        )
+
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("posthoganalytics.capture")
+    @patch("ee.tasks.send_license_usage.sync_execute", side_effect=Exception())
+    def test_send_license_error(self, mock_post, mock_capture):
+        team2 = Team.objects.create(organization=self.organization)
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+
+        send_license_usage()
+        mock_capture.assert_called_once_with(
+            self.user.distinct_id, "send license usage data error", {"error": "", "date": "2021-10-09"}
+        )
+
+
+class SendLicenseUsageNoLicenseTest(APIBaseTest):  # type: ignore
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("requests.post")
+    def test_no_license(self, mock_post):
+        # Same test, we just don't include the LicensedTestMixin so no license
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+
+        send_license_usage()
+
+        self.assertEqual(mock_post.call_count, 0)

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -291,6 +291,7 @@ def factory_test_person(event_factory, person_factory, get_events):
             self.client.post(
                 "/api/person/%s/split/" % person1.pk, {"main_distinct_id": "1"},
             )
+
             people = Person.objects.all().order_by("id")
             self.assertEqual(len(people), 3)
             self.assertEqual(people[0].distinct_ids, ["1"])

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -266,7 +266,7 @@ def clickhouse_mark_all_materialized():
 
 @app.task(ignore_result=True)
 def clickhouse_send_license_usage():
-    if is_clickhouse_enabled() and settings.EE_AVAILABLE:
+    if is_clickhouse_enabled() and not settings.MULTI_TENANCY:
         from ee.tasks.send_license_usage import send_license_usage
 
         send_license_usage()

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,5 +1,6 @@
 import os
 import time
+from random import randrange
 
 from celery import Celery
 from celery.schedules import crontab
@@ -84,6 +85,9 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         sender.add_periodic_task(120, clickhouse_part_count.s(), name="clickhouse table parts count")
         sender.add_periodic_task(120, clickhouse_mutation_count.s(), name="clickhouse table mutations count")
 
+        sender.add_periodic_task(
+            crontab(hour=0, minute=randrange(0, 40)), clickhouse_send_license_usage.s()
+        )  # every day at a random minute past midnight. Randomize to avoid overloading license.posthog.com
         try:
             from ee.settings import MATERIALIZE_COLUMNS_SCHEDULE_CRON
 
@@ -258,6 +262,14 @@ def clickhouse_mark_all_materialized():
         from ee.tasks.materialized_columns import mark_all_materialized
 
         mark_all_materialized()
+
+
+@app.task(ignore_result=True)
+def clickhouse_send_license_usage():
+    if is_clickhouse_enabled() and settings.EE_AVAILABLE:
+        from ee.tasks.send_license_usage import send_license_usage
+
+        send_license_usage()
 
 
 @app.task(ignore_result=True)


### PR DESCRIPTION
## Changes

Each day, send usage of the entire instance to the valid license (if applicable) for automatic billing purposes.

Requires https://github.com/PostHog/license/pull/16 to be merged first.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
