### PR TITLE
fix(correlation): fix recursion limit error if no steps provided

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -358,6 +358,8 @@ class FunnelCorrelation:
             correlation, e.g. "watched video"
 
         """
+        if not self._filter.entities:
+            return FunnelCorrelationResponse(events=[], skewed=False)
 
         event_contingency_tables, success_total, failure_total = self.get_partial_event_contingency_tables()
 

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -334,6 +334,33 @@ class FunnelCorrelationTest(BaseTest):
             ],
         )
 
+    def test_correlation_endpoint_request_with_no_steps_doesnt_fail(self):
+        """
+        This just checks that we get an empty result, this mimics what happens
+        with other insight endpoints. It's questionable that perhaps this whould
+        be a 400 instead.
+        """
+        self.client.force_login(self.user)
+
+        with freeze_time("2020-01-01"):
+            response = get_funnel_correlation_ok(
+                client=self.client,
+                team_id=self.team.pk,
+                request=FunnelCorrelationRequest(
+                    events=json.dumps([]),
+                    date_to="2020-01-14",
+                    date_from="2020-01-01",
+                    funnel_correlation_type=FunnelCorrelationType.PROPERTIES,
+                    funnel_correlation_names=json.dumps(["$browser"]),
+                ),
+            )
+
+        assert response == {
+            "is_cached": False,
+            "last_refresh": "2020-01-01T00:00:00Z",
+            "result": {"events": [], "skewed": False},
+        }
+
 
 @pytest.fixture(autouse=True)
 def clear_django_cache():


### PR DESCRIPTION
Previously we would attempt to generate a response even though there
were no steps. There appears to be some code paths that blow up if this
happens, so instead we return as soon as we can in this case. This
appears to be the behaviour elsewhere also.

This resolves the sentry error found here:
https://sentry.io/organizations/posthog/issues/2718768248/