### PR TITLE
Fix "current usage" padding

### DIFF
--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -145,7 +145,7 @@ export function TopNavigation(): JSX.Element {
             {preflight?.cloud && billing?.should_display_current_bill && (
                 <Link to={urls.organizationBilling()} data-attr="top-menu-billing-usage">
                     <Card
-                        bodyStyle={{ padding: 4, fontWeight: 'bold' }}
+                        bodyStyle={{ padding: '8px 16px', fontWeight: 'bold' }}
                         style={{ marginBottom: 16, cursor: 'pointer' }}
                     >
                         <span className="text-small text-muted">


### PR DESCRIPTION
## Changes

Before:

<img width="364" alt="Screenshot 2021-10-17 at 17 42 28" src="https://user-images.githubusercontent.com/53387/137634658-8071133c-198d-43e0-9046-e8d69cb40664.png">

After:

<img width="383" alt="Screenshot 2021-10-17 at 17 42 28" src="https://user-images.githubusercontent.com/53387/137634703-8fc0f840-5074-489d-b3a0-50af8c5e3a7f.png">

## How did you test this code?

Looked at the changed result, gave myself a thumbs up.

## Additional context

This went unnoticed because normally while developing we run the app without cloud billing. Thus I assume nobody saw the misaligned label for a while...

Normally I'd like to see this in a storybook, but since we'll redo this sidebar in the context of [IA](https://github.com/PostHog/posthog/issues/5346) soon enough, I didn't feel it worth the effort.