### PR TITLE
Add project-nested version of all project-dependent endpoints

### DIFF
--- a/ee/api/hooks.py
+++ b/ee/api/hooks.py
@@ -34,4 +34,4 @@ class HookViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         user = cast(User, self.request.user)
-        serializer.save(user=user, team=user.team)
+        serializer.save(user=user, team_id=self.team_id)

--- a/ee/clickhouse/views/cohort.py
+++ b/ee/clickhouse/views/cohort.py
@@ -37,3 +37,7 @@ def insert_cohort_people_into_pg(cohort: Cohort):
 
 class ClickhouseCohortViewSet(CohortViewSet):
     serializer_class = ClickhouseCohortSerializer
+
+
+class LegacyClickhouseCohortViewSet(ClickhouseCohortViewSet):
+    legacy_team_compatibility = True

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -58,3 +58,7 @@ class ClickhouseElementViewSet(ElementViewSet):
             GET_VALUES.format(), {"team_id": self.team.id, "regex": select_regex, "filter_regex": filter_regex}
         )
         return response.Response([{"name": value[0]} for value in result])
+
+
+class LegacyClickhouseElementViewSet(ClickhouseElementViewSet):
+    legacy_team_compatibility = True

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -31,7 +31,6 @@ from posthog.utils import convert_property_value, flatten
 
 
 class ClickhouseEventsViewSet(EventViewSet):
-
     serializer_class = ClickhouseEventSerializer  # type: ignore
 
     def _get_people(self, query_result: List[Dict], team: Team) -> Dict[str, Any]:
@@ -194,3 +193,7 @@ class ClickhouseEventsViewSet(EventViewSet):
             )
 
         return Response({"result": session_recording})
+
+
+class LegacyClickhouseEventsViewSet(ClickhouseEventsViewSet):
+    legacy_team_compatibility = True

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -113,3 +113,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
         filter = RetentionFilter(data=data, request=request)
         result = ClickhouseRetention().run(filter, team)
         return {"result": result}
+
+
+class LegacyClickhouseInsightsViewSet(ClickhouseInsightsViewSet):
+    legacy_team_compatibility = True

--- a/ee/clickhouse/views/paths.py
+++ b/ee/clickhouse/views/paths.py
@@ -22,3 +22,7 @@ class ClickhousePathsViewSet(PathsViewSet):
             resp.append({"name": row[0], "id": row[1], "count": row[2]})
 
         return Response(resp)
+
+
+class LegacyClickhousePathsViewSet(ClickhousePathsViewSet):
+    legacy_team_compatibility = True

--- a/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
+++ b/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
@@ -23,7 +23,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
             __default: [] as PluginLogEntry[],
             loadPluginLogsInitially: async () => {
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin-configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}`
+                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}`
                 )
                 cache.pollingInterval = setInterval(actions.loadPluginLogsBackgroundPoll, 2000)
                 actions.clearPluginLogsBackground()
@@ -31,7 +31,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
             },
             loadPluginLogsSearch: async (searchTerm: string) => {
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin-configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}&search=${searchTerm}`
+                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}&search=${searchTerm}`
                 )
                 actions.clearPluginLogsBackground()
                 return response.results
@@ -40,7 +40,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
                 const before = values.trailingEntry ? '&before=' + values.trailingEntry.timestamp : ''
                 const search = values.searchTerm ? `&search=${values.searchTerm}` : ''
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin-configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}${before}${search}`
+                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}${before}${search}`
                 )
                 if (response.count < LOGS_PORTION_LIMIT) {
                     actions.markLogsEnd()
@@ -62,7 +62,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
                 const after = values.leadingEntry ? 'after=' + values.leadingEntry.timestamp : ''
                 const search = values.searchTerm ? `search=${values.searchTerm}` : ''
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin-configs/${pluginConfigId}/logs?${[after, search]
+                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?${[after, search]
                         .filter(Boolean)
                         .join('&')}`
                 )

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -41,18 +41,18 @@ def api_not_found(request):
 router = DefaultRouterPlusPlus()
 
 # Legacy endpoints (to be removed eventually)
-router.register(r"annotation", annotation.AnnotationsViewSet)
-router.register(r"feature_flag", feature_flag.FeatureFlagViewSet)
-router.register(r"dashboard", dashboard.DashboardsViewSet)
-router.register(r"dashboard_item", dashboard.DashboardItemsViewSet)
-router.register(r"plugin_config", plugin.PluginConfigViewSet)
 router.register(r"personal_api_keys", personal_api_key.PersonalAPIKeyViewSet, "personal_api_keys")
-router.register(r"sessions_filter", sessions_filter.SessionsFilterViewSet)
+router.register(r"annotation", annotation.LegacyAnnotationsViewSet)
+router.register(r"feature_flag", feature_flag.LegacyFeatureFlagViewSet)
+router.register(r"dashboard", dashboard.LegacyDashboardsViewSet)
+router.register(r"dashboard_item", dashboard.LegacyDashboardItemsViewSet)
+router.register(r"plugin_config", plugin.LegacyPluginConfigViewSet)
+router.register(r"sessions_filter", sessions_filter.LegacySessionsFilterViewSet)
 
 # Nested endpoints
 projects_router = router.register(r"projects", team.TeamViewSet)
 project_plugins_configs_router = projects_router.register(
-    r"plugin-configs", plugin.PluginConfigViewSet, "project_plugins_configs", ["team_id", "plugin_config_id"]
+    r"plugin-configs", plugin.PluginConfigViewSet, "project_plugins_configs", ["team_id"]
 )
 project_plugins_configs_router.register(
     r"logs", plugin_log_entry.PluginLogEntryViewSet, "project_plugins_config_logs", ["team_id", "plugin_config_id"]
@@ -60,6 +60,15 @@ project_plugins_configs_router.register(
 projects_router.register(
     r"feature_flag_overrides", feature_flag.FeatureFlagOverrideViewset, "project_feature_flag_overrides", ["team_id"]
 )
+projects_router.register(r"annotation", annotation.AnnotationsViewSet, "project_annotations", ["team_id"])
+projects_router.register(r"feature_flag", feature_flag.FeatureFlagViewSet, "project_feature_flags", ["team_id"])
+projects_router.register(r"dashboard", dashboard.DashboardsViewSet, "project_dashboards", ["team_id"])
+projects_router.register(r"dashboard_item", dashboard.DashboardItemsViewSet, "project_dashboard_items", ["team_id"])
+projects_router.register(r"plugin_config", plugin.PluginConfigViewSet, "project_plugin_configs", ["team_id"])
+projects_router.register(
+    r"sessions_filter", sessions_filter.SessionsFilterViewSet, "project_session_filters", ["team_id"]
+)
+
 
 organizations_router = router.register(r"organizations", organization.OrganizationViewSet, "organizations")
 organization_plugins_router = organizations_router.register(
@@ -94,12 +103,12 @@ router.register(r"instance_status", instance_status.InstanceStatusViewSet, "inst
 if is_clickhouse_enabled():
     try:
         from ee.clickhouse.views.actions import ClickhouseActionsViewSet, LegacyClickhouseActionsViewSet
-        from ee.clickhouse.views.cohort import ClickhouseCohortViewSet
-        from ee.clickhouse.views.element import ClickhouseElementViewSet
-        from ee.clickhouse.views.events import ClickhouseEventsViewSet
-        from ee.clickhouse.views.insights import ClickhouseInsightsViewSet
-        from ee.clickhouse.views.paths import ClickhousePathsViewSet
-        from ee.clickhouse.views.person import ClickhousePersonViewSet
+        from ee.clickhouse.views.cohort import ClickhouseCohortViewSet, LegacyClickhouseCohortViewSet
+        from ee.clickhouse.views.element import ClickhouseElementViewSet, LegacyClickhouseElementViewSet
+        from ee.clickhouse.views.events import ClickhouseEventsViewSet, LegacyClickhouseEventsViewSet
+        from ee.clickhouse.views.insights import ClickhouseInsightsViewSet, LegacyClickhouseInsightsViewSet
+        from ee.clickhouse.views.paths import ClickhousePathsViewSet, LegacyClickhousePathsViewSet
+        from ee.clickhouse.views.person import ClickhousePersonViewSet, LegacyClickhousePersonViewSet
         from ee.clickhouse.views.session_recordings import ClickhouseSessionRecordingViewSet
     except ImportError as e:
         print("ClickHouse enabled but missing enterprise capabilities. Defaulting to Postgres.")
@@ -107,28 +116,40 @@ if is_clickhouse_enabled():
     else:
         # legacy endpoints (to be removed eventually)
         router.register(r"action", LegacyClickhouseActionsViewSet, basename="action")
-        router.register(r"event", ClickhouseEventsViewSet, basename="event")
-        router.register(r"insight", ClickhouseInsightsViewSet, basename="insight")
-        router.register(r"person", ClickhousePersonViewSet, basename="person")
-        router.register(r"paths", ClickhousePathsViewSet, basename="paths")
-        router.register(r"element", ClickhouseElementViewSet, basename="element")
-        router.register(r"cohort", ClickhouseCohortViewSet, basename="cohort")
+        router.register(r"event", LegacyClickhouseEventsViewSet, basename="event")
+        router.register(r"insight", LegacyClickhouseInsightsViewSet, basename="insight")
+        router.register(r"person", LegacyClickhousePersonViewSet, basename="person")
+        router.register(r"paths", LegacyClickhousePathsViewSet, basename="paths")
+        router.register(r"element", LegacyClickhouseElementViewSet, basename="element")
+        router.register(r"cohort", LegacyClickhouseCohortViewSet, basename="cohort")
         # nested endpoints
         projects_router.register(r"actions", ClickhouseActionsViewSet, "project_actions", ["team_id"])
+        projects_router.register(r"events", ClickhouseEventsViewSet, "project_events", ["team_id"])
+        projects_router.register(r"insights", ClickhouseInsightsViewSet, "project_insights", ["team_id"])
+        projects_router.register(r"persons", ClickhousePersonViewSet, "project_persons", ["team_id"])
+        projects_router.register(r"paths", ClickhousePathsViewSet, "project_paths", ["team_id"])
+        projects_router.register(r"elements", ClickhouseElementViewSet, "project_elements", ["team_id"])
+        projects_router.register(r"cohorts", ClickhouseCohortViewSet, "project_cohorts", ["team_id"])
         projects_router.register(
             r"session_recordings", ClickhouseSessionRecordingViewSet, "project_session_recordings", ["team_id"],
         )
 else:
     # legacy endpoints (to be removed eventually)
-    router.register(r"insight", insight.InsightViewSet)
+    router.register(r"insight", insight.LegacyInsightViewSet)
     router.register(r"action", action.LegacyActionViewSet)
-    router.register(r"person", person.PersonViewSet)
-    router.register(r"event", event.EventViewSet)
-    router.register(r"paths", paths.PathsViewSet, basename="paths")
-    router.register(r"element", element.ElementViewSet)
-    router.register(r"cohort", cohort.CohortViewSet)
+    router.register(r"person", person.LegacyPersonViewSet)
+    router.register(r"event", event.LegacyEventViewSet)
+    router.register(r"paths", paths.LegacyPathsViewSet, basename="paths")
+    router.register(r"element", element.LegacyElementViewSet)
+    router.register(r"cohort", cohort.LegacyCohortViewSet)
     # nested endpoints
+    projects_router.register(r"insights", insight.LegacyInsightViewSet, "project_insights", ["team_id"])
     projects_router.register(r"actions", action.ActionViewSet, "project_actions", ["team_id"])
+    projects_router.register(r"persons", person.LegacyPersonViewSet, "project_persons", ["team_id"])
+    projects_router.register(r"events", event.LegacyEventViewSet, "project_events", ["team_id"])
+    projects_router.register(r"paths", paths.LegacyPathsViewSet, "project_paths", ["team_id"])
+    projects_router.register(r"elements", element.LegacyElementViewSet, "project_elements", ["team_id"])
+    projects_router.register(r"cohorts", cohort.LegacyCohortViewSet, "project_cohorts", ["team_id"])
     projects_router.register(
         r"session_recordings", session_recording.SessionRecordingViewSet, "project_session_recordings", ["team_id"],
     )

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -40,8 +40,7 @@ def api_not_found(request):
 
 router = DefaultRouterPlusPlus()
 
-# Legacy endpoints (to be removed eventually)
-router.register(r"personal_api_keys", personal_api_key.PersonalAPIKeyViewSet, "personal_api_keys")
+# Legacy endpoints shared (to be removed eventually)
 router.register(r"annotation", annotation.LegacyAnnotationsViewSet)
 router.register(r"feature_flag", feature_flag.LegacyFeatureFlagViewSet)
 router.register(r"dashboard", dashboard.LegacyDashboardsViewSet)
@@ -49,10 +48,10 @@ router.register(r"dashboard_item", dashboard.LegacyDashboardItemsViewSet)
 router.register(r"plugin_config", plugin.LegacyPluginConfigViewSet)
 router.register(r"sessions_filter", sessions_filter.LegacySessionsFilterViewSet)
 
-# Nested endpoints
+# Nested endpoints shared
 projects_router = router.register(r"projects", team.TeamViewSet)
 project_plugins_configs_router = projects_router.register(
-    r"plugin-configs", plugin.PluginConfigViewSet, "project_plugins_configs", ["team_id"]
+    r"plugin_configs", plugin.PluginConfigViewSet, "project_plugin_configs", ["team_id"]
 )
 project_plugins_configs_router.register(
     r"logs", plugin_log_entry.PluginLogEntryViewSet, "project_plugins_config_logs", ["team_id", "plugin_config_id"]
@@ -60,13 +59,12 @@ project_plugins_configs_router.register(
 projects_router.register(
     r"feature_flag_overrides", feature_flag.FeatureFlagOverrideViewset, "project_feature_flag_overrides", ["team_id"]
 )
-projects_router.register(r"annotation", annotation.AnnotationsViewSet, "project_annotations", ["team_id"])
-projects_router.register(r"feature_flag", feature_flag.FeatureFlagViewSet, "project_feature_flags", ["team_id"])
-projects_router.register(r"dashboard", dashboard.DashboardsViewSet, "project_dashboards", ["team_id"])
-projects_router.register(r"dashboard_item", dashboard.DashboardItemsViewSet, "project_dashboard_items", ["team_id"])
-projects_router.register(r"plugin_config", plugin.PluginConfigViewSet, "project_plugin_configs", ["team_id"])
+projects_router.register(r"annotations", annotation.AnnotationsViewSet, "project_annotations", ["team_id"])
+projects_router.register(r"feature_flags", feature_flag.FeatureFlagViewSet, "project_feature_flags", ["team_id"])
+projects_router.register(r"dashboards", dashboard.DashboardsViewSet, "project_dashboards", ["team_id"])
+projects_router.register(r"dashboard_items", dashboard.DashboardItemsViewSet, "project_dashboard_items", ["team_id"])
 projects_router.register(
-    r"sessions_filter", sessions_filter.SessionsFilterViewSet, "project_session_filters", ["team_id"]
+    r"sessions_filters", sessions_filter.SessionsFilterViewSet, "project_session_filters", ["team_id"]
 )
 
 
@@ -95,9 +93,10 @@ projects_router.register(
 )
 
 
-# General endpoints (shared across EE & FOSS)
+# General endpoints (shared across CH & PG)
 router.register(r"login", authentication.LoginViewSet)
 router.register(r"users", user.UserViewSet)
+router.register(r"personal_api_keys", personal_api_key.PersonalAPIKeyViewSet, "personal_api_keys")
 router.register(r"instance_status", instance_status.InstanceStatusViewSet, "instance_status")
 
 if is_clickhouse_enabled():
@@ -114,7 +113,7 @@ if is_clickhouse_enabled():
         print("ClickHouse enabled but missing enterprise capabilities. Defaulting to Postgres.")
         print(e)
     else:
-        # legacy endpoints (to be removed eventually)
+        # Legacy endpoints CH (to be removed eventually)
         router.register(r"action", LegacyClickhouseActionsViewSet, basename="action")
         router.register(r"event", LegacyClickhouseEventsViewSet, basename="event")
         router.register(r"insight", LegacyClickhouseInsightsViewSet, basename="insight")
@@ -122,7 +121,7 @@ if is_clickhouse_enabled():
         router.register(r"paths", LegacyClickhousePathsViewSet, basename="paths")
         router.register(r"element", LegacyClickhouseElementViewSet, basename="element")
         router.register(r"cohort", LegacyClickhouseCohortViewSet, basename="cohort")
-        # nested endpoints
+        # Nested endpoints CH
         projects_router.register(r"actions", ClickhouseActionsViewSet, "project_actions", ["team_id"])
         projects_router.register(r"events", ClickhouseEventsViewSet, "project_events", ["team_id"])
         projects_router.register(r"insights", ClickhouseInsightsViewSet, "project_insights", ["team_id"])
@@ -134,7 +133,7 @@ if is_clickhouse_enabled():
             r"session_recordings", ClickhouseSessionRecordingViewSet, "project_session_recordings", ["team_id"],
         )
 else:
-    # legacy endpoints (to be removed eventually)
+    # Legacy endpoints PG (to be removed eventually)
     router.register(r"insight", insight.LegacyInsightViewSet)
     router.register(r"action", action.LegacyActionViewSet)
     router.register(r"person", person.LegacyPersonViewSet)
@@ -142,7 +141,7 @@ else:
     router.register(r"paths", paths.LegacyPathsViewSet, basename="paths")
     router.register(r"element", element.LegacyElementViewSet)
     router.register(r"cohort", cohort.LegacyCohortViewSet)
-    # nested endpoints
+    # Nested endpoints PG
     projects_router.register(r"insights", insight.LegacyInsightViewSet, "project_insights", ["team_id"])
     projects_router.register(r"actions", action.ActionViewSet, "project_actions", ["team_id"])
     projects_router.register(r"persons", person.LegacyPersonViewSet, "project_persons", ["team_id"])

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -51,8 +51,6 @@ class AnnotationSerializer(serializers.ModelSerializer):
 
 
 class AnnotationsViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = Annotation.objects.all()
     serializer_class = AnnotationSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
@@ -106,3 +104,7 @@ def annotation_created(sender, instance, created, raw, using, **kwargs):
         posthoganalytics.capture(
             instance.created_by.distinct_id, event_name, instance.get_analytics_metadata(),
         )
+
+
+class LegacyAnnotationsViewSet(AnnotationsViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -166,8 +166,6 @@ class CohortSerializer(serializers.ModelSerializer):
 
 
 class CohortViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = Cohort.objects.all()
     serializer_class = CohortSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
@@ -179,3 +177,7 @@ class CohortViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         queryset = queryset.annotate(count=Count("people"))
         return queryset.select_related("created_by").order_by("id")
+
+
+class LegacyCohortViewSet(CohortViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -119,8 +119,6 @@ class DashboardSerializer(serializers.ModelSerializer):
 
 
 class DashboardsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = Dashboard.objects.all()
     serializer_class = DashboardSerializer
     authentication_classes = [
@@ -160,9 +158,13 @@ class DashboardsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         return response.Response(serializer.data)
 
     def get_parents_query_dict(self) -> Dict[str, Any]:  # to be moved to a separate Legacy*ViewSet Class
-        if not self.request.user.is_authenticated or "share_token" in self.request.GET or not self.request.user.team:
+        if not self.request.user.is_authenticated or "share_token" in self.request.GET or not self.team_id:
             return {}
-        return {"team_id": self.request.user.team.id}
+        return {"team_id": self.team_id}
+
+
+class LegacyDashboardsViewSet(DashboardsViewSet):
+    legacy_team_compatibility = True
 
 
 class DashboardItemSerializer(serializers.ModelSerializer):
@@ -249,8 +251,6 @@ class DashboardItemSerializer(serializers.ModelSerializer):
 
 
 class DashboardItemsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = DashboardItem.objects.all()
     serializer_class = DashboardItemSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
@@ -316,3 +316,7 @@ def shared_dashboard(request: HttpRequest, share_token: str):
     return render_template(
         "shared_dashboard.html", request=request, context={"dashboard": dashboard, "team_name": dashboard.team.name},
     )
+
+
+class LegacyDashboardItemsViewSet(DashboardItemsViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -30,7 +30,6 @@ class ElementSerializer(serializers.ModelSerializer):
 
 
 class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
     filter_rewrite_rules = {"team_id": "group__team_id"}
 
     queryset = Element.objects.all()
@@ -120,3 +119,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
 
         return response.Response([{"name": value.value} for value in values])
+
+
+class LegacyElementViewSet(ElementViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -91,8 +91,6 @@ class EventSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (csvrenderers.PaginatedCSVRenderer,)
     queryset = Event.objects.all()
     serializer_class = EventSerializer
@@ -334,3 +332,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
             )
 
         return response.Response({"result": session_recording})
+
+
+class LegacyEventViewSet(EventViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -109,8 +109,6 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = FeatureFlag.objects.all()
     serializer_class = FeatureFlagSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
@@ -246,3 +244,7 @@ class FeatureFlagOverrideViewset(StructuredViewSetMixin, AnalyticsDestroyModelMi
             serializer.is_valid(raise_exception=True)
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class LegacyFeatureFlagViewSet(FeatureFlagViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -129,8 +129,6 @@ class InsightSerializer(InsightBasicSerializer):
 
 
 class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = DashboardItem.objects.all()
     serializer_class = InsightSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
@@ -330,3 +328,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         dashboard_id = request.GET.get(FROM_DASHBOARD, None)
         if dashboard_id:
             DashboardItem.objects.filter(pk=dashboard_id).update(last_refresh=now())
+
+
+class LegacyInsightViewSet(InsightViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/paths.py
+++ b/posthog/api/paths.py
@@ -13,8 +13,6 @@ from posthog.utils import dict_from_cursor_fetchall, request_to_date_query
 
 
 class PathsViewSet(StructuredViewSetMixin, viewsets.ViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
 
     @action(methods=["GET"], detail=False)
@@ -55,3 +53,7 @@ class PathsViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             filter=filter, start_point=start_point, date_query=date_query, request_type=request_type, team=team,
         )
         return resp
+
+
+class LegacyPathsViewSet(PathsViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -79,7 +79,6 @@ class PersonFilter(filters.FilterSet):
 
 
 class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (csvrenderers.PaginatedCSVRenderer,)
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
@@ -258,3 +257,7 @@ def paginated_result(
     entites: Union[List[Dict[str, Any]], ReturnDict], request: request.Request, offset: int = 0,
 ) -> Optional[str]:
     return format_next_url(request, offset, 100) if len(entites) > 99 else None
+
+
+class LegacyPersonViewSet(PersonViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -291,8 +291,6 @@ class PluginConfigSerializer(serializers.ModelSerializer):
 
 
 class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True  # to be moved to a separate Legacy*ViewSet Class
-
     queryset = PluginConfig.objects.all()
     serializer_class = PluginConfigSerializer
     permission_classes = [
@@ -362,3 +360,7 @@ def _get_secret_fields_for_plugin(plugin: Plugin) -> Set[str]:
     # A set of keys for config fields that have secret = true
     secret_fields = set([field["key"] for field in plugin.config_schema if "secret" in field and field["secret"]])
     return secret_fields
+
+
+class LegacyPluginConfigViewSet(PluginConfigViewSet):
+    legacy_team_compatibility = True

--- a/posthog/api/sessions_filter.py
+++ b/posthog/api/sessions_filter.py
@@ -32,8 +32,10 @@ class SessionsFilterSerializer(serializers.ModelSerializer):
 
 
 class SessionsFilterViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
-    legacy_team_compatibility = True
-
     queryset = SessionsFilter.objects.all().order_by("name")
     serializer_class = SessionsFilterSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
+
+
+class LegacySessionsFilterViewSet(SessionsFilterViewSet):
+    legacy_team_compatibility = True


### PR DESCRIPTION
## Changes

One step closer towards #5363.
From this PR the following endpoints are deprecated and due for removal:
- `/api/action/` (→ `/api/projects/:team_id/actions/`)
- `/api/event/` (→ `/api/projects/:team_id/events/`)
- `/api/insight/` (→ `/api/projects/:team_id/insights/`)
- `/api/person/` (→ `/api/projects/:team_id/persons/`)
- `/api/paths/` (→ `/api/projects/:team_id/paths/`)
- `/api/element/` (→ `/api/projects/:team_id/elements/`)
- `/api/cohort/` (→ `/api/projects/:team_id/cohorts/`)
- `/api/annotation/` (→ `/api/projects/:team_id/annotations/`)
- `/api/feature_flag/` (→ `/api/projects/:team_id/feature_flags/`)
- `/api/dashboard/` (→ `/api/projects/:team_id/dashboards/`)
- `/api/dashboard_item/` (→ `/api/projects/:team_id/dashboard_items/`)
- `/api/plugin_config/` (→ `/api/projects/:team_id/plugin_configs/`)
- `/api/sessions_filter/` (→ `/api/projects/:team_id/sessions_filters/`)

No changes besides the addition of the enhanced endpoints though – legacy endpoints are still in use everywhere.

## How did you test this code?

If all Django tests pass, this means that nothing existing was broken. As I move features to new endpoints frontend-wise in followup PRs, Django tests will be updated accordingly.
Also just tested the app manually.
