### PR TITLE
Capture exception if organization user is not found

### DIFF
--- a/ee/tasks/org_usage_report.py
+++ b/ee/tasks/org_usage_report.py
@@ -1,19 +1,6 @@
-import logging
-import os
-from datetime import datetime
-from typing import Dict, List, Union
+from typing import List
 
-from sentry_sdk import capture_exception
-
-from ee.clickhouse.models.event import get_agg_event_count_for_teams, get_agg_event_count_for_teams_and_period
-from posthog.event_usage import report_org_usage, report_org_usage_failure
-from posthog.models import Team, User
-from posthog.tasks.org_usage_report import OrgData, OrgReport, OrgReportMetadata, OrgUsageData, get_product_name
-from posthog.tasks.status_report import get_instance_licenses
-from posthog.utils import get_instance_realm, get_previous_day, is_clickhouse_enabled
-from posthog.version import VERSION
-
-logger = logging.getLogger(__name__)
+from posthog.tasks.org_usage_report import OrgReport, send_all_reports
 
 
 def send_all_org_usage_reports(*, dry_run: bool = False) -> List[OrgReport]:
@@ -21,71 +8,4 @@ def send_all_org_usage_reports(*, dry_run: bool = False) -> List[OrgReport]:
     Creates and sends usage reports for all teams.
     Returns a list of all the successfully sent reports.
     """
-    period_start, period_end = get_previous_day()
-    realm = get_instance_realm()
-    license_keys = get_instance_licenses()
-    metadata: OrgReportMetadata = {
-        "posthog_version": VERSION,
-        "deployment_infrastructure": os.getenv("DEPLOYMENT", "unknown"),
-        "realm": realm,
-        "is_clickhouse_enabled": is_clickhouse_enabled(),
-        "period": {"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
-        "site_url": os.getenv("SITE_URL", "unknown"),
-        "license_keys": license_keys,
-        "product": get_product_name(realm, license_keys),
-    }
-    org_data: Dict[str, OrgData] = {}
-    org_reports: List[OrgReport] = []
-
-    for team in Team.objects.exclude(organization__for_internal_metrics=True):
-        id = str(team.organization.id)
-        if id in org_data:
-            org_data[id]["teams"].append(team.id)
-        else:
-            org_data[id] = {
-                "teams": [team.id],
-                "name": team.organization.name,
-            }
-
-    for id, org in org_data.items():
-        org_first_user = User.objects.filter(current_team_id__in=org["teams"]).first()
-        if not org_first_user:
-            name = org["name"]
-            capture_exception(Exception(f"No user found for org '{name}' ({id})"))
-            continue
-        distinct_id = org_first_user.distinct_id
-        try:
-            month_start = period_start.replace(day=1)
-            usage = get_org_usage(
-                team_ids=org["teams"], period_start=period_start, period_end=period_end, month_start=month_start,
-            )
-            report: dict = {
-                **metadata,
-                **usage,
-                "organization_id": id,
-                "organization_name": org["name"],
-                "team_count": len(org["teams"]),
-            }
-            org_reports.append(report)  # type: ignore
-        except Exception as err:
-            report_org_usage_failure(distinct_id, str(err))
-        if not dry_run:
-            report_org_usage(distinct_id, report)
-
-    return org_reports
-
-
-def get_org_usage(
-    team_ids: List[Union[str, int]], period_start: datetime, period_end: datetime, month_start: datetime,
-) -> OrgUsageData:
-    default_usage: OrgUsageData = {
-        "event_count_lifetime": None,
-        "event_count_in_period": None,
-        "event_count_in_month": None,
-    }
-    usage = default_usage
-    usage["event_count_lifetime"] = get_agg_event_count_for_teams(team_ids)
-    usage["event_count_in_period"] = get_agg_event_count_for_teams_and_period(team_ids, period_start, period_end)
-    usage["event_count_in_month"] = get_agg_event_count_for_teams_and_period(team_ids, month_start, period_end)
-
-    return usage
+    return send_all_reports(dry_run=dry_run, data_source="clickhouse")

--- a/ee/tasks/test/test_org_usage_report.py
+++ b/ee/tasks/test/test_org_usage_report.py
@@ -52,7 +52,6 @@ def factory_org_usage_report(_create_person: Callable, _create_event: Callable) 
                         "new_user1", "$event2", "$mobile", now() - relativedelta(days=1, hours=1), team=self.team
                     )
                     _create_event("new_user1", "$event3", "$mobile", now() - relativedelta(weeks=5), team=self.team)
-
                     all_reports = send_all_org_usage_reports(dry_run=True)
                     org_report = all_reports[0]
 
@@ -65,39 +64,35 @@ def factory_org_usage_report(_create_person: Callable, _create_event: Callable) 
                         self.assertEqual(org_report["team_count"], 1)
 
                     _test_org_report()
-
-                    # Create usage in a different org.
-                    team_in_other_org = self.create_new_org_and_team(org_owner_email="other@example.com")
+                    team_in_other_org = self.create_new_org_and_team(
+                        org_owner_email="other@example.com"
+                    )  # Create usage in a different org.
                     _create_person("new_user1", team=team_in_other_org)
                     _create_person("new_user2", team=team_in_other_org)
                     _create_event(
                         "new_user1", "$event1", "$web", now() - relativedelta(days=1, hours=2), team=team_in_other_org
                     )
-
-                    # Make sure the original team report is unchanged
-                    _test_org_report()
-
-                    # Create an event before and after this current period
+                    _test_org_report()  # Make sure the original team report is unchanged
                     _create_event(
-                        "new_user1", "$eventAfter", "$web", now() + relativedelta(days=2, hours=2), team=self.team
+                        "new_user1",
+                        "$eventAfter",
+                        "$web",
+                        now() + relativedelta(days=2, hours=2),
+                        team=self.team,  # Create an event before and after this current period
                     )
                     _create_event(
                         "new_user1", "$eventBefore", "$web", now() - relativedelta(days=2, hours=2), team=self.team
                     )
-
                     updated_org_report = send_all_org_usage_reports(dry_run=True)[0]
-
-                    # Check event totals are updated
                     self.assertEqual(
-                        updated_org_report["event_count_lifetime"], org_report["event_count_lifetime"] + 2,
+                        updated_org_report["event_count_lifetime"],
+                        org_report["event_count_lifetime"] + 2,  # Check event totals are updated
                     )
-
-                    # Check event usage in current period is unchanged
-                    self.assertEqual(updated_org_report["event_count_in_period"], org_report["event_count_in_period"])
-
-                    # Create an internal metrics org
+                    self.assertEqual(
+                        updated_org_report["event_count_in_period"], org_report["event_count_in_period"]
+                    )  # Check event usage in current period is unchanged
                     internal_metrics_team = self.create_new_org_and_team(
-                        for_internal_metrics=True, org_owner_email="hey@posthog.com"
+                        for_internal_metrics=True, org_owner_email="hey@posthog.com"  # Create an internal metrics org
                     )
                     _create_person("new_user1", team=internal_metrics_team)
                     _create_event(
@@ -121,10 +116,11 @@ def factory_org_usage_report(_create_person: Callable, _create_event: Callable) 
                         now() - relativedelta(days=1, hours=2),
                         team=internal_metrics_team,
                     )
-                    # Verify that internal metrics events are not counted
                     self.assertEqual(
                         send_all_org_usage_reports(dry_run=True)[0]["event_count_lifetime"],
-                        updated_org_report["event_count_lifetime"],
+                        updated_org_report[
+                            "event_count_lifetime"
+                        ],  # Verify that internal metrics events are not counted
                     )
 
     return TestOrganizationUsageReport  # type: ignore

--- a/ee/tasks/test/test_org_usage_report.py
+++ b/ee/tasks/test/test_org_usage_report.py
@@ -24,5 +24,5 @@ def create_event_clickhouse(distinct_id: str, event: str, lib: str, created_at: 
     )
 
 
-class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_clickhouse, send_all_org_usage_reports, {"EE_AVAILABLE": True, "PRIMARY_DB": AnalyticsDBMS.CLICKHOUSE})):  # type: ignore
+class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_clickhouse, send_all_org_usage_reports, {"EE_AVAILABLE": True, "USE_TZ": False, "PRIMARY_DB": AnalyticsDBMS.CLICKHOUSE})):  # type: ignore
     pass

--- a/ee/tasks/test/test_org_usage_report.py
+++ b/ee/tasks/test/test_org_usage_report.py
@@ -1,129 +1,12 @@
-from typing import Callable
-from unittest.mock import patch
 from uuid import uuid4
 
-from dateutil.relativedelta import relativedelta
-from django.utils.timezone import datetime, now
-from freezegun import freeze_time
+from django.utils.timezone import datetime
 
 from ee.clickhouse.models.event import create_event
 from ee.tasks.org_usage_report import send_all_org_usage_reports
 from posthog.constants import AnalyticsDBMS
-from posthog.models import Organization, Person, Team, User
-from posthog.tasks.org_usage_report import OrgReport
-from posthog.test.base import APIBaseTest
-from posthog.version import VERSION
-
-
-def factory_org_usage_report(_create_person: Callable, _create_event: Callable) -> "TestOrganizationUsageReport":
-    class TestOrganizationUsageReport(APIBaseTest):
-        def create_new_org_and_team(
-            self, for_internal_metrics: bool = False, org_owner_email: str = "test@posthog.com"
-        ) -> Team:
-            org = Organization.objects.create(name="New Org", for_internal_metrics=for_internal_metrics)
-            team = Team.objects.create(organization=org, name="Default Project")
-            User.objects.create_and_join(org, org_owner_email, None)
-            return team
-
-        @patch("os.environ", {"DEPLOYMENT": "tests"})
-        def test_org_usage_report(self) -> None:
-            all_reports = send_all_org_usage_reports(dry_run=True)
-
-            self.assertEqual(all_reports[0]["posthog_version"], VERSION)
-            self.assertEqual(all_reports[0]["deployment_infrastructure"], "tests")
-            self.assertIsNotNone(all_reports[0]["realm"])
-            self.assertIsNotNone(all_reports[0]["is_clickhouse_enabled"])
-            self.assertIsNotNone(all_reports[0]["site_url"])
-            self.assertGreaterEqual(len(all_reports[0]["license_keys"]), 0)
-            self.assertIsNotNone(all_reports[0]["product"])
-
-        def test_event_counts(self) -> None:
-            def _test_org_report(org_report: OrgReport) -> None:
-                self.assertEqual(org_report["event_count_lifetime"], 5)
-                self.assertEqual(org_report["event_count_in_period"], 3)
-                self.assertEqual(org_report["event_count_in_month"], 4)
-                self.assertIsNotNone(org_report["organization_id"])
-                self.assertIsNotNone(org_report["organization_name"])
-                self.assertEqual(org_report["team_count"], 1)
-
-            with self.settings(**{"EE_AVAILABLE": True, "PRIMARY_DB": AnalyticsDBMS.CLICKHOUSE}):
-                with freeze_time("2020-11-02"):
-                    _create_person("old_user1", team=self.team)
-                    _create_person("old_user2", team=self.team)
-
-                with freeze_time("2020-11-11 00:30:00"):
-                    _create_person("new_user1", team=self.team)
-                    _create_person("new_user2", team=self.team)
-                    _create_event("new_user1", "$event1", "$web", now() - relativedelta(hours=12), team=self.team)
-                    _create_event("new_user1", "$event2", "$web", now() - relativedelta(hours=11), team=self.team)
-                    _create_event("new_user1", "$event2", "$web", now() - relativedelta(hours=11), team=self.team)
-                    _create_event(
-                        "new_user1", "$event2", "$mobile", now() - relativedelta(days=1, hours=1), team=self.team
-                    )
-                    _create_event("new_user1", "$event3", "$mobile", now() - relativedelta(weeks=5), team=self.team)
-                    all_reports = send_all_org_usage_reports(dry_run=True)
-                    org_report = all_reports[0]
-                    _test_org_report(org_report)
-                    team_in_other_org = self.create_new_org_and_team(
-                        org_owner_email="other@example.com"
-                    )  # Create usage in a different org.
-                    _create_person("new_user1", team=team_in_other_org)
-                    _create_person("new_user2", team=team_in_other_org)
-                    _create_event(
-                        "new_user1", "$event1", "$web", now() - relativedelta(days=1, hours=2), team=team_in_other_org
-                    )
-                    _test_org_report(org_report)  # Make sure the original team report is unchanged
-                    _create_event(
-                        "new_user1",
-                        "$eventAfter",
-                        "$web",
-                        now() + relativedelta(days=2, hours=2),
-                        team=self.team,  # Create an event before and after this current period
-                    )
-                    _create_event(
-                        "new_user1", "$eventBefore", "$web", now() - relativedelta(days=2, hours=2), team=self.team
-                    )
-                    updated_org_report = send_all_org_usage_reports(dry_run=True)[0]
-                    self.assertEqual(
-                        updated_org_report["event_count_lifetime"],
-                        org_report["event_count_lifetime"] + 2,  # Check event totals are updated
-                    )
-                    self.assertEqual(
-                        updated_org_report["event_count_in_period"], org_report["event_count_in_period"]
-                    )  # Check event usage in current period is unchanged
-                    internal_metrics_team = self.create_new_org_and_team(
-                        for_internal_metrics=True, org_owner_email="hey@posthog.com"  # Create an internal metrics org
-                    )
-                    _create_person("new_user1", team=internal_metrics_team)
-                    _create_event(
-                        "new_user1",
-                        "$event1",
-                        "$web",
-                        now() - relativedelta(days=1, hours=2),
-                        team=internal_metrics_team,
-                    )
-                    _create_event(
-                        "new_user1",
-                        "$event2",
-                        "$web",
-                        now() - relativedelta(days=1, hours=2),
-                        team=internal_metrics_team,
-                    )
-                    _create_event(
-                        "new_user1",
-                        "$event3",
-                        "$web",
-                        now() - relativedelta(days=1, hours=2),
-                        team=internal_metrics_team,
-                    )
-                    self.assertEqual(
-                        send_all_org_usage_reports(dry_run=True)[0]["event_count_lifetime"],
-                        updated_org_report[
-                            "event_count_lifetime"
-                        ],  # Verify that internal metrics events are not counted
-                    )
-
-    return TestOrganizationUsageReport  # type: ignore
+from posthog.models import Person, Team
+from posthog.tasks.test.test_org_usage_report import factory_org_usage_report
 
 
 def create_person(distinct_id: str, team: Team) -> Person:
@@ -141,5 +24,5 @@ def create_event_clickhouse(distinct_id: str, event: str, lib: str, created_at: 
     )
 
 
-class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_clickhouse)):  # type: ignore
+class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_clickhouse, send_all_org_usage_reports, {"EE_AVAILABLE": True, "PRIMARY_DB": AnalyticsDBMS.CLICKHOUSE})):  # type: ignore
     pass

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -3,6 +3,8 @@ import os
 from datetime import datetime
 from typing import Dict, List, Optional, TypedDict, Union
 
+from sentry_sdk import capture_exception
+
 from posthog.event_usage import report_org_usage, report_org_usage_failure
 from posthog.models import Event, Team, User
 from posthog.tasks.status_report import get_instance_licenses
@@ -91,7 +93,12 @@ def send_all_org_usage_reports(*, dry_run: bool = False) -> List[OrgReport]:
             }
 
     for id, org in org_data.items():
-        distinct_id = User.objects.filter(current_team_id__in=org["teams"]).first().distinct_id  # type: ignore
+        org_first_user = User.objects.filter(current_team_id__in=org["teams"]).first()
+        if not org_first_user:
+            name = org["name"]
+            capture_exception(Exception(f"No user found for org '{name}' ({id})"))
+            continue
+        distinct_id = org_first_user.distinct_id
         try:
             month_start = period_start.replace(day=1)
             usage = get_org_usage(

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Literal, Optional, TypedDict, Union
 
 from sentry_sdk import capture_exception
 
@@ -66,6 +66,16 @@ def send_all_org_usage_reports(*, dry_run: bool = False) -> List[OrgReport]:
     Creates and sends usage reports for all teams.
     Returns a list of all the successfully sent reports.
     """
+    return send_all_reports(dry_run=dry_run, data_source="postgres")
+
+
+def send_all_reports(
+    *, dry_run: bool = False, data_source: Literal["clickhouse", "postgres"] = "postgres"
+) -> List[OrgReport]:
+    """
+    Generic way to generate and send org usage reports.
+    Specify Postgres or ClickHouse for event queries.
+    """
     period_start, period_end = get_previous_day()
     realm = get_instance_realm()
     license_keys = get_instance_licenses()
@@ -102,7 +112,11 @@ def send_all_org_usage_reports(*, dry_run: bool = False) -> List[OrgReport]:
         try:
             month_start = period_start.replace(day=1)
             usage = get_org_usage(
-                team_ids=org["teams"], period_start=period_start, period_end=period_end, month_start=month_start,
+                team_ids=org["teams"],
+                period_start=period_start,
+                period_end=period_end,
+                month_start=month_start,
+                data_source=data_source,
             )
             report: dict = {
                 **metadata,
@@ -121,7 +135,11 @@ def send_all_org_usage_reports(*, dry_run: bool = False) -> List[OrgReport]:
 
 
 def get_org_usage(
-    team_ids: List[Union[str, int]], period_start: datetime, period_end: datetime, month_start: datetime,
+    team_ids: List[Union[str, int]],
+    period_start: datetime,
+    period_end: datetime,
+    month_start: datetime,
+    data_source: Literal["clickhouse", "postgres"] = "postgres",
 ) -> OrgUsageData:
     default_usage: OrgUsageData = {
         "event_count_lifetime": None,
@@ -129,13 +147,20 @@ def get_org_usage(
         "event_count_in_month": None,
     }
     usage = default_usage
-    usage["event_count_lifetime"] = Event.objects.filter(team_id__in=team_ids).count()
-    usage["event_count_in_period"] = Event.objects.filter(
-        team_id__in=team_ids, timestamp__gte=period_start, timestamp__lte=period_end,
-    ).count()
-    usage["event_count_in_month"] = Event.objects.filter(
-        team_id__in=team_ids, timestamp__gte=month_start, timestamp__lte=period_end,
-    ).count()
+    if data_source == "clickhouse":
+        from ee.clickhouse.models.event import get_agg_event_count_for_teams, get_agg_event_count_for_teams_and_period
+
+        usage["event_count_lifetime"] = get_agg_event_count_for_teams(team_ids)
+        usage["event_count_in_period"] = get_agg_event_count_for_teams_and_period(team_ids, period_start, period_end)
+        usage["event_count_in_month"] = get_agg_event_count_for_teams_and_period(team_ids, month_start, period_end)
+    else:
+        usage["event_count_lifetime"] = Event.objects.filter(team_id__in=team_ids).count()
+        usage["event_count_in_period"] = Event.objects.filter(
+            team_id__in=team_ids, timestamp__gte=period_start, timestamp__lte=period_end,
+        ).count()
+        usage["event_count_in_month"] = Event.objects.filter(
+            team_id__in=team_ids, timestamp__gte=month_start, timestamp__lte=period_end,
+        ).count()
 
     return usage
 

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -1,7 +1,16 @@
 import logging
 import os
 from datetime import datetime
-from typing import Dict, List, Literal, Optional, TypedDict, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+    cast,
+)
 
 from sentry_sdk import capture_exception, configure_scope
 
@@ -106,7 +115,7 @@ def send_all_reports(
         org_first_user = User.objects.filter(current_team_id__in=org["teams"]).first()
         if not org_first_user:
             with configure_scope() as scope:
-                scope.set_context("org", org)
+                scope.set_context("org", cast(Dict[str, Any], org))
                 name = org["name"]
                 capture_exception(Exception(f"No user found for org '{name}' ({id})"))
             continue

--- a/posthog/tasks/test/test_org_usage_report.py
+++ b/posthog/tasks/test/test_org_usage_report.py
@@ -62,37 +62,42 @@ def factory_org_usage_report(
                         "new_user1", "$event2", "$mobile", now() - relativedelta(days=1, hours=1), team=self.team
                     )
                     _create_event("new_user1", "$event3", "$mobile", now() - relativedelta(weeks=5), team=self.team)
+
                     all_reports = _send_all_org_usage_reports(dry_run=True)
                     org_report = all_reports[0]
                     _test_org_report(org_report)
-                    team_in_other_org = self.create_new_org_and_team(
-                        org_owner_email="other@example.com"
-                    )  # Create usage in a different org.
+
+                    # Create usage in a different org.
+                    team_in_other_org = self.create_new_org_and_team(org_owner_email="other@example.com")
                     _create_person("new_user1", team=team_in_other_org)
                     _create_person("new_user2", team=team_in_other_org)
                     _create_event(
                         "new_user1", "$event1", "$web", now() - relativedelta(days=1, hours=2), team=team_in_other_org
                     )
-                    _test_org_report(org_report)  # Make sure the original team report is unchanged
+
+                    # Make sure the original team report is unchanged
+                    _test_org_report(org_report)
+
+                    # Create an event before and after this current period
                     _create_event(
-                        "new_user1",
-                        "$eventAfter",
-                        "$web",
-                        now() + relativedelta(days=2, hours=2),
-                        team=self.team,  # Create an event before and after this current period
+                        "new_user1", "$eventAfter", "$web", now() + relativedelta(days=2, hours=2), team=self.team,
                     )
                     _create_event(
                         "new_user1", "$eventBefore", "$web", now() - relativedelta(days=2, hours=2), team=self.team
                     )
-                    updated_org_report = _send_all_org_usage_reports(dry_run=True)[0]  # Check event totals are updated
+
+                    # Check event totals are updated
+                    updated_org_report = _send_all_org_usage_reports(dry_run=True)[0]
                     self.assertEqual(
                         updated_org_report["event_count_lifetime"], org_report["event_count_lifetime"] + 2,
                     )
-                    self.assertEqual(
-                        updated_org_report["event_count_in_period"], org_report["event_count_in_period"]
-                    )  # Check event usage in current period is unchanged
+
+                    # Check event usage in current period is unchanged
+                    self.assertEqual(updated_org_report["event_count_in_period"], org_report["event_count_in_period"])
+
+                    # Create an internal metrics org
                     internal_metrics_team = self.create_new_org_and_team(
-                        for_internal_metrics=True, org_owner_email="hey@posthog.com"  # Create an internal metrics org
+                        for_internal_metrics=True, org_owner_email="hey@posthog.com"
                     )
                     _create_person("new_user1", team=internal_metrics_team)
                     _create_event(
@@ -116,10 +121,10 @@ def factory_org_usage_report(
                         now() - relativedelta(days=1, hours=2),
                         team=internal_metrics_team,
                     )
+
+                    # Verify that internal metrics events are not counted
                     self.assertEqual(
-                        _send_all_org_usage_reports(dry_run=True)[0][
-                            "event_count_lifetime"
-                        ],  # Verify that internal metrics events are not counted
+                        _send_all_org_usage_reports(dry_run=True)[0]["event_count_lifetime"],
                         updated_org_report["event_count_lifetime"],
                     )
 

--- a/posthog/tasks/test/test_org_usage_report.py
+++ b/posthog/tasks/test/test_org_usage_report.py
@@ -49,7 +49,6 @@ def factory_org_usage_report(_create_person: Callable, _create_event: Callable) 
                         "new_user1", "$event2", "$mobile", now() - relativedelta(days=1, hours=1), team=self.team
                     )
                     _create_event("new_user1", "$event3", "$mobile", now() - relativedelta(weeks=5), team=self.team)
-
                     all_reports = send_all_org_usage_reports(dry_run=True)
                     org_report = all_reports[0]
 
@@ -62,39 +61,34 @@ def factory_org_usage_report(_create_person: Callable, _create_event: Callable) 
                         self.assertEqual(org_report["team_count"], 1)
 
                     _test_org_report()
-
-                    # Create usage in a different org.
-                    team_in_other_org = self.create_new_org_and_team(org_owner_email="other@example.com")
+                    team_in_other_org = self.create_new_org_and_team(
+                        org_owner_email="other@example.com"
+                    )  # Create usage in a different org.
                     _create_person("new_user1", team=team_in_other_org)
                     _create_person("new_user2", team=team_in_other_org)
                     _create_event(
                         "new_user1", "$event1", "$web", now() - relativedelta(days=1, hours=2), team=team_in_other_org
                     )
-
-                    # Make sure the original team report is unchanged
-                    _test_org_report()
-
-                    # Create an event before and after this current period
+                    _test_org_report()  # Make sure the original team report is unchanged
                     _create_event(
-                        "new_user1", "$eventAfter", "$web", now() + relativedelta(days=2, hours=2), team=self.team
+                        "new_user1",
+                        "$eventAfter",
+                        "$web",
+                        now() + relativedelta(days=2, hours=2),
+                        team=self.team,  # Create an event before and after this current period
                     )
                     _create_event(
                         "new_user1", "$eventBefore", "$web", now() - relativedelta(days=2, hours=2), team=self.team
                     )
-
-                    updated_org_report = send_all_org_usage_reports(dry_run=True)[0]
-
-                    # Check event totals are updated
+                    updated_org_report = send_all_org_usage_reports(dry_run=True)[0]  # Check event totals are updated
                     self.assertEqual(
                         updated_org_report["event_count_lifetime"], org_report["event_count_lifetime"] + 2,
                     )
-
-                    # Check event usage in current period is unchanged
-                    self.assertEqual(updated_org_report["event_count_in_period"], org_report["event_count_in_period"])
-
-                    # Create an internal metrics org
+                    self.assertEqual(
+                        updated_org_report["event_count_in_period"], org_report["event_count_in_period"]
+                    )  # Check event usage in current period is unchanged
                     internal_metrics_team = self.create_new_org_and_team(
-                        for_internal_metrics=True, org_owner_email="hey@posthog.com"
+                        for_internal_metrics=True, org_owner_email="hey@posthog.com"  # Create an internal metrics org
                     )
                     _create_person("new_user1", team=internal_metrics_team)
                     _create_event(
@@ -118,9 +112,10 @@ def factory_org_usage_report(_create_person: Callable, _create_event: Callable) 
                         now() - relativedelta(days=1, hours=2),
                         team=internal_metrics_team,
                     )
-                    # Verify that internal metrics events are not counted
                     self.assertEqual(
-                        send_all_org_usage_reports(dry_run=True)[0]["event_count_lifetime"],
+                        send_all_org_usage_reports(dry_run=True)[0][
+                            "event_count_lifetime"
+                        ],  # Verify that internal metrics events are not counted
                         updated_org_report["event_count_lifetime"],
                     )
 

--- a/posthog/tasks/test/test_org_usage_report.py
+++ b/posthog/tasks/test/test_org_usage_report.py
@@ -141,5 +141,5 @@ def create_event_postgres(distinct_id: str, event: str, lib: str, created_at: da
     )
 
 
-class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_postgres, send_all_org_usage_reports, {"EE_AVAILABLE": False})):  # type: ignore
+class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_postgres, send_all_org_usage_reports, {"EE_AVAILABLE": False, "USE_TZ": False})):  # type: ignore
     pass


### PR DESCRIPTION
## Changes

1. Capture an exception to Sentry, and also **step over to the next org**, if we find a case where there are no users for a given org. (i.e. will not kill the cloud job if one org fails)
2. Refactor code and tests to remove duplicate code, make tests deterministic so they don't cause flakiness for the whole team.

Improves upon #6333.

## How did you test this code?

- See tests in changed files
- Local testing of Celery report task (via changing the schedule from daily to every 30 seconds)
