### PR TITLE
paths: remove funnel limit when querying path funnels

### DIFF
--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -21,6 +21,7 @@ class ClickhouseFunnelBase(ABC, Funnel):
     _team: Team
     _include_timestamp: Optional[bool]
     _include_preceding_timestamp: Optional[bool]
+    _no_person_limit: Optional[bool]  # used when paths are querying for filter people
 
     def __init__(
         self,
@@ -28,6 +29,7 @@ class ClickhouseFunnelBase(ABC, Funnel):
         team: Team,
         include_timestamp: Optional[bool] = None,
         include_preceding_timestamp: Optional[bool] = None,
+        no_person_limit: Optional[bool] = False,
     ) -> None:
         self._filter = filter
         self._team = team
@@ -53,6 +55,8 @@ class ClickhouseFunnelBase(ABC, Funnel):
             self.params.update(new_limit)
 
         self._update_filters()
+
+        self._no_person_limit = no_person_limit
 
     def run(self, *args, **kwargs):
         if len(self._filter.entities) == 0:

--- a/ee/clickhouse/queries/funnels/funnel_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_persons.py
@@ -1,17 +1,36 @@
-from typing import cast
+from typing import Optional, cast
 
 from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
 from ee.clickhouse.sql.funnels.funnel import FUNNEL_PERSONS_BY_STEP_SQL
 from posthog.models import Person
+from posthog.models.filters.filter import Filter
+from posthog.models.team import Team
 
 
 class ClickhouseFunnelPersons(ClickhouseFunnel):
+
+    _no_limit: Optional[bool]  # used when paths are querying for filter people
+
+    def __init__(
+        self,
+        filter: Filter,
+        team: Team,
+        include_timestamp: Optional[bool] = None,
+        include_preceding_timestamp: Optional[bool] = None,
+        no_limit: Optional[bool] = False,
+    ) -> None:
+        self._no_limit = no_limit
+        super().__init__(
+            filter, team, include_timestamp=include_timestamp, include_preceding_timestamp=include_preceding_timestamp
+        )
+
     def get_query(self):
         return FUNNEL_PERSONS_BY_STEP_SQL.format(
             offset=self._filter.offset,
             steps_per_person_query=self.get_step_counts_query(),
             persons_steps=self._get_funnel_person_step_condition(),
             extra_fields=self._get_timestamp_outer_select(),
+            limit="" if self._no_limit else "LIMIT %(limit)s",
         )
 
     def _format_results(self, results):

--- a/ee/clickhouse/queries/funnels/funnel_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_persons.py
@@ -14,7 +14,7 @@ class ClickhouseFunnelPersons(ClickhouseFunnel):
             steps_per_person_query=self.get_step_counts_query(),
             persons_steps=self._get_funnel_person_step_condition(),
             extra_fields=self._get_timestamp_outer_select(),
-            limit="" if self._no__person_limit else "LIMIT %(limit)s",
+            limit="" if self._no_person_limit else "LIMIT %(limit)s",
         )
 
     def _format_results(self, results):

--- a/ee/clickhouse/queries/funnels/funnel_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_persons.py
@@ -8,29 +8,13 @@ from posthog.models.team import Team
 
 
 class ClickhouseFunnelPersons(ClickhouseFunnel):
-
-    _no_limit: Optional[bool]  # used when paths are querying for filter people
-
-    def __init__(
-        self,
-        filter: Filter,
-        team: Team,
-        include_timestamp: Optional[bool] = None,
-        include_preceding_timestamp: Optional[bool] = None,
-        no_limit: Optional[bool] = False,
-    ) -> None:
-        self._no_limit = no_limit
-        super().__init__(
-            filter, team, include_timestamp=include_timestamp, include_preceding_timestamp=include_preceding_timestamp
-        )
-
     def get_query(self):
         return FUNNEL_PERSONS_BY_STEP_SQL.format(
             offset=self._filter.offset,
             steps_per_person_query=self.get_step_counts_query(),
             persons_steps=self._get_funnel_person_step_condition(),
             extra_fields=self._get_timestamp_outer_select(),
-            limit="" if self._no_limit else "LIMIT %(limit)s",
+            limit="" if self._no__person_limit else "LIMIT %(limit)s",
         )
 
     def _format_results(self, results):

--- a/ee/clickhouse/queries/funnels/funnel_strict_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_strict_persons.py
@@ -12,6 +12,7 @@ class ClickhouseFunnelStrictPersons(ClickhouseFunnelStrict):
             steps_per_person_query=self.get_step_counts_query(),
             persons_steps=self._get_funnel_person_step_condition(),
             extra_fields=self._get_timestamp_outer_select(),
+            limit="" if self._no_person_limit else "LIMIT %(limit)s",
         )
 
     def _format_results(self, results):

--- a/ee/clickhouse/queries/funnels/funnel_trends_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends_persons.py
@@ -34,6 +34,7 @@ class ClickhouseFunnelTrendsPersons(ClickhouseFunnelTrends):
             steps_per_person_query=step_counts_query,
             persons_steps=did_not_reach_to_step_count_condition if drop_off else reached_to_step_count_condition,
             extra_fields="",
+            limit="" if self._no_person_limit else "LIMIT %(limit)s",
         )
 
     def _summarize_data(self, results):

--- a/ee/clickhouse/queries/funnels/funnel_unordered_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_unordered_persons.py
@@ -12,6 +12,7 @@ class ClickhouseFunnelUnorderedPersons(ClickhouseFunnelUnordered):
             steps_per_person_query=self.get_step_counts_query(),
             persons_steps=self._get_funnel_person_step_condition(),
             extra_fields=self._get_timestamp_outer_select(),
+            limit="" if self._no_person_limit else "LIMIT %(limit)s",
         )
 
     def _format_results(self, results):

--- a/ee/clickhouse/queries/paths/paths.py
+++ b/ee/clickhouse/queries/paths/paths.py
@@ -146,6 +146,7 @@ class ClickhousePaths:
             self._team,
             include_timestamp=bool(self._filter.funnel_paths),
             include_preceding_timestamp=self._filter.funnel_paths == FUNNEL_PATH_BETWEEN_STEPS,
+            no_limit=True,
         )
         funnel_persons_query = funnel_persons_generator.get_query()
         funnel_persons_query_new_params = funnel_persons_query.replace("%(", "%(funnel_")

--- a/ee/clickhouse/queries/paths/paths.py
+++ b/ee/clickhouse/queries/paths/paths.py
@@ -146,7 +146,7 @@ class ClickhousePaths:
             self._team,
             include_timestamp=bool(self._filter.funnel_paths),
             include_preceding_timestamp=self._filter.funnel_paths == FUNNEL_PATH_BETWEEN_STEPS,
-            no_limit=True,
+            no_person_limit=True,
         )
         funnel_persons_query = funnel_persons_generator.get_query()
         funnel_persons_query_new_params = funnel_persons_query.replace("%(", "%(funnel_")

--- a/ee/clickhouse/sql/funnels/funnel.py
+++ b/ee/clickhouse/sql/funnels/funnel.py
@@ -5,7 +5,7 @@ FROM (
 )
 WHERE {persons_steps}
 ORDER BY person_id
-LIMIT %(limit)s
+{limit}
 OFFSET {offset}
 SETTINGS allow_experimental_window_functions = 1
 """


### PR DESCRIPTION
## Changes

*Please describe.*  
- the funnel person query CTE in paths query still has a limit on them so right now the # of persons that are included in paths are capped at 100
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*
Added a query test