### PR TITLE
Release ingestion help button

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -234,7 +234,6 @@ export const FEATURE_FLAGS = {
     INGESTION_TAXONOMY: '4267-event-property-taxonomy',
     PLUGIN_METRICS: '4871-plugin-metrics',
     SESSIONS_TABLE: '4964-sessions-table', // Expand/collapse all in sessions table (performance consideration)
-    INGESTION_HELP_BUTTON: '112-ingestion-help-button',
     SAVED_INSIGHTS: '3408-saved-insights',
     MULTIVARIATE_SUPPORT: '5440-multivariate-support',
     FUNNEL_HORIZONTAL_UI: '5730-funnel-horizontal-ui',

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -6,18 +6,15 @@ import { Button, Row, Spin, Space, Popconfirm, Dropdown, Menu, Typography } from
 import { ingestionLogic } from 'scenes/ingestion/ingestionLogic'
 import { DownOutlined, SlackSquareOutlined, ReadOutlined } from '@ant-design/icons'
 import { CreateInviteModalWithButton } from 'scenes/organization/Settings/CreateInviteModal'
+import { teamLogic } from 'scenes/teamLogic'
 
 const { Text } = Typography
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { teamLogic } from 'scenes/teamLogic'
 
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
     const { setVerify, completeOnboarding } = useActions(ingestionLogic)
     const { index, totalSteps } = useValues(ingestionLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const [isPopConfirmShowing, setPopConfirmShowing] = useState(false)
     const [isHelpMenuShowing, setHelpMenuShowing] = useState(false)
 
@@ -111,19 +108,6 @@ export function VerificationPanel(): JSX.Element {
         )
     }
 
-    function DefaultSkipCta(): JSX.Element {
-        return (
-            <b
-                data-attr="wizard-complete-button"
-                style={{ float: 'right' }}
-                className="button-border clickable"
-                onClick={completeOnboarding}
-            >
-                Continue without verifying
-            </b>
-        )
-    }
-
     return (
         <CardContainer index={index} totalSteps={totalSteps} onBack={() => setVerify(false)}>
             {!currentTeam?.ingested_event ? (
@@ -137,7 +121,7 @@ export function VerificationPanel(): JSX.Element {
                         Once you have integrated the snippet and sent an event, we will verify it sent properly and
                         continue.
                     </p>
-                    {featureFlags[FEATURE_FLAGS.INGESTION_HELP_BUTTON] ? <HelperButtonRow /> : <DefaultSkipCta />}
+                    <HelperButtonRow />
                 </>
             ) : (
                 <>


### PR DESCRIPTION
## Changes

This releases the ingestion help button if you haven't verified events have been ingested. This standalone seems like a good improvement on the experience.

## How did you test this code?

- Manually went through an ingestion flow and made sure it showed up.
