### PR TITLE
Return empty list instead of 401 in unauthenticated `my_flags`

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -130,8 +130,8 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
 
     @action(methods=["GET"], detail=False)
     def my_flags(self, request: request.Request, **kwargs):
-        if not request.user.is_authenticated:  # for mypy
-            raise exceptions.NotAuthenticated()
+        if not request.user.is_authenticated:
+            return Response([])
         feature_flags = (
             FeatureFlag.objects.filter(team=self.team, active=True, deleted=False)
             .prefetch_related(


### PR DESCRIPTION
## Changes

A user (https://app.papercups.io/conversations/all?cid=611f277b-6aa6-4f7b-9ae5-640d82e2bab0) cannot use Actions in the Toolbar because of the below issue:

<img width="825" alt="5708bb1cd93349d1a5a4030a1f65b454-Screenshot-2021-09-22-at-16 10 48" src="https://user-images.githubusercontent.com/4550621/134695308-6e702b37-b8c1-4080-9bb5-abd1ec2390f7.png">
<img width="1726" alt="e8a76a9a5b97467ba3fa9b499b988032-Screenshot-2021-09-24-at-14 12 17" src="https://user-images.githubusercontent.com/4550621/134695316-7256e7fa-a399-43a0-9b32-a60640f5ade8.png">

This may fix it by just returning an empty list instead of a 401. But maybe this is wrong and there should never be a 401 here?
