### PR TITLE
add type hints to resolve some reported errors when running tests

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -83,7 +83,7 @@ SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG, type_cast=str_to_bool)
 USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
 CALCULATE_X_COHORTS_PARALLEL = get_from_env("CALCULATE_X_COHORTS_PARALLEL", 2, type_cast=int)
 
-SITE_URL = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
+SITE_URL: str = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
 
 if DEBUG:
     JS_URL = os.getenv("JS_URL", "http://localhost:8234/")
@@ -340,7 +340,7 @@ SOCIAL_AUTH_JSONFIELD_ENABLED = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", not DEBUG, type_cast=str_to_bool)
 
-AUTHENTICATION_BACKENDS = [
+AUTHENTICATION_BACKENDS: List[str] = [
     "axes.backends.AxesBackend",
     "social_core.backends.github.GithubOAuth2",
     "social_core.backends.gitlab.GitLabOAuth2",


### PR DESCRIPTION
## Changes

When running the tests I was receiving the following errors

```
ee/settings.py:29: error: Cannot determine type of 'AUTHENTICATION_BACKENDS'
ee/settings.py:36: error: Cannot determine type of 'SITE_URL'
```
![Screenshot 2021-10-18 at 12 30 28](https://user-images.githubusercontent.com/984817/137722499-192d85ca-f9b3-4faa-9b35-056fea2225ae.png)

This changes adds type hints to those two settings

## How did you test this code?

by running the tests and seeing the errors go away
