### PR TITLE
switches from sentry's push_scope

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -9,7 +9,7 @@ from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
-from sentry_sdk import capture_exception, push_scope
+from sentry_sdk import capture_exception, configure_scope
 from statshog.defaults.django import statsd
 
 from posthog.api.utils import get_token
@@ -249,7 +249,8 @@ def get_event(request):
 
         library = event["properties"].get("$lib", "unknown")
         library_version = event["properties"].get("$lib_version", "unknown")
-        with push_scope() as scope:
+
+        with configure_scope() as scope:
             scope.set_tag("library", library)
             scope.set_tag("library.version", library_version)
 

--- a/posthog/api/test/mock_sentry.py
+++ b/posthog/api/test/mock_sentry.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 
-def mock_sentry_context_for_tagging(patched_push_scope):
+def mock_sentry_context_for_tagging(patched_scope):
     mock_scope = Mock()
     mock_set_tag = Mock()
     mock_scope.set_context = Mock()
@@ -9,5 +9,5 @@ def mock_sentry_context_for_tagging(patched_push_scope):
     mock_context_manager = Mock()
     mock_context_manager.__enter__ = Mock(return_value=mock_scope)
     mock_context_manager.__exit__ = Mock(return_value=None)
-    patched_push_scope.return_value = mock_context_manager
+    patched_scope.return_value = mock_context_manager
     return mock_set_tag

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -3,7 +3,7 @@ import gzip
 import json
 from datetime import timedelta
 from typing import Any, Dict, List, Union
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, call, patch
 from urllib.parse import quote
 
 import lzstring
@@ -87,10 +87,10 @@ class TestCapture(BaseTest):
             },
         )
 
-    @patch("posthog.api.capture.push_scope")
+    @patch("posthog.api.capture.configure_scope")
     @patch("posthog.api.capture.celery_app.send_task", MagicMock())
-    def test_capture_event_adds_library_to_sentry(self, patch_push_scope):
-        mock_set_tag = mock_sentry_context_for_tagging(patch_push_scope)
+    def test_capture_event_adds_library_to_sentry(self, patched_scope):
+        mock_set_tag = mock_sentry_context_for_tagging(patched_scope)
 
         data = {
             "event": "$autocapture",
@@ -112,10 +112,10 @@ class TestCapture(BaseTest):
 
         mock_set_tag.assert_has_calls([call("library", "web"), call("library.version", "1.14.1")])
 
-    @patch("posthog.api.capture.push_scope")
+    @patch("posthog.api.capture.configure_scope")
     @patch("posthog.api.capture.celery_app.send_task", MagicMock())
-    def test_capture_event_adds_unknown_to_sentry_when_no_properties_sent(self, patch_push_scope):
-        mock_set_tag = mock_sentry_context_for_tagging(patch_push_scope)
+    def test_capture_event_adds_unknown_to_sentry_when_no_properties_sent(self, patched_scope):
+        mock_set_tag = mock_sentry_context_for_tagging(patched_scope)
 
         data = {
             "event": "$autocapture",


### PR DESCRIPTION
## Changes

 which only tags messages captured in the same method to configure_scope which applies to the entire django request

https://docs.sentry.io/platforms/python/guides/django/enriching-events/scopes/#configuring-the-scope

see #4816 

## How did you test this code?

unti tests
