### PR TITLE
Insight logic refactor

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -21,9 +21,9 @@ interface ChartFilterProps {
 }
 
 export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { chartFilter } = useValues(chartFilterLogic({ id: insight?.id || 'new' }))
-    const { setChartFilter } = useActions(chartFilterLogic({ id: insight?.id || 'new' }))
+    const { insightProps } = useValues(insightLogic)
+    const { chartFilter } = useValues(chartFilterLogic(insightProps))
+    const { setChartFilter } = useActions(chartFilterLogic(insightProps))
     const { preflight } = useValues(preflightLogic)
 
     const linearDisabled = !!filters.session && filters.session === 'dist'

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -12,6 +12,7 @@ import {
 } from '@ant-design/icons'
 import { ChartDisplayType, FilterType, FunnelVizType, ViewType } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface ChartFilterProps {
     filters: FilterType
@@ -20,8 +21,9 @@ interface ChartFilterProps {
 }
 
 export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): JSX.Element {
-    const { chartFilter } = useValues(chartFilterLogic)
-    const { setChartFilter } = useActions(chartFilterLogic)
+    const { insight } = useValues(insightLogic)
+    const { chartFilter } = useValues(chartFilterLogic({ id: insight?.id || 'new' }))
+    const { setChartFilter } = useActions(chartFilterLogic({ id: insight?.id || 'new' }))
     const { preflight } = useValues(preflightLogic)
 
     const linearDisabled = !!filters.session && filters.session === 'dist'

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { router } from 'kea-router'
 import { objectsEqual } from 'lib/utils'
 import { chartFilterLogicType } from './chartFilterLogicType'
-import { ChartDisplayType, FunnelVizType, ViewType } from '~/types'
+import { ChartDisplayType, FilterType, FunnelVizType, ViewType } from '~/types'
 
 function isFunnelVizType(filter: FunnelVizType | ChartDisplayType): filter is FunnelVizType {
     return Object.values(FunnelVizType).includes(filter as FunnelVizType)
@@ -22,24 +22,30 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
     },
     listeners: ({ values }) => ({
         setChartFilter: ({ filter }) => {
-            const { display, funnel_viz_type, ...searchParams } = router.values.searchParams // eslint-disable-line
+            const { display, funnel_viz_type, ..._params }: Partial<FilterType> = {
+                ...router.values.searchParams,
+                ...router.values.hashParams,
+            } // eslint-disable-line
             const { pathname } = router.values.location
+
+            const hashParams = _params as Partial<FilterType>
             if (isFunnelVizType(filter)) {
-                searchParams.funnel_viz_type = filter
-                searchParams.display = ChartDisplayType.FunnelViz
+                hashParams.funnel_viz_type = filter
+                hashParams.display = ChartDisplayType.FunnelViz
             } else {
-                searchParams.display = values.chartFilter
+                hashParams.display = values.chartFilter as ChartDisplayType
             }
             if (
                 (!isFunnelVizType(filter) && !objectsEqual(display, values.chartFilter)) ||
                 (isFunnelVizType(filter) && !objectsEqual(funnel_viz_type, values.chartFilter))
             ) {
-                router.actions.replace(pathname, searchParams)
+                router.actions.replace(pathname, {}, hashParams)
             }
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights': (_, { display, insight, funnel_viz_type }) => {
+        '/insights': (_, searchParams, hashParams) => {
+            const { display, insight, funnel_viz_type }: Partial<FilterType> = { ...searchParams, ...hashParams.q }
             if (display === ChartDisplayType.FunnelViz && !funnel_viz_type) {
                 actions.setChartFilter(FunnelVizType.Steps)
             } else if (display && !funnel_viz_type) {
@@ -47,7 +53,7 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
             } else if (insight === ViewType.RETENTION) {
                 actions.setChartFilter(ChartDisplayType.ActionsTable)
             } else if (insight === ViewType.FUNNELS) {
-                actions.setChartFilter(funnel_viz_type || FunnelVizType.Steps)
+                actions.setChartFilter((funnel_viz_type as FunnelVizType) || FunnelVizType.Steps)
             }
         },
     }),

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -9,15 +9,15 @@ function isFunnelVizType(filter: FunnelVizType | ChartDisplayType): filter is Fu
 }
 
 interface ChartFilterLogicProps {
-    id: number | 'new'
+    dashboardItemId?: number
 }
 
 export const chartFilterLogic = kea<chartFilterLogicType<ChartFilterLogicProps>>({
     props: {} as ChartFilterLogicProps,
-    key: (props) => props.id || 'new',
+    key: (props) => props.dashboardItemId || 'new',
     connect: (props: ChartFilterLogicProps) => ({
-        values: [insightLogic(props), ['filters']],
-        actions: [insightLogic(props), ['updateInsightFilters']],
+        values: [insightLogic({ id: props.dashboardItemId }), ['filters']],
+        actions: [insightLogic({ id: props.dashboardItemId }), ['updateInsightFilters']],
     }),
     actions: () => ({
         setChartFilter: (filter: ChartDisplayType | FunnelVizType) => ({ filter }),

--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import { useValues, useActions } from 'kea'
 import { Checkbox } from 'antd'
 import { compareFilterLogic } from './compareFilterLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function CompareFilter(): JSX.Element {
-    const { compare, disabled } = useValues(compareFilterLogic)
-    const { setCompare } = useActions(compareFilterLogic)
+    const { insight } = useValues(insightLogic)
+    const { compare, disabled } = useValues(compareFilterLogic({ id: insight?.id || 'new' }))
+    const { setCompare } = useActions(compareFilterLogic({ id: insight?.id || 'new' }))
     return (
         <Checkbox
             onChange={(e) => {

--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -5,9 +5,9 @@ import { compareFilterLogic } from './compareFilterLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function CompareFilter(): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { compare, disabled } = useValues(compareFilterLogic({ id: insight?.id || 'new' }))
-    const { setCompare } = useActions(compareFilterLogic({ id: insight?.id || 'new' }))
+    const { insightProps } = useValues(insightLogic)
+    const { compare, disabled } = useValues(compareFilterLogic(insightProps))
+    const { setCompare } = useActions(compareFilterLogic(insightProps))
     return (
         <Checkbox
             onChange={(e) => {

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -5,15 +5,15 @@ import { compareFilterLogicType } from './compareFilterLogicType'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface CompareFilterLogicProps {
-    id: number | 'new'
+    dashboardItemId?: number
 }
 
 export const compareFilterLogic = kea<compareFilterLogicType<CompareFilterLogicProps>>({
     props: {} as CompareFilterLogicProps,
-    key: (props) => props.id || 'new',
+    key: (props) => props.dashboardItemId || 'new',
     connect: (props: CompareFilterLogicProps) => ({
-        values: [insightLogic(props), ['filters']],
-        actions: [insightLogic(props), ['updateInsightFilters']],
+        values: [insightLogic({ id: props.dashboardItemId }), ['filters']],
+        actions: [insightLogic({ id: props.dashboardItemId }), ['updateInsightFilters']],
     }),
     actions: () => ({
         setCompare: (compare: boolean) => ({ compare }),

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -1,22 +1,33 @@
 import { kea } from 'kea'
-import { router } from 'kea-router'
 import { objectsEqual } from 'lib/utils'
-import { FilterType, ViewType } from '~/types'
+import { ViewType } from '~/types'
 import { compareFilterLogicType } from './compareFilterLogicType'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
-export const compareFilterLogic = kea<compareFilterLogicType>({
+interface CompareFilterLogicProps {
+    id: number | 'new'
+}
+
+export const compareFilterLogic = kea<compareFilterLogicType<CompareFilterLogicProps>>({
+    props: {} as CompareFilterLogicProps,
+    key: (props) => props.id || 'new',
+    connect: (props: CompareFilterLogicProps) => ({
+        values: [insightLogic(props), ['filters']],
+        actions: [insightLogic(props), ['updateInsightFilters']],
+    }),
     actions: () => ({
         setCompare: (compare: boolean) => ({ compare }),
         setDisabled: (disabled: boolean) => ({ disabled }),
         toggleCompare: true,
     }),
-    reducers: () => ({
-        compare: [
-            false,
-            {
-                setCompare: (_, { compare }) => compare,
-            },
+    selectors: {
+        compare: [(s) => [s.filters], (filters) => !!filters.compare],
+        disabled: [
+            (s) => [s.filters],
+            ({ insight, date_from }) => insight === ViewType.LIFECYCLE || date_from === 'all',
         ],
+    },
+    reducers: () => ({
         disabled: [
             false,
             {
@@ -25,31 +36,13 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
         ],
     }),
     listeners: ({ actions, values }) => ({
-        setCompare: () => {
-            const { compare, ...searchParams } = router.values.searchParams // eslint-disable-line
-            const { pathname } = router.values.location
-
-            searchParams.compare = values.compare
-
+        setCompare: ({ compare }) => {
             if (!objectsEqual(compare, values.compare)) {
-                router.actions.replace(pathname, searchParams)
+                actions.updateInsightFilters({ ...values.filters, compare })
             }
         },
         toggleCompare: () => {
             actions.setCompare(!values.compare)
-        },
-    }),
-    urlToAction: ({ actions }) => ({
-        '/insights': (_, searchParams, hashParams) => {
-            const { compare, insight, date_from }: Partial<FilterType> = { ...searchParams, ...hashParams.q }
-            if (compare !== undefined) {
-                actions.setCompare(compare)
-            }
-            if (insight === ViewType.LIFECYCLE || date_from === 'all') {
-                actions.setDisabled(true)
-            } else {
-                actions.setDisabled(false)
-            }
         },
     }),
 })

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import { objectsEqual } from 'lib/utils'
-import { InsightType, ViewType } from '~/types'
+import { FilterType, ViewType } from '~/types'
 import { compareFilterLogicType } from './compareFilterLogicType'
 
 export const compareFilterLogic = kea<compareFilterLogicType>({
@@ -40,18 +40,8 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights': (
-            _: any,
-            {
-                compare,
-                insight,
-                date_from,
-            }: {
-                compare?: boolean
-                insight?: InsightType
-                date_from?: string
-            }
-        ) => {
+        '/insights': (_, searchParams, hashParams) => {
+            const { compare, insight, date_from }: Partial<FilterType> = { ...searchParams, ...hashParams.q }
             if (compare !== undefined) {
                 actions.setCompare(compare)
             }

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -16,8 +16,8 @@ export interface DateFilterProps {
 }
 
 interface RawDateFilterProps extends DateFilterProps {
-    dateFrom?: string | dayjs.Dayjs
-    dateTo?: string | dayjs.Dayjs
+    dateFrom?: string | null | dayjs.Dayjs
+    dateTo?: string | null | dayjs.Dayjs
 }
 
 export function DateFilter({

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -6,6 +6,7 @@ import { disableHourFor, disableMinuteFor } from 'lib/utils'
 import { CalendarOutlined } from '@ant-design/icons'
 import { defaultInterval, IntervalKeyType, intervals } from 'lib/components/IntervalFilter/intervals'
 import { ViewType } from '~/types'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface InvertalFilterProps {
     view: ViewType
@@ -13,8 +14,9 @@ interface InvertalFilterProps {
 }
 
 export function IntervalFilter({ view, disabled }: InvertalFilterProps): JSX.Element {
-    const { interval } = useValues(intervalFilterLogic)
-    const { setIntervalFilter, setDateFrom } = useActions(intervalFilterLogic)
+    const { insight } = useValues(insightLogic)
+    const { interval } = useValues(intervalFilterLogic({ id: insight?.id || 'new' }))
+    const { setIntervalFilter, setDateFrom } = useActions(intervalFilterLogic({ id: insight?.id || 'new' }))
     const options = Object.entries(intervals).map(([key, { label }]) => ({
         key,
         value: key,

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -14,9 +14,9 @@ interface InvertalFilterProps {
 }
 
 export function IntervalFilter({ view, disabled }: InvertalFilterProps): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { interval } = useValues(intervalFilterLogic({ id: insight?.id || 'new' }))
-    const { setIntervalFilter, setDateFrom } = useActions(intervalFilterLogic({ id: insight?.id || 'new' }))
+    const { insightProps } = useValues(insightLogic)
+    const { interval } = useValues(intervalFilterLogic(insightProps))
+    const { setIntervalFilter, setDateFrom } = useActions(intervalFilterLogic(insightProps))
     const options = Object.entries(intervals).map(([key, { label }]) => ({
         key,
         value: key,

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -5,15 +5,15 @@ import { IntervalKeyType } from 'lib/components/IntervalFilter/intervals'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface IntervalFilterLogicProps {
-    id: number | 'new'
+    dashboardItemId?: number
 }
 
 export const intervalFilterLogic = kea<intervalFilterLogicType<IntervalFilterLogicProps>>({
     props: {} as IntervalFilterLogicProps,
-    key: (props) => props.id || 'new',
+    key: (props) => props.dashboardItemId || 'new',
     connect: (props: IntervalFilterLogicProps) => ({
-        values: [insightLogic(props), ['filters']],
-        actions: [insightLogic(props), ['updateInsightFilters']],
+        values: [insightLogic({ id: props.dashboardItemId }), ['filters']],
+        actions: [insightLogic({ id: props.dashboardItemId }), ['updateInsightFilters']],
     }),
     actions: () => ({
         setIntervalFilter: (interval: IntervalKeyType) => ({ interval }),

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -3,6 +3,7 @@ import { router } from 'kea-router'
 import { objectsEqual } from 'lib/utils'
 import { intervalFilterLogicType } from './intervalFilterLogicType'
 import { IntervalKeyType } from 'lib/components/IntervalFilter/intervals'
+import { FilterType } from '~/types'
 
 export const intervalFilterLogic = kea<intervalFilterLogicType>({
     actions: () => ({
@@ -46,7 +47,8 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights': (_, { interval, date_from }) => {
+        '/insights': (_, searchParams, hashParams) => {
+            const { interval, date_from }: Partial<FilterType> = { ...searchParams, ...hashParams.q }
             if (interval) {
                 actions.setIntervalFilter(interval)
             }

--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -27,7 +27,7 @@ export function PathItemFilters({
     style = {},
     groupTypes,
 }: PropertyFiltersProps): JSX.Element {
-    const logicProps = { propertyFilters, onChange, pageKey, urlOverride: 'exclude_events' }
+    const logicProps = { propertyFilters, onChange, pageKey }
     const { filters } = useValues(propertyFilterLogic(logicProps))
     const { setFilter, remove, setFilters } = useActions(propertyFilterLogic(logicProps))
 

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -1,6 +1,4 @@
 import { kea } from 'kea'
-import { objectsEqual } from 'lib/utils'
-import { router } from 'kea-router'
 
 import { propertyFilterLogicType } from './propertyFilterLogicType'
 import { AnyPropertyFilter, EmptyPropertyFilter, PropertyFilter } from '~/types'
@@ -69,37 +67,7 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
             if (props.onChange) {
                 props.onChange(cleanedFilters)
             } else {
-                const { [`${props.urlOverride || 'properties'}`]: properties, ...searchParams } =
-                    router.values.searchParams // eslint-disable-line
-                const { pathname } = router.values.location
-
-                searchParams[props.urlOverride || 'properties'] = cleanedFilters
-
-                if (!objectsEqual(properties, cleanedFilters)) {
-                    router.actions.replace(pathname, searchParams)
-                }
-            }
-        },
-    }),
-
-    urlToAction: ({ actions, values, props }) => ({
-        '*': (_, { [`${props.urlOverride || 'properties'}`]: properties }) => {
-            if (props.onChange) {
-                return
-            }
-            let filters
-            try {
-                filters = values.filters
-            } catch (error) {
-                // since this is a catch-all route, this code might run during or after the logic was unmounted
-                // if we have an error accessing the filter value, the logic is gone and we should return
-                return
-            }
-            properties = parseProperties(properties)
-
-            if (!objectsEqual(properties || {}, filters)) {
-                // {} adds an empty row, which shows 'New Filter'
-                actions.setFilters(properties ? [...properties, {}] : [{}])
+                throw new Error('Still running propertFilterLogic without onChange from somewhere!')
             }
         },
     }),

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -5,9 +5,8 @@ export interface PropertyFilterBaseProps {
 }
 
 export interface PropertyFilterLogicProps extends PropertyFilterBaseProps {
-    propertyFilters?: AnyPropertyFilter[] | null
-    onChange?: null | ((filters: AnyPropertyFilter[]) => void)
-    urlOverride?: string
+    propertyFilters: AnyPropertyFilter[] | null
+    onChange: null | ((filters: AnyPropertyFilter[]) => void)
 }
 
 export interface TaxonomicPropertyFilterLogicProps extends PropertyFilterBaseProps {

--- a/frontend/src/scenes/cleanFilters.ts
+++ b/frontend/src/scenes/cleanFilters.ts
@@ -1,0 +1,118 @@
+import { ChartDisplayType, EntityTypes, FilterType, ViewType } from '~/types'
+import { cleanFunnelParams } from 'scenes/funnels/funnelLogic'
+import { isStepsEmpty } from 'scenes/funnels/funnelUtils'
+import { getDefaultEventName } from 'lib/utils/getAppContext'
+import { defaultFilterTestAccounts } from 'scenes/insights/url'
+import { ShownAsValue } from 'lib/constants'
+import { getDefaultTrendsFilters } from 'scenes/trends/trendsLogic'
+import { cleanPathParams } from 'scenes/paths/pathsLogic'
+import { autocorrectInterval } from 'lib/utils'
+
+export function cleanFilters(queryParams: Partial<FilterType>): Partial<FilterType> {
+    if (queryParams.insight === ViewType.FUNNELS) {
+        const cleanedParams = cleanFunnelParams(queryParams)
+        if (isStepsEmpty(cleanedParams)) {
+            const event = getDefaultEventName()
+            cleanedParams.events = [
+                {
+                    id: event,
+                    name: event,
+                    type: EntityTypes.EVENTS,
+                    order: 0,
+                },
+            ]
+        }
+        return cleanedParams
+    } else if (queryParams.insight === ViewType.PATHS) {
+        return cleanPathParams(queryParams)
+    } else if (
+        !queryParams.insight ||
+        queryParams.insight === ViewType.TRENDS ||
+        queryParams.insight === ViewType.SESSIONS ||
+        queryParams.insight === ViewType.STICKINESS ||
+        queryParams.insight === ViewType.LIFECYCLE
+    ) {
+        const cleanSearchParams = cleanTrendsFilters(queryParams)
+
+        const keys = Object.keys(queryParams)
+
+        if (keys.length === 0 || (!queryParams.actions && !queryParams.events)) {
+            cleanSearchParams.filter_test_accounts = defaultFilterTestAccounts()
+        }
+
+        // TODO: Deprecated; should be removed once backend is updated
+        if (queryParams.insight === ViewType.STICKINESS) {
+            cleanSearchParams['shown_as'] = ShownAsValue.STICKINESS
+        }
+        if (queryParams.insight === ViewType.LIFECYCLE) {
+            cleanSearchParams['shown_as'] = ShownAsValue.LIFECYCLE
+        }
+
+        if (queryParams.insight === ViewType.SESSIONS && !queryParams.session) {
+            cleanSearchParams['session'] = 'avg'
+        }
+
+        if (queryParams.date_from === 'all' || queryParams.insight === ViewType.LIFECYCLE) {
+            cleanSearchParams['compare'] = false
+        }
+
+        Object.assign(cleanSearchParams, getDefaultTrendsFilters(cleanSearchParams))
+
+        if (cleanSearchParams.insight === ViewType.LIFECYCLE) {
+            if (cleanSearchParams.events?.length) {
+                return {
+                    ...cleanSearchParams,
+                    events: [
+                        {
+                            ...cleanSearchParams.events[0],
+                            math: 'total',
+                        },
+                    ],
+                    actions: [],
+                }
+            } else if (cleanSearchParams.actions?.length) {
+                return {
+                    ...cleanSearchParams,
+                    events: [],
+                    actions: [
+                        {
+                            ...cleanSearchParams.actions[0],
+                            math: 'total',
+                        },
+                    ],
+                }
+            }
+        }
+
+        return cleanSearchParams
+    } else {
+        return queryParams
+    }
+}
+
+export function cleanTrendsFilters(filters: Partial<FilterType>): Partial<FilterType> {
+    return {
+        insight: ViewType.TRENDS,
+        ...filters,
+        interval: autocorrectInterval(filters),
+        display:
+            filters.session && filters.session === 'dist'
+                ? ChartDisplayType.ActionsTable
+                : filters.display || ChartDisplayType.ActionsLineGraphLinear,
+        actions: Array.isArray(filters.actions) ? filters.actions : undefined,
+        events: Array.isArray(filters.events) ? filters.events : undefined,
+        properties: filters.properties || [],
+        ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
+    }
+}
+
+export function filterTrendsClientSideParams(filters: Partial<FilterType>): Partial<FilterType> {
+    const {
+        people_day: _skip_this_one, // eslint-disable-line
+        people_action: _skip_this_too, // eslint-disable-line
+        stickiness_days: __and_this, // eslint-disable-line
+        ...newFilters
+    } = filters
+
+    return newFilters
+}

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -1,6 +1,6 @@
 import './DashboardItems.scss'
 import { Link } from 'lib/components/Link'
-import { BuiltLogic, Logic, useActions, useValues } from 'kea'
+import { BuiltLogic, Logic, useActions, useValues, BindLogic } from 'kea'
 import { Dropdown, Menu, Alert, Skeleton } from 'antd'
 import { combineUrl, router } from 'kea-router'
 import { deleteWithUndo, Loading } from 'lib/utils'
@@ -248,7 +248,7 @@ export function DashboardItem({
         cachedResults: (item as any).result,
         preventLoading,
     }
-    const { showTimeoutMessage, showErrorMessage } = useValues(insightLogic)
+    const { showTimeoutMessage, showErrorMessage } = useValues(insightLogic({ id: item.id, for: 'dashboard' }))
     const { reportDashboardItemRefreshed } = useActions(eventUsageLogic)
     const { loadResults } = useActions(getLogicFromInsight(item.filters.insight, logicProps))
     const { results, resultsLoading, isLoading } = useValues(getLogicFromInsight(item.filters.insight, logicProps))
@@ -300,165 +300,244 @@ export function DashboardItem({
     })()
 
     return (
-        <div
-            key={item.id}
-            className={`dashboard-item ${item.color || 'white'} di-width-${layout?.w || 0} di-height-${
-                layout?.h || 0
-            } ph-no-capture`}
-            {...longPressProps}
-            data-attr={'dashboard-item-' + index}
-            style={{ border: isHighlighted ? '2px solid var(--primary)' : undefined, opacity: isReloading ? 0.5 : 1 }}
-        >
-            <div className={`dashboard-item-container ${className}`}>
-                <div className="dashboard-item-header" style={{ cursor: isOnEditMode ? 'move' : 'inherit' }}>
-                    <div className="dashboard-item-title" data-attr="dashboard-item-title">
-                        {dashboardMode === DashboardMode.Public ? (
-                            item.name
-                        ) : (
-                            <Link
-                                draggable={false}
-                                to={link}
-                                title={item.name}
-                                preventClick
-                                onClick={() => {
-                                    if (!isDraggingRef?.current) {
-                                        onClick ? onClick() : router.actions.push(link)
-                                    }
-                                }}
-                                style={{ fontSize: 16, fontWeight: 500 }}
-                            >
-                                {item.name || `Untitled ${insightTypeDisplayName} Query`}
-                            </Link>
-                        )}
-                    </div>
-                    {dashboardMode !== DashboardMode.Public && (
-                        <div className="dashboard-item-settings">
-                            {saveDashboardItem &&
-                                dashboardMode !== DashboardMode.Internal &&
-                                (!item.saved && item.dashboard ? (
-                                    <Link to={'/dashboard/' + item.dashboard}>
-                                        <small>View dashboard</small>
-                                    </Link>
-                                ) : (
-                                    <Tooltip title="Save insight">
-                                        <SaveOutlined
-                                            style={{
-                                                cursor: 'pointer',
-                                                marginTop: -3,
-                                                ...(item.saved
-                                                    ? {
-                                                          background: 'var(--primary)',
-                                                          color: 'white',
-                                                      }
-                                                    : {}),
-                                            }}
-                                            onClick={() => {
-                                                if (item.saved) {
-                                                    return saveDashboardItem({ ...item, saved: false })
-                                                }
-                                                if (item.name) {
-                                                    // If item already has a name we don't have to ask for it again
-                                                    return saveDashboardItem({ ...item, saved: true })
-                                                }
-                                                setShowSaveModal(true)
-                                            }}
-                                        />
-                                    </Tooltip>
-                                ))}
-                            {dashboardMode !== DashboardMode.Internal && (
-                                <>
-                                    {featureFlags[FEATURE_FLAGS.DIVE_DASHBOARDS] && (
-                                        <>
-                                            <LinkButton
-                                                to={link}
-                                                icon={<EyeOutlined />}
-                                                data-attr="dive-btn-view"
-                                                className="dive-btn dive-btn-view"
-                                            >
-                                                View
-                                            </LinkButton>
-                                            {typeof item.dive_dashboard === 'number' && (
-                                                <Tooltip
-                                                    title={`Dive to ${diveDashboard?.name || 'connected dashboard'}`}
+        <BindLogic logic={insightLogic} props={{ id: item.id, for: 'dashboard' }}>
+            <div
+                key={item.id}
+                className={`dashboard-item ${item.color || 'white'} di-width-${layout?.w || 0} di-height-${
+                    layout?.h || 0
+                } ph-no-capture`}
+                {...longPressProps}
+                data-attr={'dashboard-item-' + index}
+                style={{
+                    border: isHighlighted ? '2px solid var(--primary)' : undefined,
+                    opacity: isReloading ? 0.5 : 1,
+                }}
+            >
+                <div className={`dashboard-item-container ${className}`}>
+                    <div className="dashboard-item-header" style={{ cursor: isOnEditMode ? 'move' : 'inherit' }}>
+                        <div className="dashboard-item-title" data-attr="dashboard-item-title">
+                            {dashboardMode === DashboardMode.Public ? (
+                                item.name
+                            ) : (
+                                <Link
+                                    draggable={false}
+                                    to={link}
+                                    title={item.name}
+                                    preventClick
+                                    onClick={() => {
+                                        if (!isDraggingRef?.current) {
+                                            onClick ? onClick() : router.actions.push(link)
+                                        }
+                                    }}
+                                    style={{ fontSize: 16, fontWeight: 500 }}
+                                >
+                                    {item.name || `Untitled ${insightTypeDisplayName} Query`}
+                                </Link>
+                            )}
+                        </div>
+                        {dashboardMode !== DashboardMode.Public && (
+                            <div className="dashboard-item-settings">
+                                {saveDashboardItem &&
+                                    dashboardMode !== DashboardMode.Internal &&
+                                    (!item.saved && item.dashboard ? (
+                                        <Link to={'/dashboard/' + item.dashboard}>
+                                            <small>View dashboard</small>
+                                        </Link>
+                                    ) : (
+                                        <Tooltip title="Save insight">
+                                            <SaveOutlined
+                                                style={{
+                                                    cursor: 'pointer',
+                                                    marginTop: -3,
+                                                    ...(item.saved
+                                                        ? {
+                                                              background: 'var(--primary)',
+                                                              color: 'white',
+                                                          }
+                                                        : {}),
+                                                }}
+                                                onClick={() => {
+                                                    if (item.saved) {
+                                                        return saveDashboardItem({ ...item, saved: false })
+                                                    }
+                                                    if (item.name) {
+                                                        // If item already has a name we don't have to ask for it again
+                                                        return saveDashboardItem({ ...item, saved: true })
+                                                    }
+                                                    setShowSaveModal(true)
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    ))}
+                                {dashboardMode !== DashboardMode.Internal && (
+                                    <>
+                                        {featureFlags[FEATURE_FLAGS.DIVE_DASHBOARDS] && (
+                                            <>
+                                                <LinkButton
+                                                    to={link}
+                                                    icon={<EyeOutlined />}
+                                                    data-attr="dive-btn-view"
+                                                    className="dive-btn dive-btn-view"
                                                 >
-                                                    <LinkButton
-                                                        to={dashboardDiveLink(item.dive_dashboard, item.id)}
-                                                        icon={
-                                                            <span role="img" aria-label="dive" className="anticon">
-                                                                <DiveIcon />
-                                                            </span>
-                                                        }
-                                                        data-attr="dive-btn-dive"
-                                                        className="dive-btn dive-btn-dive"
-                                                    >
-                                                        Dive
-                                                    </LinkButton>
-                                                </Tooltip>
-                                            )}
-                                        </>
-                                    )}
-                                    <Dropdown
-                                        overlayStyle={{ minWidth: 240, border: '1px solid var(--primary)' }}
-                                        placement="bottomRight"
-                                        trigger={['click']}
-                                        overlay={
-                                            <Menu
-                                                data-attr={'dashboard-item-' + index + '-dropdown-menu'}
-                                                style={{ padding: '12px 4px' }}
-                                            >
-                                                <Menu.Item data-attr={'dashboard-item-' + index + '-dropdown-view'}>
-                                                    <Link to={link}>{viewText}</Link>
-                                                </Menu.Item>
-                                                <Menu.Item
-                                                    data-attr={'dashboard-item-' + index + '-dropdown-refresh'}
-                                                    onClick={() => {
-                                                        loadResults(true)
-                                                        reportDashboardItemRefreshed(item)
-                                                    }}
-                                                >
+                                                    View
+                                                </LinkButton>
+                                                {typeof item.dive_dashboard === 'number' && (
                                                     <Tooltip
-                                                        placement="left"
-                                                        title={
-                                                            <i>
-                                                                Last updated:{' '}
-                                                                {item.last_refresh
-                                                                    ? dayjs(item.last_refresh).fromNow()
-                                                                    : 'recently'}
-                                                            </i>
-                                                        }
+                                                        title={`Dive to ${
+                                                            diveDashboard?.name || 'connected dashboard'
+                                                        }`}
                                                     >
-                                                        Refresh
+                                                        <LinkButton
+                                                            to={dashboardDiveLink(item.dive_dashboard, item.id)}
+                                                            icon={
+                                                                <span role="img" aria-label="dive" className="anticon">
+                                                                    <DiveIcon />
+                                                                </span>
+                                                            }
+                                                            data-attr="dive-btn-dive"
+                                                            className="dive-btn dive-btn-dive"
+                                                        >
+                                                            Dive
+                                                        </LinkButton>
                                                     </Tooltip>
-                                                </Menu.Item>
-                                                <Menu.Item
-                                                    data-attr={'dashboard-item-' + index + '-dropdown-rename'}
-                                                    onClick={() => renameDashboardItem(item)}
+                                                )}
+                                            </>
+                                        )}
+                                        <Dropdown
+                                            overlayStyle={{ minWidth: 240, border: '1px solid var(--primary)' }}
+                                            placement="bottomRight"
+                                            trigger={['click']}
+                                            overlay={
+                                                <Menu
+                                                    data-attr={'dashboard-item-' + index + '-dropdown-menu'}
+                                                    style={{ padding: '12px 4px' }}
                                                 >
-                                                    Rename
-                                                </Menu.Item>
-                                                {updateItemColor && (
-                                                    <Menu.SubMenu
-                                                        data-attr={'dashboard-item-' + index + '-dropdown-color'}
-                                                        key="colors"
-                                                        title="Set color"
+                                                    <Menu.Item data-attr={'dashboard-item-' + index + '-dropdown-view'}>
+                                                        <Link to={link}>{viewText}</Link>
+                                                    </Menu.Item>
+                                                    <Menu.Item
+                                                        data-attr={'dashboard-item-' + index + '-dropdown-refresh'}
+                                                        onClick={() => {
+                                                            loadResults(true)
+                                                            reportDashboardItemRefreshed(item)
+                                                        }}
                                                     >
-                                                        {Object.entries(dashboardColorNames).map(
-                                                            ([itemClassName, itemColor], colorIndex) => (
+                                                        <Tooltip
+                                                            placement="left"
+                                                            title={
+                                                                <i>
+                                                                    Last updated:{' '}
+                                                                    {item.last_refresh
+                                                                        ? dayjs(item.last_refresh).fromNow()
+                                                                        : 'recently'}
+                                                                </i>
+                                                            }
+                                                        >
+                                                            Refresh
+                                                        </Tooltip>
+                                                    </Menu.Item>
+                                                    <Menu.Item
+                                                        data-attr={'dashboard-item-' + index + '-dropdown-rename'}
+                                                        onClick={() => renameDashboardItem(item)}
+                                                    >
+                                                        Rename
+                                                    </Menu.Item>
+                                                    {updateItemColor && (
+                                                        <Menu.SubMenu
+                                                            data-attr={'dashboard-item-' + index + '-dropdown-color'}
+                                                            key="colors"
+                                                            title="Set color"
+                                                        >
+                                                            {Object.entries(dashboardColorNames).map(
+                                                                ([itemClassName, itemColor], colorIndex) => (
+                                                                    <Menu.Item
+                                                                        key={itemClassName}
+                                                                        onClick={() =>
+                                                                            updateItemColor(item.id, itemClassName)
+                                                                        }
+                                                                        data-attr={
+                                                                            'dashboard-item-' +
+                                                                            index +
+                                                                            '-dropdown-color-' +
+                                                                            colorIndex
+                                                                        }
+                                                                    >
+                                                                        <span
+                                                                            style={{
+                                                                                background:
+                                                                                    dashboardColors[itemClassName],
+                                                                                border: '1px solid #eee',
+                                                                                display: 'inline-block',
+                                                                                width: 13,
+                                                                                height: 13,
+                                                                                verticalAlign: 'middle',
+                                                                                marginRight: 5,
+                                                                                marginBottom: 1,
+                                                                            }}
+                                                                        />
+                                                                        {itemColor}
+                                                                    </Menu.Item>
+                                                                )
+                                                            )}
+                                                        </Menu.SubMenu>
+                                                    )}
+                                                    {featureFlags[FEATURE_FLAGS.DIVE_DASHBOARDS] && setDiveDashboard && (
+                                                        <Menu.SubMenu
+                                                            data-attr={'dashboard-item-' + index + '-dive-dashboard'}
+                                                            key="dive"
+                                                            title={`Set dive dashboard`}
+                                                        >
+                                                            {otherDashboards.map((dashboard, diveIndex) => (
                                                                 <Menu.Item
-                                                                    key={itemClassName}
-                                                                    onClick={() =>
-                                                                        updateItemColor(item.id, itemClassName)
-                                                                    }
                                                                     data-attr={
                                                                         'dashboard-item-' +
                                                                         index +
-                                                                        '-dropdown-color-' +
-                                                                        colorIndex
+                                                                        '-dive-dashboard-' +
+                                                                        diveIndex
+                                                                    }
+                                                                    key={dashboard.id}
+                                                                    onClick={() =>
+                                                                        setDiveDashboard(item.id, dashboard.id)
+                                                                    }
+                                                                    disabled={dashboard.id === item.dive_dashboard}
+                                                                >
+                                                                    {dashboard.name}
+                                                                </Menu.Item>
+                                                            ))}
+                                                            <Menu.Item
+                                                                data-attr={
+                                                                    'dashboard-item-' + index + '-dive-dashboard-remove'
+                                                                }
+                                                                key="remove"
+                                                                onClick={() => setDiveDashboard(item.id, null)}
+                                                                className="text-danger"
+                                                            >
+                                                                Remove
+                                                            </Menu.Item>
+                                                        </Menu.SubMenu>
+                                                    )}
+                                                    {duplicateDashboardItem && otherDashboards.length > 0 && (
+                                                        <Menu.SubMenu
+                                                            data-attr={'dashboard-item-' + index + '-dropdown-copy'}
+                                                            key="copy"
+                                                            title="Copy to"
+                                                        >
+                                                            {otherDashboards.map((dashboard, copyIndex) => (
+                                                                <Menu.Item
+                                                                    data-attr={
+                                                                        'dashboard-item-' +
+                                                                        index +
+                                                                        '-dropdown-copy-' +
+                                                                        copyIndex
+                                                                    }
+                                                                    key={dashboard.id}
+                                                                    onClick={() =>
+                                                                        duplicateDashboardItem(item, dashboard.id)
                                                                     }
                                                                 >
                                                                     <span
                                                                         style={{
-                                                                            background: dashboardColors[itemClassName],
+                                                                            background: dashboardColors[className],
                                                                             border: '1px solid #eee',
                                                                             display: 'inline-block',
                                                                             width: 13,
@@ -468,185 +547,120 @@ export function DashboardItem({
                                                                             marginBottom: 1,
                                                                         }}
                                                                     />
-                                                                    {itemColor}
-                                                                </Menu.Item>
-                                                            )
-                                                        )}
-                                                    </Menu.SubMenu>
-                                                )}
-                                                {featureFlags[FEATURE_FLAGS.DIVE_DASHBOARDS] && setDiveDashboard && (
-                                                    <Menu.SubMenu
-                                                        data-attr={'dashboard-item-' + index + '-dive-dashboard'}
-                                                        key="dive"
-                                                        title={`Set dive dashboard`}
-                                                    >
-                                                        {otherDashboards.map((dashboard, diveIndex) => (
-                                                            <Menu.Item
-                                                                data-attr={
-                                                                    'dashboard-item-' +
-                                                                    index +
-                                                                    '-dive-dashboard-' +
-                                                                    diveIndex
-                                                                }
-                                                                key={dashboard.id}
-                                                                onClick={() => setDiveDashboard(item.id, dashboard.id)}
-                                                                disabled={dashboard.id === item.dive_dashboard}
-                                                            >
-                                                                {dashboard.name}
-                                                            </Menu.Item>
-                                                        ))}
-                                                        <Menu.Item
-                                                            data-attr={
-                                                                'dashboard-item-' + index + '-dive-dashboard-remove'
-                                                            }
-                                                            key="remove"
-                                                            onClick={() => setDiveDashboard(item.id, null)}
-                                                            className="text-danger"
-                                                        >
-                                                            Remove
-                                                        </Menu.Item>
-                                                    </Menu.SubMenu>
-                                                )}
-                                                {duplicateDashboardItem && otherDashboards.length > 0 && (
-                                                    <Menu.SubMenu
-                                                        data-attr={'dashboard-item-' + index + '-dropdown-copy'}
-                                                        key="copy"
-                                                        title="Copy to"
-                                                    >
-                                                        {otherDashboards.map((dashboard, copyIndex) => (
-                                                            <Menu.Item
-                                                                data-attr={
-                                                                    'dashboard-item-' +
-                                                                    index +
-                                                                    '-dropdown-copy-' +
-                                                                    copyIndex
-                                                                }
-                                                                key={dashboard.id}
-                                                                onClick={() =>
-                                                                    duplicateDashboardItem(item, dashboard.id)
-                                                                }
-                                                            >
-                                                                <span
-                                                                    style={{
-                                                                        background: dashboardColors[className],
-                                                                        border: '1px solid #eee',
-                                                                        display: 'inline-block',
-                                                                        width: 13,
-                                                                        height: 13,
-                                                                        verticalAlign: 'middle',
-                                                                        marginRight: 5,
-                                                                        marginBottom: 1,
-                                                                    }}
-                                                                />
-                                                                {dashboard.name}
-                                                            </Menu.Item>
-                                                        ))}
-                                                    </Menu.SubMenu>
-                                                )}
-                                                {moveDashboardItem &&
-                                                    (otherDashboards.length > 0 ? (
-                                                        <Menu.SubMenu
-                                                            data-attr={'dashboard-item-' + index + '-dropdown-move'}
-                                                            key="move"
-                                                            title="Move to"
-                                                        >
-                                                            {otherDashboards.map((dashboard, moveIndex) => (
-                                                                <Menu.Item
-                                                                    data-attr={
-                                                                        'dashboard-item-' +
-                                                                        index +
-                                                                        '-dropdown-move-' +
-                                                                        moveIndex
-                                                                    }
-                                                                    key={dashboard.id}
-                                                                    onClick={() =>
-                                                                        moveDashboardItem(item, dashboard.id)
-                                                                    }
-                                                                >
                                                                     {dashboard.name}
                                                                 </Menu.Item>
                                                             ))}
                                                         </Menu.SubMenu>
-                                                    ) : null)}
-                                                {duplicateDashboardItem && (
+                                                    )}
+                                                    {moveDashboardItem &&
+                                                        (otherDashboards.length > 0 ? (
+                                                            <Menu.SubMenu
+                                                                data-attr={'dashboard-item-' + index + '-dropdown-move'}
+                                                                key="move"
+                                                                title="Move to"
+                                                            >
+                                                                {otherDashboards.map((dashboard, moveIndex) => (
+                                                                    <Menu.Item
+                                                                        data-attr={
+                                                                            'dashboard-item-' +
+                                                                            index +
+                                                                            '-dropdown-move-' +
+                                                                            moveIndex
+                                                                        }
+                                                                        key={dashboard.id}
+                                                                        onClick={() =>
+                                                                            moveDashboardItem(item, dashboard.id)
+                                                                        }
+                                                                    >
+                                                                        {dashboard.name}
+                                                                    </Menu.Item>
+                                                                ))}
+                                                            </Menu.SubMenu>
+                                                        ) : null)}
+                                                    {duplicateDashboardItem && (
+                                                        <Menu.Item
+                                                            data-attr={
+                                                                'dashboard-item-' + index + '-dropdown-duplicate'
+                                                            }
+                                                            onClick={() => duplicateDashboardItem(item)}
+                                                        >
+                                                            Duplicate
+                                                        </Menu.Item>
+                                                    )}
                                                     <Menu.Item
-                                                        data-attr={'dashboard-item-' + index + '-dropdown-duplicate'}
-                                                        onClick={() => duplicateDashboardItem(item)}
+                                                        data-attr={'dashboard-item-' + index + '-dropdown-delete'}
+                                                        onClick={() =>
+                                                            deleteWithUndo({
+                                                                object: item,
+                                                                endpoint: 'insight',
+                                                                callback: loadDashboardItems,
+                                                            })
+                                                        }
+                                                        className="text-danger"
                                                     >
-                                                        Duplicate
+                                                        Delete
                                                     </Menu.Item>
-                                                )}
-                                                <Menu.Item
-                                                    data-attr={'dashboard-item-' + index + '-dropdown-delete'}
-                                                    onClick={() =>
-                                                        deleteWithUndo({
-                                                            object: item,
-                                                            endpoint: 'insight',
-                                                            callback: loadDashboardItems,
-                                                        })
-                                                    }
-                                                    className="text-danger"
-                                                >
-                                                    Delete
-                                                </Menu.Item>
-                                            </Menu>
-                                        }
-                                    >
-                                        <span
-                                            data-attr={'dashboard-item-' + index + '-dropdown'}
-                                            style={{ cursor: 'pointer', marginTop: -3 }}
+                                                </Menu>
+                                            }
                                         >
-                                            <EllipsisOutlined />
-                                        </span>
-                                    </Dropdown>
-                                </>
-                            )}
-                        </div>
+                                            <span
+                                                data-attr={'dashboard-item-' + index + '-dropdown'}
+                                                style={{ cursor: 'pointer', marginTop: -3 }}
+                                            >
+                                                <EllipsisOutlined />
+                                            </span>
+                                        </Dropdown>
+                                    </>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                    {item.description && (
+                        <div style={{ padding: '0 16px', marginBottom: 16, fontSize: 12 }}>{item.description}</div>
                     )}
-                </div>
-                {item.description && (
-                    <div style={{ padding: '0 16px', marginBottom: 16, fontSize: 12 }}>{item.description}</div>
-                )}
 
-                <div className={`dashboard-item-content ${_type}`} onClickCapture={onClick}>
-                    {!BlockingEmptyState && CoexistingEmptyState}
-                    {!!BlockingEmptyState ? (
-                        BlockingEmptyState
-                    ) : (
-                        <Alert.ErrorBoundary message="Error rendering graph!">
-                            {(dashboardMode === DashboardMode.Public || preventLoading) && !results && !item.result ? (
-                                <Skeleton />
-                            ) : (
-                                <Element
-                                    dashboardItemId={item.id}
-                                    cachedResults={item.result}
-                                    filters={filters}
-                                    color={color}
-                                    theme={color === 'white' ? 'light' : 'dark'}
-                                    inSharedMode={dashboardMode === DashboardMode.Public}
-                                />
-                            )}
-                        </Alert.ErrorBoundary>
-                    )}
+                    <div className={`dashboard-item-content ${_type}`} onClickCapture={onClick}>
+                        {!BlockingEmptyState && CoexistingEmptyState}
+                        {!!BlockingEmptyState ? (
+                            BlockingEmptyState
+                        ) : (
+                            <Alert.ErrorBoundary message="Error rendering graph!">
+                                {(dashboardMode === DashboardMode.Public || preventLoading) &&
+                                !results &&
+                                !item.result ? (
+                                    <Skeleton />
+                                ) : (
+                                    <Element
+                                        dashboardItemId={item.id}
+                                        cachedResults={item.result}
+                                        filters={filters}
+                                        color={color}
+                                        theme={color === 'white' ? 'light' : 'dark'}
+                                        inSharedMode={dashboardMode === DashboardMode.Public}
+                                    />
+                                )}
+                            </Alert.ErrorBoundary>
+                        )}
+                    </div>
+                    {footer}
                 </div>
-                {footer}
+                {showSaveModal && saveDashboardItem && (
+                    <SaveModal
+                        title="Save Chart"
+                        prompt="Name of Chart"
+                        textLabel="Name"
+                        textPlaceholder="DAUs Last 14 days"
+                        visible={true}
+                        onCancel={() => {
+                            setShowSaveModal(false)
+                        }}
+                        onSubmit={(text) => {
+                            saveDashboardItem({ ...item, name: text, saved: true })
+                            setShowSaveModal(false)
+                        }}
+                    />
+                )}
             </div>
-            {showSaveModal && saveDashboardItem && (
-                <SaveModal
-                    title="Save Chart"
-                    prompt="Name of Chart"
-                    textLabel="Name"
-                    textPlaceholder="DAUs Last 14 days"
-                    visible={true}
-                    onCancel={() => {
-                        setShowSaveModal(false)
-                    }}
-                    onSubmit={(text) => {
-                        saveDashboardItem({ ...item, name: text, saved: true })
-                        setShowSaveModal(false)
-                    }}
-                />
-            )}
-        </div>
+        </BindLogic>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -78,42 +78,42 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
         element: ActionsLineGraph,
         viewText: 'View graph',
         link: ({ filters, id, dashboard, name }: DashboardItemType): string =>
-            combineUrl('/insights', filters, { fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
+            combineUrl('/insights', {}, { q: filters, fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
     },
     ActionsLineGraphCumulative: {
         className: 'graph',
         element: ActionsLineGraph,
         viewText: 'View graph',
         link: ({ filters, id, dashboard, name }: DashboardItemType): string =>
-            combineUrl('/insights', filters, { fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
+            combineUrl('/insights', {}, { q: filters, fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
     },
     ActionsBar: {
         className: 'bar',
         element: ActionsLineGraph,
         viewText: 'View graph',
         link: ({ filters, id, dashboard, name }: DashboardItemType): string =>
-            combineUrl('/insights', filters, { fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
+            combineUrl('/insights', {}, { q: filters, fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
     },
     ActionsBarValue: {
         className: 'bar',
         element: ActionsBarValueGraph,
         viewText: 'View graph',
         link: ({ filters, id, dashboard, name }: DashboardItemType): string =>
-            combineUrl('/insights', filters, { fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
+            combineUrl('/insights', {}, { q: filters, fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
     },
     ActionsTable: {
         className: 'table',
         element: ActionsTable,
         viewText: 'View table',
         link: ({ filters, id, dashboard, name }: DashboardItemType): string =>
-            combineUrl('/insights', filters, { fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
+            combineUrl('/insights', {}, { q: filters, fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
     },
     ActionsPie: {
         className: 'pie',
         element: ActionsPie,
         viewText: 'View graph',
         link: ({ filters, id, dashboard, name }: DashboardItemType): string =>
-            combineUrl('/insights', filters, { fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
+            combineUrl('/insights', {}, { q: filters, fromItem: id, fromItemName: name, fromDashboard: dashboard }).url,
     },
     FunnelViz: {
         className: 'funnel',
@@ -122,8 +122,13 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
         link: ({ id, dashboard, name, filters }: DashboardItemType): string => {
             return combineUrl(
                 `/insights`,
-                { insight: ViewType.FUNNELS, ...filters },
-                { fromItem: id, fromItemName: name, fromDashboard: dashboard }
+                {},
+                {
+                    q: { insight: ViewType.FUNNELS, ...filters },
+                    fromItem: id,
+                    fromItemName: name,
+                    fromDashboard: dashboard,
+                }
             ).url
         },
     },
@@ -134,8 +139,13 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
         link: ({ id, dashboard, name, filters }: DashboardItemType): string => {
             return combineUrl(
                 `/insights`,
-                { insight: ViewType.RETENTION, ...filters },
-                { fromItem: id, fromItemName: name, fromDashboard: dashboard }
+                {},
+                {
+                    q: { insight: ViewType.RETENTION, ...filters },
+                    fromItem: id,
+                    fromItemName: name,
+                    fromDashboard: dashboard,
+                }
             ).url
         },
     },
@@ -146,8 +156,13 @@ export const displayMap: Record<DisplayedType, DisplayProps> = {
         link: ({ id, dashboard, name, filters }: DashboardItemType): string => {
             return combineUrl(
                 `/insights`,
-                { insight: ViewType.PATHS, ...filters },
-                { fromItem: id, fromItemName: name, fromDashboard: dashboard }
+                {},
+                {
+                    q: { insight: ViewType.PATHS, ...filters },
+                    fromItem: id,
+                    fromItemName: name,
+                    fromDashboard: dashboard,
+                }
             ).url
         },
     },

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -58,7 +58,7 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
         highlightEvents,
     } = useValues(logic)
     const { propertyNames } = useValues(propertyDefinitionsModel)
-    const { fetchNextEvents, prependNewEvents, setColumnConfig, setEventFilter, toggleAutomaticLoad } =
+    const { fetchNextEvents, prependNewEvents, setColumnConfig, setEventFilter, toggleAutomaticLoad, setProperties } =
         useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -299,7 +299,14 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
                     />
                 </Col>
                 <Col span={24}>
-                    {filtersEnabled ? <PropertyFilters pageKey={'EventsTable'} style={{ marginBottom: 0 }} /> : null}
+                    {filtersEnabled ? (
+                        <PropertyFilters
+                            pageKey={'EventsTable'}
+                            style={{ marginBottom: 0 }}
+                            propertyFilters={properties}
+                            onChange={setProperties}
+                        />
+                    ) : null}
                 </Col>
             </Row>
 

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -32,6 +32,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { getActionFilterFromFunnelStep } from 'scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils'
 import { FunnelStepDropdown } from './FunnelStepDropdown'
+import { insightLogic } from 'scenes/insights/insightLogic'
 interface BarProps {
     percentage: number
     name?: string
@@ -217,7 +218,8 @@ function Bar({
     const [labelPosition, setLabelPosition] = useState<LabelPosition>('inside')
     const [labelVisible, setLabelVisible] = useState(true)
     const LABEL_POSITION_OFFSET = 8 // Defined here and in SCSS
-    const { clickhouseFeaturesEnabled } = useValues(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
     const cursorType = clickhouseFeaturesEnabled && !disabled ? 'pointer' : ''
     const hasBreakdownSum = isBreakdown && typeof breakdownSumPercentage === 'number'
     const shouldShowLabel = !isBreakdown || (hasBreakdownSum && labelVisible)
@@ -507,9 +509,7 @@ export function FunnelBarGraph({
                                     filters.funnel_order_type !== StepOrderValue.UNORDERED &&
                                     stepIndex > 0 &&
                                     step.action_id === steps[stepIndex - 1].action_id && <DuplicateStepIndicator />}
-                                {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI] && (
-                                    <FunnelStepDropdown index={stepIndex} dashboardItemId={dashboardItemId} />
-                                )}
+                                {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI] && <FunnelStepDropdown index={stepIndex} />}
                             </div>
                             <div className={`funnel-step-metadata funnel-time-metadata ${layout}`}>
                                 {step.average_conversion_time && step.average_conversion_time >= 0 + Number.EPSILON ? (

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -14,9 +14,9 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { FunnelStepsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelStepsPicker'
 
 export function FunnelCanvasLabel(): JSX.Element | null {
-    const { conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic)
-    const { filters } = useValues(insightLogic)
-    const { setChartFilter } = useActions(chartFilterLogic)
+    const { filters, insightProps } = useValues(insightLogic)
+    const { conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
+    const { setChartFilter } = useActions(chartFilterLogic(insightProps))
 
     if (filters.insight !== 'FUNNELS') {
         return null

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -15,15 +15,15 @@ import { FunnelStepsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelS
 
 export function FunnelCanvasLabel(): JSX.Element | null {
     const { conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic)
-    const { allFilters } = useValues(insightLogic)
+    const { filters } = useValues(insightLogic)
     const { setChartFilter } = useActions(chartFilterLogic)
 
-    if (allFilters.insight !== 'FUNNELS') {
+    if (filters.insight !== 'FUNNELS') {
         return null
     }
 
     const labels = [
-        ...(allFilters.funnel_viz_type !== FunnelVizType.TimeToConvert
+        ...(filters.funnel_viz_type !== FunnelVizType.TimeToConvert
             ? [
                   <>
                       <span className="text-muted-alt">
@@ -32,13 +32,13 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                           </Tooltip>
                           Total conversion rate{' '}
                       </span>
-                      {allFilters.funnel_viz_type === FunnelVizType.Trends && <FunnelStepsPicker />}
+                      {filters.funnel_viz_type === FunnelVizType.Trends && <FunnelStepsPicker />}
                       <span className="text-muted-alt mr-025">:</span>
                       <span className="l4">{formatDisplayPercentage(conversionMetrics.totalRate)}%</span>
                   </>,
               ]
             : []),
-        ...(allFilters.funnel_viz_type !== FunnelVizType.Trends
+        ...(filters.funnel_viz_type !== FunnelVizType.Trends
             ? [
                   <>
                       <span className="text-muted-alt">
@@ -47,13 +47,13 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                           </Tooltip>
                           Average time to convert{' '}
                       </span>
-                      {allFilters.funnel_viz_type === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
+                      {filters.funnel_viz_type === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
                       <span className="text-muted-alt mr-025">:</span>
                       <Button
                           type="link"
                           onClick={() => setChartFilter(FunnelVizType.TimeToConvert)}
                           disabled={
-                              !clickhouseFeaturesEnabled || allFilters.funnel_viz_type === FunnelVizType.TimeToConvert
+                              !clickhouseFeaturesEnabled || filters.funnel_viz_type === FunnelVizType.TimeToConvert
                           }
                       >
                           <span className="l4">{humanFriendlyDuration(conversionMetrics.averageTime)}</span>

--- a/frontend/src/scenes/funnels/FunnelStepDropdown.tsx
+++ b/frontend/src/scenes/funnels/FunnelStepDropdown.tsx
@@ -4,15 +4,11 @@ import { A, combineUrl, encodeParams } from 'kea-router'
 import { FunnelPathType, ViewType } from '~/types'
 import { funnelLogic } from './funnelLogic'
 import { useValues } from 'kea'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
-export function FunnelStepDropdown({
-    dashboardItemId,
-    index,
-}: {
-    dashboardItemId?: number
-    index: number
-}): JSX.Element {
-    const logic = funnelLogic({ dashboardItemId })
+export function FunnelStepDropdown({ index }: { index: number }): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const logic = funnelLogic(insightProps)
     const { propertiesForUrl: filterProps } = useValues(logic)
 
     const adjustedIndex = index + 1

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -248,7 +248,7 @@ export const funnelLogic = kea<funnelLogicType<FunnelLogicProps>>({
                     : null
             },
         ],
-        lastAppliedFilters: [(s) => [s.results], (results) => results.filters],
+        lastAppliedFilters: [(s) => [s.results], (results) => results.filters || {}],
         peopleSorted: [
             () => [selectors.stepsWithCount, selectors.people],
             (steps, people) => {

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -10,6 +10,7 @@ import { entityFilterLogic } from 'scenes/insights/ActionFilter/entityFilterLogi
 import { Button, Empty } from 'antd'
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { SavedInsightsTabs } from '~/types'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function LineGraphEmptyState({ color, isDashboard }: { color: string; isDashboard?: boolean }): JSX.Element {
     return (
@@ -167,8 +168,9 @@ export function ErrorMessage(): JSX.Element {
 }
 
 export function FunnelInvalidFiltersEmptyState(): JSX.Element {
-    const { filters, clickhouseFeaturesEnabled } = useValues(funnelLogic)
-    const { setFilters } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filters, clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
+    const { setFilters } = useActions(funnelLogic(insightProps))
     const { addFilter } = useActions(entityFilterLogic({ setFilters, filters, typeKey: 'EditFunnel-action' }))
 
     return (

--- a/frontend/src/scenes/insights/FunnelInsight.tsx
+++ b/frontend/src/scenes/insights/FunnelInsight.tsx
@@ -11,10 +11,8 @@ import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelInsight(): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { isValidFunnel, isLoading, filters, areFiltersValid } = useValues(
-        funnelLogic({ dashboardItemId: insight?.id })
-    )
+    const { insightProps } = useValues(insightLogic)
+    const { isValidFunnel, isLoading, filters, areFiltersValid } = useValues(funnelLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
     const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)

--- a/frontend/src/scenes/insights/FunnelInsight.tsx
+++ b/frontend/src/scenes/insights/FunnelInsight.tsx
@@ -8,9 +8,13 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { FunnelVizType, ViewType } from '~/types'
 import { PersonModal } from 'scenes/trends/PersonModal'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelInsight(): JSX.Element {
-    const { isValidFunnel, isLoading, filters, areFiltersValid } = useValues(funnelLogic({}))
+    const { insight } = useValues(insightLogic)
+    const { isValidFunnel, isLoading, filters, areFiltersValid } = useValues(
+        funnelLogic({ dashboardItemId: insight?.id })
+    )
     const { featureFlags } = useValues(featureFlagLogic)
     const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -53,7 +53,7 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
     } = useValues(router)
     const { clearAnnotationsToCreate } = useActions(annotationsLogic({ pageKey: fromItem }))
     const { annotationsToCreate } = useValues(annotationsLogic({ pageKey: fromItem }))
-    const { lastRefresh, isLoading, activeView, allFilters, insightMode, showTimeoutMessage, showErrorMessage } =
+    const { lastRefresh, isLoading, activeView, filters, insightMode, showTimeoutMessage, showErrorMessage } =
         useValues(insightLogic)
     const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic)
 
@@ -98,7 +98,7 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
             !showTimeoutMessage &&
             areFiltersValid &&
             activeView === ViewType.FUNNELS &&
-            allFilters.display === FUNNEL_VIZ
+            filters.display === FUNNEL_VIZ
         ) {
             return <People />
         }
@@ -109,26 +109,25 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
             !showErrorMessage &&
             !showTimeoutMessage &&
             areFiltersValid &&
-            allFilters.funnel_viz_type === FunnelVizType.Steps &&
-            (!featureFlags[FEATURE_FLAGS.FUNNEL_VERTICAL_BREAKDOWN] || allFilters.layout === FunnelLayout.horizontal)
+            filters.funnel_viz_type === FunnelVizType.Steps &&
+            (!featureFlags[FEATURE_FLAGS.FUNNEL_VERTICAL_BREAKDOWN] || filters.layout === FunnelLayout.horizontal)
         ) {
-            return <FunnelStepTable filters={allFilters} />
+            return <FunnelStepTable filters={filters} />
         }
         if (
-            (!allFilters.display ||
-                (allFilters.display !== ACTIONS_TABLE && allFilters.display !== ACTIONS_BAR_CHART_VALUE)) &&
+            (!filters.display || (filters.display !== ACTIONS_TABLE && filters.display !== ACTIONS_BAR_CHART_VALUE)) &&
             (activeView === ViewType.TRENDS || activeView === ViewType.SESSIONS)
         ) {
-            /* InsightsTable is loaded for all trend views (except below), plus the sessions view.
-    Exclusions:
-        1. Table view. Because table is already loaded anyways in `Trends.tsx` as the main component.
-        2. Bar value chart. Because this view displays data in completely different dimensions.
-    */
+            /*  InsightsTable is loaded for all trend views (except below), plus the sessions view.
+                Exclusions:
+                1. Table view. Because table is already loaded anyways in `Trends.tsx` as the main component.
+                2. Bar value chart. Because this view displays data in completely different dimensions.
+            */
             return (
                 <Card style={{ marginTop: 8 }}>
                     <BindLogic
                         logic={trendsLogic}
-                        props={{ dashboardItemId: null, view: activeView, filters: allFilters }}
+                        props={{ dashboardItemId: fromItem, view: activeView, filters: filters }}
                     >
                         <h3 className="l3">Details table</h3>
                         <InsightsTable showTotalCount={activeView !== ViewType.SESSIONS} />
@@ -148,7 +147,7 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
                     <InsightDisplayConfig
                         activeView={activeView}
                         insightMode={insightMode}
-                        allFilters={allFilters}
+                        filters={filters}
                         annotationsToCreate={annotationsToCreate}
                         clearAnnotationsToCreate={clearAnnotationsToCreate}
                     />

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -53,9 +53,18 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
     } = useValues(router)
     const { clearAnnotationsToCreate } = useActions(annotationsLogic({ pageKey: fromItem }))
     const { annotationsToCreate } = useValues(annotationsLogic({ pageKey: fromItem }))
-    const { lastRefresh, isLoading, activeView, filters, insightMode, showTimeoutMessage, showErrorMessage } =
-        useValues(insightLogic)
-    const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic)
+    const {
+        lastRefresh,
+        isLoading,
+        activeView,
+        filters,
+        insightMode,
+        showTimeoutMessage,
+        showErrorMessage,
+        insightProps,
+    } = useValues(insightLogic)
+
+    const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {

--- a/frontend/src/scenes/insights/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/InsightDateFilter/InsightDateFilter.tsx
@@ -3,13 +3,15 @@ import { useValues, useActions } from 'kea'
 import { insightDateFilterLogic } from './insightDateFilterLogic'
 import { DateFilterProps, DateFilter } from 'lib/components/DateFilter/DateFilter'
 import './index.scss'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function InsightDateFilter(props: DateFilterProps): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
     const {
         dates: { dateFrom, dateTo },
         highlightDateChange,
-    } = useValues(insightDateFilterLogic)
-    const { setDates } = useActions(insightDateFilterLogic)
+    } = useValues(insightDateFilterLogic(insightProps))
+    const { setDates } = useActions(insightDateFilterLogic(insightProps))
 
     return (
         <span className={highlightDateChange ? 'insights-date-filter highlighted' : ''}>

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -64,7 +64,8 @@ export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
         },
     }),
     urlToAction: ({ actions, values }) => ({
-        '/insights': (_: any, { date_from, date_to }: UrlParams) => {
+        '/insights': (_, searchParams, hashParams) => {
+            const { date_from, date_to }: UrlParams = { ...searchParams, ...hashParams.q }
             if (!values.initialLoad && !objectsEqual(date_from, values.dates.dateFrom)) {
                 actions.dateAutomaticallyChanged()
             }

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -5,15 +5,15 @@ import { insightDateFilterLogicType } from './insightDateFilterLogicType'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface InsightDateFilterLogicProps {
-    id: number | 'new'
+    dashboardItemId?: number
 }
 
 export const insightDateFilterLogic = kea<insightDateFilterLogicType<InsightDateFilterLogicProps>>({
     props: {} as InsightDateFilterLogicProps,
-    key: (props) => props.id || 'new',
+    key: (props) => props.dashboardItemId || 'new',
     connect: (props: InsightDateFilterLogicProps) => ({
-        values: [insightLogic(props), ['filters']],
-        actions: [insightLogic(props), ['updateInsightFilters']],
+        values: [insightLogic({ id: props.dashboardItemId }), ['filters']],
+        actions: [insightLogic({ id: props.dashboardItemId }), ['updateInsightFilters']],
     }),
     actions: () => ({
         setDates: (dateFrom: string | Dayjs | undefined, dateTo: string | Dayjs | undefined) => ({

--- a/frontend/src/scenes/insights/InsightHistoryPanel/insightHistoryLogic.ts
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/insightHistoryLogic.ts
@@ -163,7 +163,9 @@ export const insightHistoryLogic = kea<insightHistoryLogicType>({
             const insight = await api.create('api/insight', {
                 filters,
             })
-            insightLogic.actions.setInsight(insight)
+            // TODO: if (insightLogic({ id: insight.id }).isMounted()) {
+            insightLogic({ id: insight.id }).actions.setInsight(insight)
+            // TODO: }
         },
         updateInsight: async ({ insight }) => {
             await api.update(`api/insight/${insight.id}`, insight)

--- a/frontend/src/scenes/insights/InsightMetadata/InsightMetadata.tsx
+++ b/frontend/src/scenes/insights/InsightMetadata/InsightMetadata.tsx
@@ -19,7 +19,7 @@ interface MetadataProps {
 
 function Title({ insight, insightMode }: MetadataProps): JSX.Element {
     const property = 'name'
-    const logic = insightMetadataLogic({ insight: { [property]: insight?.[property] } })
+    const logic = insightMetadataLogic({ insight: { id: insight?.id, [property]: insight?.[property] } })
     const { editableProps, isEditable } = useValues(logic)
     const { setInsightMetadata, saveInsightMetadata, cancelInsightMetadata, showEditMode } = useActions(logic)
     const placeholder = insight[property] ?? `Insight #${insight.id ?? '...'}`

--- a/frontend/src/scenes/insights/InsightMetadata/insightMetadataLogic.ts
+++ b/frontend/src/scenes/insights/InsightMetadata/insightMetadataLogic.ts
@@ -23,9 +23,9 @@ export const insightMetadataLogic = kea<insightMetadataLogicType<InsightMetadata
         showEditMode: (property: keyof DashboardItemType) => ({ property }),
         showViewMode: (property: keyof DashboardItemType) => ({ property }),
     },
-    connect: {
-        actions: [insightLogic, ['setInsight', 'updateInsight']],
-    },
+    connect: (props: InsightMetadataLogicProps) => ({
+        actions: [insightLogic({ id: props.insight?.id || 'new' }), ['setInsight', 'updateInsight']],
+    }),
     reducers: ({ props }) => ({
         insightMetadata: [
             cleanMetadataValues(props.insight ?? {}),

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -7,6 +7,7 @@ import { BinCountValue } from '~/types'
 import { BarChartOutlined } from '@ant-design/icons'
 import clsx from 'clsx'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface BinOption {
     key?: string
@@ -37,8 +38,9 @@ const options: BinOption[] = [
 ]
 
 export function FunnelBinsPicker(): JSX.Element {
-    const { filters, numericBinCount } = useValues(funnelLogic)
-    const { setBinCount } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filters, numericBinCount } = useValues(funnelLogic(insightProps))
+    const { setBinCount } = useActions(funnelLogic(insightProps))
 
     return (
         <Select

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
@@ -7,6 +7,7 @@ import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelConversionWindow, FunnelConversionWindowTimeUnit } from '~/types'
 import { Tooltip } from 'lib/components/Tooltip'
 import { RefSelectProps } from 'antd/lib/select'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 const TIME_INTERVAL_BOUNDS: Record<FunnelConversionWindowTimeUnit, number[]> = {
     [FunnelConversionWindowTimeUnit.Minute]: [1, 1440],
@@ -17,8 +18,9 @@ const TIME_INTERVAL_BOUNDS: Record<FunnelConversionWindowTimeUnit, number[]> = {
 }
 
 export function FunnelConversionWindowFilter(): JSX.Element {
-    const { conversionWindow } = useValues(funnelLogic)
-    const { setConversionWindow } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { conversionWindow } = useValues(funnelLogic(insightProps))
+    const { setConversionWindow } = useActions(funnelLogic(insightProps))
     const [localConversionWindow, setLocalConversionWindow] = useState<FunnelConversionWindow>(conversionWindow)
     const timeUnitRef: React.RefObject<RefSelectProps> | null = useRef(null)
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelDisplayLayoutPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelDisplayLayoutPicker.tsx
@@ -4,10 +4,12 @@ import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelPlotOutlined, BarChartOutlined } from '@ant-design/icons'
 import { FunnelLayout } from 'lib/constants'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelDisplayLayoutPicker(): JSX.Element {
-    const { barGraphLayout } = useValues(funnelLogic)
-    const { setFilters } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { barGraphLayout } = useValues(funnelLogic(insightProps))
+    const { setFilters } = useActions(funnelLogic(insightProps))
     const options = [
         {
             value: FunnelLayout.vertical,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
@@ -8,6 +8,7 @@ import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { FunnelStepRangeEntityFilter, ActionFilter as ActionFilterType, EntityTypes } from '~/types'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 function ExclusionRowSuffix({
     filter,
@@ -20,8 +21,9 @@ function ExclusionRowSuffix({
     onClose?: () => void
     isVertical: boolean
 }): JSX.Element | null {
-    const { filters, areFiltersValid, numberOfSeries, exclusionDefaultStepRange } = useValues(funnelLogic)
-    const { setOneEventExclusionFilter } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filters, areFiltersValid, numberOfSeries, exclusionDefaultStepRange } = useValues(funnelLogic(insightProps))
+    const { setOneEventExclusionFilter } = useActions(funnelLogic(insightProps))
 
     const stepRange = {
         funnel_from_step: filters.exclusions?.[index]?.funnel_from_step ?? exclusionDefaultStepRange.funnel_from_step,
@@ -131,8 +133,9 @@ function ExclusionRow({
 }
 
 export function FunnelExclusionsFilter(): JSX.Element | null {
-    const { exclusionFilters, areFiltersValid, exclusionDefaultStepRange } = useValues(funnelLogic)
-    const { setEventExclusionFilters } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { exclusionFilters, areFiltersValid, exclusionDefaultStepRange } = useValues(funnelLogic(insightProps))
+    const { setEventExclusionFilters } = useActions(funnelLogic(insightProps))
     const ref = useRef(null)
     const [width] = useSize(ref)
     const isVerticalLayout = !!width && width < 450 // If filter container shrinks below 500px, initiate verticality

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepOrderPicker.tsx
@@ -4,6 +4,7 @@ import { Select } from 'antd'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface StepOption {
     key?: string
@@ -27,8 +28,9 @@ const options: StepOption[] = [
 ]
 
 export function FunnelStepOrderPicker(): JSX.Element {
-    const { filters } = useValues(funnelLogic)
-    const { setFilters } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filters } = useValues(funnelLogic(insightProps))
+    const { setFilters } = useActions(funnelLogic(insightProps))
 
     return (
         <Select

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepReferencePicker.tsx
@@ -3,6 +3,7 @@ import { Select } from 'antd'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { PercentageOutlined } from '@ant-design/icons'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export enum FunnelStepReference {
     total = 'total',
@@ -10,8 +11,9 @@ export enum FunnelStepReference {
 }
 
 export function FunnelStepReferencePicker(): JSX.Element {
-    const { stepReference } = useValues(funnelLogic)
-    const { setStepReference } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { stepReference } = useValues(funnelLogic(insightProps))
+    const { setStepReference } = useActions(funnelLogic(insightProps))
     const options = [
         {
             value: FunnelStepReference.total,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsPicker.tsx
@@ -5,10 +5,12 @@ import { EntityFilter, FunnelVizType } from '~/types'
 import { Row, Select } from 'antd'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelStepsPicker(): JSX.Element | null {
-    const { filters, numberOfSeries, areFiltersValid, filterSteps } = useValues(funnelLogic)
-    const { changeStepRange } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filters, numberOfSeries, areFiltersValid, filterSteps } = useValues(funnelLogic(insightProps))
+    const { changeStepRange } = useActions(funnelLogic(insightProps))
 
     if (filters.funnel_viz_type === FunnelVizType.Steps) {
         return null

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -24,11 +24,13 @@ import { FunnelExclusionsFilter } from 'scenes/insights/InsightTabs/FunnelTab/Fu
 import { SavedFunnels } from 'scenes/insights/SavedCard'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelTab(): JSX.Element {
     useMountedLogic(funnelCommandLogic)
-    const { isStepsEmpty, filters, clickhouseFeaturesEnabled } = useValues(funnelLogic)
-    const { loadResults, clearFunnel, setFilters, saveFunnelInsight } = useActions(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { isStepsEmpty, filters, clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
+    const { loadResults, clearFunnel, setFilters, saveFunnelInsight } = useActions(funnelLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
     const [savingModal, setSavingModal] = useState<boolean>(false)
     const screens = useBreakpoint()
@@ -213,7 +215,10 @@ export function FunnelTab(): JSX.Element {
 }
 
 function CalculateFunnelButton({ style }: { style: React.CSSProperties }): JSX.Element {
-    const { filters, areFiltersValid, filtersDirty, clickhouseFeaturesEnabled, isLoading } = useValues(funnelLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filters, areFiltersValid, filtersDirty, clickhouseFeaturesEnabled, isLoading } = useValues(
+        funnelLogic(insightProps)
+    )
     const [tooltipOpen, setTooltipOpen] = useState(false)
     const shouldRecalculate = filtersDirty && areFiltersValid && !isLoading && !clickhouseFeaturesEnabled
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/ToggleButtonChartFilter.tsx
@@ -5,6 +5,7 @@ import { FunnelVizType } from '~/types'
 import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { DropdownSelector } from 'lib/components/DropdownSelector/DropdownSelector'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface ToggleButtonChartFilterProps {
     onChange?: (chartFilter: FunnelVizType) => void
@@ -17,9 +18,10 @@ export function ToggleButtonChartFilter({
     onChange = noop,
     disabled = false,
 }: ToggleButtonChartFilterProps): JSX.Element | null {
-    const { clickhouseFeaturesEnabled } = useValues(funnelLogic())
-    const { chartFilter } = useValues(chartFilterLogic)
-    const { setChartFilter } = useActions(chartFilterLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
+    const { chartFilter } = useValues(chartFilterLogic(insightProps))
+    const { setChartFilter } = useActions(chartFilterLogic(insightProps))
     const defaultDisplay = FunnelVizType.Steps
 
     const options = [

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
@@ -18,6 +18,7 @@ import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { FunnelStepDropdown } from 'scenes/funnels/FunnelStepDropdown'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function getColor(step: FlattenedFunnelStep, fallbackColor: string, isBreakdown?: boolean): string {
     return getSeriesColor(isBreakdown ? step.breakdownIndex : step.order, false, fallbackColor)
@@ -48,7 +49,8 @@ function BreakdownBarGroupWrapper({
     dashboardItemId?: number
     showLabels: boolean
 }): JSX.Element {
-    const logic = funnelLogic({ dashboardItemId })
+    const { insightProps } = useValues(insightLogic)
+    const logic = funnelLogic(insightProps)
     const {
         stepReference,
         visibleStepsWithConversionMetrics: steps,
@@ -150,9 +152,7 @@ export const renderGraphAndHeader = (
                             ) : (
                                 <PropertyKeyInfo value={step?.name ?? ''} disableIcon className="funnel-step-name" />
                             )}
-                            {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI] && (
-                                <FunnelStepDropdown index={stepIndex} dashboardItemId={dashboardItemId} />
-                            )}
+                            {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI] && <FunnelStepDropdown index={stepIndex} />}
                         </div>
                     ),
                     props: {
@@ -190,9 +190,7 @@ export const renderGraphAndHeader = (
                         <div className="funnel-step-title">
                             <span className="funnel-step-glyph">{zeroPad(humanizeOrder(stepIndex), 2)}</span>
                             <PropertyKeyInfo value={step?.name ?? ''} disableIcon className="funnel-step-name" />
-                            {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI] && (
-                                <FunnelStepDropdown index={stepIndex} dashboardItemId={dashboardItemId} />
-                            )}
+                            {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI] && <FunnelStepDropdown index={stepIndex} />}
                         </div>
                     ),
                     props: {

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -16,7 +16,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useValues } from 'kea'
 interface InsightDisplayConfigProps {
     clearAnnotationsToCreate: () => void
-    allFilters: FilterType
+    filters: FilterType
     activeView: ViewType
     insightMode: ItemMode
     annotationsToCreate: Record<string, any>[] // TODO: Annotate properly
@@ -80,7 +80,7 @@ const isFunnelEmpty = (filters: FilterType): boolean => {
 }
 
 export function InsightDisplayConfig({
-    allFilters,
+    filters,
     insightMode,
     activeView,
     clearAnnotationsToCreate,
@@ -90,7 +90,7 @@ export function InsightDisplayConfig({
 
     const { featureFlags } = useValues(featureFlagLogic)
     const dateFilterDisabled =
-        (showFunnelBarOptions && isFunnelEmpty(allFilters)) ||
+        (showFunnelBarOptions && isFunnelEmpty(filters)) ||
         (!!featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && insightMode === ItemMode.View)
 
     return (
@@ -106,22 +106,22 @@ export function InsightDisplayConfig({
                                 clearAnnotationsToCreate()
                             }
                         }}
-                        filters={allFilters}
-                        disabled={allFilters.insight === ViewType.LIFECYCLE}
+                        filters={filters}
+                        disabled={filters.insight === ViewType.LIFECYCLE}
                     />
                 )}
-                {showIntervalFilter(activeView, allFilters) && <IntervalFilter view={activeView} />}
+                {showIntervalFilter(activeView, filters) && <IntervalFilter view={activeView} />}
 
                 {activeView === ViewType.RETENTION && <RetentionDatePicker />}
 
-                {showFunnelBarOptions && allFilters.funnel_viz_type === FunnelVizType.Steps && (
+                {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.Steps && (
                     <>
                         <FunnelDisplayLayoutPicker />
                         <FunnelStepReferencePicker />
                     </>
                 )}
 
-                {showFunnelBarOptions && allFilters.funnel_viz_type === FunnelVizType.TimeToConvert && (
+                {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.TimeToConvert && (
                     <>
                         <FunnelBinsPicker />
                     </>

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -458,7 +458,11 @@ export function NewPathTab(): JSX.Element {
                 </Col>
                 <Col span={12} style={{ marginTop: isSmallScreen ? '2rem' : 0, paddingLeft: 32 }}>
                     <GlobalFiltersTitle title={'Filters'} unit="actions/events" />
-                    <PropertyFilters pageKey="insight-path" />
+                    <PropertyFilters
+                        pageKey="insight-path"
+                        propertyFilters={filter.properties}
+                        onChange={(properties) => setFilter({ properties })}
+                    />
                     <TestAccountFilter filters={filter} onChange={setFilter} />
                     <hr />
                     <h4 className="secondary">

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -20,10 +20,12 @@ import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { combineUrl, encodeParams, router } from 'kea-router'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function NewPathTab(): JSX.Element {
-    const { filter } = useValues(pathsLogic({ dashboardItemId: null }))
-    const { setFilter, updateExclusions } = useActions(pathsLogic({ dashboardItemId: null }))
+    const { insight } = useValues(insightLogic)
+    const { filter } = useValues(pathsLogic({ dashboardItemId: insight?.id }))
+    const { setFilter, updateExclusions } = useActions(pathsLogic({ dashboardItemId: insight?.id }))
     const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
     const { featureFlags } = useValues(featureFlagLogic)

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -23,9 +23,9 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function NewPathTab(): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { filter } = useValues(pathsLogic({ dashboardItemId: insight?.id }))
-    const { setFilter, updateExclusions } = useActions(pathsLogic({ dashboardItemId: insight?.id }))
+    const { insightProps } = useValues(insightLogic)
+    const { filter } = useValues(pathsLogic(insightProps))
+    const { setFilter, updateExclusions } = useActions(pathsLogic(insightProps))
     const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
     const { featureFlags } = useValues(featureFlagLogic)

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathStepPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathStepPicker.tsx
@@ -5,6 +5,7 @@ import { BarsOutlined } from '@ant-design/icons'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
 import { DEFAULT_STEP_LIMIT } from 'scenes/paths/pathsLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface StepOption {
     label: string
@@ -20,8 +21,9 @@ const options: StepOption[] = Array.from(Array.from(Array.from(Array(MAX + 1).ke
 }))
 
 export function PathStepPicker(): JSX.Element {
-    const { filter } = useValues(pathsLogic)
-    const { setFilter } = useActions(pathsLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { filter } = useValues(pathsLogic(insightProps))
+    const { setFilter } = useActions(pathsLogic(insightProps))
 
     return (
         <Select

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -20,10 +20,10 @@ export function PathTab(): JSX.Element {
 }
 
 export function OldPathTab(): JSX.Element {
-    const { insight } = useValues(insightLogic)
+    const { insightProps } = useValues(insightLogic)
     const { customEventNames } = useValues(eventDefinitionsModel)
-    const { filter } = useValues(pathsLogic({ dashboardItemId: insight?.id }))
-    const { setFilter } = useActions(pathsLogic({ dashboardItemId: insight?.id }))
+    const { filter } = useValues(pathsLogic(insightProps))
+    const { setFilter } = useActions(pathsLogic(insightProps))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -71,7 +71,11 @@ export function OldPathTab(): JSX.Element {
             </Col>
             <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                 <GlobalFiltersTitle unit="actions/events" />
-                <PropertyFilters pageKey="insight-path" />
+                <PropertyFilters
+                    pageKey="insight-path"
+                    propertyFilters={filter.properties}
+                    onChange={(properties) => setFilter({ properties })}
+                />
                 <TestAccountFilter filters={filter} onChange={setFilter} />
             </Col>
         </Row>

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -12,6 +12,7 @@ import { GlobalFiltersTitle } from '../../common'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { NewPathTab } from './NewPathTab'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function PathTab(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
@@ -19,9 +20,10 @@ export function PathTab(): JSX.Element {
 }
 
 export function OldPathTab(): JSX.Element {
+    const { insight } = useValues(insightLogic)
     const { customEventNames } = useValues(eventDefinitionsModel)
-    const { filter } = useValues(pathsLogic({ dashboardItemId: null }))
-    const { setFilter } = useActions(pathsLogic({ dashboardItemId: null }))
+    const { filter } = useValues(pathsLogic({ dashboardItemId: insight?.id }))
+    const { setFilter } = useActions(pathsLogic({ dashboardItemId: insight?.id }))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -23,7 +23,7 @@ export function OldPathTab(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { customEventNames } = useValues(eventDefinitionsModel)
     const { filter } = useValues(pathsLogic(insightProps))
-    const { setFilter } = useActions(pathsLogic(insightProps))
+    const { setFilters } = useActions(pathsLogic(insightProps))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)
@@ -38,7 +38,7 @@ export function OldPathTab(): JSX.Element {
                             value={filter?.path_type || PathType.PageView}
                             defaultValue={PathType.PageView}
                             dropdownMatchSelectWidth={false}
-                            onChange={(value): void => setFilter({ path_type: value, start_point: null })}
+                            onChange={(value): void => setFilters({ path_type: value, start_point: undefined })}
                             style={{ paddingTop: 2 }}
                         >
                             {Object.entries(pathOptionsToLabels).map(([value, name], index) => {
@@ -60,7 +60,7 @@ export function OldPathTab(): JSX.Element {
                                       }))
                                     : undefined
                             }
-                            onSet={(value: string | number): void => setFilter({ start_point: value })}
+                            onSet={(value: string | number): void => setFilters({ start_point: value })}
                             propertyKey={pathOptionsToProperty[filter.path_type || PathType.PageView]}
                             type="event"
                             style={{ width: 200, paddingTop: 2 }}
@@ -76,9 +76,9 @@ export function OldPathTab(): JSX.Element {
                 <PropertyFilters
                     pageKey="insight-path"
                     propertyFilters={filter.properties}
-                    onChange={(properties) => setFilter({ properties })}
+                    onChange={(properties) => setFilters({ properties })}
                 />
-                <TestAccountFilter filters={filter} onChange={setFilter} />
+                <TestAccountFilter filters={filter} onChange={setFilters} />
             </Col>
         </Row>
     )

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -6,7 +6,7 @@ import { InfoCircleOutlined } from '@ant-design/icons'
 import { retentionTableLogic, dateOptions, retentionOptionDescriptions } from 'scenes/retention/retentionTableLogic'
 import { Select, Row, Col } from 'antd'
 
-import { FilterType, RetentionType } from '~/types'
+import { FilterType, PropertyFilter, RetentionType } from '~/types'
 import { TestAccountFilter } from '../TestAccountFilter'
 import './RetentionTab.scss'
 import { RETENTION_FIRST_TIME, RETENTION_RECURRING } from 'lib/constants'
@@ -138,7 +138,11 @@ export function RetentionTab(): JSX.Element {
                 </Col>
                 <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                     <GlobalFiltersTitle unit="actions/events" />
-                    <PropertyFilters pageKey="insight-retention" />
+                    <PropertyFilters
+                        pageKey="insight-retention"
+                        propertyFilters={filters.properties}
+                        onChange={(properties) => setFilters({ properties: properties as PropertyFilter[] })}
+                    />
                     <TestAccountFilter filters={filters} onChange={setFilters} />
                 </Col>
             </Row>

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -18,11 +18,11 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function RetentionTab(): JSX.Element {
-    const { insight } = useValues(insightLogic)
+    const { insightProps } = useValues(insightLogic)
     const { filters, actionFilterTargetEntity, actionFilterReturningEntity } = useValues(
-        retentionTableLogic({ dashboardItemId: insight?.id })
+        retentionTableLogic(insightProps)
     )
-    const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: insight?.id }))
+    const { setFilters } = useActions(retentionTableLogic(insightProps))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -15,12 +15,14 @@ import { IconExternalLink } from 'lib/components/icons'
 import { GlobalFiltersTitle } from '../common'
 import { ActionFilter } from '../ActionFilter/ActionFilter'
 import { Tooltip } from 'lib/components/Tooltip'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function RetentionTab(): JSX.Element {
+    const { insight } = useValues(insightLogic)
     const { filters, actionFilterTargetEntity, actionFilterReturningEntity } = useValues(
-        retentionTableLogic({ dashboardItemId: null })
+        retentionTableLogic({ dashboardItemId: insight?.id })
     )
-    const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: null }))
+    const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: insight?.id }))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)

--- a/frontend/src/scenes/insights/InsightTabs/SessionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/SessionTab.tsx
@@ -52,7 +52,11 @@ export function SessionTab(): JSX.Element {
             </Col>
             <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                 <GlobalFiltersTitle unit="actions/events" />
-                <PropertyFilters pageKey="insight-retention" />
+                <PropertyFilters
+                    pageKey="insight-retention"
+                    propertyFilters={filters.properties}
+                    onChange={(properties) => setFilters({ properties })}
+                />
                 <TestAccountFilter filters={filters} onChange={setFilters} />
             </Col>
         </Row>

--- a/frontend/src/scenes/insights/InsightTabs/SessionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/SessionTab.tsx
@@ -11,10 +11,12 @@ import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { GlobalFiltersTitle } from '../common'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function SessionTab(): JSX.Element {
-    const { filters } = useValues(trendsLogic({ dashboardItemId: null, view: ViewType.SESSIONS }))
-    const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view: ViewType.SESSIONS }))
+    const { insight } = useValues(insightLogic)
+    const { filters } = useValues(trendsLogic({ dashboardItemId: insight?.id, view: ViewType.SESSIONS }))
+    const { setFilters } = useActions(trendsLogic({ dashboardItemId: insight?.id, view: ViewType.SESSIONS }))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)

--- a/frontend/src/scenes/insights/InsightTabs/SessionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/SessionTab.tsx
@@ -14,9 +14,9 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function SessionTab(): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { filters } = useValues(trendsLogic({ dashboardItemId: insight?.id, view: ViewType.SESSIONS }))
-    const { setFilters } = useActions(trendsLogic({ dashboardItemId: insight?.id, view: ViewType.SESSIONS }))
+    const { insightProps } = useValues(insightLogic)
+    const { filters } = useValues(trendsLogic(insightProps))
+    const { setFilters } = useActions(trendsLogic(insightProps))
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -15,17 +15,18 @@ import './TrendTab.scss'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 import { GlobalFiltersTitle } from 'scenes/insights/common'
 import { Tooltip } from 'lib/components/Tooltip'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export interface TrendTabProps {
     view: string
 }
 
 export function TrendTab({ view }: TrendTabProps): JSX.Element {
-    const { filters } = useValues(trendsLogic({ dashboardItemId: null, view }))
-    const { setFilters } = useActions(trendsLogic({ dashboardItemId: null, view }))
+    const { insight } = useValues(insightLogic)
+    const { filters } = useValues(trendsLogic({ dashboardItemId: insight?.id, view }))
+    const { setFilters, toggleLifecycle } = useActions(trendsLogic({ dashboardItemId: insight?.id, view }))
     const { preflight } = useValues(preflightLogic)
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
-    const { toggleLifecycle } = useActions(trendsLogic)
     const lifecycles = [
         { name: 'new', tooltip: 'Users that are new.' },
         { name: 'resurrecting', tooltip: 'Users who were once active but became dormant, and are now active again.' },

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -89,7 +89,11 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     {filters.insight !== ViewType.LIFECYCLE && (
                         <>
                             <GlobalFiltersTitle />
-                            <PropertyFilters pageKey="trends-filters" />
+                            <PropertyFilters
+                                pageKey="trends-filters"
+                                propertyFilters={filters.properties}
+                                onChange={(properties) => setFilters({ properties })}
+                            />
                             <TestAccountFilter filters={filters} onChange={setFilters} />
                             {formulaAvailable && (
                                 <>

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -22,9 +22,9 @@ export interface TrendTabProps {
 }
 
 export function TrendTab({ view }: TrendTabProps): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { filters } = useValues(trendsLogic({ dashboardItemId: insight?.id, view }))
-    const { setFilters, toggleLifecycle } = useActions(trendsLogic({ dashboardItemId: insight?.id, view }))
+    const { insightProps } = useValues(insightLogic)
+    const { filters } = useValues(trendsLogic(insightProps))
+    const { setFilters, toggleLifecycle } = useActions(trendsLogic(insightProps))
     const { preflight } = useValues(preflightLogic)
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
     const lifecycles = [
@@ -188,7 +188,9 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                                     />
                                     {filters.breakdown && (
                                         <CloseButton
-                                            onClick={(): void => setFilters({ breakdown: false, breakdown_type: null })}
+                                            onClick={(): void =>
+                                                setFilters({ breakdown: undefined, breakdown_type: null })
+                                            }
                                             style={{ marginTop: 1, marginLeft: 5 }}
                                         />
                                     )}

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -33,11 +33,9 @@ const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
 }
 
 export function InsightsTable({ isLegend = true, showTotalCount = false }: InsightsTableProps): JSX.Element | null {
-    const { insight } = useValues(insightLogic)
-    const { indexedResults, visibilityMap, filters, resultsLoading } = useValues(
-        trendsLogic({ dashboardItemId: insight?.id })
-    )
-    const { toggleVisibility } = useActions(trendsLogic({ dashboardItemId: insight?.id }))
+    const { insightProps } = useValues(insightLogic)
+    const { indexedResults, visibilityMap, filters, resultsLoading } = useValues(trendsLogic(insightProps))
+    const { toggleVisibility } = useActions(trendsLogic(insightProps))
     const { cohorts } = useValues(cohortsModel)
     const { reportInsightsTableCalcToggled } = useActions(eventUsageLogic)
     const hasMathUniqueFilter = !!(

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -19,6 +19,7 @@ import { SeriesToggleWrapper } from './components/SeriesToggleWrapper'
 import { ACTIONS_LINE_GRAPH_CUMULATIVE, ACTIONS_PIE_CHART, ACTIONS_TABLE, FEATURE_FLAGS } from 'lib/constants'
 import { IndexedTrendResult } from 'scenes/trends/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface InsightsTableProps {
     isLegend?: boolean // `true` -> Used as a supporting legend at the bottom of another graph; `false` -> used as it's own display
@@ -32,8 +33,11 @@ const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
 }
 
 export function InsightsTable({ isLegend = true, showTotalCount = false }: InsightsTableProps): JSX.Element | null {
-    const { indexedResults, visibilityMap, filters, resultsLoading } = useValues(trendsLogic)
-    const { toggleVisibility } = useActions(trendsLogic)
+    const { insight } = useValues(insightLogic)
+    const { indexedResults, visibilityMap, filters, resultsLoading } = useValues(
+        trendsLogic({ dashboardItemId: insight?.id })
+    )
+    const { toggleVisibility } = useActions(trendsLogic({ dashboardItemId: insight?.id }))
     const { cohorts } = useValues(cohortsModel)
     const { reportInsightsTableCalcToggled } = useActions(eventUsageLogic)
     const hasMathUniqueFilter = !!(

--- a/frontend/src/scenes/insights/RetentionDatePicker.tsx
+++ b/frontend/src/scenes/insights/RetentionDatePicker.tsx
@@ -11,9 +11,9 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
 export function RetentionDatePicker(): JSX.Element {
-    const { insight } = useValues(insightLogic)
-    const { filters } = useValues(retentionTableLogic({ dashboardItemId: insight?.id }))
-    const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: insight?.id }))
+    const { insightProps } = useValues(insightLogic)
+    const { filters } = useValues(retentionTableLogic(insightProps))
+    const { setFilters } = useActions(retentionTableLogic(insightProps))
     const yearSuffix = filters.date_to && dayjs(filters.date_to).year() !== dayjs().year() ? ', YYYY' : ''
     return (
         <>

--- a/frontend/src/scenes/insights/RetentionDatePicker.tsx
+++ b/frontend/src/scenes/insights/RetentionDatePicker.tsx
@@ -6,12 +6,14 @@ import { useActions, useValues } from 'kea'
 import { retentionTableLogic } from 'scenes/retention/retentionTableLogic'
 import { CalendarOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
 export function RetentionDatePicker(): JSX.Element {
-    const { filters } = useValues(retentionTableLogic({ dashboardItemId: null }))
-    const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: null }))
+    const { insight } = useValues(insightLogic)
+    const { filters } = useValues(retentionTableLogic({ dashboardItemId: insight?.id }))
+    const { setFilters } = useActions(retentionTableLogic({ dashboardItemId: insight?.id }))
     const yearSuffix = filters.date_to && dayjs(filters.date_to).year() !== dayjs().year() ? ', YYYY' : ''
     return (
         <>

--- a/frontend/src/scenes/insights/insightCommandLogic.ts
+++ b/frontend/src/scenes/insights/insightCommandLogic.ts
@@ -1,45 +1,41 @@
-import { Command, commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
+import { commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { kea } from 'kea'
 import { insightCommandLogicType } from './insightCommandLogicType'
-import { compareFilterLogic } from 'lib/components/CompareFilter/compareFilterLogic'
-import { RiseOutlined } from '@ant-design/icons'
-import { insightDateFilterLogic } from 'scenes/insights/InsightDateFilter/insightDateFilterLogic'
-import { dateMapping } from 'lib/utils'
 
-const INSIGHT_COMMAND_SCOPE = 'insights'
+// const INSIGHT_COMMAND_SCOPE = 'insights'
 
 export const insightCommandLogic = kea<insightCommandLogicType>({
-    connect: [commandPaletteLogic, compareFilterLogic, insightDateFilterLogic],
+    connect: [commandPaletteLogic], //, compareFilterLogic, insightDateFilterLogic],
     events: () => ({
         afterMount: () => {
-            const funnelCommands: Command[] = [
-                {
-                    key: 'insight-graph',
-                    resolver: [
-                        {
-                            icon: RiseOutlined,
-                            display: 'Toggle "Compare Previous" on Graph',
-                            executor: () => {
-                                compareFilterLogic.actions.toggleCompare()
-                            },
-                        },
-                        ...Object.entries(dateMapping).map(([key, { values }]) => ({
-                            icon: RiseOutlined,
-                            display: `Set Time Range to ${key}`,
-                            executor: () => {
-                                insightDateFilterLogic.actions.setDates(values[0], values[1])
-                            },
-                        })),
-                    ],
-                    scope: INSIGHT_COMMAND_SCOPE,
-                },
-            ]
-            for (const command of funnelCommands) {
-                commandPaletteLogic.actions.registerCommand(command)
-            }
+            // const funnelCommands: Command[] = [
+            //     {
+            //         key: 'insight-graph',
+            //         resolver: [
+            //             {
+            //                 icon: RiseOutlined,
+            //                 display: 'Toggle "Compare Previous" on Graph',
+            //                 executor: () => {
+            //                     compareFilterLogic.actions.toggleCompare()
+            //                 },
+            //             },
+            //             ...Object.entries(dateMapping).map(([key, { values }]) => ({
+            //                 icon: RiseOutlined,
+            //                 display: `Set Time Range to ${key}`,
+            //                 executor: () => {
+            //                     insightDateFilterLogic.actions.setDates(values[0], values[1])
+            //                 },
+            //             })),
+            //         ],
+            //         scope: INSIGHT_COMMAND_SCOPE,
+            //     },
+            // ]
+            // for (const command of funnelCommands) {
+            //     commandPaletteLogic.actions.registerCommand(command)
+            // }
         },
         beforeUnmount: () => {
-            commandPaletteLogic.actions.deregisterScope(INSIGHT_COMMAND_SCOPE)
+            // commandPaletteLogic.actions.deregisterScope(INSIGHT_COMMAND_SCOPE)
         },
     }),
 })

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { toParams, fromParams, errorToast } from 'lib/utils'
+import { errorToast } from 'lib/utils'
 import posthog from 'posthog-js'
 import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
 import { insightLogicType } from './insightLogicType'
@@ -42,7 +42,6 @@ export const insightLogic = kea<insightLogicType>({
     actions: () => ({
         setActiveView: (type: ViewType) => ({ type }),
         updateActiveView: (type: ViewType) => ({ type }),
-        setCachedUrl: (type: ViewType, url: string) => ({ type, url }),
         setAllFilters: (filters) => ({ filters }),
         startQuery: (queryId: string) => ({ queryId }),
         endQuery: (queryId: string, view: ViewType, lastRefresh: string | null, exception?: Record<string, any>) => ({
@@ -117,12 +116,6 @@ export const insightLogic = kea<insightLogicType>({
                 endQuery: (_, { exception }) => exception?.status >= 400,
                 startQuery: () => false,
                 setActiveView: () => false,
-            },
-        ],
-        cachedUrls: [
-            {} as Record<string, string>,
-            {
-                setCachedUrl: (state, { type, url }) => ({ ...state, [type]: url }),
             },
         ],
         activeView: [
@@ -313,16 +306,7 @@ export const insightLogic = kea<insightLogicType>({
     }),
     actionToUrl: ({ actions, values }) => ({
         setActiveView: ({ type }) => {
-            const params = fromParams()
-            const { properties, ...restParams } = params
-
-            actions.setCachedUrl(values.activeView, window.location.pathname + '?' + toParams(restParams))
-            const cachedUrl = values.cachedUrls[type]
             actions.updateActiveView(type)
-
-            if (cachedUrl) {
-                return cachedUrl + '&' + toParams({ properties })
-            }
 
             const urlParams: UrlParams = {
                 insight: type,

--- a/frontend/src/scenes/insights/url.ts
+++ b/frontend/src/scenes/insights/url.ts
@@ -1,0 +1,41 @@
+// must keep separately from utils.ts, as that will make a cyclic import -> funnelLogic.ts -> utils.tsx -> funnelLogic.ts
+import { Entity, FilterType, FunnelVizType, PropertyFilter, ViewType } from '~/types'
+
+export const defaultFilterTestAccounts = (): boolean => {
+    return localStorage.getItem('default_filter_test_accounts') === 'true' || false
+}
+
+interface UrlParams {
+    insight: string
+    properties: PropertyFilter[] | undefined
+    filter_test_accounts: boolean
+    funnel_viz_type?: string
+    display?: string
+    events?: Entity[]
+    actions?: Entity[]
+}
+
+export function getInsightUrl(
+    filters: Partial<FilterType>,
+    hashParams: Record<string, any>,
+    insightId?: number
+): [string, Record<string, any>, Record<string, any>, { replace: true }] {
+    const urlParams: UrlParams = {
+        insight: filters.insight || 'TRENDS',
+        properties: filters.properties,
+        filter_test_accounts: defaultFilterTestAccounts(),
+        events: (filters.events || []) as Entity[],
+        actions: (filters.actions || []) as Entity[],
+    }
+    if (filters.insight === ViewType.FUNNELS) {
+        urlParams.funnel_viz_type = FunnelVizType.Steps
+        urlParams.display = 'FunnelViz'
+    }
+    const { q: _q, fromItem: otherFromItem, ...otherHashParams } = hashParams
+    return [
+        `/insights`,
+        {},
+        { q: urlParams, ...otherHashParams, fromItem: insightId || otherFromItem },
+        { replace: true },
+    ]
+}

--- a/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
+++ b/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
@@ -41,8 +41,8 @@ export function MetricsChart({ plugin }: { plugin: PluginTypeWithConfig }): JSX.
         properties: [pluginNameFilter, pluginTagFilter],
     } as Partial<FilterType>
 
-    const { insight } = useValues(insightLogic)
-    const { loadResults } = useActions(trendsLogic({ filters, dashboardItemId: insight?.id, view: ViewType.TRENDS }))
+    const { insightProps } = useValues(insightLogic)
+    const { loadResults } = useActions(trendsLogic(insightProps))
 
     useEffect(() => {
         loadResults()

--- a/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
+++ b/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { ActionsLineGraph } from 'scenes/trends/viz'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import './styles/metrics-drawer.scss'
 import { PluginTypeWithConfig } from '../types'
 import { FilterType, ViewType } from '~/types'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 const baseFilters = {
     insight: 'TRENDS',
@@ -40,7 +41,8 @@ export function MetricsChart({ plugin }: { plugin: PluginTypeWithConfig }): JSX.
         properties: [pluginNameFilter, pluginTagFilter],
     } as Partial<FilterType>
 
-    const { loadResults } = useActions(trendsLogic({ filters, dashboardItemId: null, view: ViewType.TRENDS }))
+    const { insight } = useValues(insightLogic)
+    const { loadResults } = useActions(trendsLogic({ filters, dashboardItemId: insight?.id, view: ViewType.TRENDS }))
 
     useEffect(() => {
         loadResults()

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -18,9 +18,11 @@ dayjs.extend(utc)
 
 import { ColumnsType } from 'antd/lib/table'
 import clsx from 'clsx'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: number | null }): JSX.Element | null {
-    const logic = retentionTableLogic({ dashboardItemId })
+    const { insightProps } = useValues(insightLogic)
+    const logic = retentionTableLogic(insightProps)
     const {
         results: _results,
         resultsLoading,

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -15,6 +15,7 @@ import {
     RetentionTrendPeoplePayload,
 } from 'scenes/retention/types'
 import { dashboardsModel } from '~/models/dashboardsModel'
+import { getInsightUrl } from 'scenes/insights/url'
 
 export const dateOptions = ['Hour', 'Day', 'Week', 'Month']
 
@@ -165,23 +166,24 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
             if (props.dashboardItemId) {
                 return // don't use the URL if on the dashboard
             }
-            return ['/insights', values.filters, router.values.hashParams, { replace: true }]
+            return getInsightUrl(values.filters, router.values.hashParams, router.values.hashParams.fromItem)
         },
         setProperties: () => {
             if (props.dashboardItemId) {
                 return // don't use the URL if on the dashboard
             }
-            return ['/insights', values.filters, router.values.hashParams, { replace: true }]
+            return getInsightUrl(values.filters, router.values.hashParams, router.values.hashParams.fromItem)
         },
     }),
     urlToAction: ({ actions, values, key }) => ({
-        '/insights': ({}, searchParams: Record<string, any>) => {
-            if (searchParams.insight === ViewType.RETENTION) {
+        '/insights': (_, searchParams, hashParams) => {
+            const queryParams = { ...searchParams, ...hashParams.q }
+            if (queryParams.insight === ViewType.RETENTION) {
                 if (key != DEFAULT_RETENTION_LOGIC_KEY) {
                     return
                 }
 
-                const cleanSearchParams = searchParams
+                const cleanSearchParams = queryParams
                 const cleanedFilters = values.filters
 
                 if (cleanSearchParams.display !== cleanedFilters.display) {

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -18,20 +18,22 @@ import { InsightsTable } from 'scenes/insights/InsightsTable'
 import { Button } from 'antd'
 import { personsModalLogic } from './personsModalLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 interface Props {
     view: ViewType
 }
 
 export function TrendInsight({ view }: Props): JSX.Element {
+    const { insight } = useValues(insightLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
     const {
         filters: _filters,
         loadMoreBreakdownUrl,
         breakdownValuesLoading,
-    } = useValues(trendsLogic({ dashboardItemId: null, filters: null }))
-    const { loadMoreBreakdownValues } = useActions(trendsLogic({ dashboardItemId: null, filters: null }))
+    } = useValues(trendsLogic({ dashboardItemId: insight?.id }))
+    const { loadMoreBreakdownValues } = useActions(trendsLogic({ dashboardItemId: insight?.id }))
     const { showingPeople } = useValues(personsModalLogic)
     const { saveCohortWithFilters } = useActions(personsModalLogic)
     const { reportCohortCreatedFromPersonModal } = useActions(eventUsageLogic)
@@ -49,7 +51,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                 return <ActionsTable filters={_filters} view={view} />
             }
             return (
-                <BindLogic logic={trendsLogic} props={{ dashboardItemId: null, view, filters: null }}>
+                <BindLogic logic={trendsLogic} props={{ dashboardItemId: insight?.id, view, filters: null }}>
                     <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
                 </BindLogic>
             )

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BindLogic, useActions, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { PersonModal } from './PersonModal'
 import {
     ACTIONS_LINE_GRAPH_LINEAR,
@@ -25,15 +25,11 @@ interface Props {
 }
 
 export function TrendInsight({ view }: Props): JSX.Element {
-    const { insight } = useValues(insightLogic)
+    const { insightProps } = useValues(insightLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
-    const {
-        filters: _filters,
-        loadMoreBreakdownUrl,
-        breakdownValuesLoading,
-    } = useValues(trendsLogic({ dashboardItemId: insight?.id }))
-    const { loadMoreBreakdownValues } = useActions(trendsLogic({ dashboardItemId: insight?.id }))
+    const { filters: _filters, loadMoreBreakdownUrl, breakdownValuesLoading } = useValues(trendsLogic(insightProps))
+    const { loadMoreBreakdownValues } = useActions(trendsLogic(insightProps))
     const { showingPeople } = useValues(personsModalLogic)
     const { saveCohortWithFilters } = useActions(personsModalLogic)
     const { reportCohortCreatedFromPersonModal } = useActions(eventUsageLogic)
@@ -50,11 +46,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
             if (view === ViewType.SESSIONS && _filters.session === 'dist') {
                 return <ActionsTable filters={_filters} view={view} />
             }
-            return (
-                <BindLogic logic={trendsLogic} props={{ dashboardItemId: insight?.id, view, filters: null }}>
-                    <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
-                </BindLogic>
-            )
+            return <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
         }
         if (_filters.display === ACTIONS_PIE_CHART) {
             return <ActionsPie filters={_filters} view={view} />

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { LineGraph } from '../../insights/LineGraph'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
@@ -6,11 +6,10 @@ import { LineGraphEmptyState } from '../../insights/EmptyStates'
 import { ACTIONS_BAR_CHART } from 'lib/constants'
 import { ChartParams } from '~/types'
 import { ViewType } from '~/types'
-import { router } from 'kea-router'
 import { personsModalLogic } from '../personsModalLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function ActionsLineGraph({
-    dashboardItemId,
     color = 'white',
     filters: filtersParam,
     cachedResults,
@@ -18,15 +17,15 @@ export function ActionsLineGraph({
     showPersonsModal = true,
     view,
 }: ChartParams): JSX.Element | null {
+    const { insight } = useValues(insightLogic)
     const logic = trendsLogic({
-        dashboardItemId,
+        dashboardItemId: insight?.id,
         view: view || filtersParam?.insight,
         filters: filtersParam,
         cachedResults,
     })
     const { filters, indexedResults, visibilityMap } = useValues(logic)
     const { loadPeople } = useActions(personsModalLogic)
-    const [{ fromItem }] = useState(router.values.hashParams)
 
     return indexedResults &&
         indexedResults[0]?.data &&
@@ -39,13 +38,13 @@ export function ActionsLineGraph({
             visibilityMap={visibilityMap}
             labels={(indexedResults[0] && indexedResults[0].labels) || []}
             isInProgress={!filters.date_to}
-            dashboardItemId={dashboardItemId || fromItem /* used only for annotations, not to init any other logic */}
+            dashboardItemId={insight?.id /* used only for annotations, not to init any other logic */}
             inSharedMode={inSharedMode}
             interval={filters.interval}
             showPersonsModal={showPersonsModal}
             tooltipPreferAltTitle={filters.insight === ViewType.STICKINESS}
             onClick={
-                dashboardItemId
+                insight?.id
                     ? null
                     : (point) => {
                           const { dataset, day } = point
@@ -63,6 +62,6 @@ export function ActionsLineGraph({
             }
         />
     ) : (
-        <LineGraphEmptyState color={color} isDashboard={!!dashboardItemId} />
+        <LineGraphEmptyState color={color} isDashboard={!!insight?.id} />
     )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -543,6 +543,7 @@ export interface DashboardItemType {
     result: any | null
     updated_at: string
     tags: string[]
+    next?: string
 }
 
 export interface DashboardType {
@@ -965,10 +966,7 @@ export interface ChartParams {
 
 // Shared between dashboardItemLogic, trendsLogic, funnelLogic, pathsLogic, retentionTableLogic
 export interface SharedInsightLogicProps {
-    // the chart is displayed on a dashboard right now, used in the key if present
     dashboardItemId?: number | null
-    // the insight is connected to a dashboard item, yet viewed on the insights scene
-    fromDashboardItemId?: number | null
     cachedResults?: any
     filters?: Partial<FilterType> | null
     preventLoading?: boolean


### PR DESCRIPTION
## Changes

- **Still WIP. Once I figure out what I want from all of this, I'll chunk it down into reviewable PRs.**
- Completely reworks a lot of the insight logics. 
- Changes the URL for insights from `/insights?filtersAndParams#fromItem=123` to `/insights#q=filtersAndParams&fromItem=123` to solve the case when the URL is too long to hit django (but gets discarded anyway).
- Trying to avoid further URL and legacy variable name (`dashboardItemId`) changes in this PR
- ... (to be edited)

## How did you test this code?

Still testing....
