### PR TITLE
Allow excluding wildcards in paths

### DIFF
--- a/ee/clickhouse/queries/paths/path_event_query.py
+++ b/ee/clickhouse/queries/paths/path_event_query.py
@@ -121,7 +121,7 @@ class PathEventQuery(ClickhouseEventQuery):
             conditions.append(f"({' OR '.join(or_conditions)})")
 
         if self._filter.exclude_events:
-            conditions.append(f"NOT path_item_ungrouped IN %(exclude_events)s")
+            conditions.append(f"NOT path_item IN %(exclude_events)s")
             params["exclude_events"] = self._filter.exclude_events
 
         if conditions:

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1004,6 +1004,11 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             response, [{"source": "1_/1", "target": "2_/3", "value": 3, "average_conversion_time": 3 * ONE_MINUTE},],
         )
 
+        filter = filter.with_data({"path_groupings": ["/xxx/invalid/*"]})
+        response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(len(response), 6)
+
     def test_event_inclusion_exclusion_filters_across_single_person(self):
 
         # P1 for pageview event, screen event, and custom event all together


### PR DESCRIPTION
## Changes

Wildcards can now be used in exclude events filter

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
