### PR TITLE
switches to a more human-readable error message for #4816

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,11 +1,14 @@
 from django.test import TestCase
+from django.test.client import RequestFactory
 from freezegun import freeze_time
 
+from posthog.exceptions import RequestParsingError
 from posthog.models import EventDefinition
 from posthog.test.base import BaseTest
 from posthog.utils import (
     get_available_timezones_with_offsets,
     get_default_event_name,
+    load_data_from_request,
     mask_email_address,
     relative_date_parse,
 )
@@ -78,3 +81,29 @@ class TestDefaultEventName(BaseTest):
         EventDefinition.objects.create(name="$pageview", team=self.team)
         EventDefinition.objects.create(name="$screen", team=self.team)
         self.assertEqual(get_default_event_name(), "$pageview")
+
+
+class TestLoadDataFromRequest(TestCase):
+    def test_fails_to_JSON_parse_the_literal_string_undefined_when_not_compressed(self):
+        """
+        load_data_from_request assumes that any data
+        that has been received (and possibly decompressed) from the body
+        can be parsed as JSON
+        this test maintains the default (and possibly undesirable) behaviour for the uncompressed case
+        """
+        rf = RequestFactory()
+        post_request = rf.post("/s/", "undefined", "text/plain")
+
+        with self.assertRaises(RequestParsingError) as ctx:
+            load_data_from_request(post_request)
+
+        self.assertEqual("Invalid JSON: Expecting value: line 1 column 1 (char 0)", str(ctx.exception))
+
+    def test_raises_specific_error_for_the_literal_string_undefined_when_compressed(self):
+        rf = RequestFactory()
+        post_request = rf.post("/s/?compression=gzip-js", "undefined", "text/plain")
+
+        with self.assertRaises(RequestParsingError) as ctx:
+            load_data_from_request(post_request)
+
+        self.assertEqual("data being loaded for decompression is the literal string 'undefined'", str(ctx.exception))

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -106,4 +106,7 @@ class TestLoadDataFromRequest(TestCase):
         with self.assertRaises(RequestParsingError) as ctx:
             load_data_from_request(post_request)
 
-        self.assertEqual("data being loaded for decompression is the literal string 'undefined'", str(ctx.exception))
+        self.assertEqual(
+            "data being loaded from the request body for decompression is the literal string 'undefined'",
+            str(ctx.exception),
+        )

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -399,6 +399,11 @@ def load_data_from_request(request):
     compression = compression.lower()
 
     if compression == "gzip" or compression == "gzip-js":
+        if data == b"undefined":
+            raise RequestParsingError(
+                "data being loaded from the request body for decompression is the literal string 'undefined'"
+            )
+
         try:
             data = gzip.decompress(data)
         except (EOFError, OSError) as error:


### PR DESCRIPTION
## Changes

In some instances of Sentry Issue [POSTHOG-2PA](https://sentry.io/organizations/posthog/issues/2352164178/?project=1899813&query=is%3Aunresolved) we receive the error `Failed to decompress data. Not a gzipped file (b'un')` on receiving the string "undefined" as the request body

This provides a clearer error message in case it is not possible to avoid this error

## Checklist

- [x] Django backend tests
