### PR TITLE
Move more Sentry logging to configure_scope

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -87,7 +87,7 @@ class TestDefaultEventName(BaseTest):
 
 
 class TestLoadDataFromRequest(TestCase):
-    @patch("posthog.utils.push_scope")
+    @patch("posthog.utils.configure_scope")
     def test_pushes_request_origin_into_sentry_scope(self, push_scope):
         origin = "potato.io"
 

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import call, patch
 
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -88,20 +88,35 @@ class TestDefaultEventName(BaseTest):
 
 class TestLoadDataFromRequest(TestCase):
     @patch("posthog.utils.configure_scope")
-    def test_pushes_request_origin_into_sentry_scope(self, push_scope):
+    def test_pushes_request_origin_into_sentry_scope(self, patched_scope):
         origin = "potato.io"
+        referer = "https://" + origin
 
-        mock_set_tag = mock_sentry_context_for_tagging(push_scope)
+        mock_set_tag = mock_sentry_context_for_tagging(patched_scope)
 
         rf = RequestFactory()
         post_request = rf.post("/s/", "content", "text/plain")
         post_request.META["REMOTE_HOST"] = origin
+        post_request.META["HTTP_REFERER"] = referer
 
         with self.assertRaises(RequestParsingError) as ctx:
             load_data_from_request(post_request)
 
-        push_scope.assert_called_once()
-        mock_set_tag.assert_called_once_with("origin", origin)
+        patched_scope.assert_called_once()
+        mock_set_tag.assert_has_calls([call("origin", origin), call("referer", referer)])
+
+    @patch("posthog.utils.configure_scope")
+    def test_pushes_request_origin_into_sentry_scope_even_when_not_available(self, patched_scope):
+        mock_set_tag = mock_sentry_context_for_tagging(patched_scope)
+
+        rf = RequestFactory()
+        post_request = rf.post("/s/", "content", "text/plain")
+
+        with self.assertRaises(RequestParsingError):
+            load_data_from_request(post_request)
+
+        patched_scope.assert_called_once()
+        mock_set_tag.assert_has_calls([call("origin", "unknown"), call("referer", "unknown")])
 
     def test_fails_to_JSON_parse_the_literal_string_undefined_when_not_compressed(self):
         """

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -37,7 +37,7 @@ from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
 from django.utils import timezone
 from rest_framework.request import Request
-from sentry_sdk import push_scope
+from sentry_sdk import configure_scope
 
 from posthog.constants import AnalyticsDBMS, AvailableFeature
 from posthog.exceptions import RequestParsingError
@@ -390,7 +390,7 @@ def load_data_from_request(request):
         return None
 
     # add the data in sentry's scope in case there's an exception
-    with push_scope() as scope:
+    with configure_scope() as scope:
         scope.set_context("data", data)
         scope.set_tag("origin", request.META.get("REMOTE_HOST"))
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -392,7 +392,8 @@ def load_data_from_request(request):
     # add the data in sentry's scope in case there's an exception
     with configure_scope() as scope:
         scope.set_context("data", data)
-        scope.set_tag("origin", request.META.get("REMOTE_HOST"))
+        scope.set_tag("origin", request.META.get("REMOTE_HOST", "unknown"))
+        scope.set_tag("referer", request.META.get("HTTP_REFERER", "unknown"))
 
     compression = (
         request.GET.get("compression") or request.POST.get("compression") or request.headers.get("content-encoding", "")


### PR DESCRIPTION
## Changes

Sentry was being used as push_scope. That only sets data on scope within that python block

Configure_scope sets data for the entire django request

see #4816 

## How did you test this code?

unit tests and running locally
