### PR TITLE
dev(clickhouse): strip out comments before executing sql

### DIFF
--- a/ee/clickhouse/test/test_client.py
+++ b/ee/clickhouse/test/test_client.py
@@ -67,7 +67,8 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
                     SELECT 1
                 """
             )
-            (first_query,) = sqls
+            self.assertEqual(len(sqls), 1)
+            first_query = sqls[0]
             self.assertIn(f"SELECT 1", first_query)
             self.assertNotIn("this request returns", first_query)
 

--- a/ee/clickhouse/test/test_client.py
+++ b/ee/clickhouse/test/test_client.py
@@ -1,15 +1,15 @@
 import datetime
-from unittest.mock import patch
 
 import fakeredis
-from clickhouse_driver import Client
 from django.test import TestCase
 from freezegun import freeze_time
 
+from ee.clickhouse import client
 from ee.clickhouse.client import CACHE_TTL, _deserialize, _key_hash, cache_sync_execute, sync_execute
+from ee.clickhouse.util import ClickhouseTestMixin
 
 
-class ClickhouseClientTestCase(TestCase):
+class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def setUp(self):
         self.redis_client = fakeredis.FakeStrictRedis()
 
@@ -57,11 +57,20 @@ class ClickhouseClientTestCase(TestCase):
         Note I'm not really testing much complexity, I trust that those will
         come out as failures in other tests.
         """
-        query = f"""
-            -- this request returns 1
-            SELECT 1
-        """
-        with patch.object(Client, "execute") as mock_execute:
-            sync_execute(query)
-            self.assertIn(f"SELECT 1", mock_execute.call_args[0][0])
-            self.assertNotIn("this request returns", mock_execute.call_args[0][0])
+        # First add in the request information that should be added to the sql.
+        # We check this to make sure it is not removed by the comment stripping
+        with self.capture_select_queries() as sqls:
+            client._request_information = {"kind": "request", "id": "1"}
+            sync_execute(
+                query="""
+                    -- this request returns 1
+                    SELECT 1
+                """
+            )
+            (first_query,) = sqls
+            self.assertIn(f"SELECT 1", first_query)
+            self.assertNotIn("this request returns", first_query)
+
+            # Make sure it still includes the "annotation" comment that includes
+            # request routing information for debugging purposes
+            self.assertIn("/* request:1 */", first_query)

--- a/ee/clickhouse/util.py
+++ b/ee/clickhouse/util.py
@@ -2,9 +2,10 @@ from contextlib import contextmanager
 from typing import List
 from unittest.mock import patch
 
+import sqlparse
 from django.db import DEFAULT_DB_ALIAS
 
-from ee.clickhouse.client import sync_execute
+from ee.clickhouse.client import ch_pool, sync_execute
 from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
 from ee.clickhouse.sql.person import DROP_PERSON_TABLE_SQL, PERSONS_TABLE_SQL
 from posthog.test.base import BaseTest
@@ -26,17 +27,28 @@ class ClickhouseTestMixin:
 
     @contextmanager
     def capture_select_queries(self):
-        from ee.clickhouse.client import _annotate_tagged_query
+        queries = []
+        original_get_client = ch_pool.get_client
 
-        sqls: List[str] = []
+        # Spy on the `clichhouse_driver.Client.execute` method. This is a bit of
+        # a roundabout way to handle this, but it seems tricky to spy on the
+        # unbound class method `Client.execute` directly easily
+        @contextmanager
+        def get_client():
+            with original_get_client() as client:
+                original_client_execute = client.execute
 
-        def wrapped_method(*args):
-            if args[0].strip().startswith("SELECT"):
-                sqls.append(args[0])
-            return _annotate_tagged_query(*args)
+                def execute_wrapper(query, *args, **kwargs):
+                    queries.append(query)
+                    return original_client_execute(query, *args, **kwargs)
 
-        with patch("ee.clickhouse.client._annotate_tagged_query", wraps=wrapped_method) as wrapped_annotate:
-            yield sqls
+                with patch.object(client, "execute", wraps=execute_wrapper) as _:
+                    yield client
+
+        with patch("ee.clickhouse.client.ch_pool.get_client", wraps=get_client) as _:
+            yield [
+                query for query in queries if sqlparse.format(query, strip_comments=True).strip().startswith("SELECT")
+            ]
 
 
 class ClickhouseDestroyTablesMixin(BaseTest):


### PR DESCRIPTION
This is so we can easily copy/paste from e.g. Metabase by querying the
system.query_log. In metabase is doesn't display new lines (although you
can download to file for this), but it's not very practical.