### PR TITLE
Fix broken count operator on cohort building

### DIFF
--- a/frontend/src/scenes/cohorts/CohortMatchingCriteriaSection/MatchCriteriaSelector.tsx
+++ b/frontend/src/scenes/cohorts/CohortMatchingCriteriaSection/MatchCriteriaSelector.tsx
@@ -27,6 +27,12 @@ export function MatchCriteriaSelector({
     const onMatchTypeChange = (input: MatchType): void => {
         onCriteriaChange({
             matchType: input,
+            ...(input === ENTITY_MATCH_TYPE
+                ? {
+                      count_operator: 'gte',
+                      days: '1',
+                  }
+                : {}),
         })
     }
 


### PR DESCRIPTION
## Changes

**Problem**: When building cohorts on entity matching types, the "at least" parameter doesn't work. It behaves like an "exactly" operator. See bug report here - https://posthogusers.slack.com/archives/G01JXEDAL22/p1633541518410600

<img width="808" alt="Screen Shot 2021-10-06 at 10 53 28 AM" src="https://user-images.githubusercontent.com/13460330/136257231-6648bd5f-f292-460f-93cc-37b138554bd6.png">


**Root cause**: When switching from "user property" match type to "performed action or event" match type, the interface auto sets the `count_operator` to "at least" and `days` to 1; however, none of these parameters are set in state, causing the frontend to send null values for these parameters to the backend. The backend defaults these to "exactly" and "1" respectively.

## How did you test this code?

*Please describe.*
