### PR TITLE
Ingestion grid: no unneeded scroll bars

### DIFF
--- a/frontend/src/scenes/ingestion/panels/FrameworkGrid.tsx
+++ b/frontend/src/scenes/ingestion/panels/FrameworkGrid.tsx
@@ -48,7 +48,7 @@ function TabContents(frameworks: Record<string, string>, sort?: boolean): JSX.El
 
     return (
         <List
-            style={{ height: 300, maxHeight: 300, overflowY: 'scroll' }}
+            style={{ height: 300, maxHeight: 300, overflowY: 'auto' }}
             grid={{}}
             size={'large'}
             dataSource={getDataSource(frameworks, sort) as Framework[]}


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog/commit/bb4abb7f6ab80b7251fb36e47cf8d670d8205fbf introduced tweaks to the ingestion setup guide - including some ugly scroll bars. Fixed it.

## How did you test this code?

*Please describe.*
