### PR TITLE
Bump ulimit for services on ECS

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -140,6 +140,11 @@
                 }
             ],
             "entryPoint": ["./bin/plugin-server", "--no-restart-loop"],
+            "Ulimit": {
+                "name": "nofile",
+                "hardLimit": 1024000,
+                "softLimit": 1024000
+            },
             "linuxParameters": {
                 "initProcessEnabled": true
             }

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -255,6 +255,11 @@
             ],
             "entryPoint": ["sh", "-c"],
             "command": ["./bin/docker-server"],
+            "Ulimit": {
+                "name": "nofile",
+                "hardLimit": 1024000,
+                "softLimit": 1024000
+            },
             "linuxParameters": {
                 "initProcessEnabled": true
             }

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -249,6 +249,11 @@
             ],
             "entryPoint": ["sh", "-c"],
             "command": ["./bin/docker-worker-celery --with-scheduler"],
+            "Ulimit": {
+                "name": "nofile",
+                "hardLimit": 1024000,
+                "softLimit": 1024000
+            },
             "linuxParameters": {
                 "initProcessEnabled": true
             }


### PR DESCRIPTION
## Changes

This will allow us to absorb more traffic per task on ECS
ECS Config Docs:
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html

## How did you test this code?

Very Carefully ™️ 
