### PR TITLE
ci(cypress): don't use cypress parallel option

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,11 @@ jobs:
                   install: false
                   # We already install cypress separately, we don't need to install it again here
                   install-command: echo "no"
+              env:
+                  # Required for `sessions.js` to pass
+                  # TODO: #6347 remove dependence on having `GITHUB_TOKEN` for
+                  # `sessions.js` to pass
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Archive test screenshots
               uses: actions/upload-artifact@v1
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,15 +8,6 @@ jobs:
         name: Cypress E2E tests
         runs-on: ubuntu-18.04
 
-        strategy:
-            # when one test fails, DO NOT cancel the other
-            # containers, because this will kill Cypress processes
-            # leaving the Dashboard hanging ...
-            # https://github.com/cypress-io/github-action/issues/48
-            fail-fast: false
-            matrix:
-                # run 7 copies of the current job in parallel
-                containers: [1, 2, 3, 4, 5, 6, 7]
         services:
             postgres:
                 image: postgres:12
@@ -103,20 +94,11 @@ jobs:
               uses: cypress-io/github-action@v2
               with:
                   config-file: cypress.e2e.json
-                  record: true
-                  parallel: true
-                  group: 'PostHog Frontend'
                   # We're already installing cypress above
                   # We have to install it separately otherwise the tests fail.
                   install: false
                   # We already install cypress separately, we don't need to install it again here
                   install-command: echo "no"
-              env:
-                  # pass the Dashboard record key as an environment variable
-                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  # Recommended: pass the GitHub token lets this action correctly
-                  # determine the unique run id necessary to re-run the checks
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Archive test screenshots
               uses: actions/upload-artifact@v1
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,10 @@
 name: E2E
 
 on:
-    - pull_request
+    pull_request:
+    push:
+        branches:
+            - master
 
 jobs:
     cypress:
@@ -62,7 +65,7 @@ jobs:
                       ~/.cache/Cypress
                   key: ${{ runner.os }}-cypress-node-modules-2-${{ hashFiles('**/yarn.lock') }}
                   restore-keys: |
-                      ${{ runner.os }}-cypress-node-modules-2
+                      ${{ runner.os }}-cypress-node-modules-2-
             - name: Yarn install deps
               if: steps.cypress-node-modules-cache-2.outputs.cache-hit != 'true'
               run: |


### PR DESCRIPTION
## Changes

The parallel run feature is imo not worth it, we can just manually split
the tests into parallel batches. This will be a little more predictable
as we remove the requirement to connect to cypress.io, which comes with
tiering issues etc for not much benefit.

I'm not parallelizing them yet, just playing around initially to see how
fast things are without any parallelization. There are other issues as
well, for instance contention on the caching.

Aside from this, we also run cypress tests on merging to master, which 
means we will get caching of yarn deps on first run

## How did you test this code?

It should be enough to see that the pipeline passes, but it's tricky to test the caching functionality as requires master