### PR TITLE
Add library and type version to Sentry events from api/capture

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,5 +1,7 @@
 import posthog from 'posthog-js'
+import { version } from 'posthog-js/package.json'
 import * as Sentry from '@sentry/browser'
+import { Event } from '@sentry/browser'
 
 const configWithSentry = (config: posthog.Config): posthog.Config => {
     if ((window as any).SENTRY_DSN) {
@@ -48,6 +50,12 @@ export function loadPostHogJS(): void {
             ...(window.location.host.indexOf('app.posthog.com') > -1 && {
                 integrations: [new posthog.SentryIntegration(posthog, 'posthog', 1899813)],
             }),
+            beforeSend(event: Event): PromiseLike<Event | null> | Event | null {
+                event.tags = event.tags || {}
+                event.tags['posthog-js.version'] = version
+                console.log({ sentryEvent: event, version })
+                return event
+            },
         })
     }
 }

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,7 +1,5 @@
 import posthog from 'posthog-js'
-import { version } from 'posthog-js/package.json'
 import * as Sentry from '@sentry/browser'
-import { Event } from '@sentry/browser'
 
 const configWithSentry = (config: posthog.Config): posthog.Config => {
     if ((window as any).SENTRY_DSN) {
@@ -50,12 +48,6 @@ export function loadPostHogJS(): void {
             ...(window.location.host.indexOf('app.posthog.com') > -1 && {
                 integrations: [new posthog.SentryIntegration(posthog, 'posthog', 1899813)],
             }),
-            beforeSend(event: Event): PromiseLike<Event | null> | Event | null {
-                event.tags = event.tags || {}
-                event.tags['posthog-js.version'] = version
-                console.log({ sentryEvent: event, version })
-                return event
-            },
         })
     }
 }

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -3,7 +3,7 @@ import gzip
 import json
 from datetime import timedelta
 from typing import Any, Dict, List, Union
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 from urllib.parse import quote
 
 import lzstring
@@ -85,6 +85,64 @@ class TestCapture(BaseTest):
                 "team_id": self.team.pk,
             },
         )
+
+    @patch("posthog.api.capture.push_scope")
+    def test_capture_event_adds_library_to_sentry(self, patch_push_scope):
+        mock_set_tag = self.mock_sentry_context(patch_push_scope)
+
+        data = {
+            "event": "$autocapture",
+            "properties": {
+                "$lib": "web",
+                "$lib_version": "1.14.1",
+                "distinct_id": 2,
+                "token": self.team.api_token,
+                "$elements": [
+                    {"tag_name": "a", "nth_child": 1, "nth_of_type": 2, "attr__class": "btn btn-sm",},
+                    {"tag_name": "div", "nth_child": 1, "nth_of_type": 2, "$el_text": "💻",},
+                ],
+            },
+        }
+        with freeze_time(timezone.now()):
+            self.client.get(
+                "/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",
+            )
+
+        mock_set_tag.assert_has_calls([call("library", "web"), call("library.version", "1.14.1")])
+
+    @patch("posthog.api.capture.push_scope")
+    def test_capture_event_adds_unknown_to_sentry_when_no_properties_sent(self, patch_push_scope):
+        mock_set_tag = self.mock_sentry_context(patch_push_scope)
+
+        data = {
+            "event": "$autocapture",
+            "properties": {
+                "distinct_id": 2,
+                "token": self.team.api_token,
+                "$elements": [
+                    {"tag_name": "a", "nth_child": 1, "nth_of_type": 2, "attr__class": "btn btn-sm",},
+                    {"tag_name": "div", "nth_child": 1, "nth_of_type": 2, "$el_text": "💻",},
+                ],
+            },
+        }
+        with freeze_time(timezone.now()):
+            self.client.get(
+                "/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",
+            )
+
+        mock_set_tag.assert_has_calls([call("library", "unknown"), call("library.version", "unknown")])
+
+    @staticmethod
+    def mock_sentry_context(push_scope):
+        mock_scope = Mock()
+        mock_set_tag = Mock()
+        mock_scope.set_context = Mock()
+        mock_scope.set_tag = mock_set_tag
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=mock_scope)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        push_scope.return_value = mock_context_manager
+        return mock_set_tag
 
     @patch("posthog.models.team.TEAM_CACHE", {})
     @patch("posthog.api.capture.celery_app.send_task")

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -104,9 +104,10 @@ class TestCapture(BaseTest):
             },
         }
         with freeze_time(timezone.now()):
-            self.client.get(
-                "/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",
-            )
+            with self.assertNumQueries(2):
+                self.client.get(
+                    "/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",
+                )
 
         mock_set_tag.assert_has_calls([call("library", "web"), call("library.version", "1.14.1")])
 
@@ -126,9 +127,10 @@ class TestCapture(BaseTest):
             },
         }
         with freeze_time(timezone.now()):
-            self.client.get(
-                "/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",
-            )
+            with self.assertNumQueries(1):
+                self.client.get(
+                    "/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",
+                )
 
         mock_set_tag.assert_has_calls([call("library", "unknown"), call("library.version", "unknown")])
 


### PR DESCRIPTION
## Changes

~~Adds the version of posthog-js to sentry errors from app.posthog.com~~

For every event sent to `api/capture` attempts to read the Library and Library Version properties and set them as tags in Sentry. This will allow us to track errors in Sentry broken down by those tags

## How did you test this code?

added unit tests for known and unknown versions when tagging
by running it locally
