### PR TITLE
`.github/workflows/docker-vuln-scan.yml` run on main/master

### DIFF
--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -1,6 +1,10 @@
 name: Docker
 on:
-    - pull_request
+    push:
+        branches:
+            - main
+            - master
+    pull_request:
 
 jobs:
     build:


### PR DESCRIPTION
## Changes
Run `.github/workflows/docker-vuln-scan.yml` also on push to `main` / `master` branches. 

## Why?
The job is already providing useful insights about security vulnerabilities in our container images but in order to determine the alerts introduced or fixed by a pull request, we need to scan `main`/ `master` branches as well (see example [here](https://github.com/PostHog/posthog/pull/6567/checks?check_run_id=3949218291)).