### PR TITLE
Clean up Storybook workflows

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -1,25 +1,18 @@
-# .github/workflows/chromatic.yml
-
-# Workflow name
 name: 'Storybook Chromatic'
 
-# Event for the workflow
-on: push
+on: pull_request
 
-# List of jobs
 jobs:
     storybook-chromatic:
-        # Operating System
         runs-on: ubuntu-latest
-        # Job steps
         steps:
             - uses: actions/checkout@v1
+
             - name: Install dependencies and chromatic
               run: yarn add --dev chromatic
-              # 👇 Adds Chromatic as a step in the workflow
+
             - name: Publish to Chromatic
               uses: chromaui/action@v1
-              # Chromatic GitHub Action options
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   # 👇 Chromatic projectToken, refer to the manage page to obtain it.

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,43 +1,41 @@
-# .github/workflows/chromatic.yml
-
-# Workflow name
 name: 'Storybook Deployment'
 
-# Event for the workflow
 on:
     push:
         branches:
             - master
             - main
 
-# List of jobs
 jobs:
     storybook-deployment:
-        # Operating System
         runs-on: ubuntu-latest
-        # Job steps
         steps:
             - name: Check out PostHog/posthog repo
               uses: actions/checkout@v2
               with:
                   path: posthog
                   fetch-depth: 0
+
             - name: Install dependencies (yarn)
               run: cd posthog && yarn
+
             - name: Build storybook
               run: cd posthog && yarn build-storybook
+
             - name: Check out PostHog/storybook-build repo
               uses: actions/checkout@v2
               with:
                   path: storybook-build
                   repository: PostHog/storybook-build
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+
             - name: Copy built changes to PostHog/storybook-build repo
               run: |
                   # keep the CNAME file, but discard all the rest
                   cp storybook-build/docs/CNAME posthog/storybook-static/
                   rm -rf storybook-build/docs
                   cp -a posthog/storybook-static storybook-build/docs
+
             - name: Commit update
               if: github.repository == 'PostHog/posthog'
               uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
## Changes

This makes the YAML look a bit nicer, but most importantly changes the trigger for the `storybook-chromatic` job from `push` (push on _any_ branch) to `pr` (push on branches that have a PR open). It doesn't seem useful to run this on PR-less branches.