### PR TITLE
Hotfix: update TypedDict import in org usage report

### DIFF
--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -1,9 +1,7 @@
 import logging
 import os
 from datetime import datetime
-from typing import Dict, List, Optional, Union
-
-from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict, Union
 
 from posthog.event_usage import report_org_usage, report_org_usage_failure
 from posthog.models import Event, Team, User


### PR DESCRIPTION
## Changes

This somehow made it past our linting/type-checking pipeline and into prod, where it caused the job to fail.

See [Sentry](https://sentry.io/organizations/posthog/issues/2720402660) for the exception.

## How did you test this code?

*Please describe.*
