### PR TITLE
Use assertRegex for Python 3.11 compatibility.

### DIFF
--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -82,7 +82,7 @@ class TestDashboard(APIBaseTest):
         dashboard_item = DashboardItem.objects.get()
         self.assertEqual(dashboard_item.name, "dashboard item")
         # Short ID is automatically generated
-        self.assertRegexpMatches(dashboard_item.short_id, r"[0-9A-Za-z_-]{8}")
+        self.assertRegex(dashboard_item.short_id, r"[0-9A-Za-z_-]{8}")
 
     def test_token_auth(self):
         self.client.logout()

--- a/posthog/test/test_dashboard.py
+++ b/posthog/test/test_dashboard.py
@@ -20,4 +20,4 @@ class TestDashboardItemModel(BaseTest):
 
     def test_short_id_is_automatically_generated(self):
         d = DashboardItem.objects.create(team=self.team)
-        self.assertRegexpMatches(d.short_id, r"[0-9A-Za-z_-]{8}")
+        self.assertRegex(d.short_id, r"[0-9A-Za-z_-]{8}")


### PR DESCRIPTION
## Changes

These methods were deprecated and removed in Python 3.11.

https://github.com/python/cpython/pull/28268