### PR TITLE
Fix password reset

### DIFF
--- a/cypress/integration/auth.js
+++ b/cypress/integration/auth.js
@@ -112,6 +112,8 @@ describe('Password Reset', () => {
         cy.get('#passwordConfirm').type('NEW123456789')
         cy.get('button[type=submit]').click()
         cy.get('.Toastify__toast--success').should('be.visible')
-        cy.location('pathname').should('contain', '/insights')
+
+        // assert the user was redirected; can't test actual redirection to /insights because the test handler doesn't actually log in the user
+        cy.location('pathname').should('not.contain', '/reset/e2e_test_user/e2e_test_token')
     })
 })

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -1,5 +1,4 @@
 import { kea } from 'kea'
-import { router } from 'kea-router'
 import api from 'lib/api'
 import { successToast } from 'lib/utils'
 
@@ -93,7 +92,7 @@ export const passwordResetLogic = kea<
                     'Your password was successfully changed. Redirecting you...'
                 )
                 await breakpoint(3000)
-                router.actions.push('/')
+                window.location.href = '/' // We need the refresh
             }
         },
     },

--- a/posthog/templates/email/password_reset.html
+++ b/posthog/templates/email/password_reset.html
@@ -1,7 +1,7 @@
 {% extends "email/base_transactional.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
 <p>
-    Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{% else
-    %} hosted on {% strip_protocol site_url %}{% endif %}.
+    Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{%else%}
+    hosted on {% strip_protocol site_url %}{% endif %}.
 </p>
 {% if social_providers|length > 0 %}
 <div class="mt mb">


### PR DESCRIPTION
## Changes

Fixes two minor bugs with password reset:
- The reset email had a rendering issue in which a Django template tag wasn't parsed.
- After resetting your password, when you're redirected to the home page, you saw errors pop up because the `user` object wasn't fetched again.

## How did you test this code?

- Opened the app, went through an entire password reset flow and made sure everything worked as expected. Used Mailgun for testing the actual email result.
