### PR TITLE
remove session recording retention from self-hosted clickhouse

### DIFF
--- a/frontend/src/scenes/project/Settings/SessionRecording.tsx
+++ b/frontend/src/scenes/project/Settings/SessionRecording.tsx
@@ -35,7 +35,7 @@ export function SessionRecording(): JSX.Element {
                 </label>
             </div>
 
-            {currentTeam?.session_recording_opt_in && !preflight?.cloud && (
+            {currentTeam?.session_recording_opt_in && !preflight?.cloud && !preflight?.is_clickhouse_enabled && (
                 <>
                     <div style={{ marginBottom: 8 }}>
                         <Switch


### PR DESCRIPTION
## Changes

Quick fix to remove the session recording retention setting from clickhouse instances. It doesn't do anything on clickhouse instances, so showing it was deceptive.

More context from @macobo on slack:

https://posthog.slack.com/archives/C01G8S5T08Z/p1634134417040500

### Screenshot of the setting now (same as cloud):
![image](https://user-images.githubusercontent.com/4813045/137185362-8fce2c14-a49e-45a2-b406-e319fbd74a0d.png)


## How did you test this code?

Set up a clickhouse dev-env and verified the setting is no longer there. Then, I set up a pg dev-env and verified the setting is still there.
