### PR TITLE
fix(funnel): `TypeError` for funnel with display=ActionsLineGraph

### DIFF
--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -192,7 +192,7 @@ class Funnel(BaseQuery):
         ).format(
             interval=sql.Literal(filter.interval),
             particular_steps=sql.SQL(",\n").join(particular_steps),
-            steps_query=self._build_query(within_time="'1 day'"),
+            steps_query=sql.SQL(self._build_query(within_time="'1 day'")),
             interval_field=sql.SQL("step_0")
             if filter.interval != "week"
             else sql.SQL("(\"step_0\" + interval '1 day') AT TIME ZONE 'UTC'"),

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -77,7 +77,9 @@ class Funnel(BaseQuery):
                 # not after `ON pdi.distinct_id = posthog_event.distinct_id`
                 r'FROM "posthog_event"( [A-Z][0-9])?',
                 r"FROM posthog_event\1 JOIN posthog_persondistinctid pdi "
-                r"ON pdi.distinct_id = posthog_event.distinct_id",
+                #  NOTE: here we are joining on the unique identifier of the
+                #  persondistinctid table, i.e. (team_id, distinct_id)
+                r"ON pdi.distinct_id = posthog_event.distinct_id AND pdi.team_id = posthog_event.team_id",
                 event_string,
             )
             query = sql.SQL(event_string)
@@ -99,40 +101,23 @@ class Funnel(BaseQuery):
             "type": step.type,
         }
 
-    def _build_query(self, query_bodies: dict):
+    def _build_query(self, within_time: Optional[str] = None):
         """Build query using lateral joins using a combination of Django generated SQL
-           and sql built using psycopg2
+        and sql built using psycopg2
         """
+        query_bodies = self._gen_lateral_bodies(within_time=within_time)
 
         ON_TRUE = "ON TRUE"
         LEFT_JOIN_LATERAL = "LEFT JOIN LATERAL"
-        QUERY_HEADER = "SELECT {people}, {fields} FROM "
         LAT_JOIN_BODY = (
             """({query}) {step} {on_true} {join}""" if len(query_bodies) > 1 else """({query}) {step} {on_true} """
         )
-        PERSON_FIELDS = [
-            [sql.Identifier("posthog_person"), sql.Identifier("uuid")],
-            [sql.Identifier("posthog_person"), sql.Identifier("created_at")],
-            [sql.Identifier("posthog_person"), sql.Identifier("team_id")],
-            [sql.Identifier("posthog_person"), sql.Identifier("properties")],
-            [sql.Identifier("posthog_person"), sql.Identifier("is_user_id")],
-        ]
-        QUERY_FOOTER = sql.SQL(
-            """
-            JOIN posthog_person ON posthog_person.id = {step0}.person_id
-            WHERE {step0}.person_id IS NOT NULL
-            GROUP BY {group_by}"""
-        )
 
-        person_fields = sql.SQL(",").join([sql.SQL(".").join(col) for col in PERSON_FIELDS])
-
-        steps = [sql.Identifier(step) for step, query in query_bodies.items()]
+        steps = [sql.Identifier(step) for step, _ in query_bodies.items()]
         select_steps = [
-            sql.Composed([sql.SQL("MIN("), step, sql.SQL("."), sql.Identifier("step_ts"), sql.SQL(") as "), step,])
-            for step in steps
+            sql.Composed([step, sql.SQL("."), sql.Identifier("step_ts"), sql.SQL(" as "), step,]) for step in steps
         ]
         lateral_joins = []
-        query = sql.SQL(QUERY_HEADER).format(fields=sql.SQL(",").join(select_steps), people=person_fields)
         i = 0
         for step, qb in query_bodies.items():
             if i > 0:
@@ -165,8 +150,29 @@ class Funnel(BaseQuery):
                 )
             lateral_joins.append(base_body)
             i += 1
-        query_footer = QUERY_FOOTER.format(step0=steps[0], group_by=person_fields)
-        query = query + sql.SQL(" ").join(lateral_joins) + query_footer
+
+        event_chain_query = sql.SQL(" ").join(lateral_joins).as_string(connection.connection)
+
+        query = f"""
+            SELECT
+                DISTINCT ON (person.id)
+                person.uuid,
+                person.created_at,
+                person.team_id,
+                person.properties,
+                person.is_user_id,
+                {sql.SQL(",").join(select_steps).as_string(connection.connection)}
+            FROM posthog_person person
+            JOIN posthog_persondistinctid pdi ON pdi.person_id = person.id
+            JOIN {event_chain_query}
+            -- join on person_id for the first event.
+            -- NOTE: there is some implicit coupling here in that I am
+            -- assuming the name of the first event select is "step_0".
+            -- Maybe worth cleaning up in the future
+            ON person.id = step_0.person_id
+            WHERE person.team_id = {self._team.pk} AND person.id IS NOT NULL
+            ORDER BY person.id, step_0.step_ts ASC
+        """
         return query
 
     def _build_trends_query(self, filter: Filter) -> sql.SQL:
@@ -186,7 +192,7 @@ class Funnel(BaseQuery):
         ).format(
             interval=sql.Literal(filter.interval),
             particular_steps=sql.SQL(",\n").join(particular_steps),
-            steps_query=self._build_query(self._gen_lateral_bodies(within_time="'1 day'")),
+            steps_query=self._build_query(within_time="'1 day'"),
             interval_field=sql.SQL("step_0")
             if filter.interval != "week"
             else sql.SQL("(\"step_0\" + interval '1 day') AT TIME ZONE 'UTC'"),
@@ -277,6 +283,20 @@ class Funnel(BaseQuery):
         return steps
 
     def run(self, *args, **kwargs) -> List[Dict[str, Any]]:
+        """
+        Builds and runs a query to get all persons that have been in the funnel
+        steps defined by `self._filter.entities`. For example, entities may be
+        defined as:
+
+            1. event with event name "user signed up"
+            2. event with event name "user looked at report"
+
+        For a person to match they have to have gone through all `entities` in
+        order. We also only return one such chain of entities, the earliest one
+        we find.
+        """
+
+        # If no steps are defined, then there's no point in querying the database
         if len(self._filter.entities) == 0:
             return []
 
@@ -284,7 +304,9 @@ class Funnel(BaseQuery):
             return self._get_trends()
 
         with connection.cursor() as cursor:
-            qstring = self._build_query(self._gen_lateral_bodies()).as_string(cursor.connection)
+            # Then we build a query to query for them in order
+            qstring = self._build_query(within_time=None)
+
             cursor.execute(qstring)
             results = namedtuplefetchall(cursor)
         return self.data_to_return(results)

--- a/posthog/queries/funnel.py
+++ b/posthog/queries/funnel.py
@@ -77,9 +77,7 @@ class Funnel(BaseQuery):
                 # not after `ON pdi.distinct_id = posthog_event.distinct_id`
                 r'FROM "posthog_event"( [A-Z][0-9])?',
                 r"FROM posthog_event\1 JOIN posthog_persondistinctid pdi "
-                #  NOTE: here we are joining on the unique identifier of the
-                #  persondistinctid table, i.e. (team_id, distinct_id)
-                r"ON pdi.distinct_id = posthog_event.distinct_id AND pdi.team_id = posthog_event.team_id",
+                r"ON pdi.distinct_id = posthog_event.distinct_id",
                 event_string,
             )
             query = sql.SQL(event_string)
@@ -101,23 +99,40 @@ class Funnel(BaseQuery):
             "type": step.type,
         }
 
-    def _build_query(self, within_time: Optional[str] = None):
+    def _build_query(self, query_bodies: dict):
         """Build query using lateral joins using a combination of Django generated SQL
-        and sql built using psycopg2
+           and sql built using psycopg2
         """
-        query_bodies = self._gen_lateral_bodies(within_time=within_time)
 
         ON_TRUE = "ON TRUE"
         LEFT_JOIN_LATERAL = "LEFT JOIN LATERAL"
+        QUERY_HEADER = "SELECT {people}, {fields} FROM "
         LAT_JOIN_BODY = (
             """({query}) {step} {on_true} {join}""" if len(query_bodies) > 1 else """({query}) {step} {on_true} """
         )
+        PERSON_FIELDS = [
+            [sql.Identifier("posthog_person"), sql.Identifier("uuid")],
+            [sql.Identifier("posthog_person"), sql.Identifier("created_at")],
+            [sql.Identifier("posthog_person"), sql.Identifier("team_id")],
+            [sql.Identifier("posthog_person"), sql.Identifier("properties")],
+            [sql.Identifier("posthog_person"), sql.Identifier("is_user_id")],
+        ]
+        QUERY_FOOTER = sql.SQL(
+            """
+            JOIN posthog_person ON posthog_person.id = {step0}.person_id
+            WHERE {step0}.person_id IS NOT NULL
+            GROUP BY {group_by}"""
+        )
 
-        steps = [sql.Identifier(step) for step, _ in query_bodies.items()]
+        person_fields = sql.SQL(",").join([sql.SQL(".").join(col) for col in PERSON_FIELDS])
+
+        steps = [sql.Identifier(step) for step, query in query_bodies.items()]
         select_steps = [
-            sql.Composed([step, sql.SQL("."), sql.Identifier("step_ts"), sql.SQL(" as "), step,]) for step in steps
+            sql.Composed([sql.SQL("MIN("), step, sql.SQL("."), sql.Identifier("step_ts"), sql.SQL(") as "), step,])
+            for step in steps
         ]
         lateral_joins = []
+        query = sql.SQL(QUERY_HEADER).format(fields=sql.SQL(",").join(select_steps), people=person_fields)
         i = 0
         for step, qb in query_bodies.items():
             if i > 0:
@@ -150,29 +165,8 @@ class Funnel(BaseQuery):
                 )
             lateral_joins.append(base_body)
             i += 1
-
-        event_chain_query = sql.SQL(" ").join(lateral_joins).as_string(connection.connection)
-
-        query = f"""
-            SELECT
-                DISTINCT ON (person.id)
-                person.uuid,
-                person.created_at,
-                person.team_id,
-                person.properties,
-                person.is_user_id,
-                {sql.SQL(",").join(select_steps).as_string(connection.connection)}
-            FROM posthog_person person
-            JOIN posthog_persondistinctid pdi ON pdi.person_id = person.id
-            JOIN {event_chain_query}
-            -- join on person_id for the first event.
-            -- NOTE: there is some implicit coupling here in that I am
-            -- assuming the name of the first event select is "step_0".
-            -- Maybe worth cleaning up in the future
-            ON person.id = step_0.person_id
-            WHERE person.team_id = {self._team.pk} AND person.id IS NOT NULL
-            ORDER BY person.id, step_0.step_ts ASC
-        """
+        query_footer = QUERY_FOOTER.format(step0=steps[0], group_by=person_fields)
+        query = query + sql.SQL(" ").join(lateral_joins) + query_footer
         return query
 
     def _build_trends_query(self, filter: Filter) -> sql.SQL:
@@ -192,7 +186,7 @@ class Funnel(BaseQuery):
         ).format(
             interval=sql.Literal(filter.interval),
             particular_steps=sql.SQL(",\n").join(particular_steps),
-            steps_query=self._build_query(within_time="'1 day'"),
+            steps_query=self._build_query(self._gen_lateral_bodies(within_time="'1 day'")),
             interval_field=sql.SQL("step_0")
             if filter.interval != "week"
             else sql.SQL("(\"step_0\" + interval '1 day') AT TIME ZONE 'UTC'"),
@@ -283,20 +277,6 @@ class Funnel(BaseQuery):
         return steps
 
     def run(self, *args, **kwargs) -> List[Dict[str, Any]]:
-        """
-        Builds and runs a query to get all persons that have been in the funnel
-        steps defined by `self._filter.entities`. For example, entities may be
-        defined as:
-
-            1. event with event name "user signed up"
-            2. event with event name "user looked at report"
-
-        For a person to match they have to have gone through all `entities` in
-        order. We also only return one such chain of entities, the earliest one
-        we find.
-        """
-
-        # If no steps are defined, then there's no point in querying the database
         if len(self._filter.entities) == 0:
             return []
 
@@ -304,9 +284,7 @@ class Funnel(BaseQuery):
             return self._get_trends()
 
         with connection.cursor() as cursor:
-            # Then we build a query to query for them in order
-            qstring = self._build_query(within_time=None)
-
+            qstring = self._build_query(self._gen_lateral_bodies()).as_string(cursor.connection)
             cursor.execute(qstring)
             results = namedtuplefetchall(cursor)
         return self.data_to_return(results)

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -414,48 +414,52 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertEqual(result[0]["count"], 2)
 
-        @pytest.mark.skipif(is_clickhouse_enabled(), reason="This test is specifically for postgres backend")
-        def test_funnel_with_display_set_to_trends_linear(self):
-            """
-            This is a limited regression test to ensure that the issue
-            highlighted by https://github.com/PostHog/posthog/issues/6530 is
-            resolved.
-
-            I am not attempting to evaluate the correctness of
-            `ActionsLineGraph` with this test, just that it is the same as
-            before https://github.com/PostHog/posthog/pull/5997#event-5326521193
-            was introduceed.
-            """
-            with freeze_time("2020-01-01"):
-                person_factory(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"})
-                event_factory(distinct_id="person1", event="event1", team=self.team)
-                event_factory(distinct_id="person1", event="event2", team=self.team)
-
-                result = Funnel(
-                    filter=Filter(
-                        data={
-                            "events": [{"id": "event1"}, {"id": "event2"}],
-                            "insight": INSIGHT_FUNNELS,
-                            "display": "ActionsLineGraph",
-                            "interval": "day",
-                            # Just get today, so the response isn't massive
-                            "date_from": "-0days",
-                        }
-                    ),
-                    team=self.team,
-                ).run()
-
-            assert result == [
-                {
-                    "count": 0,
-                    "data": [100],
-                    "days": [datetime(2020, 1, 1).replace(tzinfo=pytz.UTC)],
-                    "labels": ["1-Jan-2020"],
-                }
-            ]
-
     return TestGetFunnel
 
 
 class TestFunnel(funnel_test_factory(Funnel, Event.objects.create, Person.objects.create)):  # type: ignore
     pass
+
+
+@patch("posthog.celery.update_cache_item_task.delay", update_cache_item)
+class TestGetFunnel(APIBaseTest):
+    def test_funnel_with_display_set_to_trends_linear(self):
+        """
+        This is a limited regression test to ensure that the issue
+        highlighted by https://github.com/PostHog/posthog/issues/6530 is
+        resolved.
+
+        I am not attempting to evaluate the correctness of
+        `ActionsLineGraph` with this test, just that it is the same as
+        before https://github.com/PostHog/posthog/pull/5997#event-5326521193
+        was introduceed.
+        """
+        with freeze_time("2020-01-01"):
+            Person.objects.create(
+                distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@posthog.com"}
+            )
+            Event.objects.create(distinct_id="person1", event="event1", team=self.team)
+            Event.objects.create(distinct_id="person1", event="event2", team=self.team)
+
+            result = Funnel(
+                filter=Filter(
+                    data={
+                        "events": [{"id": "event1"}, {"id": "event2"}],
+                        "insight": INSIGHT_FUNNELS,
+                        "display": "ActionsLineGraph",
+                        "interval": "day",
+                        # Just get today, so the response isn't massive
+                        "date_from": "-0days",
+                    }
+                ),
+                team=self.team,
+            ).run()
+
+        assert result == [
+            {
+                "count": 0,
+                "data": [100],
+                "days": [datetime(2020, 1, 1).replace(tzinfo=pytz.UTC)],
+                "labels": ["1-Jan-2020"],
+            }
+        ]

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -1,9 +1,8 @@
-from unittest.mock import patch
 from datetime import datetime
+from unittest.mock import patch
 
-import pytz
 import pytest
-
+import pytz
 from freezegun import freeze_time
 
 from posthog.constants import FILTER_TEST_ACCOUNTS, INSIGHT_FUNNELS

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from unittest.mock import patch
 
-import pytest
 import pytz
 from freezegun import freeze_time
 
@@ -12,7 +11,6 @@ from posthog.queries.funnel import Funnel
 from posthog.tasks.calculate_action import calculate_actions_from_last_calculation
 from posthog.tasks.update_cache import update_cache_item
 from posthog.test.base import APIBaseTest, test_with_materialized_columns
-from posthog.utils import is_clickhouse_enabled
 
 
 def funnel_test_factory(Funnel, event_factory, person_factory):

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from datetime import datetime
 
 import pytz
+import pytest
 
 from freezegun import freeze_time
 
@@ -12,6 +13,7 @@ from posthog.queries.funnel import Funnel
 from posthog.tasks.calculate_action import calculate_actions_from_last_calculation
 from posthog.tasks.update_cache import update_cache_item
 from posthog.test.base import APIBaseTest, test_with_materialized_columns
+from posthog.utils import is_clickhouse_enabled
 
 
 def funnel_test_factory(Funnel, event_factory, person_factory):
@@ -413,6 +415,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertEqual(result[0]["count"], 2)
 
+        @pytest.mark.skipif(is_clickhouse_enabled(), reason="This test is specifically for postgres backend")
         def test_funnel_with_display_set_to_trends_linear(self):
             """
             This is a limited regression test to ensure that the issue

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -416,11 +416,6 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
 
 class TestFunnel(funnel_test_factory(Funnel, Event.objects.create, Person.objects.create)):  # type: ignore
-    pass
-
-
-@patch("posthog.celery.update_cache_item_task.delay", update_cache_item)
-class TestGetFunnel(APIBaseTest):
     def test_funnel_with_display_set_to_trends_linear(self):
         """
         This is a limited regression test to ensure that the issue


### PR DESCRIPTION
This resolves an issue what was introduced by
https://github.com/PostHog/posthog/pull/5997 where we would fail to
calculate a funnel result if display="ActionsLineGraph" was specified.
The fix was simply to wrap a string in `sql.SQL`.

Resolves https://github.com/PostHog/posthog/issues/6530