### PR TITLE
Vertical breakdowns followup

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -83,7 +83,7 @@ export const cleanFunnelParams = (filters: Partial<FilterType>, discardFiltersNo
             : {}),
         ...(filters.funnel_window_interval ? { funnel_window_interval: filters.funnel_window_interval } : {}),
         ...(filters.funnel_order_type ? { funnel_order_type: filters.funnel_order_type } : {}),
-        ...(filters.hidden_map ? { hidden_map: filters.hidden_map } : {}),
+        ...(filters.hiddenLegendKeys ? { hiddenLegendKeys: filters.hiddenLegendKeys } : {}),
         exclusions: deepCleanFunnelExclusionEvents(filters),
         interval: autocorrectInterval(filters),
         breakdown: breakdownEnabled ? filters.breakdown || undefined : undefined,
@@ -543,18 +543,22 @@ export const funnelLogic = kea<funnelLogicType>({
                 })
             },
         ],
-        hiddenMap: [
+        hiddenLegendKeys: [
             () => [selectors.filters],
             (filters) => {
                 if (!featureFlagLogic.values.featureFlags[FEATURE_FLAGS.FUNNEL_VERTICAL_BREAKDOWN]) {
                     return {}
                 }
-                return filters.hidden_map ?? {}
+                return filters.hiddenLegendKeys ?? {}
             },
         ],
         visibleStepsWithConversionMetrics: [
-            () => [selectors.stepsWithConversionMetrics, selectors.hiddenMap, selectors.flattenedStepsByBreakdown],
-            (steps, hiddenMap, flattenedStepsByBreakdown) => {
+            () => [
+                selectors.stepsWithConversionMetrics,
+                selectors.hiddenLegendKeys,
+                selectors.flattenedStepsByBreakdown,
+            ],
+            (steps, hiddenLegendKeys, flattenedStepsByBreakdown) => {
                 const baseLineSteps = flattenedStepsByBreakdown.find((b) => b.isBaseline)
                 return steps.map((step, stepIndex) => ({
                     ...step,
@@ -567,7 +571,7 @@ export const funnelLogic = kea<funnelLogicType>({
                             order: breakdownIndex,
                         }))
                         ?.filter((b) => {
-                            return !hiddenMap[getVisibilityIndex(step, b.breakdown_value)]
+                            return !hiddenLegendKeys[getVisibilityIndex(step, b.breakdown_value)]
                         }),
                 }))
             },
@@ -696,7 +700,7 @@ export const funnelLogic = kea<funnelLogicType>({
 
     listeners: ({ actions, values, props }) => ({
         loadResultsSuccess: async () => {
-            // set visibility of baseline or first five breakdowns for each step
+            // hide all but the first five breakdowns for each step
             values.steps?.forEach((step) => {
                 values.flattenedStepsByBreakdown
                     ?.filter((s) => !!s.breakdown)
@@ -723,17 +727,17 @@ export const funnelLogic = kea<funnelLogicType>({
         toggleVisibilityByBreakdown: ({ breakdownValue }) => {
             values.visibleStepsWithConversionMetrics?.forEach((step) => {
                 const key = getVisibilityIndex(step, breakdownValue)
-                const currentIsHidden = !!values.hiddenMap?.[key]
+                const currentIsHidden = !!values.hiddenLegendKeys?.[key]
 
                 actions.setHiddenById({ [key]: currentIsHidden ? undefined : true })
             })
         },
         toggleVisibility: ({ index }) => {
-            const currentIsHidden = !!values.hiddenMap?.[index]
+            const currentIsHidden = !!values.hiddenLegendKeys?.[index]
 
             actions.setFilters({
-                hidden_map: {
-                    ...values.hiddenMap,
+                hiddenLegendKeys: {
+                    ...values.hiddenLegendKeys,
                     [`${index}`]: currentIsHidden ? undefined : true,
                 },
             })
@@ -744,8 +748,8 @@ export const funnelLogic = kea<funnelLogicType>({
             )
 
             actions.setFilters({
-                hidden_map: {
-                    ...values.hiddenMap,
+                hiddenLegendKeys: {
+                    ...values.hiddenLegendKeys,
                     ...nextEntries,
                 },
             })
@@ -759,8 +763,8 @@ export const funnelLogic = kea<funnelLogicType>({
             const shouldRefresh = filterLength(values.filters) === 2 && filterLength(values.lastAppliedFilters) === 1
             // If layout or visibility is the only thing that changes
             const onlyLayoutOrVisibilityChanged = equal(
-                Object.assign({}, values.filters, { layout: undefined, hidden_map: undefined }),
-                Object.assign({}, values.lastAppliedFilters, { layout: undefined, hidden_map: undefined })
+                Object.assign({}, values.filters, { layout: undefined, hiddenLegendKeys: undefined }),
+                Object.assign({}, values.lastAppliedFilters, { layout: undefined, hiddenLegendKeys: undefined })
             )
 
             if (!onlyLayoutOrVisibilityChanged && (refresh || shouldRefresh || clickhouseFeaturesEnabled)) {

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -32,7 +32,7 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
         filters,
         steps,
         visibleStepsWithConversionMetrics,
-        hiddenMap,
+        hiddenLegendKeys,
         barGraphLayout,
         flattenedStepsByBreakdown,
         flattenedBreakdowns,
@@ -51,7 +51,10 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
             _columns.push({
                 render: function RenderCheckbox({}, breakdown: FlattenedFunnelStepByBreakdown, rowIndex) {
                     const checked = !!flattenedBreakdowns?.every(
-                        (b) => !hiddenMap[getVisibilityIndex(visibleStepsWithConversionMetrics?.[0], b.breakdown_value)]
+                        (b) =>
+                            !hiddenLegendKeys[
+                                getVisibilityIndex(visibleStepsWithConversionMetrics?.[0], b.breakdown_value)
+                            ]
                     )
 
                     return renderGraphAndHeader(
@@ -59,7 +62,7 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
                         0,
                         <PHCheckbox
                             checked={
-                                !hiddenMap[
+                                !hiddenLegendKeys[
                                     getVisibilityIndex(
                                         visibleStepsWithConversionMetrics?.[0],
                                         breakdown.breakdown_value
@@ -72,7 +75,7 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
                             checked={checked}
                             indeterminate={flattenedBreakdowns?.some(
                                 (b) =>
-                                    !hiddenMap[
+                                    !hiddenLegendKeys[
                                         getVisibilityIndex(visibleStepsWithConversionMetrics?.[0], b.breakdown_value)
                                     ]
                             )}
@@ -83,7 +86,7 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
                                         visibleStepsWithConversionMetrics.flatMap((s) =>
                                             flattenedBreakdowns.map((b) => [
                                                 getVisibilityIndex(s, b.breakdown_value),
-                                                !checked,
+                                                checked,
                                             ])
                                         )
                                     )
@@ -321,11 +324,13 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
                     if (step.breakdownIndex === undefined && (step.nestedRowKeys ?? []).length > 0) {
                         return (
                             <PHCheckbox
-                                checked={!!step.nestedRowKeys?.every((rowKey) => !hiddenMap[rowKey])}
-                                indeterminate={step.nestedRowKeys?.some((rowKey) => !hiddenMap[rowKey])}
+                                checked={!!step.nestedRowKeys?.every((rowKey) => !hiddenLegendKeys[rowKey])}
+                                indeterminate={step.nestedRowKeys?.some((rowKey) => !hiddenLegendKeys[rowKey])}
                                 onChange={() => {
                                     // either toggle all data on or off
-                                    const currentState = !!step.nestedRowKeys?.every((rowKey) => !hiddenMap[rowKey])
+                                    const currentState = !!step.nestedRowKeys?.every(
+                                        (rowKey) => !hiddenLegendKeys[rowKey]
+                                    )
                                     setHiddenById(
                                         Object.fromEntries(
                                             (
@@ -340,7 +345,7 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
                     // Breakdown child
                     return (
                         <PHCheckbox
-                            checked={!hiddenMap[step.rowKey]}
+                            checked={!hiddenLegendKeys[step.rowKey]}
                             onChange={() => toggleVisibilityByBreakdown(step.breakdownIndex as number)}
                         />
                     )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -707,7 +707,7 @@ export interface FilterType {
     funnel_window_interval?: number | undefined // length of conversion window
     funnel_order_type?: StepOrderValue
     exclusions?: FunnelStepRangeEntityFilter[] // used in funnel exclusion filters
-    hidden_map?: Record<string, boolean | undefined> // used to toggle visibility of breakdowns with legend
+    hiddenLegendKeys?: Record<string, boolean | undefined> // used to toggle visibility of breakdowns with legend
 }
 
 export interface SystemStatusSubrows {


### PR DESCRIPTION
## Changes

Follow up PR addressing remaining feedback for #5733. Specifically:

- [x] Broken toggling all breakdowns
- [x] Naming of hidden map

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
