### PR TITLE
CI: Restore workflow due to faulty marking

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -116,7 +116,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog/ --cov --cov-report=xml:coverage-postgres.xml
+                  pytest -m "not ee" posthog/ --cov --cov-report=xml:coverage-postgres.xml
             - name: Run EE tests
               env:
                   PRIMARY_DB: 'clickhouse'
@@ -126,6 +126,7 @@ jobs:
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
                   pytest ee -m "not saml_only" --cov --cov-report=xml:coverage-clickhouse.xml
+                  pytest posthog -m "ee"
             - uses: codecov/codecov-action@v2
               with:
                   files: ./coverage-postgres.xml,./coverage-clickhouse.xml
@@ -173,7 +174,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog/
+                  pytest -m "not ee" posthog/
             - name: Run EE tests
               env:
                   PRIMARY_DB: 'clickhouse'
@@ -183,6 +184,7 @@ jobs:
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
                   pytest ee/
+                  pytest posthog -m "ee"
 
     cloud:
         name: Django tests – Cloud
@@ -266,7 +268,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog --reuse-db -m "not skip_on_multitenancy"
+                  pytest posthog --reuse-db -m "not (skip_on_multitenancy or ee)"
 
             - name: Run cloud tests (posthog-cloud)
               env:
@@ -281,6 +283,7 @@ jobs:
               run: |
                   cd deploy/
                   pytest ee -m "not skip_on_multitenancy"
+                  pytest posthog -m "ee"
 
     foss:
         name: Django tests – FOSS

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -116,7 +116,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -m "not ee" posthog/ --cov --cov-report=xml:coverage-postgres.xml
+                  pytest posthog/ --cov --cov-report=xml:coverage-postgres.xml
             - name: Run EE tests
               env:
                   PRIMARY_DB: 'clickhouse'
@@ -173,7 +173,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest -m "not ee" posthog/
+                  pytest posthog/
             - name: Run EE tests
               env:
                   PRIMARY_DB: 'clickhouse'
@@ -266,7 +266,7 @@ jobs:
                   touch frontend/dist/index.html
                   touch frontend/dist/layout.html
                   touch frontend/dist/shared_dashboard.html
-                  pytest posthog --reuse-db -m "not (skip_on_multitenancy or ee)"
+                  pytest posthog --reuse-db -m "not skip_on_multitenancy"
 
             - name: Run cloud tests (posthog-cloud)
               env:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -283,7 +283,7 @@ jobs:
               run: |
                   cd deploy/
                   pytest ee -m "not skip_on_multitenancy"
-                  pytest posthog -m "ee"
+                  pytest posthog -m "ee and not skip_on_multitenancy"
 
     foss:
         name: Django tests – FOSS

--- a/posthog/api/test/test_trends.py
+++ b/posthog/api/test/test_trends.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
 from datetime import datetime
-from typing import Any, Dict, List, TypedDict
+from typing import Any, Dict, List, TypedDict, Union
 
 import pytest
 from django.test import Client
@@ -118,7 +118,7 @@ class TrendsRequest:
     date_to: str
     interval: str
     insight: str
-    breakdown: List[int]
+    breakdown: Union[List[int], str]
     breakdown_type: str
     display: str
     events: List[Dict[str, Any]]

--- a/posthog/api/test/test_trends.py
+++ b/posthog/api/test/test_trends.py
@@ -41,13 +41,13 @@ def test_includes_only_intervals_within_range(client: Client):
     #  this is what was used demonstrated in
     #  https://github.com/PostHog/posthog/issues/2675 but it might not be the
     #  simplest way to reproduce
-    cohort = create_cohort_ok(client=client, name="test cohort", groups=[{"properties": {"cohort_identifier": 1}}])
 
     # "2021-09-19" is a sunday, i.e. beginning of week
     with freeze_time("2021-09-20T16:00:00"):
         #  First identify as a member of the cohort
         distinct_id = "abc"
         identify(distinct_id=distinct_id, team_id=team.id, properties={"cohort_identifier": 1})
+        cohort = create_cohort_ok(client=client, name="test cohort", groups=[{"properties": {"cohort_identifier": 1}}])
 
         for date in ["2021-09-04", "2021-09-05", "2021-09-12", "2021-09-19"]:
             capture_event(
@@ -67,7 +67,7 @@ def test_includes_only_intervals_within_range(client: Client):
                 date_to="2021-09-21",
                 interval="week",
                 insight="TRENDS",
-                breakdown=[cohort["id"]],
+                breakdown=json.dumps([cohort["id"]]),
                 breakdown_type="cohort",
                 display="ActionsLineGraph",
                 events=[


### PR DESCRIPTION
## Changes

*Please describe.*  
This [PR on posthog-cloud](https://github.com/PostHog/posthog-cloud/pull/141) has a faulty trends test which should be unrelated to any of the test changes made in the commits. What's happening is posthog-cloud never got an updated CI workflow from `pytest posthog --reuse-db -m "not skip_on_multitenancy"` to `pytest posthog --reuse-db -m "not (skip_on_multitenancy or ee)"` from this [patch](https://github.com/PostHog/posthog/pull/6053/files) so it successfully ran this test `test_includes_only_intervals_within_range` which fails when backed by postgres (the clickhouse backed test succeeds). 

The problem here is that the test above is double marked (both django_db and ee) however the "not ee" flag caused it to be omitted even though it had the django_db mark.


## Additional details

~~It may have been omitting some other tests, I haven't yet double checked the consequences of mixing tags.~~ We were deselecting a few dozen tests. None of them failed when opening this PR except the faulty one we had been looking at and it was failing due to the test mocking data out of order so there shouldn't be any major consequences we had been missing. 
