### PR TITLE
Add sort by value at date to details table

### DIFF
--- a/frontend/src/lib/components/DateDisplay/DateDisplay.scss
+++ b/frontend/src/lib/components/DateDisplay/DateDisplay.scss
@@ -6,4 +6,5 @@
     border: 1px solid $border_light;
     background-color: white;
     border-radius: $radius;
+    white-space: nowrap;
 }

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -143,6 +143,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
             render: function RenderPeriod({}, item: IndexedTrendResult) {
                 return maybeAddCommasToInteger(item.data[index])
             },
+            sorter: (a, b) => a.data[index] - b.data[index],
             align: 'center',
         }))
 


### PR DESCRIPTION
## Changes

A user was asking why the details table can't be sorted by value at date. Well, why not make it possible?

<img width="1512" alt="Screen Shot 2021-09-23 at 16 46 29" src="https://user-images.githubusercontent.com/4550621/134529815-2fe53063-b1bc-4f80-8c45-3cfa6588101d.png">
