### PR TITLE
Fix dashboards loading error

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -17,14 +17,14 @@ import { NotFound } from 'lib/components/NotFound'
 import { DashboardReloadAction, LastRefreshText } from 'scenes/dashboard/DashboardReloadAction'
 
 interface Props {
-    id: string
+    id?: string
     shareToken?: string
     internal?: boolean
 }
 
 export function Dashboard({ id, shareToken, internal }: Props): JSX.Element {
     return (
-        <BindLogic logic={dashboardLogic} props={{ id: parseInt(id), shareToken, internal }}>
+        <BindLogic logic={dashboardLogic} props={{ id: id ? parseInt(id) : undefined, shareToken, internal }}>
             <DashboardView />
         </BindLogic>
     )

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -27,17 +27,13 @@ describe('dashboardLogic', () => {
         }
     })
 
-    initKeaTestLogic({
-        logic: dashboardLogic,
-        props: {
-            id: 5,
-        },
-        onLogic: (l) => (logic = l),
-    })
-
-    describe('core assumptions', () => {
-        it('mounts other logics', async () => {
-            await expectLogic(logic).toMount([dashboardsModel, dashboardItemsModel, eventUsageLogic])
+    describe('when there is no props id', () => {
+        initKeaTestLogic({
+            logic: dashboardLogic,
+            props: {
+                id: undefined as unknown as number,
+            },
+            onLogic: (l) => (logic = l),
         })
 
         it('fetches dashboard items on mount', async () => {
@@ -55,42 +51,72 @@ describe('dashboardLogic', () => {
         })
     })
 
-    describe('reload all items', () => {
-        it('reloads when called', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.refreshAllDashboardItemsManual()
+    describe('when props id is set to a number', () => {
+        initKeaTestLogic({
+            logic: dashboardLogic,
+            props: {
+                id: 5,
+            },
+            onLogic: (l) => (logic = l),
+        })
+
+        describe('core assumptions', () => {
+            it('mounts other logics', async () => {
+                await expectLogic(logic).toMount([dashboardsModel, dashboardItemsModel, eventUsageLogic])
             })
-                .toDispatchActions([
-                    // starts loading
-                    'refreshAllDashboardItemsManual',
-                    'refreshAllDashboardItems',
-                ])
-                .toDispatchActionsInAnyOrder([
-                    // sets the "reloading" status
-                    logic.actionCreators.setRefreshStatus(dashboardJson.items[0].id, true),
-                    logic.actionCreators.setRefreshStatus(dashboardJson.items[1].id, true),
-                ])
-                .toMatchValues({
-                    refreshStatus: {
-                        172: { loading: true },
-                        175: { loading: true },
-                    },
+
+            it('fetches dashboard items on mount', async () => {
+                expectLogic(logic)
+                    .toDispatchActions(['loadDashboardItems'])
+                    .toMatchValues({
+                        allItems: null,
+                        items: undefined,
+                    })
+                    .toDispatchActions(['loadDashboardItemsSuccess'])
+                    .toMatchValues({
+                        allItems: dashboardJson,
+                        items: truth((items) => items.length === 2),
+                    })
+            })
+        })
+
+        describe('reload all items', () => {
+            it('reloads when called', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.refreshAllDashboardItemsManual()
                 })
-                .toDispatchActionsInAnyOrder([
-                    // calls the "setCachedResults" directly on the sub-logics (trendsLogic.172 this case)
-                    trendsLogic({ dashboardItemId: dashboardJson.items[0].id }).actionTypes.setCachedResults,
-                    trendsLogic({ dashboardItemId: dashboardJson.items[1].id }).actionTypes.setCachedResults,
-                    // and updates the action in the model
-                    (a) =>
-                        a.type === dashboardsModel.actionTypes.updateDashboardItem &&
-                        a.payload.item.id === dashboardJson.items[1].id,
-                    (a) =>
-                        a.type === dashboardsModel.actionTypes.updateDashboardItem &&
-                        a.payload.item.id === dashboardJson.items[0].id,
-                    // no longer reloading
-                    logic.actionCreators.setRefreshStatus(dashboardJson.items[0].id, false),
-                    logic.actionCreators.setRefreshStatus(dashboardJson.items[1].id, false),
-                ])
+                    .toDispatchActions([
+                        // starts loading
+                        'refreshAllDashboardItemsManual',
+                        'refreshAllDashboardItems',
+                    ])
+                    .toDispatchActionsInAnyOrder([
+                        // sets the "reloading" status
+                        logic.actionCreators.setRefreshStatus(dashboardJson.items[0].id, true),
+                        logic.actionCreators.setRefreshStatus(dashboardJson.items[1].id, true),
+                    ])
+                    .toMatchValues({
+                        refreshStatus: {
+                            172: { loading: true },
+                            175: { loading: true },
+                        },
+                    })
+                    .toDispatchActionsInAnyOrder([
+                        // calls the "setCachedResults" directly on the sub-logics (trendsLogic.172 this case)
+                        trendsLogic({ dashboardItemId: dashboardJson.items[0].id }).actionTypes.setCachedResults,
+                        trendsLogic({ dashboardItemId: dashboardJson.items[1].id }).actionTypes.setCachedResults,
+                        // and updates the action in the model
+                        (a) =>
+                            a.type === dashboardsModel.actionTypes.updateDashboardItem &&
+                            a.payload.item.id === dashboardJson.items[1].id,
+                        (a) =>
+                            a.type === dashboardsModel.actionTypes.updateDashboardItem &&
+                            a.payload.item.id === dashboardJson.items[0].id,
+                        // no longer reloading
+                        logic.actionCreators.setRefreshStatus(dashboardJson.items[0].id, false),
+                        logic.actionCreators.setRefreshStatus(dashboardJson.items[1].id, false),
+                    ])
+            })
         })
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -182,7 +182,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     return {
                         ...state,
                         items:
-                            item.dashboard === parseInt(props.id.toString())
+                            props.id && item.dashboard === parseInt(props.id.toString())
                                 ? [...(state?.items || []), item]
                                 : state?.items,
                     } as DashboardType
@@ -268,11 +268,11 @@ export const dashboardLogic = kea<dashboardLogicType>({
         ],
         dashboard: [
             () => [dashboardsModel.selectors.sharedDashboards, dashboardsModel.selectors.dashboards],
-            (sharedDashboards, dashboards) => {
-                if (sharedDashboards && !!sharedDashboards[props.id]) {
+            (sharedDashboards, dashboards): DashboardType | null => {
+                if (sharedDashboards && props.id && !!sharedDashboards[props.id]) {
                     return sharedDashboards[props.id]
                 }
-                return dashboards.find((d) => d.id === props.id)
+                return dashboards.find((d) => d.id === props.id) ?? null
             },
         ],
         breakpoints: [() => [], () => ({ lg: 1600, sm: 940, xs: 480, xxs: 0 } as Record<DashboardLayoutSize, number>)],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -558,7 +558,7 @@ export interface DashboardType {
     deleted: boolean
     filters: Record<string, any>
     creation_mode: 'default' | 'template' | 'duplicate'
-    tags: string[]
+    tags: string[] // TODO: To be implemented
 }
 
 export type DashboardLayoutSize = 'lg' | 'sm' | 'xs' | 'xxs'


### PR DESCRIPTION
## Changes

Originally reported [here](https://posthogusers.slack.com/archives/C026SNNE430/p1633186312137000) by a focus customer. Issue was that when loading the `Dashboard` component as a scene, `id` is undefined and we try to convert undefined to integer and then make an API request with that.

From a user standpoint, you would see an error toast, even though everything is working as expected.

## How did you test this code?

- Manually opening a dashboard both from a link and from navigating from a different scene and seeing no error toasts pop up. You can open any dashboard on PostHog Cloud to see the error case.
