### PR TITLE
Better display of Feature flags table with long key and description

### DIFF
--- a/frontend/src/lib/utils/stringWithWBR.tsx
+++ b/frontend/src/lib/utils/stringWithWBR.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function stringWithWBR(text: string): JSX.Element {
+export default function stringWithWBR(text: string, splitAt = 30): JSX.Element {
     const addWBRAfter = [',', '.', '/', '\\']
     const naturalSplit = [' ', '-']
 
@@ -14,7 +14,7 @@ export default function stringWithWBR(text: string): JSX.Element {
     }
 
     text.split('').forEach((letter) => {
-        if (addWBRAfter.indexOf(letter) >= 0 || sinceSplit >= 30) {
+        if (addWBRAfter.indexOf(letter) >= 0 || sinceSplit >= splitAt) {
             sinceSplit = 0
             final += letter
             returnArray.push(<span key={i++}>{final}</span>)

--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -15,6 +15,7 @@ import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { normalizeColumnTitle, useIsTableScrolling } from 'lib/components/Table/utils'
 import { urls } from 'scenes/urls'
 import { Tooltip } from 'lib/components/Tooltip'
+import stringWithWBR from 'lib/utils/stringWithWBR'
 
 export function FeatureFlags(): JSX.Element {
     const { featureFlags, featureFlagsLoading } = useValues(featureFlagsLogic)
@@ -54,9 +55,7 @@ export function FeatureFlags(): JSX.Element {
                                 explicitValue={featureFlag.key}
                             />
                         </div>
-                        <Typography.Text ellipsis={true} title={featureFlag.key}>
-                            {featureFlag.key}
-                        </Typography.Text>
+                        <Typography.Text title={featureFlag.key}>{stringWithWBR(featureFlag.key, 20)}</Typography.Text>
                     </div>
                 )
             },

--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
 import { featureFlagsLogic } from './featureFlagsLogic'
-import { Table, Switch } from 'antd'
+import { Table, Switch, Typography } from 'antd'
 import { Link } from 'lib/components/Link'
 import { DeleteWithUndo } from 'lib/utils'
 import { ExportOutlined, PlusOutlined, DeleteOutlined, EditOutlined, DisconnectOutlined } from '@ant-design/icons'
@@ -54,7 +54,9 @@ export function FeatureFlags(): JSX.Element {
                                 explicitValue={featureFlag.key}
                             />
                         </div>
-                        <span style={{ marginRight: 4 }}>{featureFlag.key}</span>
+                        <Typography.Text ellipsis={true} title={featureFlag.key}>
+                            {featureFlag.key}
+                        </Typography.Text>
                     </div>
                 )
             },
@@ -71,7 +73,9 @@ export function FeatureFlags(): JSX.Element {
                             whiteSpace: 'break-spaces',
                         }}
                     >
-                        {featureFlag.name}
+                        <Typography.Text ellipsis={true} title={featureFlag.name}>
+                            {featureFlag.name}
+                        </Typography.Text>
                     </div>
                 )
             },

--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -67,15 +67,21 @@ export function FeatureFlags(): JSX.Element {
                 return (
                     <div
                         style={{
+                            display: 'flex',
                             wordWrap: 'break-word',
                             maxWidth: 450,
                             width: 'auto',
                             whiteSpace: 'break-spaces',
                         }}
                     >
-                        <Typography.Text ellipsis={true} title={featureFlag.name}>
+                        <Typography.Paragraph
+                            ellipsis={{
+                                rows: 5,
+                            }}
+                            title={featureFlag.name}
+                        >
                             {featureFlag.name}
-                        </Typography.Text>
+                        </Typography.Paragraph>
                     </div>
                 )
             },

--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -55,7 +55,7 @@ export function FeatureFlags(): JSX.Element {
                                 explicitValue={featureFlag.key}
                             />
                         </div>
-                        <Typography.Text title={featureFlag.key}>{stringWithWBR(featureFlag.key, 20)}</Typography.Text>
+                        <Typography.Text title={featureFlag.key}>{stringWithWBR(featureFlag.key, 17)}</Typography.Text>
                     </div>
                 )
             },


### PR DESCRIPTION
## Changes

relates to #6396 

The feature flags table did not handle very long values well. Columns would overlap

<img width="681" alt="Screenshot 2021-10-13 at 15 20 09" src="https://user-images.githubusercontent.com/984817/137151798-a2bd5c0c-2c92-4d06-bde6-b26def845c5e.png">

This change does not alter what length the values have but rather allows the table to handle displaying long values better

<img width="677" alt="Screenshot 2021-10-13 at 15 18 47" src="https://user-images.githubusercontent.com/984817/137151820-944f66be-0e7c-4e06-9f06-a4c24190fbb5.png">

## How did you test this code?

by running locally
