### PR TITLE
Simplify cohort filters

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,8 +101,8 @@ jobs:
 
             - name: Compare results
               run: |
-                  asv compare $(cat ee/benchmarks/results/last-master-commit) HEAD --config ee/benchmarks/asv.conf.json --factor 1.5 | tee pr_vs_master.txt
-                  asv compare $(cat ee/benchmarks/results/last-master-commit) HEAD --config ee/benchmarks/asv.conf.json --factor 1.5 --only-changed | tee pr_vs_master_changed.txt
+                  asv compare $(cat ee/benchmarks/results/last-master-commit) HEAD --config ee/benchmarks/asv.conf.json --factor 1.2 | tee pr_vs_master.txt
+                  asv compare $(cat ee/benchmarks/results/last-master-commit) HEAD --config ee/benchmarks/asv.conf.json --factor 1.2 --only-changed | tee pr_vs_master_changed.txt
 
             - name: Save last benchmarked commit
               if: ${{ github.ref == 'refs/heads/master' }}

--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -19,8 +19,8 @@ MATERIALIZED_PROPERTIES: List[Tuple[TableWithProperties, PropertyName]] = [
     ("person", "$browser"),
 ]
 
-DATE_RANGE = {"date_from": "2021-01-01", "date_to": "2021-10-01"}
-SHORT_DATE_RANGE = {"date_from": "2021-07-01", "date_to": "2021-10-01"}
+DATE_RANGE = {"date_from": "2021-01-01", "date_to": "2021-10-01", "interval": "week"}
+SHORT_DATE_RANGE = {"date_from": "2021-07-01", "date_to": "2021-10-01", "interval": "week"}
 
 
 class QuerySuite:
@@ -42,14 +42,15 @@ class QuerySuite:
             team = Team.objects.create(id=2, organization=organization, name="The Bakery")
         self.team = team
 
-        self.cohort = Cohort.objects.create(
-            team_id=2,
-            name="benchmarking cohort",
-            groups=[{"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}]}],
-        )
-        self.cohort.calculate_people_ch()
-
-        assert self.cohort.last_calculation is not None
+        cohort = Cohort.objects.filter(name="benchmarking cohort").first()
+        if cohort is None:
+            cohort = Cohort.objects.create(
+                team_id=2,
+                name="benchmarking cohort",
+                groups=[{"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch()
+        self.cohort = cohort
 
     @benchmark_clickhouse
     def track_trends_no_filter(self):

--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -140,7 +140,7 @@ class QuerySuite:
                 "properties": [{"key": "id", "value": self.cohort.pk, "type": "cohort"}],
                 **DATE_RANGE,
             },
-            team_id=self.team.pk,
+            team=self.team,
         )
         ClickhouseTrends().run(filter, self.team)
 
@@ -155,7 +155,7 @@ class QuerySuite:
                 "properties": [{"key": "id", "value": self.cohort.pk, "type": "cohort"}],
                 **DATE_RANGE,
             },
-            team_id=self.team.pk,
+            team=self.team,
         )
 
         with no_materialized_columns():
@@ -172,7 +172,7 @@ class QuerySuite:
                 "properties": [{"key": "id", "value": self.cohort.pk, "type": "cohort"}],
                 **DATE_RANGE,
             },
-            team_id=self.team.pk,
+            team=self.team,
         )
 
         ClickhouseTrends().run(filter, self.team)

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -211,7 +211,6 @@ def parse_cohort_timestamps(start_time: Optional[str], end_time: Optional[str]) 
 
 
 def is_precalculated_query(cohort: Cohort) -> bool:
-
     if (
         cohort.last_calculation
         and cohort.last_calculation > TEMP_PRECALCULATED_MARKER

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -6,7 +6,11 @@ from rest_framework import exceptions
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.materialized_columns.columns import TableWithProperties, get_materialized_columns
-from ee.clickhouse.models.cohort import format_filter_query, format_precalculated_cohort_query, format_static_cohort_query
+from ee.clickhouse.models.cohort import (
+    format_filter_query,
+    format_precalculated_cohort_query,
+    format_static_cohort_query,
+)
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
 from ee.clickhouse.sql.person import GET_DISTINCT_IDS_BY_PROPERTY_SQL
@@ -87,11 +91,17 @@ def parse_prop_clauses(
             final.append(f"{filter_query} AND {table_name}team_id = %(team_id)s" if team_id else filter_query)
             params.update(filter_params)
         elif prop.type == "static-cohort":
-            filter_query, filter_params = format_static_cohort_query(prop.value, idx, prepend=prepend, custom_match_field="person_id")
+            cohort_id = cast(int, prop.value)
+            filter_query, filter_params = format_static_cohort_query(
+                cohort_id, idx, prepend=prepend, custom_match_field="person_id"
+            )
             final.append(f" AND {filter_query}")
             params.update(filter_params)
         elif prop.type == "precalculated-cohort":
-            filter_query, filter_params = format_precalculated_cohort_query(prop.value, idx, prepend=prepend, custom_match_field="person_id")
+            cohort_id = cast(int, prop.value)
+            filter_query, filter_params = format_precalculated_cohort_query(
+                cohort_id, idx, prepend=prepend, custom_match_field="person_id"
+            )
             final.append(f" AND {filter_query}")
             params.update(filter_params)
 

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -255,7 +255,11 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
 
         cohort1 = Cohort.objects.create(
-            team=self.team, groups=[{"properties": {"$some_prop__is_not": "something"}}], name="cohort1",
+            team=self.team,
+            groups=[
+                {"properties": [{"type": "person", "key": "$some_prop", "operator": "is_not", "value": "something"}]}
+            ],
+            name="cohort1",
         )
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
@@ -666,7 +670,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
                 WHERE person_id IN
                     (SELECT person_id
                     FROM person_static_cohort
-                    WHERE cohort_id = %(cohort_id_0)s
+                    WHERE cohort_id = %(_cohort_id_0)s
                     AND team_id = %(team_id)s)
                 """,
                     reindent=True,

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -106,7 +106,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
         cohort1 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk}], name="cohort1",)
 
-        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
         query, params = parse_prop_clauses(filter.properties, self.team.pk)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
@@ -143,7 +143,9 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
                 team=self.team, groups=[{"event_id": "$pageview", "days": 1}], name="cohort1",
             )
 
-            filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+            filter = Filter(
+                data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team
+            )
             query, params = parse_prop_clauses(filter.properties, self.team.pk)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
@@ -153,7 +155,9 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
                 team=self.team, groups=[{"event_id": "$pageview", "days": 7}], name="cohort2",
             )
 
-            filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],})
+            filter = Filter(
+                data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team
+            )
             query, params = parse_prop_clauses(filter.properties, self.team.pk)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
@@ -191,7 +195,9 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
                 team=self.team, groups=[{"action_id": action.pk, "days": 1}], name="cohort1",
             )
 
-            filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+            filter = Filter(
+                data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team
+            )
             query, params = parse_prop_clauses(filter.properties, self.team.pk)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
@@ -201,7 +207,9 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
                 team=self.team, groups=[{"action_id": action.pk, "days": 7}], name="cohort2",
             )
 
-            filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],})
+            filter = Filter(
+                data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team
+            )
             query, params = parse_prop_clauses(filter.properties, self.team.pk)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
@@ -226,7 +234,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             name="cohort1",
         )
 
-        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
         query, params = parse_prop_clauses(filter.properties, self.team.pk)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
@@ -250,7 +258,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             team=self.team, groups=[{"properties": {"$some_prop__is_not": "something"}}], name="cohort1",
         )
 
-        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
         query, params = parse_prop_clauses(filter.properties, self.team.pk)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -133,6 +133,33 @@ class TestFilters(PGTestFilters):
             {"properties": [{"type": "cohort", "key": "id", "value": 555_555, "operator": None}]},
         )
 
+    def test_simplify_entities(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}]}],
+        )
+        filter = Filter(
+            data={"events": [{"id": "$pageview", "properties": [{"type": "cohort", "key": "id", "value": cohort.pk}]}]}
+        )
+
+        self.assertEqual(
+            filter.simplify(self.team).entities_to_dict(),
+            {
+                "events": [
+                    {
+                        "type": "events",
+                        "id": "$pageview",
+                        "math": None,
+                        "math_property": None,
+                        "custom_name": None,
+                        "order": None,
+                        "name": "$pageview",
+                        "properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"},],
+                    }
+                ],
+            },
+        )
+
 
 class TestFiltering(
     ClickhouseTestMixin, property_to_Q_test_factory(_filter_events, _create_event, _create_person),  # type: ignore

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -67,7 +67,7 @@ class TestFiltering(
             team=self.team, groups=[{"properties": {"$some_prop__is_not": "something"}}], name="cohort2"
         )
 
-        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
 
         prop_clause, prop_clause_params = parse_prop_clauses(filter.properties, self.team.pk)
         query = """
@@ -80,7 +80,7 @@ class TestFiltering(
         self.assertEqual(result, person1_distinct_id)
 
         # test cohort2 with negation
-        filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],})
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team)
         prop_clause, prop_clause_params = parse_prop_clauses(filter.properties, self.team.pk)
         query = """
         SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -3,13 +3,13 @@ from uuid import uuid4
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.event import ClickhouseEventSerializer, create_event
-from ee.clickhouse.models.person import ClickhousePersonSerializer
 from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.sql.events import GET_EVENTS_WITH_PROPERTIES
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.models.cohort import Cohort
 from posthog.models.event import Event
 from posthog.models.filters import Filter
+from posthog.models.filters.test.test_filter import TestFilter as PGTestFilters
 from posthog.models.filters.test.test_filter import property_to_Q_test_factory
 from posthog.models.person import Person
 from posthog.models.team import Team
@@ -44,6 +44,94 @@ def _create_event(**kwargs):
     kwargs.update({"event_uuid": uuid})
     create_event(**kwargs)
     return Event(id=str(uuid))
+
+
+class TestFilters(PGTestFilters):
+    def test_simplify_cohorts(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}]}],
+        )
+        cohort.calculate_people_ch()
+
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": cohort.pk}]})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"},]},
+        )
+
+        with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
+            self.assertEqual(
+                filter.simplify(self.team).properties_to_dict(),
+                {"properties": [{"type": "precalculated-cohort", "key": "id", "value": cohort.pk, "operator": None},]},
+            )
+
+    def test_simplify_not_ee(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}]}],
+        )
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": cohort.pk}]})
+
+        self.assertEqual(
+            filter.simplify(self.team, is_clickhouse_enabled=False).properties_to_dict(),
+            {"properties": [{"type": "cohort", "key": "id", "value": cohort.pk, "operator": None}]},
+        )
+
+    def test_simplify_static_cohort(self):
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": cohort.pk}]})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"type": "static-cohort", "key": "id", "value": cohort.pk, "operator": None},]},
+        )
+
+    def test_simplify_hasdone_cohort(self):
+        cohort = Cohort.objects.create(team=self.team, groups=[{"event_id": "$pageview", "days": 1}])
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": cohort.pk}]})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"type": "cohort", "key": "id", "value": cohort.pk, "operator": None}]},
+        )
+
+    def test_simplify_multi_group_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": {"$some_prop": "something"}}, {"properties": {"$another_prop": "something"}}],
+        )
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": cohort.pk}]})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"type": "cohort", "key": "id", "value": cohort.pk, "operator": None}]},
+        )
+
+    def test_recursive_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}]}],
+        )
+        recursive_cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"type": "cohort", "key": "id", "value": cohort.pk, "operator": None}]}],
+        )
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": recursive_cohort.pk}]})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"},]},
+        )
+
+    def test_simplify_no_such_cohort(self):
+        filter = Filter(data={"properties": [{"type": "cohort", "key": "id", "value": 555_555}]})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"type": "cohort", "key": "id", "value": 555_555, "operator": None}]},
+        )
 
 
 class TestFiltering(

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -44,7 +44,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         self._team_id = team_id
         self._column_optimizer = ColumnOptimizer(self._filter, self._team_id)
         self._person_query = ClickhousePersonQuery(
-            self._filter, self._team_id, self._column_optimizer, self._extra_person_fields
+            self._filter, self._team_id, self._column_optimizer, extra_person_fields
         )
         self.params: Dict[str, Any] = {
             "team_id": self._team_id,

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -174,7 +174,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
 
         person_id_query, cohort_filter_params = (
             format_precalculated_cohort_query(
-                cohort.pk, 0, team_id=cohort.team_id, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"
+                cohort.pk, 0, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"
             )
             if is_precalculated
             else format_person_query(cohort, 0, custom_match_field=f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id")

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -21,6 +21,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
     _filter: Union[Filter, PathFilter, RetentionFilter]
     _team_id: int
     _column_optimizer: ColumnOptimizer
+    _person_query: ClickhousePersonQuery
     _should_join_distinct_ids = False
     _should_join_persons = False
     _should_round_interval = False
@@ -42,6 +43,9 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         self._filter = filter
         self._team_id = team_id
         self._column_optimizer = ColumnOptimizer(self._filter, self._team_id)
+        self._person_query = ClickhousePersonQuery(
+            self._filter, self._team_id, self._column_optimizer, self._extra_person_fields
+        )
         self.params: Dict[str, Any] = {
             "team_id": self._team_id,
         }
@@ -77,7 +81,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
             return ""
 
     def _determine_should_join_persons(self) -> None:
-        if self._column_optimizer.is_using_person_properties:
+        if self._person_query.is_used:
             self._should_join_distinct_ids = True
             self._should_join_persons = True
             return
@@ -102,9 +106,6 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
             return
 
     def _should_property_join_persons(self, prop: Property) -> bool:
-        if prop.type in ("person", "static-cohort", "precalculated-cohort"):
-            return True
-
         return prop.type == "cohort" and self._does_cohort_need_persons(prop)
 
     def _does_cohort_need_persons(self, prop: Property) -> bool:
@@ -125,7 +126,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         if self._should_join_persons:
             return f"""
             INNER JOIN (
-                {ClickhousePersonQuery(self._filter, self._team_id, self._column_optimizer, self._extra_person_fields).get_query()}
+                {self._person_query.get_query()}
             ) {self.PERSON_TABLE_ALIAS}
             ON {self.PERSON_TABLE_ALIAS}.id = {self.DISTINCT_ID_TABLE_ALIAS}.person_id
             """

--- a/ee/clickhouse/queries/person_query.py
+++ b/ee/clickhouse/queries/person_query.py
@@ -5,6 +5,7 @@ from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from posthog.models import Filter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
+from posthog.models.property import Property
 
 
 class ClickhousePersonQuery:
@@ -58,7 +59,15 @@ class ClickhousePersonQuery:
     @property
     def is_used(self):
         "Returns whether properties or any other columns are actually being queried"
+        if any(self._uses_person_id(prop) for prop in self._filter.properties):
+            return True
+        if any(self._uses_person_id(prop) for entity in self._filter.entities for prop in entity.properties):
+            return True
+
         return (
             self._column_optimizer.should_query_person_properties_column
             or len(self._column_optimizer.materialized_person_columns_to_query) > 0
         )
+
+    def _uses_person_id(self, prop: Property) -> bool:
+        return prop.type in ("person", "static-cohort", "precalculated-cohort")

--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -26,7 +26,7 @@ class ClickhouseSessionsAvg:
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
-        filters, params = parse_prop_clauses(filter.properties, team.pk)
+        filters, params = parse_prop_clauses(filter.properties, team.pk, has_person_id_joined=False)
 
         trunc_func = get_trunc_func_ch(filter.interval)
         interval_func = get_interval_func_ch(filter.interval)

--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -12,7 +12,7 @@ class ClickhouseSessionsDist:
 
         parsed_date_from, parsed_date_to, _ = parse_timestamps(filter, team.pk)
 
-        filters, params = parse_prop_clauses(filter.properties, team.pk)
+        filters, params = parse_prop_clauses(filter.properties, team.pk, has_person_id_joined=False)
 
         entity_conditions, entity_params = entity_query_conditions(filter, team)
         if not entity_conditions:

--- a/ee/clickhouse/queries/sessions/list.py
+++ b/ee/clickhouse/queries/sessions/list.py
@@ -157,7 +157,7 @@ def format_action_filter_aggregate(entity: Entity, prepend: str):
     filter_sql, params = format_entity_filter(entity, prepend=prepend, filter_by_team=False)
     if entity.properties:
         filters, filter_params = parse_prop_clauses(
-            entity.properties, prepend=prepend, team_id=None, allow_denormalized_props=False
+            entity.properties, prepend=prepend, team_id=None, allow_denormalized_props=False, has_person_id_joined=False
         )
         filter_sql += f" {filters}"
         params = {**params, **filter_params}

--- a/ee/clickhouse/queries/sessions/util.py
+++ b/ee/clickhouse/queries/sessions/util.py
@@ -13,7 +13,11 @@ def event_entity_to_query(entity: Entity, team: Team, prepend="event_entity") ->
         from ee.clickhouse.models.property import parse_prop_clauses
 
         prop_query, prop_params = parse_prop_clauses(
-            entity.properties, team_id=team.pk, prepend="{}_props".format(prepend), allow_denormalized_props=False
+            entity.properties,
+            team_id=team.pk,
+            prepend="{}_props".format(prepend),
+            allow_denormalized_props=False,
+            has_person_id_joined=False,
         )
         event_query += prop_query
         params = {**params, **prop_params}

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -194,7 +194,8 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
                 "date_to": "2021-05-07 00:00:00",
                 "events": [{"id": "viewed", "order": 0},],
                 "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
-            }
+            },
+            team=self.team,
         )
 
         self._run_query(filter)
@@ -213,7 +214,9 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         self.team.test_account_filters = [{"key": "id", "value": cohort.pk, "type": "cohort"}]
         self.team.save()
 
-        filter = Filter(data={"events": [{"id": "event_name", "order": 0},], "filter_test_accounts": True})
+        filter = Filter(
+            data={"events": [{"id": "event_name", "order": 0},], "filter_test_accounts": True}, team=self.team
+        )
 
         self._run_query(filter)
 

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -628,7 +628,7 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
         result = ClickhouseTrends().run(filter, self.team,)
         self.assertEqual(result[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 0.0])
 
-    @test_with_materialized_columns(person_properties=["name"], verify_no_jsonextract=False)
+    @test_with_materialized_columns(event_properties=["key"], person_properties=["name"])
     def test_filter_test_accounts(self):
         p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
         _create_event(

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -62,6 +62,6 @@ WHERE team_id = %(team_id)s {date_query} AND {entity_query}
 GROUP BY person_id HAVING count(*) {count_operator} %(count)s
 """
 
-GET_PERSON_ID_BY_COHORT_ID = """
-SELECT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id_{index})s GROUP BY person_id, cohort_id, team_id HAVING sum(sign) > 0
+GET_PERSON_ID_BY_PRECALCULATED_COHORT_ID = """
+SELECT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %({prepend}_cohort_id_{index})s GROUP BY person_id, cohort_id, team_id HAVING sum(sign) > 0
 """

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -280,6 +280,14 @@ WHERE person_id IN
     filters="{filters}", GET_TEAM_PERSON_DISTINCT_IDS=GET_TEAM_PERSON_DISTINCT_IDS,
 )
 
+GET_DISTINCT_IDS_BY_PERSON_ID_FILTER = """
+SELECT distinct_id
+FROM ({GET_TEAM_PERSON_DISTINCT_IDS})
+WHERE {filters}
+""".format(
+    filters="{filters}", GET_TEAM_PERSON_DISTINCT_IDS=GET_TEAM_PERSON_DISTINCT_IDS,
+)
+
 GET_PERSON_PROPERTIES_COUNT = """
 SELECT tupleElement(keysAndValues, 1) as key, count(*) as count
 FROM person

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -37,7 +37,7 @@ class Group(object):
         event_id: Optional[str] = None,
         days: Optional[int] = None,
         count: Optional[int] = None,
-        count_operator: Optional[str] = None,
+        count_operator: Optional[Literal["eq", "lte", "gte"]] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         label: Optional[str] = None,

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, List, TypeVar
 from posthog.utils import is_clickhouse_enabled
 
 if TYPE_CHECKING:  # Avoid circular import
-    from posthog.models import Cohort, Property, Team
+    from posthog.models import Property, Team
 
 T = TypeVar("T")
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -15,7 +15,7 @@ class SimplifyFilterMixin:
 
         Actions taken:
         - if filter.filter_test_accounts, adds property filters to `filter.properties`
-        - expands cohort filters
+        - for cohort properties, replaces them with more concrete lookups or with cohort conditions
         """
 
         result: Any = self

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -28,16 +28,18 @@ class SimplifyFilterMixin:
                 }
             )
 
-        simplified_properties = [self.simplified_property(prop) for prop in result.properties]
+        simplified_properties = []
+        for prop in result.properties:
+            simplified_properties.extend(self.simplify_property(team, prop))
 
         return result.with_data({"properties": simplified_properties, "is_simplified": True,})
 
     def simplify_property(
         self, team: "Team", property: "Property", is_clickhouse_enabled=is_clickhouse_enabled()
-    ) -> List[Property]:
+    ) -> List["Property"]:
         if property.type == "cohort" and is_clickhouse_enabled:
             from ee.clickhouse.models.cohort import simplified_cohort_filter_properties
-            from posthog.models.filters import Filter
+            from posthog.models import Cohort
 
             # :TODO: Handle cohort not existing
             cohort = Cohort.objects.get(pk=property.value, team_id=team.pk)

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -19,14 +19,11 @@ class SimplifyFilterMixin:
         - for cohort properties, replaces them with more concrete lookups or with cohort conditions
         """
 
-        result: Any = self
+        # :TRICKY: Make a copy to avoid caching issues
+        result: Any = self.with_data({"is_simplified": True})
         if getattr(self, "filter_test_accounts", False):
             result = result.with_data(
-                {
-                    "properties": result.properties + team.test_account_filters,
-                    "filter_test_accounts": False,
-                    "is_simplified": True,
-                }
+                {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False,}
             )
 
         updated_entities = {}
@@ -38,7 +35,6 @@ class SimplifyFilterMixin:
             {
                 **updated_entities,
                 "properties": self._simplify_properties(team, result.properties, **kwargs),  # type: ignore
-                "is_simplified": True,
             }
         )
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -20,7 +20,7 @@ class SimplifyFilterMixin:
         """
 
         # :TRICKY: Make a copy to avoid caching issues
-        result: Any = self.with_data({"is_simplified": True})
+        result: Any = self.with_data({"is_simplified": True})  # type: ignore
         if getattr(self, "filter_test_accounts", False):
             result = result.with_data(
                 {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False,}

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, List, TypeVar
+
+from posthog.utils import is_clickhouse_enabled
 
 if TYPE_CHECKING:  # Avoid circular import
-    from posthog.models.team import Team
+    from posthog.models import Cohort, Property, Team
 
 T = TypeVar("T")
 
@@ -13,15 +15,36 @@ class SimplifyFilterMixin:
 
         Actions taken:
         - if filter.filter_test_accounts, adds property filters to `filter.properties`
+        - expands cohort filters
         """
 
-        result = self.with_data({"is_simplified": True})  # type: ignore
+        result: Any = self
         if getattr(self, "filter_test_accounts", False):
             result = result.with_data(
-                {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False}
+                {
+                    "properties": result.properties + team.test_account_filters,
+                    "filter_test_accounts": False,
+                    "is_simplified": True,
+                }
             )
 
-        return result
+        simplified_properties = [self.simplified_property(prop) for prop in result.properties]
+
+        return result.with_data({"properties": simplified_properties, "is_simplified": True,})
+
+    def simplify_property(
+        self, team: "Team", property: "Property", is_clickhouse_enabled=is_clickhouse_enabled()
+    ) -> List[Property]:
+        if property.type == "cohort" and is_clickhouse_enabled:
+            from ee.clickhouse.models.cohort import simplified_cohort_filter_properties
+            from posthog.models.filters import Filter
+
+            # :TODO: Handle cohort not existing
+            cohort = Cohort.objects.get(pk=property.value, team_id=team.pk)
+
+            return simplified_cohort_filter_properties(cohort, team)
+
+        return [property]
 
     @property
     def is_simplified(self) -> bool:

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -3,12 +3,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, TypeVar
 from posthog.utils import is_clickhouse_enabled
 
 if TYPE_CHECKING:  # Avoid circular import
-    from posthog.models import Entity, Property, Team
+    from posthog.models import Property, Team
 
 T = TypeVar("T")
 
 
 class SimplifyFilterMixin:
+    # :KLUDGE: A lot of this logic ignores typing since generics w/ mixins are hard to get working properly
     def simplify(self: T, team: "Team", **kwargs) -> T:
         """
         Expands this filter to not refer to external resources of the team.
@@ -31,12 +32,12 @@ class SimplifyFilterMixin:
         updated_entities = {}
         if hasattr(result, "entities_to_dict"):
             for entity_type, entities in result.entities_to_dict().items():
-                updated_entities[entity_type] = [self._simplify_entity(team, entity, **kwargs) for entity in entities]
+                updated_entities[entity_type] = [self._simplify_entity(team, entity, **kwargs) for entity in entities]  # type: ignore
 
         return result.with_data(
             {
                 **updated_entities,
-                "properties": self._simplify_properties(team, result.properties, **kwargs),
+                "properties": self._simplify_properties(team, result.properties, **kwargs),  # type: ignore
                 "is_simplified": True,
             }
         )

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -38,7 +38,7 @@ class TestFilter(BaseTest):
             list(filter.to_dict().keys()), ["events", "display", "compare", "insight", "date_from", "interval"],
         )
 
-    def test_simplify(self):
+    def test_simplify_test_accounts(self):
         self.team.test_account_filters = [
             {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"}
         ]

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -22,7 +22,6 @@ class Property:
     value: ValueT
     type: PropertyType
 
-    # :TODO: Multiple dispatch creating!
     def __init__(
         self,
         key: str,
@@ -90,61 +89,6 @@ class Property:
         else:
             assert not isinstance(value, list)
             return Q(**{f"properties__{self.key}__{self.operator}": value})
-
-
-class HasDoneProperty(Property):
-    """
-    Specialized filter property for "user has done X in time range [operator] N times"
-    """
-
-    type: Literal["hasdone"]
-
-    event_id: Optional[str]
-    action_id: Optional[int]
-    days: Optional[str]
-    start_time: Optional[str]
-    end_time: Optional[str]
-    count: Optional[int]
-    count_operator: Optional[Literal["eq", "lte", "gte"]]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.event_id = kwargs.get("event_id")
-        self.action_id = kwargs.get("action_id")
-        self.days = kwargs.get("days")
-        self.start_time = kwargs.get("start_time")
-        self.end_time = kwargs.get("end_time")
-        self.count = kwargs.get("count")
-        self.count_operator = kwargs.get("count_operator")
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            **super().to_dict(),
-            "event_id": self.event_id,
-            "action_id": self.action_id,
-            "days": self.days,
-            "start_time": self.start_time,
-            "end_time": self.end_time,
-            "count": self.count,
-            "count_operator": self.count_operator,
-        }
-
-
-class OrProperty(Property):
-    """
-    Specialized filter property for either A OR B
-    """
-
-    type: Literal["or"]
-    groups: List[List[Property]]
-
-    def __init__(self, type: Literal["or"], groups: List[List[Property]]):
-        self.type = type
-        self.groups = groups
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {"type": self.type, "groups": self.groups}
 
 
 def lookup_q(key: str, value: Any) -> Q:

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -105,7 +105,7 @@ class HasDoneProperty(Property):
     start_time: Optional[str]
     end_time: Optional[str]
     count: Optional[int]
-    count_operator: Optional[OperatorType]
+    count_operator: Optional[Literal["eq", "lte", "gte"]]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -36,7 +36,9 @@ class Property:
         self.type = type if type else "event"
 
     def __repr__(self):
-        return f"Property({self.to_dict()})"
+        return "Property({}: {}{}={})".format(
+            self.type, self.key, "__{}".format(self.operator) if self.operator else "", self.value,
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -6,7 +6,7 @@ from django.db.models import Exists, OuterRef, Q
 from posthog.utils import is_valid_regex
 
 ValueT = Union[str, int, List[str]]
-PropertyType = Literal["event", "person", "cohort", "element", "hasdone"]
+PropertyType = Literal["event", "person", "cohort", "element", "hasdone", "static-cohort", "precalculated-cohort"]
 PropertyName = str
 TableWithProperties = Literal["events", "person"]
 OperatorType = Literal[

--- a/posthog/queries/sessions/test/test_sessions.py
+++ b/posthog/queries/sessions/test/test_sessions.py
@@ -367,6 +367,7 @@ def sessions_test_factory(sessions, event_factory, person_factory):
             cohort = Cohort.objects.create(
                 team=self.team, groups=[{"properties": [{"key": "name", "value": "Jane", "type": "person"}]}],
             )
+            cohort.calculate_people()
             cohort.calculate_people_ch()
 
             with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):

--- a/posthog/queries/sessions/test/test_sessions.py
+++ b/posthog/queries/sessions/test/test_sessions.py
@@ -3,7 +3,7 @@ import unittest
 from freezegun import freeze_time
 
 from posthog.constants import FILTER_TEST_ACCOUNTS
-from posthog.models import Event
+from posthog.models import Cohort, Event
 from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.models.person import Person
 from posthog.queries.sessions.sessions import Sessions
@@ -349,6 +349,41 @@ def sessions_test_factory(sessions, event_factory, person_factory):
                     self.team,
                 )
                 self.assertEqual(response[0]["data"][6], 26)
+
+        def test_filter_sessions_precalculated_cohort(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["2"], properties={"name": "Jane"})
+            person_factory(
+                team_id=self.team.pk, distinct_ids=["4"],
+            )
+
+            with freeze_time("2012-01-11T01:25:30.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="2")
+                event_factory(team=self.team, event="1st action", distinct_id="4")
+            with freeze_time("2012-01-11T01:31:30.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="2")
+            with freeze_time("2012-01-11T01:51:30.000Z"):
+                event_factory(team=self.team, event="1st action", distinct_id="4")
+
+            cohort = Cohort.objects.create(
+                team=self.team, groups=[{"properties": [{"key": "name", "value": "Jane", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch()
+
+            with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
+                with freeze_time("2012-01-12T03:40:30.000Z"):
+                    response = sessions().run(
+                        SessionsFilter(
+                            data={
+                                "interval": "day",
+                                "session": "avg",
+                                "events": [{"id": "1st action"},],
+                                "properties": [{"type": "cohort", "key": "id", "value": cohort.pk}],
+                            },
+                            team=self.team,
+                        ),
+                        self.team,
+                    )
+                    self.assertEqual(response[0]["data"][6], 6)
 
     return TestSessions
 

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1301,7 +1301,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["labels"][5], "2-Jan-2020")
             self.assertEqual(response[0]["data"][5], 0)
 
-        @test_with_materialized_columns(person_properties=["name"], verify_no_jsonextract=False)
+        @test_with_materialized_columns(person_properties=["name"])
         def test_filter_events_by_cohort(self):
             person1 = person_factory(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
             person2 = person_factory(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
@@ -2158,7 +2158,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             result = trends().run(filter_3, self.team,)
             self.assertEqual(result[0]["count"], 1)
 
-        @test_with_materialized_columns(person_properties=["name"], verify_no_jsonextract=False)
+        @test_with_materialized_columns(person_properties=["name"])
         def test_filter_test_accounts_cohorts(self):
             person_factory(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
             person_factory(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1327,7 +1327,8 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                     data={
                         "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
                         "events": [{"id": "event_name"}],
-                    }
+                    },
+                    team=self.team,
                 ),
                 self.team,
             )

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -2183,6 +2183,67 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(response[0]["count"], 2)
             self.assertEqual(response[0]["data"][-1], 2)
 
+        def test_filter_by_precalculated_cohort(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
+
+            event_factory(event="event_name", team=self.team, distinct_id="person_1")
+            event_factory(event="event_name", team=self.team, distinct_id="person_2")
+            event_factory(event="event_name", team=self.team, distinct_id="person_2")
+
+            cohort = cohort_factory(
+                team=self.team,
+                name="cohort1",
+                groups=[{"properties": [{"key": "name", "value": "Jane", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch()
+            with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
+                response = trends().run(
+                    Filter(
+                        data={
+                            "events": [{"id": "event_name"}],
+                            "properties": [{"type": "cohort", "key": "id", "value": cohort.pk}],
+                        },
+                        team=self.team,
+                    ),
+                    self.team,
+                )
+
+            self.assertEqual(response[0]["count"], 2)
+            self.assertEqual(response[0]["data"][-1], 2)
+
+        def test_breakdown_filter_by_precalculated_cohort(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
+            person_factory(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
+
+            event_factory(event="event_name", team=self.team, distinct_id="person_1")
+            event_factory(event="event_name", team=self.team, distinct_id="person_2")
+            event_factory(event="event_name", team=self.team, distinct_id="person_2")
+
+            cohort = cohort_factory(
+                team=self.team,
+                name="cohort1",
+                groups=[{"properties": [{"key": "name", "value": "Jane", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch()
+
+            with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
+                response = trends().run(
+                    Filter(
+                        data={
+                            "events": [{"id": "event_name"}],
+                            "properties": [{"type": "cohort", "key": "id", "value": cohort.pk}],
+                            "breakdown": "name",
+                            "breakdown_type": "person",
+                        },
+                        team=self.team,
+                    ),
+                    self.team,
+                )
+
+            self.assertEqual(response[0]["count"], 2)
+            self.assertEqual(response[0]["data"][-1], 2)
+
         def test_bar_chart_by_value(self):
             self._create_events()
 


### PR DESCRIPTION
## Changes

Follow-up to https://github.com/PostHog/posthog/pull/6221

This PR starts "simplifying" cohort filters. The idea is to have the business logic bits happen before we do query building, which allows to do better optimizations, e.g. avoid unneeded subqueries.

The cases that got simplified are:
- Cohort has person property filters - we add these filters to the filter object
- Cohort would query precalculated/static cohort tables - we add that query.
  -  There was one sessions query which did not join distinct_ids -> needed to take special care here.

Not everything is simplified yet. There's 3 cases which I'd love to tackle in a follow-up:
- When the cohort does not exist anymore
- Cohort has action filter (e.g. has done X in timerange)
- Cohort has multiple filters combined with an OR

Once all of these are done we can "delete" a lot of special-case query building logic :)

One benchmark got slower. This is because a large column got communicated between threads which was previously used only in a subquery. This will be improved again by #5850 which this is a prerequisite for.

## How did you test this code?

See test coverage. I verified all of insights + sessions work with the new cohort cases.