### PR TITLE
Make date filter read only on view mode

### DIFF
--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -53,9 +53,15 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
     } = useValues(router)
     const { clearAnnotationsToCreate } = useActions(annotationsLogic({ pageKey: fromItem }))
     const { annotationsToCreate } = useValues(annotationsLogic({ pageKey: fromItem }))
-    const { lastRefresh, isLoading, activeView, allFilters, showTimeoutMessage, showErrorMessage } = useValues(
-        insightLogic
-    )
+    const {
+        lastRefresh,
+        isLoading,
+        activeView,
+        allFilters,
+        insightMode,
+        showTimeoutMessage,
+        showErrorMessage,
+    } = useValues(insightLogic)
     const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic)
 
     // Empty states that completely replace the graph
@@ -148,6 +154,7 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
                 title={
                     <InsightDisplayConfig
                         activeView={activeView}
+                        insightMode={insightMode}
                         allFilters={allFilters}
                         annotationsToCreate={annotationsToCreate}
                         clearAnnotationsToCreate={clearAnnotationsToCreate}
@@ -163,7 +170,7 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
                         className={clsx('insights-graph-header', {
                             funnels: activeView === ViewType.FUNNELS,
                         })}
-                        align="top"
+                        align="middle"
                         justify="space-between"
                         style={{
                             marginTop: -8,

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -3,18 +3,21 @@ import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
 import { TZIndicator } from 'lib/components/TimezoneAware'
-import { ACTIONS_BAR_CHART_VALUE, ACTIONS_PIE_CHART, ACTIONS_TABLE } from 'lib/constants'
-import { ChartDisplayType, FilterType, FunnelVizType, ViewType } from '~/types'
+import { ACTIONS_BAR_CHART_VALUE, ACTIONS_PIE_CHART, ACTIONS_TABLE, FEATURE_FLAGS } from 'lib/constants'
+import { ChartDisplayType, FilterType, FunnelVizType, ItemMode, ViewType } from '~/types'
 import { CalendarOutlined } from '@ant-design/icons'
 import { InsightDateFilter } from '../InsightDateFilter'
 import { RetentionDatePicker } from '../RetentionDatePicker'
 import { FunnelStepReferencePicker } from './FunnelTab/FunnelStepReferencePicker'
 import { FunnelDisplayLayoutPicker } from './FunnelTab/FunnelDisplayLayoutPicker'
 import { FunnelBinsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { useValues } from 'kea'
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
     allFilters: FilterType
     activeView: ViewType
+    insightMode: ItemMode
     annotationsToCreate: Record<string, any>[] // TODO: Annotate properly
 }
 
@@ -77,11 +80,15 @@ const isFunnelEmpty = (filters: FilterType): boolean => {
 
 export function InsightDisplayConfig({
     allFilters,
+    insightMode,
     activeView,
     clearAnnotationsToCreate,
 }: InsightDisplayConfigProps): JSX.Element {
     const showFunnelBarOptions = activeView === ViewType.FUNNELS
-    const dateFilterDisabled = showFunnelBarOptions && isFunnelEmpty(allFilters)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const dateFilterDisabled =
+        (showFunnelBarOptions && isFunnelEmpty(allFilters)) ||
+        (!!featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && insightMode === ItemMode.View)
 
     return (
         <div className="display-config-inner">


### PR DESCRIPTION
## Changes

Hot Fixes #6101 

<img width="1258" alt="Screen Shot 2021-09-27 at 11 30 38 AM" src="https://user-images.githubusercontent.com/13460330/134965544-1de0c463-1752-4ac0-8427-8042a087605a.png">

Ideally we'd want to better define functionalities between View mode from Edit mode, but this should suffice for now.

## How did you test this code?

Disabled date filter, which means user can't click it to accidentally trigger edit mode.
