### PR TITLE
Use _sign instead of sign in create function

### DIFF
--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -75,7 +75,7 @@ def create_person(
 
 
 def create_person_distinct_id(team_id: int, distinct_id: str, person_id: str, sign=1) -> None:
-    data = {"distinct_id": distinct_id, "person_id": person_id, "team_id": team_id, "sign": sign}
+    data = {"distinct_id": distinct_id, "person_id": person_id, "team_id": team_id, "_sign": sign}
     p = ClickhouseProducer()
     p.produce(topic=KAFKA_PERSON_UNIQUE_ID, sql=INSERT_PERSON_DISTINCT_ID, data=data)
 

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -214,7 +214,7 @@ INSERT INTO person (id, created_at, team_id, properties, is_identified, _timesta
 """
 
 INSERT_PERSON_DISTINCT_ID = """
-INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(sign)s, now(), 0 VALUES
+INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(_sign)s, now(), 0 VALUES
 """
 
 DELETE_PERSON_BY_ID = """


### PR DESCRIPTION
## Changes

*Please describe.*  
- currently, our create function pass `sign` into the payload. This is parsed properly by the query when test settings are active. However, when the actual kafkaproducer is used in production, `sign` isn't matching the actual column name `_sign` and therefore kafka isn't reading the value as expected

*If this affects the frontend, include screenshots.*  

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
