### PR TITLE
ci(backend): run backend tests on master

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,7 +1,10 @@
 name: Backend CI
 
 on:
-    - pull_request
+    push:
+        branches:
+            - master
+    pull_request:
 env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'


### PR DESCRIPTION
At the moment we're just running tests on pull requests. The immediate
reason I'm making this change is to ensure we are producing a code
coverage report for master, which allows us to produce a patch
difference of coverage.

Sidenote: I'm also hoping will also trigger annotations to start being
added to PRs highlighting untested code, which I thought should have
started with https://github.com/PostHog/posthog/pull/6082

I would also suggest that it's good practice to have the master branch tested. 
As far as I can tell failures here won't cause deployment to halt, but I leave this as 
a separate issue to address.