### PR TITLE
Various funnel breakdown fixes

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -76,6 +76,7 @@ interface BreakdownBarGroupProps {
     showLabels: boolean
     onBarClick?: (breakdown_value: string | undefined | number) => void
     isClickable: boolean
+    isSingleSeries?: boolean
 }
 
 export function BreakdownVerticalBarGroup({
@@ -85,6 +86,7 @@ export function BreakdownVerticalBarGroup({
     showLabels,
     onBarClick,
     isClickable,
+    isSingleSeries = false,
 }: BreakdownBarGroupProps): JSX.Element {
     const ref = useRef<HTMLDivElement | null>(null)
     const [, height] = useSize(ref)
@@ -97,7 +99,8 @@ export function BreakdownVerticalBarGroup({
                 const currentBarHeight = (height * breakdown.count) / basisBreakdownCount
                 const previousBarHeight =
                     (height * (previousStep?.nested_breakdown?.[breakdownIndex]?.count ?? 0)) / basisBreakdownCount
-                const color = getSeriesColor(breakdown.order) as string
+                const color = getSeriesColor(breakdown.order, isSingleSeries) as string
+
                 const popoverMetrics = [
                     {
                         title: 'Completed step',

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -155,10 +155,9 @@ export function BreakdownVerticalBarGroup({
                                     altTitle={
                                         <div style={{ wordWrap: 'break-word' }}>
                                             <PropertyKeyInfo value={currentStep.name} />
-                                            {' • '}
                                             {(breakdown.breakdown_value === 'Baseline'
-                                                ? 'None'
-                                                : breakdown.breakdown) ?? 'Other'}
+                                                ? ''
+                                                : ` • ${breakdown.breakdown}`) ?? ' • Other'}
                                         </div>
                                     }
                                 >

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -99,7 +99,7 @@ export function BreakdownVerticalBarGroup({
                 const currentBarHeight = (height * breakdown.count) / basisBreakdownCount
                 const previousBarHeight =
                     (height * (previousStep?.nested_breakdown?.[breakdownIndex]?.count ?? 0)) / basisBreakdownCount
-                const color = getSeriesColor(breakdown.order, isSingleSeries) as string
+                const color = getSeriesColor(breakdown.order, isSingleSeries)
 
                 const popoverMetrics = [
                     {

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -56,7 +56,10 @@ export function humanizeOrder(order: number): number {
     return order + 1
 }
 
-export function getSeriesColor(index?: number): string | undefined {
+export function getSeriesColor(index?: number, isSingleSeries: boolean = false): string | undefined {
+    if (isSingleSeries) {
+        return 'var(--primary)'
+    }
     if (typeof index === 'number' && index >= 0) {
         return getChartColors('white')[index]
     }

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -56,13 +56,14 @@ export function humanizeOrder(order: number): number {
     return order + 1
 }
 
-export function getSeriesColor(index?: number, isSingleSeries: boolean = false): string | undefined {
+export function getSeriesColor(index?: number, isSingleSeries: boolean = false, fallbackColor?: string): string {
     if (isSingleSeries) {
         return 'var(--primary)'
     }
     if (typeof index === 'number' && index >= 0) {
         return getChartColors('white')[index]
     }
+    return fallbackColor ?? getChartColors('white')[0]
 }
 
 export function getBreakdownMaxIndex(breakdown?: FunnelStep[]): number | undefined {

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -51,8 +51,6 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
             const useCustomName = !!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]
             const isOnlySeries = flattenedBreakdowns.length === 1
 
-            console.log('breakdown', isOnlySeries)
-
             _columns.push({
                 render: function RenderCheckbox({}, breakdown: FlattenedFunnelStepByBreakdown, rowIndex) {
                     const checked = !!flattenedBreakdowns?.every(

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -141,7 +141,7 @@ export function FunnelStepTable({ filters: _filters, dashboardItemId }: Omit<Cha
                         rowIndex,
                         2,
                         <span>{formatDisplayPercentage(breakdown?.conversionRates?.total ?? 0)}%</span>,
-                        renderSubColumnTitle('Comp. rate'),
+                        renderSubColumnTitle('Rate'),
                         showLabels,
                         undefined,
                         dashboardItemId,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
@@ -46,7 +46,12 @@ function BreakdownBarGroupWrapper({
     showLabels: boolean
 }): JSX.Element {
     const logic = funnelLogic({ dashboardItemId })
-    const { stepReference, visibleStepsWithConversionMetrics: steps, clickhouseFeaturesEnabled } = useValues(logic)
+    const {
+        stepReference,
+        visibleStepsWithConversionMetrics: steps,
+        clickhouseFeaturesEnabled,
+        flattenedBreakdowns,
+    } = useValues(logic)
     const { openPersonsModal } = useActions(logic)
     const basisStep = getReferenceStep(steps, stepReference, step.order)
     const previousStep = getReferenceStep(steps, FunnelStepReference.previous, step.order)
@@ -65,6 +70,7 @@ function BreakdownBarGroupWrapper({
                     }
                 }}
                 isClickable={isClickable}
+                isSingleSeries={flattenedBreakdowns.length === 1}
             />
             <div className="funnel-bar-empty-space" />
             <div className="funnel-bar-axis">

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
@@ -17,7 +17,7 @@ import { zeroPad } from 'lib/utils'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 
 export function getColor(step: FlattenedFunnelStep, fallbackColor: string, isBreakdown?: boolean): string {
-    return getSeriesColor(isBreakdown ? step.breakdownIndex : step.order) || fallbackColor
+    return getSeriesColor(isBreakdown ? step.breakdownIndex : step.order, false, fallbackColor)
 }
 
 export function getStepColor(step: FlattenedFunnelStep, isBreakdown?: boolean): string {


### PR DESCRIPTION
## Changes

Fixes #6109

- [x] The checkbox has a foreign blue hue, ideally we would want to match the series color.
- [x] We've changed the main bar color from the main primary color but I think this helped make more obvious that you can click on the bar.
- [x] We use "Comp. rate" & "rate" interchangeably in the table header.
- [x] The average time can get into 2 lines in some cases which doesn't look great.
- [x] The tooltip's title shows a "None" (probably a breakdown value) but it doesn't make sense in this context.
- [x] The "Baseline" label can be confusing if you don't have a breakdown.   

<img width="818" alt="Screen Shot 2021-09-27 at 2 07 03 PM" src="https://user-images.githubusercontent.com/13460330/134985350-344b900a-c99e-426f-a825-90334ac4e268.png">

<img width="881" alt="Screen Shot 2021-09-27 at 2 10 30 PM" src="https://user-images.githubusercontent.com/13460330/134985810-8a4fcb58-22de-40b7-b91a-f1c30ba1628a.png">


## How did you test this code?

Stylistic improvements don't require extensive testing.