### PR TITLE
Fix project reset token endpoint

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -169,4 +169,4 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         team = self.get_object()
         team.api_token = generate_random_token_project()
         team.save()
-        return response.Response(TeamSerializer(team).data)
+        return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -134,16 +134,18 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         Special permissions handling for create requests as the organization is inferred from the current user.
         """
         base_permissions = [permission() for permission in self.permission_classes]
-        if self.action == "create":
-            organization = getattr(self.request.user, "organization", None)
-            if not organization:
-                raise exceptions.ValidationError("You need to belong to an organization.")
-            # To be used later by OrganizationAdminWritePermissions and TeamSerializer
-            self.organization = organization
-            base_permissions.append(OrganizationAdminWritePermissions())
-        elif self.action != "list":
-            # Skip TeamMemberAccessPermission for list action, as list is serialized with limited TeamBasicSerializer
-            base_permissions.append(TeamMemberLightManagementPermission())
+        if self.action:
+            # Return early for non-actions (e.g. OPTIONS)
+            if self.action == "create":
+                organization = getattr(self.request.user, "organization", None)
+                if not organization:
+                    raise exceptions.ValidationError("You need to belong to an organization.")
+                # To be used later by OrganizationAdminWritePermissions and TeamSerializer
+                self.organization = organization
+                base_permissions.append(OrganizationAdminWritePermissions())
+            elif self.action != "list":
+                # Skip TeamMemberAccessPermission for list action, as list is serialized with limited TeamBasicSerializer
+                base_permissions.append(TeamMemberLightManagementPermission())
         return base_permissions
 
     def get_object(self):

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -129,3 +129,16 @@ class TestTeamAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Team.objects.filter(organization=self.organization).count(), 1)
+
+    def test_reset_token(self):
+        self.team.api_token = "xyz"
+        self.team.save()
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/reset_token/")
+        response_data = response.json()
+
+        self.team.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(response_data["api_token"], "xyz")
+        self.assertEqual(response_data["api_token"], self.team.api_token)
+        self.assertTrue(response_data["api_token"].startswith("phc_"))

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -181,7 +181,7 @@ class TeamMemberLightManagementPermission(BasePermission):
 
     def has_permission(self, request, view) -> bool:
         try:
-            if request.resolver_match.url_name == "team-detail":
+            if request.resolver_match.url_name.startswith("team-"):
                 # /projects/ endpoint handling
                 team = view.get_object()
             else:


### PR DESCRIPTION
## Changes

`reset_token` was not playing well with permissioning. Now it is.

## How did you test this code?

Added an endpoint test.
