### PR TITLE
fix kafka partition key

### DIFF
--- a/ee/kafka_client/client.py
+++ b/ee/kafka_client/client.py
@@ -45,7 +45,7 @@ class _KafkaProducer:
         if not value_serializer:
             value_serializer = self.json_serializer
         b = value_serializer(data)
-        self.producer.send(topic, value=b, key=key)
+        self.producer.send(topic, value=b, key=key.encode())
 
     def close(self):
         self.producer.flush()


### PR DESCRIPTION
## Changes


We were passing a partition key as a string, where it expected bytes.

Broke ingestion


## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
