### PR TITLE
Available features selector

### DIFF
--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -16,13 +16,13 @@ import { UploadFile } from 'antd/lib/upload/interface'
 import { CalculatorOutlined, OrderedListOutlined } from '@ant-design/icons'
 import { DropdownSelector } from 'lib/components/DropdownSelector/DropdownSelector'
 import { Tooltip } from 'antd'
-import { organizationLogic } from '../organizationLogic'
+import { userLogic } from 'scenes/userLogic'
 
 export function Cohort(props: { cohort: CohortType }): JSX.Element {
     const logic = cohortLogic(props)
     const { setCohort } = useActions(logic)
     const { cohort, submitted } = useValues(logic)
-    const { currentOrganization } = useValues(organizationLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
 
     const onDescriptionChange = (description: string): void => {
         setCohort({
@@ -102,7 +102,7 @@ export function Cohort(props: { cohort: CohortType }): JSX.Element {
                     )}
                 </Col>
             </Row>
-            {currentOrganization?.available_features.includes(AvailableFeature.DASHBOARD_COLLABORATION) && (
+            {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && (
                 <Row gutter={16} className="mt">
                     <Col span={24}>
                         <CohortDescriptionInput description={cohort.description} onChange={onDescriptionChange} />

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -20,7 +20,7 @@ export function Dashboards(): JSX.Element {
     const { deleteDashboard, unpinDashboard, pinDashboard, addDashboard } = useActions(dashboardsModel)
     const { setNewDashboardDrawer } = useActions(dashboardsLogic)
     const { dashboards, newDashboardDrawer, dashboardTags } = useValues(dashboardsLogic)
-    const { user } = useValues(userLogic)
+    const { user, hasAvailableFeature } = useValues(userLogic)
     const [displayedColumns, setDisplayedColumns] = useState([] as ColumnType<DashboardType>[])
 
     const columns: ColumnType<DashboardType>[] = [
@@ -114,7 +114,7 @@ export function Dashboards(): JSX.Element {
     ]
 
     useEffect(() => {
-        if (!user?.organization?.available_features.includes(AvailableFeature.DASHBOARD_COLLABORATION)) {
+        if (!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)) {
             setDisplayedColumns(
                 columns.filter((col) => !col.dataIndex || !['description', 'tags'].includes(col.dataIndex.toString()))
             )

--- a/frontend/src/scenes/project/Settings/AccessControl.tsx
+++ b/frontend/src/scenes/project/Settings/AccessControl.tsx
@@ -7,16 +7,17 @@ import { RestrictedComponentProps } from '../../../lib/components/RestrictedArea
 import { sceneLogic } from '../../sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { LockOutlined, UnlockOutlined } from '@ant-design/icons'
+import { userLogic } from 'scenes/userLogic'
 
 export function AccessControl({ isRestricted }: RestrictedComponentProps): JSX.Element {
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
     const { guardAvailableFeature } = useActions(sceneLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
 
     const projectPermissioningEnabled =
-        currentOrganization?.available_features.includes(AvailableFeature.PROJECT_BASED_PERMISSIONING) &&
-        currentTeam?.access_control
+        hasAvailableFeature(AvailableFeature.PROJECT_BASED_PERMISSIONING) && currentTeam?.access_control
 
     return (
         <div>

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -22,12 +22,12 @@ import { FEATURE_FLAGS, OrganizationMembershipLevel } from '../../../lib/constan
 import { TestAccountFiltersConfig } from './TestAccountFiltersConfig'
 import { TimezoneConfig } from './TimezoneConfig'
 import { DataAttributes } from 'scenes/project/Settings/DataAttributes'
-import { organizationLogic } from '../../organizationLogic'
 import { featureFlagLogic } from '../../../lib/logic/featureFlagLogic'
 import { AvailableFeature, UserType } from '../../../types'
 import { TeamMembers } from './TeamMembers'
 import { teamMembersLogic } from './teamMembersLogic'
 import { AccessControl } from './AccessControl'
+import { userLogic } from 'scenes/userLogic'
 
 function DisplayName(): JSX.Element {
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
@@ -70,10 +70,10 @@ function DisplayName(): JSX.Element {
 
 export function ProjectSettings({ user }: { user: UserType }): JSX.Element {
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
-    const { currentOrganization } = useValues(organizationLogic)
     const { resetToken } = useActions(teamLogic)
     const { location } = useValues(router)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
 
     useAnchor(location.hash)
 
@@ -244,13 +244,12 @@ export function ProjectSettings({ user }: { user: UserType }): JSX.Element {
                 <Divider />
                 <RestrictedArea Component={AccessControl} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
                 <Divider />
-                {currentTeam?.access_control &&
-                    currentOrganization?.available_features.includes(AvailableFeature.PROJECT_BASED_PERMISSIONING) && (
-                        <BindLogic logic={teamMembersLogic} props={{ team: currentTeam }}>
-                            <TeamMembers user={user} team={currentTeam} />
-                            <Divider />
-                        </BindLogic>
-                    )}
+                {currentTeam?.access_control && hasAvailableFeature(AvailableFeature.PROJECT_BASED_PERMISSIONING) && (
+                    <BindLogic logic={teamMembersLogic} props={{ team: currentTeam }}>
+                        <TeamMembers user={user} team={currentTeam} />
+                        <Divider />
+                    </BindLogic>
+                )}
                 <RestrictedArea
                     Component={DangerZone}
                     minimumAccessLevel={OrganizationMembershipLevel.Admin}

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -13,7 +13,6 @@ import { afterLoginRedirect } from './authentication/loginLogic'
 import { ErrorProjectUnavailable as ErrorProjectUnavailableComponent } from '../layout/ErrorProjectUnavailable'
 import { teamLogic } from './teamLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { organizationLogic } from './organizationLogic'
 import { urls } from 'scenes/urls'
 
 export enum Scene {
@@ -393,16 +392,15 @@ export const sceneLogic = kea<sceneLogicType<LoadedScene, Params, Scene, SceneCo
         },
         guardAvailableFeature: ({ featureKey, featureName, featureCaption, featureAvailableCallback, guardOn }) => {
             const { preflight } = preflightLogic.values
-            const { currentOrganization } = organizationLogic.values
             let featureAvailable: boolean
-            if (!preflight || !currentOrganization) {
+            if (!preflight) {
                 featureAvailable = false
             } else if (!guardOn.cloud && preflight.cloud) {
                 featureAvailable = true
             } else if (!guardOn.selfHosted && !preflight.cloud) {
                 featureAvailable = true
             } else {
-                featureAvailable = !!currentOrganization?.available_features.includes(featureKey)
+                featureAvailable = userLogic.values.hasAvailableFeature(featureKey)
             }
             if (featureAvailable) {
                 featureAvailableCallback?.()

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { kea } from 'kea'
 import api from 'lib/api'
 import { userLogicType } from './userLogicType'
-import { UserType } from '~/types'
+import { AvailableFeature, UserType } from '~/types'
 import posthog from 'posthog-js'
 import { toast } from 'react-toastify'
 import { getAppContext } from 'lib/utils/getAppContext'
@@ -112,6 +112,14 @@ export const userLogic = kea<userLogicType>({
             window.location.href = destination || '/'
         },
     }),
+    selectors: {
+        hasAvailableFeature: [
+            (s) => [s.user],
+            (user) => {
+                return (feature: AvailableFeature) => !!user?.organization?.available_features.includes(feature)
+            },
+        ],
+    },
     events: ({ actions }) => ({
         afterMount: () => {
             const preloadedUser = getAppContext()?.current_user


### PR DESCRIPTION
## Changes

Based on @mariusandra suggestion in a recent PR this introduces a simple selector to handle checks on whether a user has features available. Opted to use `userLogic` as opposed to organization because we preload this and only display the app once this is loaded.

## How did you test this code?

- Manually setting up available features on my test org via the Django console.
- Also relying on the `dashboardPremium` E2E test.
