### PR TITLE
Fix Error on Property Correlations

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -615,7 +615,10 @@ export const funnelLogic = kea<funnelLogicType>({
     }),
 
     listeners: ({ actions, values, props }) => ({
-        loadResultsSuccess: async () => {
+        loadResultsSuccess: async ({ insight }) => {
+            if (insight.filters?.insight !== ViewType.FUNNELS) {
+                return
+            }
             // hide all but the first five breakdowns for each step
             values.steps?.forEach((step) => {
                 values.flattenedStepsByBreakdown


### PR DESCRIPTION
## Changes

Fixes this:

![2021-10-11 20 46 12](https://user-images.githubusercontent.com/53387/136839434-ca97ddea-7079-4042-a047-a6ad39eb5805.gif)

The `funnelLogic` was listening to `loadResultsSuccess` and flipping switches. This used to always run for loading funnel results, but after the last insights refactor, this will be run for any result that's loaded.

## How did you test this code?

Made the fix and didn't see the error anymore
