### PR TITLE
Speed improvements for the arm64 ClickHouse build

### DIFF
--- a/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
+++ b/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
@@ -25,7 +25,7 @@ ENV LC_ALL en_US.UTF-8
 ENV TZ UTC
 
 RUN apt-get -y install git cmake python ninja-build
-RUN git clone --depth 1 --branch $GIT_TAG --recursive https://github.com/ClickHouse/ClickHouse.git
+RUN git clone --depth 1 --shallow-submodules --branch $GIT_TAG --recursive https://github.com/ClickHouse/ClickHouse.git
 
 RUN apt-get -y install clang-12 build-essential
 ENV CC clang-12

--- a/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
+++ b/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
@@ -25,14 +25,14 @@ ENV LC_ALL en_US.UTF-8
 ENV TZ UTC
 
 RUN apt-get -y install git cmake python ninja-build
-RUN git clone --branch $GIT_TAG --recursive https://github.com/ClickHouse/ClickHouse.git
+RUN git clone --depth 1 --branch $GIT_TAG --recursive https://github.com/ClickHouse/ClickHouse.git
 
 RUN apt-get -y install clang-12 build-essential
 ENV CC clang-12
 ENV CXX clang++-12
 
 RUN cd ClickHouse && mkdir build && cd build && cmake ..
-RUN cd ClickHouse/build && ninja -j 2
+RUN cd ClickHouse/build && ninja -j $(nproc)
 RUN mv ClickHouse/build/programs/clickhouse* /usr/bin/
 
 RUN mkdir /docker-entrypoint-initdb.d


### PR DESCRIPTION
## Changes
Speedup improvements for the ClickHouse build on `arm64`. On my laptop it's a > 60% improvement wall time (~70 min VS ~110).

1. during ClickHouse code checkout, don't download of all the history up to the specified revision
2. let `ninja` to use all the available CPU cores

## How did you test this code?
On my Apple M1 laptop

**Before**
```
➜  posthog git:(master) ✗ yarn arm64:build:clickhouse
[...]
✨  Done in 6849.11s.
```

**After**

Deleted first the layers created in the initial run: `docker system prune -a`
```
➜  posthog git:(master) ✗ yarn arm64:build:clickhouse
[...]
✨  Done in 4300.05s.
```