### PR TITLE
ci(e2e): use fixed width email address to avoid flaky test

### DIFF
--- a/cypress/integration/invitesMembers.js
+++ b/cypress/integration/invitesMembers.js
@@ -29,7 +29,10 @@ describe('Invite Signup', () => {
     })
 
     it('New user can use invite', () => {
-        const target_email = `newuser+${Math.floor(Math.random() * 10000)}@posthog.com`
+        const target_email = `newuser+${Math.floor(Math.random() * 10000)
+            .toString()
+            // Ensure we have a fixed width
+            .padStart(4, '0')}@posthog.com`
         cy.request({
             method: 'POST',
             url: '/api/organizations/@current/invites/',


### PR DESCRIPTION
We were using random * 10000 which includes values < 1000. That doesn't
work with the expectation of having a certain value in the email input
box.

This is to remove the flaky that is reported by cypress.io:
https://dashboard.cypress.io/projects/twojfp/analytics/flaky-tests/96da51b2-06c5-fcf1-0a71-67319b1c29d8-b56a9111-62a3-6754-812b-e0fad951b8a2