### PR TITLE
Insights: make sure to remove shown_as when switching to trends from stickiness

### DIFF
--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -1,5 +1,6 @@
 import { cleanFilters } from './cleanFilters'
 import { ChartDisplayType } from '~/types'
+import { ShownAsValue } from 'lib/constants'
 
 describe('cleanFilters', () => {
     it('switches display to table if moving from TRENDS to RETENTION', () => {
@@ -9,5 +10,14 @@ describe('cleanFilters', () => {
                 { insight: 'TRENDS', display: ChartDisplayType.ActionsLineGraphLinear }
             )
         ).toEqual(expect.objectContaining({ insight: 'RETENTION', display: ChartDisplayType.ActionsTable }))
+    })
+
+    it('removes shownas if moving from stickiness to trends', () => {
+        expect(
+            cleanFilters(
+                { insight: 'TRENDS', shown_as: ShownAsValue.STICKINESS },
+                { insight: 'STICKINESS', shown_as: ShownAsValue.STICKINESS }
+            )
+        ).toEqual(expect.objectContaining({ insight: 'TRENDS', shown_as: undefined }))
     })
 })

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -133,9 +133,10 @@ export function cleanFilters(filters: Partial<FilterType>, oldFilters?: Partial<
         // TODO: Deprecated; should be removed once backend is updated
         if (filters.insight === ViewType.STICKINESS) {
             cleanSearchParams['shown_as'] = ShownAsValue.STICKINESS
-        }
-        if (filters.insight === ViewType.LIFECYCLE) {
+        } else if (filters.insight === ViewType.LIFECYCLE) {
             cleanSearchParams['shown_as'] = ShownAsValue.LIFECYCLE
+        } else {
+            cleanSearchParams['shown_as'] = undefined
         }
 
         if (filters.insight === ViewType.SESSIONS && !filters.session) {


### PR DESCRIPTION
## Changes

*Please describe.*  
- when switching from stickiness to trends, shown_as was persisting which caused the api to return stickiness data and display it on a trends chart
- this ensures that shown_as will be cleared when switching to trends
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*
Logic test