### PR TITLE
Split bin tests into two test files

### DIFF
--- a/bin/ee-tests
+++ b/bin/ee-tests
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+if ! command -v nodemon &> /dev/null
+then
+    echo "Please install nodemon (npm install -g nodemon) to automatically run tests."
+    exit
+fi
+
+pytest_args=$*
+
+if [ $# -eq 0 ]; then
+    echo "Are you sure you want to run all backend tests? You can run specific tests by doing:"
+    echo " "
+    echo "bin/ee-tests ee/api/test/test_team.py::TestProjectEnterpriseAPI::test_create_project"
+    echo " "
+    read -r -p "Run all tests? [y/N] " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
+    then
+        echo "OK!"
+        pytest_args="ee"
+    else
+        exit
+    fi
+fi
+
+for ((i=1; i<=$#; i++))
+do
+  if [[ "${!i}" != ee* ]]
+  then
+    echo "${!i} is not an ee test. Did you mean to run ./bin/posthog-tests"
+    exit 1
+  fi
+done
+
+export REDIS_URL='redis:///'
+export TEST=1
+export DEBUG=1
+export PRIMARY_DB=clickhouse
+nodemon -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db -s $pytest_args; mypy ee"

--- a/bin/posthog-tests
+++ b/bin/posthog-tests
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+if ! command -v nodemon &> /dev/null
+then
+    echo "Please install nodemon (npm install -g nodemon) to automatically run tests."
+    exit
+fi
+
+pytest_args=$*
+
+if [ $# -eq 0 ]; then
+    echo "Are you sure you want to run all backend tests? You can run specific tests by doing:"
+    echo " "
+    echo "bin/posthog-tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user"
+    echo " "
+    read -r -p "Run all tests? [y/N] " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
+    then
+        echo "OK!"
+        pytest_args="posthog"
+    else
+        exit
+    fi
+fi
+
+for ((i=1; i<=$#; i++))
+do
+  if [[ "${!i}" != posthog* ]]
+  then
+    echo "${!i} is not a posthog test. Did you mean to run ./bin/ee-tests"
+    exit 1
+  fi
+done
+
+export REDIS_URL='redis:///'
+export TEST=1
+export DEBUG=1
+psql posthog -c "drop database if exists test_posthog"
+nodemon -w ./posthog --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db -s $pytest_args; mypy posthog"

--- a/bin/tests
+++ b/bin/tests
@@ -1,28 +1,8 @@
 #!/bin/bash
 set -e
 
-if ! command -v nodemon &> /dev/null
-then
-    echo "Please install nodemon (npm install -g nodemon) to automatically run tests."
-    exit
-fi
+echo "bin/tests is deprecated"
+echo "use bin/posthog-tests to run the posthog tests"
+echo "or bin/ee-tests to run the ee tests"
 
-
-if [ $# -eq 0 ]; then
-    echo "Are you sure you want to run all backend tests? You can run specific tests by doing:"
-    echo " "
-    echo "bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user"
-    echo " "
-    read -r -p "Run all tests? [y/N] " response
-    if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
-    then
-        echo "OK!"
-    else
-        exit
-    fi
-fi
-
-export REDIS_URL='redis:///'
-export TEST=1
-psql posthog -c "drop database if exists test_posthog"
-nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db -s $*; mypy posthog ee"
+exit 1


### PR DESCRIPTION
## Changes

If you want to run the system tests using `bin/tests` you need to know which environment variables to set. This is because the environment variables for tests in the `ee` folder are different from those in the `posthog` folder

This change deprecates the single test file and adds two new files. One of the `posthog` folder and one for `ee`

## How did you test this code?

by running each file individually to run all tests
by running each file with invalid input to see advice on what to do
by running each file with specific test patterns to run to see them run only matching tests
