### PR TITLE
Capture metadata on signup

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -49,9 +49,7 @@ class SignupSerializer(serializers.Serializer):
         organization_name = validated_data.pop("organization_name", validated_data["first_name"])
 
         self._organization, self._team, self._user = User.objects.bootstrap(
-            organization_name=organization_name,
-            create_team=self.create_team,
-            **validated_data,
+            organization_name=organization_name, create_team=self.create_team, **validated_data,
         )
         user = self._user
 
@@ -61,9 +59,7 @@ class SignupSerializer(serializers.Serializer):
             self._organization.save()
 
         login(
-            self.context["request"],
-            user,
-            backend="django.contrib.auth.backends.ModelBackend",
+            self.context["request"], user, backend="django.contrib.auth.backends.ModelBackend",
         )
 
         report_user_signed_up(
@@ -164,9 +160,7 @@ class InviteSignupSerializer(serializers.Serializer):
 
         if is_new_user:
             login(
-                self.context["request"],
-                user,
-                backend="django.contrib.auth.backends.ModelBackend",
+                self.context["request"], user, backend="django.contrib.auth.backends.ModelBackend",
             )
 
             report_user_signed_up(

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -78,18 +78,16 @@ class TestSignupAPI(APIBaseTest):
         self.assertEqual(organization.name, "Hedgehogs United, LLC")
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
-        mock_capture.assert_called_once_with(
-            user.distinct_id,
-            "user signed up",
-            properties={
-                "is_first_user": True,
-                "is_organization_first_user": True,
-                "new_onboarding_enabled": False,
-                "signup_backend_processor": "OrganizationSignupSerializer",
-                "signup_social_provider": "",
-                "realm": get_instance_realm(),
-            },
-        )
+        mock_capture.assert_called_once()
+        self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
+        self.assertEqual("user signed up", mock_capture.call_args.args[1])
+        event_props = mock_capture.call_args.kwargs["properties"]
+        self.assertEqual(event_props["is_first_user"], True)
+        self.assertEqual(event_props["is_organization_first_user"], True)
+        self.assertEqual(event_props["new_onboarding_enabled"], False)
+        self.assertEqual(event_props["signup_backend_processor"], "OrganizationSignupSerializer")
+        self.assertEqual(event_props["signup_social_provider"], "")
+        self.assertEqual(event_props["realm"], get_instance_realm())
 
         # Assert that the user is logged in
         response = self.client.get("/api/users/@me/")
@@ -599,18 +597,16 @@ class TestInviteSignup(APIBaseTest):
         self.assertEqual(user.email_opt_in, True)
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
-        mock_capture.assert_called_once_with(
-            user.distinct_id,
-            "user signed up",
-            properties={
-                "is_first_user": False,
-                "is_organization_first_user": False,
-                "new_onboarding_enabled": False,
-                "signup_backend_processor": "OrganizationInviteSignupSerializer",
-                "signup_social_provider": "",
-                "realm": get_instance_realm(),
-            },
-        )
+        mock_capture.assert_called_once()
+        self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
+        self.assertEqual("user signed up", mock_capture.call_args.args[1])
+        event_props = mock_capture.call_args.kwargs["properties"]
+        self.assertEqual(event_props["is_first_user"], False)
+        self.assertEqual(event_props["is_organization_first_user"], False)
+        self.assertEqual(event_props["new_onboarding_enabled"], False)
+        self.assertEqual(event_props["signup_backend_processor"], "OrganizationInviteSignupSerializer")
+        self.assertEqual(event_props["signup_social_provider"], "")
+        self.assertEqual(event_props["realm"], get_instance_realm())
 
         # Assert that the user is logged in
         response = self.client.get("/api/users/@me/")

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -81,6 +81,7 @@ class TestSignupAPI(APIBaseTest):
         mock_capture.assert_called_once()
         self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
         self.assertEqual("user signed up", mock_capture.call_args.args[1])
+        # Assert that key properties were set properly
         event_props = mock_capture.call_args.kwargs["properties"]
         self.assertEqual(event_props["is_first_user"], True)
         self.assertEqual(event_props["is_organization_first_user"], True)
@@ -170,9 +171,9 @@ class TestSignupAPI(APIBaseTest):
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_identify.assert_called_once()
         mock_capture.assert_called_once()
-
         self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
         self.assertEqual("user signed up", mock_capture.call_args.args[1])
+        # Assert that key properties were set properly
         event_props = mock_capture.call_args.kwargs["properties"]
         self.assertEqual(event_props["is_first_user"], True)
         self.assertEqual(event_props["is_organization_first_user"], True)
@@ -600,6 +601,7 @@ class TestInviteSignup(APIBaseTest):
         mock_capture.assert_called_once()
         self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
         self.assertEqual("user signed up", mock_capture.call_args.args[1])
+        # Assert that key properties were set properly
         event_props = mock_capture.call_args.kwargs["properties"]
         self.assertEqual(event_props["is_first_user"], False)
         self.assertEqual(event_props["is_organization_first_user"], False)

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -172,7 +172,6 @@ class TestSignupAPI(APIBaseTest):
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_identify.assert_called_once()
         mock_capture.assert_called_once()
-        mock_identify.assert_called_once()
 
         self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
         self.assertEqual("user signed up", mock_capture.call_args.args[1])

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -103,11 +103,13 @@ class TestSignupAPI(APIBaseTest):
     def test_signup_disallowed_on_self_hosted_by_default(self):
         with self.settings(MULTI_TENANCY=False):
             response = self.client.post(
-                "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
+                "/api/signup/",
+                {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
             )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             response = self.client.post(
-                "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
+                "/api/signup/",
+                {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
             )
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(
@@ -126,7 +128,10 @@ class TestSignupAPI(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
+            key="key_123",
+            plan="enterprise",
+            valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7),
+            max_users=3,
         )
 
         Organization.objects.create(name="name")
@@ -134,7 +139,8 @@ class TestSignupAPI(APIBaseTest):
         count = Organization.objects.count()
         with self.settings(MULTI_TENANCY=False, MULTI_ORG_ENABLED=True):
             response = self.client.post(
-                "/api/signup/", {"first_name": "Jane", "email": "hedgehog4@posthog.com", "password": "notsecure"},
+                "/api/signup/",
+                {"first_name": "Jane", "email": "hedgehog4@posthog.com", "password": "notsecure"},
             )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["email"], "hedgehog4@posthog.com")
@@ -145,7 +151,8 @@ class TestSignupAPI(APIBaseTest):
     @patch("posthoganalytics.identify")
     def test_signup_minimum_attrs(self, mock_identify, mock_capture):
         response = self.client.post(
-            "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
+            "/api/signup/",
+            {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -171,18 +178,18 @@ class TestSignupAPI(APIBaseTest):
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_identify.assert_called_once()
-        mock_capture.assert_called_once_with(
-            user.distinct_id,
-            "user signed up",
-            properties={
-                "is_first_user": True,
-                "is_organization_first_user": True,
-                "new_onboarding_enabled": False,
-                "signup_backend_processor": "OrganizationSignupSerializer",
-                "signup_social_provider": "",
-                "realm": get_instance_realm(),
-            },
-        )
+        mock_capture.assert_called_once()
+        mock_identify.assert_called_once()
+
+        self.assertEqual(user.distinct_id, mock_capture.call_args.args[0])
+        self.assertEqual("user signed up", mock_capture.call_args.args[1])
+        event_props = mock_capture.call_args.kwargs["properties"]
+        self.assertEqual(event_props["is_first_user"], True)
+        self.assertEqual(event_props["is_organization_first_user"], True)
+        self.assertEqual(event_props["new_onboarding_enabled"], False)
+        self.assertEqual(event_props["signup_backend_processor"], "OrganizationSignupSerializer")
+        self.assertEqual(event_props["signup_social_provider"], "")
+        self.assertEqual(event_props["realm"], get_instance_realm())
 
         # Assert that the user is logged in
         response = self.client.get("/api/users/@me/")
@@ -233,7 +240,8 @@ class TestSignupAPI(APIBaseTest):
         team_count: int = Team.objects.count()
 
         response = self.client.post(
-            "/api/signup/", {"first_name": "Jane", "email": "failed@posthog.com", "password": "123"},
+            "/api/signup/",
+            {"first_name": "Jane", "email": "failed@posthog.com", "password": "123"},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -301,7 +309,10 @@ class TestSignupAPI(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
+            key="key_123",
+            plan="enterprise",
+            valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7),
+            max_users=3,
         )
 
         response = self.client.get(reverse("social:begin", kwargs={"backend": "gitlab"}))
@@ -325,7 +336,10 @@ class TestSignupAPI(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
+            key="key_123",
+            plan="enterprise",
+            valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7),
+            max_users=3,
         )
 
         response = self.client.get(reverse("social:begin", kwargs={"backend": "gitlab"}))
@@ -455,7 +469,8 @@ class TestInviteSignup(APIBaseTest):
 
     def test_api_invite_sign_up_prevalidate(self):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+19@posthog.com", organization=self.organization,
+            target_email="test+19@posthog.com",
+            organization=self.organization,
         )
 
         response = self.client.get(f"/api/signup/{invite.id}/")
@@ -491,7 +506,8 @@ class TestInviteSignup(APIBaseTest):
         user = self._create_user("test+29@posthog.com", "test_password")
         new_org = Organization.objects.create(name="Test, Inc")
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+29@posthog.com", organization=new_org,
+            target_email="test+29@posthog.com",
+            organization=new_org,
         )
 
         self.client.force_login(user)
@@ -525,7 +541,8 @@ class TestInviteSignup(APIBaseTest):
     def test_existing_user_cant_claim_invite_if_it_doesnt_match_target_email(self):
         user = self._create_user("test+39@posthog.com", "test_password")
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+49@posthog.com", organization=self.organization,
+            target_email="test+49@posthog.com",
+            organization=self.organization,
         )
 
         self.client.force_login(user)
@@ -544,7 +561,8 @@ class TestInviteSignup(APIBaseTest):
 
     def test_api_invite_sign_up_prevalidate_expired_invite(self):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+59@posthog.com", organization=self.organization,
+            target_email="test+59@posthog.com",
+            organization=self.organization,
         )
         invite.created_at = datetime.datetime(2020, 12, 1, tzinfo=pytz.UTC)
         invite.save()
@@ -567,11 +585,13 @@ class TestInviteSignup(APIBaseTest):
     @patch("posthog.api.organization.settings.EE_AVAILABLE", True)
     def test_api_invite_sign_up(self, mock_capture):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+99@posthog.com", organization=self.organization,
+            target_email="test+99@posthog.com",
+            organization=self.organization,
         )
 
         response = self.client.post(
-            f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+            f"/api/signup/{invite.id}/",
+            {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         user = cast(User, User.objects.order_by("-pk")[0])
@@ -624,12 +644,14 @@ class TestInviteSignup(APIBaseTest):
     @patch("posthog.api.organization.settings.EE_AVAILABLE", False)
     def test_api_invite_sign_up_member_joined_email_is_not_sent_for_initial_member(self):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+100@posthog.com", organization=self.organization,
+            target_email="test+100@posthog.com",
+            organization=self.organization,
         )
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
             response = self.client.post(
-                f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+                f"/api/signup/{invite.id}/",
+                {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -641,12 +663,14 @@ class TestInviteSignup(APIBaseTest):
         initial_user = User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+100@posthog.com", organization=self.organization,
+            target_email="test+100@posthog.com",
+            organization=self.organization,
         )
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
             response = self.client.post(
-                f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+                f"/api/signup/{invite.id}/",
+                {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -662,12 +686,14 @@ class TestInviteSignup(APIBaseTest):
         initial_user = User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+100@posthog.com", organization=self.organization,
+            target_email="test+100@posthog.com",
+            organization=self.organization,
         )
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
             response = self.client.post(
-                f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+                f"/api/signup/{invite.id}/",
+                {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -682,7 +708,8 @@ class TestInviteSignup(APIBaseTest):
         new_org = Organization.objects.create(name="TestCo")
         new_team = Team.objects.create(organization=new_org)
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+159@posthog.com", organization=new_org,
+            target_email="test+159@posthog.com",
+            organization=new_org,
         )
 
         self.client.force_login(user)
@@ -750,7 +777,8 @@ class TestInviteSignup(APIBaseTest):
 
         Team.objects.create(organization=new_org)
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+189@posthog.com", organization=new_org,
+            target_email="test+189@posthog.com",
+            organization=new_org,
         )
 
         self.client.force_login(user)
@@ -800,7 +828,8 @@ class TestInviteSignup(APIBaseTest):
         ]
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+799@posthog.com", organization=self.organization,
+            target_email="test+799@posthog.com",
+            organization=self.organization,
         )
 
         for attribute in required_attributes:
@@ -832,7 +861,8 @@ class TestInviteSignup(APIBaseTest):
         org_count: int = Organization.objects.count()
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+799@posthog.com", organization=self.organization,
+            target_email="test+799@posthog.com",
+            organization=self.organization,
         )
 
         response = self.client.post(f"/api/signup/{invite.id}/", {"first_name": "Charlie", "password": "123"})
@@ -880,7 +910,8 @@ class TestInviteSignup(APIBaseTest):
         org_count: int = Organization.objects.count()
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+799@posthog.com", organization=self.organization,
+            target_email="test+799@posthog.com",
+            organization=self.organization,
         )
         invite.created_at = datetime.datetime(2020, 3, 3, tzinfo=pytz.UTC)
         invite.save()

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -103,13 +103,11 @@ class TestSignupAPI(APIBaseTest):
     def test_signup_disallowed_on_self_hosted_by_default(self):
         with self.settings(MULTI_TENANCY=False):
             response = self.client.post(
-                "/api/signup/",
-                {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
+                "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
             )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             response = self.client.post(
-                "/api/signup/",
-                {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
+                "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
             )
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(
@@ -128,10 +126,7 @@ class TestSignupAPI(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123",
-            plan="enterprise",
-            valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7),
-            max_users=3,
+            key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
         )
 
         Organization.objects.create(name="name")
@@ -139,8 +134,7 @@ class TestSignupAPI(APIBaseTest):
         count = Organization.objects.count()
         with self.settings(MULTI_TENANCY=False, MULTI_ORG_ENABLED=True):
             response = self.client.post(
-                "/api/signup/",
-                {"first_name": "Jane", "email": "hedgehog4@posthog.com", "password": "notsecure"},
+                "/api/signup/", {"first_name": "Jane", "email": "hedgehog4@posthog.com", "password": "notsecure"},
             )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["email"], "hedgehog4@posthog.com")
@@ -151,8 +145,7 @@ class TestSignupAPI(APIBaseTest):
     @patch("posthoganalytics.identify")
     def test_signup_minimum_attrs(self, mock_identify, mock_capture):
         response = self.client.post(
-            "/api/signup/",
-            {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
+            "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -240,8 +233,7 @@ class TestSignupAPI(APIBaseTest):
         team_count: int = Team.objects.count()
 
         response = self.client.post(
-            "/api/signup/",
-            {"first_name": "Jane", "email": "failed@posthog.com", "password": "123"},
+            "/api/signup/", {"first_name": "Jane", "email": "failed@posthog.com", "password": "123"},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -309,10 +301,7 @@ class TestSignupAPI(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123",
-            plan="enterprise",
-            valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7),
-            max_users=3,
+            key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
         )
 
         response = self.client.get(reverse("social:begin", kwargs={"backend": "gitlab"}))
@@ -336,10 +325,7 @@ class TestSignupAPI(APIBaseTest):
         from ee.models.license import License, LicenseManager
 
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            key="key_123",
-            plan="enterprise",
-            valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7),
-            max_users=3,
+            key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7), max_users=3,
         )
 
         response = self.client.get(reverse("social:begin", kwargs={"backend": "gitlab"}))
@@ -469,8 +455,7 @@ class TestInviteSignup(APIBaseTest):
 
     def test_api_invite_sign_up_prevalidate(self):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+19@posthog.com",
-            organization=self.organization,
+            target_email="test+19@posthog.com", organization=self.organization,
         )
 
         response = self.client.get(f"/api/signup/{invite.id}/")
@@ -506,8 +491,7 @@ class TestInviteSignup(APIBaseTest):
         user = self._create_user("test+29@posthog.com", "test_password")
         new_org = Organization.objects.create(name="Test, Inc")
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+29@posthog.com",
-            organization=new_org,
+            target_email="test+29@posthog.com", organization=new_org,
         )
 
         self.client.force_login(user)
@@ -541,8 +525,7 @@ class TestInviteSignup(APIBaseTest):
     def test_existing_user_cant_claim_invite_if_it_doesnt_match_target_email(self):
         user = self._create_user("test+39@posthog.com", "test_password")
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+49@posthog.com",
-            organization=self.organization,
+            target_email="test+49@posthog.com", organization=self.organization,
         )
 
         self.client.force_login(user)
@@ -561,8 +544,7 @@ class TestInviteSignup(APIBaseTest):
 
     def test_api_invite_sign_up_prevalidate_expired_invite(self):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+59@posthog.com",
-            organization=self.organization,
+            target_email="test+59@posthog.com", organization=self.organization,
         )
         invite.created_at = datetime.datetime(2020, 12, 1, tzinfo=pytz.UTC)
         invite.save()
@@ -585,13 +567,11 @@ class TestInviteSignup(APIBaseTest):
     @patch("posthog.api.organization.settings.EE_AVAILABLE", True)
     def test_api_invite_sign_up(self, mock_capture):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+99@posthog.com",
-            organization=self.organization,
+            target_email="test+99@posthog.com", organization=self.organization,
         )
 
         response = self.client.post(
-            f"/api/signup/{invite.id}/",
-            {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+            f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         user = cast(User, User.objects.order_by("-pk")[0])
@@ -644,14 +624,12 @@ class TestInviteSignup(APIBaseTest):
     @patch("posthog.api.organization.settings.EE_AVAILABLE", False)
     def test_api_invite_sign_up_member_joined_email_is_not_sent_for_initial_member(self):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+100@posthog.com",
-            organization=self.organization,
+            target_email="test+100@posthog.com", organization=self.organization,
         )
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
             response = self.client.post(
-                f"/api/signup/{invite.id}/",
-                {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+                f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -663,14 +641,12 @@ class TestInviteSignup(APIBaseTest):
         initial_user = User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+100@posthog.com",
-            organization=self.organization,
+            target_email="test+100@posthog.com", organization=self.organization,
         )
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
             response = self.client.post(
-                f"/api/signup/{invite.id}/",
-                {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+                f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -686,14 +662,12 @@ class TestInviteSignup(APIBaseTest):
         initial_user = User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+100@posthog.com",
-            organization=self.organization,
+            target_email="test+100@posthog.com", organization=self.organization,
         )
 
         with self.settings(EMAIL_ENABLED=True, EMAIL_HOST="localhost", SITE_URL="http://test.posthog.com"):
             response = self.client.post(
-                f"/api/signup/{invite.id}/",
-                {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
+                f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": "test_password", "email_opt_in": True},
             )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -708,8 +682,7 @@ class TestInviteSignup(APIBaseTest):
         new_org = Organization.objects.create(name="TestCo")
         new_team = Team.objects.create(organization=new_org)
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+159@posthog.com",
-            organization=new_org,
+            target_email="test+159@posthog.com", organization=new_org,
         )
 
         self.client.force_login(user)
@@ -777,8 +750,7 @@ class TestInviteSignup(APIBaseTest):
 
         Team.objects.create(organization=new_org)
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+189@posthog.com",
-            organization=new_org,
+            target_email="test+189@posthog.com", organization=new_org,
         )
 
         self.client.force_login(user)
@@ -828,8 +800,7 @@ class TestInviteSignup(APIBaseTest):
         ]
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+799@posthog.com",
-            organization=self.organization,
+            target_email="test+799@posthog.com", organization=self.organization,
         )
 
         for attribute in required_attributes:
@@ -861,8 +832,7 @@ class TestInviteSignup(APIBaseTest):
         org_count: int = Organization.objects.count()
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+799@posthog.com",
-            organization=self.organization,
+            target_email="test+799@posthog.com", organization=self.organization,
         )
 
         response = self.client.post(f"/api/signup/{invite.id}/", {"first_name": "Charlie", "password": "123"})
@@ -910,8 +880,7 @@ class TestInviteSignup(APIBaseTest):
         org_count: int = Organization.objects.count()
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
-            target_email="test+799@posthog.com",
-            organization=self.organization,
+            target_email="test+799@posthog.com", organization=self.organization,
         )
         invite.created_at = datetime.datetime(2020, 3, 3, tzinfo=pytz.UTC)
         invite.save()

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -2,7 +2,7 @@
 Module to centralize event reporting on the server-side.
 """
 
-from typing import List
+from typing import List, Optional
 
 import posthoganalytics
 
@@ -17,6 +17,8 @@ def report_user_signed_up(
     new_onboarding_enabled: bool = False,
     backend_processor: str = "",  # which serializer/view processed the request
     social_provider: str = "",  # which third-party provider processed the login (empty = no third-party)
+    user_analytics_metadata: Optional[dict] = None,  # analytics metadata taken from the User object
+    org_analytics_metadata: Optional[dict] = None,  # analytics metadata taken from the Organization object
 ) -> None:
     """
     Reports that a new user has joined. Only triggered when a new user is actually created (i.e. when an existing user
@@ -31,6 +33,12 @@ def report_user_signed_up(
         "signup_social_provider": social_provider,
         "realm": get_instance_realm(),
     }
+    if user_analytics_metadata is not None:
+        props.update(user_analytics_metadata)
+
+    if org_analytics_metadata is not None:
+        for k, v in org_analytics_metadata.items():
+            props[f"org__{k}"] = v
 
     # TODO: This should be $set_once as user props.
     posthoganalytics.identify(distinct_id, props)
@@ -74,7 +82,9 @@ def report_onboarding_completed(organization: Organization, current_user: User) 
     # TODO: This should be $set_once as user props.
     posthoganalytics.identify(current_user.distinct_id, {"onboarding_completed": True})
     posthoganalytics.capture(
-        current_user.distinct_id, "onboarding completed", properties={"team_members_count": team_members_count},
+        current_user.distinct_id,
+        "onboarding completed",
+        properties={"team_members_count": team_members_count},
     )
 
 
@@ -85,12 +95,18 @@ def report_user_updated(user: User, updated_attrs: List[str]) -> None:
 
     updated_attrs.sort()
     posthoganalytics.capture(
-        user.distinct_id, "user updated", properties={"updated_attrs": updated_attrs},
+        user.distinct_id,
+        "user updated",
+        properties={"updated_attrs": updated_attrs},
     )
 
 
 def report_team_member_invited(
-    distinct_id: str, name_provided: bool, current_invite_count: int, current_member_count: int, email_available: bool,
+    distinct_id: str,
+    name_provided: bool,
+    current_invite_count: int,
+    current_member_count: int,
+    email_available: bool,
 ) -> None:
     """
     Triggered after a user creates an **individual** invite for a new team member. See `report_bulk_invited`

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -82,9 +82,7 @@ def report_onboarding_completed(organization: Organization, current_user: User) 
     # TODO: This should be $set_once as user props.
     posthoganalytics.identify(current_user.distinct_id, {"onboarding_completed": True})
     posthoganalytics.capture(
-        current_user.distinct_id,
-        "onboarding completed",
-        properties={"team_members_count": team_members_count},
+        current_user.distinct_id, "onboarding completed", properties={"team_members_count": team_members_count},
     )
 
 
@@ -95,18 +93,12 @@ def report_user_updated(user: User, updated_attrs: List[str]) -> None:
 
     updated_attrs.sort()
     posthoganalytics.capture(
-        user.distinct_id,
-        "user updated",
-        properties={"updated_attrs": updated_attrs},
+        user.distinct_id, "user updated", properties={"updated_attrs": updated_attrs},
     )
 
 
 def report_team_member_invited(
-    distinct_id: str,
-    name_provided: bool,
-    current_invite_count: int,
-    current_member_count: int,
-    email_available: bool,
+    distinct_id: str, name_provided: bool, current_invite_count: int, current_member_count: int, email_available: bool,
 ) -> None:
     """
     Triggered after a user creates an **individual** invite for a new team member. See `report_bulk_invited`

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -26,7 +26,11 @@ INVITE_DAYS_VALIDITY = 3  # number of days for which team invites are valid
 
 class OrganizationManager(models.Manager):
     def bootstrap(
-        self, user: Any, *, team_fields: Optional[Dict[str, Any]] = None, **kwargs,
+        self,
+        user: Any,
+        *,
+        team_fields: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Tuple["Organization", Optional["OrganizationMembership"], Any]:
         """Instead of doing the legwork of creating an organization yourself, delegate the details with bootstrap."""
         from .team import Team  # Avoiding circular import
@@ -37,7 +41,9 @@ class OrganizationManager(models.Manager):
             organization_membership: Optional[OrganizationMembership] = None
             if user is not None:
                 organization_membership = OrganizationMembership.objects.create(
-                    organization=organization, user=user, level=OrganizationMembership.Level.OWNER,
+                    organization=organization,
+                    user=user,
+                    level=OrganizationMembership.Level.OWNER,
                 )
                 user.current_organization = organization
                 user.current_team = team
@@ -155,6 +161,7 @@ class Organization(UUIDModel):
             "person_count": sum((team.person_set.count() for team in self.teams.all())),
             "setup_section_2_completed": self.setup_section_2_completed,
             "personalization": self.personalization,
+            "name": self.name,
         }
 
 
@@ -228,7 +235,10 @@ class OrganizationMembership(UUIDModel):
 
 class OrganizationInvite(UUIDModel):
     organization: models.ForeignKey = models.ForeignKey(
-        "posthog.Organization", on_delete=models.CASCADE, related_name="invites", related_query_name="invite",
+        "posthog.Organization",
+        on_delete=models.CASCADE,
+        related_name="invites",
+        related_query_name="invite",
     )
     target_email: models.EmailField = models.EmailField(null=True, db_index=True)
     first_name: models.CharField = models.CharField(max_length=30, blank=True, default="")
@@ -255,16 +265,19 @@ class OrganizationInvite(UUIDModel):
 
         if self.is_expired():
             raise exceptions.ValidationError(
-                "This invite has expired. Please ask your admin for a new one.", code="expired",
+                "This invite has expired. Please ask your admin for a new one.",
+                code="expired",
             )
 
         if OrganizationMembership.objects.filter(organization=self.organization, user=user).exists():
             raise exceptions.ValidationError(
-                "You already are a member of this organization.", code="user_already_member",
+                "You already are a member of this organization.",
+                code="user_already_member",
             )
 
         if OrganizationMembership.objects.filter(
-            organization=self.organization, user__email=self.target_email,
+            organization=self.organization,
+            user__email=self.target_email,
         ).exists():
             raise exceptions.ValidationError(
                 "Another user with this email address already belongs to this organization.",

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -26,11 +26,7 @@ INVITE_DAYS_VALIDITY = 3  # number of days for which team invites are valid
 
 class OrganizationManager(models.Manager):
     def bootstrap(
-        self,
-        user: Any,
-        *,
-        team_fields: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        self, user: Any, *, team_fields: Optional[Dict[str, Any]] = None, **kwargs,
     ) -> Tuple["Organization", Optional["OrganizationMembership"], Any]:
         """Instead of doing the legwork of creating an organization yourself, delegate the details with bootstrap."""
         from .team import Team  # Avoiding circular import
@@ -41,9 +37,7 @@ class OrganizationManager(models.Manager):
             organization_membership: Optional[OrganizationMembership] = None
             if user is not None:
                 organization_membership = OrganizationMembership.objects.create(
-                    organization=organization,
-                    user=user,
-                    level=OrganizationMembership.Level.OWNER,
+                    organization=organization, user=user, level=OrganizationMembership.Level.OWNER,
                 )
                 user.current_organization = organization
                 user.current_team = team
@@ -235,10 +229,7 @@ class OrganizationMembership(UUIDModel):
 
 class OrganizationInvite(UUIDModel):
     organization: models.ForeignKey = models.ForeignKey(
-        "posthog.Organization",
-        on_delete=models.CASCADE,
-        related_name="invites",
-        related_query_name="invite",
+        "posthog.Organization", on_delete=models.CASCADE, related_name="invites", related_query_name="invite",
     )
     target_email: models.EmailField = models.EmailField(null=True, db_index=True)
     first_name: models.CharField = models.CharField(max_length=30, blank=True, default="")
@@ -265,19 +256,16 @@ class OrganizationInvite(UUIDModel):
 
         if self.is_expired():
             raise exceptions.ValidationError(
-                "This invite has expired. Please ask your admin for a new one.",
-                code="expired",
+                "This invite has expired. Please ask your admin for a new one.", code="expired",
             )
 
         if OrganizationMembership.objects.filter(organization=self.organization, user=user).exists():
             raise exceptions.ValidationError(
-                "You already are a member of this organization.",
-                code="user_already_member",
+                "You already are a member of this organization.", code="user_already_member",
             )
 
         if OrganizationMembership.objects.filter(
-            organization=self.organization,
-            user__email=self.target_email,
+            organization=self.organization, user__email=self.target_email,
         ).exists():
             raise exceptions.ValidationError(
                 "Another user with this email address already belongs to this organization.",


### PR DESCRIPTION
## Changes
Sends the `analytics_metadata` object for users and orgs as properties for sign up events.

Note: cloud tests are failing since they need to be updated in that repo. 

The failures are due to additional properties coming back from this object. I've switched the test to check for a few key properties (the ones being checked historically) instead of the entire dictionary, checking each property makes updating instrumentation a lot more involved than it should be most cases.

## How did you test this code?
- Hit the signup flows locally
- Updated the unit tests (cloud still needs to be updated)


