### PR TITLE
Add dead letter queue to capture endpoint

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -76,3 +76,60 @@ class TestCaptureAPI(APIBaseTest):
 
         self.assertEquals(type(kafka_produce_call1["data"]["uuid"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["uuid"]), str)
+
+    @patch("posthog.models.Team.objects.get_team_from_token", side_effect=mocked_get_team_from_token)
+    @patch("posthog.api.capture.log_event_to_dead_letter_queue")
+    def test_unable_to_fetch_team(self, log_event_to_dead_letter_queue, _):
+        # In this situation we won't ingest the events, we'll add them to the dead letter queue
+
+        self.client.post(
+            "/track/",
+            {
+                "data": json.dumps(
+                    [
+                        {"event": "event1", "properties": {"distinct_id": "eeee", "token": self.team.api_token,},},
+                        {"event": "event2", "properties": {"distinct_id": "aaaa", "token": self.team.api_token,},},
+                    ]
+                ),
+                "api_key": self.team.api_token,
+            },
+        )
+
+        self.assertEqual(log_event_to_dead_letter_queue.call_count, 2)
+
+        log_event_to_dead_letter_queue_call1 = log_event_to_dead_letter_queue.call_args_list[0].args
+        log_event_to_dead_letter_queue_call2 = log_event_to_dead_letter_queue.call_args_list[1].args
+
+        self.assertEqual(type(log_event_to_dead_letter_queue_call1[0]), list)  # event
+        self.assertEqual(type(log_event_to_dead_letter_queue_call2[0]), list)  # event
+
+        self.assertEqual(log_event_to_dead_letter_queue_call1[1], "event1")  # event_name
+        self.assertEqual(log_event_to_dead_letter_queue_call2[1], "event2")  # event_name
+
+        self.assertEqual(type(log_event_to_dead_letter_queue_call1[2]), dict)  # event
+        self.assertEqual(type(log_event_to_dead_letter_queue_call2[2]), dict)  # event
+
+        self.assertEqual(
+            log_event_to_dead_letter_queue_call1[3],
+            "Unable to fetch team from Postgres. Error: Exception('test exception')",
+        )  # error_message
+
+        self.assertEqual(
+            log_event_to_dead_letter_queue_call2[3],
+            "Unable to fetch team from Postgres. Error: Exception('test exception')",
+        )  # error_message
+
+        self.assertEqual(log_event_to_dead_letter_queue_call1[4], "django_server_capture_endpoint")  # error_location
+        self.assertEqual(log_event_to_dead_letter_queue_call2[4], "django_server_capture_endpoint")  # error_location
+
+    # unit test the underlying util that handles the DB being down
+    @patch("posthog.models.Team.objects.get_team_from_token", side_effect=mocked_get_team_from_token)
+    def test_determine_team_from_request_data_ch(self, _):
+        team, send_events_to_dead_letter_queue, fetch_team_error, error_response = determine_team_from_request_data(
+            HttpRequest(), {}, ""
+        )
+
+        self.assertEqual(team, None)
+        self.assertEqual(send_events_to_dead_letter_queue, True)
+        self.assertEqual(fetch_team_error, "Exception('test exception')")
+        self.assertEqual(error_response, None)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -249,7 +249,8 @@ def parse_event(event, distinct_id, team, is_test_env):
         scope.set_tag("library", library)
         scope.set_tag("library.version", library_version)
 
-    _ensure_web_feature_flags_in_properties(event, team, distinct_id)
+    if team:
+        _ensure_web_feature_flags_in_properties(event, team, distinct_id)
 
     return event
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -161,7 +161,7 @@ def get_event(request):
 
     team, db_error, error_response = get_team(request, data, token)
 
-    if error_response or not team:
+    if error_response:
         return error_response
 
     send_events_to_dead_letter_queue = False

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -161,11 +161,12 @@ def get_event(request):
 
     team, db_error, error_response = get_team(request, data, token)
 
+    if error_response or not team:
+        return error_response
+
     send_events_to_dead_letter_queue = False
     if db_error and is_clickhouse_enabled():
         send_events_to_dead_letter_queue = True
-    elif error_response or not team:
-        return error_response
 
     if isinstance(data, dict):
         if data.get("batch"):  # posthog-python and posthog-ruby

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -78,6 +78,8 @@ if is_clickhouse_enabled():
             statsd.incr(EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC)
         except Exception as e:
             capture_exception(e)
+            print("Failed to produce to events dead letter queue with error:", e)
+            statsd.incr("events_dead_letter_queue_produce_error")
 
 
 def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -49,10 +49,10 @@ if is_clickhouse_enabled():
             "sent_at": sent_at.isoformat() if sent_at else "",
         }
 
-    def log_event(data: Dict, topic: str = KAFKA_EVENTS_PLUGIN_INGESTION,) -> None:
+    def log_event(data: Dict, event_name: str, topic: str = KAFKA_EVENTS_PLUGIN_INGESTION,) -> None:
         if settings.DEBUG:
-            print(f'Logging event {data["event"]} to Kafka topic {topic}')
-        KafkaProducer().produce(topic=topic, key=data["ip"], data=data)
+            print(f"Logging event {event_name} to Kafka topic {topic}")
+        KafkaProducer().produce(topic=topic, data=data)
 
     def log_event_to_dead_letter_queue(
         raw_payload: Dict,
@@ -279,7 +279,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
             sent_at=sent_at,
             event_uuid=event_uuid,
         )
-        log_event(parsed_event)
+        log_event(parsed_event, event["event"])
     else:
         task_name = "posthog.tasks.process_event.process_event_with_plugins"
         celery_queue = settings.PLUGINS_CELERY_QUEUE

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -20,11 +20,12 @@ from posthog.helpers.session_recording import preprocess_session_recording_event
 from posthog.models import Team
 from posthog.models.feature_flag import get_active_feature_flags
 from posthog.models.utils import UUIDT
+from posthog.settings import EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC
 from posthog.utils import cors_response, get_ip_address, is_clickhouse_enabled
 
 if is_clickhouse_enabled():
     from ee.kafka_client.client import KafkaProducer
-    from ee.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION
+    from ee.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE, KAFKA_EVENTS_PLUGIN_INGESTION
 
     def parse_kafka_event_data(
         distinct_id: str,
@@ -51,6 +52,30 @@ if is_clickhouse_enabled():
         if settings.DEBUG:
             print(f'Logging event {data["event"]} to Kafka topic {topic}')
         KafkaProducer().produce(topic=topic, key=data["ip"], data=data)
+
+    def log_event_to_dead_letter_queue(
+        raw_payload: Dict,
+        event_name: str,
+        event: Dict,
+        error_message: str,
+        error_location: str,
+        topic: str = KAFKA_DEAD_LETTER_QUEUE,
+    ):
+        data = event.copy()
+        data["failure_timestamp"] = datetime.now().isoformat()
+        data["error_location"] = error_location
+        data["error"] = error_message
+        data["elements_chain"] = ""
+        data["id"] = str(UUIDT())
+        data["event_uuid"] = event["uuid"]
+        data["event"] = event_name
+        data["raw_payload"] = json.dumps(raw_payload)
+
+        del data["uuid"]
+
+        KafkaProducer().produce(topic=topic, data=data)
+
+        statsd.incr(EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC)
 
 
 def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
@@ -127,7 +152,9 @@ def get_event(request):
             ),
         )
 
-    team, error_response = determine_team_from_request_data(request, data, token)
+    team, send_events_to_dead_letter_queue, fetch_team_error, error_response = determine_team_from_request_data(
+        request, data, token
+    )
 
     if error_response:
         return error_response
@@ -153,10 +180,19 @@ def get_event(request):
 
     site_url = request.build_absolute_uri("/")[:-1]
 
-    ip = None if team.anonymize_ips else get_ip_address(request)  # type: ignore
+    ip = None if send_events_to_dead_letter_queue or team.anonymize_ips else get_ip_address(request)  # type: ignore
     for event in events:
         parse_and_enqueue_event(
-            data, event, site_url, ip, now, sent_at, team, is_test_env,
+            data,
+            event,
+            site_url,
+            ip,
+            now,
+            sent_at,
+            team,
+            is_test_env,
+            send_events_to_dead_letter_queue,
+            fetch_team_error,
         )
 
     timer.stop()
@@ -166,7 +202,9 @@ def get_event(request):
     return cors_response(request, JsonResponse({"status": 1}))
 
 
-def parse_and_enqueue_event(data, event, site_url, ip, now, sent_at, team, is_test_env) -> None:
+def parse_and_enqueue_event(
+    data, event, site_url, ip, now, sent_at, team, is_test_env, send_to_dead_letter_queue=False, fetch_team_error=""
+) -> None:
     try:
         distinct_id = _get_distinct_id(event)
     except KeyError:
@@ -193,6 +231,27 @@ def parse_and_enqueue_event(data, event, site_url, ip, now, sent_at, team, is_te
     with push_scope() as scope:
         scope.set_tag("library", library)
         scope.set_tag("library.version", library_version)
+
+    if send_to_dead_letter_queue:
+        kafka_event = parse_kafka_event_data(
+            distinct_id=distinct_id,
+            ip=None,
+            site_url=site_url,
+            team_id=None,
+            now=now,
+            event_uuid=event_uuid,
+            data=event,
+            sent_at=sent_at,
+        )
+
+        log_event_to_dead_letter_queue(
+            data,
+            event["event"],
+            kafka_event,
+            f"Unable to fetch team from Postgres. Error: {fetch_team_error}",
+            "django_server_capture_endpoint",
+        )
+        return
 
     _ensure_web_feature_flags_in_properties(event, team, distinct_id)
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -222,7 +222,7 @@ def get_event(request):
             continue
 
         statsd.incr("posthog_cloud_plugin_server_ingestion")
-        capture_internal(event, distinct_id, ip, site_url, now, sent_at, team.pk, event_uuid)
+        capture_internal(event, distinct_id, ip, site_url, now, sent_at, team.pk, event_uuid)  # type: ignore
 
     timer.stop()
     statsd.incr(

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -49,10 +49,7 @@ if is_clickhouse_enabled():
             "sent_at": sent_at.isoformat() if sent_at else "",
         }
 
-    def log_event(
-        data: Dict,
-        topic: str = KAFKA_EVENTS_PLUGIN_INGESTION,
-    ) -> None:
+    def log_event(data: Dict, topic: str = KAFKA_EVENTS_PLUGIN_INGESTION,) -> None:
         if settings.DEBUG:
             print(f'Logging event {data["event"]} to Kafka topic {topic}')
         KafkaProducer().produce(topic=topic, key=data["ip"], data=data)
@@ -202,10 +199,7 @@ def get_event(request):
 
     timer.stop()
     statsd.incr(
-        f"posthog_cloud_raw_endpoint_success",
-        tags={
-            "endpoint": "capture",
-        },
+        f"posthog_cloud_raw_endpoint_success", tags={"endpoint": "capture",},
     )
     return cors_response(request, JsonResponse({"status": 1}))
 
@@ -286,13 +280,5 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
         celery_app.send_task(
             name=task_name,
             queue=celery_queue,
-            args=[
-                distinct_id,
-                ip,
-                site_url,
-                event,
-                team_id,
-                now.isoformat(),
-                sent_at,
-            ],
+            args=[distinct_id, ip, site_url, event, team_id, now.isoformat(), sent_at,],
         )

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from posthog.api.test.test_capture import mocked_get_team_from_token
 from posthog.api.utils import determine_team_from_request_data, extract_data_from_request
 from posthog.test.base import BaseTest
+from posthog.utils import load_data_from_request
 
 
 def return_true():
@@ -17,25 +18,37 @@ def return_true():
 class TestUtils(BaseTest):
     def test_determine_team_from_request_data(self):
         # No data at all
-        team, error_response = determine_team_from_request_data(HttpRequest(), {}, "")
+        team, send_events_to_dead_letter_queue, fetch_team_error, error_response = determine_team_from_request_data(
+            HttpRequest(), {}, ""
+        )
 
         self.assertEqual(team, None)
+        self.assertEqual(send_events_to_dead_letter_queue, False)
+        self.assertEqual(fetch_team_error, None)
         self.assertEqual(type(error_response), JsonResponse)
         self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)  # type: ignore
         self.assertEqual("Project API key invalid" in json.loads(error_response.getvalue())["detail"], True)  # type: ignore
 
         # project_id exists but is invalid: should look for a personal API key and fail
-        team, error_response = determine_team_from_request_data(HttpRequest(), {"project_id": 438483483}, "")
+        team, send_events_to_dead_letter_queue, fetch_team_error, error_response = determine_team_from_request_data(
+            HttpRequest(), {"project_id": 438483483}, ""
+        )
 
         self.assertEqual(team, None)
+        self.assertEqual(send_events_to_dead_letter_queue, False)
+        self.assertEqual(fetch_team_error, None)
         self.assertEqual(type(error_response), JsonResponse)
         self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)  # type: ignore
         self.assertEqual(json.loads(error_response.getvalue())["detail"], "Invalid Personal API key.")  # type: ignore
 
         # Correct token
-        team, error_response = determine_team_from_request_data(HttpRequest(), {}, self.team.api_token)
+        team, send_events_to_dead_letter_queue, fetch_team_error, error_response = determine_team_from_request_data(
+            HttpRequest(), {}, self.team.api_token
+        )
 
         self.assertEqual(team, self.team)
+        self.assertEqual(send_events_to_dead_letter_queue, False)
+        self.assertEqual(fetch_team_error, None)
         self.assertEqual(error_response, None)
 
         get_team_from_token_patcher = patch(
@@ -44,9 +57,13 @@ class TestUtils(BaseTest):
         get_team_from_token_patcher.start()
 
         # Postgres fetch team error
-        team, error_response = determine_team_from_request_data(HttpRequest(), {}, self.team.api_token)
+        team, send_events_to_dead_letter_queue, fetch_team_error, error_response = determine_team_from_request_data(
+            HttpRequest(), {}, self.team.api_token
+        )
 
         self.assertEqual(team, None)
+        self.assertEqual(send_events_to_dead_letter_queue, False)
+        self.assertEqual(fetch_team_error, None)
         self.assertEqual(error_response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)  # type: ignore
 
         get_team_from_token_patcher.stop()

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -151,16 +151,17 @@ def get_team(request, data, token) -> Tuple[Optional[Team], Optional[str], Optio
 
         db_error = getattr(e, "message", repr(e))
 
-        error_response = cors_response(
-            request,
-            generate_exception_response(
-                "capture",
-                "Unable to fetch team from database.",
-                type="server_error",
-                code="fetch_team_fail",
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            ),
-        )
+        if not is_clickhouse_enabled():
+            error_response = cors_response(
+                request,
+                generate_exception_response(
+                    "capture",
+                    "Unable to fetch team from database.",
+                    type="server_error",
+                    code="fetch_team_fail",
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                ),
+            )
 
         return None, db_error, error_response
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -640,3 +640,6 @@ LOGGING = {
         "statsd": {"handlers": ["console"], "level": "WARNING", "propagate": True,},
     },
 }
+
+# keep in sync with plugin-server
+EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC = "events_added_to_dead_letter_queue"


### PR DESCRIPTION
## Important

I split this off from #6230 to make the changes easier to review

The base of this PR is `capture-refactor-plus-dlq` so it is safe to merge. We should also review and merge this before #6230

## Changes

Send events to the dead letter queue if the DB throws an error when we try to fetch the team

## How did you test this code?

Added CH and Postgres tests + tested manually
