### PR TITLE
Add scale plan in license.py

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -66,7 +66,7 @@ class License(models.Model):
     ENTERPRISE_FEATURES = SCALE_FEATURES + [
         AvailableFeature.SAML,
     ]
-    PLANS = {SCALE_PLAN: SCALE_PLAN, ENTERPRISE_PLAN: ENTERPRISE_FEATURES}
+    PLANS = {SCALE_PLAN: SCALE_FEATURES, ENTERPRISE_PLAN: ENTERPRISE_FEATURES}
 
     @property
     def available_features(self) -> List[AvailableFeature]:

--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -52,17 +52,21 @@ class License(models.Model):
     key: models.CharField = models.CharField(max_length=200)
     max_users: models.IntegerField = models.IntegerField(default=None, null=True)  # None = no restriction
 
-    ENTERPRISE_PLAN = "enterprise"
-    ENTERPRISE_FEATURES = [
+    SCALE_PLAN = "scale"
+    SCALE_FEATURES = [
         AvailableFeature.ZAPIER,
         AvailableFeature.ORGANIZATIONS_PROJECTS,
         AvailableFeature.PROJECT_BASED_PERMISSIONING,
         AvailableFeature.GOOGLE_LOGIN,
-        AvailableFeature.SAML,
         AvailableFeature.DASHBOARD_COLLABORATION,
         AvailableFeature.INGESTION_TAXONOMY,
-    ]  # Base premium features
-    PLANS = {ENTERPRISE_PLAN: ENTERPRISE_FEATURES}
+    ]
+
+    ENTERPRISE_PLAN = "enterprise"
+    ENTERPRISE_FEATURES = SCALE_FEATURES + [
+        AvailableFeature.SAML,
+    ]
+    PLANS = {SCALE_PLAN: SCALE_PLAN, ENTERPRISE_PLAN: ENTERPRISE_FEATURES}
 
     @property
     def available_features(self) -> List[AvailableFeature]:


### PR DESCRIPTION
## Changes

This adds a scale plan to the possible options in license.py. Want to get this in before the next release so we can start handing out license keys for scale.

Right now enterprise only has SAML as an extra feature but that will change.

## How did you test this code?

Haven't yet, will do with the preview
