### PR TITLE
Recording filters are stored in URL

### DIFF
--- a/frontend/src/scenes/sessionRecordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/sessionRecordings/SessionRecordingsTable.tsx
@@ -191,7 +191,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                     }}
                     dataSource={sessionRecordings}
                     columns={columns}
-                    loading={sessionRecordings.length === 0 && sessionRecordingsResponseLoading}
+                    loading={sessionRecordingsResponseLoading}
                     pagination={false}
                     onRow={(sessionRecording) => ({
                         onClick: (e) => {

--- a/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.ts
@@ -1,7 +1,14 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
-import { EntityTypes, FilterType, PropertyOperator, RecordingDurationFilter, SessionRecordingType } from '~/types'
+import {
+    EntityTypes,
+    FilterType,
+    PropertyOperator,
+    RecordingDurationFilter,
+    RecordingFilters,
+    SessionRecordingsResponse,
+} from '~/types'
 import { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
 import { router } from 'kea-router'
 import dayjs from 'dayjs'
@@ -10,14 +17,9 @@ import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 export type SessionRecordingId = string
 export type PersonUUID = string
 interface Params {
-    properties?: any
+    filters?: RecordingFilters
     sessionRecordingId?: SessionRecordingId
     source?: RecordingWatchedSource
-}
-
-export interface SessionRecordingsResponse {
-    results: SessionRecordingType[]
-    has_next: boolean
 }
 
 const LIMIT = 50
@@ -35,9 +37,7 @@ export const DEFAULT_ENTITY_FILTERS = {
     ],
 }
 
-export const sessionRecordingsTableLogic = kea<
-    sessionRecordingsTableLogicType<PersonUUID, SessionRecordingId, SessionRecordingsResponse>
->({
+export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<PersonUUID, SessionRecordingId>>({
     key: (props) => props.personUUID || 'global',
     props: {} as {
         personUUID?: PersonUUID
@@ -53,6 +53,7 @@ export const sessionRecordingsTableLogic = kea<
         loadNext: true,
         loadPrev: true,
         enableEntityFilter: true,
+        setOffset: (offset: number) => ({ offset }),
         setDateRange: (incomingFromDate: string | undefined, incomingToDate: string | undefined) => ({
             incomingFromDate,
             incomingToDate,
@@ -67,16 +68,12 @@ export const sessionRecordingsTableLogic = kea<
             } as SessionRecordingsResponse,
             {
                 getSessionRecordings: async (_, breakpoint) => {
-                    const params = toParams({
+                    const paramsDict = {
+                        ...values.filterQueryParams,
                         person_uuid: props.personUUID ?? '',
-                        actions: values.entityFilters.actions,
-                        events: values.entityFilters.events,
-                        date_from: values.fromDate,
-                        date_to: values.toDate,
-                        offset: values.offset,
-                        session_recording_duration: values.durationFilter,
                         limit: LIMIT,
-                    })
+                    }
+                    const params = toParams(paramsDict)
                     await breakpoint(100) // Debounce for lots of quick filter changes
                     const response = await api.get(`api/projects/@current/session_recordings?${params}`)
                     breakpoint()
@@ -129,7 +126,7 @@ export const sessionRecordingsTableLogic = kea<
         entityFilters: [
             DEFAULT_ENTITY_FILTERS as FilterType,
             {
-                setEntityFilters: (state, { filters }) => ({ ...state, ...filters }),
+                setEntityFilters: (_, { filters }) => ({ ...filters }),
             },
         ],
         durationFilter: [
@@ -148,6 +145,7 @@ export const sessionRecordingsTableLogic = kea<
             {
                 loadNext: (previousOffset) => previousOffset + LIMIT,
                 loadPrev: (previousOffset) => Math.max(previousOffset - LIMIT),
+                setOffset: (_, { offset }) => offset,
             },
         ],
         fromDate: [
@@ -192,6 +190,19 @@ export const sessionRecordingsTableLogic = kea<
                 return entityFilterEnabled || entityFilters !== DEFAULT_ENTITY_FILTERS
             },
         ],
+        filterQueryParams: [
+            (s) => [s.entityFilters, s.fromDate, s.toDate, s.offset, s.durationFilter],
+            (entityFilters, fromDate, toDate, offset, durationFilter) => {
+                return {
+                    actions: entityFilters.actions,
+                    events: entityFilters.events,
+                    date_from: fromDate,
+                    date_to: toDate,
+                    offset: offset,
+                    session_recording_duration: durationFilter,
+                }
+            },
+        ],
     },
     actionToUrl: ({ values }) => {
         const buildURL = (
@@ -205,13 +216,11 @@ export const sessionRecordingsTableLogic = kea<
                 replace: boolean
             }
         ] => {
-            const { properties } = router.values.searchParams
             const params: Params = {
-                properties: properties || undefined,
                 sessionRecordingId: values.sessionRecordingId || undefined,
+                filters: values.filterQueryParams,
                 ...overrides,
             }
-
             return [router.values.location.pathname, params, router.values.hashParams, { replace }]
         }
 
@@ -219,6 +228,11 @@ export const sessionRecordingsTableLogic = kea<
             loadSessionRecordings: () => buildURL({}, true),
             openSessionPlayer: ({ source }) => buildURL({ source }),
             closeSessionPlayer: () => buildURL({ sessionRecordingId: undefined }),
+            setEntityFilters: () => buildURL({}, true),
+            setDateRange: () => buildURL({}, true),
+            setDurationFilter: () => buildURL({}, true),
+            loadNext: () => buildURL({}, true),
+            loadPrev: () => buildURL({}, true),
         }
     },
 
@@ -227,6 +241,25 @@ export const sessionRecordingsTableLogic = kea<
             const nulledSessionRecordingId = params.sessionRecordingId ?? null
             if (nulledSessionRecordingId !== values.sessionRecordingId) {
                 actions.openSessionPlayer(nulledSessionRecordingId, RecordingWatchedSource.Direct)
+            }
+
+            const filters = params.filters
+            if (filters) {
+                if ((filters.actions && filters.actions.length > 0) || (filters.events && filters.events.length > 0)) {
+                    actions.setEntityFilters({
+                        events: filters.events || [],
+                        actions: filters.actions || [],
+                    })
+                }
+                if (filters.date_from || filters.date_to) {
+                    actions.setDateRange(filters.date_from ?? undefined, filters.date_to ?? undefined)
+                }
+                if (filters.offset) {
+                    actions.setOffset(filters.offset)
+                }
+                if (filters.session_recording_duration) {
+                    actions.setDurationFilter(filters.session_recording_duration)
+                }
             }
         }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -320,6 +320,19 @@ export interface RecordingDurationFilter extends BasePropertyFilter {
     operator: PropertyOperator
 }
 
+export interface RecordingFilters {
+    date_from?: string | null
+    date_to?: string | null
+    events?: Record<string, any>[]
+    actions?: Record<string, any>[]
+    offset?: number
+    session_recording_duration?: RecordingDurationFilter
+}
+export interface SessionRecordingsResponse {
+    results: SessionRecordingType[]
+    has_next: boolean
+}
+
 interface RecordingNotViewedFilter extends BasePropertyFilter {
     type: 'recording'
     key: 'unseen'


### PR DESCRIPTION
## Changes

This PR stores recording filters in the URL. Now:
* Every time you update a filter on the recordings page, it is added as a query param on the URL
* When you open a recording, the query params are read from the URL and applied to the list

(Closing: https://github.com/PostHog/posthog/issues/6318)

🐛 Fix: The loading indicator on the list now appears every time the list is updating.

## How did you test this code?

* The URL work is tested via logic tests.
* The bug fix was verified locally by updating filters and seeing the loading indicator appear.
