### PR TITLE
Enable running correlations over all properties and respect conversio…

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -73,6 +73,20 @@ class FunnelCorrelation:
             self._filter = self._filter.with_data({"funnel_step": 1})
             # Funnel Step by default set to 1, to give us all people who entered the funnel
 
+        # Used for generating the funnel persons cte
+        self._funnel_persons_generator = ClickhouseFunnelPersons(
+            self._filter,
+            self._team,
+            # NOTE: we want to include the latest timestamp of the `target_step`,
+            # from this we can deduce if the person reached the end of the funnel,
+            # i.e. successful
+            include_timestamp=True,
+            # NOTE: we don't need these as we have all the information we need to
+            # deduce if the person was successful or not
+            include_preceding_timestamp=False,
+            no_person_limit=True,
+        )
+
     def get_contingency_table_query(self) -> Tuple[str, Dict[str, Any]]:
         """
         Returns a query string and params, which are used to generate the contingency table.
@@ -137,7 +151,11 @@ class FunnelCorrelation:
                 -- to include events that happened within the bounds of the 
                 -- persons time in the funnel.
                 AND event.timestamp > person.first_timestamp
-                AND event.timestamp < COALESCE(person.final_timestamp, date_to)
+                AND event.timestamp < COALESCE(
+                    person.final_timestamp,
+                    person.first_timestamp + INTERVAL {self._funnel_persons_generator._filter.funnel_window_interval} {self._funnel_persons_generator._filter.funnel_window_interval_unit_ch()},
+                    date_to)
+                    -- Ensure that the event is not outside the bounds of the funnel conversion window
 
                 -- Exclude funnel steps
                 AND event.event NOT IN funnel_step_names
@@ -179,15 +197,7 @@ class FunnelCorrelation:
 
         funnel_persons_query, funnel_persons_params = self.get_funnel_persons_cte()
 
-        person_property_expressions = []
-        person_property_params = {}
-        for index, property_name in enumerate(self._filter.correlation_property_names):
-            param_name = f"property_name_{index}"
-            expression, _ = get_property_string_expr(
-                "person", property_name, f"%({param_name})s", ClickhousePersonQuery.PERSON_PROPERTIES_ALIAS,
-            )
-            person_property_params[param_name] = property_name
-            person_property_expressions.append(expression)
+        prop_query, prop_params = self._get_properties_prop_clause()
 
         person_query = ClickhousePersonQuery(
             self._filter, self._team.pk, ColumnOptimizer(self._filter, self._team.pk)
@@ -230,10 +240,7 @@ class FunnelCorrelation:
                         To avoid clashes and clarify the values, we also zip with the property name, to generate
                         tuples like: (property_name, property_value), which we then group by
                     */
-                    arrayJoin(arrayZip(
-                        %(property_names)s,
-                        [{','.join(person_property_expressions)}]
-                    )) as prop
+                    {prop_query}
                 FROM funnel_people
                 JOIN ({person_query}) person
                 ON person.id = funnel_people.person_id
@@ -249,12 +256,48 @@ class FunnelCorrelation:
         """
         params = {
             **funnel_persons_params,
-            **person_property_params,
+            **prop_params,
             "target_step": len(self._filter.entities),
             "property_names": self._filter.correlation_property_names,
         }
 
         return query, params
+
+    def _get_properties_prop_clause(self):
+
+        if self._filter.get_all_properties:
+            return (
+                f"""
+            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw({ClickhousePersonQuery.PERSON_PROPERTIES_ALIAS})) as person_prop_keys,
+            arrayJoin(
+                arrayZip(
+                    person_prop_keys,
+                    arrayMap(x -> trim(BOTH '"' FROM JSONExtractRaw({ClickhousePersonQuery.PERSON_PROPERTIES_ALIAS}, x)), person_prop_keys)
+                )
+            ) as prop
+            """,
+                {},
+            )
+        else:
+            person_property_expressions = []
+            person_property_params = {}
+            for index, property_name in enumerate(cast(list, self._filter.correlation_property_names)):
+                param_name = f"property_name_{index}"
+                expression, _ = get_property_string_expr(
+                    "person", property_name, f"%({param_name})s", ClickhousePersonQuery.PERSON_PROPERTIES_ALIAS,
+                )
+                person_property_params[param_name] = property_name
+                person_property_expressions.append(expression)
+
+            return (
+                f"""
+                arrayJoin(arrayZip(
+                        %(property_names)s,
+                        [{','.join(person_property_expressions)}]
+                    )) as prop
+            """,
+                person_property_params,
+            )
 
     def run(self) -> FunnelCorrelationResponse:
         """
@@ -314,12 +357,8 @@ class FunnelCorrelation:
             correlation, e.g. "watched video"
 
         """
-        query, params = self.get_contingency_table_query()
-        results_with_total = sync_execute(query, params)
 
-        event_contingency_tables, success_total, failure_total = self.get_partial_event_contingency_tables(
-            results_with_total
-        )
+        event_contingency_tables, success_total, failure_total = self.get_partial_event_contingency_tables()
 
         if not success_total or not failure_total:
             return {"events": [], "skewed": True}
@@ -355,9 +394,7 @@ class FunnelCorrelation:
             "skewed": skewed_totals,
         }
 
-    def get_partial_event_contingency_tables(
-        self, results_with_total: list
-    ) -> Tuple[List[EventContingencyTable], int, int]:
+    def get_partial_event_contingency_tables(self) -> Tuple[List[EventContingencyTable], int, int]:
         """
         For each event a person that started going through the funnel, gets stats
         for how many of these users are sucessful and how many are unsuccessful.
@@ -366,6 +403,9 @@ class FunnelCorrelation:
         event, but does include the total success/failure numbers, which is enough
         for us to calculate the odds ratio.
         """
+
+        query, params = self.get_contingency_table_query()
+        results_with_total = sync_execute(query, params)
 
         # Get the total success/failure counts from the results
         results = [result for result in results_with_total if result[0] != self.TOTAL_IDENTIFIER]
@@ -390,22 +430,10 @@ class FunnelCorrelation:
         )
 
     def get_funnel_persons_cte(self) -> Tuple[str, Dict[str, Any]]:
-        funnel_persons_generator = ClickhouseFunnelPersons(
-            self._filter,
-            self._team,
-            # NOTE: we want to include the latest timestamp of the `target_step`,
-            # from this we can deduce if the person reached the end of the funnel,
-            # i.e. successful
-            include_timestamp=True,
-            # NOTE: we don't need these as we have all the information we need to
-            # deduce if the person was successful or not
-            include_preceding_timestamp=False,
-            no_person_limit=True,
-        )
 
         return (
-            funnel_persons_generator.get_query(extra_fields=["steps", "final_timestamp", "first_timestamp"]),
-            funnel_persons_generator.params,
+            self._funnel_persons_generator.get_query(extra_fields=["steps", "final_timestamp", "first_timestamp"]),
+            self._funnel_persons_generator.params,
         )
 
     @staticmethod

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -237,6 +237,12 @@ class FunnelCorrelationMixin(BaseParamMixin):
             return json.loads(property_names)
         return property_names
 
+    @property
+    def get_all_properties(self) -> bool:
+        if not self.correlation_property_names:
+            return False
+        return "$all" in self.correlation_property_names
+
     @include_dict
     def funnel_correlation_to_dict(self):
         result_dict: Dict = {}

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -237,12 +237,6 @@ class FunnelCorrelationMixin(BaseParamMixin):
             return json.loads(property_names)
         return property_names
 
-    @property
-    def get_all_properties(self) -> bool:
-        if not self.correlation_property_names:
-            return False
-        return "$all" in self.correlation_property_names
-
     @include_dict
     def funnel_correlation_to_dict(self):
         result_dict: Dict = {}


### PR DESCRIPTION
…n window

## Changes

1. Allows the option to run correlation analysis over all user props by passing in the `$all` special property.
2. Ensures that event correlations [RESTECP](https://www.youtube.com/watch?v=YWLMnX8F45M) the conversion window.

## How did you test this code?

Wrote a unit test