### PR TITLE
choose either count or aggregated value when sorting the insights tab…

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -189,7 +189,7 @@ export function InsightsTable({ isLegend = true, showTotalCount = false }: Insig
                 )
             },
             defaultSortOrder: 'descend',
-            sorter: (a, b) => a.count - b.count,
+            sorter: (a, b) => (a.count || a.aggregated_value) - (b.count || b.aggregated_value),
             dataIndex: 'count',
             fixed: 'right',
             width: 120,


### PR DESCRIPTION
…le so that it doesn't matter if clickhouse or postgres returns the value

workaround to close #6180 

## Changes

tells the insights table react component to read from a count property and if that is nor present to read from an aggregated_value property

## How did you test this code?
by running it locally