### PR TITLE
ci(ci-backend): checkout branch when deciding path-filtering

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -25,7 +25,10 @@ jobs:
         outputs:
             backend: ${{ steps.filter.outputs.backend }}
         steps:
-            # For pull requests it's not necessary to checkout the code
+            # For pull requests it's not necessary to checkout the code, but we
+            # also want this to run on master so we need to checkout
+            - uses: actions/checkout@v2
+
             - uses: dorny/paths-filter@v2
               id: filter
               with:


### PR DESCRIPTION
Previously we were just running on PRs. In
https://github.com/PostHog/posthog/pull/6579 we also run on master. As a
result we need to checkout the repo as well.