### PR TITLE
Add advanced options behind FF for Paths

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -242,6 +242,7 @@ export const FEATURE_FLAGS = {
     PLUGINS_UI_JOBS: '5720-plugins-ui-jobs',
     DIVE_DASHBOARDS: 'hackathon-dive-dashboards',
     NEW_PATHS_UI: 'new-paths-ui',
+    NEW_PATHS_UI_EDGE_WEIGHTS: 'new-paths-ui-edge-weights',
     PROJECT_BASED_PERMISSIONING: 'project-based-permissioning',
     SPLIT_PERSON: '5898-split-persons',
     TOOLBAR_FEATURE_FLAGS: 'posthog-toolbar-feature-flags',

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useValues, useActions } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
-import { Button, Checkbox, Col, Row, Select } from 'antd'
+import { Button, Checkbox, Col, Collapse, InputNumber, Row, Select } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { TestAccountFilter } from '../../TestAccountFilter'
-import { PathType } from '~/types'
+import { PathEdgeParameters, PathType } from '~/types'
 import './NewPathTab.scss'
 import { GlobalFiltersTitle } from '../../common'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
@@ -15,10 +15,19 @@ import { PathItemFilters } from 'lib/components/PropertyFilters/PathItemFilters'
 import { CloseButton } from 'lib/components/CloseButton'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Tooltip } from 'lib/components/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function NewPathTab(): JSX.Element {
     const { filter } = useValues(pathsLogic({ dashboardItemId: null }))
     const { setFilter, updateExclusions } = useActions(pathsLogic({ dashboardItemId: null }))
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const [localEdgeParameters, setLocalEdgeParameters] = useState<PathEdgeParameters>({
+        edge_limit: filter.edge_limit,
+        min_edge_weight: filter.min_edge_weight,
+        max_edge_weight: filter.max_edge_weight,
+    })
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)
@@ -33,6 +42,16 @@ export function NewPathTab(): JSX.Element {
               }
           })
         : []
+
+    const updateEdgeParameters = (): void => {
+        if (
+            localEdgeParameters.edge_limit !== filter.edge_limit ||
+            localEdgeParameters.min_edge_weight !== filter.min_edge_weight ||
+            localEdgeParameters.max_edge_weight !== filter.max_edge_weight
+        ) {
+            setFilter({ ...localEdgeParameters })
+        }
+    }
 
     const onClickPathtype = (pathType: PathType): void => {
         if (filter.include_event_types) {
@@ -237,6 +256,92 @@ export function NewPathTab(): JSX.Element {
                                 </PathItemSelector>
                             </Col>
                         </Row>
+                        {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI_EDGE_WEIGHTS] && (
+                            <>
+                                <hr />
+                                <Row align="middle">
+                                    <Col span={24}>
+                                        <Collapse expandIconPosition="right">
+                                            <Collapse.Panel header="Advanced Options" key="1">
+                                                <Col>
+                                                    <Row gutter={8} align="middle" className="mt-05">
+                                                        <Col>Maximum number of Paths</Col>
+                                                        <Col>
+                                                            <InputNumber
+                                                                style={{
+                                                                    paddingTop: 2,
+                                                                    width: '80px',
+                                                                    marginLeft: 5,
+                                                                    marginRight: 5,
+                                                                }}
+                                                                size="small"
+                                                                min={0}
+                                                                max={1000}
+                                                                defaultValue={50}
+                                                                onChange={(value): void =>
+                                                                    setLocalEdgeParameters((state) => ({
+                                                                        ...state,
+                                                                        edge_limit: Number(value),
+                                                                    }))
+                                                                }
+                                                                onBlur={updateEdgeParameters}
+                                                                onPressEnter={updateEdgeParameters}
+                                                            />
+                                                        </Col>
+                                                    </Row>
+                                                    <Row gutter={8} align="middle" className="mt-05">
+                                                        <Col>Number of people on each Path between</Col>
+                                                        <Col>
+                                                            <InputNumber
+                                                                style={{
+                                                                    paddingTop: 2,
+                                                                    width: '80px',
+                                                                    marginLeft: 5,
+                                                                    marginRight: 5,
+                                                                }}
+                                                                size="small"
+                                                                min={0}
+                                                                max={100000}
+                                                                onChange={(value): void =>
+                                                                    setLocalEdgeParameters((state) => ({
+                                                                        ...state,
+                                                                        min_edge_weight: Number(value),
+                                                                    }))
+                                                                }
+                                                                onBlur={updateEdgeParameters}
+                                                                onPressEnter={updateEdgeParameters}
+                                                            />
+                                                        </Col>
+                                                        <Col>and</Col>
+                                                        <Col>
+                                                            <InputNumber
+                                                                style={{
+                                                                    paddingTop: 2,
+                                                                    width: '80px',
+                                                                    marginLeft: 5,
+                                                                    marginRight: 5,
+                                                                }}
+                                                                size="small"
+                                                                onChange={(value): void =>
+                                                                    setLocalEdgeParameters((state) => ({
+                                                                        ...state,
+                                                                        max_edge_weight: Number(value),
+                                                                    }))
+                                                                }
+                                                                min={0}
+                                                                max={100000}
+                                                                onBlur={updateEdgeParameters}
+                                                                onPressEnter={updateEdgeParameters}
+                                                            />
+                                                        </Col>
+                                                    </Row>
+                                                </Col>
+                                            </Collapse.Panel>
+                                        </Collapse>
+                                    </Col>
+                                </Row>
+                            </>
+                        )}
                     </Col>
                 </Col>
                 <Col span={12} style={{ marginTop: isSmallScreen ? '2rem' : 0, paddingLeft: 32 }}>

--- a/frontend/src/scenes/paths/NewPaths.js
+++ b/frontend/src/scenes/paths/NewPaths.js
@@ -344,7 +344,7 @@ export function NewPaths({ dashboardItemId = null, filters = null, color = 'whit
                                                         Average time{' '}
                                                     </span>
                                                     {humanFriendlyDuration(
-                                                        pathItemCard.targetLinks[0].average_conversion_time
+                                                        pathItemCard.targetLinks[0].average_conversion_time / 1000
                                                     )}
                                                 </Menu.Item>
                                             )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -753,6 +753,9 @@ export interface FilterType {
     hiddenLegendKeys?: Record<string, boolean | undefined> // used to toggle visibility of breakdowns with legend
     exclude_events?: string[] // Paths Exclusion type
     step_limit?: number // Paths Step Limit
+    edge_limit?: number | undefined // Paths edge limit
+    min_edge_weight?: number | undefined // Paths
+    max_edge_weight?: number | undefined // Paths
 }
 
 export interface SystemStatusSubrows {
@@ -1180,3 +1183,9 @@ export interface AppContext {
 }
 
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'
+
+export interface PathEdgeParameters {
+    edge_limit?: number | undefined
+    min_edge_weight?: number | undefined
+    max_edge_weight?: number | undefined
+}


### PR DESCRIPTION
## Changes

We need more information on the limits of Sankey visualisation + what we can do with edge weights.

This PR: Introduces these advanced options behind a FF.

Note that: This FF is for now for internal use only. We'll beautify the UI more if we decide to publish this externally. Right now, we need it internally to figure out solutions to visualisation issues.

## How did you test this code?

Manually: run the branch locally and see that it works fine: There's an advanced tab option, and changing the options triggers an API request.