### PR TITLE
paths viz: add extra handling if prop changes

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react'
+import React, { CSSProperties, useEffect } from 'react'
 import { useValues, BindLogic, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 import 'scenes/actions/Actions.scss'
@@ -9,6 +9,7 @@ import { PlusCircleOutlined } from '@ant-design/icons'
 import { FilterButton } from './components/PropertyFilterButton'
 import { CloseButton } from '../CloseButton'
 import { TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
+import { objectsEqual } from 'lib/utils'
 
 interface PropertyFiltersProps {
     endpoint?: string | null
@@ -28,7 +29,13 @@ export function PathItemFilters({
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, urlOverride: 'exclude_events' }
     const { filters } = useValues(propertyFilterLogic(logicProps))
-    const { setFilter, remove } = useActions(propertyFilterLogic(logicProps))
+    const { setFilter, remove, setFilters } = useActions(propertyFilterLogic(logicProps))
+
+    useEffect(() => {
+        if (propertyFilters && !objectsEqual(propertyFilters, filters)) {
+            setFilters([...propertyFilters, {}])
+        }
+    }, [propertyFilters])
 
     return (
         <div className="mb" style={style}>


### PR DESCRIPTION
## Changes

*Please describe.*  
- exclusion filters that were added from the path item dropdown weren't being added to the UI
- this happened because the logic is initialized with the props but any later changes to the component passed propertyfilters weren't updating the logic
- i don't think this is the best pattern but it exists throughout the app still and entirely sure the best practice with kea here 
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*
manual QA of UI