### PR TITLE
Injects a logger during posthog init which sends an exception to Sentry when there is an XHR error

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -19,6 +19,15 @@ export function loadPostHogJS(): void {
             loaded: function (ph) {
                 ph.opt_out_capturing()
             },
+            onXHRError: (failedRequest) => {
+                Sentry.captureException({
+                    name: 'ErrorSendingToPostHog',
+                    message: `Failed with status ${failedRequest.status} while sending to PostHog`,
+                    status: failedRequest.status,
+                    text: failedRequest.statusText,
+                    context: failedRequest,
+                })
+            },
         })
     }
 
@@ -29,6 +38,5 @@ export function loadPostHogJS(): void {
                 integrations: [new posthog.SentryIntegration(posthog, 'posthog', 1899813)],
             }),
         })
-        ;(window as any).Sentry = Sentry
     }
 }

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -19,7 +19,7 @@ export function loadPostHogJS(): void {
             loaded: function (ph) {
                 ph.opt_out_capturing()
             },
-            onXHRError: (failedRequest) => {
+            onXHRError: (failedRequest: XMLHttpRequest) => {
                 Sentry.captureException({
                     name: 'ErrorSendingToPostHog',
                     message: `Failed with status ${failedRequest.status} while sending to PostHog`,

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -29,5 +29,6 @@ export function loadPostHogJS(): void {
                 integrations: [new posthog.SentryIntegration(posthog, 'posthog', 1899813)],
             }),
         })
+        ;(window as any).Sentry = Sentry
     }
 }

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -4,13 +4,12 @@ import * as Sentry from '@sentry/browser'
 const configWithSentry = (config: posthog.Config): posthog.Config => {
     if ((window as any).SENTRY_DSN) {
         config.on_xhr_error = (failedRequest: XMLHttpRequest) => {
-            Sentry.captureException({
-                name: 'ErrorSendingToPostHog',
-                message: `Failed with status ${failedRequest.status} while sending to PostHog`,
-                status: failedRequest.status,
-                text: failedRequest.statusText,
-                context: failedRequest,
-            })
+            const status = failedRequest.status
+            const statusText = failedRequest.statusText || 'no status text in error'
+            Sentry.captureException(
+                new Error(`Failed with status ${status} while sending to PostHog. Message: ${statusText}`),
+                { tags: { status, statusText } }
+            )
         }
     }
     return config

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser'
 
 const configWithSentry = (config: posthog.Config): posthog.Config => {
     if ((window as any).SENTRY_DSN) {
-        config.onXHRError = (failedRequest: XMLHttpRequest) => {
+        config.on_xhr_error = (failedRequest: XMLHttpRequest) => {
             Sentry.captureException({
                 name: 'ErrorSendingToPostHog',
                 message: `Failed with status ${failedRequest.status} while sending to PostHog`,


### PR DESCRIPTION
For PostHog/posthog-js#290

## Changes

Injects a logger during posthog init which sends an exception to Sentry when there is an XHR error

Depends on PostHog/posthog-js#296

![Screenshot 2021-10-04 at 12 53 15](https://user-images.githubusercontent.com/984817/135847040-831b9660-ff5f-40ce-b56f-f89ca19aebf4.png)## How did you test this code?

tested by running locally
