### PR TITLE
Linking to GH issue in Cloud Announcement

### DIFF
--- a/frontend/src/layout/navigation/CloudAnnouncement.tsx
+++ b/frontend/src/layout/navigation/CloudAnnouncement.tsx
@@ -2,17 +2,16 @@ import React from 'react'
 import { Alert, Space, Button } from 'antd'
 
 export function CloudAnnouncement({ message }: { message: string }): JSX.Element | null {
-    const parsed_message = message.split('_').join(' ');
-    const github_issue_regex = /ph-([0-9]{1,8})/ig;
-    const github_issue_ids = github_issue_regex.exec(message);
+    const parsedMessage = message.split('_').join(' ')
+    const githubIssueIds = message.match(/ph-([0-9]{1,8})/i)
     return (
         <div style={{ marginTop: 15 }}>
             <Alert 
-                message={parsed_message.replace(github_issue_regex, '')} 
+                message={parsedMessage.replace(/ph-[0-9]{1,8}/ig, '')} 
                     action={
-                        github_issue_ids ? (
+                        githubIssueIds ? (
                         <Space>
-                            <Button size="small" type="ghost" href={'https://github.com/PostHog/posthog/issues/' + github_issue_ids[1]} target='_blank'>
+                            <Button size="small" type="ghost" href={'https://github.com/PostHog/posthog/issues/' + githubIssueIds[1]} target='_blank'>
                                 More details
                             </Button>
                         </Space>

--- a/frontend/src/layout/navigation/CloudAnnouncement.tsx
+++ b/frontend/src/layout/navigation/CloudAnnouncement.tsx
@@ -6,18 +6,26 @@ export function CloudAnnouncement({ message }: { message: string }): JSX.Element
     const githubIssueIds = message.match(/ph-([0-9]{1,8})/i)
     return (
         <div style={{ marginTop: 15 }}>
-            <Alert 
-                message={parsedMessage.replace(/ph-[0-9]{1,8}/ig, '')} 
-                    action={
-                        githubIssueIds ? (
+            <Alert
+                message={parsedMessage.replace(/ph-[0-9]{1,8}/gi, '')}
+                action={
+                    githubIssueIds ? (
                         <Space>
-                            <Button size="small" type="ghost" href={'https://github.com/PostHog/posthog/issues/' + githubIssueIds[1]} target='_blank'>
+                            <Button
+                                size="small"
+                                type="ghost"
+                                href={'https://github.com/PostHog/posthog/issues/' + githubIssueIds[1]}
+                                target="_blank"
+                            >
                                 More details
                             </Button>
                         </Space>
-                        ): null
-                    }
-            type="warning" showIcon closable />
+                    ) : null
+                }
+                type="warning"
+                showIcon
+                closable
+            />
         </div>
     )
 }

--- a/frontend/src/layout/navigation/CloudAnnouncement.tsx
+++ b/frontend/src/layout/navigation/CloudAnnouncement.tsx
@@ -1,10 +1,24 @@
 import React from 'react'
-import { Alert } from 'antd'
+import { Alert, Space, Button } from 'antd'
 
 export function CloudAnnouncement({ message }: { message: string }): JSX.Element | null {
+    const parsed_message = message.split('_').join(' ');
+    const github_issue_regex = /ph-([0-9]{1,8})/ig;
+    const github_issue_ids = github_issue_regex.exec(message);
     return (
         <div style={{ marginTop: 15 }}>
-            <Alert message={message.split('_').join(' ')} type="warning" showIcon closable />
+            <Alert 
+                message={parsed_message.replace(github_issue_regex, '')} 
+                    action={
+                        github_issue_ids ? (
+                        <Space>
+                            <Button size="small" type="ghost" href={'https://github.com/PostHog/posthog/issues/' + github_issue_ids[1]} target='_blank'>
+                                More details
+                            </Button>
+                        </Space>
+                        ): null
+                    }
+            type="warning" showIcon closable />
         </div>
     )
 }


### PR DESCRIPTION
## Changes

Added the ability to include a link to a GitHub issue in a cloud announcement - so that our customers can get more detail on what's going on, see our progress and have confidence we're solving it.

This works by parsing issues in the format `ph-1234` from the cloud-announcement feature flag and converting them to links to issues in the PostHog repo. It only supports one issue at a time, if you include multiple issues only the first will be used on the link - all issue reference will be stripped from the text.

Will document here: https://github.com/PostHog/posthog.com/pull/2173

## How did you test this code?

1. Does it work as before with no issue tags in the text
<img width="1305" alt="image" src="https://user-images.githubusercontent.com/85295485/136008107-f3c577b2-e503-4ce7-ad2a-04aab7c6bba4.png">
<img width="1305" alt="image" src="https://user-images.githubusercontent.com/85295485/136008172-447977a6-8f3f-49f4-83d2-89ddc3bd6e0f.png">


2. If I add one issue tag to the text does it use to the correct link and open in a new window
<img width="1295" alt="image" src="https://user-images.githubusercontent.com/85295485/136008244-ecdd12ae-c837-4ed2-97b0-328319a2d710.png">

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/85295485/136008292-373b1e79-b78e-4aa5-ad53-e9c6ee7b4889.png">

(bottom left - will open the correct URL in a new tab)
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/85295485/136008354-7cb215e4-04fc-4166-a21a-0ab7da19b31a.png">

And here's the tab...
<img width="247" alt="image" src="https://user-images.githubusercontent.com/85295485/136008426-f83cf1ba-c3a9-405f-aca8-b1f8214e6936.png">

3. If I add multiple issues to the text, is only the first one used and others stripped from the text
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/85295485/136008530-70c1a758-98ab-457e-8d40-de309c009c6b.png">

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/85295485/136008588-91c6996f-4649-45ee-a9de-75809e5fc129.png">

Correct, only links to the first issue - all other issues are stripped from the text.
