### PR TITLE
fixes test that checks if empty filters are not used on the events table view

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -342,7 +342,7 @@ describe('eventsTableLogic', () => {
 
             it('can filter partial properties inside the array', async () => {
                 const propertyFilter = makePropertyFilter()
-                const partialPropertyFilter = { key: 'value' } as EmptyPropertyFilter
+                const partialPropertyFilter = { type: 't' } as EmptyPropertyFilter
                 await expectLogic(logic, () => {
                     logic.actions.setProperties([propertyFilter, partialPropertyFilter])
                 }).toMatchValues({ properties: [propertyFilter] })


### PR DESCRIPTION
…

## Changes

The last change to #6079 changed the meaning of what a non-empty property filter is from the perspective of the tests. This fixes the test

## How did you test this code?

by running the unit tests
