### PR TITLE
Use FunnelStep properly in Correlation Queries

### DIFF
--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -148,7 +148,12 @@ class ClickhouseFunnelBase(ABC, Funnel):
             return ""
 
     def _get_timestamp_selects(self) -> Tuple[str, str]:
+        """
+        Returns timestamp selectors for the target step and optionally the preceding step.
+        In either case, always returns the timestamp for the last step as well.
+        """
         target_step = self._filter.funnel_step
+        final_step = len(self._filter.entities) - 1
 
         if not target_step:
             return "", ""
@@ -169,11 +174,14 @@ class ClickhouseFunnelBase(ABC, Funnel):
                 raise ValueError("Cannot request preceding step timestamp if target funnel step is the first step")
 
             return (
-                f", latest_{target_step}, latest_{target_step - 1}",
-                f", argMax(latest_{target_step}, steps) as max_timestamp, argMax(latest_{target_step - 1}, steps) as min_timestamp",
+                f", latest_{target_step}, latest_{target_step - 1}, latest_{final_step}",
+                f", argMax(latest_{target_step}, steps) as max_timestamp, argMax(latest_{target_step - 1}, steps) as min_timestamp, argMax(latest_{final_step}, steps) as final_timestamp",
             )
         elif self._include_timestamp:
-            return f", latest_{target_step}", f", argMax(latest_{target_step}, steps) as timestamp"
+            return (
+                f", latest_{target_step}, latest_{final_step}",
+                f", argMax(latest_{target_step}, steps) as timestamp, argMax(latest_{final_step}, steps) as final_timestamp",
+            )
         else:
             return "", ""
 

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -150,10 +150,11 @@ class ClickhouseFunnelBase(ABC, Funnel):
     def _get_timestamp_selects(self) -> Tuple[str, str]:
         """
         Returns timestamp selectors for the target step and optionally the preceding step.
-        In either case, always returns the timestamp for the last step as well.
+        In the former case, always returns the timestamp for the first and last step as well.
         """
         target_step = self._filter.funnel_step
         final_step = len(self._filter.entities) - 1
+        first_step = 0
 
         if not target_step:
             return "", ""
@@ -174,13 +175,13 @@ class ClickhouseFunnelBase(ABC, Funnel):
                 raise ValueError("Cannot request preceding step timestamp if target funnel step is the first step")
 
             return (
-                f", latest_{target_step}, latest_{target_step - 1}, latest_{final_step}",
-                f", argMax(latest_{target_step}, steps) as max_timestamp, argMax(latest_{target_step - 1}, steps) as min_timestamp, argMax(latest_{final_step}, steps) as final_timestamp",
+                f", latest_{target_step}, latest_{target_step - 1}",
+                f", argMax(latest_{target_step}, steps) as max_timestamp, argMax(latest_{target_step - 1}, steps) as min_timestamp",
             )
         elif self._include_timestamp:
             return (
-                f", latest_{target_step}, latest_{final_step}",
-                f", argMax(latest_{target_step}, steps) as timestamp, argMax(latest_{final_step}, steps) as final_timestamp",
+                f", latest_{target_step}, latest_{final_step}, latest_{first_step}",
+                f", argMax(latest_{target_step}, steps) as timestamp, argMax(latest_{final_step}, steps) as final_timestamp, argMax(latest_{first_step}, steps) as first_timestamp",
             )
         else:
             return "", ""

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -175,7 +175,7 @@ class FunnelCorrelation:
             -- failing that, date_to
             -- TODO: add a lower bounds for events
             WHERE event.timestamp < COALESCE(person.final_timestamp, date_to)
-            AND event.timestamp >= person.timestamp
+            AND event.timestamp >= person.first_timestamp
             GROUP BY name
             WITH TOTALS
         """
@@ -219,7 +219,7 @@ class FunnelCorrelation:
         )
 
         return (
-            funnel_persons_generator.get_query(extra_fields=["steps", "final_timestamp"]),
+            funnel_persons_generator.get_query(extra_fields=["steps", "final_timestamp", "first_timestamp"]),
             funnel_persons_generator.params,
         )
 

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Literal, Tuple, TypedDict
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.queries.funnels.funnel_persons import ClickhouseFunnelPersons
+from posthog.constants import FunnelCorrelationType
 from posthog.models import Filter, Team
 from posthog.models.filters import Filter
 
@@ -55,9 +56,10 @@ class FunnelCorrelation:
         self._team = team
 
         if self._filter.funnel_step is None:
-            self._filter = self._filter.with_data({"funnel_step": len(self._filter.entities)})
+            self._filter = self._filter.with_data({"funnel_step": 1})
+            # Funnel Step by default set to 1, to give us all people who entered the funnel
 
-    def run(self, *args, **kwargs) -> FunnelCorrelationResponse:
+    def run(self) -> FunnelCorrelationResponse:
         """
         Run the diagnose query.
 
@@ -159,7 +161,7 @@ class FunnelCorrelation:
                 countIf(person.steps = target_step) AS success_count,
 
                 -- And the converse being for failures
-                countIf(person.timestamp <> target_step) AS failure_count
+                countIf(person.steps <> target_step) AS failure_count
             FROM events AS event
             
             JOIN person_distinct_id AS pdi
@@ -172,14 +174,15 @@ class FunnelCorrelation:
             -- Make sure we're only looking at events before the final step, or
             -- failing that, date_to
             -- TODO: add a lower bounds for events
-            WHERE event.timestamp < COALESCE(person.timestamp, date_to)
+            WHERE event.timestamp < COALESCE(person.final_timestamp, date_to)
+            AND event.timestamp >= person.timestamp
             GROUP BY name
             WITH TOTALS
         """
         params = {
             **funnel_persons_params,
             "date_to": self._filter.date_to,
-            "target_step": self._filter.funnel_step,
+            "target_step": len(self._filter.entities),
         }
         results_then_total = sync_execute(query, params)
 
@@ -216,7 +219,7 @@ class FunnelCorrelation:
         )
 
         return (
-            funnel_persons_generator.get_query(extra_fields=["steps"]),
+            funnel_persons_generator.get_query(extra_fields=["steps", "final_timestamp"]),
             funnel_persons_generator.params,
         )
 

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -21,6 +21,8 @@ class FunnelCorrelationTest(BaseTest):
     we just return mock data
     """
 
+    maxDiff = None
+
     def test_requires_authn(self):
         response = get_funnel_correlation(
             client=self.client,
@@ -81,7 +83,6 @@ class FunnelCorrelationTest(BaseTest):
                 team_id=self.team.pk,
                 request=FunnelCorrelationRequest(
                     events=json.dumps([EventPattern(id="signup"), EventPattern(id="view insights")]),
-                    funnel_step=2,
                     date_to="2020-04-04",
                 ),
             )
@@ -120,8 +121,8 @@ class EventPattern(TypedDict):
 class FunnelCorrelationRequest:
     # Needs to be json encoded list of `EventPattern`s
     events: str
-    funnel_step: int
     date_to: str
+    funnel_step: Optional[int] = None
     date_from: Optional[str] = None
 
 


### PR DESCRIPTION
## Changes

Return both beginning and ending timestamps in the Funnel Persons query, to use for Correlation lower and upper bound

## How did you test this code?

Unit tests
