### PR TITLE
Fix event table re-render loop if person == null 

### DIFF
--- a/frontend/src/scenes/persons/personHeaderLogic.test.ts
+++ b/frontend/src/scenes/persons/personHeaderLogic.test.ts
@@ -98,7 +98,7 @@ describe('the person header', () => {
             onLogic: (l) => (logic = l),
         })
 
-        it('is a UUID regardless of props', async () => {
+        it('is a hash', async () => {
             await expectLogic(logic).then(() => {
                 expect(logic.key).toEqual('2442792429')
             })
@@ -116,9 +116,9 @@ describe('the person header', () => {
             onLogic: (l) => (logic = l),
         })
 
-        it('to a UUID', async () => {
+        it('to a string "unidentified"', async () => {
             await expectLogic(logic).then(() => {
-                expect(logic.key).toEqual(uuid())
+                expect(logic.key).toEqual('unidentified')
             })
         })
     })

--- a/frontend/src/scenes/persons/personHeaderLogic.ts
+++ b/frontend/src/scenes/persons/personHeaderLogic.ts
@@ -1,7 +1,6 @@
 import { kea } from 'kea'
 import { PersonType } from '~/types'
 import { PersonHeaderProps } from 'scenes/persons/PersonHeader'
-import { uuid } from 'lib/utils'
 
 import { personHeaderLogicType } from './personHeaderLogicType'
 import { urls } from 'scenes/urls'
@@ -19,7 +18,7 @@ const hashCode = (str: string): string => {
 
 export const personHeaderLogic = kea<personHeaderLogicType>({
     props: {} as PersonHeaderProps,
-    key: (props) => (props.person ? hashCode(JSON.stringify(props)) : uuid()),
+    key: (props) => (props.person ? hashCode(JSON.stringify(props)) : 'unidentified'),
     reducers: ({ props }) => ({
         withIcon: [props.withIcon || false],
         personLink: [(props.person?.distinct_ids?.length ? urls.person(props.person.distinct_ids[0]) : '') as string],


### PR DESCRIPTION
## Changes

- The logic was getting a random key every time it was rendered, causing it to then re-render, endlessly.
- Fixes https://github.com/PostHog/posthog/issues/6449

## How did you test this code?

- Copied a list of broken events from impersonating a user, realised the bug was `person === null`, fixed things until the page loaded locally without crashing.
