### PR TITLE
Fix `test_analytics_metadata` flakiness

### DIFF
--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -132,6 +132,8 @@ class User(AbstractUser, UUIDClassicModel):
     @property
     def organization(self) -> Optional[Organization]:
         if self.current_organization is None:
+            if self.current_team is not None:
+                self.current_organization_id = self.current_team.organization_id
             self.current_organization = self.organizations.first()
             self.save()
         return self.current_organization
@@ -139,7 +141,7 @@ class User(AbstractUser, UUIDClassicModel):
     @property
     def team(self) -> Optional[Team]:
         if self.current_team is None and self.organization is not None:
-            self.current_team = self.organization.teams.order_by("access_control").first()  # Prefer open projects
+            self.current_team = self.organization.teams.order_by("access_control", "id").first()  # Prefer open projects
             self.save()
         return self.current_team
 


### PR DESCRIPTION
## Changes

Test `test_analytics_metadata` got flaky after https://github.com/PostHog/posthog/pull/6068/ (see https://github.com/PostHog/posthog/pull/6187/checks?check_run_id=3754830663).

Looks like this is because I added an `ORDER BY` clause to the query that ensures the user has a team set – the clause orders on `Team.access_control` so that open projects are preferred to private ones in autosetting. But actually adding an `ORDER BY` makes the result _more random_ in a way. Because Postgres uses non-stable quicksort, when all rows have the same `access_control` value, without `ORDER BY` the rows are returned in the order of insertion (in practical terms, as theoretically this is not guaranteed _at all_), but quicksort messes that up.

The fix is just explicitly sorting by `access_control` AND `id`.

## How did you test this code?

Ran the test n times.
