### PR TITLE
Simplified UI for breakdown properties

### DIFF
--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -18,7 +18,7 @@ export function TaxonomicBreakdownButton({
     onlyCohorts,
 }: TaxonomicBreakdownButtonProps): JSX.Element {
     const [open, setOpen] = useState(false)
-    console.log({ breakdownType, needle: TaxonomicFilterGroupType.Cohorts })
+
     return (
         <Popup
             overlay={

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -1,6 +1,4 @@
-import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
-import { useValues } from 'kea'
-import { cohortsModel } from '~/models/cohortsModel'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import React, { useState } from 'react'
 import { Popup } from 'lib/components/Popup/Popup'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
@@ -9,37 +7,22 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { PlusCircleOutlined } from '@ant-design/icons'
 
 export interface TaxonomicBreakdownButtonProps {
-    breakdown?: TaxonomicFilterValue
     breakdownType?: TaxonomicFilterGroupType
     onChange: (breakdown: string | number, groupType: TaxonomicFilterGroupType) => void
     onlyCohorts?: boolean
 }
 
 export function TaxonomicBreakdownButton({
-    breakdown,
     breakdownType,
     onChange,
     onlyCohorts,
 }: TaxonomicBreakdownButtonProps): JSX.Element {
-    const { cohorts } = useValues(cohortsModel)
     const [open, setOpen] = useState(false)
-
-    let label: string | null = breakdown ? `${breakdown}` : null
-
-    if (breakdown && breakdownType === TaxonomicFilterGroupType.CohortsWithAllUsers) {
-        label =
-            breakdown === 'all'
-                ? 'All Users'
-                : cohorts.filter((c) => c.id == breakdown)[0]?.name || `Cohort ${breakdown}`
-    }
-
-    return label ? (
-        <></>
-    ) : (
+    console.log({ breakdownType, needle: TaxonomicFilterGroupType.Cohorts })
+    return (
         <Popup
             overlay={
                 <TaxonomicFilter
-                    value={breakdown}
                     groupType={breakdownType}
                     onChange={(groupType, value) => {
                         if (value) {
@@ -65,14 +48,20 @@ export function TaxonomicBreakdownButton({
         >
             {({ setRef }) => (
                 <Button
-                    type={breakdown ? 'primary' : 'link'}
-                    icon={!breakdown ? <PlusCircleOutlined /> : undefined}
+                    type={'link'}
+                    icon={<PlusCircleOutlined />}
                     data-attr="add-breakdown-button"
-                    style={breakdown ? { color: '#fff' } : { paddingLeft: 0 }}
                     onClick={() => setOpen(!open)}
+                    className="taxonomic-breakdown-filter tag-button"
                     ref={setRef}
                 >
-                    <PropertyKeyInfo value={label ?? (onlyCohorts ? 'Add cohort' : 'Add breakdown')} />
+                    <PropertyKeyInfo
+                        value={
+                            breakdownType === TaxonomicFilterGroupType.CohortsWithAllUsers
+                                ? 'Add cohort'
+                                : 'Add breakdown'
+                        }
+                    />
                 </Button>
             )}
         </Popup>

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -33,7 +33,9 @@ export function TaxonomicBreakdownButton({
                 : cohorts.filter((c) => c.id == breakdown)[0]?.name || `Cohort ${breakdown}`
     }
 
-    return (
+    return label ? (
+        <></>
+    ) : (
         <Popup
             overlay={
                 <TaxonomicFilter

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
@@ -1,16 +1,23 @@
 @import '~/vars';
 
 .taxonomic-breakdown-filter {
+    &.tag-button {
+        padding: 8px 12px;
+        line-height: 16px;
+        font-size: 14px;
+        height: auto;
+    }
+
     &.tag-pill {
         vertical-align: bottom;
-        line-height: 15px;
+        padding: 8px 12px;
+        line-height: 16px;
         color: $bg_depth;
         background-color: $border;
         border: 1px solid $border;
         border-radius: 40px;
-        padding: 8px 12px;
         font-weight: 400;
-        font-size: 15px;
+        font-size: 14px;
 
         span.ant-typography-ellipsis-single-line {
             vertical-align: baseline;
@@ -18,8 +25,8 @@
 
         span.anticon {
             vertical-align: bottom;
-            line-height: 15px;
-            font-size: 15px;
+            line-height: 16px;
+            font-size: 14px;
             color: $bg_depth;
         }
     }

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
@@ -1,0 +1,22 @@
+@import '~/vars';
+
+.taxonomic-breakdown-filter {
+    &.tag-pill {
+        vertical-align: bottom;
+        line-height: 15px;
+        color: $bg_depth;
+        background-color: $border;
+        border: 1px solid $border;
+        border-radius: 40px;
+        padding: 8px 12px;
+        font-weight: 400;
+        font-size: 15px;
+
+        span.anticon {
+            vertical-align: bottom;
+            line-height: 15px;
+            font-size: 15px;
+            color: $bg_depth;
+        }
+    }
+}

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
@@ -12,6 +12,10 @@
         font-weight: 400;
         font-size: 15px;
 
+        span.ant-typography-ellipsis-single-line {
+            vertical-align: baseline;
+        }
+
         span.anticon {
             vertical-align: bottom;
             line-height: 15px;

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -33,7 +33,6 @@ export function BreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilte
     const tags = breakdownArray
         .filter((b) => !!b)
         .map((t, index) => {
-            console.log({ t, index })
             const onClose =
                 typeof t === 'string' && t !== 'all'
                     ? () => setFilters({ breakdown: undefined, breakdown_type: null })
@@ -67,13 +66,7 @@ export function BreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilte
                             const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(
                                 groupType
                             ) as BreakdownType
-                            console.log({
-                                groupType,
-                                changedBreakdownType,
-                                changedBreakdown,
-                                breakdownParts,
-                                needle: TaxonomicFilterGroupType.CohortsWithAllUsers,
-                            })
+
                             if (changedBreakdownType) {
                                 setFilters({
                                     breakdown:

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Row, Tag } from 'antd'
+import { Space, Tag } from 'antd'
 import { BreakdownType, FilterType } from '~/types'
 import {
     propertyFilterTypeToTaxonomicFilterType,
@@ -14,11 +14,10 @@ import './TaxonomicBreakdownFilter.scss'
 
 export interface TaxonomicBreakdownFilterProps {
     filters: Partial<FilterType>
-    onChange: (value: string | number | (string | number)[] | null, groupType: BreakdownType | null) => void
     setFilters: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
 }
 
-export function BreakdownFilter({ filters, onChange, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
+export function BreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
     const { breakdown, breakdown_type } = filters
 
     let breakdownType = propertyFilterTypeToTaxonomicFilterType(breakdown_type)
@@ -26,11 +25,7 @@ export function BreakdownFilter({ filters, onChange, setFilters }: TaxonomicBrea
         breakdownType = TaxonomicFilterGroupType.CohortsWithAllUsers
     }
 
-    /**
-     * this is a list of "tags" representing breakdowns each of which can be removed followed by a button to add more
-     * if the tag is a cohort there can be zero to many in the list
-     * if the tag is a breakdown there can be zero or one in the list
-     */
+    const hasSelectedBreakdown = breakdown && typeof breakdown === 'string'
 
     const breakdownArray = (Array.isArray(breakdown) ? breakdown : [breakdown]).filter((b) => !!b)
     const breakdownParts = breakdownArray.map((b) => (b === 'all' ? b : parseInt(`${b}`)))
@@ -38,6 +33,7 @@ export function BreakdownFilter({ filters, onChange, setFilters }: TaxonomicBrea
     const tags = breakdownArray
         .filter((b) => !!b)
         .map((t, index) => {
+            console.log({ t, index })
             const onClose =
                 typeof t === 'string' && t !== 'all'
                     ? () => setFilters({ breakdown: undefined, breakdown_type: null })
@@ -60,48 +56,37 @@ export function BreakdownFilter({ filters, onChange, setFilters }: TaxonomicBrea
             )
         })
 
-    if (breakdownType === TaxonomicFilterGroupType.CohortsWithAllUsers && breakdown) {
-        return (
-            <>
-                {tags}
-                {[...breakdownParts, 0].map((breakdownPart, index) => (
-                    <Row key={index} style={{ marginBottom: 8 }}>
-                        <TaxonomicBreakdownButton
-                            onlyCohorts={index > 0 || breakdownParts.length > 1}
-                            breakdown={breakdownPart}
-                            breakdownType={breakdownType}
-                            onChange={(changedBreakdown) => {
-                                const fullChangedBreakdown = [...breakdownParts, ''] // add empty element in teh end we could change it in `map`
-                                    .map((b, i) => (i === index ? changedBreakdown : b))
-                                    .filter((b) => !!b)
-                                    .map((b) => (b === 'all' ? b : parseInt(`${b}`)))
-
-                                onChange(fullChangedBreakdown, 'cohort')
-                            }}
-                        />
-                    </Row>
-                ))}
-            </>
-        )
-    }
-
     return (
         <>
-            {tags}
-            <TaxonomicBreakdownButton
-                breakdown={(Array.isArray(breakdown) ? breakdown[0] : breakdown) || undefined}
-                breakdownType={breakdownType}
-                onChange={(changedBreakdown, groupType) => {
-                    const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(groupType) as BreakdownType
-                    if (changedBreakdownType) {
-                        if (groupType === TaxonomicFilterGroupType.CohortsWithAllUsers) {
-                            onChange([changedBreakdown], changedBreakdownType)
-                        } else {
-                            onChange(changedBreakdown, changedBreakdownType)
-                        }
-                    }
-                }}
-            />
+            <Space direction={'horizontal'} wrap={true}>
+                {tags}
+                {hasSelectedBreakdown ? null : (
+                    <TaxonomicBreakdownButton
+                        breakdownType={breakdownType}
+                        onChange={(changedBreakdown, groupType) => {
+                            const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(
+                                groupType
+                            ) as BreakdownType
+                            console.log({
+                                groupType,
+                                changedBreakdownType,
+                                changedBreakdown,
+                                breakdownParts,
+                                needle: TaxonomicFilterGroupType.CohortsWithAllUsers,
+                            })
+                            if (changedBreakdownType) {
+                                setFilters({
+                                    breakdown:
+                                        groupType === TaxonomicFilterGroupType.CohortsWithAllUsers
+                                            ? [...breakdownParts, changedBreakdown]
+                                            : changedBreakdown,
+                                    breakdown_type: changedBreakdownType,
+                                })
+                            }
+                        }}
+                    />
+                )}
+            </Space>
         </>
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -18,7 +18,6 @@ import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 import { FunnelVizType } from '~/types'
 import { BreakdownFilter } from 'scenes/insights/BreakdownFilter'
-import { CloseButton } from 'lib/components/CloseButton'
 import { FunnelConversionWindowFilter } from 'scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter'
 import { FunnelExclusionsFilter } from 'scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter'
 import { SavedFunnels } from 'scenes/insights/SavedCard'
@@ -177,29 +176,9 @@ export function FunnelTab(): JSX.Element {
                                     <InfoCircleOutlined className="info-indicator" />
                                 </Tooltip>
                             </h4>
-                            {filters.breakdown_type === 'cohort' && filters.breakdown ? (
-                                <BreakdownFilter
-                                    filters={filters}
-                                    onChange={(breakdown, breakdown_type): void =>
-                                        setFilters({ breakdown, breakdown_type })
-                                    }
-                                />
-                            ) : (
-                                <Row align="middle">
-                                    <BreakdownFilter
-                                        filters={filters}
-                                        onChange={(breakdown, breakdown_type): void =>
-                                            setFilters({ breakdown, breakdown_type })
-                                        }
-                                    />
-                                    {filters.breakdown && (
-                                        <CloseButton
-                                            onClick={(): void => setFilters({ breakdown: null, breakdown_type: null })}
-                                            style={{ marginTop: 1, marginLeft: 5 }}
-                                        />
-                                    )}
-                                </Row>
-                            )}
+                            <Row align="middle">
+                                <BreakdownFilter filters={filters} setFilters={setFilters} />
+                            </Row>
                         </>
                     )}
                     <hr />

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -168,23 +168,13 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                                 </Tooltip>
                             </h4>
                             <Row align="middle">
-                                {filters.breakdown_type === 'cohort' && filters.breakdown ? (
-                                    <BreakdownFilter
-                                        filters={filters}
-                                        setFilters={setFilters}
-                                        onChange={(breakdown, breakdown_type): void =>
-                                            setFilters({ breakdown, breakdown_type })
-                                        }
-                                    />
-                                ) : (
-                                    <BreakdownFilter
-                                        filters={filters}
-                                        setFilters={setFilters}
-                                        onChange={(breakdown, breakdown_type): void =>
-                                            setFilters({ breakdown, breakdown_type })
-                                        }
-                                    />
-                                )}
+                                <BreakdownFilter
+                                    filters={filters}
+                                    setFilters={setFilters}
+                                    onChange={(breakdown, breakdown_type): void =>
+                                        setFilters({ breakdown, breakdown_type })
+                                    }
+                                />
                             </Row>
                         </>
                     )}

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -168,13 +168,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                                 </Tooltip>
                             </h4>
                             <Row align="middle">
-                                <BreakdownFilter
-                                    filters={filters}
-                                    setFilters={setFilters}
-                                    onChange={(breakdown, breakdown_type): void =>
-                                        setFilters({ breakdown, breakdown_type })
-                                    }
-                                />
+                                <BreakdownFilter filters={filters} setFilters={setFilters} />
                             </Row>
                         </>
                     )}

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -167,29 +167,25 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                                     <InfoCircleOutlined className="info-indicator" />
                                 </Tooltip>
                             </h4>
-                            {filters.breakdown_type === 'cohort' && filters.breakdown ? (
-                                <BreakdownFilter
-                                    filters={filters}
-                                    onChange={(breakdown, breakdown_type): void =>
-                                        setFilters({ breakdown, breakdown_type })
-                                    }
-                                />
-                            ) : (
-                                <Row align="middle">
+                            <Row align="middle">
+                                {filters.breakdown_type === 'cohort' && filters.breakdown ? (
                                     <BreakdownFilter
                                         filters={filters}
+                                        setFilters={setFilters}
                                         onChange={(breakdown, breakdown_type): void =>
                                             setFilters({ breakdown, breakdown_type })
                                         }
                                     />
-                                    {filters.breakdown && (
-                                        <CloseButton
-                                            onClick={() => setFilters({ breakdown: undefined, breakdown_type: null })}
-                                            style={{ marginTop: 1, marginLeft: 5 }}
-                                        />
-                                    )}
-                                </Row>
-                            )}
+                                ) : (
+                                    <BreakdownFilter
+                                        filters={filters}
+                                        setFilters={setFilters}
+                                        onChange={(breakdown, breakdown_type): void =>
+                                            setFilters({ breakdown, breakdown_type })
+                                        }
+                                    />
+                                )}
+                            </Row>
                         </>
                     )}
                 </Col>


### PR DESCRIPTION
## Changes

The UI code for breakdown properties was relatively complex. That made adding a featureflag for #938 difficult

This moves to a simpler n=model to allow that feature flag and to move the design in the desired direction where items like these removable properties are ant tags and not ant buttons

## on a narrow screen

![pill-breakdown-narrow](https://user-images.githubusercontent.com/984817/137977425-249ff241-0264-48c6-aa48-21db06facdba.gif)

## on a wider screen

![pill-breakdown-wide](https://user-images.githubusercontent.com/984817/137977433-92a81b70-9f70-469f-8163-86fbe68bd92d.gif)

## How did you test this code?

by running it locally
