### PR TITLE
Don't count internal metrics for billing purposes

### DIFF
--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -16,7 +16,7 @@ def send_license_usage():
         date_from = (timezone.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
         date_to = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         events_count = sync_execute(
-            "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s",
+            "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s and not startsWith(events, '$$')",
             {"date_from": date_from, "date_to": date_to},
         )[0][0]
         response = requests.post(

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -16,7 +16,7 @@ def send_license_usage():
         date_from = (timezone.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
         date_to = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         events_count = sync_execute(
-            "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s and not startsWith(events, '$$')",
+            "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s and not startsWith(event, '$$')",
             {"date_from": date_from, "date_to": date_to},
         )[0][0]
         response = requests.post(

--- a/ee/tasks/test/test_send_license_usage.py
+++ b/ee/tasks/test/test_send_license_usage.py
@@ -27,6 +27,12 @@ class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIB
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(
+            event="$$internal_metrics_shouldnt_be_billed",
+            team=self.team,
+            distinct_id=1,
+            timestamp="2021-10-09T13:01:01Z",
+        )
         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
 
@@ -45,6 +51,12 @@ class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIB
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(
+            event="$$internal_metrics_shouldnt_be_billed",
+            team=self.team,
+            distinct_id=1,
+            timestamp="2021-10-09T13:01:01Z",
+        )
         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
 


### PR DESCRIPTION
## Changes

If you set `capture_internal_metrics=True` in your env variables you'll generate a load of events that start with `$$`. We shouldn't bill for these events. It's unlikely any active customers have set this variable so shouldn't be a big discrepancy with billing.

## How did you test this code?

*Please describe.*
