### PR TITLE
Hotfix simplify filters: avoid double expansion

### DIFF
--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -19,12 +19,12 @@ class SimplifyFilterMixin:
         - for cohort properties, replaces them with more concrete lookups or with cohort conditions
         """
 
-        if self._data.get("is_simplified"):
+        if self._data.get("is_simplified"):  # type: ignore
             return self
 
         # :TRICKY: Make a copy to avoid caching issues
         result: Any = self.with_data({"is_simplified": True})  # type: ignore
-        if getattr(self, "filter_test_accounts", False):
+        if getattr(result, "filter_test_accounts", False):
             result = result.with_data(
                 {"properties": result.properties + team.test_account_filters, "filter_test_accounts": False,}
             )

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -19,6 +19,9 @@ class SimplifyFilterMixin:
         - for cohort properties, replaces them with more concrete lookups or with cohort conditions
         """
 
+        if self._data.get("is_simplified"):
+            return self
+
         # :TRICKY: Make a copy to avoid caching issues
         result: Any = self.with_data({"is_simplified": True})  # type: ignore
         if getattr(self, "filter_test_accounts", False):

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -66,6 +66,16 @@ class TestFilter(BaseTest):
         )
         self.assertTrue(filter.is_simplified)
 
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {
+                "properties": [
+                    {"key": "attr", "value": "some_val", "operator": None, "type": "event"},
+                    {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"},
+                ]
+            },
+        )
+
 
 def property_to_Q_test_factory(filter_events: Callable, event_factory, person_factory):
     class TestPropertiesToQ(BaseTest):


### PR DESCRIPTION
## Changes

Related to https://github.com/PostHog/posthog/issues/6349 - allowing double expansion caused issued for us. In this case the issue was related to caching of instance methods.

Manually removed the unneeded test_account_filters in production

## How did you test this code?

*Please describe.*
