### PR TITLE
ci(cypress): run cypress tests on master as well

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,10 @@
 name: E2E
 
 on:
-    - pull_request
+    pull_request:
+    push:
+        branches:
+            - master
 
 jobs:
     cypress:
@@ -71,7 +74,7 @@ jobs:
                       ~/.cache/Cypress
                   key: ${{ runner.os }}-cypress-node-modules-2-${{ hashFiles('**/yarn.lock') }}
                   restore-keys: |
-                      ${{ runner.os }}-cypress-node-modules-2
+                      ${{ runner.os }}-cypress-node-modules-2-
             - name: Yarn install deps
               if: steps.cypress-node-modules-cache-2.outputs.cache-hit != 'true'
               run: |


### PR DESCRIPTION
We do this for a couple of reasons:

 1. we want to validate master branch. We may have tested on branch, but
    that doesn't guarantee that we're tested something equivalent to
    master. e.g. the branch may no longer be a decendant of master
 2. we fix the caching issue. Caches are scoped to a. the branch, and b.
    the branch to which we are merging.

This eliminates 2:30 time off the initial E2E build, and some time off the `yarn build` (maybe a couple of minutes although that's anecdotal)  presumably due to `babel-loader` caching.