### PR TITLE
ci(tests): show untested code in PR with codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+source = 
+    posthog/
+    ee/
+
+branch = true
+
+omit =
+   */migrations/*
+   manage.py

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -111,7 +111,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -m "not ee" posthog/
+                  pytest -m "not ee" posthog/ --cov --cov-report=xml:coverage-postgres.xml
             - name: Run EE tests
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -125,7 +125,12 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest ee -m "not saml_only"
+                  pytest ee -m "not saml_only" --cov --cov-report=xml:coverage-clickhouse.xml
+            - uses: codecov/codecov-action@v2
+              with:
+                  files: ./coverage-postgres.xml,./coverage-clickhouse.xml
+                  fail_ci_if_error: false
+                  verbose: true
 
     saml:
         name: Django tests – with SAML

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+# Disable PR comments for now to not spam PRs. We should still have annotations
+# on files
+comment: false

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -27,3 +27,4 @@ isort
 pytest
 pytest-django
 pytest-mock
+pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,6 +33,8 @@ coreapi==2.3.3
     # via djangorestframework-stubs
 coreschema==0.0.4
     # via coreapi
+coverage==5.5
+    # via pytest-cov
 django-stubs-ext==0.2.0
     # via django-stubs
 django-stubs==1.8.0
@@ -118,6 +120,8 @@ pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging
+pytest-cov==2.12.1
+    # via -r requirements-dev.in
 pytest-django==4.1.0
     # via -r requirements-dev.in
 pytest-mock==3.5.1
@@ -125,6 +129,7 @@ pytest-mock==3.5.1
 pytest==6.2.2
     # via
     #   -r requirements-dev.in
+    #   pytest-cov
     #   pytest-django
     #   pytest-mock
 python-dateutil==2.8.1
@@ -164,6 +169,7 @@ toml==0.10.1
     # via
     #   black
     #   pytest
+    #   pytest-cov
 typed-ast==1.4.1
     # via
     #   black


### PR DESCRIPTION
## Changes

Personally I would find it useful to be able to see which paths I have or haven't tested with my PRs. This should add annotations to any modified files highlighting which lines have not been tested.

Note that I have:

 * disabled PR comments to avoid new spam
 * enabled branch checking: https://coverage.readthedocs.io/en/latest/branch.html

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
