### PR TITLE
Paths dashboard item fix

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -50,7 +50,7 @@
     .dashboard-item-content {
         height: 100%;
         margin: 8px 15px 15px 15px;
-        overflow: hidden;
+        overflow: scroll;
         flex-grow: 1;
         position: relative;
         .graph-container {

--- a/frontend/src/scenes/paths/NewPaths.tsx
+++ b/frontend/src/scenes/paths/NewPaths.tsx
@@ -282,6 +282,7 @@ export function NewPaths({ dashboardItemId = null, color = 'white' }: PathsProps
             style={{
                 position: 'relative',
                 overflowX: 'scroll',
+                overflowY: 'scroll',
             }}
             id={`'${dashboardItemId || DEFAULT_PATHS_ID}'`}
         >


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

I think it's unreasonable to try to squish a giant paths viz inside of the tiny dashboard item box, so let's enable scrolling inside of it?

https://user-images.githubusercontent.com/25164963/136963787-86a863ce-90bb-4e5f-85c3-84a3013fc749.mov



## How did you test this code?

*Please describe.*
