### PR TITLE
Rename org user exception to avoid log spam

### DIFF
--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -116,8 +116,7 @@ def send_all_reports(
         if not org_first_user:
             with configure_scope() as scope:
                 scope.set_context("org", cast(Dict[str, Any], org))
-                name = org["name"]
-                capture_exception(Exception(f"No user found for org '{name}' ({id})"))
+                capture_exception(Exception("No user found for org while generating report"))
             continue
         distinct_id = org_first_user.distinct_id
         try:


### PR DESCRIPTION
## Changes

Renames Sentry exceptions like [this one](https://sentry.io/organizations/posthog/issues/2732655437/?project=1899813&query=is%3Aunresolved+no+user+found+for+org&statsPeriod=14d#grouping-info) such that it groups together related events and doesn't spam the logs. The Sentry context already contains org metadata.

## How did you test this code?

--
