### PR TITLE
dev(docker): use arm builds of zookeeper and kafka, just for arm compose

### DIFF
--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -30,10 +30,10 @@ services:
             - ../docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ../docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
     zookeeper:
-        image: wurstmeister/zookeeper
+        image: zookeeper
         restart: always
     kafka:
-        image: wurstmeister/kafka
+        image: cfei/kafka
         depends_on:
             - zookeeper
         ports:


### PR DESCRIPTION
I've been getting lot's of errors with the qemu emulated x86 version.
I'm just changing the arm docker-compose as I don't want my issues with
local dev to affect others.