### PR TITLE
Don't fail test_migrations_are_null if new migrations on master

### DIFF
--- a/posthog/management/commands/test_migrations_are_null.py
+++ b/posthog/management/commands/test_migrations_are_null.py
@@ -2,7 +2,7 @@ import re
 import sys
 
 from django.core.management import call_command
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from posthog.models import Team
 
@@ -21,7 +21,7 @@ class Command(BaseCommand):
                         "red",
                     )
                     sys.exit(1)
-            except IndexError:
+            except (IndexError, CommandError):
                 pass
 
         for data in sys.stdin:


### PR DESCRIPTION
Currently, this task would throw when master has new migrations not on
branch, causing all backend builds to fail.

## How did you test this code?

*Please describe.*
