### PR TITLE
fix(correlation): add lower bounds for selected events

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -152,6 +152,7 @@ class FunnelCorrelation:
             WITH 
                 funnel_people AS ({funnel_persons_query}),
                 toDateTime(%(date_to)s) AS date_to,
+                toDateTime(%(date_from)s) AS date_from,
                 %(target_step)s AS target_step
             SELECT 
                 event.event AS name, 
@@ -173,9 +174,11 @@ class FunnelCorrelation:
 
             -- Make sure we're only looking at events before the final step, or
             -- failing that, date_to
-            -- TODO: add a lower bounds for events
-            WHERE event.timestamp < COALESCE(person.final_timestamp, date_to)
-            AND event.timestamp >= person.first_timestamp
+            WHERE 
+                event.timestamp >= date_from
+                AND event.timestamp > person.first_timestamp
+                AND event.timestamp < date_to
+                AND event.timestamp < COALESCE(person.timestamp, date_to)
             GROUP BY name
             WITH TOTALS
         """

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -208,6 +208,8 @@ class FunnelCorrelation:
                 event.timestamp >= date_from
                 AND event.timestamp < date_to
 
+                AND event.team_id = {self._team.pk}
+
                 -- Add in per person filtering on event time range. We just want
                 -- to include events that happened within the bounds of the 
                 -- persons time in the funnel.

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -176,7 +176,7 @@ class FunnelCorrelation:
                 event.event AS name, 
 
                 -- If we have a `person.steps = target_step`, we know the person 
-                -- reached the end of the funnel (I think)
+                -- reached the end of the funnel
                 countDistinctIf(
                     person.person_id, 
                     person.steps = target_step

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -242,7 +242,7 @@ class FunnelCorrelation:
         """
         params = {
             **funnel_persons_params,
-            "funnel_step_names": [entity.id for entity in self._filter.entities],
+            "funnel_step_names": [entity.id for entity in self._filter.events],
             "target_step": len(self._filter.entities),
         }
         results_with_total = sync_execute(query, params)

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -165,7 +165,7 @@ class FunnelCorrelation:
             FROM events AS event
             
             JOIN person_distinct_id AS pdi
-                ON pdi.distinct_id = events.distinct_id
+                ON pdi.distinct_id = events.distinct_id AND pdi.team_id = event.team_id
 
             -- Right join, so we can get the total success/failure numbers as well
             RIGHT JOIN funnel_people AS person

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -190,7 +190,7 @@ class FunnelCorrelation:
             FROM events AS event
             
             JOIN ({non_deleted_distinct_ids}) AS pdi
-                ON pdi.distinct_id = events.distinct_id AND pdi.team_id = event.team_id
+                ON pdi.distinct_id = events.distinct_id
 
             -- NOTE: I would love to right join here, so we count get total
             -- success/failure numbers in one pass, but this causes out of memory

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -18,8 +18,7 @@ from posthog.test.base import BaseTest
 @pytest.mark.clickhouse_only
 class FunnelCorrelationTest(BaseTest):
     """
-    TODO: fill in details of request structure. At the moment it's not needed as
-    we just return mock data
+    Tests for /api/projects/:project_id/funnel/correlation/
     """
 
     CLASS_DATA_LEVEL_SETUP = False
@@ -76,10 +75,6 @@ class FunnelCorrelationTest(BaseTest):
 
             create_events(events_by_person=events, team=self.team)
 
-            # We need to make sure we clear the cache other tests that have run
-            # done interfere with this test
-            cache.clear()
-
             odds = get_funnel_correlation_ok(
                 client=self.client,
                 team_id=self.team.pk,
@@ -133,10 +128,6 @@ class FunnelCorrelationTest(BaseTest):
             }
 
             create_events(events_by_person=events, team=self.team)
-
-            # We need to make sure we clear the cache other tests that have run
-            # done interfere with this test
-            cache.clear()
 
             odds_before = get_funnel_correlation_ok(
                 client=self.client,
@@ -245,6 +236,11 @@ class FunnelCorrelationTest(BaseTest):
             "last_refresh": "2020-01-01T00:00:00Z",
             "result": {"events": []},
         }
+
+
+@pytest.fixture(autouse=True)
+def clear_django_cache():
+    cache.clear()
 
 
 def create_team(organization):


### PR DESCRIPTION
Previously we would consider all events for correlation calculation. Now
we use the funnel `date_from` as the lower bounds.