### PR TITLE
No history on saved insights

### DIFF
--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.scss
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.scss
@@ -1,3 +1,4 @@
+// DEPRECATED; this feature will be removed soon
 .insight-history-panel {
     margin-bottom: 5rem;
     .dashboard-item {

--- a/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/InsightHistoryPanel.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED; this feature will be removed soon
 import React, { useEffect, useState } from 'react'
 import { Tabs, Col, Row, Button, Spin } from 'antd'
 import { Loading } from 'lib/utils'

--- a/frontend/src/scenes/insights/InsightHistoryPanel/index.ts
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/index.ts
@@ -1,1 +1,2 @@
+// DEPRECATED; this feature will be removed soon
 export * from './InsightHistoryPanel'

--- a/frontend/src/scenes/insights/InsightHistoryPanel/insightHistoryLogic.ts
+++ b/frontend/src/scenes/insights/InsightHistoryPanel/insightHistoryLogic.ts
@@ -1,3 +1,4 @@
+// DEPRECATED; this feature will be removed soon
 import { kea } from 'kea'
 import api from 'lib/api'
 import { toParams, deleteWithUndo } from 'lib/utils'

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -14,6 +14,7 @@ $funnel_canvas_background: #fafafa;
 
         .ant-tabs-tab {
             padding: 0; // More compact tabs to save vertical space
+            padding-bottom: 6px;
         }
     }
 

--- a/frontend/src/scenes/insights/InsightsNav.tsx
+++ b/frontend/src/scenes/insights/InsightsNav.tsx
@@ -6,6 +6,8 @@ import { HotKeys, ViewType } from '~/types'
 import { insightLogic } from './insightLogic'
 import { ClockCircleOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 const { TabPane } = Tabs
 
@@ -16,6 +18,7 @@ function InsightHotkey({ hotkey }: { hotkey: HotKeys }): JSX.Element {
 export function InsightsNav(): JSX.Element {
     const { activeView } = useValues(insightLogic)
     const { setActiveView } = useActions(insightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <Row justify="space-between" align="middle" className="top-bar">
@@ -27,21 +30,25 @@ export function InsightsNav(): JSX.Element {
                 className="top-bar"
                 onChange={(key) => setActiveView(key as ViewType)}
                 animated={false}
-                tabBarExtraContent={{
-                    right: (
-                        <Button
-                            type="link"
-                            data-attr="insight-history-button"
-                            className={`insight-history-button${
-                                (activeView as ViewType) === ViewType.HISTORY ? ' active' : ''
-                            }`}
-                            onClick={() => setActiveView(ViewType.HISTORY)}
-                            icon={<ClockCircleOutlined />}
-                        >
-                            History
-                        </Button>
-                    ),
-                }}
+                tabBarExtraContent={
+                    featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS]
+                        ? undefined
+                        : {
+                              right: (
+                                  <Button
+                                      type="link"
+                                      data-attr="insight-history-button"
+                                      className={`insight-history-button${
+                                          (activeView as ViewType) === ViewType.HISTORY ? ' active' : ''
+                                      }`}
+                                      onClick={() => setActiveView(ViewType.HISTORY)}
+                                      icon={<ClockCircleOutlined />}
+                                  >
+                                      History
+                                  </Button>
+                              ),
+                          }
+                }
             >
                 <TabPane
                     tab={


### PR DESCRIPTION
## Changes

Removes the insight history button when the saved insights flag is enabled in preparation for #6478. Other miscellaneous fixes.



## How did you test this code?

- Manually enabled and disabled the feature flag to make sure the button appeared when relevant.
