### PR TITLE
allow annotations on line graphs when comparing with previous

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -69,11 +69,7 @@ export function LineGraph({
     const { featureFlags } = useValues(featureFlagLogic)
 
     const annotationsCondition =
-        type === 'line' &&
-        datasets?.length > 0 &&
-        !datasets[0].compare &&
-        !inSharedMode &&
-        datasets[0].labels?.[0] !== '1 day' // stickiness graphs
+        type === 'line' && datasets?.length > 0 && !inSharedMode && datasets[0].labels?.[0] !== '1 day' // stickiness graphs
 
     const colors = getGraphColors(color === 'white')
 


### PR DESCRIPTION
## Changes

see #6363 

this allows annotations to show when comparing previous

it does not colour code the annotations

## How did you test this code?

by running locally
