### PR TITLE
Allow filtering /api/events by cohort filter

### DIFF
--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -56,7 +56,7 @@ class ClickhouseEventsViewSet(EventViewSet):
             },
             long_date_from,
         )
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk, has_person_id_joined=False)
 
         if request.GET.get("action_id"):
             try:


### PR DESCRIPTION
This broke due to the cohort refactoring - query constructed did not
have access to `person_id`

Closes https://github.com/PostHog/posthog/issues/6427

## How did you test this code?

See tests + manual verification
