### PR TITLE
Remove scrollbar

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
@@ -20,7 +20,7 @@
         cursor: pointer;
         border: none;
         white-space: nowrap;
-        overflow-x: scroll;
+        overflow-x: auto;
 
         &.hover {
             background: rgba(0, 0, 0, 0.1);

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -231,7 +231,7 @@ export function InfiniteList(): JSX.Element {
                             height={height}
                             rowCount={isLoading && totalCount === 0 ? 7 : totalCount}
                             overscanRowCount={100}
-                            rowHeight={40}
+                            rowHeight={32}
                             rowRenderer={renderItem}
                             onRowsRendered={onRowsRendered}
                             scrollToIndex={index}


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/6301

- Before:
![image](https://user-images.githubusercontent.com/53387/136343540-9a84e9bb-27c6-4959-8012-279b02bf8418.png)

- After 1:
![image](https://user-images.githubusercontent.com/53387/136343421-46eb49da-0e45-47ae-aa10-2491e6ba018f.png)

- After 2 (see "More context"):
![image](https://user-images.githubusercontent.com/53387/136344166-5348c1c3-a82a-449a-88ee-9389bccc3df5.png)


## How did you test this code?

- Enabled scrollbars on my mac and tried before and after.

## More context

The list items feel huge somehow? [This line](https://github.com/PostHog/posthog/pull/5825/files#diff-1603084f58cd5111ebfae4c1108de44eb0ed8c530703c5a1e8772ab8edb6a847R235) seems to have changed them from 32px to 40px . I reverted it now, but @liyiy was there any reason for that change that I'm not seeing?