### PR TITLE
dev(pytest): skip tests based on env setup

### DIFF
--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -12,6 +12,8 @@ from posthog.settings import (
 from posthog.test.base import TestMixin
 from posthog.utils import is_clickhouse_enabled
 
+pytestmark = pytest.mark.ee
+
 
 def reset_clickhouse_tables():
     # Reset clickhouse tables to default before running test

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -1,0 +1,2 @@
+# Use the same pytest setup we use for ee/ tests
+from ee.conftest import *  # noqa: F403,F401


### PR DESCRIPTION
This is mainly to simplify running of tests so we can just use `pytest`
easily, without having to add `-m x y z`. Not very explicit however.