### PR TITLE
Fix: session recording table was reloading unnecessarily 

### DIFF
--- a/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.test.ts
+++ b/frontend/src/scenes/sessionRecordings/sessionRecordingsTableLogic.test.ts
@@ -3,6 +3,7 @@ import {
     PersonUUID,
     SessionRecordingId,
     DEFAULT_ENTITY_FILTERS,
+    DEFAULT_DURATION_FILTER,
 } from './sessionRecordingsTableLogic'
 import { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
 import { BuiltLogic } from 'kea'
@@ -143,14 +144,9 @@ describe('sessionRecordingsTableLogic', () => {
             })
         })
         describe('duration filter', () => {
-            it('starts filtered by gt 1 min', () => {
+            it('starts filtered by default filter', () => {
                 expectLogic(logic).toMatchValues({
-                    durationFilter: {
-                        type: 'recording',
-                        key: 'duration',
-                        value: 60,
-                        operator: PropertyOperator.GreaterThan,
-                    },
+                    durationFilter: DEFAULT_DURATION_FILTER,
                 })
             })
             it('is set by setDurationFilter and fetches results from server and sets the url', async () => {


### PR DESCRIPTION
## Changes

This is a small fix for the session recording table. It was reloading too often leading to:
* The list refreshing when closing a recording modal.
* Potential reload loops on the person page (I think causing this: https://sentry.io/organizations/posthog/issues/2720143865/?project=1899813)

## How did you test this code?

1) Opened a session recording from the session recording list. Closed the session recording. Verified the list no longer reloaded.
2) Opened the session recording tab on a person page. Applied a filter. Clicked the events tab. Verified a reload loop did not occur.
3) Adjusted the filters and verified they still worked as expected
4) Loaded the session recording page with filters in the URL. Verified that they were correct.
