### PR TITLE
Include the insight ID in the url for "saved funnels"

### DIFF
--- a/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
+++ b/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
@@ -37,7 +37,9 @@ export function SavedFunnels(): JSX.Element {
                         <Col style={{ whiteSpace: 'pre-line', width: '100%', padding: 0 }}>
                             <Row justify="space-between" align="middle">
                                 <Link
-                                    to={`/insights?${toParams(funnel.filters)}#fromItem=${funnel.id}`}
+                                    to={`/insights?${toParams(funnel.filters)}#fromItem=${
+                                        funnel.id
+                                    }&fromSavedFunnels=true`}
                                     style={{ flex: 1 }}
                                 >
                                     {funnel.name}

--- a/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
+++ b/frontend/src/scenes/insights/SavedCard/SavedFunnels.tsx
@@ -36,7 +36,10 @@ export function SavedFunnels(): JSX.Element {
                     <List.Item>
                         <Col style={{ whiteSpace: 'pre-line', width: '100%', padding: 0 }}>
                             <Row justify="space-between" align="middle">
-                                <Link to={'/insights?' + toParams(funnel.filters)} style={{ flex: 1 }}>
+                                <Link
+                                    to={`/insights?${toParams(funnel.filters)}#fromItem=${funnel.id}`}
+                                    style={{ flex: 1 }}
+                                >
                                     {funnel.name}
                                 </Link>
                                 <Popconfirm

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -515,7 +515,9 @@ export const insightLogic = kea<insightLogicType>({
                     // - not saved if on the history "insight" for some reason
                     (insight.filters.insight as ViewType) !== ViewType.HISTORY &&
                     // - not saved if we came from a dashboard --> there's a separate "save" button for that
-                    !router.values.hashParams.fromDashboard
+                    !router.values.hashParams.fromDashboard &&
+                    // - not saved if we come from the "saved funnels" list, TO BE REMOVED with release of "3408-saved-insights"
+                    !router.values.hashParams.fromSavedFunnels
                 ) {
                     const filterLength = Object.keys(insight.filters).length
                     if (filterLength === 0 || (filterLength === 1 && 'from_dashboard' in insight.filters)) {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/6284
- Clicking on saved funnels opens the saved insight normally
- Making changes on the saved funnel will not persist those changes automatically, you'll need to "Save to dashboard" into another funnel for them to be saved as another "saved funnel"

## How did you test this code?

- Ran it locally to make sure it worked, discovered it overrode filters on dashboards, fixed that, tested again, all good
