### PR TITLE
More robust code freeze releases

### DIFF
--- a/.github/workflows/docker-latest-release-image-publish.yml
+++ b/.github/workflows/docker-latest-release-image-publish.yml
@@ -1,18 +1,23 @@
-# Generates the `posthog/posthog:latest-release` Docker image and pushes to Docker Hub
-name: Docker latest-release image
+# Generates the `posthog/posthog:latest-release` & `posthog/posthog:release-[version]` Docker images
+# and pushes to Docker Hub
+name: Docker release image
 
 on:
-    push:
-        tags:
-            - '*.**'
+    - pull_request
+      # push:
+      #     tags:
+      #         - '*.**'
 
 jobs:
-    build-release-push:
+    build-push:
         name: Build & push Docker release image
         runs-on: ubuntu-20.04
         steps:
             - name: Checkout default branch
               uses: actions/checkout@v2
+
+            - name: Get tag name
+              run: echo "TAG_NAME=$(echo ${GITHUB_REF#refs/tags/} | tr / -)" >> $GITHUB_ENV
 
             - name: Update git SHA
               run: echo "GIT_SHA = '${GITHUB_SHA}'" > posthog/gitsha.py
@@ -39,7 +44,9 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: posthog/posthog:latest-release
+                  tags: |
+                      posthog/posthog:test-test-unstable-latest-release
+                      posthog/posthog:test-test-unstable-release-${{ env.TAG_NAME  }}
 
             - name: Image digest
               if: github.repository == 'PostHog/posthog'

--- a/.github/workflows/docker-latest-release-image-publish.yml
+++ b/.github/workflows/docker-latest-release-image-publish.yml
@@ -3,10 +3,9 @@
 name: Docker release image
 
 on:
-    - pull_request
-      # push:
-      #     tags:
-      #         - '*.**'
+    push:
+        tags:
+            - '*.**'
 
 jobs:
     build-push:
@@ -45,8 +44,8 @@ jobs:
                   context: .
                   push: true
                   tags: |
-                      posthog/posthog:test-test-unstable-latest-release
-                      posthog/posthog:test-test-unstable-release-${{ env.TAG_NAME  }}
+                      posthog/posthog:latest-release
+                      posthog/posthog:release-${{ env.TAG_NAME  }}
 
             - name: Image digest
               if: github.repository == 'PostHog/posthog'

--- a/.github/workflows/docker-release-image-publish.yml
+++ b/.github/workflows/docker-release-image-publish.yml
@@ -1,4 +1,4 @@
-# Generates the `posthog/posthog:release-[version]` Docker image and pushes to Docker Hub
+# Generates the `posthog/posthog:release-[version]-unstable` Docker image and pushes to Docker Hub
 # when a branch that matches `release-[version]` is pushed. Image can be used for break the release sessions.
 name: Docker image for release
 
@@ -43,7 +43,7 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: posthog/posthog:${{ env.BRANCH_NAME  }}
+                  tags: posthog/posthog:${{ env.BRANCH_NAME  }}-unstable
 
             - name: Image digest
               if: github.repository == 'PostHog/posthog'

--- a/.github/workflows/docker-unstable-image.yml
+++ b/.github/workflows/docker-unstable-image.yml
@@ -3,10 +3,9 @@
 name: Docker unstable image for code freeze
 
 on:
-    - pull_request
-      # push:
-      #     branches:
-      #         - 'release-*.*'
+    push:
+        branches:
+            - 'release-*.*'
 
 jobs:
     build-release-push:
@@ -44,7 +43,7 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: posthog/posthog:${{ env.BRANCH_NAME  }}-unstable-temp
+                  tags: posthog/posthog:${{ env.BRANCH_NAME  }}-unstable
 
             - name: Image digest
               if: github.repository == 'PostHog/posthog'

--- a/.github/workflows/docker-unstable-image.yml
+++ b/.github/workflows/docker-unstable-image.yml
@@ -1,6 +1,6 @@
 # Generates the `posthog/posthog:release-[version]-unstable` Docker image and pushes to Docker Hub
 # when a branch that matches `release-[version]` is pushed. Image can be used for break the release sessions.
-name: Docker image for release
+name: Docker unstable image for code freeze
 
 on:
     push:

--- a/.github/workflows/docker-unstable-image.yml
+++ b/.github/workflows/docker-unstable-image.yml
@@ -3,9 +3,10 @@
 name: Docker unstable image for code freeze
 
 on:
-    push:
-        branches:
-            - 'release-*.*'
+    - pull_request
+      # push:
+      #     branches:
+      #         - 'release-*.*'
 
 jobs:
     build-release-push:
@@ -43,7 +44,7 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: posthog/posthog:${{ env.BRANCH_NAME  }}-unstable
+                  tags: posthog/posthog:${{ env.BRANCH_NAME  }}-unstable-temp
 
             - name: Image digest
               if: github.repository == 'PostHog/posthog'


### PR DESCRIPTION
## Changes

Another step in https://github.com/PostHog/product-internal/issues/171.
- When pushing to a branch `release-[version]` the code freeze image will be generated, **but appending an -unstable suffix**. This way it'll be clear for users not to update until it's actually released.
- The `latest-release` and `release-[version]` real images will be automatically generated on the same step (same build) when pushing a `*.*` tag to GitHub.

## How did you test this code?

I updated the workflows to run on PR/push (adding some test prefixes to avoid any confusion) and made sure the builds were properly generated.
