### PR TITLE
Fix: check if posthog-js is undefined

### DIFF
--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -102,14 +102,17 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
     events: ({ actions }) => ({
         afterMount: () => {
             actions.getUserFlags()
-            ;(window['posthog'] as PostHog).onFeatureFlags((_, variants) => {
-                if (variants) {
-                    toolbarLogic.actions.updateFeatureFlags(variants)
+            const posthogJs = window['posthog'] as PostHog
+            if (posthogJs) {
+                posthogJs.onFeatureFlags((_, variants) => {
+                    if (variants) {
+                        toolbarLogic.actions.updateFeatureFlags(variants)
+                    }
+                })
+                const locallyOverrideFeatureFlags = posthogJs.get_property('$override_feature_flags')
+                if (locallyOverrideFeatureFlags) {
+                    actions.setShowLocalFeatureFlagWarning(true)
                 }
-            })
-            const locallyOverrideFeatureFlags = (window['posthog'] as PostHog).get_property('$override_feature_flags')
-            if (locallyOverrideFeatureFlags) {
-                actions.setShowLocalFeatureFlagWarning(true)
             }
         },
     }),


### PR DESCRIPTION
## Changes

This is a quick fix to stop the toolbar from crashing. I need to put some more thought into how to handle this case properly though.

Related: https://github.com/PostHog/posthog-js/issues/291#issuecomment-928231312 and https://github.com/PostHog/posthog/pull/6100

## How did you test this code?

*Please describe.*
