### PR TITLE
Clarify copy on data point click

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -52,7 +52,7 @@ export function InsightTooltip({
             {inspectPersonsLabel && (
                 <div className="inspect-persons-label">
                     <IconHandClick />
-                    Click to view persons
+                    Click on data point to view persons
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Changes

Based on user feedback, change copy to make it clear where to click.

<img width="345" alt="" src="https://user-images.githubusercontent.com/5864173/136033009-20597820-f1c0-438f-a31a-682c9e9747b6.png">


## How did you test this code?

Opened a graph manually, took screenshot above.
