### PR TITLE
dev(arm): use x86 kafka image even on arm

### DIFF
--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -33,7 +33,7 @@ services:
         image: zookeeper
         restart: always
     kafka:
-        image: cfei/kafka
+        image: wurstmeister/kafka
         depends_on:
             - zookeeper
         ports:


### PR DESCRIPTION
We'll be using qemu that ships with docker for mac. I'd updated this at
the same time as zookeeper but obviously never removed the kafka
container from before somehow.