### PR TITLE
Handle case where feature flag variants is undefined

### DIFF
--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -103,7 +103,9 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         afterMount: () => {
             actions.getUserFlags()
             ;(window['posthog'] as PostHog).onFeatureFlags((_, variants) => {
-                toolbarLogic.actions.updateFeatureFlags(variants)
+                if (variants) {
+                    toolbarLogic.actions.updateFeatureFlags(variants)
+                }
             })
             const locallyOverrideFeatureFlags = (window['posthog'] as PostHog).get_property('$override_feature_flags')
             if (locallyOverrideFeatureFlags) {


### PR DESCRIPTION
## Changes

A quick fix to handle the case where posthog-js sends back `undefined` for the feature flag variants (Going to look into why `undefined` is being sent)

This user (https://app.papercups.io/conversations/all?cid=611f277b-6aa6-4f7b-9ae5-640d82e2bab0) can't use the toolbar because of it.

Related: https://github.com/PostHog/posthog/pull/6100

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
