### PR TITLE
Revert "Test conditional workflows with backend tests"

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,21 +1,7 @@
 name: Backend CI
 
 on:
-    pull_request:
-        paths:
-            # Avoid running backend tests for irrelevant changes
-            # NOTE: we are at risk of missing a dependency here. We could make
-            # the dependencies more clear if we separated the backend/frontend
-            # code completely
-            - 'ee/**/*'
-            - 'posthog/**/*'
-            - requirements.txt
-            - requirements-dev.txt
-            - mypy.ini
-            - pytest.ini
-            # Make sure we run if someone is explicitly change the workflow
-            - .github/workflows/ci-backend.yml
-
+    - pull_request
 env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'


### PR DESCRIPTION
I initially put this in to avoid any flakiness from backend tests affecting unrelated changes. This works, except these are also required checks, and thus we wait endlessly.

There's probably a solution for this in https://github.community/t/github-actions-and-required-checks-in-a-monorepo-using-paths-to-limit-execution/16586/7

Specifically https://github.com/dorny/paths-filter#conditional-execution

But it's take too much of my time already 😢 

Reverts PostHog/posthog#6338