### PR TITLE
Remove extraneous deletes in org/project `pre_delete`s

### DIFF
--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -164,11 +164,6 @@ def organization_about_to_be_created(sender, instance: Organization, raw, using,
         instance.update_available_features()
 
 
-@receiver(models.signals.pre_delete, sender=Organization)
-def organization_about_to_be_deleted(sender, instance, **kwargs):
-    instance.teams.all().delete()
-
-
 class OrganizationMembership(UUIDModel):
     class Level(models.IntegerChoices):
         """Keep in sync with TeamMembership.Level (only difference being projects not having an Owner)."""

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -166,11 +166,3 @@ class Team(UUIDClassicModel):
         return str(self.pk)
 
     __repr__ = sane_repr("uuid", "name", "api_token")
-
-
-@receiver(models.signals.pre_delete, sender=Team)
-def team_deleted(sender: Type[Team], instance: Team, **kwargs):
-    instance.event_set.all().delete()
-    instance.elementgroup_set.all().delete()
-    instance.person_set.all().delete()
-    instance.persondistinctid_set.all().delete()


### PR DESCRIPTION
## Changes

Looks like these `pre_delete` handlers are just messing up Django's model cache, which causes _more_ problems with deleting orgs and projects than letting Django handle everything automatically.