### PR TITLE
add a clearer loading state on the events table

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -341,7 +341,9 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
                     key={columnConfig === 'DEFAULT' ? 'default' : columnConfig.join('-')}
                     className="ph-no-capture"
                     locale={{
-                        emptyText: (
+                        emptyText: isLoading ? (
+                            <span>&nbsp;</span>
+                        ) : (
                             <span>
                                 You don't have any items here! If you haven't integrated PostHog yet,{' '}
                                 <Link to="/project/settings">click here to set PostHog up on your app</Link>.

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -119,9 +119,9 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             },
         ],
         isLoading: [
-            false,
+            true,
             {
-                fetchEvents: (state) => state,
+                fetchEvents: () => true,
                 setDelayedLoading: () => true,
                 fetchEventsSuccess: () => false,
                 fetchOrPollFailure: () => false,


### PR DESCRIPTION
## Changes

Starts the event table in a loading state and adds a clearer empty loading state. Particularly helpful on slower connections or when the event query is slow

closes #6192 

adds _clearer_ loading spinner to event table... 
![slowloading3](https://user-images.githubusercontent.com/984817/136033761-dd07f6f5-f69a-426a-b61f-9d5ce234c881.gif)

before this change
![events-loading-before](https://user-images.githubusercontent.com/984817/136034542-94add5f2-099c-48e9-9703-edc8935b7026.gif)

after this change
![events-loading-after](https://user-images.githubusercontent.com/984817/136034577-cf400506-ae3c-4ae6-b9f7-8b8c994d22b4.gif)

## How did you test this code?

added logic tests for the events table and ran locally
