### PR TITLE
tags request origins in Sentry when loading request data from the body

### DIFF
--- a/posthog/api/test/mock_sentry.py
+++ b/posthog/api/test/mock_sentry.py
@@ -1,0 +1,13 @@
+from unittest.mock import Mock
+
+
+def mock_sentry_context_for_tagging(patched_push_scope):
+    mock_scope = Mock()
+    mock_set_tag = Mock()
+    mock_scope.set_context = Mock()
+    mock_scope.set_tag = mock_set_tag
+    mock_context_manager = Mock()
+    mock_context_manager.__enter__ = Mock(return_value=mock_scope)
+    mock_context_manager.__exit__ = Mock(return_value=None)
+    patched_push_scope.return_value = mock_context_manager
+    return mock_set_tag

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 
+from posthog.api.test.mock_sentry import mock_sentry_context_for_tagging
 from posthog.constants import ENVIRONMENT_TEST
 from posthog.models import PersonalAPIKey
 from posthog.models.feature_flag import FeatureFlag
@@ -89,7 +90,7 @@ class TestCapture(BaseTest):
     @patch("posthog.api.capture.push_scope")
     @patch("posthog.api.capture.celery_app.send_task", MagicMock())
     def test_capture_event_adds_library_to_sentry(self, patch_push_scope):
-        mock_set_tag = self.mock_sentry_context(patch_push_scope)
+        mock_set_tag = mock_sentry_context_for_tagging(patch_push_scope)
 
         data = {
             "event": "$autocapture",
@@ -114,7 +115,7 @@ class TestCapture(BaseTest):
     @patch("posthog.api.capture.push_scope")
     @patch("posthog.api.capture.celery_app.send_task", MagicMock())
     def test_capture_event_adds_unknown_to_sentry_when_no_properties_sent(self, patch_push_scope):
-        mock_set_tag = self.mock_sentry_context(patch_push_scope)
+        mock_set_tag = mock_sentry_context_for_tagging(patch_push_scope)
 
         data = {
             "event": "$autocapture",
@@ -133,18 +134,6 @@ class TestCapture(BaseTest):
             )
 
         mock_set_tag.assert_has_calls([call("library", "unknown"), call("library.version", "unknown")])
-
-    @staticmethod
-    def mock_sentry_context(push_scope):
-        mock_scope = Mock()
-        mock_set_tag = Mock()
-        mock_scope.set_context = Mock()
-        mock_scope.set_tag = mock_set_tag
-        mock_context_manager = Mock()
-        mock_context_manager.__enter__ = Mock(return_value=mock_scope)
-        mock_context_manager.__exit__ = Mock(return_value=None)
-        push_scope.return_value = mock_context_manager
-        return mock_set_tag
 
     @patch("posthog.models.team.TEAM_CACHE", {})
     @patch("posthog.api.capture.celery_app.send_task")

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -100,7 +100,7 @@ class TestLoadDataFromRequest(TestCase):
             load_data_from_request(post_request)
 
         push_scope.assert_called_once()
-        mock_set_tag.assert_called_once_with(origin)
+        mock_set_tag.assert_called_once_with("origin", origin)
 
     def test_fails_to_JSON_parse_the_literal_string_undefined_when_not_compressed(self):
         """

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -392,6 +392,7 @@ def load_data_from_request(request):
     # add the data in sentry's scope in case there's an exception
     with push_scope() as scope:
         scope.set_context("data", data)
+        scope.set_tag("origin", request.META.get("REMOTE_HOST"))
 
     compression = (
         request.GET.get("compression") or request.POST.get("compression") or request.headers.get("content-encoding", "")


### PR DESCRIPTION
## Changes

adds the request origin to sentry messages when loading data from the body

allows categorisation of errors in sentry by origin

## How did you test this code?

added unit test for the behaviour
