### PR TITLE
Always allow filtering on distinct id

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -213,6 +213,10 @@ def get_property_string_expr(
 ) -> Tuple[str, bool]:
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
+    # We still want to be able to filter on distinct_id even if it wasn't set in properties
+    if property_name == "distinct_id":
+        return "distinct_id"
+
     if allow_denormalized_props and property_name in materialized_columns:
         return materialized_columns[property_name], True
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -215,7 +215,7 @@ def get_property_string_expr(
 
     # We still want to be able to filter on distinct_id even if it wasn't set in properties
     if property_name == "distinct_id":
-        return "distinct_id"
+        return "distinct_id", True
 
     if allow_denormalized_props and property_name in materialized_columns:
         return materialized_columns[property_name], True

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -215,7 +215,7 @@ def get_property_string_expr(
 
     # We still want to be able to filter on distinct_id even if it wasn't set in properties
     if property_name == "distinct_id":
-        return "distinct_id", True
+        return f"{table}.distinct_id", True
 
     if allow_denormalized_props and property_name in materialized_columns:
         return materialized_columns[property_name], True

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -214,7 +214,7 @@ def get_property_string_expr(
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
     # We still want to be able to filter on distinct_id even if it wasn't set in properties
-    if property_name == "distinct_id":
+    if property_name == "distinct_id" and table == "events":
         return f"{table}.distinct_id", True
 
     if allow_denormalized_props and property_name in materialized_columns:

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -416,26 +416,6 @@ def factory_test_event_api(event_factory, person_factory, _):
 
             self.assertEqual(len(response_person_1["result"]), 1)
 
-        def test_distinct_id_is_email(self):
-            # Regression test, emails didn't work as distinct id filter
-            another_team = Team.objects.create(organization=self.organization)
-
-            Person.objects.create(team=self.team, distinct_ids=["test+test@gmail.com"])
-            Person.objects.create(team=another_team, distinct_ids=["test+test@gmail.com"])
-
-            with freeze_time("2012-01-14T03:21:34.000Z"):
-                event_factory(team=self.team, event="1st action", distinct_id="test+test@gmail.com")
-
-            with freeze_time("2012-01-14T03:25:34.000Z"):
-                event_factory(team=self.team, event="2nd action", distinct_id="test+test@gmail.com")
-                event_factory(team=another_team, event="2nd action", distinct_id="test+test@gmail.com")
-                event_factory(team=self.team, event="2nd action", distinct_id="test+test@gmail.com")
-
-            response = self.client.get(
-                f"/api/event/sessions/?distinct_id=test+test@gmail.com&date_from=2012-01-14T03:00:34&date_to=2012-01-15T04:00:00"
-            ).json()
-            self.assertEqual(len(response["result"]), 1)
-
         def test_events_in_future(self):
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 event_factory(team=self.team, event="5th action", distinct_id="2", properties={"$os": "Windows 95"})

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -416,6 +416,26 @@ def factory_test_event_api(event_factory, person_factory, _):
 
             self.assertEqual(len(response_person_1["result"]), 1)
 
+        def test_distinct_id_is_email(self):
+            # Regression test, emails didn't work as distinct id filter
+            another_team = Team.objects.create(organization=self.organization)
+
+            Person.objects.create(team=self.team, distinct_ids=["test+test@gmail.com"])
+            Person.objects.create(team=another_team, distinct_ids=["test+test@gmail.com"])
+
+            with freeze_time("2012-01-14T03:21:34.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="test+test@gmail.com")
+
+            with freeze_time("2012-01-14T03:25:34.000Z"):
+                event_factory(team=self.team, event="2nd action", distinct_id="test+test@gmail.com")
+                event_factory(team=another_team, event="2nd action", distinct_id="test+test@gmail.com")
+                event_factory(team=self.team, event="2nd action", distinct_id="test+test@gmail.com")
+
+            response = self.client.get(
+                f"/api/event/sessions/?distinct_id=test+test@gmail.com&date_from=2012-01-14T03:00:34&date_to=2012-01-15T04:00:00"
+            ).json()
+            self.assertEqual(len(response["result"]), 1)
+
         def test_events_in_future(self):
             with freeze_time("2012-01-15T04:01:34.000Z"):
                 event_factory(team=self.team, event="5th action", distinct_id="2", properties={"$os": "Windows 95"})

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -417,6 +417,18 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
             events = filter_events(filter=filter, team=self.team, person_query=True)
             self.assertEqual(len(events), 1)
 
+        def test_filter_on_distinct_id(self):
+            # Distinct_id is a special case in that we still want to filter on it even if it wasn't set as a property
+            person1 = person_factory(team_id=self.team.pk, distinct_ids=["user_1"])
+            person2 = person_factory(team_id=self.team.pk, distinct_ids=["user_2"])
+            event_factory(team=self.team, distinct_id="user_1", event="$pageview")
+            event_factory(team=self.team, distinct_id="user_2", event="$pageview")
+            filter = Filter(
+                data={"events": [{"id": "$pageview"}], "properties": [{"key": "distinct_id", "value": "user_1"}]}
+            )
+            events = filter_events(filter=filter, team=self.team)
+            self.assertEqual(len(events), 1)
+
     return TestPropertiesToQ
 
 

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -95,7 +95,7 @@ class Property:
             return lookup_q(key, value)
         else:
             assert not isinstance(value, list)
-            return Q(**{"{key}__{self.operator}": value})
+            return Q(**{"{}__{}".format(key, self.operator): value})
 
 
 def lookup_q(key: str, value: Any) -> Q:


### PR DESCRIPTION
## Changes

Some of our libraries do not always send `distinct_id` in the properties, or when people insert events manually via API or some other source it might not be set either, so in that case filtering on distinct id won't work. This PR special cases distinct_id to use the field on the table instead so it should always work.

## How did you test this code?

Exclusively unit tests. I feel very confident in them for this part of the system.
