### PR TITLE
Some Paths fixes for Start/End Buttons

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.scss
@@ -42,3 +42,16 @@
         padding: 0;
     }
 }
+
+.paths-close-button {
+    cursor: 'pointer';
+    float: 'none';
+    padding-left: 8;
+    align-self: 'center';
+
+    &:hover {
+        border-radius: 4px 4px 0px 0px;
+        color: black;
+        z-index: 999;
+    }
+}

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -166,19 +166,24 @@ export function NewPathTab(): JSX.Element {
                                     >
                                         {filter.start_point ? (
                                             <>
-                                                {filter.start_point}
-                                                <CloseButton
-                                                    onClick={(e: Event) => {
-                                                        setFilter({ start_point: null })
-                                                        e.stopPropagation()
-                                                    }}
-                                                    style={{
-                                                        cursor: 'pointer',
-                                                        float: 'none',
-                                                        paddingLeft: 8,
-                                                        alignSelf: 'center',
-                                                    }}
-                                                />
+                                                <Col span={22} style={{ overflow: 'hidden' }}>
+                                                    {filter.start_point}
+                                                </Col>
+                                                <Col span={2}>
+                                                    <CloseButton
+                                                        onClick={(e: Event) => {
+                                                            setFilter({ start_point: null })
+                                                            e.stopPropagation()
+                                                        }}
+                                                        className="paths-close-button"
+                                                        style={{
+                                                            cursor: 'pointer',
+                                                            float: 'none',
+                                                            paddingLeft: 8,
+                                                            alignSelf: 'center',
+                                                        }}
+                                                    />
+                                                </Col>
                                             </>
                                         ) : (
                                             <span style={{ color: 'var(--muted)' }}>Add start point</span>
@@ -222,6 +227,7 @@ export function NewPathTab(): JSX.Element {
                                                         setFilter({ end_point: null })
                                                         e.stopPropagation()
                                                     }}
+                                                    className="paths-close-button"
                                                     style={{
                                                         cursor: 'pointer',
                                                         float: 'none',

--- a/frontend/src/scenes/paths/NewPaths.js
+++ b/frontend/src/scenes/paths/NewPaths.js
@@ -99,6 +99,7 @@ export function NewPaths({ dashboardItemId = null, filters = null, color = 'whit
         elements.forEach((node) => node.parentNode.removeChild(node))
 
         if (!paths || paths.nodes.length === 0) {
+            setPathItemCards([])
             return
         }
         let width = canvas.current.offsetWidth
@@ -344,7 +345,7 @@ export function NewPaths({ dashboardItemId = null, filters = null, color = 'whit
                                                         Average time{' '}
                                                     </span>
                                                     {humanFriendlyDuration(
-                                                        pathItemCard.targetLinks[0].average_conversion_time
+                                                        pathItemCard.targetLinks[0].average_conversion_time / 1000
                                                     )}
                                                 </Menu.Item>
                                             )}


### PR DESCRIPTION
## Changes

Part of https://github.com/PostHog/posthog/issues/6157

- Fixes start and end point buttons
- Removes Card items when empty result set

## How did you test this code?

Manually: See that the UI looks good when running locally
