### PR TITLE
Make PRINT_SQL output readable

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -200,7 +200,7 @@ def _prepare_query(client: SyncClient, query: str, args: QueryArgs):
 
     if app_settings.SHELL_PLUS_PRINT_SQL:
         print()
-        print(format_sql(rendered_sql))
+        print(format_sql(formatted_sql))
 
     return annotated_sql, args, tags
 


### PR DESCRIPTION
Our queries now contain a lot of comment noise that's not relevant when
developing. This change makes PRINT_SQL env variable usable again by
stripping these comments.


## How did you test this code?

*Please describe.*
