### PR TITLE
Make sure exclude_events string is parsed

### DIFF
--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -100,7 +100,11 @@ class TargetEventsMixin(BaseParamMixin):
 
     @cached_property
     def exclude_events(self) -> List[str]:
-        return self._data.get(PATHS_EXCLUDE_EVENTS, [])
+        _exclude_events = self._data.get(PATHS_EXCLUDE_EVENTS, [])
+        if isinstance(_exclude_events, str):
+            return json.loads(_exclude_events)
+
+        return _exclude_events
 
     @property
     def include_pageviews(self) -> bool:


### PR DESCRIPTION
## Changes

*Please describe.*  
- the param handler in filters didn't account for this list being passed as a string
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*
