### PR TITLE
Fix duplicated action name error message

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -1,17 +1,17 @@
 describe('Actions', () => {
+    let actionName = Cypress._.random(0, 1e6)
     beforeEach(() => {
         cy.clickNavMenu('events')
         cy.get('[data-attr=events-actions-tab]').click()
     })
 
     it('Create action', () => {
-        let name = Cypress._.random(0, 1e6)
         cy.get('[data-attr=create-action]').click()
         cy.get('.ant-card-head-title').should('contain', 'event or pageview')
         cy.get('[data-attr=new-action-pageview]').click()
         cy.get('h1').should('contain', 'Creating action')
 
-        cy.get('[data-attr=edit-action-input]').type(name)
+        cy.get('[data-attr=edit-action-input]').type(actionName)
         cy.get('.ant-radio-group > :nth-child(3)').click()
         cy.get('[data-attr=edit-action-url-input]').type(Cypress.config().baseUrl)
         cy.wait(300)
@@ -26,10 +26,27 @@ describe('Actions', () => {
 
         cy.contains('Add graph series').click()
         cy.get('[data-attr=trend-element-subject-1]').click()
-        cy.get('[data-attr=taxonomic-filter-searchfield]').type(name)
+        cy.get('[data-attr=taxonomic-filter-searchfield]').type(actionName)
         cy.get('[data-attr=taxonomic-tab-actions]').click()
         cy.get('[data-attr=prop-filter-actions-0]').click()
-        cy.get('[data-attr=trend-element-subject-1] span').should('contain', name)
+        cy.get('[data-attr=trend-element-subject-1] span').should('contain', actionName)
+    })
+
+    it('Notifies when an action with this name already exists', () => {
+        // Let's create a whole new action, similarly to "Create action"
+        cy.get('[data-attr=create-action]').click()
+        cy.get('[data-attr=new-action-pageview]').click()
+        // This time we'll use a "Custom event" type match group
+        cy.get('[data-attr=edit-action-input]').type(actionName)
+        cy.get('.ant-radio-group > :nth-child(2)').click()
+        // Let's save the action
+        cy.get('[data-attr=save-action-button]').click()
+        // Oh noes, there already is an action with name `actionName`
+        cy.contains('Action with this name already exists').should('exist')
+        // Let's see it
+        cy.contains('Click here to edit').click()
+        // We should now be seeing the action from "Create action"
+        cy.get('[data-attr=edit-action-url-input]').should('have.value', Cypress.config().baseUrl)
     })
 
     it('Click on an action', () => {

--- a/frontend/src/scenes/actions/ActionEdit.js
+++ b/frontend/src/scenes/actions/ActionEdit.js
@@ -14,7 +14,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import dayjs from 'dayjs'
 import { compactNumber } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
-import { urls } from 'scenes/sceneLogic'
+import { urls } from 'scenes/urls'
 
 export function ActionEdit({ action: loadedAction, actionId, onSave, temporaryToken }) {
     let logic = actionEditLogic({

--- a/frontend/src/scenes/actions/actionEditLogic.ts
+++ b/frontend/src/scenes/actions/actionEditLogic.ts
@@ -78,8 +78,11 @@ export const actionEditLogic = kea<actionEditLogicType<ActionEditType, Props>>({
                     action = await api.create('api/action/' + token, action)
                 }
             } catch (response) {
-                if (response.detail === 'action-exists') {
-                    return actions.actionAlreadyExists(response.id)
+                if (response.code === 'unique') {
+                    // Below works because `detail` in the format:
+                    // `This project already has an action with this name, ID ${errorActionId}`
+                    actions.actionAlreadyExists(response.detail.split(' ').pop())
+                    return
                 } else {
                     throw response
                 }

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -102,9 +102,15 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
             attrs["team_id"] = self.context["view"].team_id
             include_args = {"team_id": attrs["team_id"]}
 
-        if Action.objects.filter(name=attrs["name"], deleted=False, **include_args).exclude(**exclude_args).exists():
+        colliding_action_ids = list(
+            Action.objects.filter(name=attrs["name"], deleted=False, **include_args)
+            .exclude(**exclude_args)[:1]
+            .values_list("id", flat=True)
+        )
+        if colliding_action_ids:
             raise serializers.ValidationError(
-                {"name": "This project already has an action with that name."}, code="unique"
+                {"name": f"This project already has an action with this name, ID {colliding_action_ids[0]}"},
+                code="unique",
             )
 
         return attrs

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -55,8 +55,7 @@ def factory_test_action_api(event_factory):
             )
 
         def test_cant_create_action_with_the_same_name(self, *args):
-
-            Action.objects.create(name="user signed up", team=self.team)
+            original_action = Action.objects.create(name="user signed up", team=self.team)
             user2 = self._create_user("tim2")
             self.client.force_login(user2)
 
@@ -71,7 +70,7 @@ def factory_test_action_api(event_factory):
                 {
                     "type": "validation_error",
                     "code": "unique",
-                    "detail": "This project already has an action with that name.",
+                    "detail": f"This project already has an action with this name, ID {original_action.id}",
                     "attr": "name",
                 },
             )


### PR DESCRIPTION
## Changes

Turns out this was broken for 6 months (since https://github.com/PostHog/posthog/pull/3796). 🙈  I noticed this today because https://github.com/PostHog/posthog/pull/6369 additionally introduced an improper import, but it didn't break anything, since the feature wasn't working anyway.

![Zrzut ekranu 2021-10-14 o 22 41 32](https://user-images.githubusercontent.com/4550621/137397627-13a835d0-d2f6-4827-a3b4-749aa5da2ade.png)

## How did you test this code?

Added a Cypress test like a boss. Also updated `posthog.api.test.test_action`.
