### PR TITLE
Org usage report: query for organization owner or first user via OrganizationMembership

### DIFF
--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -15,7 +15,7 @@ from typing import (
 from sentry_sdk import capture_exception, configure_scope
 
 from posthog.event_usage import report_org_usage, report_org_usage_failure
-from posthog.models import Event, Team, User
+from posthog.models import Event, OrganizationMembership, Team, User
 from posthog.tasks.status_report import get_instance_licenses
 from posthog.utils import get_instance_realm, get_previous_day, is_clickhouse_enabled
 from posthog.version import VERSION
@@ -112,13 +112,10 @@ def send_all_reports(
             }
 
     for id, org in org_data.items():
-        org_first_user = User.objects.filter(current_team_id__in=org["teams"]).first()
-        if not org_first_user:
-            with configure_scope() as scope:
-                scope.set_context("org", cast(Dict[str, Any], org))
-                capture_exception(Exception("No user found for org while generating report"))
+        org_owner = get_org_owner_or_first_user(id)
+        if not org_owner:
             continue
-        distinct_id = org_first_user.distinct_id
+        distinct_id = org_owner.distinct_id
         try:
             month_start = period_start.replace(day=1)
             usage = get_org_usage(
@@ -182,3 +179,27 @@ def get_product_name(realm: str, license_keys: List[str]) -> str:
         return "scale" if len(license_keys) else "open source"
     else:
         return "unknown"
+
+
+def get_org_owner_or_first_user(organization_id: str) -> Optional[User]:
+    # Find the membership object for the org owner
+    membership = OrganizationMembership.objects.filter(
+        organization_id=organization_id, level=OrganizationMembership.Level.OWNER
+    ).first()
+    if not membership:
+        # If no owner membership is present, pick the first membership association we can find
+        membership = OrganizationMembership.objects.filter(organization_id=organization_id).first()
+    try:
+        user = membership.user  # type: ignore
+    except AttributeError:
+        # Report problem in next block
+        pass
+    if not user:
+        report_no_org_user_found(organization_id)
+    return user  # type: ignore
+
+
+def report_no_org_user_found(organization_id: str) -> None:
+    with configure_scope() as scope:
+        scope.set_context("org", {"organization_id": organization_id})
+        capture_exception(Exception("No user found for org while generating report"))

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -194,12 +194,10 @@ def get_org_owner_or_first_user(organization_id: str) -> Optional[User]:
     except AttributeError:
         # Report problem in next block
         pass
-    if not user:
-        report_no_org_user_found(organization_id)
-    return user  # type: ignore
-
-
-def report_no_org_user_found(organization_id: str) -> None:
-    with configure_scope() as scope:
-        scope.set_context("org", {"organization_id": organization_id})
-        capture_exception(Exception("No user found for org while generating report"))
+    finally:
+        if not user:
+            capture_exception(
+                Exception("No user found for org while generating report"),
+                {"org": {"organization_id": organization_id}},
+            )
+        return user  # type: ignore

--- a/posthog/tasks/test/test_org_usage_report.py
+++ b/posthog/tasks/test/test_org_usage_report.py
@@ -6,6 +6,7 @@ from django.utils.timezone import datetime, now
 from freezegun import freeze_time
 
 from posthog.models import Event, Organization, Person, Team, User
+from posthog.models.organization import OrganizationMembership
 from posthog.tasks.org_usage_report import OrgReport, send_all_org_usage_reports
 from posthog.test.base import APIBaseTest
 from posthog.version import VERSION
@@ -23,7 +24,9 @@ def factory_org_usage_report(
         ) -> Team:
             org = Organization.objects.create(name="New Org", for_internal_metrics=for_internal_metrics)
             team = Team.objects.create(organization=org, name="Default Project")
-            User.objects.create_and_join(org, org_owner_email, None)
+            User.objects.create_and_join(
+                organization=org, email=org_owner_email, password=None, level=OrganizationMembership.Level.OWNER
+            )
             return team
 
         def select_report_by_org_id(self, org_id: str, reports: List[OrgReport]) -> OrgReport:


### PR DESCRIPTION
## Changes

`current_team_id__in` is an unreliable way of querying for users within an organization.

This PR changes the logic for selecting the optimal user for the org usage report.

Logic for each organization:

1. if we can find the user with org membership level `OWNER`, use that for the report distinct id
2. if we cannot find the owner, use the first user we can find for that org, any membership level
3. if we cannot find any valid users, bail out and report an exception to Sentry.
4. continue to the next organization.

## How did you test this code?

Unit tests and manual triggering of the job (locally)
