### PR TITLE
Rename "Explore" to "New Insight"

### DIFF
--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -229,7 +229,7 @@ function MenuItems(): JSX.Element {
             )}
             {featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && (
                 <MenuItem
-                    title="Explore"
+                    title="New Insight"
                     icon={<IconExplore />}
                     identifier="insights"
                     to={urls.insightView(ViewType.TRENDS)}


### PR DESCRIPTION
## Changes

When saved insights are enabled, this renames the first sidebar button from "Explore" to "New Insight"

This [seems to improve UX](https://github.com/PostHog/posthog/issues/6288).

![image](https://user-images.githubusercontent.com/53387/136969310-881a1970-2411-4149-b36a-9815bfd30e6d.png)

... especially as the blue "New Insight" button on the insights scene is so far to the right to be slightly invisible.

![image](https://user-images.githubusercontent.com/53387/136969146-762a231b-e3ff-43c3-ae67-c253d75c772a.png)

## How did you test this code?

*Please describe.*
