### PR TITLE
Recordings watched & analyzed instrumentation

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -56,12 +56,12 @@ export enum RecordingWatchedSource {
     SessionsListPlayAll = 'sessions_list_play_all', // DEPRECATED play all button on sessions list
 }
 
-interface RecordingWatchedProps {
+interface RecordingViewedProps {
     delay: number // Not reported: Number of delayed **seconds** to report event (useful to measure insights where users don't navigate immediately away)
     load_time: number // How much time it took to load the session (backend) (milliseconds)
     duration: number // How long is the total recording (milliseconds)
     start_time?: string // Start time of the session
-    events_length: number
+    page_change_events_length: number
     recording_width?: number
     user_is_identified?: boolean
     source: RecordingWatchedSource
@@ -133,7 +133,7 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
     }
 }
 
-export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource, RecordingWatchedProps>>({
+export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource, RecordingViewedProps>>({
     connect: [preflightLogic],
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
@@ -249,7 +249,7 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource, Rec
         reportInsightsControlsCollapseToggle: (collapsed: boolean) => ({ collapsed }),
         reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
         reportInsightShortUrlVisited: (valid: boolean, insight: InsightType | null) => ({ valid, insight }),
-        reportRecordingWatched: (payload: RecordingWatchedProps) => ({ payload }),
+        reportRecordingViewed: (payload: RecordingViewedProps) => ({ payload }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -591,9 +591,9 @@ export const eventUsageLogic = kea<eventUsageLogicType<DashboardEventSource, Rec
         reportInsightShortUrlVisited: (props) => {
             posthog.capture('insight short url visited', props)
         },
-        reportRecordingWatched: ({ payload }) => {
+        reportRecordingViewed: ({ payload }) => {
             const { delay, ...props } = payload
-            posthog.capture(`recording ${delay ? 'analyzed' : 'watched'}`, props)
+            posthog.capture(`recording ${delay ? 'analyzed' : 'viewed'}`, props)
         },
     },
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -48,6 +48,14 @@ export enum InsightEventSource {
     AddDescription = 'add_insight_description',
 }
 
+export enum RecordingWatchedSource {
+    Direct = 'direct', // Visiting the URL directly
+    Unknown = 'unknown',
+    RecordingsList = 'recordings_list', // New recordings list page
+    SessionsList = 'sessions_list', // DEPRECATED sessions list page
+    SessionsListPlayAll = 'sessions_list_play_all', // DEPRECATED play all button on sessions list
+}
+
 interface RecordingWatchedProps {
     delay: number // Not reported: Number of delayed **seconds** to report event (useful to measure insights where users don't navigate immediately away)
     load_time: number // How much time it took to load the session (backend) (milliseconds)
@@ -56,6 +64,7 @@ interface RecordingWatchedProps {
     events_length: number
     recording_width?: number
     user_is_identified?: boolean
+    source: RecordingWatchedSource
 }
 
 function flattenProperties(properties: PropertyFilter[]): string[] {

--- a/frontend/src/scenes/sessionRecordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/sessionRecordings/SessionRecordingsTable.tsx
@@ -8,6 +8,7 @@ import { sessionRecordingsTableLogic } from './sessionRecordingsTableLogic'
 import { PlayCircleOutlined } from '@ant-design/icons'
 import { useIsTableScrolling } from 'lib/components/Table/utils'
 import { SessionPlayerDrawer } from './SessionPlayerDrawer'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 
 interface SessionRecordingsTableProps {
     distinctId?: string
@@ -80,7 +81,7 @@ export function SessionRecordingsTable({ distinctId, isPersonPage = false }: Ses
                     pagination={{ pageSize: 99999, hideOnSinglePage: true }}
                     onRow={(sessionRecording) => ({
                         onClick: () => {
-                            openSessionPlayer(sessionRecording.id)
+                            openSessionPlayer(sessionRecording.id, RecordingWatchedSource.RecordingsList)
                         },
                     })}
                     size="small"

--- a/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.test.tsx
+++ b/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.test.tsx
@@ -4,6 +4,7 @@ import { BuiltLogic } from 'kea'
 import { mockAPI } from 'lib/api.mock'
 import { expectLogic, initKeaTestLogic } from '~/test/kea-test-utils'
 import { router } from 'kea-router'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 
 jest.mock('lib/api')
 
@@ -46,8 +47,11 @@ describe('sessionRecordingsTableLogic', () => {
                 expectLogic(logic).toMatchValues({ sessionRecordingId: null })
             })
             it('is set by openSessionPlayer and cleared by closeSessionPlayer', async () => {
-                expectLogic(logic, () => logic.actions.openSessionPlayer('abc')).toMatchValues({
+                expectLogic(logic, () =>
+                    logic.actions.openSessionPlayer('abc', RecordingWatchedSource.Direct)
+                ).toMatchValues({
                     sessionRecordingId: 'abc',
+                    source: RecordingWatchedSource.Direct,
                 })
                 expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
 

--- a/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.test.tsx
+++ b/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.test.tsx
@@ -48,10 +48,9 @@ describe('sessionRecordingsTableLogic', () => {
             })
             it('is set by openSessionPlayer and cleared by closeSessionPlayer', async () => {
                 expectLogic(logic, () =>
-                    logic.actions.openSessionPlayer('abc', RecordingWatchedSource.Direct)
+                    logic.actions.openSessionPlayer('abc', RecordingWatchedSource.RecordingsList)
                 ).toMatchValues({
                     sessionRecordingId: 'abc',
-                    source: RecordingWatchedSource.Direct,
                 })
                 expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
 

--- a/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.ts
@@ -4,11 +4,13 @@ import { toParams } from 'lib/utils'
 import { SessionRecordingType } from '~/types'
 import { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
 import { router } from 'kea-router'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 
 type SessionRecordingId = string
 interface Params {
     properties?: any
     sessionRecordingId?: SessionRecordingId
+    source?: RecordingWatchedSource
 }
 
 export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<SessionRecordingId>>({
@@ -18,7 +20,10 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<S
     },
     actions: {
         getSessionRecordings: true,
-        openSessionPlayer: (sessionRecordingId: SessionRecordingId | null) => ({ sessionRecordingId }),
+        openSessionPlayer: (sessionRecordingId: SessionRecordingId | null, source: RecordingWatchedSource) => ({
+            sessionRecordingId,
+            source,
+        }),
         closeSessionPlayer: true,
     },
     loaders: ({ props }) => ({
@@ -74,7 +79,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<S
 
         return {
             loadSessionRecordings: () => buildURL({}, true),
-            openSessionPlayer: () => buildURL(),
+            openSessionPlayer: ({ source }) => buildURL({ source }),
             closeSessionPlayer: () => buildURL({ sessionRecordingId: undefined }),
         }
     },
@@ -83,7 +88,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<S
         const urlToAction = (_: any, params: Params): void => {
             const nulledSessionRecordingId = params.sessionRecordingId ?? null
             if (nulledSessionRecordingId !== values.sessionRecordingId) {
-                actions.openSessionPlayer(nulledSessionRecordingId)
+                actions.openSessionPlayer(nulledSessionRecordingId, RecordingWatchedSource.Direct)
             }
         }
 

--- a/frontend/src/scenes/sessions/SessionRecordingsButton.tsx
+++ b/frontend/src/scenes/sessions/SessionRecordingsButton.tsx
@@ -8,16 +8,18 @@ import { Button } from 'antd'
 import { Popup } from '../../lib/components/Popup/Popup'
 import clsx from 'clsx'
 import { Tooltip } from '../../lib/components/Tooltip'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 
 interface SessionRecordingsButtonProps {
     sessionRecordings: SessionRecordingType[]
+    source: RecordingWatchedSource
 }
 
-export const sessionPlayerUrl = (sessionRecordingId: string): string => {
-    return `${location.pathname}?${toParams({ ...fromParams(), sessionRecordingId })}`
+export const sessionPlayerUrl = (sessionRecordingId: string, source: RecordingWatchedSource): string => {
+    return `${location.pathname}?${toParams({ ...fromParams(), sessionRecordingId, source })}`
 }
 
-export function SessionRecordingsButton({ sessionRecordings }: SessionRecordingsButtonProps): JSX.Element {
+export function SessionRecordingsButton({ sessionRecordings, source }: SessionRecordingsButtonProps): JSX.Element {
     const [areRecordingsShown, setAreRecordingsShown] = useState(false)
 
     const wereAllRecordingsViewed = !sessionRecordings.some(({ viewed }) => !viewed)
@@ -33,7 +35,7 @@ export function SessionRecordingsButton({ sessionRecordings }: SessionRecordings
                 return isSingleRecording ? (
                     <div className="session-recordings-button__wrapper" ref={setRef}>
                         <Link
-                            to={sessionPlayerUrl(sessionRecordings[0].id)}
+                            to={sessionPlayerUrl(sessionRecordings[0].id, source)}
                             onClick={(event) => {
                                 event.stopPropagation()
                                 setAreRecordingsShown(false)
@@ -69,7 +71,7 @@ export function SessionRecordingsButton({ sessionRecordings }: SessionRecordings
             overlay={sessionRecordings.map(({ id, viewed, recording_duration, start_time }, index) => (
                 <Link
                     key={id}
-                    to={sessionPlayerUrl(id)}
+                    to={sessionPlayerUrl(id, source)}
                     className={clsx(
                         'session-recordings-popup__link',
                         viewed && 'session-recordings-popup__link--viewed'

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -32,6 +32,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from '../sceneLogic'
 import { SessionPlayerDrawer } from 'scenes/sessionRecordings/SessionPlayerDrawer'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -152,7 +153,10 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
             ),
             render: function RenderEndPoint(session: SessionType) {
                 return session.session_recordings.length ? (
-                    <SessionRecordingsButton sessionRecordings={session.session_recordings} />
+                    <SessionRecordingsButton
+                        sessionRecordings={session.session_recordings}
+                        source={RecordingWatchedSource.SessionsList}
+                    />
                 ) : null
             },
             span: 4,
@@ -224,7 +228,11 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                         }
                     >
                         <LinkButton
-                            to={firstRecordingId ? sessionPlayerUrl(firstRecordingId) : '#'}
+                            to={
+                                firstRecordingId
+                                    ? sessionPlayerUrl(firstRecordingId, RecordingWatchedSource.SessionsListPlayAll)
+                                    : '#'
+                            }
                             type="primary"
                             data-attr="play-all-recordings"
                             disabled={firstRecordingId === null} // We allow playback of previously recorded sessions even if new recordings are disabled

--- a/frontend/src/scenes/sessions/sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsPlayLogic.ts
@@ -112,15 +112,15 @@ export const sessionsPlayLogic = kea<sessionsPlayLogicType<SessionPlayerData, Se
                 load_time: loadTime,
                 duration: eventIndex.getDuration(),
                 start_time: recordingData?.start_time,
-                events_length: eventIndex.pageChangeEvents().length,
+                page_change_events_length: eventIndex.pageChangeEvents().length,
                 recording_width: eventIndex.getRecordingMetadata(0)[0]?.width,
                 user_is_identified: recordingData.person?.is_identified,
                 source: values.source,
             }
-            eventUsageLogic.actions.reportRecordingWatched({ delay: 0, ...payload })
+            eventUsageLogic.actions.reportRecordingViewed({ delay: 0, ...payload })
             // tests will wait for all breakpoints to finish
             await breakpoint(IS_TEST_MODE ? 1 : 10000)
-            eventUsageLogic.actions.reportRecordingWatched({ delay: 10, ...payload })
+            eventUsageLogic.actions.reportRecordingViewed({ delay: 10, ...payload })
         },
     }),
     loaders: ({ values, actions }) => ({

--- a/frontend/src/scenes/sessions/sessionsTableLogic.ts
+++ b/frontend/src/scenes/sessions/sessionsTableLogic.ts
@@ -9,6 +9,7 @@ import { router } from 'kea-router'
 import { sessionsFiltersLogic } from 'scenes/sessions/filters/sessionsFiltersLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 
 type SessionRecordingId = string
 
@@ -22,6 +23,7 @@ interface Params {
     properties?: any
     sessionRecordingId?: SessionRecordingId
     filters?: Array<SessionsPropertyFilter>
+    source?: RecordingWatchedSource
 }
 
 export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>>({
@@ -65,7 +67,10 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
             properties,
             selectedDate,
         }),
-        setSessionRecordingId: (sessionRecordingId: SessionRecordingId | null) => ({ sessionRecordingId }),
+        setSessionRecordingId: (sessionRecordingId: SessionRecordingId | null, source?: RecordingWatchedSource) => ({
+            sessionRecordingId,
+            source,
+        }),
         closeSessionPlayer: true,
         loadSessionEvents: (session: SessionType) => ({ session }),
         addSessionEvents: (session: SessionType, events: EventType[]) => ({ session, events }),
@@ -274,7 +279,7 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
         return {
             setFilters: () => buildURL({}, true),
             loadSessions: () => buildURL({}, true),
-            setSessionRecordingId: () => buildURL(),
+            setSessionRecordingId: ({ source }) => buildURL({ source }),
             closeSessionPlayer: () => buildURL({ sessionRecordingId: undefined }),
         }
     },
@@ -293,7 +298,10 @@ export const sessionsTableLogic = kea<sessionsTableLogicType<SessionRecordingId>
             }
 
             if (params.sessionRecordingId !== values.sessionRecordingId) {
-                actions.setSessionRecordingId(params.sessionRecordingId ?? null)
+                actions.setSessionRecordingId(
+                    params.sessionRecordingId ?? null,
+                    params.source || RecordingWatchedSource.Direct
+                )
             }
 
             if (JSON.stringify(params.filters || {}) !== JSON.stringify(values.filters)) {


### PR DESCRIPTION
## Changes

- Captures `recording watched` & `recording analyzed` (after 10 seconds) events to gather usage data on recordings.
- Sends useful metadata such as time to load, recording duration, number of events, end-user's device resolution and where user came from.

## How did you test this code?

- Tested opening recordings and seeing the event being logged on the console via posthog-js.
- Tested navigating away before 10 seconds to make sure recording analyzed isn't sent if user navigates away.
- Tested navigating away before the recording loads initially to make sure recording watched event isn't sent.
- Tested with multiple recordings to make sure metadata events matches.
- Tested with and without `6050-remove-sessions` feature flag to make sure event is fired every time.
