### PR TITLE
Discard low significance items, alter odds definition, mention skewed…

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -1,4 +1,5 @@
 import dataclasses
+from os import stat
 from typing import Any, Dict, List, Literal, Tuple, TypedDict, cast
 
 from rest_framework.exceptions import ValidationError
@@ -337,7 +338,7 @@ class FunnelCorrelation:
         odds_ratios = [
             get_entity_odds_ratio(event_stats, FunnelCorrelation.PRIOR_COUNT)
             for event_stats in event_contingency_tables
-            if not self.are_results_insignificant(event_stats)
+            if not FunnelCorrelation.are_results_insignificant(event_stats)
         ]
 
         positively_correlated_events = sorted(
@@ -401,7 +402,8 @@ class FunnelCorrelation:
             funnel_persons_generator.params,
         )
 
-    def are_results_insignificant(self, event_contingency_table: EventContingencyTable) -> bool:
+    @staticmethod
+    def are_results_insignificant(event_contingency_table: EventContingencyTable) -> bool:
         """
         Check if the results are insignificant, i.e. if the success/failure counts are
         significantly different from the total counts

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -32,6 +32,7 @@ class FunnelCorrelationResponse(TypedDict):
     """
 
     events: List[EventOddsRatio]
+    skewed: bool
 
 
 @dataclasses.dataclass
@@ -59,6 +60,9 @@ class EventContingencyTable:
 class FunnelCorrelation:
 
     TOTAL_IDENTIFIER = "Total_Values_In_Query"
+    MIN_PERSON_COUNT = 25
+    MIN_PERSON_PERCENTAGE = 0.02
+    PRIOR_COUNT = 1
 
     def __init__(self, filter: Filter, team: Team) -> None:
         self._filter = filter
@@ -275,12 +279,12 @@ class FunnelCorrelation:
 
 
         Then the odds that a person signs up given they watched the video is 5 /
-        6.
+        1.
         
         And the odds that a person signs up given they didn't watch the video is
-        2 / 12.
+        2 / 10.
 
-        So we say the odds ratio is 5 / 6 over 2 / 12 = 5 . The further away the
+        So we say the odds ratio is 5 / 1 over 2 / 10 = 25 . The further away the
         odds ratio is from 1, the greater the correlation.
 
         Requirements:
@@ -312,9 +316,29 @@ class FunnelCorrelation:
         query, params = self.get_contingency_table_query()
         results_with_total = sync_execute(query, params)
 
-        event_contingency_tables = self.get_partial_event_contingency_tables(results_with_total)
+        # Get the total success/failure counts from the results
+        results = [result for result in results_with_total if result[0] != self.TOTAL_IDENTIFIER]
+        _, success_total, failure_total = [
+            result for result in results_with_total if result[0] == self.TOTAL_IDENTIFIER
+        ][0]
 
-        odds_ratios = [get_entity_odds_ratio(event_stats) for event_stats in event_contingency_tables]
+        if not success_total or not failure_total:
+            return {"events": [], "skewed": True}
+
+        skewed_totals = False
+
+        # If the ratio is greater than 1:10, then we have a skewed result, so we should
+        # warn the user.
+        if success_total / failure_total > 10 or failure_total / success_total > 10:
+            skewed_totals = True
+
+        event_contingency_tables = self.get_partial_event_contingency_tables(results, success_total, failure_total)
+
+        odds_ratios = [
+            get_entity_odds_ratio(event_stats, FunnelCorrelation.PRIOR_COUNT)
+            for event_stats in event_contingency_tables
+            if not self.are_results_insignificant(event_stats)
+        ]
 
         positively_correlated_events = sorted(
             [odds_ratio for odds_ratio in odds_ratios if odds_ratio["correlation_type"] == "success"],
@@ -329,9 +353,14 @@ class FunnelCorrelation:
         )
 
         # Return the top ten positively correlated events, and top then negatively correlated events
-        return {"events": positively_correlated_events[:10] + negatively_correlated_events[:10]}
+        return {
+            "events": positively_correlated_events[:10] + negatively_correlated_events[:10],
+            "skewed": skewed_totals,
+        }
 
-    def get_partial_event_contingency_tables(self, results_with_total: list) -> List[EventContingencyTable]:
+    def get_partial_event_contingency_tables(
+        self, results: list, success_total: int, failure_total: int
+    ) -> List[EventContingencyTable]:
         """
         For each event a person that started going through the funnel, gets stats
         for how many of these users are sucessful and how many are unsuccessful.
@@ -340,12 +369,6 @@ class FunnelCorrelation:
         event, but does include the total success/failure numbers, which is enough
         for us to calculate the odds ratio.
         """
-
-        # Get the total success/failure counts from the results
-        results = [result for result in results_with_total if result[0] != self.TOTAL_IDENTIFIER]
-        _, success_total, failure_total = [
-            result for result in results_with_total if result[0] == self.TOTAL_IDENTIFIER
-        ][0]
 
         # Add a little structure, and keep it close to the query definition so it's
         # obvious what's going on with result indices.
@@ -378,22 +401,32 @@ class FunnelCorrelation:
             funnel_persons_generator.params,
         )
 
+    def are_results_insignificant(self, event_contingency_table: EventContingencyTable) -> bool:
+        """
+        Check if the results are insignificant, i.e. if the success/failure counts are
+        significantly different from the total counts
+        """
 
-def get_entity_odds_ratio(event_contingency_table: EventContingencyTable) -> EventOddsRatio:
+        total_count = event_contingency_table.success_total + event_contingency_table.failure_total
+
+        if event_contingency_table.visited.success_count + event_contingency_table.visited.failure_count < min(
+            FunnelCorrelation.MIN_PERSON_COUNT, FunnelCorrelation.MIN_PERSON_PERCENTAGE * total_count
+        ):
+            return True
+
+        return False
+
+
+def get_entity_odds_ratio(event_contingency_table: EventContingencyTable, prior_counts: int) -> EventOddsRatio:
 
     # Add 1 to all values to prevent divide by zero errors, and introduce a [prior](https://en.wikipedia.org/wiki/Prior_probability)
-
-    prior_counts = 1
-    if event_contingency_table.success_total and event_contingency_table.failure_total:
-        odds_ratio = (
-            (event_contingency_table.visited.success_count + prior_counts)
-            * (event_contingency_table.failure_total + prior_counts)
-        ) / (
-            (event_contingency_table.success_total + prior_counts)
-            * (event_contingency_table.visited.failure_count + prior_counts)
-        )
-    else:
-        odds_ratio = 1
+    odds_ratio = (
+        (event_contingency_table.visited.success_count + prior_counts)
+        * (event_contingency_table.failure_total - event_contingency_table.visited.failure_count + prior_counts)
+    ) / (
+        (event_contingency_table.success_total - event_contingency_table.visited.success_count + prior_counts)
+        * (event_contingency_table.visited.failure_count + prior_counts)
+    )
 
     return EventOddsRatio(
         event=event_contingency_table.event,


### PR DESCRIPTION
… results

## Changes

Noticed a slight inconsistency in odds calculation: Odds ratios are relative to other events that happened, not the total ( https://en.wikipedia.org/wiki/Odds_ratio ) - fixed this (and the painful test update that follows)

Discard items where count is less than 2% of total or 25, whichever is lower.

And finally, sends a `skewed` parameter from the API call which lets you know if the results are unreliable (i.e. original data is too skewed in one direction)

## How did you test this code?

Unit tests!
