### PR TITLE
Hide conversion rate on trends

### DIFF
--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -23,16 +23,15 @@ export function FunnelCanvasLabel(): JSX.Element | null {
     }
 
     const labels = [
-        ...(filters.funnel_viz_type !== FunnelVizType.TimeToConvert
+        ...(filters.funnel_viz_type === FunnelVizType.Steps
             ? [
                   <>
                       <span className="text-muted-alt">
                           <Tooltip title="Overall conversion rate for all users on the entire funnel.">
                               <InfoCircleOutlined className="info-indicator left" />
                           </Tooltip>
-                          Total conversion rate{' '}
+                          Total conversion rate
                       </span>
-                      {filters.funnel_viz_type === FunnelVizType.Trends && <FunnelStepsPicker />}
                       <span className="text-muted-alt mr-025">:</span>
                       <span className="l4">{formatDisplayPercentage(conversionMetrics.totalRate)}%</span>
                   </>,


### PR DESCRIPTION
## Changes

See title. And it looks like this 👇 ,

<img width="869" alt="" src="https://user-images.githubusercontent.com/5864173/138003799-f61ff16c-fe8e-4bfd-9b38-093269bead37.png">

Regular funnel conversion still looks as expected,
<img width="878" alt="" src="https://user-images.githubusercontent.com/5864173/138003793-a2b5a0ca-2866-4bca-8822-4080adae569c.png">


## How did you test this code?

- Manually created a trends & steps graph to make sure everything looked as expected.
