### PR TITLE
Advanced User Controls and Proper Path Validation

### DIFF
--- a/ee/clickhouse/queries/paths/paths.py
+++ b/ee/clickhouse/queries/paths/paths.py
@@ -39,12 +39,9 @@ class ClickhousePaths:
         if not self._filter.limit:
             self._filter = self._filter.with_data({LIMIT: 100})
 
-        if self._filter.edge_limit is None:
-            if self._filter.start_point and self._filter.end_point:
-                # no edge restriction when both start and end points are defined
-                self._filter = self._filter.with_data({PATH_EDGE_LIMIT: 0})
-            else:
-                self._filter = self._filter.with_data({PATH_EDGE_LIMIT: 100})
+        if self._filter.edge_limit is None and not (self._filter.start_point and self._filter.end_point):
+            # no edge restriction when both start and end points are defined
+            self._filter = self._filter.with_data({PATH_EDGE_LIMIT: 100})
 
         if self._filter.max_edge_weight and self._filter.min_edge_weight:
             if self._filter.max_edge_weight < self._filter.min_edge_weight:
@@ -132,7 +129,7 @@ class ClickhousePaths:
             ORDER BY event_count DESC,
                     source_event,
                     target_event
-            LIMIT %(edge_limit)s
+            {'LIMIT %(edge_limit)s' if self._filter.edge_limit else ''}
         """
 
     def get_path_query_funnel_cte(self, funnel_filter: Filter):

--- a/ee/clickhouse/queries/paths/paths_persons.py
+++ b/ee/clickhouse/queries/paths/paths_persons.py
@@ -67,3 +67,7 @@ class ClickhousePathsPersons(ClickhousePaths):
         from posthog.api.person import PersonSerializer
 
         return PersonSerializer(people, many=True).data, len(results) > cast(int, self._filter.limit) - 1
+
+    def run(self, *args, **kwargs):
+        results = self._exec_query()
+        return self._format_results(results)

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1599,3 +1599,6 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
         self.assertEqual(
             response, [{"source": "1_/5", "target": "2_/about", "value": 2, "average_conversion_time": 60000.0}]
         )
+
+        # TODO: fix test, complete validation conditions: doesn't need to happen every time. And figure out what to do with UI.
+        # Separate from the edge weight limit mods

--- a/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useValues, useActions } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { pathOptionsToLabels, pathOptionsToProperty, pathsLogic } from 'scenes/paths/pathsLogic'
-import { Col, Row, Select } from 'antd'
+import { Col, InputNumber, Row, Select } from 'antd'
 import { PropertyValue } from 'lib/components/PropertyFilters'
 import { TestAccountFilter } from '../TestAccountFilter'
 import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
@@ -57,6 +57,43 @@ export function PathTab(): JSX.Element {
                             value={filter.start_point}
                             placeholder={'Select start element'}
                             autoFocus={false}
+                        />
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>Edge limit</Col>
+                    <Col>
+                        <InputNumber
+                            style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
+                            size="small"
+                            min={10}
+                            max={1000}
+                            defaultValue={100}
+                            onChange={(value): void => {
+                                if (value) {
+                                    setFilter({ edge_limit: value })
+                                }
+                            }}
+                            // onBlur={onChange}
+                            // onPressEnter={onChange}
+                        />
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>Edge Weight between</Col>
+                    <Col>
+                        <InputNumber
+                            style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
+                            size="small"
+                            onChange={(value): void => setFilter({ min_edge_weight: value })}
+                        />
+                    </Col>
+                    <Col>and</Col>
+                    <Col>
+                        <InputNumber
+                            style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
+                            size="small"
+                            onChange={(value): void => setFilter({ max_edge_weight: value })}
                         />
                     </Col>
                 </Row>

--- a/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
@@ -99,6 +99,8 @@ export function PathTab(): JSX.Element {
                         <InputNumber
                             style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
                             size="small"
+                            min={0}
+                            max={100000}
                             onChange={(value): void =>
                                 setLocalEdgeParameters((state) => ({
                                     ...state,
@@ -120,6 +122,8 @@ export function PathTab(): JSX.Element {
                                     max_edge_weight: Number(value),
                                 }))
                             }
+                            min={0}
+                            max={100000}
                             onBlur={updateEdgeParameters}
                             onPressEnter={updateEdgeParameters}
                         />

--- a/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useValues, useActions } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { pathOptionsToLabels, pathOptionsToProperty, pathsLogic } from 'scenes/paths/pathsLogic'
@@ -7,17 +7,30 @@ import { PropertyValue } from 'lib/components/PropertyFilters'
 import { TestAccountFilter } from '../TestAccountFilter'
 import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
-import { PathType } from '~/types'
+import { PathEdgeParameters, PathType } from '~/types'
 import { GlobalFiltersTitle } from '../common'
 
 export function PathTab(): JSX.Element {
     const { customEventNames } = useValues(eventDefinitionsModel)
     const { filter } = useValues(pathsLogic({ dashboardItemId: null }))
     const { setFilter } = useActions(pathsLogic({ dashboardItemId: null }))
-
+    const [localEdgeParameters, setLocalEdgeParameters] = useState<PathEdgeParameters>({
+        edge_limit: filter.edge_limit,
+        min_edge_weight: filter.min_edge_weight,
+        max_edge_weight: filter.max_edge_weight,
+    })
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)
 
+    const updateEdgeParameters = (): void => {
+        if (
+            localEdgeParameters.edge_limit !== filter.edge_limit ||
+            localEdgeParameters.min_edge_weight !== filter.min_edge_weight ||
+            localEdgeParameters.max_edge_weight !== filter.max_edge_weight
+        ) {
+            setFilter({ ...localEdgeParameters })
+        }
+    }
     return (
         <Row gutter={16}>
             <Col md={16} xs={24}>
@@ -60,32 +73,40 @@ export function PathTab(): JSX.Element {
                         />
                     </Col>
                 </Row>
-                <Row>
-                    <Col>Edge limit</Col>
+                <Row gutter={8} align="middle" className="mt-05">
+                    <Col>Maximum number of Paths</Col>
                     <Col>
                         <InputNumber
                             style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
                             size="small"
-                            min={10}
+                            min={0}
                             max={1000}
                             defaultValue={100}
-                            onChange={(value): void => {
-                                if (value) {
-                                    setFilter({ edge_limit: value })
-                                }
-                            }}
-                            // onBlur={onChange}
-                            // onPressEnter={onChange}
+                            onChange={(value): void =>
+                                setLocalEdgeParameters((state) => ({
+                                    ...state,
+                                    edge_limit: Number(value),
+                                }))
+                            }
+                            onBlur={updateEdgeParameters}
+                            onPressEnter={updateEdgeParameters}
                         />
                     </Col>
                 </Row>
-                <Row>
-                    <Col>Edge Weight between</Col>
+                <Row gutter={8} align="middle" className="mt-05">
+                    <Col>Number of people on each Path between</Col>
                     <Col>
                         <InputNumber
                             style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
                             size="small"
-                            onChange={(value): void => setFilter({ min_edge_weight: value })}
+                            onChange={(value): void =>
+                                setLocalEdgeParameters((state) => ({
+                                    ...state,
+                                    min_edge_weight: Number(value),
+                                }))
+                            }
+                            onBlur={updateEdgeParameters}
+                            onPressEnter={updateEdgeParameters}
                         />
                     </Col>
                     <Col>and</Col>
@@ -93,7 +114,14 @@ export function PathTab(): JSX.Element {
                         <InputNumber
                             style={{ paddingTop: 2, width: '80px', marginLeft: 5, marginRight: 5 }}
                             size="small"
-                            onChange={(value): void => setFilter({ max_edge_weight: value })}
+                            onChange={(value): void =>
+                                setLocalEdgeParameters((state) => ({
+                                    ...state,
+                                    max_edge_weight: Number(value),
+                                }))
+                            }
+                            onBlur={updateEdgeParameters}
+                            onPressEnter={updateEdgeParameters}
                         />
                     </Col>
                 </Row>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -742,6 +742,9 @@ export interface FilterType {
     funnel_order_type?: StepOrderValue
     exclusions?: FunnelStepRangeEntityFilter[] // used in funnel exclusion filters
     hiddenLegendKeys?: Record<string, boolean | undefined> // used to toggle visibility of breakdowns with legend
+    edge_limit?: number | undefined // Paths edge limit
+    min_edge_weight?: number | undefined // Paths
+    max_edge_weight?: number | undefined // Paths
 }
 
 export interface SystemStatusSubrows {
@@ -1162,3 +1165,9 @@ export interface AppContext {
 }
 
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'
+
+export interface PathEdgeParameters {
+    edge_limit?: number | undefined
+    min_edge_weight?: number | undefined
+    max_edge_weight?: number | undefined
+}

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -126,6 +126,9 @@ FUNNEL_PATH_BETWEEN_STEPS = "funneL_path_between_steps"
 PATH_GROUPINGS = "path_groupings"
 PATH_START_KEY = "path_start_key"
 PATH_END_KEY = "path_end_key"
+PATH_MIN_EDGE_WEIGHT = "min_edge_weight"
+PATH_MAX_EDGE_WEIGHT = "max_edge_weight"
+PATH_EDGE_LIMIT = "edge_limit"
 
 
 class FunnelOrderType(str, Enum):

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -6,8 +6,11 @@ from posthog.constants import (
     END_POINT,
     FUNNEL_PATHS,
     PAGEVIEW_EVENT,
+    PATH_EDGE_LIMIT,
     PATH_END_KEY,
     PATH_GROUPINGS,
+    PATH_MAX_EDGE_WEIGHT,
+    PATH_MIN_EDGE_WEIGHT,
     PATH_START_KEY,
     PATH_TYPE,
     PATHS_EXCLUDE_EVENTS,
@@ -179,5 +182,36 @@ class PathPersonsMixin(BaseParamMixin):
 
         if self.path_end_key:
             result[PATH_END_KEY] = self.path_end_key
+
+        return result
+
+
+class PathLimitsMixin(BaseParamMixin):
+    @cached_property
+    def edge_limit(self) -> Optional[int]:
+        raw_value = self._data.get(PATH_EDGE_LIMIT, None)
+        return int(raw_value) if raw_value else None
+
+    @cached_property
+    def min_edge_weight(self) -> Optional[int]:
+        raw_value = self._data.get(PATH_MIN_EDGE_WEIGHT, None)
+        return int(raw_value) if raw_value else None
+
+    @cached_property
+    def max_edge_weight(self) -> Optional[int]:
+        raw_value = self._data.get(PATH_MAX_EDGE_WEIGHT, None)
+        return int(raw_value) if raw_value else None
+
+    @include_dict
+    def path_edge_limit_to_dict(self):
+        result = {}
+        if self.edge_limit:
+            result[PATH_EDGE_LIMIT] = self.edge_limit
+
+        if self.min_edge_weight:
+            result[PATH_MIN_EDGE_WEIGHT] = self.min_edge_weight
+
+        if self.max_edge_weight:
+            result[PATH_MAX_EDGE_WEIGHT] = self.max_edge_weight
 
         return result

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -190,7 +190,7 @@ class PathLimitsMixin(BaseParamMixin):
     @cached_property
     def edge_limit(self) -> Optional[int]:
         raw_value = self._data.get(PATH_EDGE_LIMIT, None)
-        return int(raw_value) if raw_value else None
+        return int(raw_value) if raw_value is not None else None
 
     @cached_property
     def min_edge_weight(self) -> Optional[int]:

--- a/posthog/models/filters/path_filter.py
+++ b/posthog/models/filters/path_filter.py
@@ -21,6 +21,7 @@ from posthog.models.filters.mixins.paths import (
     EndPointMixin,
     FunnelPathsMixin,
     PathGroupingMixin,
+    PathLimitsMixin,
     PathPersonsMixin,
     PathStepLimitMixin,
     PropTypeDerivedMixin,
@@ -54,6 +55,7 @@ class PathFilter(
     PathPersonsMixin,
     LimitMixin,
     OffsetMixin,
+    PathLimitsMixin,
     # TODO: proper fix for EventQuery abstraction
     BaseFilter,
 ):


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog/issues/6041 <- more context about the solution there. I haven't heard any strong opposition yet, so went ahead with the approach.

This PR:

1. Introduces advanced Path manipulation options. I'm putting these on the old UI right now (as I myself want to test what happens with these & iterate). Looking for some quick feedback, if it's okay as is, or needs to be behind a FF / needs an Advanced Options section. (cc: @clarkus , @paolodamico )
    
![image](https://user-images.githubusercontent.com/7115141/134677216-e89a353c-7519-410c-9f2e-f396b491258f.png)

2. On the backend, introduce the Path manipulation operators: Min and max edge weights, plus total edge count.

3. Validates the paths graph returned from the query, removing all dangling edges. I decided for now to do this in all cases except when Min or Max edge weight is defined (kinda open question if we want to do this here as well). See `test_path_min_edge_weight` for why it makes sense to not do this here. When min weight is defined, it's very much possible that the initial edges will be removed, and then removing the dangling edges destroys the graph, which we probably don't want to happen.

Thoughts welcome!

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
