### PR TITLE
dev(react): add react hook eslint rules, as warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
         ecmaVersion: 2018,
         sourceType: 'module',
     },
-    plugins: ['prettier', 'react', 'cypress', '@typescript-eslint'],
+    plugins: ['prettier', 'react', 'react-hooks', 'cypress', '@typescript-eslint'],
     rules: {
         'react/prop-types': [0],
         'react/no-unescaped-entities': [0],
@@ -37,6 +37,8 @@ module.exports = {
                 html: true,
             },
         ],
+        'react-hooks/rules-of-hooks': 'warn',
+        'react-hooks/exhaustive-deps': 'warn',
         'no-unused-vars': ['error', { ignoreRestSiblings: true }],
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
         "eslint-plugin-cypress": "^2.11.2",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.20.3",
+        "eslint-plugin-react-hooks": "^4.2.0",
         "file-loader": "^6.1.0",
         "givens": "^1.3.6",
         "history": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7862,6 +7862,11 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@^7.20.3:
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"


### PR DESCRIPTION
Here I have installed react-hooks eslint rules. See
https://reactjs.org/docs/hooks-rules.html#eslint-plugin for reference.

The specific trigger for this was [this
fix](https://github.com/PostHog/posthog/pull/6407/commits/abdbe546634b3b734c049fc5af375f1bc71cb1d7)
I put in for a bug, which would have been caught by the
`react-hooks/exhaustive-deps` rule.

I've added these both as warnings as there are currently 69 :smirk:
problems:

```
$ yarn eslint
...
✖ 69 problems (6 errors, 63 warnings)
```

At least this will highlight in editors that support it. We can make
these errors in a follow up PR, but this is valuable in itself without
getting into some yak shaving.