### PR TITLE
Simplify test accounts

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -23,7 +23,6 @@ def parse_prop_clauses(
     prepend: str = "global",
     table_name: str = "",
     allow_denormalized_props: bool = True,
-    filter_test_accounts=False,
     is_person_query=False,
     person_properties_column: Optional[str] = None,
 ) -> Tuple[str, Dict]:
@@ -33,10 +32,6 @@ def parse_prop_clauses(
         params["team_id"] = team_id
     if table_name != "":
         table_name += "."
-
-    if filter_test_accounts:
-        test_account_filters = Team.objects.only("test_account_filters").get(id=team_id).test_account_filters
-        filters.extend([Property(**prop) for prop in test_account_filters])
 
     for idx, prop in enumerate(filters):
         if prop.type == "cohort":

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -18,9 +18,7 @@ from posthog.models.team import Team
 def _filter_events(
     filter: Filter, team: Team, person_query: Optional[bool] = False, order_by: Optional[str] = None,
 ):
-    prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
-    )
+    prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
     params = {"team_id": team.pk, **prop_filter_params}
 
     if order_by == "id":

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -34,7 +34,6 @@ def get_breakdown_prop_values(
         team_id,
         table_name="e",
         prepend="e_brkdwn",
-        filter_test_accounts=filter.filter_test_accounts,
         person_properties_column="person_props",
         allow_denormalized_props=True,
     )

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -105,9 +105,7 @@ class ClickhouseRetention(Retention):
         period = filter.period
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
-        )
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
 
         returning_entity = filter.returning_entity if filter.selected_interval > 0 else filter.target_entity
         target_query, target_params = self._get_condition(filter.target_entity, table="e")

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -90,7 +90,7 @@ def _format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
 
 def _process_content_sql(target_entity: Entity, filter: StickinessFilter, team: Team) -> Tuple[str, Dict[str, Any]]:
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team.pk)
-    prop_filters, prop_filter_params = parse_prop_clauses(filter.properties + target_entity.properties)
+    prop_filters, prop_filter_params = parse_prop_clauses(filter.properties + target_entity.properties, team.pk)
     entity_sql, entity_params = _format_entity_filter(entity=target_entity)
     trunc_func = get_trunc_func_ch(filter.interval)
 

--- a/ee/clickhouse/queries/clickhouse_stickiness.py
+++ b/ee/clickhouse/queries/clickhouse_stickiness.py
@@ -35,9 +35,7 @@ class ClickhouseStickiness(Stickiness):
     def stickiness(self, entity: Entity, filter: StickinessFilter, team_id: int) -> Dict[str, Any]:
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team_id)
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            filter.properties + entity.properties, team_id, filter_test_accounts=filter.filter_test_accounts,
-        )
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties + entity.properties, team_id)
         trunc_func = get_trunc_func_ch(filter.interval)
 
         params: Dict = {"team_id": team_id}
@@ -92,9 +90,7 @@ def _format_entity_filter(entity: Entity) -> Tuple[str, Dict]:
 
 def _process_content_sql(target_entity: Entity, filter: StickinessFilter, team: Team) -> Tuple[str, Dict[str, Any]]:
     parsed_date_from, parsed_date_to, _ = parse_timestamps(filter=filter, team_id=team.pk)
-    prop_filters, prop_filter_params = parse_prop_clauses(
-        filter.properties + target_entity.properties, team.pk, filter_test_accounts=filter.filter_test_accounts,
-    )
+    prop_filters, prop_filter_params = parse_prop_clauses(filter.properties + target_entity.properties)
     entity_sql, entity_params = _format_entity_filter(entity=target_entity)
     trunc_func = get_trunc_func_ch(filter.interval)
 

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -66,12 +66,6 @@ class ColumnOptimizer:
         if has_element_type_property(self.filter.properties):
             return True
 
-        if self.filter.filter_test_accounts:
-            test_account_filters = Team.objects.only("test_account_filters").get(id=self.team_id).test_account_filters
-            properties = [Property(**prop) for prop in test_account_filters]
-            if has_element_type_property(properties):
-                return True
-
         # Both entities and funnel exclusions can contain nested elements_chain inclusions
         for entity in self.filter.entities + cast(List[Entity], self.filter.exclusions):
             if has_element_type_property(entity.properties):
@@ -92,9 +86,6 @@ class ColumnOptimizer:
         result: Set[Tuple[PropertyName, PropertyType]] = set()
 
         result |= extract_tables_and_properties(self.filter.properties)
-        if self.filter.filter_test_accounts:
-            test_account_filters = Team.objects.only("test_account_filters").get(id=self.team_id).test_account_filters
-            result |= extract_tables_and_properties([Property(**prop) for prop in test_account_filters])
 
         # Some breakdown types read properties
         #

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -101,14 +101,6 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
             self._should_join_persons = True
             return
 
-        if self._filter.filter_test_accounts:
-            test_account_filters = Team.objects.only("test_account_filters").get(id=self._team_id).test_account_filters
-            test_filter_props = [Property(**prop) for prop in test_account_filters]
-            if any(self._should_property_join_persons(prop) for prop in test_filter_props):
-                self._should_join_distinct_ids = True
-                self._should_join_persons = True
-                return
-
     def _should_property_join_persons(self, prop: Property) -> bool:
         if prop.type == "person":
             return True
@@ -152,17 +144,10 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         return query, date_params
 
     def _get_props(self, filters: List[Property]) -> Tuple[str, Dict]:
-
-        filter_test_accounts = self._filter.filter_test_accounts
-        team_id = self._team_id
         prepend = "global"
 
         final = []
         params: Dict[str, Any] = {}
-
-        if filter_test_accounts:
-            test_account_filters = Team.objects.only("test_account_filters").get(id=team_id).test_account_filters
-            filters += [Property(**prop) for prop in test_account_filters]
 
         for idx, prop in enumerate(filters):
             if prop.type == "cohort":

--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -26,9 +26,7 @@ class ClickhouseSessionsAvg:
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
-        filters, params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
-        )
+        filters, params = parse_prop_clauses(filter.properties, team.pk)
 
         trunc_func = get_trunc_func_ch(filter.interval)
         interval_func = get_interval_func_ch(filter.interval)

--- a/ee/clickhouse/queries/sessions/clickhouse_sessions.py
+++ b/ee/clickhouse/queries/sessions/clickhouse_sessions.py
@@ -27,7 +27,7 @@ def set_default_dates(filter: SessionsFilter) -> SessionsFilter:
             data.update({"date_from": relative_date_parse("-7d")})
         if not filter._date_to:
             data.update({"date_to": timezone.now()})
-    return SessionsFilter(data={**filter._data, **data, "user_id": filter.user_id})
+    return filter.with_data({**data, "user_id": filter.user_id})
 
 
 class ClickhouseSessions(BaseQuery, ClickhouseSessionsAvg, ClickhouseSessionsDist):

--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -12,9 +12,7 @@ class ClickhouseSessionsDist:
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
-        filters, params = parse_prop_clauses(
-            filter.properties, team.pk, filter_test_accounts=filter.filter_test_accounts
-        )
+        filters, params = parse_prop_clauses(filter.properties, team.pk)
 
         entity_conditions, entity_params = entity_query_conditions(filter, team)
         if not entity_conditions:

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -13,7 +13,6 @@ PROPERTIES_OF_ALL_TYPES = [
 ]
 
 BASE_FILTER = Filter({"events": [{"id": "$pageview", "type": "events", "order": 0}]})
-FILTER_BY_TEST_ACCOUNTS = BASE_FILTER.with_data({"filter_test_accounts": True})
 FILTER_WITH_PROPERTIES = BASE_FILTER.with_data({"properties": PROPERTIES_OF_ALL_TYPES})
 
 
@@ -27,10 +26,6 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         properties_used_in_filter = lambda filter: ColumnOptimizer(filter, self.team.id).properties_used_in_filter
 
         self.assertEqual(properties_used_in_filter(BASE_FILTER), set())
-        self.assertEqual(
-            properties_used_in_filter(FILTER_BY_TEST_ACCOUNTS),
-            {("event_prop", "event"), ("person_prop", "person"), ("id", "cohort"), ("tag_name", "element")},
-        )
         self.assertEqual(
             properties_used_in_filter(FILTER_WITH_PROPERTIES),
             {("event_prop", "event"), ("person_prop", "person"), ("id", "cohort"), ("tag_name", "element")},
@@ -134,14 +129,6 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         ).should_query_elements_chain_column
 
         self.assertEqual(should_query_elements_chain_column(BASE_FILTER), False)
-
-        self.assertEqual(should_query_elements_chain_column(FILTER_BY_TEST_ACCOUNTS), True)
-
-        self.team.test_account_filters = PROPERTIES_OF_ALL_TYPES[:2]  # Without the element filter
-        self.team.save()
-
-        self.assertEqual(should_query_elements_chain_column(FILTER_BY_TEST_ACCOUNTS), False)
-
         self.assertEqual(should_query_elements_chain_column(FILTER_WITH_PROPERTIES), True)
 
         filter = Filter(

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -660,7 +660,15 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         )
         result = ClickhouseTrends().run(filter, self.team,)
         self.assertEqual(result[0]["count"], 1)
-        result = ClickhouseTrends().run(filter.with_data({"filter_test_accounts": "false"}), self.team,)
+        filter2 = Filter(
+            {
+                "date_from": "2020-01-01T00:00:00Z",
+                "date_to": "2020-01-12T00:00:00Z",
+                "events": [{"id": "$pageview", "type": "events", "order": 0}],
+            },
+            team=self.team,
+        )
+        result = ClickhouseTrends().run(filter2, self.team,)
         self.assertEqual(result[0]["count"], 2)
         result = ClickhouseTrends().run(filter.with_data({"breakdown": "key"}), self.team,)
         self.assertEqual(result[0]["count"], 1)

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -655,7 +655,8 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
                 "date_to": "2020-01-12T00:00:00Z",
                 "events": [{"id": "$pageview", "type": "events", "order": 0}],
                 "filter_test_accounts": "true",
-            }
+            },
+            team=self.team,
         )
         result = ClickhouseTrends().run(filter, self.team,)
         self.assertEqual(result[0]["count"], 1)

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -47,11 +47,7 @@ class ClickhouseTrendsBreakdown:
 
         props_to_filter = [*self.filter.properties, *self.entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter,
-            self.team_id,
-            table_name="e",
-            filter_test_accounts=self.filter.filter_test_accounts,
-            person_properties_column="person_props",
+            props_to_filter, self.team_id, table_name="e", person_properties_column="person_props",
         )
         aggregate_operation, _, math_params = process_math(self.entity)
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -49,9 +49,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         event_params: Dict[str, Any] = {}
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
-        )
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
 
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
@@ -140,9 +138,7 @@ class ClickhouseLifecycle(LifecycleTrend):
             event_params = {"event": entity.id}
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, team_id, filter_test_accounts=filter.filter_test_accounts
-        )
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
 
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(

--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -42,7 +42,7 @@ class ClickhouseActionsViewSet(ActionViewSet):
     @action(methods=["GET"], detail=False)
     def people(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # type: ignore
         team = self.team
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
         entity = get_target_entity(request)
 
         current_url = request.get_full_path()

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -13,7 +13,7 @@ from posthog.models.filters import Filter
 class ClickhouseElementViewSet(ElementViewSet):
     @action(methods=["GET"], detail=False)
     def stats(self, request: request.Request, **kwargs) -> response.Response:  # type: ignore
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
 
         date_from, date_to, _ = parse_timestamps(filter, team_id=self.team.pk)
 

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -96,7 +96,7 @@ class ClickhouseEventsViewSet(EventViewSet):
             limit = min(limit, self.CSV_EXPORT_MAXIMUM_LIMIT)
 
         team = self.team
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
 
         query_result = self._query_events_list(filter, team, request, limit=limit)
 
@@ -184,7 +184,9 @@ class ClickhouseEventsViewSet(EventViewSet):
             )
 
         session_recording = SessionRecording().run(
-            team=self.team, filter=Filter(request=request), session_recording_id=request.GET["session_recording_id"]
+            team=self.team,
+            filter=Filter(request=request, team=self.team),
+            session_recording_id=request.GET["session_recording_id"],
         )
 
         if request.GET.get("save_view"):

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -153,7 +153,7 @@ class ClickhouseEventsViewSet(EventViewSet):
 
     @action(methods=["GET"], detail=False)
     def sessions(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # type: ignore
-        filter = SessionsFilter(request=request)
+        filter = SessionsFilter(request=request, team=self.team)
 
         sessions, pagination = ClickhouseSessionsList.run(team=self.team, filter=filter)
         return Response({"result": sessions, "pagination": pagination})
@@ -162,7 +162,7 @@ class ClickhouseEventsViewSet(EventViewSet):
     def session_events(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # type: ignore
         from ee.clickhouse.queries.sessions.events import SessionsListEvents
 
-        filter = SessionEventsFilter(request=request)
+        filter = SessionEventsFilter(request=request, team=self.team)
         return Response({"result": SessionsListEvents().run(filter=filter, team=self.team)})
 
     # ******************************************

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -61,7 +61,8 @@ class ClickhouseInsightsViewSet(InsightViewSet):
     def calculate_session(self, request: Request) -> Dict[str, Any]:
         return {
             "result": ClickhouseSessions().run(
-                team=self.team, filter=SessionsFilter(request=request, data={"insight": INSIGHT_SESSIONS})
+                team=self.team,
+                filter=SessionsFilter(request=request, data={"insight": INSIGHT_SESSIONS}, team=self.team),
             )
         }
 

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -43,7 +43,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
     @cached_function
     def calculate_trends(self, request: Request) -> Dict[str, Any]:
         team = self.team
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
 
         if filter.insight == INSIGHT_STICKINESS or filter.shown_as == TRENDS_STICKINESS:
             stickiness_filter = StickinessFilter(
@@ -68,14 +68,14 @@ class ClickhouseInsightsViewSet(InsightViewSet):
     @cached_function
     def calculate_path(self, request: Request) -> Dict[str, Any]:
         team = self.team
-        filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS})
+        filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS}, team=self.team)
 
         funnel_filter = None
         funnel_filter_data = request.GET.get("funnel_filter") or request.data.get("funnel_filter")
         if funnel_filter_data:
             if isinstance(funnel_filter_data, str):
                 funnel_filter_data = json.loads(funnel_filter_data)
-            funnel_filter = Filter(data={"insight": INSIGHT_FUNNELS, **funnel_filter_data})
+            funnel_filter = Filter(data={"insight": INSIGHT_FUNNELS, **funnel_filter_data}, team=self.team)
 
         #  backwards compatibility
         if filter.path_type:
@@ -87,7 +87,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
     @cached_function
     def calculate_funnel(self, request: Request) -> Dict[str, Any]:
         team = self.team
-        filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS})
+        filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS}, team=self.team)
 
         funnel_order_class: Type[ClickhouseFunnelBase] = ClickhouseFunnel
         if filter.funnel_order_type == FunnelOrderType.UNORDERED:
@@ -137,7 +137,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
         data = {}
         if not request.GET.get("date_from"):
             data.update({"date_from": "-11d"})
-        filter = RetentionFilter(data=data, request=request)
+        filter = RetentionFilter(data=data, request=request, team=self.team)
         result = ClickhouseRetention().run(filter, team)
         return {"result": result}
 

--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -55,7 +55,7 @@ class ClickhousePersonViewSet(PersonViewSet):
             return {"result": ([], None, None)}
 
         team = self.team
-        filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS})
+        filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS}, team=self.team)
         funnel_class: Callable = ClickhouseFunnelPersons
 
         if filter.funnel_viz_type == FunnelVizType.TRENDS:
@@ -100,8 +100,13 @@ class ClickhousePersonViewSet(PersonViewSet):
         if request.user.is_anonymous or not self.team:
             return {"result": ([], None, None)}
 
+<<<<<<< HEAD
         team = self.team
         filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS})
+=======
+        team = request.user.team
+        filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS}, team=team)
+>>>>>>> d6577bfc0... Simplify filters ASAP if filter is created
 
         funnel_filter = None
         funnel_filter_data = request.GET.get("funnel_filter") or request.data.get("funnel_filter")

--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -54,14 +54,13 @@ class ClickhousePersonViewSet(PersonViewSet):
         if request.user.is_anonymous or not self.team:
             return {"result": ([], None, None)}
 
-        team = self.team
         filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS}, team=self.team)
         funnel_class: Callable = ClickhouseFunnelPersons
 
         if filter.funnel_viz_type == FunnelVizType.TRENDS:
             funnel_class = ClickhouseFunnelTrendsPersons
 
-        people, should_paginate = funnel_class(filter, team).run()
+        people, should_paginate = funnel_class(filter, self.team).run()
         limit = filter.limit if filter.limit else 100
         next_url = format_offset_absolute_url(request, filter.offset + limit) if should_paginate else None
         initial_url = format_offset_absolute_url(request, 0)
@@ -100,22 +99,16 @@ class ClickhousePersonViewSet(PersonViewSet):
         if request.user.is_anonymous or not self.team:
             return {"result": ([], None, None)}
 
-<<<<<<< HEAD
-        team = self.team
-        filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS})
-=======
-        team = request.user.team
-        filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS}, team=team)
->>>>>>> d6577bfc0... Simplify filters ASAP if filter is created
+        filter = PathFilter(request=request, data={"insight": INSIGHT_PATHS}, team=self.team)
 
         funnel_filter = None
         funnel_filter_data = request.GET.get("funnel_filter") or request.data.get("funnel_filter")
         if funnel_filter_data:
             if isinstance(funnel_filter_data, str):
                 funnel_filter_data = json.loads(funnel_filter_data)
-            funnel_filter = Filter(data={"insight": INSIGHT_FUNNELS, **funnel_filter_data})
+            funnel_filter = Filter(data={"insight": INSIGHT_FUNNELS, **funnel_filter_data}, team=self.team)
 
-        people, should_paginate = ClickhousePathsPersons(filter, team, funnel_filter=funnel_filter).run()
+        people, should_paginate = ClickhousePathsPersons(filter, self.team, funnel_filter=funnel_filter).run()
         limit = filter.limit or 100
         next_url = format_offset_absolute_url(request, filter.offset + limit) if should_paginate else None
         initial_url = format_offset_absolute_url(request, 0)

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -88,7 +88,7 @@ class CohortSerializer(serializers.ModelSerializer):
             self._calculate_static_by_csv(request.FILES["csv"], cohort)
         else:
             try:
-                filter = Filter(request=request)
+                filter = Filter(request=request, team=self.team)
                 team = cast(User, request.user).team
                 target_entity = get_target_entity(request)
                 if filter.shown_as == TRENDS_STICKINESS:

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -88,7 +88,7 @@ class CohortSerializer(serializers.ModelSerializer):
             self._calculate_static_by_csv(request.FILES["csv"], cohort)
         else:
             try:
-                filter = Filter(request=request, team=self.team)
+                filter = Filter(request=request)
                 team = cast(User, request.user).team
                 target_entity = get_target_entity(request)
                 if filter.shown_as == TRENDS_STICKINESS:

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -45,7 +45,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False)
     def stats(self, request: request.Request, **kwargs) -> response.Response:
         team_id = self.team_id
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
 
         events = (
             Event.objects.filter(team_id=team_id, event="$autocapture")
@@ -97,7 +97,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             """
             SELECT
                 value, COUNT(1) as id
-            FROM ( 
+            FROM (
                 SELECT
                     ("posthog_element"."{key}") as "value"
                 FROM

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -323,7 +323,9 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
                 status=400,
             )
         session_recording = SessionRecording().run(
-            team=self.team, filter=Filter(request=request), session_recording_id=request.GET["session_recording_id"]
+            team=self.team,
+            filter=Filter(request=request, team=self.team),
+            session_recording_id=request.GET["session_recording_id"],
         )
 
         if request.GET.get("save_view"):

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -293,7 +293,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
     def sessions(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         from posthog.queries.sessions.sessions_list import SessionsList
 
-        filter = SessionsFilter(request=request)
+        filter = SessionsFilter(request=request, team=self.team)
 
         sessions, pagination = SessionsList.run(filter=filter, team=self.team)
         return Response({"result": sessions, "pagination": pagination})
@@ -302,7 +302,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
     def session_events(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         from posthog.queries.sessions.sessions_list_events import SessionsListEvents
 
-        filter = SessionEventsFilter(request=request)
+        filter = SessionEventsFilter(request=request, team=self.team)
         return Response({"result": SessionsListEvents().run(filter=filter, team=self.team)})
 
     # ******************************************

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -201,14 +201,14 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False)
     def trend(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         result = self.calculate_trends(request)
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
         next = format_next_url(request, filter.offset, 20) if len(result["result"]) > 20 else None
         return Response({**result, "next": next})
 
     @cached_function
     def calculate_trends(self, request: request.Request) -> Dict[str, Any]:
         team = self.team
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
         if filter.insight == INSIGHT_STICKINESS or filter.shown_as == TRENDS_STICKINESS:
             earliest_timestamp_func = lambda team_id: Event.objects.earliest_timestamp(team_id)
             stickiness_filter = StickinessFilter(

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -235,7 +235,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     @cached_function
     def calculate_session(self, request: request.Request) -> Dict[str, Any]:
-        result = Sessions().run(filter=SessionsFilter(request=request), team=self.team)
+        result = Sessions().run(filter=SessionsFilter(request=request, team=self.team), team=self.team)
         return {"result": result}
 
     # ******************************************

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -179,7 +179,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 status=400,
             )
 
-        filter = Filter(request=request)
+        filter = Filter(request=request, team=self.team)
         target_date = request.GET.get("target_date", None)
         if target_date is None:
             return response.Response(

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -23,6 +23,10 @@ class BaseFilter(BaseParamMixin):
         self._data = data
         self.kwargs = kwargs
 
+        if "team" in kwargs and hasattr(self, "simplify"):
+            simplified_filter = getattr(self, "simplify")(kwargs["team"])
+            self._data = simplified_filter._data
+
     def to_dict(self) -> Dict[str, Any]:
         ret = {}
 

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -23,7 +23,7 @@ class BaseFilter(BaseParamMixin):
         self._data = data
         self.kwargs = kwargs
 
-        if "team" in kwargs and hasattr(self, "simplify"):
+        if "team" in kwargs and hasattr(self, "simplify") and not getattr(self, "is_simplified", False):
             simplified_filter = getattr(self, "simplify")(kwargs["team"])
             self._data = simplified_filter._data
 

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -39,6 +39,7 @@ from posthog.models.filters.mixins.funnel import (
     HistogramMixin,
 )
 from posthog.models.filters.mixins.property import PropertyMixin
+from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
 
 
 class Filter(
@@ -69,8 +70,9 @@ class Filter(
     FunnelPersonsStepBreakdownMixin,
     FunnelLayoutMixin,
     FunnelTypeMixin,
-    HistogramMixin,
+    HistogramM(ixin,
     FunnelCorrelationMixin,
+    SimplifyFilterMixin,
     BaseFilter,
 ):
     """

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -108,3 +108,7 @@ class Filter(
 
         self._data = data
         self.kwargs = kwargs
+
+        if "team" in kwargs:
+            simplified_filter = self.simplify(kwargs["team"])
+            self._data = simplified_filter._data

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -70,7 +70,7 @@ class Filter(
     FunnelPersonsStepBreakdownMixin,
     FunnelLayoutMixin,
     FunnelTypeMixin,
-    HistogramM(ixin,
+    HistogramMixin,
     FunnelCorrelationMixin,
     SimplifyFilterMixin,
     BaseFilter,

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -109,6 +109,6 @@ class Filter(
         self._data = data
         self.kwargs = kwargs
 
-        if "team" in kwargs:
+        if "team" in kwargs and not self.is_simplified:
             simplified_filter = self.simplify(kwargs["team"])
             self._data = simplified_filter._data

--- a/posthog/models/filters/mixins/property.py
+++ b/posthog/models/filters/mixins/property.py
@@ -28,11 +28,14 @@ class PropertyMixin(BaseParamMixin):
         if isinstance(properties, list):
             _properties = []
             for prop_params in properties:
-                try:
-                    new_prop = Property(**prop_params)
-                    _properties.append(new_prop)
-                except:
-                    continue
+                if isinstance(prop_params, Property):
+                    _properties.append(prop_params)
+                else:
+                    try:
+                        new_prop = Property(**prop_params)
+                        _properties.append(new_prop)
+                    except:
+                        continue
             return _properties
         if not properties:
             return []

--- a/posthog/models/filters/mixins/sessions.py
+++ b/posthog/models/filters/mixins/sessions.py
@@ -98,4 +98,4 @@ class UserIdMixin(BaseFilter):
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[Request] = None, **kwargs) -> None:
         self.user_id = request.user.pk if request else (data or {}).get("user_id")
-        super().__init__(data, request)
+        super().__init__(data, request, **kwargs)

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -7,7 +7,7 @@ T = TypeVar("T")
 
 
 class SimplifyFilterMixin:
-    def simplify(self: T, team: "Team") -> T:  # type: ignore
+    def simplify(self: T, team: "Team") -> T:
         """
         Expands this filter to not refer to external resources of the team.
 
@@ -15,10 +15,14 @@ class SimplifyFilterMixin:
         - if filter.filter_test_accounts, adds property filters to `filter.properties`
         """
 
-        result = self.with_data({"is_simplified": True})
+        result = self.with_data({"is_simplified": True})  # type: ignore
         if getattr(self, "filter_test_accounts", False):
             result = result.with_data(
                 {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False}
-            )
+            )  # type: ignore
 
         return result
+
+    @property
+    def is_simplified(self) -> bool:
+        return self._data.get("is_simplified", False)  # type: ignore

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -15,7 +15,7 @@ class SimplifyFilterMixin:
         - if filter.filter_test_accounts, adds property filters to `filter.properties`
         """
 
-        result = self
+        result = self.with_data({"is_simplified": True})
         if getattr(self, "filter_test_accounts", False):
             result = result.with_data(
                 {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False}

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -19,7 +19,7 @@ class SimplifyFilterMixin:
         if getattr(self, "filter_test_accounts", False):
             result = result.with_data(
                 {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False}
-            )  # type: ignore
+            )
 
         return result
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:  # Avoid circular import
+    from posthog.models.team import Team
+
+T = TypeVar("T")
+
+
+class SimplifyFilterMixin:
+    def simplify(self: T, team: "Team") -> T:  # type: ignore
+        """
+        Expands this filter to not refer to external resources of the team.
+
+        Actions taken:
+        - if filter.filter_test_accounts, adds property filters to `filter.properties`
+        """
+
+        result = self
+        if getattr(self, "filter_test_accounts", False):
+            result = result.with_data(
+                {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False}
+            )
+
+        return result

--- a/posthog/models/filters/path_filter.py
+++ b/posthog/models/filters/path_filter.py
@@ -30,6 +30,7 @@ from posthog.models.filters.mixins.paths import (
     TargetEventsMixin,
 )
 from posthog.models.filters.mixins.property import PropertyMixin
+from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
 
 
 class PathFilter(
@@ -57,6 +58,7 @@ class PathFilter(
     OffsetMixin,
     PathLimitsMixin,
     FunnelCorrelationMixin,  # Typing pain because ColumnOptimizer expects a uniform filter
+    SimplifyFilterMixin,
     # TODO: proper fix for EventQuery abstraction
     BaseFilter,
 ):

--- a/posthog/models/filters/retention_filter.py
+++ b/posthog/models/filters/retention_filter.py
@@ -15,6 +15,7 @@ from posthog.models.filters.mixins.common import (
 from posthog.models.filters.mixins.funnel import FunnelCorrelationMixin
 from posthog.models.filters.mixins.property import PropertyMixin
 from posthog.models.filters.mixins.retention import EntitiesDerivedMixin, RetentionDateDerivedMixin, RetentionTypeMixin
+from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
 
 RETENTION_DEFAULT_INTERVALS = 11
 
@@ -32,6 +33,7 @@ class RetentionFilter(
     OffsetMixin,
     FunnelCorrelationMixin,  # Typing pain because ColumnOptimizer expects a uniform filter
     # TODO: proper fix for EventQuery abstraction, make filters uniform
+    SimplifyFilterMixin,
     BaseFilter,
 ):
     def __init__(self, data: Dict[str, Any] = {}, request: Optional[Request] = None, **kwargs) -> None:

--- a/posthog/models/filters/stickiness_filter.py
+++ b/posthog/models/filters/stickiness_filter.py
@@ -14,6 +14,7 @@ from posthog.models.filters.mixins.common import (
     ShownAsMixin,
 )
 from posthog.models.filters.mixins.property import PropertyMixin
+from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
 from posthog.models.filters.mixins.stickiness import SelectedIntervalMixin, TotalIntervalsDerivedMixin
 from posthog.models.team import Team
 
@@ -28,6 +29,7 @@ class StickinessFilter(
     CompareMixin,
     ShownAsMixin,
     InsightMixin,
+    SimplifyFilterMixin,
     BaseFilter,
 ):
     get_earliest_timestamp: Callable

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -426,9 +426,7 @@ def _filter_events(filter: Filter, team: Team, person_query: Optional[bool] = Fa
     if person_query:
         events = events.add_person_id(team.pk)
 
-    events = events.filter(
-        properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
-    )
+    events = events.filter(properties_to_Q(filter.properties, team_id=team.pk))
     events = events.filter(team_id=team.pk)
     if order_by:
         events = events.order_by(order_by)

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -413,7 +413,7 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
             self.team.save()
             event_factory(team=self.team, distinct_id="team_member", event="$pageview")
             event_factory(team=self.team, distinct_id="random_user", event="$pageview")
-            filter = Filter(data={FILTER_TEST_ACCOUNTS: True, "events": [{"id": "$pageview"}]})
+            filter = Filter(data={FILTER_TEST_ACCOUNTS: True, "events": [{"id": "$pageview"}]}, team=self.team)
             events = filter_events(filter=filter, team=self.team, person_query=True)
             self.assertEqual(len(events), 1)
 

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -34,13 +34,15 @@ def get_filter(team, data: dict = {}, request: Optional[Request] = None):
     if not insight and request:
         insight = request.GET.get("insight") or request.data.get("insight")
     if insight == INSIGHT_RETENTION:
-        return RetentionFilter(data={**data, "insight": INSIGHT_RETENTION}, request=request)
+        return RetentionFilter(data={**data, "insight": INSIGHT_RETENTION}, request=request, team=team)
     elif insight == INSIGHT_SESSIONS:
-        return SessionsFilter(data={**data, "insight": INSIGHT_SESSIONS}, request=request)
+        return SessionsFilter(data={**data, "insight": INSIGHT_SESSIONS}, request=request, team=team)
     elif insight == INSIGHT_STICKINESS or (insight == INSIGHT_TRENDS and data.get("shown_as") == "Stickiness"):
         return StickinessFilter(data=data, request=request, team=team, get_earliest_timestamp=earliest_timestamp_func)
     elif insight == INSIGHT_PATHS:
-        return PathFilter(data={**data, "insight": INSIGHT_PATHS}, request=request)
+        return PathFilter(data={**data, "insight": INSIGHT_PATHS}, request=request, team=team)
     elif insight == INSIGHT_FUNNELS:
-        return Filter(data={**data, **(request.data if request else {}), "insight": INSIGHT_FUNNELS}, request=request)
-    return Filter(data=data, request=request)
+        return Filter(
+            data={**data, **(request.data if request else {}), "insight": INSIGHT_FUNNELS}, request=request, team=team
+        )
+    return Filter(data=data, request=request, team=team)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -115,25 +115,19 @@ def filter_events(
         filters &= Q(timestamp__gte=date_from)
     if include_dates:
         filters &= Q(timestamp__lte=filter.date_to + relativity)
-    if filter.properties or filter.filter_test_accounts:
-        filters &= properties_to_Q(filter.properties, team_id=team_id, filter_test_accounts=filter.filter_test_accounts)
+    if filter.properties:
+        filters &= properties_to_Q(filter.properties, team_id=team_id)
     if entity and entity.properties:
         filters &= properties_to_Q(entity.properties, team_id=team_id)
     return filters
 
 
-def properties_to_Q(
-    properties: List[Property], team_id: int, is_person_query: bool = False, filter_test_accounts: bool = False
-) -> Q:
+def properties_to_Q(properties: List[Property], team_id: int, is_person_query: bool = False) -> Q:
     """
     Converts a filter to Q, for use in Django ORM .filter()
     If you're filtering a Person QuerySet, use is_person_query to avoid doing an unnecessary nested loop
     """
     filters = Q()
-
-    if filter_test_accounts:
-        test_account_filters = Team.objects.only("test_account_filters").get(id=team_id).test_account_filters
-        properties.extend([Property(**prop) for prop in test_account_filters])
 
     if len(properties) == 0:
         return filters

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -48,13 +48,7 @@ class Funnel(BaseQuery):
                         else {}
                     ),
                 )
-                .filter(
-                    properties_to_Q(
-                        self._filter.properties,
-                        team_id=self._team.pk,
-                        filter_test_accounts=self._filter.filter_test_accounts,
-                    )
-                )
+                .filter(properties_to_Q(self._filter.properties, team_id=self._team.pk,))
                 .filter(properties_to_Q(step.properties, team_id=self._team.pk))
             )
             with connection.cursor() as cursor:
@@ -160,9 +154,9 @@ class Funnel(BaseQuery):
         event_chain_query = sql.SQL(" ").join(lateral_joins).as_string(connection.connection)
 
         query = f"""
-            SELECT 
+            SELECT
                 DISTINCT ON (person.id)
-                person.uuid, 
+                person.uuid,
                 person.created_at,
                 person.team_id,
                 person.properties,
@@ -171,7 +165,7 @@ class Funnel(BaseQuery):
             FROM posthog_person person
             JOIN posthog_persondistinctid pdi ON pdi.person_id = person.id
             JOIN {event_chain_query}
-            -- join on person_id for the first event. 
+            -- join on person_id for the first event.
             -- NOTE: there is some implicit coupling here in that I am
             -- assuming the name of the first event select is "step_0".
             -- Maybe worth cleaning up in the future

--- a/posthog/queries/paths.py
+++ b/posthog/queries/paths.py
@@ -70,11 +70,7 @@ class Paths(BaseQuery):
                 if event is None
                 else Q()
             )
-            .filter(
-                properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
-                if filter and (filter.properties or filter.filter_test_accounts)
-                else Q()
-            )
+            .filter(properties_to_Q(filter.properties, team_id=team.pk) if filter and filter.properties else Q())
             .annotate(
                 previous_timestamp=Window(
                     expression=Lag("timestamp", default=None),

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -100,9 +100,7 @@ class Retention(BaseQuery):
         trunc, fields = self._get_trunc_func("timestamp", period)
 
         if is_first_time_retention:
-            filtered_events = events.filter(
-                properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
-            )
+            filtered_events = events.filter(properties_to_Q(filter.properties, team_id=team.pk))
             first_date = (
                 filtered_events.filter(entity_condition)
                 .values("person_id", "event", "action")
@@ -118,7 +116,7 @@ class Retention(BaseQuery):
             )
         else:
             filtered_events = events.filter(filter.date_filter_Q).filter(
-                properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
+                properties_to_Q(filter.properties, team_id=team.pk)
             )
             first_date = (
                 filtered_events.filter(entity_condition)
@@ -206,14 +204,12 @@ class Retention(BaseQuery):
         events = Event.objects.filter(team_id=team.pk).add_person_id(team.pk)
 
         filtered_events = events.filter(filter.recurring_date_filter_Q()).filter(
-            properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
+            properties_to_Q(filter.properties, team_id=team.pk)
         )
 
         inner_events = (
             Event.objects.filter(team_id=team.pk)
-            .filter(
-                properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
-            )
+            .filter(properties_to_Q(filter.properties, team_id=team.pk))
             .add_person_id(team.pk)
             .filter(**{"person_id": OuterRef("id")})
             .filter(entity_condition)
@@ -224,9 +220,7 @@ class Retention(BaseQuery):
             if is_first_time_retention
             else Event.objects.filter(team_id=team.pk)
             .filter(filter.reference_date_filter_Q())
-            .filter(
-                properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
-            )
+            .filter(properties_to_Q(filter.properties, team_id=team.pk))
             .add_person_id(team.pk)
             .filter(**{"person_id": OuterRef("id")})
             .filter(entity_condition)

--- a/posthog/queries/sessions/sessions.py
+++ b/posthog/queries/sessions/sessions.py
@@ -89,9 +89,7 @@ class Sessions(BaseQuery):
             Event.objects.filter(team=team)
             .add_person_id(team.pk)
             .filter(~Q(event="$feature_flag_called"))
-            .filter(
-                properties_to_Q(filter.properties, team_id=team.pk, filter_test_accounts=filter.filter_test_accounts)
-            )
+            .filter(properties_to_Q(filter.properties, team_id=team.pk))
             .order_by("-timestamp")
         )
 

--- a/posthog/queries/sessions/test/test_sessions.py
+++ b/posthog/queries/sessions/test/test_sessions.py
@@ -328,7 +328,8 @@ def sessions_test_factory(sessions, event_factory, person_factory):
                             "session": "dist",
                             FILTER_TEST_ACCOUNTS: True,
                             "events": [{"id": "1st action"},],
-                        }
+                        },
+                        team=self.team,
                     ),
                     self.team,
                 )
@@ -342,7 +343,8 @@ def sessions_test_factory(sessions, event_factory, person_factory):
                             "session": "avg",
                             FILTER_TEST_ACCOUNTS: True,
                             "events": [{"id": "1st action"},],
-                        }
+                        },
+                        team=self.team,
                     ),
                     self.team,
                 )

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -344,7 +344,8 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                         "insight": INSIGHT_FUNNELS,
                         FILTER_TEST_ACCOUNTS: True,
                         "funnel_window_days": 14,
-                    }
+                    },
+                    team=self.team,
                 ),
                 team=self.team,
             ).run()

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -571,7 +571,8 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                         "events": [{"id": "$pageview", "type": "events", "order": 0}],
                         "shown_as": TRENDS_LIFECYCLE,
                         FILTER_TEST_ACCOUNTS: True,
-                    }
+                    },
+                    team=self.team,
                 ),
                 self.team,
             )
@@ -597,7 +598,8 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                         "events": [{"id": "$pageview", "type": "events", "order": 0}],
                         "shown_as": TRENDS_LIFECYCLE,
                         FILTER_TEST_ACCOUNTS: True,
-                    }
+                    },
+                    team=self.team,
                 ),
                 self.team.pk,
                 relative_date_parse("2020-01-13T00:00:00Z"),

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -123,14 +123,14 @@ def paths_test_factory(paths, event_factory, person_factory):
                 self.assertEqual(len(response), 4)
 
                 # Test account filter
-                filter = PathFilter(data={**date_params, FILTER_TEST_ACCOUNTS: True})
+                filter = PathFilter(data={**date_params, FILTER_TEST_ACCOUNTS: True}, team=self.team)
                 response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
                 self.assertEqual(len(response), 3)
 
                 date_from = now() + relativedelta(days=7)
                 date_to = now() - relativedelta(days=7)
                 date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
-                filter = PathFilter(data={**date_params})
+                filter = PathFilter(data={**date_params}, team=self.team)
                 response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
                 self.assertEqual(len(response), 0)
 

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -871,7 +871,8 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
 
             # even if set to hour 6 it should default to beginning of day and include all pageviews above
             result = retention().run(
-                RetentionFilter(data={"date_to": self._date(10, hour=6), FILTER_TEST_ACCOUNTS: True}), self.team
+                RetentionFilter(data={"date_to": self._date(10, hour=6), FILTER_TEST_ACCOUNTS: True}, team=self.team),
+                self.team,
             )
             self.assertEqual(len(result), 11)
             self.assertEqual(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -2147,9 +2147,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 "events": [{"id": "$pageview", "type": "events", "order": 0}],
                 "filter_test_accounts": "true",
             }
-            filter = Filter(data=data)
-            filter_2 = Filter(data={**data, "filter_test_accounts": "false",})
-            filter_3 = Filter(data={**data, "breakdown": "key"})
+            filter = Filter(data=data, team=self.team)
+            filter_2 = Filter(data={**data, "filter_test_accounts": "false",}, team=self.team)
+            filter_3 = Filter(data={**data, "breakdown": "key"}, team=self.team)
             result = trends().run(filter, self.team,)
             self.assertEqual(result[0]["count"], 1)
             result = trends().run(filter_2, self.team,)
@@ -2175,7 +2175,8 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.team.save()
 
             response = trends().run(
-                Filter(data={"events": [{"id": "event_name"}], "filter_test_accounts": True}), self.team,
+                Filter(data={"events": [{"id": "event_name"}], "filter_test_accounts": True}, team=self.team),
+                self.team,
             )
 
             self.assertEqual(response[0]["count"], 2)


### PR DESCRIPTION
This PR introduces the concept of "simplifying" filters. See #5877 for more detail

This is the first part of refactoring for #5854 - I'm planning on introducing "simplification" for cohort filters as well, but want to avoid excessive bloat.

Going forward, all controllers should pass team to filters on creation - we'll eventually make this mandatory as well.

## How did you test this code?

Manual testing + existing code coverage
