### PR TITLE
Don't use `@current` in backend tests

### DIFF
--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -18,7 +18,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         event = EnterpriseEventDefinition.objects.create(
             team=self.team, name="enterprise event", owner=self.user, tags=["deprecated"]
         )
-        response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(response_data["name"], "enterprise event")
@@ -31,7 +31,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             plan="enterprise", valid_until=timezone.datetime(2500, 1, 19, 3, 14, 7)
         )
         event = EventDefinition.objects.create(team=self.team, name="event")
-        response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         enterprise_event = EnterpriseEventDefinition.objects.all().first()
         event.refresh_from_db()
@@ -50,7 +50,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             team=self.team, name="regular event", owner=self.user, tags=["deprecated"]
         )
 
-        response = self.client.get(f"/api/projects/@current/event_definitions/?search=enter")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=enter")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
@@ -60,17 +60,17 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         self.assertEqual(response_data["results"][0]["tags"], ["deprecated"])
         self.assertEqual(response_data["results"][0]["owner"]["id"], self.user.id)
 
-        response = self.client.get(f"/api/projects/@current/event_definitions/?search=enterprise")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=enterprise")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
 
-        response = self.client.get(f"/api/projects/@current/event_definitions/?search=e ev")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=e ev")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 2)
 
-        response = self.client.get(f"/api/projects/@current/event_definitions/?search=bust")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=bust")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 0)
@@ -81,7 +81,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         )
         event = EnterpriseEventDefinition.objects.create(team=self.team, name="enterprise event", owner=self.user)
         response = self.client.patch(
-            f"/api/projects/@current/event_definitions/{str(event.id)}/",
+            f"/api/projects/{self.team.id}/event_definitions/{str(event.id)}/",
             {"description": "This is a description.", "tags": ["official", "internal"],},
         )
         response_data = response.json()
@@ -96,7 +96,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
     def test_update_event_without_license(self):
         event = EnterpriseEventDefinition.objects.create(team=self.team, name="enterprise event")
         response = self.client.patch(
-            f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
+            f"/api/projects/{self.team.id}/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
         self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])
@@ -107,7 +107,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         )
         event = EnterpriseEventDefinition.objects.create(team=self.team, name="description test")
         response = self.client.patch(
-            f"/api/projects/@current/event_definitions/{str(event.id)}/", data={"description": "test"},
+            f"/api/projects/{self.team.id}/event_definitions/{str(event.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
         self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])

--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -17,7 +17,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         property = EnterprisePropertyDefinition.objects.create(
             team=self.team, name="enterprise property", tags=["deprecated"]
         )
-        response = self.client.get(f"/api/projects/@current/property_definitions/{property.id}")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/{property.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(response_data["name"], "enterprise property")
@@ -29,7 +29,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             plan="enterprise", valid_until=timezone.datetime(2500, 1, 19, 3, 14, 7)
         )
         property = PropertyDefinition.objects.create(team=self.team, name="property")
-        response = self.client.get(f"/api/projects/@current/property_definitions/{property.id}")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/{property.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         enterprise_property = EnterprisePropertyDefinition.objects.all().first()
         property.refresh_from_db()
@@ -48,7 +48,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             team=self.team, name="other property", description="", tags=["deprecated"]
         )
 
-        response = self.client.get(f"/api/projects/@current/property_definitions/?search=enter")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=enter")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
@@ -57,17 +57,17 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         self.assertEqual(response_data["results"][0]["description"], "")
         self.assertEqual(response_data["results"][0]["tags"], ["deprecated"])
 
-        response = self.client.get(f"/api/projects/@current/property_definitions/?search=enterprise")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=enterprise")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
 
-        response = self.client.get(f"/api/projects/@current/property_definitions/?search=er pr")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=er pr")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 2)
 
-        response = self.client.get(f"/api/projects/@current/property_definitions/?search=bust")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=bust")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 0)
@@ -78,7 +78,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         )
         property = EnterprisePropertyDefinition.objects.create(team=self.team, name="enterprise property")
         response = self.client.patch(
-            f"/api/projects/@current/property_definitions/{str(property.id)}/",
+            f"/api/projects/{self.team.id}/property_definitions/{str(property.id)}/",
             {"description": "This is a description.", "tags": ["official", "internal"],},
         )
         response_data = response.json()
@@ -92,7 +92,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
     def test_update_property_without_license(self):
         property = EnterprisePropertyDefinition.objects.create(team=self.team, name="enterprise property")
         response = self.client.patch(
-            f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
+            f"/api/projects/{self.team.id}/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
         self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])
@@ -103,7 +103,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         )
         property = EnterprisePropertyDefinition.objects.create(team=self.team, name="description test")
         response = self.client.patch(
-            f"/api/projects/@current/property_definitions/{str(property.id)}/", data={"description": "test"},
+            f"/api/projects/{self.team.id}/property_definitions/{str(property.id)}/", data={"description": "test"},
         )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
         self.assertIn("This feature is part of the premium PostHog offering.", response.json()["detail"])
@@ -116,7 +116,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         EnterprisePropertyDefinition.objects.create(team=self.team, name="purchase")
         EnterprisePropertyDefinition.objects.create(team=self.team, name="app_rating")
 
-        response = self.client.get("/api/projects/@current/property_definitions/?properties=plan,app_rating")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?properties=plan,app_rating")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(response.json()["count"], 2)

--- a/ee/api/test/test_team_memberships.py
+++ b/ee/api/test/test_team_memberships.py
@@ -19,7 +19,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         self.assertEqual(self.team.explicit_memberships.count(), 0)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictContainsSubset(
@@ -38,7 +38,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         self.assertEqual(self.team.explicit_memberships.count(), 0)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictContainsSubset(
@@ -57,7 +57,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         self.assertEqual(self.team.explicit_memberships.count(), 0)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictEqual(
@@ -73,7 +73,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         self.assertEqual(self.team.explicit_memberships.count(), 0)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": self.user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": self.user.uuid})
         response_data = response.json()
 
         self.assertDictEqual(
@@ -89,7 +89,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         self.assertEqual(self.team.explicit_memberships.count(), 0)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": self.user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": self.user.uuid})
         response_data = response.json()
 
         self.assertDictEqual(
@@ -110,7 +110,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         self.assertEqual(self.team.explicit_memberships.count(), 1)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictEqual(
@@ -131,7 +131,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictContainsSubset(
@@ -151,7 +151,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictContainsSubset(
@@ -167,7 +167,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 
         response = self.client.post(
-            "/api/projects/@current/explicit_members/",
+            f"/api/projects/{self.team.id}/explicit_members/",
             {"user_uuid": new_user.uuid, "level": ExplicitTeamMembership.Level.ADMIN},
         )
         response_data = response.json()
@@ -188,7 +188,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 
         response = self.client.post(
-            "/api/projects/@current/explicit_members/",
+            f"/api/projects/{self.team.id}/explicit_members/",
             {"user_uuid": new_user.uuid, "level": ExplicitTeamMembership.Level.ADMIN},
         )
         response_data = response.json()
@@ -208,7 +208,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 
         response = self.client.post(
-            "/api/projects/@current/explicit_members/",
+            f"/api/projects/{self.team.id}/explicit_members/",
             {"user_uuid": new_user.uuid, "level": ExplicitTeamMembership.Level.ADMIN},
         )
         response_data = response.json()
@@ -255,7 +255,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         self.organization_membership.save()
         _, new_team, new_user = User.objects.bootstrap("Acme", "mallory@acme.com", None)
 
-        response = self.client.post(f"/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid,})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid,})
         response_data = response.json()
 
         self.assertDictEqual(
@@ -287,7 +287,8 @@ class TestTeamMembershipsAPI(APILicensedTest):
         )
 
         response = self.client.patch(
-            f"/api/projects/@current/explicit_members/{new_user.uuid}", {"level": ExplicitTeamMembership.Level.ADMIN}
+            f"/api/projects/{self.team.id}/explicit_members/{new_user.uuid}",
+            {"level": ExplicitTeamMembership.Level.ADMIN},
         )
         response_data = response.json()
 
@@ -310,7 +311,8 @@ class TestTeamMembershipsAPI(APILicensedTest):
         )
 
         response = self.client.patch(
-            f"/api/projects/@current/explicit_members/{new_user.uuid}", {"level": ExplicitTeamMembership.Level.ADMIN}
+            f"/api/projects/{self.team.id}/explicit_members/{new_user.uuid}",
+            {"level": ExplicitTeamMembership.Level.ADMIN},
         )
         response_data = response.json()
 
@@ -327,7 +329,8 @@ class TestTeamMembershipsAPI(APILicensedTest):
         )
 
         response = self.client.patch(
-            f"/api/projects/@current/explicit_members/{self.user.uuid}", {"level": ExplicitTeamMembership.Level.MEMBER}
+            f"/api/projects/{self.team.id}/explicit_members/{self.user.uuid}",
+            {"level": ExplicitTeamMembership.Level.MEMBER},
         )
         response_data = response.json()
 
@@ -352,7 +355,8 @@ class TestTeamMembershipsAPI(APILicensedTest):
         )
 
         response = self.client.patch(
-            f"/api/projects/@current/explicit_members/{new_user.uuid}", {"level": ExplicitTeamMembership.Level.ADMIN}
+            f"/api/projects/{self.team.id}/explicit_members/{new_user.uuid}",
+            {"level": ExplicitTeamMembership.Level.ADMIN},
         )
         response_data = response.json()
 
@@ -374,7 +378,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
             team=self.team, parent_membership=new_org_membership
         )
 
-        response = self.client.delete(f"/api/projects/@current/explicit_members/{new_user.uuid}")
+        response = self.client.delete(f"/api/projects/{self.team.id}/explicit_members/{new_user.uuid}")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -390,7 +394,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
             team=self.team, parent_membership=new_org_membership
         )
 
-        response = self.client.delete(f"/api/projects/@current/explicit_members/{new_user.uuid}")
+        response = self.client.delete(f"/api/projects/{self.team.id}/explicit_members/{new_user.uuid}")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -409,7 +413,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
             team=self.team, parent_membership=new_org_membership
         )
 
-        response = self.client.delete(f"/api/projects/@current/explicit_members/{new_user.uuid}")
+        response = self.client.delete(f"/api/projects/{self.team.id}/explicit_members/{new_user.uuid}")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -421,7 +425,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 
-        response = self.client.post("/api/projects/@current/explicit_members/", {"user_uuid": new_user.uuid})
+        response = self.client.post(f"/api/projects/{self.team.id}/explicit_members/", {"user_uuid": new_user.uuid})
         response_data = response.json()
 
         self.assertDictEqual(
@@ -441,7 +445,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
-        response = self.client.delete(f"/api/projects/@current/explicit_members/{self.user.uuid}")
+        response = self.client.delete(f"/api/projects/{self.team.id}/explicit_members/{self.user.uuid}")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_leave_project_as_admin_member(self):
@@ -452,5 +456,5 @@ class TestTeamMembershipsAPI(APILicensedTest):
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.MEMBER
         )
 
-        response = self.client.delete(f"/api/projects/@current/explicit_members/{self.user.uuid}")
+        response = self.client.delete(f"/api/projects/{self.team.id}/explicit_members/{self.user.uuid}")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -15,7 +15,6 @@ from posthog.test.base import APIBaseTest
 
 @freeze_time("2020-01-02")
 class TestEventDefinitionAPI(APIBaseTest):
-
     demo_team: Team = None  # type: ignore
 
     EXPECTED_EVENT_DEFINITIONS: List[Dict[str, Any]] = [
@@ -51,7 +50,7 @@ class TestEventDefinitionAPI(APIBaseTest):
         calculate_event_property_usage_for_team(cls.demo_team.pk)
 
     def test_list_event_definitions(self):
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], len(self.EXPECTED_EVENT_DEFINITIONS))
         self.assertEqual(len(response.json()["results"]), len(self.EXPECTED_EVENT_DEFINITIONS))
@@ -71,7 +70,7 @@ class TestEventDefinitionAPI(APIBaseTest):
             [EventDefinition(team=self.demo_team, name="z_event_{}".format(i)) for i in range(1, 301)]
         )
 
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 306)
         self.assertEqual(len(response.json()["results"]), 100)  # Default page size
@@ -101,7 +100,7 @@ class TestEventDefinitionAPI(APIBaseTest):
 
         EventDefinition.objects.create(team=team, name="should_be_invisible")
 
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for item in response.json()["results"]:
             self.assertNotIn("should_be_invisible", item["name"])
@@ -112,33 +111,32 @@ class TestEventDefinitionAPI(APIBaseTest):
         self.assertEqual(response.json(), self.permission_denied_response())
 
     def test_query_event_definitions(self):
-
         # Regular search
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=app")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/?search=app")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 2)  # rated app, installed app
 
         # Search should be case insensitive
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=App")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/?search=App")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 2)  # rated app, installed app
 
         # Fuzzy search 1
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=free tri")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/?search=free tri")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["entered_free_trial"])
 
         # Handles URL encoding properly
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=free%20tri%20")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/?search=free%20tri%20")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["entered_free_trial"])
 
         # Fuzzy search 2
-        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=ed mov")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/event_definitions/?search=ed mov")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -51,7 +51,7 @@ class TestEventDefinitionAPI(APIBaseTest):
         calculate_event_property_usage_for_team(cls.demo_team.pk)
 
     def test_list_event_definitions(self):
-        response = self.client.get("/api/projects/@current/event_definitions/")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], len(self.EXPECTED_EVENT_DEFINITIONS))
         self.assertEqual(len(response.json()["results"]), len(self.EXPECTED_EVENT_DEFINITIONS))
@@ -71,7 +71,7 @@ class TestEventDefinitionAPI(APIBaseTest):
             [EventDefinition(team=self.demo_team, name="z_event_{}".format(i)) for i in range(1, 301)]
         )
 
-        response = self.client.get("/api/projects/@current/event_definitions/")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 306)
         self.assertEqual(len(response.json()["results"]), 100)  # Default page size
@@ -101,7 +101,7 @@ class TestEventDefinitionAPI(APIBaseTest):
 
         EventDefinition.objects.create(team=team, name="should_be_invisible")
 
-        response = self.client.get("/api/projects/@current/event_definitions/")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for item in response.json()["results"]:
             self.assertNotIn("should_be_invisible", item["name"])
@@ -114,31 +114,31 @@ class TestEventDefinitionAPI(APIBaseTest):
     def test_query_event_definitions(self):
 
         # Regular search
-        response = self.client.get("/api/projects/@current/event_definitions/?search=app")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=app")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 2)  # rated app, installed app
 
         # Search should be case insensitive
-        response = self.client.get("/api/projects/@current/event_definitions/?search=App")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=App")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 2)  # rated app, installed app
 
         # Fuzzy search 1
-        response = self.client.get("/api/projects/@current/event_definitions/?search=free tri")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=free tri")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["entered_free_trial"])
 
         # Handles URL encoding properly
-        response = self.client.get("/api/projects/@current/event_definitions/?search=free%20tri%20")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=free%20tri%20")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["entered_free_trial"])
 
         # Fuzzy search 2
-        response = self.client.get("/api/projects/@current/event_definitions/?search=ed mov")
+        response = self.client.get(f"/api/projects/{self.team.id}/event_definitions/?search=ed mov")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -518,10 +518,10 @@ class TestFeatureFlag(APIBaseTest):
 
     def test_create_override_for_feature_flag_in_another_team(self):
         feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        _, _, team_2_user = User.objects.bootstrap("Test", "team2@posthog.com", None)
+        _, team_2, team_2_user = User.objects.bootstrap("Test", "team2@posthog.com", None)
         self.client.force_login(team_2_user)
         response = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
+            f"/api/projects/{team_2.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": True},
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -409,7 +409,7 @@ class TestFeatureFlag(APIBaseTest):
         # Boolean override value
         feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": True},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -422,7 +422,7 @@ class TestFeatureFlag(APIBaseTest):
         # String override value
         feature_flag_instance_2 = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature-2")
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance_2.id, "override_value": "hey-hey"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -452,7 +452,7 @@ class TestFeatureFlag(APIBaseTest):
         # Create an override and, and make sure the my_flags response shows it
         feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": "hey-hey"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -465,7 +465,7 @@ class TestFeatureFlag(APIBaseTest):
 
         # Update the override, and make sure the my_flags response reflects the update
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": "new-override"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -485,7 +485,7 @@ class TestFeatureFlag(APIBaseTest):
         # Create an override and, and make sure the my_flags response shows it
         feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": "hey-hey"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -498,7 +498,7 @@ class TestFeatureFlag(APIBaseTest):
 
         # Delete the override, and make sure the my_flags response reflects the update
         existing_override_id = first_flag["override"]["id"]
-        response = self.client.delete(f"/api/projects/@current/feature_flag_overrides/{existing_override_id}",)
+        response = self.client.delete(f"/api/projects/{self.team.id}/feature_flag_overrides/{existing_override_id}",)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         response = self.client.get("/api/feature_flag/my_flags")
@@ -511,7 +511,7 @@ class TestFeatureFlag(APIBaseTest):
     def test_create_override_with_invalid_override(self):
         feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": {"key": "a dict"}},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -521,7 +521,7 @@ class TestFeatureFlag(APIBaseTest):
         _, _, team_2_user = User.objects.bootstrap("Test", "team2@posthog.com", None)
         self.client.force_login(team_2_user)
         response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/my_overrides",
             {"feature_flag": feature_flag_instance.id, "override_value": True},
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -534,7 +534,9 @@ class TestFeatureFlag(APIBaseTest):
         feature_flag_override_id = feature_flag_override.id
         _, _, user_2 = User.objects.bootstrap(self.organization.name, "user2@posthog.com", None)
         self.client.force_login(user_2)
-        response = self.client.delete(f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}",)
+        response = self.client.delete(
+            f"/api/projects/{self.team.id}/feature_flag_overrides/{feature_flag_override_id}",
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_standard_viewset_endpoints_are_not_available(self):
@@ -545,25 +547,25 @@ class TestFeatureFlag(APIBaseTest):
         feature_flag_override_id = feature_flag_override.id
 
         response = self.client.put(
-            f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/{feature_flag_override_id}",
             {"feature_flag": feature_flag_instance.id, "override_value": True},
         )
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
         response = self.client.patch(
-            f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/{feature_flag_override_id}",
             {"feature_flag": feature_flag_instance.id, "override_value": True},
         )
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-        response = self.client.get(f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}")
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flag_overrides/{feature_flag_override_id}")
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-        response = self.client.get(f"/api/projects/@current/feature_flag_overrides/")
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flag_overrides/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         response = self.client.post(
-            f"/api/projects/@current/feature_flag_overrides/",
+            f"/api/projects/{self.team.id}/feature_flag_overrides/",
             {"feature_flag": feature_flag_instance.id, "override_value": True},
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -14,7 +14,7 @@ class TestOrganizationAPI(APIBaseTest):
         self.organization.domain_whitelist = ["hogflix.posthog.com"]
         self.organization.save()
 
-        response = self.client.get("/api/organizations/@current")
+        response = self.client.get(f"/api/organizations/{self.organization.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(response_data["id"], str(self.organization.id))
@@ -27,7 +27,7 @@ class TestOrganizationAPI(APIBaseTest):
         self.organization.setup_section_2_completed = False
         self.organization.save()
 
-        response_data = self.client.get("/api/organizations/@current").json()
+        response_data = self.client.get(f"/api/organizations/{self.organization.id}").json()
         self.assertEqual(response_data["setup"]["is_active"], True)
         self.assertEqual(response_data["setup"]["current_section"], 1)
         self.assertEqual(response_data["setup"]["any_project_completed_snippet_onboarding"], False)
@@ -41,7 +41,7 @@ class TestOrganizationAPI(APIBaseTest):
         self.team.is_demo = True
         self.team.save()
 
-        response_data = self.client.get("/api/organizations/@current").json()
+        response_data = self.client.get(f"/api/organizations/{self.organization.id}").json()
 
         self.assertEqual(response_data["id"], str(self.organization.id))
         self.assertEqual(response_data["setup"]["any_project_ingested_events"], False)
@@ -133,7 +133,7 @@ class TestOrganizationAPI(APIBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
         response = self.client.patch(
-            f"/api/organizations/@current", {"domain_whitelist": ["posthog.com", "movies.posthog.com"]}
+            f"/api/organizations/{self.organization.id}", {"domain_whitelist": ["posthog.com", "movies.posthog.com"]}
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.organization.refresh_from_db()
@@ -151,7 +151,7 @@ class TestOrganizationAPI(APIBaseTest):
             self.organization.setup_section_2_completed = False
             self.organization.save()
 
-            response = self.client.post(f"/api/organizations/@current/onboarding")
+            response = self.client.post(f"/api/organizations/{self.organization.id}/onboarding")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(response.json()["setup"], {"is_active": False, "current_section": None})
             self.organization.refresh_from_db()
@@ -185,7 +185,7 @@ class TestOrganizationAPI(APIBaseTest):
         self.organization.setup_section_2_completed = True
         self.organization.save()
 
-        response = self.client.post(f"/api/organizations/@current/onboarding")
+        response = self.client.post(f"/api/organizations/{self.organization.id}/onboarding")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json(),

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -45,7 +45,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
 
     @patch("posthoganalytics.capture")
     def test_add_organization_invite_email_required(self, mock_capture):
-        response = self.client.post("/api/organizations/@current/invites/")
+        response = self.client.post(f"/api/organizations/{self.organization.id}/invites/")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         response_data = response.json()
         self.assertDictEqual(
@@ -65,7 +65,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         email = "x@x.com"
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
-            response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
+            response = self.client.post(f"/api/organizations/{self.organization.id}/invites/", {"target_email": email})
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(OrganizationInvite.objects.exists())
@@ -112,7 +112,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         count = OrganizationInvite.objects.count()
 
         for _ in range(0, 2):
-            response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
+            response = self.client.post(f"/api/organizations/{self.organization.id}/invites/", {"target_email": email})
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             obj = OrganizationInvite.objects.get(id=response.json()["id"])
             self.assertEqual(obj.target_email, email)
@@ -139,7 +139,9 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         payload = self.helper_generate_bulk_invite_payload(7)
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
-            response = self.client.post("/api/organizations/@current/invites/bulk/", payload, format="json",)
+            response = self.client.post(
+                f"/api/organizations/{self.organization.id}/invites/bulk/", payload, format="json",
+            )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_data = response.json()
 
@@ -176,7 +178,9 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         payload = self.helper_generate_bulk_invite_payload(21)
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
-            response = self.client.post("/api/organizations/@current/invites/bulk/", payload, format="json",)
+            response = self.client.post(
+                f"/api/organizations/{self.organization.id}/invites/bulk/", payload, format="json",
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -201,7 +205,9 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         payload[4]["target_email"] = None
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
-            response = self.client.post("/api/organizations/@current/invites/bulk/", payload, format="json",)
+            response = self.client.post(
+                f"/api/organizations/{self.organization.id}/invites/bulk/", payload, format="json",
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -235,7 +241,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
         invite = OrganizationInvite.objects.create(organization=self.organization)
-        response = self.client.delete(f"/api/organizations/@current/invites/{invite.id}")
+        response = self.client.delete(f"/api/organizations/{self.organization.id}/invites/{invite.id}")
         self.assertEqual(response.content, b"")  # Empty response
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(OrganizationInvite.objects.exists())

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -8,7 +8,7 @@ from posthog.test.base import APIBaseTest
 class TestOrganizationMembersAPI(APIBaseTest):
     def test_list_organization_members(self):
 
-        response = self.client.get("/api/organizations/@current/members/")
+        response = self.client.get(f"/api/organizations/{self.organization.id}/members/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()["results"]
@@ -37,19 +37,19 @@ class TestOrganizationMembersAPI(APIBaseTest):
         self.assertTrue(membership_queryset.exists())
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        response = self.client.delete(f"/api/organizations/@current/members/{user.uuid}/")
+        response = self.client.delete(f"/api/organizations/{self.organization.id}/members/{user.uuid}/")
         self.assertEqual(response.status_code, 403)
         self.assertTrue(membership_queryset.exists())
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
-        response = self.client.delete(f"/api/organizations/@current/members/{user.uuid}/")
+        response = self.client.delete(f"/api/organizations/{self.organization.id}/members/{user.uuid}/")
         self.assertEqual(response.status_code, 204)
         self.assertFalse(membership_queryset.exists(), False)
 
     def test_leave_organization(self):
         membership_queryset = OrganizationMembership.objects.filter(user=self.user, organization=self.organization)
         self.assertEqual(membership_queryset.count(), 1)
-        response = self.client.delete(f"/api/organizations/@current/members/{self.user.uuid}/")
+        response = self.client.delete(f"/api/organizations/{self.organization.id}/members/{self.user.uuid}/")
         self.assertEqual(response.status_code, 204)
         self.assertEqual(membership_queryset.count(), 0)
 
@@ -60,7 +60,8 @@ class TestOrganizationMembersAPI(APIBaseTest):
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
         response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}", {"level": OrganizationMembership.Level.ADMIN},
+            f"/api/organizations/{self.organization.id}/members/{user.uuid}",
+            {"level": OrganizationMembership.Level.ADMIN},
         )
         self.assertEqual(response.status_code, 200)
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
@@ -90,7 +91,8 @@ class TestOrganizationMembersAPI(APIBaseTest):
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
         response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}", {"level": OrganizationMembership.Level.ADMIN},
+            f"/api/organizations/{self.organization.id}/members/{user.uuid}",
+            {"level": OrganizationMembership.Level.ADMIN},
         )
         self.assertEqual(response.status_code, 200)
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
@@ -101,7 +103,8 @@ class TestOrganizationMembersAPI(APIBaseTest):
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
         response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}/", {"level": OrganizationMembership.Level.ADMIN},
+            f"/api/organizations/{self.organization.id}/members/{user.uuid}/",
+            {"level": OrganizationMembership.Level.ADMIN},
         )
 
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
@@ -121,7 +124,8 @@ class TestOrganizationMembersAPI(APIBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
         response = self.client.patch(
-            f"/api/organizations/@current/members/{self.user.uuid}", {"level": OrganizationMembership.Level.MEMBER},
+            f"/api/organizations/{self.organization.id}/members/{self.user.uuid}",
+            {"level": OrganizationMembership.Level.MEMBER},
         )
         self.organization_membership.refresh_from_db()
         self.assertEqual(self.organization_membership.level, OrganizationMembership.Level.ADMIN)
@@ -144,7 +148,8 @@ class TestOrganizationMembersAPI(APIBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.OWNER
         self.organization_membership.save()
         response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}/", {"level": OrganizationMembership.Level.OWNER},
+            f"/api/organizations/{self.organization.id}/members/{user.uuid}/",
+            {"level": OrganizationMembership.Level.OWNER},
         )
         self.organization_membership.refresh_from_db()
         membership.refresh_from_db()
@@ -166,7 +171,8 @@ class TestOrganizationMembersAPI(APIBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
         response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}/", {"level": OrganizationMembership.Level.OWNER},
+            f"/api/organizations/{self.organization.id}/members/{user.uuid}/",
+            {"level": OrganizationMembership.Level.OWNER},
         )
         self.organization_membership.refresh_from_db()
         membership.refresh_from_db()

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -264,7 +264,7 @@ class TestPluginAPI(APIBaseTest):
         self.user.current_organization = other_org
         self.user.save()
 
-        api_url = f"/api/organizations/{self.organization.id}/plugins/{response.json()['id']}"
+        api_url = f"/api/organizations/{other_org.id}/plugins/{response.json()['id']}"
         response = self.client.delete(api_url)
 
         self.assertEqual(response.status_code, 404)

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -35,7 +35,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
 
     def test_list_property_definitions(self):
 
-        response = self.client.get("/api/projects/@current/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], len(self.EXPECTED_PROPERTY_DEFINITIONS))
 
@@ -51,7 +51,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             [PropertyDefinition(team=self.demo_team, name="z_property_{}".format(i)) for i in range(1, 301)]
         )
 
-        response = self.client.get("/api/projects/@current/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 308)
         self.assertEqual(len(response.json()["results"]), 100)  # Default page size
@@ -80,7 +80,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         team.event_properties = self.demo_team.event_properties + [f"should_be_invisible_{i}" for i in range(0, 5)]
         team.save()
 
-        response = self.client.get("/api/projects/@current/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for item in response.json()["results"]:
             self.assertNotIn("should_be_invisible", item["name"])
@@ -93,27 +93,27 @@ class TestPropertyDefinitionAPI(APIBaseTest):
     def test_query_property_definitions(self):
 
         # Regular search
-        response = self.client.get("/api/projects/@current/property_definitions/?search=firs")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=firs")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(response_data["count"], 2)  # first_visit, is_first_movie
 
         # Fuzzy search
-        response = self.client.get("/api/projects/@current/property_definitions/?search=p ting")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=p ting")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["app_rating"])
 
         # Handles URL encoding properly
-        response = self.client.get("/api/projects/@current/property_definitions/?search=%24cur")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=%24cur")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["$current_url"])
 
         # Fuzzy search 2
-        response = self.client.get("/api/projects/@current/property_definitions/?search=hase%20")
+        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=hase%20")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(response.json()["count"], 2)

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -35,7 +35,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
 
     def test_list_property_definitions(self):
 
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], len(self.EXPECTED_PROPERTY_DEFINITIONS))
 
@@ -51,7 +51,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             [PropertyDefinition(team=self.demo_team, name="z_property_{}".format(i)) for i in range(1, 301)]
         )
 
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 308)
         self.assertEqual(len(response.json()["results"]), 100)  # Default page size
@@ -80,7 +80,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         team.event_properties = self.demo_team.event_properties + [f"should_be_invisible_{i}" for i in range(0, 5)]
         team.save()
 
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for item in response.json()["results"]:
             self.assertNotIn("should_be_invisible", item["name"])
@@ -91,29 +91,28 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         self.assertEqual(response.json(), self.permission_denied_response())
 
     def test_query_property_definitions(self):
-
         # Regular search
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=firs")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/?search=firs")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(response_data["count"], 2)  # first_visit, is_first_movie
 
         # Fuzzy search
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=p ting")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/?search=p ting")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["app_rating"])
 
         # Handles URL encoding properly
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=%24cur")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/?search=%24cur")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["$current_url"])
 
         # Fuzzy search 2
-        response = self.client.get(f"/api/projects/{self.team.id}/property_definitions/?search=hase%20")
+        response = self.client.get(f"/api/projects/{self.demo_team.id}/property_definitions/?search=hase%20")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(response.json()["count"], 2)

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -32,7 +32,7 @@ def factory_test_session_recordings_api(session_recording_event_factory):
             self.create_snapshot("user2", "2", base_time + relativedelta(seconds=20))
             self.create_snapshot("user", "1", base_time + relativedelta(seconds=30))
 
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response_data = response.json()
             self.assertEqual(len(response_data["results"]), 2)
@@ -61,7 +61,7 @@ def factory_test_session_recordings_api(session_recording_event_factory):
             self.create_snapshot("user", "1", now(), team_id=another_team.pk)
             self.create_snapshot("user", "2", now())
 
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response_data = response.json()
             self.assertEqual(len(response_data["results"]), 1)
@@ -75,7 +75,7 @@ def factory_test_session_recordings_api(session_recording_event_factory):
             )
             self.create_snapshot("d1", "1", now())
             self.create_snapshot("d2", "2", now() + relativedelta(seconds=30))
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             response_data = response.json()
             self.assertEqual(len(response_data["results"]), 2)
             self.assertEqual(response_data["results"][0]["email"], "bob@bob.com")
@@ -85,7 +85,7 @@ def factory_test_session_recordings_api(session_recording_event_factory):
             SessionRecordingViewed.objects.create(team=self.team, user=self.user, session_id="1")
             self.create_snapshot("u1", "1", now())
             self.create_snapshot("u1", "2", now() + relativedelta(seconds=30))
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             response_data = response.json()
             self.assertEqual(len(response_data["results"]), 2)
             self.assertEqual(response_data["results"][0]["id"], "2")
@@ -100,7 +100,7 @@ def factory_test_session_recordings_api(session_recording_event_factory):
             base_time = now()
             self.create_snapshot("d1", "1", base_time)
             self.create_snapshot("d1", "1", base_time + relativedelta(seconds=30))
-            response = self.client.get("/api/projects/@current/session_recordings/1")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
             response_data = response.json()
             self.assertEqual(response_data["result"]["snapshots"][0], {"timestamp": base_time.timestamp(), "type": 2})
             self.assertEqual(
@@ -113,34 +113,34 @@ def factory_test_session_recordings_api(session_recording_event_factory):
         def test_single_session_recording_doesnt_leak_teams(self):
             another_team = Team.objects.create(organization=self.organization)
             self.create_snapshot("user", "1", now(), team_id=another_team.pk)
-            response = self.client.get("/api/projects/@current/session_recordings/1")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         def test_session_recording_with_no_person(self):
             self.create_snapshot("d1", "1", now())
-            response = self.client.get("/api/projects/@current/session_recordings/1")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
             response_data = response.json()
             self.assertEqual(response_data["result"]["person"], None)
 
         def test_session_recording_doesnt_exist(self):
-            response = self.client.get("/api/projects/@current/session_recordings/1")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         def test_setting_viewed_state_of_session_recording(self):
             self.create_snapshot("u1", "1", now())
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             response_data = response.json()
             # Make sure it starts not viewed
             self.assertEqual(response_data["results"][0]["viewed"], False)
 
-            response = self.client.get("/api/projects/@current/session_recordings/1")
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             response_data = response.json()
             # Make sure it remains not viewed
             self.assertEqual(response_data["results"][0]["viewed"], False)
 
-            response = self.client.get("/api/projects/@current/session_recordings/1?save_view=True")
-            response = self.client.get("/api/projects/@current/session_recordings")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1?save_view=True")
+            response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
             response_data = response.json()
             # Make sure the query param sets it to viewed
             self.assertEqual(response_data["results"][0]["viewed"], True)

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -27,7 +27,7 @@ class TestTeamAPI(APIBaseTest):
 
     def test_retrieve_project(self):
 
-        response = self.client.get("/api/projects/@current/")
+        response = self.client.get(f"/api/projects/{self.team.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
@@ -72,7 +72,7 @@ class TestTeamAPI(APIBaseTest):
 
     def test_update_project_timezone(self):
 
-        response = self.client.patch("/api/projects/@current/", {"timezone": "Europe/Istanbul"})
+        response = self.client.patch(f"/api/projects/{self.team.id}/", {"timezone": "Europe/Istanbul"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
@@ -83,7 +83,7 @@ class TestTeamAPI(APIBaseTest):
         self.assertEqual(self.team.timezone, "Europe/Istanbul")
 
     def test_cannot_set_invalid_timezone_for_project(self):
-        response = self.client.patch("/api/projects/@current/", {"timezone": "America/I_Dont_Exist"})
+        response = self.client.patch(f"/api/projects/{self.team.id}/", {"timezone": "America/I_Dont_Exist"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json(),

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -102,7 +102,7 @@ class TestUserAPI(APIBaseTest):
     def test_creating_users_on_this_endpoint_is_not_supported(self):
         """
         At this moment we don't support creating users on this endpoint. Refer to /api/signup or
-        /api/organization/@current/members to add users.
+        /api/organization/:id/members to add users.
         """
         count = User.objects.count()
 


### PR DESCRIPTION
## Changes

Reduces our dependency on special ID `@current`. We need to eliminate it completely on the way to solving #5363.

## How did you test this code?

Literally ran the updated tests.
