### PR TITLE
Override filters if bad api result

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -12,7 +12,10 @@ describe('insightLogic', () => {
     let logic: ReturnType<typeof insightLogic.build>
 
     mockAPI(async (url) => {
-        const { pathname } = url
+        const { pathname, searchParams } = url
+        const throwAPIError = (): void => {
+            throw { status: 0, statusText: 'error from the API' }
+        }
         if (['api/insight/42', 'api/insight/43'].includes(pathname)) {
             return {
                 result: pathname === 'api/insight/42' ? ['result from api'] : null,
@@ -23,9 +26,14 @@ describe('insightLogic', () => {
                     properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' }],
                 },
             }
+        } else if (['api/insight/44'].includes(pathname)) {
+            throwAPIError()
         } else if (
             ['api/insight', 'api/insight/session/', 'api/insight/trend/', 'api/insight/funnel/'].includes(pathname)
         ) {
+            if (searchParams?.events?.[0]?.throw) {
+                throwAPIError()
+            }
             return { result: ['result from api'] }
         }
         return defaultAPIMocks(url, { availableFeatures: [AvailableFeature.DASHBOARD_COLLABORATION] })
@@ -130,6 +138,36 @@ describe('insightLogic', () => {
             })
         })
 
+        describe('props with filters, no cached results, error from API', () => {
+            initKeaTestLogic({
+                logic: insightLogic,
+                props: {
+                    dashboardItemId: 42,
+                    cachedResults: undefined,
+                    filters: {
+                        insight: ViewType.TRENDS,
+                        events: [{ id: 3, throw: true }],
+                        properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' }],
+                    },
+                },
+                onLogic: (l) => (logic = l),
+            })
+
+            it('makes a query to load the results', async () => {
+                await expectLogic(logic)
+                    .toDispatchActions(['loadResults', 'loadResultsFailure'])
+                    .toMatchValues({
+                        insight: expect.objectContaining({ id: 42, result: null }),
+                        filters: expect.objectContaining({
+                            events: [expect.objectContaining({ id: 3 })],
+                            properties: [expect.objectContaining({ value: 'a' })],
+                        }),
+                    })
+                    .delay(1)
+                    .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
+            })
+        })
+
         describe('props with no filters, no cached results, results from API', () => {
             initKeaTestLogic({
                 logic: insightLogic,
@@ -184,6 +222,29 @@ describe('insightLogic', () => {
                             properties: [expect.objectContaining({ value: 'a' })],
                         }),
                     })
+            })
+        })
+
+        describe('props with no filters, no cached results, API throws', () => {
+            initKeaTestLogic({
+                logic: insightLogic,
+                props: {
+                    dashboardItemId: 44, // 44 --> result: throws
+                    cachedResults: undefined,
+                    filters: undefined,
+                },
+                onLogic: (l) => (logic = l),
+            })
+
+            it('makes a query to load the results', async () => {
+                await expectLogic(logic)
+                    .toDispatchActions(['loadInsight', 'loadInsightFailure'])
+                    .toMatchValues({
+                        insight: expect.objectContaining({ id: 44, result: null, filters: {} }),
+                        filters: {},
+                    })
+                    .delay(1)
+                    .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
             })
         })
     })

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -174,7 +174,7 @@ export const insightLogic = kea<insightLogicType>({
                                 e.message
                             )
                         }
-                        return values.insight
+                        throw e
                     }
                     breakpoint()
                     cache.abortController = null

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -122,7 +122,7 @@ export const insightLogic = kea<insightLogicType>({
 
                     const dashboardItemId = props.dashboardItemId
                     actions.startQuery(queryId)
-                    if (dashboardItemId) {
+                    if (dashboardItemId && dashboardsModel.isMounted()) {
                         dashboardsModel.actions.updateDashboardRefreshStatus(dashboardItemId, true, null)
                     }
 
@@ -161,7 +161,7 @@ export const insightLogic = kea<insightLogicType>({
                         breakpoint()
                         cache.abortController = null
                         actions.endQuery(queryId, insight, null, e)
-                        if (dashboardItemId) {
+                        if (dashboardItemId && dashboardsModel.isMounted()) {
                             dashboardsModel.actions.updateDashboardRefreshStatus(dashboardItemId, false, null)
                         }
                         if (filters.insight === ViewType.FUNNELS) {
@@ -183,7 +183,7 @@ export const insightLogic = kea<insightLogicType>({
                         (values.filters.insight as ViewType) || ViewType.TRENDS,
                         response.last_refresh
                     )
-                    if (dashboardItemId) {
+                    if (dashboardItemId && dashboardsModel.isMounted()) {
                         dashboardsModel.actions.updateDashboardRefreshStatus(
                             dashboardItemId,
                             false,


### PR DESCRIPTION
## Changes

- Possibly fixes https://github.com/PostHog/posthog/issues/6439
- Because on a thrown API error the `loadResults` loader returned the existing insight (instead of throwing), which might have been one with a default set `filters: {}`, it dispatched `loadResultsSuccess` and we assumed everything was great. This in turn updated the insight with the "new" filters returned from the API.
- Added tests to make sure API failures are handled properly.
- Flyby change to not mount dashboardsModel when it's not already mounted. Saves a bit of time intests.


## How did you test this code?

- Wrote tests for this
