### PR TITLE
feat(correlation): add warning when funnel skewed

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -493,6 +493,12 @@ export const funnelLogic = kea<funnelLogicType>({
                 }
             },
         ],
+        isSkewed: [
+            () => [selectors.conversionMetrics],
+            (conversionMetrics: FunnelTimeConversionMetrics) => {
+                return conversionMetrics.totalRate < 0.1 || conversionMetrics.totalRate > 0.9
+            },
+        ],
         apiParams: [
             (s) => [s.filters],
             (filters) => {

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -1,0 +1,57 @@
+import { Card } from 'antd'
+import { useValues, kea } from 'kea'
+import React from 'react'
+import { funnelLogic } from 'scenes/funnels/funnelLogic'
+import { insightLogic } from './insightLogic'
+import WarningOutlined from '@ant-design/icons/lib/icons/WarningOutlined'
+
+import { FunnelCorrelationTable } from './InsightTabs/FunnelTab/FunnelCorrelationTable'
+import { FunnelPropertyCorrelationTable } from './InsightTabs/FunnelTab/FunnelPropertyCorrelationTable'
+import { FunnelTimeConversionMetrics } from '~/types'
+
+const funnelCorrelationLogic = kea({
+    connect: {
+        // pull in values from `funnelLogic`
+        values: [funnelLogic, ['conversionMetrics']],
+    },
+
+    selectors: ({ selectors }) => ({
+        isSkewed: [
+            () => [selectors.conversionMetrics],
+            (conversionMetrics: FunnelTimeConversionMetrics): boolean => {
+                return conversionMetrics.totalRate < 0.1 || conversionMetrics.totalRate > 0.9
+            },
+        ],
+    }),
+})
+
+const useIsSkewed = (): boolean => {
+    const { insightProps } = useValues(insightLogic)
+    const { isSkewed } = useValues(funnelCorrelationLogic(insightProps))
+    return isSkewed
+}
+
+export const FunnelCorrelation = (): JSX.Element => {
+    const skewed = useIsSkewed()
+
+    return (
+        <>
+            {skewed ? (
+                <Card style={{ marginTop: '1em' }}>
+                    <div style={{ display: 'flex' }}>
+                        <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+                            <WarningOutlined className="text-warning" style={{ paddingRight: 8 }} />
+                            <b>Funnel skewed!</b>
+                            Your funnel has a large skew to either successes or failures. With such funnels it's hard to
+                            get meaningful odds for events and property correlations. Try adjusting your funnel to have
+                            a more balanced success/failure ratio.
+                        </div>
+                    </div>
+                </Card>
+            ) : null}
+
+            <FunnelCorrelationTable />
+            <FunnelPropertyCorrelationTable />
+        </>
+    )
+}

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -1,5 +1,5 @@
 import { Card } from 'antd'
-import { useValues, kea } from 'kea'
+import { useValues } from 'kea'
 import React from 'react'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic } from './insightLogic'
@@ -7,28 +7,11 @@ import WarningOutlined from '@ant-design/icons/lib/icons/WarningOutlined'
 
 import { FunnelCorrelationTable } from './InsightTabs/FunnelTab/FunnelCorrelationTable'
 import { FunnelPropertyCorrelationTable } from './InsightTabs/FunnelTab/FunnelPropertyCorrelationTable'
-import { FunnelTimeConversionMetrics } from '~/types'
-
-const funnelCorrelationLogic = kea({
-    connect: {
-        // pull in values from `funnelLogic`
-        values: [funnelLogic, ['conversionMetrics']],
-    },
-
-    selectors: ({ selectors }) => ({
-        isSkewed: [
-            () => [selectors.conversionMetrics],
-            (conversionMetrics: FunnelTimeConversionMetrics): boolean => {
-                return conversionMetrics.totalRate < 0.1 || conversionMetrics.totalRate > 0.9
-            },
-        ],
-    }),
-})
 
 const useIsSkewed = (): boolean => {
     const { insightProps } = useValues(insightLogic)
-    const { isSkewed } = useValues(funnelCorrelationLogic(insightProps))
-    return isSkewed
+    const { conversionMetrics } = useValues(funnelLogic(insightProps))
+    return conversionMetrics.totalRate < 0.1 || conversionMetrics.totalRate > 0.9
 }
 
 export const FunnelCorrelation = (): JSX.Element => {

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -8,18 +8,13 @@ import WarningOutlined from '@ant-design/icons/lib/icons/WarningOutlined'
 import { FunnelCorrelationTable } from './InsightTabs/FunnelTab/FunnelCorrelationTable'
 import { FunnelPropertyCorrelationTable } from './InsightTabs/FunnelTab/FunnelPropertyCorrelationTable'
 
-const useIsSkewed = (): boolean => {
-    const { insightProps } = useValues(insightLogic)
-    const { conversionMetrics } = useValues(funnelLogic(insightProps))
-    return conversionMetrics.totalRate < 0.1 || conversionMetrics.totalRate > 0.9
-}
-
 export const FunnelCorrelation = (): JSX.Element => {
-    const skewed = useIsSkewed()
+    const { insightProps } = useValues(insightLogic)
+    const { isSkewed } = useValues(funnelLogic(insightProps))
 
     return (
         <>
-            {skewed ? (
+            {isSkewed ? (
                 <Card style={{ marginTop: '1em' }}>
                     <div style={{ display: 'flex' }}>
                         <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -29,10 +29,8 @@ import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import clsx from 'clsx'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FunnelCorrelationTable } from './InsightTabs/FunnelTab/FunnelCorrelationTable'
 import { PathCanvasLabel } from 'scenes/paths/PathsLabel'
-import { FunnelPropertyCorrelationTable } from './InsightTabs/FunnelTab/FunnelPropertyCorrelationTable'
-import WarningOutlined from '@ant-design/icons/lib/icons/WarningOutlined'
+import { FunnelCorrelation } from './FunnelCorrelation'
 
 interface Props {
     loadResults: () => void
@@ -203,41 +201,6 @@ export function InsightContainer({ loadResults, resultsLoading }: Props): JSX.El
             featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] ? (
                 <FunnelCorrelation />
             ) : null}
-        </>
-    )
-}
-
-const FunnelCorrelation: React.FC = () => {
-    const { insightProps } = useValues(insightLogic)
-    const { stepsWithCount } = useValues(funnelLogic(insightProps))
-
-    // If the ratio of success to failure if too great, we want to give a
-    // warning that we are unlikely to have accurate results.
-    let skewed = false
-    if (stepsWithCount?.length) {
-        const totalPeople = stepsWithCount[0].count
-        const successfulPeople = stepsWithCount.slice(-1)[0].count
-        skewed = Math.abs((2 * successfulPeople) / totalPeople - 1) > 0.8
-    }
-
-    return (
-        <>
-            {skewed ? (
-                <Card style={{ marginTop: '1em' }}>
-                    <div style={{ display: 'flex' }}>
-                        <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
-                            <WarningOutlined className="text-warning" style={{ paddingRight: 8 }} />
-                            <b>Funnel skewed!</b>
-                            Your funnel has a large skew to either successes or failures. With such funnels it's hard to
-                            get meaningful odds for events and property correlations. Try adjusting your funnel to have
-                            a more balanced success/failure ratio.
-                        </div>
-                    </div>
-                </Card>
-            ) : null}
-
-            <FunnelCorrelationTable />
-            <FunnelPropertyCorrelationTable />
         </>
     )
 }


### PR DESCRIPTION
This actual just uses the funnel numbers rather than the correlation
endpoint as this gives us a little more freedom to, for instance, add
details of why we think there might be inaccurate results, without
having to update the definition in the backend as well.

And alternative option might be to introduce an error code along with a
human readable message that includes the details of skew reasoning,
returned from the API, but I think this gives us what we want.

<img width="1792" alt="Screenshot 2021-10-12 at 10 39 35" src="https://user-images.githubusercontent.com/128561/136932191-c93c41e6-9345-4eb9-a5aa-21a840a358a8.png">
