### PR TITLE
Don't show tooltip with empty content on Formulas

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -136,6 +136,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                                                     ? 'Please add at least one graph series to use formulas'
                                                     : undefined
                                             }
+                                            visible={formulaEnabled ? false : undefined}
                                         >
                                             <Button
                                                 onClick={() => setIsUsingFormulas(true)}


### PR DESCRIPTION
## Changes

Fixes a bug in which a tooltip may be shown with empty content.

<img width="180" alt="Screen Shot 2021-09-29 at 5 28 28 PM" src="https://user-images.githubusercontent.com/4645779/135550518-9aabccd3-940a-407e-a52a-c25fc329de6a.png">

The tooltip not be visible if the empty-content condition is true. Else, the tooltip will be visible on hover only.