### PR TITLE
Export from the beginning -> Export historical events

### DIFF
--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -21,7 +21,7 @@ const requiredRule = {
 }
 
 // keep in sync with plugin-server's export-historical-events.ts
-const HISTORICAL_EXPORT_JOB_NAME = 'Export events from the beginning'
+const HISTORICAL_EXPORT_JOB_NAME = 'Export historical events'
 
 export function PluginJobConfiguration({
     jobName,

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -27,9 +27,9 @@ export function PluginJobOptions({ plugin, pluginConfigId }: PluginJobOptionsPro
                 }
                 return (
                     <div key={jobName}>
-                        {jobName === 'Export events from the beginning' ? (
+                        {jobName === 'Export historical events' ? (
                             <Tooltip title="Run this plugin on all historical events ingested until now">
-                                <i>Export events from the beginning</i>
+                                <i>Export historical events</i>
                             </Tooltip>
                         ) : (
                             <i>{jobName}</i>


### PR DESCRIPTION
## Changes

After https://github.com/PostHog/posthog/pull/5996 the name is now incorrect. One can export on any date range, not just from the beginning.

Pair PR https://github.com/PostHog/plugin-server/pull/604

## How did you test this code?

*Please describe.*
