### PR TITLE
paths: Adjust styling for close button 

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.scss
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.scss
@@ -43,15 +43,27 @@
     }
 }
 
-.paths-close-button {
-    cursor: 'pointer';
-    float: 'none';
-    padding-left: 8;
-    align-self: 'center';
+.paths-endpoint-field {
+    .label-container {
+        display: flex;
+        width: 100%;
+        justify-content: space-between;
+    }
 
-    &:hover {
-        border-radius: 4px 4px 0px 0px;
-        color: black;
-        z-index: 999;
+    .label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .close-button {
+        cursor: pointer;
+        padding-left: 8px;
+        align-self: center;
+
+        &:hover {
+            border-radius: 4px 4px 0px 0px;
+            color: black;
+            z-index: 999;
+        }
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -175,35 +175,22 @@ export function NewPathTab(): JSX.Element {
                                     <Button
                                         data-attr={'new-prop-filter-' + 1}
                                         block={true}
+                                        className="paths-endpoint-field"
                                         style={{
-                                            maxWidth: '100%',
-                                            display: 'flex',
-                                            alignItems: 'center',
-                                            justifyContent: 'space-between',
-                                            overflow: 'hidden',
+                                            textAlign: 'left',
                                         }}
                                     >
                                         {filter.start_point ? (
-                                            <>
-                                                <Col span={22} style={{ overflow: 'hidden' }}>
-                                                    {filter.start_point}
-                                                </Col>
-                                                <Col span={2}>
-                                                    <CloseButton
-                                                        onClick={(e: Event) => {
-                                                            setFilter({ start_point: null })
-                                                            e.stopPropagation()
-                                                        }}
-                                                        className="paths-close-button"
-                                                        style={{
-                                                            cursor: 'pointer',
-                                                            float: 'none',
-                                                            paddingLeft: 8,
-                                                            alignSelf: 'center',
-                                                        }}
-                                                    />
-                                                </Col>
-                                            </>
+                                            <div className="label-container">
+                                                <span className="label">{filter.start_point}</span>
+                                                <CloseButton
+                                                    onClick={(e: Event) => {
+                                                        setFilter({ start_point: null })
+                                                        e.stopPropagation()
+                                                    }}
+                                                    className="close-button"
+                                                />
+                                            </div>
                                         ) : (
                                             <span style={{ color: 'var(--muted)' }}>Add start point</span>
                                         )}
@@ -230,31 +217,22 @@ export function NewPathTab(): JSX.Element {
                                     <Button
                                         data-attr={'new-prop-filter-' + 0}
                                         block={true}
+                                        className="paths-endpoint-field"
                                         style={{
-                                            maxWidth: '100%',
-                                            display: 'flex',
-                                            alignItems: 'center',
-                                            justifyContent: 'space-between',
-                                            overflow: 'hidden',
+                                            textAlign: 'left',
                                         }}
                                     >
                                         {filter.end_point ? (
-                                            <>
-                                                {filter.end_point}
+                                            <div className="label-container">
+                                                <span className="label">{filter.end_point}</span>
                                                 <CloseButton
                                                     onClick={(e: Event) => {
                                                         setFilter({ end_point: null })
                                                         e.stopPropagation()
                                                     }}
-                                                    className="paths-close-button"
-                                                    style={{
-                                                        cursor: 'pointer',
-                                                        float: 'none',
-                                                        paddingLeft: 8,
-                                                        alignSelf: 'center',
-                                                    }}
+                                                    className="close-button"
                                                 />
-                                            </>
+                                            </div>
                                         ) : (
                                             <span style={{ color: 'var(--muted)' }}>Add end point</span>
                                         )}


### PR DESCRIPTION
## Changes

*Please describe.*  
- address the close button being covered in #6157 
*If this affects the frontend, include screenshots.*  
<img width="442" alt="Screen Shot 2021-09-29 at 1 20 46 PM" src="https://user-images.githubusercontent.com/13127476/135318008-7cba8c79-823e-4511-9cf7-68f8b3f0d5f4.png">

## How did you test this code?

*Please describe.*
Manual QA to make sure the bug was solved
