### PR TITLE
Adds a hot key keypress detection method that isn't flummoxed by the shadow DOM

### DIFF
--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -35,7 +35,7 @@ type AllHotkeysInterface = Partial<Record<AllHotKeys, HotkeyInterface>>
  * @param ignorableElements
  */
 const isToolbarInput = (event: Event, ignorableElements: string[]): boolean => {
-    const path = (event as any).path || event.composedPath()
+    const path = event.composedPath() || (event as any).path
     if (!path) {
         return false
     }

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -41,7 +41,7 @@ const isToolbarInput = (event: Event, ignorableElements: string[]): boolean => {
     }
 
     const sourceElement = path[0] as HTMLElement
-    const tagName = sourceElement.tagName
+    const tagName = sourceElement.tagName || 'not an html element'
     return ignorableElements.includes(tagName.toLowerCase())
 }
 

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 import { useEventListener } from 'lib/hooks/useEventListener'
 import { DependencyList } from 'react'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
-import { HotKeys, GlobalHotKeys } from '~/types'
+import { GlobalHotKeys, HotKeys } from '~/types'
 
 export interface HotkeyInterface {
     action: () => void
@@ -26,6 +26,21 @@ export const useGlobalKeyboardHotkeys = (hotkeys: GlobalHotkeysInterface, deps?:
 
 type AllHotKeys = GlobalHotKeys | HotKeys
 type AllHotkeysInterface = Partial<Record<AllHotKeys, HotkeyInterface>>
+
+/**
+ * input boxes in the hovering toolbar do not have event target of input.
+ * they are detected as for e.g.div#__POSTHOG_TOOLBAR__.ph-no-capture
+ * see https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
+ * @param event
+ * @param ignorableElements
+ */
+const isToolbarInput = (event: Event, ignorableElements: string[]): boolean => {
+    const path = (event as any).path || event.composedPath()
+    const sourceElement = path[0] as HTMLElement
+    const tagName = sourceElement.tagName
+    return ignorableElements.includes(tagName.toLowerCase())
+}
+
 /**
  *
  * @param hotkeys Hotkeys to listen to and actions to execute
@@ -51,7 +66,8 @@ function _useKeyboardHotkeys(hotkeys: AllHotkeysInterface, deps?: DependencyList
             }
 
             // Ignore typing on inputs (default behavior); except Esc key
-            if (key !== 'Escape' && IGNORE_INPUTS.includes((event.target as HTMLElement).tagName.toLowerCase())) {
+            const isDOMInput = IGNORE_INPUTS.includes((event.target as HTMLElement).tagName.toLowerCase())
+            if (key !== 'Escape' && (isDOMInput || isToolbarInput(event, IGNORE_INPUTS))) {
                 return
             }
 

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -36,6 +36,10 @@ type AllHotkeysInterface = Partial<Record<AllHotKeys, HotkeyInterface>>
  */
 const isToolbarInput = (event: Event, ignorableElements: string[]): boolean => {
     const path = (event as any).path || event.composedPath()
+    if (!path) {
+        return false
+    }
+
     const sourceElement = path[0] as HTMLElement
     const tagName = sourceElement.tagName
     return ignorableElements.includes(tagName.toLowerCase())


### PR DESCRIPTION
## Changes

Input boxes in modals from the hovering toolbar *on app.posthog.com* were ignoring keypresses of any hotkey and the UI was navigating from the hotkey underneath the modal

This was because the hotkey hook was checking if the target of the key event was an input. But in the modal the triggering event was shown as the toolbar's outer div

https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath This method is now available in some browsers to allow you to discover a path of an event in the shadow DOM. 

This change adds a new test to the hotkey hook which also checks if the root of the path in the shadow DOM for the event was an input

# Before this change
![typing in an input and displaying only some of the keys](https://user-images.githubusercontent.com/984817/136005439-bd60a83c-a3b4-45c4-a995-b0a8ecaab55e.gif)

# After this change
![typing in an input and displaying all of the keys](https://user-images.githubusercontent.com/984817/136005646-4c674f7c-1259-44b9-ae50-1bfcf5ea3d66.gif)


## How did you test this code?

by running it locally
