### PR TITLE
Funnel bin count not persisting

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -310,12 +310,6 @@ export const funnelLogic = kea<funnelLogicType<FunnelLogicProps>>({
                 setIsGroupingOutliers: (_, { isGroupingOutliers }) => isGroupingOutliers,
             },
         ],
-        binCount: [
-            BinCountAuto as BinCountValue,
-            {
-                setBinCount: (_, { binCount }) => binCount,
-            },
-        ],
         error: [
             null as any, // TODO: Error typing in typescript doesn't exist natively
             {
@@ -672,12 +666,12 @@ export const funnelLogic = kea<funnelLogicType<FunnelLogicProps>>({
             },
         ],
         numericBinCount: [
-            () => [selectors.binCount, selectors.timeConversionResults],
-            (binCount, timeConversionResults): number => {
-                if (binCount === BinCountAuto) {
+            () => [selectors.filters, selectors.timeConversionResults],
+            (filters, timeConversionResults): number => {
+                if (filters.bin_count === BinCountAuto) {
                     return timeConversionResults?.bins?.length ?? 0
                 }
-                return binCount
+                return filters.bin_count ?? 0
             },
         ],
         exclusionDefaultStepRange: [
@@ -820,8 +814,7 @@ export const funnelLogic = kea<funnelLogicType<FunnelLogicProps>>({
                 funnel_to_step,
             })
         },
-        setBinCount: async () => {
-            const { binCount } = values
+        setBinCount: async ({ binCount }) => {
             actions.setFilters(binCount && binCount !== BinCountAuto ? { bin_count: binCount } : {})
         },
         setConversionWindow: async () => {

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -37,7 +37,7 @@ const options: BinOption[] = [
 ]
 
 export function FunnelBinsPicker(): JSX.Element {
-    const { binCount, numericBinCount } = useValues(funnelLogic)
+    const { filters, numericBinCount } = useValues(funnelLogic)
     const { setBinCount } = useActions(funnelLogic)
 
     return (
@@ -46,7 +46,7 @@ export function FunnelBinsPicker(): JSX.Element {
             dropdownClassName="funnel-bin-filter-dropdown"
             data-attr="funnel-bin-filter"
             defaultValue={BinCountAuto}
-            value={binCount || BinCountAuto}
+            value={filters.bin_count || BinCountAuto}
             onSelect={(count) => setBinCount(count)}
             dropdownRender={(menu) => {
                 return (


### PR DESCRIPTION
## Changes

A bug where bin counts aren't persisting across saved insights/dashboards. This happens b/c the bin count picker reads the bin count value from a separate reducer value instead `filters` from the url.

https://user-images.githubusercontent.com/13460330/134960507-be9ba107-84d6-4873-896c-835f38a73c79.mov

This is easily fixed by removing the reducer altogether and using `filters.bin_count` as the source of truth.

Fixed:

https://user-images.githubusercontent.com/13460330/134960645-103f3dbf-14ce-4203-a4de-3eb82b09dfd9.mov


## How did you test this code?

This was a bug in the way we consumed a reducer in `funnelLogic` inside of a component. I think the most robust way to catch this bug was an e2e test. Not quite sure how I would test this in logic tests because it was just a matter of using an incorrect pattern.
