### PR TITLE
dev(direnv): add direnv and nix config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,21 @@
+# Default to running in django DEBUG mode. For tests this should be set to 0
+DEBUG=1
+
+# Make psql default to local settings
+PGHOST=localhost
+PGUSER=posthog
+PGPASSWORD=posthog
+PGPORT=5432
+PGDATABASE=posthog
+
+# Django settings
+
+## Update to postgres to use postgres for all event queries
+PRIMARY_DB=clickhouse
+DATABASE_URL=postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}
+KAFKA_ENABLED=true
+KAFKA_HOSTS=localhost:9092
+
+# Clickhouse settings
+CLICKHOUSE_DATABASE=posthog_test
+CLICKHOUSE_VERIFY=False

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This is intented to be used with direnv: https://direnv.net/
+
+# It's just so I can have my env setup when cding to this dir, i.e. being able
+# to run psql with no additional args, being able to run ./manage.py runserver
+# without having to do any further setup etc.
+
+# It's doing a couple of things:
+#
+#   1. sources nix, which installs things like postgresql, redis etc that I like
+#      to run locally
+#   2. sets up env vars by sourcing .env
+#
+# It's not doing anything with python env atm but certainly could. I had some
+# issues with xmlsec however when trying to get it to work, specifically with
+# icu4c when compiling.
+
+# Setups up python and venv etc.
+use_nix
+
+# Use dotenv so we get reloads on config changes
+dotenv .env

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,30 @@
+# Defines a dev env with python 3.9 and node. Also includes docker for running
+# services. Perhaps this is a bit overkill for doing so little, but I've been
+# having some issues with python env not being isolated, specifically running
+# pip-compile was picking up version information from somewhere else.
+
+let
+  pkgs = import <nixpkgs> {};
+in
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.python39
+    pkgs.python39Packages.pip
+    pkgs.python39Packages.setuptools
+    pkgs.python39Packages.virtualenv
+
+    # Required to build psycopg2
+    pkgs.openssl
+
+    # Required for frontend build
+    pkgs.nodejs
+    pkgs.yarn
+    
+    # Service dependencies
+    pkgs.docker];
+    
+  shellHook = ''
+    python -m venv env
+    source env/bin/activate
+  '';
+}


### PR DESCRIPTION
This is what I have been using locally, but perhaps others can benefit
also? It's not a complete solution, but it's a start.

I've added a `.env` file which is setup for `PRIMARY_DB=clickhouse`,
which I guess we want as the default given it should be the only one in
the future. It doesn't contain anything confidential so I do not see any
issue with committiing it, and these vars are required for running a
local dev env. The only other place I've seen these vars is in the
handbook, which isn't very convinient but maybe I've missed something.

It is required to have both https://nixos.wiki/ and https://direnv.net/
installed (and maybe dotenv).

Let me know if it's possible to get this in, otherwise I'll continue with these locally only.