### PR TITLE
Rewrite migration 0169 to use null

### DIFF
--- a/posthog/migrations/0169_person_properties_last_updated_at.py
+++ b/posthog/migrations/0169_person_properties_last_updated_at.py
@@ -11,6 +11,8 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name="person", name="properties_last_updated_at", field=models.JSONField(default=dict),
+            model_name="person",
+            name="properties_last_updated_at",
+            field=models.JSONField(blank=True, default=dict, null=True),
         ),
     ]

--- a/posthog/models/person.py
+++ b/posthog/models/person.py
@@ -67,7 +67,7 @@ class Person(models.Model):
     created_at: models.DateTimeField = models.DateTimeField(auto_now_add=True, blank=True)
 
     # used to prevent race conditions with set and set_once
-    properties_last_updated_at: models.JSONField = models.JSONField(default=dict)
+    properties_last_updated_at: models.JSONField = models.JSONField(default=dict, null=True, blank=True)
     team: models.ForeignKey = models.ForeignKey("Team", on_delete=models.CASCADE)
     properties: models.JSONField = models.JSONField(default=dict)
     is_user: models.ForeignKey = models.ForeignKey("User", on_delete=models.CASCADE, null=True, blank=True)


### PR DESCRIPTION
## Changes

Because this migration was created as not null, it locked the entire person table while rewriting all the columns.

Rewriting this migration should be safe.

**I tested the following scenarios**
Migrated with it set to default=dict (broken migration)
- create new persons (default will be {})
- Update existing persons (they'll already have {} set)
- We _cannot_ create a new person with properties_last_updated_at=None

migrated with null=True (this PR)
- create new persons (default will be {})
- Update existing persons (they'll have properties_last_updated_at=None so we'll need to check for that case, but tests should default to this in the future)
- We _can_ create a new person with properties_last_updated_at but we _shouldn't_ as we'd break people who have now migrated.

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
