### PR TITLE
package.json: restrict node engines to < 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/posthog/posthog#readme",
     "license": "MIT",
     "engines": {
-        "node": ">=14"
+        "node": ">=14 <17"
     },
     "scripts": {
         "copy-scripts": "yarn copy-scripts:array && yarn copy-scripts:recorder",


### PR DESCRIPTION
## Changes
Restrict Node.js engine version to < 17.

## Why?
Node.js v17 has been released [yesterday](https://medium.com/the-node-js-collection/node-js-17-is-here-8dba1e14e382) and it's currently breaking on some dependency

```
node:internal/crypto/hash:67
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:130:10)
    at module.exports (/tmp/build_d668ec3a/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/tmp/build_d668ec3a/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/tmp/build_d668ec3a/node_modules/webpack/lib/NormalModule.js:471:10)
    at /tmp/build_d668ec3a/node_modules/webpack/lib/NormalModule.js:503:5
    at /tmp/build_d668ec3a/node_modules/webpack/lib/NormalModule.js:358:12
    at /tmp/build_d668ec3a/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/tmp/build_d668ec3a/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/tmp/build_d668ec3a/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /tmp/build_d668ec3a/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/tmp/build_d668ec3a/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /tmp/build_d668ec3a/node_modules/babel-loader/lib/index.js:59:71 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
Node.js v17.0.0
error Command failed with exit code 1.
```

This is a known regression:

> If you hit an ERR_OSSL_EVP_UNSUPPORTED error in your application with Node.js 17, it’s likely that your application or a module you’re using is attempting to use an algorithm or key size which is no longer allowed by default with OpenSSL 3.0

## Test
Deployment is ✅ (see below)