### PR TITLE
paths bug: add properties to path cleanfilters

### DIFF
--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -91,6 +91,7 @@ export function cleanFilters(filters: Partial<FilterType>, oldFilters?: Partial<
     } else if (filters.insight === ViewType.PATHS) {
         return {
             insight: ViewType.PATHS,
+            properties: filters.properties || [],
             start_point: filters.start_point || undefined,
             end_point: filters.end_point || undefined,
             step_limit: filters.step_limit || DEFAULT_STEP_LIMIT,


### PR DESCRIPTION
## Changes

*Please describe.*  
- cleanFilters was missing properties field for paths so property filtering wasn't working on paths
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*

