### PR TITLE
Dashboard initial load in batches of 4

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -19,7 +19,15 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { SaveModal } from 'scenes/insights/SaveModal'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
-import { DashboardItemType, DashboardMode, DashboardType, ChartDisplayType, ViewType, FilterType } from '~/types'
+import {
+    DashboardItemType,
+    DashboardMode,
+    DashboardType,
+    ChartDisplayType,
+    ViewType,
+    FilterType,
+    InsightLogicProps,
+} from '~/types'
 import { ActionsBarValueGraph } from 'scenes/trends/viz'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
@@ -56,7 +64,6 @@ interface Props {
     layout?: any
     footer?: JSX.Element
     onClick?: () => void
-    preventLoading?: boolean
     moveDashboardItem?: (it: DashboardItemType, dashboardId: number) => void
     saveDashboardItem?: (it: DashboardItemType) => void
     duplicateDashboardItem?: (it: DashboardItemType, dashboardId?: number) => void
@@ -185,7 +192,6 @@ export function DashboardItem({
     layout,
     footer,
     onClick,
-    preventLoading,
     moveDashboardItem,
     saveDashboardItem,
     duplicateDashboardItem,
@@ -228,11 +234,11 @@ export function DashboardItem({
     })
 
     const filters = { ...item.filters, from_dashboard: item.id }
-    const logicProps = {
+    const logicProps: InsightLogicProps = {
         dashboardItemId: item.id,
         filters: filters,
         cachedResults: (item as any).result,
-        preventLoading,
+        doNotLoad: true,
     }
     const { insightProps, showTimeoutMessage, showErrorMessage, insight, insightLoading, isLoading } = useValues(
         insightLogic(logicProps)
@@ -609,9 +615,7 @@ export function DashboardItem({
                         BlockingEmptyState
                     ) : (
                         <Alert.ErrorBoundary message="Error rendering graph!">
-                            {(dashboardMode === DashboardMode.Public || preventLoading) &&
-                            !insight.result &&
-                            !item.result ? (
+                            {dashboardMode === DashboardMode.Public && !insight.result && !item.result ? (
                                 <Skeleton />
                             ) : (
                                 <Element

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -68,6 +68,7 @@ interface Props {
     saveDashboardItem?: (it: DashboardItemType) => void
     duplicateDashboardItem?: (it: DashboardItemType, dashboardId?: number) => void
     isHighlighted?: boolean
+    doNotLoad?: boolean
 }
 
 export type DisplayedType = ChartDisplayType | 'RetentionContainer'
@@ -196,6 +197,7 @@ export function DashboardItem({
     saveDashboardItem,
     duplicateDashboardItem,
     isHighlighted = false,
+    doNotLoad = false,
 }: Props): JSX.Element {
     const [initialLoaded, setInitialLoaded] = useState(false)
     const [showSaveModal, setShowSaveModal] = useState(false)
@@ -238,7 +240,7 @@ export function DashboardItem({
         dashboardItemId: item.id,
         filters: filters,
         cachedResults: (item as any).result,
-        doNotLoad: true,
+        doNotLoad,
     }
     const { insightProps, showTimeoutMessage, showErrorMessage, insight, insightLoading, isLoading } = useValues(
         insightLogic(logicProps)

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -98,6 +98,7 @@ export function DashboardItems(): JSX.Element {
                 <div key={item.id} className="dashboard-item-wrapper">
                     <DashboardItem
                         key={item.id}
+                        doNotLoad
                         dashboardId={dashboard?.id}
                         item={item}
                         layout={

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -8,6 +8,7 @@ import { dashboardLogicType } from 'scenes/dashboard/dashboardLogicType'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { dashboardItemsModel } from '~/models/dashboardItemsModel'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DashboardItemType } from '~/types'
 
 jest.mock('lib/api')
 
@@ -18,6 +19,16 @@ describe('dashboardLogic', () => {
         const { pathname } = url
         if (pathname === 'api/dashboard/5/') {
             return dashboardJson
+        } else if (pathname === 'api/dashboard/6/') {
+            return {
+                ...dashboardJson,
+                items: [
+                    { ...dashboardJson.items[0], result: null },
+                    { ...dashboardJson.items[1], result: null },
+                    { ...dashboardJson.items[0], id: 666 },
+                    { ...dashboardJson.items[1], id: 999 },
+                ],
+            }
         } else if (pathname.startsWith('api/dashboard_item/')) {
             return dashboardJson.items.find(({ id }) => id === parseInt(pathname.split('/')[2]))
         }
@@ -47,7 +58,7 @@ describe('dashboardLogic', () => {
             onLogic: (l) => (logic = l),
         })
 
-        describe('core assumptions', () => {
+        describe('on load', () => {
             it('mounts other logics', async () => {
                 await expectLogic(logic).toMount([dashboardsModel, dashboardItemsModel, eventUsageLogic])
             })
@@ -65,6 +76,8 @@ describe('dashboardLogic', () => {
                         items: truth((items) => items.length === 2),
                     })
             })
+
+            it('fetches unloaded results on mount')
         })
 
         describe('reload items', () => {
@@ -149,6 +162,47 @@ describe('dashboardLogic', () => {
                         },
                     })
             })
+        })
+    })
+
+    describe('with a half-cached dashboard', () => {
+        initKeaTestLogic({
+            logic: dashboardLogic,
+            props: {
+                id: 6,
+            },
+            onLogic: (l) => (logic = l),
+        })
+
+        it('fetches dashboard items on mount', async () => {
+            await expectLogic(logic)
+                .toDispatchActions(['loadDashboardItemsSuccess'])
+                .toMatchValues({
+                    allItems: truth(
+                        ({ items }) => items.filter((i: DashboardItemType) => i.result === null).length === 2
+                    ),
+                    items: truth((items) => items.length === 4),
+                })
+                .toDispatchActions(['refreshAllDashboardItems', 'setRefreshStatuses'])
+                .toMatchValues({
+                    refreshMetrics: {
+                        completed: 0,
+                        total: 2,
+                    },
+                })
+                .toDispatchActions(['setRefreshStatus', 'setRefreshStatus'])
+                .toMatchValues({
+                    refreshMetrics: {
+                        completed: 2,
+                        total: 2,
+                    },
+                })
+                .toMatchValues({
+                    allItems: truth(
+                        ({ items }) => items.filter((i: DashboardItemType) => i.result === null).length === 0
+                    ),
+                    items: truth((items) => items.length === 4),
+                })
         })
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -76,8 +76,6 @@ describe('dashboardLogic', () => {
                         items: truth((items) => items.length === 2),
                     })
             })
-
-            it('fetches unloaded results on mount')
         })
 
         describe('reload items', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -613,7 +613,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
             document.title = title ? `${title} • PostHog` : 'PostHog'
         },
         loadDashboardItemsSuccess: () => {
-            const unloadedItems = values.allItems?.items?.filter((i) => !i.result)
+            // Initial load of actual data for dashboard items after general dashboard is fetched
+            const notYetLoadedItems = values.allItems?.items?.filter((i) => !i.result)
+            actions.refreshAllDashboardItems(notYetLoadedItems)
             actions.refreshAllDashboardItems(unloadedItems)
         },
     }),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -612,5 +612,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
         setPageTitle: ({ title }) => {
             document.title = title ? `${title} • PostHog` : 'PostHog'
         },
+        loadDashboardItemsSuccess: () => {
+            const unloadedItems = values.allItems?.items?.filter((i) => !i.result)
+            actions.refreshAllDashboardItems(unloadedItems)
+        },
     }),
 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -616,7 +616,6 @@ export const dashboardLogic = kea<dashboardLogicType>({
             // Initial load of actual data for dashboard items after general dashboard is fetched
             const notYetLoadedItems = values.allItems?.items?.filter((i) => !i.result)
             actions.refreshAllDashboardItems(notYetLoadedItems)
-            actions.refreshAllDashboardItems(unloadedItems)
         },
     }),
 })

--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -86,7 +86,6 @@ function InsightPane({
                                       }
                                     : undefined
                             }
-                            preventLoading={true}
                             footer={<div className="dashboard-item-footer">{footer(insight)}</div>}
                             index={index}
                             isOnEditMode={false}

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.js
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.js
@@ -208,7 +208,7 @@ export function LineGraph({
                     return processDataset(datasetCopy, index)
                 }),
             ]
-            if (visibilityMap) {
+            if (visibilityMap && Object.keys(visibilityMap).length > 0) {
                 datasets = datasets.filter((data) => visibilityMap[data.id])
             }
         } else {

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -168,6 +168,36 @@ describe('insightLogic', () => {
             })
         })
 
+        describe('props with filters, no cached results, respects doNotLoad', () => {
+            initKeaTestLogic({
+                logic: insightLogic,
+                props: {
+                    dashboardItemId: 42,
+                    cachedResults: undefined,
+                    filters: {
+                        insight: ViewType.TRENDS,
+                        events: [{ id: 3, throw: true }],
+                        properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' }],
+                    },
+                    doNotLoad: true,
+                },
+                onLogic: (l) => (logic = l),
+            })
+
+            it('does not make a query', async () => {
+                await expectLogic(logic)
+                    .toMatchValues({
+                        insight: expect.objectContaining({ id: 42, result: null }),
+                        filters: expect.objectContaining({
+                            events: [expect.objectContaining({ id: 3 })],
+                            properties: [expect.objectContaining({ value: 'a' })],
+                        }),
+                    })
+                    .delay(1)
+                    .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
+            })
+        })
+
         describe('props with no filters, no cached results, results from API', () => {
             initKeaTestLogic({
                 logic: insightLogic,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -573,7 +573,7 @@ export const insightLogic = kea<insightLogicType>({
             if (!props.cachedResults) {
                 if (props.dashboardItemId && !props.filters) {
                     actions.loadInsight(props.dashboardItemId)
-                } else {
+                } else if (!props.doNotLoad) {
                     actions.loadResults()
                 }
             }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -420,7 +420,6 @@ export function SavedInsights(): JSX.Element {
                                                     window.open(displayMap[_type].link(insight))
                                                 }
                                             }}
-                                            preventLoading={true}
                                             index={index}
                                             isOnEditMode={false}
                                             footer={

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1001,10 +1001,10 @@ export interface InsightLogicProps {
     cachedResults?: any
     /** cached filters, avoid making a request */
     filters?: Partial<FilterType> | null
-    /** not sure about this one */
-    preventLoading?: boolean
     /** enable this to make unsaved queries */
     doNotPersist?: boolean
+    /** enable this to avoid API requests */
+    doNotLoad?: boolean
 }
 
 export interface FeatureFlagGroupType {


### PR DESCRIPTION
## Changes

- Load all uncached items (`result: null` in the `items` array for the dashboard) in sequence on the dashboard
- Previously while **re**loads worked in sequence, the initial loading was uncontrolled, and all items loaded at once
- Might fix a bug with saved dashboard items not loading if they're not cached

## How did you test this code?

- Wrote tests for it
- Changed [the cache key](https://github.com/PostHog/posthog/blob/074d633c53c2d6437321d94a301b7efac7e3f6be/posthog/utils.py#L375) to something random (`cache2_`) and saw this:

![2021-10-15 23 30 28](https://user-images.githubusercontent.com/53387/137555791-bff4ae6b-c8c5-4e75-9e68-91bfc12630ec.gif)

## What's missing

There's apparently a bug that trends don't show well if they are reloaded on a dashboard. See the gif above. It could be an easy fix, but I'm out of steam for now. This PR could already be merged, as it might help https://github.com/PostHog/posthog/issues/6402