### PR TITLE
Default to None if there is no key, encode only if there is data

### DIFF
--- a/ee/kafka_client/client.py
+++ b/ee/kafka_client/client.py
@@ -45,9 +45,9 @@ class _KafkaProducer:
         if not value_serializer:
             value_serializer = self.json_serializer
         b = value_serializer(data)
-        if key is None:
-            key = ""
-        self.producer.send(topic, value=b, key=key.encode("utf-8"))
+        if key is not None:
+            key = key.encode("utf-8")
+        self.producer.send(topic, value=b, key=key)
 
     def close(self):
         self.producer.flush()


### PR DESCRIPTION
## Changes

This makes it a bit more clean from partitioning perspective since Kafka will default to murmur hashing for partitioning when key is `None`

## Checklist

- [ ] All querysets/queries filter by Organization, by Team, and by User
- [ ] Django backend tests
- [ ] Jest frontend tests
- [ ] Cypress end-to-end tests
- [ ] Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious
- [ ] New/changed UI is decent on smartphones (viewport width around 360px)
