### PR TITLE
Add .github/workflows/docker-vuln-scan.yml

### DIFF
--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -36,6 +36,7 @@ jobs:
               if: github.repository == 'PostHog/posthog'
               with:
                   image-ref: 'posthog/posthog:vuln-scan-${{ github.sha }}'
+                  ignore-unfixed: true
                   vuln-type: 'os,library'
                   severity: 'CRITICAL,HIGH'
                   format: 'template'

--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -36,8 +36,12 @@ jobs:
               if: github.repository == 'PostHog/posthog'
               with:
                   image-ref: 'posthog/posthog:vuln-scan-${{ github.sha }}'
-                  format: 'table'
-                  exit-code: '1'
-                  ignore-unfixed: true
-                  vuln-type: 'os,library'
-                  severity: 'CRITICAL,HIGH'
+                  format: 'template'
+                  template: '@/contrib/sarif.tpl'
+                  output: 'trivy-results.sarif'
+
+            - name: Upload Trivy scan results to GitHub Security tab
+              uses: github/codeql-action/upload-sarif@v1
+              if: github.repository == 'PostHog/posthog'
+              with:
+                  sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -36,6 +36,8 @@ jobs:
               if: github.repository == 'PostHog/posthog'
               with:
                   image-ref: 'posthog/posthog:vuln-scan-${{ github.sha }}'
+                  vuln-type: 'os,library'
+                  severity: 'CRITICAL,HIGH'
                   format: 'template'
                   template: '@/contrib/sarif.tpl'
                   output: 'trivy-results.sarif'

--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -1,0 +1,34 @@
+name: Docker
+on:
+    - pull_request
+
+jobs:
+    build:
+        name: Vulnerabilty Scan
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+
+            - name: Build image
+              uses: docker/build-push-action@v2
+              with:
+                  push: false
+                  tags: posthog/posthog:vuln-scan
+
+            - name: Run Trivy vulnerability scanner
+              uses: aquasecurity/trivy-action@master
+              with:
+                  image-ref: 'posthog/posthog:vuln-scan'
+                  format: 'table'
+                  exit-code: '1'
+                  ignore-unfixed: true
+                  vuln-type: 'os,library'
+                  severity: 'CRITICAL,HIGH'

--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -17,16 +17,25 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
 
+            - name: Login to DockerHub
+              if: github.repository == 'PostHog/posthog'
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
             - name: Build image
               uses: docker/build-push-action@v2
+              if: github.repository == 'PostHog/posthog'
               with:
-                  push: false
-                  tags: posthog/posthog:vuln-scan
+                  push: true
+                  tags: posthog/posthog:vuln-scan-${{ github.sha }}
 
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@master
+              if: github.repository == 'PostHog/posthog'
               with:
-                  image-ref: 'posthog/posthog:vuln-scan'
+                  image-ref: 'posthog/posthog:vuln-scan-${{ github.sha }}'
                   format: 'table'
                   exit-code: '1'
                   ignore-unfixed: true


### PR DESCRIPTION
## Changes
This PR adds a new GitHub action workflow to:

* build and upload to Docker Hub a new artifact image
* scan that artifact image via [Trivy](https://github.com/aquasecurity/trivy) 

## How did you test this code?
* see image created [here](https://hub.docker.com/layers/posthog/posthog/vuln-scan-77bd076af0761635f7e2e9c658376fa8b87a17c3/images/sha256-7668b0f6a8de46ac45913ce1734014312927a0719663b545658006b23dc0cb85?context=repo) 
* see scan results [here](https://github.com/PostHog/posthog/security/code-scanning?query=is%3Aopen+pr%3A6479)
