### PR TITLE
adds a search box to the toolbar featureflag list

### DIFF
--- a/cypress/integration/invitesMembers.js
+++ b/cypress/integration/invitesMembers.js
@@ -61,7 +61,7 @@ describe('Invite Signup', () => {
         cy.get('[data-attr=invite-teammate-button]').first().click()
         // Enter invite the user
         cy.get('[data-attr=invite-email-input]').type(`fake+${Math.floor(Math.random() * 10000)}@posthog.com`)
-        cy.get('[data-attr=invite-team-member-submit]').click()
+        cy.get('[data-attr=invite-team-member-submit]').should('not.be.disabled').click()
 
         // Log in as invited user
         cy.get('[data-attr=invite-link]')

--- a/frontend/src/test/init.ts
+++ b/frontend/src/test/init.ts
@@ -9,10 +9,10 @@ export function initKeaTestLogic<L extends Logic = Logic>({
     props,
     onLogic,
 }: {
-    logic: LogicWrapper<L>
+    logic?: LogicWrapper<L>
     props?: LogicWrapper<L>['props']
     onLogic?: (l: BuiltLogic<L>) => any
-}): void {
+} = {}): void {
     let builtLogic: BuiltLogic<L>
     let unmount: () => void
 
@@ -33,13 +33,17 @@ export function initKeaTestLogic<L extends Logic = Logic>({
         ;(history as any).pushState = history.push
         ;(history as any).replaceState = history.replace
         initKea({ beforePlugins: [testUtilsPlugin], routerLocation: history.location, routerHistory: history })
-        builtLogic = logic.build({ ...props })
-        await onLogic?.(builtLogic)
-        unmount = builtLogic.mount()
+        if (logic) {
+            builtLogic = logic.build({ ...props })
+            await onLogic?.(builtLogic)
+            unmount = builtLogic.mount()
+        }
     })
 
     afterEach(async () => {
-        unmount()
-        await expectLogic(logic).toFinishAllListeners()
+        if (logic) {
+            unmount()
+            await expectLogic(logic).toFinishAllListeners()
+        }
     })
 }

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -9,11 +9,9 @@ import { PostHog } from 'posthog-js'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { urls } from 'scenes/urls'
 import { IconExternalLinkBold } from 'lib/components/icons'
-import clsx from 'clsx'
 
 export function FeatureFlags(): JSX.Element {
-    const { userFlagsWithCalculatedInfo, showLocalFeatureFlagWarning, searchTerm, isHiddenBySearch } =
-        useValues(featureFlagsLogic)
+    const { showLocalFeatureFlagWarning, searchTerm, filteredFlags } = useValues(featureFlagsLogic)
     const { setOverriddenUserFlag, deleteOverriddenUserFlag, setShowLocalFeatureFlagWarning, setSearchTerm } =
         useActions(featureFlagsLogic)
     const { apiURL } = useValues(toolbarLogic)
@@ -52,7 +50,7 @@ export function FeatureFlags(): JSX.Element {
                         onChange={(e) => setSearchTerm(e.target.value)}
                     />
                     <List
-                        dataSource={userFlagsWithCalculatedInfo}
+                        dataSource={filteredFlags}
                         renderItem={({
                             feature_flag,
                             value_for_user_without_override,
@@ -61,12 +59,7 @@ export function FeatureFlags(): JSX.Element {
                             currentValue,
                         }) => {
                             return (
-                                <div
-                                    className={clsx([
-                                        'feature-flag-row',
-                                        { hidden: isHiddenBySearch(feature_flag.name) },
-                                    ])}
-                                >
+                                <div className={'feature-flag-row'}>
                                     <Row
                                         className={
                                             override ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -3,16 +3,18 @@ import './featureFlags.scss'
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
-import { Radio, Switch, Row, Typography, List, Button } from 'antd'
+import { Radio, Switch, Row, Typography, List, Button, Input } from 'antd'
 import { AnimatedCollapsible } from './AnimatedCollapsible'
 import { PostHog } from 'posthog-js'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { urls } from 'scenes/urls'
 import { IconExternalLinkBold } from 'lib/components/icons'
+import clsx from 'clsx'
 
 export function FeatureFlags(): JSX.Element {
-    const { userFlagsWithCalculatedInfo, showLocalFeatureFlagWarning } = useValues(featureFlagsLogic)
-    const { setOverriddenUserFlag, deleteOverriddenUserFlag, setShowLocalFeatureFlagWarning } =
+    const { userFlagsWithCalculatedInfo, showLocalFeatureFlagWarning, searchTerm, isHiddenBySearch } =
+        useValues(featureFlagsLogic)
+    const { setOverriddenUserFlag, deleteOverriddenUserFlag, setShowLocalFeatureFlagWarning, setSearchTerm } =
         useActions(featureFlagsLogic)
     const { apiURL } = useValues(toolbarLogic)
 
@@ -40,79 +42,99 @@ export function FeatureFlags(): JSX.Element {
                     </div>
                 </div>
             ) : (
-                <List
-                    dataSource={userFlagsWithCalculatedInfo}
-                    renderItem={({
-                        feature_flag,
-                        value_for_user_without_override,
-                        override,
-                        hasVariants,
-                        currentValue,
-                    }) => {
-                        return (
-                            <div className="feature-flag-row">
-                                <Row
-                                    className={
-                                        override ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'
-                                    }
+                <>
+                    <Input.Search
+                        allowClear
+                        autoFocus
+                        placeholder="Search"
+                        value={searchTerm}
+                        className={'feature-flag-row'}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                    />
+                    <List
+                        dataSource={userFlagsWithCalculatedInfo}
+                        renderItem={({
+                            feature_flag,
+                            value_for_user_without_override,
+                            override,
+                            hasVariants,
+                            currentValue,
+                        }) => {
+                            return (
+                                <div
+                                    className={clsx([
+                                        'feature-flag-row',
+                                        { hidden: isHiddenBySearch(feature_flag.name) },
+                                    ])}
                                 >
-                                    <Typography.Text ellipsis className="feature-flag-title">
-                                        {feature_flag.key}
-                                    </Typography.Text>
-                                    <a
-                                        className="feature-flag-external-link"
-                                        href={`${apiURL}${
-                                            feature_flag.id ? urls.featureFlag(feature_flag.id) : urls.featureFlags()
-                                        }`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        <IconExternalLinkBold />
-                                    </a>
-                                    <Switch
-                                        checked={!!currentValue}
-                                        onChange={(checked) => {
-                                            const newValue =
-                                                hasVariants && checked
-                                                    ? (feature_flag.filters?.multivariate?.variants[0]?.key as string)
-                                                    : checked
-                                            if (newValue === value_for_user_without_override && override) {
-                                                deleteOverriddenUserFlag(override.id as number)
-                                            } else {
-                                                setOverriddenUserFlag(feature_flag.id as number, newValue)
-                                            }
-                                        }}
-                                    />
-                                </Row>
-
-                                <AnimatedCollapsible collapsed={!hasVariants || !currentValue}>
                                     <Row
-                                        className={override ? 'variant-radio-group overridden' : 'variant-radio-group'}
+                                        className={
+                                            override ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'
+                                        }
                                     >
-                                        <Radio.Group
-                                            disabled={!currentValue}
-                                            value={currentValue}
-                                            onChange={(event) => {
-                                                const newValue = event.target.value
+                                        <Typography.Text ellipsis className="feature-flag-title">
+                                            {feature_flag.key}
+                                        </Typography.Text>
+                                        <a
+                                            className="feature-flag-external-link"
+                                            href={`${apiURL}${
+                                                feature_flag.id
+                                                    ? urls.featureFlag(feature_flag.id)
+                                                    : urls.featureFlags()
+                                            }`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            <IconExternalLinkBold />
+                                        </a>
+                                        <Switch
+                                            checked={!!currentValue}
+                                            onChange={(checked) => {
+                                                const newValue =
+                                                    hasVariants && checked
+                                                        ? (feature_flag.filters?.multivariate?.variants[0]
+                                                              ?.key as string)
+                                                        : checked
                                                 if (newValue === value_for_user_without_override && override) {
                                                     deleteOverriddenUserFlag(override.id as number)
                                                 } else {
                                                     setOverriddenUserFlag(feature_flag.id as number, newValue)
                                                 }
                                             }}
-                                        >
-                                            {feature_flag.filters?.multivariate?.variants.map((variant) => (
-                                                <Radio key={variant.key} value={variant.key}>
-                                                    {`${variant.key} - ${variant.name} (${variant.rollout_percentage}%)`}
-                                                </Radio>
-                                            ))}
-                                        </Radio.Group>
+                                        />
                                     </Row>
-                                </AnimatedCollapsible>
-                            </div>
-                        )
-                    }}
-                />
+
+                                    <AnimatedCollapsible collapsed={!hasVariants || !currentValue}>
+                                        <Row
+                                            className={
+                                                override ? 'variant-radio-group overridden' : 'variant-radio-group'
+                                            }
+                                        >
+                                            <Radio.Group
+                                                disabled={!currentValue}
+                                                value={currentValue}
+                                                onChange={(event) => {
+                                                    const newValue = event.target.value
+                                                    if (newValue === value_for_user_without_override && override) {
+                                                        deleteOverriddenUserFlag(override.id as number)
+                                                    } else {
+                                                        setOverriddenUserFlag(feature_flag.id as number, newValue)
+                                                    }
+                                                }}
+                                            >
+                                                {feature_flag.filters?.multivariate?.variants.map((variant) => (
+                                                    <Radio key={variant.key} value={variant.key}>
+                                                        {`${variant.key} - ${variant.name} (${variant.rollout_percentage}%)`}
+                                                    </Radio>
+                                                ))}
+                                            </Radio.Group>
+                                        </Row>
+                                    </AnimatedCollapsible>
+                                </div>
+                            )
+                        }}
+                    />
+                </>
             )}
         </div>
     )

--- a/frontend/src/toolbar/flags/featureFlags.scss
+++ b/frontend/src/toolbar/flags/featureFlags.scss
@@ -9,6 +9,10 @@
         margin-bottom: 5px;
         padding: 0 8px 0 8px;
 
+        &.hidden {
+            display: none;
+        }
+
         .feature-flag-row-header {
             background-color: #fafafa;
             border-radius: 4px;

--- a/frontend/src/toolbar/flags/featureFlags.scss
+++ b/frontend/src/toolbar/flags/featureFlags.scss
@@ -9,10 +9,6 @@
         margin-bottom: 5px;
         padding: 0 8px 0 8px;
 
-        &.hidden {
-            display: none;
-        }
-
         .feature-flag-row-header {
             background-color: #fafafa;
             border-radius: 4px;

--- a/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
@@ -2,6 +2,24 @@ import { expectLogic } from 'kea-test-utils'
 import { initKeaTestLogic } from '~/test/init'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
+import { CombinedFeatureFlagAndOverrideType } from '~/types'
+
+const featureFlags = [
+    { feature_flag: { name: 'flag 1' } },
+    { feature_flag: { name: 'flag 2' } },
+] as CombinedFeatureFlagAndOverrideType[]
+
+const featureFlagsWithExtraInfo = [
+    { currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 1' } },
+    { currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 2' } },
+]
+
+global.fetch = jest.fn(() =>
+    Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(featureFlags),
+    } as any as Response)
+)
 
 describe('feature flags logic', () => {
     let logic: ReturnType<typeof featureFlagsLogic.build>
@@ -16,7 +34,17 @@ describe('feature flags logic', () => {
 
     it('has expected defaults', () => {
         expectLogic(logic).toMatchValues({
-            userFlags: [],
+            userFlags: featureFlags,
+            searchTerm: '',
+            filteredFlags: featureFlagsWithExtraInfo,
+        })
+    })
+
+    it('can filter the flags', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setSearchTerm('2')
+        }).toMatchValues({
+            filteredFlags: [{ currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 2' } }],
         })
     })
 })

--- a/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
@@ -1,0 +1,22 @@
+import { expectLogic } from 'kea-test-utils'
+import { initKeaTestLogic } from '~/test/init'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
+import { toolbarLogic } from '~/toolbar/toolbarLogic'
+
+describe('feature flags logic', () => {
+    let logic: ReturnType<typeof featureFlagsLogic.build>
+
+    initKeaTestLogic()
+
+    beforeEach(() => {
+        toolbarLogic({ apiURL: 'http://localhost' }).mount()
+        logic = featureFlagsLogic()
+        logic.mount()
+    })
+
+    it('has expected defaults', () => {
+        expectLogic(logic).toMatchValues({
+            userFlags: [],
+        })
+    })
+})

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -102,17 +102,14 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         filteredFlags: [
             (s) => [s.searchTerm, s.userFlagsWithCalculatedInfo],
             (searchTerm, userFlagsWithCalculatedInfo) => {
-                const flagNames = userFlagsWithCalculatedInfo.map((uf) => uf.feature_flag.name)
-                const filteredNames = new Set(
-                    searchTerm
-                        ? new Fuse(flagNames, {
-                              threshold: 0.3,
-                          })
-                              .search(searchTerm)
-                              .map(({ item }) => item)
-                        : flagNames
-                )
-                return userFlagsWithCalculatedInfo.filter((uf) => filteredNames.has(uf.feature_flag.name))
+                return searchTerm
+                    ? new Fuse(userFlagsWithCalculatedInfo, {
+                          threshold: 0.3,
+                          keys: ['feature_flag.name'],
+                      })
+                          .search(searchTerm)
+                          .map(({ item }) => item)
+                    : userFlagsWithCalculatedInfo
             },
         ],
         countFlagsOverridden: [(s) => [s.userFlags], (userFlags) => userFlags.filter((flag) => !!flag.override).length],

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -102,18 +102,21 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         flagNames: [(s) => [s.userFlags], (userFlags) => userFlags.map((uf) => uf.feature_flag.name)],
         searchMatches: [
             (s) => [s.searchTerm, s.flagNames],
-            (searchTerm, flagNames) =>
-                searchTerm
+            (searchTerm, flagNames) => {
+                const filteredNames = searchTerm
                     ? new Fuse(flagNames, {
                           threshold: 0.3,
                       })
                           .search(searchTerm)
                           .map(({ item }) => item)
-                    : flagNames,
+                    : flagNames
+                return new Set(filteredNames)
+            },
         ],
-        isHiddenBySearch: [
-            (s) => [s.searchMatches],
-            (searchMatches) => (featureFlagName: string) => !searchMatches.includes(featureFlagName),
+        filteredFlags: [
+            (s) => [s.searchMatches, s.userFlagsWithCalculatedInfo],
+            (searchMatches, userFlagsWithCalculatedInfo) =>
+                userFlagsWithCalculatedInfo.filter((uf) => searchMatches.has(uf.feature_flag.name)),
         ],
         countFlagsOverridden: [(s) => [s.userFlags], (userFlags) => userFlags.filter((flag) => !!flag.override).length],
     },

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -99,24 +99,21 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                 })
             },
         ],
-        flagNames: [(s) => [s.userFlags], (userFlags) => userFlags.map((uf) => uf.feature_flag.name)],
-        searchMatches: [
-            (s) => [s.searchTerm, s.flagNames],
-            (searchTerm, flagNames) => {
-                const filteredNames = searchTerm
-                    ? new Fuse(flagNames, {
-                          threshold: 0.3,
-                      })
-                          .search(searchTerm)
-                          .map(({ item }) => item)
-                    : flagNames
-                return new Set(filteredNames)
-            },
-        ],
         filteredFlags: [
-            (s) => [s.searchMatches, s.userFlagsWithCalculatedInfo],
-            (searchMatches, userFlagsWithCalculatedInfo) =>
-                userFlagsWithCalculatedInfo.filter((uf) => searchMatches.has(uf.feature_flag.name)),
+            (s) => [s.searchTerm, s.userFlagsWithCalculatedInfo],
+            (searchTerm, userFlagsWithCalculatedInfo) => {
+                const flagNames = userFlagsWithCalculatedInfo.map((uf) => uf.feature_flag.name)
+                const filteredNames = new Set(
+                    searchTerm
+                        ? new Fuse(flagNames, {
+                              threshold: 0.3,
+                          })
+                              .search(searchTerm)
+                              .map(({ item }) => item)
+                        : flagNames
+                )
+                return userFlagsWithCalculatedInfo.filter((uf) => filteredNames.has(uf.feature_flag.name))
+            },
         ],
         countFlagsOverridden: [(s) => [s.userFlags], (userFlags) => userFlags.filter((flag) => !!flag.override).length],
     },

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -4,6 +4,7 @@ import { featureFlagsLogicType } from './featureFlagsLogicType'
 import { PostHog } from 'posthog-js'
 import { toolbarFetch } from '~/toolbar/utils'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
+import Fuse from 'fuse.js'
 
 export const featureFlagsLogic = kea<featureFlagsLogicType>({
     actions: {
@@ -11,6 +12,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         setOverriddenUserFlag: (flagId: number, overrideValue: string | boolean) => ({ flagId, overrideValue }),
         deleteOverriddenUserFlag: (overrideId: number) => ({ overrideId }),
         setShowLocalFeatureFlagWarning: (showWarning: boolean) => ({ showWarning }),
+        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
     },
 
     loaders: ({ values }) => ({
@@ -23,8 +25,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                     if (!response.ok) {
                         return []
                     }
-                    const results = await response.json()
-                    return results
+                    return await response.json()
                 },
                 setOverriddenUserFlag: async ({ flagId, overrideValue }, breakpoint) => {
                     const response = await toolbarFetch(
@@ -67,6 +68,12 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         ],
     }),
     reducers: {
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
+            },
+        ],
         showLocalFeatureFlagWarning: [
             false,
             {
@@ -92,12 +99,23 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                 })
             },
         ],
-        countFlagsOverridden: [
-            (s) => [s.userFlags],
-            (userFlags) => {
-                return userFlags.filter((flag) => !!flag.override).length
-            },
+        flagNames: [(s) => [s.userFlags], (userFlags) => userFlags.map((uf) => uf.feature_flag.name)],
+        searchMatches: [
+            (s) => [s.searchTerm, s.flagNames],
+            (searchTerm, flagNames) =>
+                searchTerm
+                    ? new Fuse(flagNames, {
+                          threshold: 0.3,
+                      })
+                          .search(searchTerm)
+                          .map(({ item }) => item)
+                    : flagNames,
         ],
+        isHiddenBySearch: [
+            (s) => [s.searchMatches],
+            (searchMatches) => (featureFlagName: string) => !searchMatches.includes(featureFlagName),
+        ],
+        countFlagsOverridden: [(s) => [s.userFlags], (userFlags) => userFlags.filter((flag) => !!flag.override).length],
     },
     events: ({ actions }) => ({
         afterMount: () => {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -182,10 +182,7 @@ export default {
     // transform: undefined,
 
     // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-    // transformIgnorePatterns: [
-    //   "/node_modules/",
-    //   "\\.pnp\\.[^\\/]+$"
-    // ],
+    transformIgnorePatterns: ['node_modules/(?!(query-selector-shadow-dom)/)'],
 
     // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
     // unmockedModulePathPatterns: undefined,


### PR DESCRIPTION
## Changes

When there are lots of feature flags it is hard to find flags in the toolbar feature flags list.

This adds a search box that filters the list of flags

![feature-flag-list-search](https://user-images.githubusercontent.com/984817/137808638-532f7f98-2f71-4343-80cc-21ec50e1b686.gif)

## How did you test this code?

by running it locally

attempting to write a test case for the feature flag logic led to a test runner error

```
/Users/pauldambra/github/posthog/node_modules/query-selector-shadow-dom/src/querySelectorDeep.js:6
    import { normalizeSelector } from './normalize';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module
```

So I didn't write any tests 