### PR TITLE
Fix feature flags not loading in toolbar

### DIFF
--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -64,7 +64,10 @@ class FeatureFlag(models.Model):
 
     @property
     def variants(self):
-        return self.get_filters().get("multivariate", {}).get("variants", [])
+        # :TRICKY: "multivariate" can be "null" inside json, causing .get("dictkey", {}) to be "None" and throw
+        multivariate = self.get_filters().get("multivariate", None)
+        if isinstance(multivariate, dict):
+            return multivariate.get("variants", []) or []  # can explicitly be "null" inside the json
 
     def get_filters(self):
         if "groups" in self.filters:

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -67,7 +67,7 @@ class FeatureFlag(models.Model):
         # :TRICKY: .get("multivariate", {}) returns "None" if the key is explicitly set to "null" inside json filters
         multivariate = self.get_filters().get("multivariate", None)
         if isinstance(multivariate, dict):
-            variants = multivariate.get("variants", [])
+            variants = multivariate.get("variants", None)
             if isinstance(variants, list):
                 return variants
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -64,10 +64,12 @@ class FeatureFlag(models.Model):
 
     @property
     def variants(self):
-        # :TRICKY: "multivariate" can be "null" inside json, causing .get("dictkey", {}) to be "None" and throw
+        # :TRICKY: .get("multivariate", {}) returns "None" if the key is explicitly set to "null" inside json filters
         multivariate = self.get_filters().get("multivariate", None)
         if isinstance(multivariate, dict):
-            return multivariate.get("variants", []) or []  # can explicitly be "null" inside the json
+            variants = multivariate.get("variants", [])
+            if isinstance(variants, list):
+                return variants
 
     def get_filters(self):
         if "groups" in self.filters:

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -60,7 +60,7 @@ class FeatureFlag(models.Model):
 
     @property
     def groups(self):
-        return self.get_filters().get("groups", [])
+        return self.get_filters().get("groups", []) or []
 
     @property
     def variants(self):
@@ -70,6 +70,7 @@ class FeatureFlag(models.Model):
             variants = multivariate.get("variants", None)
             if isinstance(variants, list):
                 return variants
+        return []
 
     def get_filters(self):
         if "groups" in self.filters:


### PR DESCRIPTION
## Changes

- Couldn't get the flags to show up, turns out we were parsing bad JSON.
- The code `self.filters.get("multivariate", {})` returns `None` (and not `{}`) if the key is explicitly set to `null` inside the json, which it was.


## How did you test this code?

Opened a python shell and ran various combinations of `dict.get('key', None) or []` to make sure I'm getting this right, in the end settled on the simplest code that also provides the tiniest bit of type safety.
