### PR TITLE
docs(dev): add an initial CHEATSHEET with clickhouse testing detail

### DIFF
--- a/DEVELOPER_CHEATSHEET.md
+++ b/DEVELOPER_CHEATSHEET.md
@@ -1,0 +1,19 @@
+# Quick reference to common development tasks
+
+## ClickHouse debugging
+
+### How do I see which queries are sent to ClickHouse
+
+In tests, run:
+
+```
+pytest <path-to-test> --log-cli-level=DEBUG
+```
+
+This should dump all debug log messages (not just ClickHouse) to stdout
+
+In dev or production, you can run, for example:
+
+```
+echo "select query from system.query_log limit 10" | clickhouse-client
+```


### PR DESCRIPTION
Perhaps we can add some more here over time, although it would be nice
not to make this a crutch where would could easily just make things work