### PR TITLE
Fix white screening from paths filter exclusion dropdown

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -495,7 +495,7 @@ export function NewPathTab(): JSX.Element {
                             }))
                         }
                         onChange={(values) => {
-                            const exclusion = values[0] ? [values[0].value] : values
+                            const exclusion = values.length > 0 ? values.map((v) => v.value) : values
                             updateExclusions(exclusion as string[])
                         }}
                         wildcardOptions={wildcards}

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -494,7 +494,10 @@ export function NewPathTab(): JSX.Element {
                                 type: 'event',
                             }))
                         }
-                        onChange={(values) => updateExclusions(values.filter((a) => !!a) as string[])}
+                        onChange={(values) => {
+                            const exclusion = values[0] ? [values[0].value] : values
+                            updateExclusions(exclusion as string[])
+                        }}
                         wildcardOptions={wildcards}
                     />
                 </Col>


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

This was causing a white screen because we were passing incorrect values to the exclusions parameter

<img width="771" alt="Screen Shot 2021-10-12 at 11 17 33 AM" src="https://user-images.githubusercontent.com/25164963/136983506-1299dc20-02fe-4c93-8f91-29d0c3161768.png">


## How did you test this code?

*Please describe.*
