### PR TITLE
Fix the destination for "Insights" on feature flag page

### DIFF
--- a/frontend/src/scenes/experimentation/FeatureFlags.tsx
+++ b/frontend/src/scenes/experimentation/FeatureFlags.tsx
@@ -124,12 +124,7 @@ export function FeatureFlags(): JSX.Element {
             render: function Render(_: string, featureFlag: FeatureFlagType) {
                 return (
                     <Link
-                        to={
-                            '/insights?events=[{"id":"$pageview","name":"$pageview","type":"events","math":"dau"}]&properties=[{"key":"$active_feature_flags","operator":"icontains","value":"' +
-                            featureFlag.key +
-                            '"}]&breakdown_type=event' +
-                            BackTo
-                        }
+                        to={`/insights?events=[{"id":"$pageview","name":"$pageview","type":"events","math":"dau"}]&breakdown_type=event&breakdown=$feature/${featureFlag.key}${BackTo}`}
                         data-attr="usage"
                         onClick={(e) => e.stopPropagation()}
                     >


### PR DESCRIPTION
## Changes

The [feature flag list page](https://app.posthog.com/feature_flags) currently leads to an invalid insight when you click `Insights ➡️`. This PR fixes that.

Simply removing `breakdown_type=event` will cause the query to run OK, but it is interesting to compare users with the flag versus without. For that reason this PR sets a breakdown on property `$feature/key-name`.

The caveat is that the `$feature/` properties require a recent version of posthog-js and not all users will have it.

### Also considered

An approach where 2 graph series are created, one where active feature flags `contains` key and one where it `does not contain` key. This would work regardless of the user's posthog-js version, _but_:

- The graph series titles are then both just `Pageview (Unique)`
- We should move toward new query semantics IMO even if it breaks some out-of-date client usage

## How did you test this code?

Manual testing
