### PR TITLE
WIP example materialized psql setup:

### DIFF
--- a/ee/clickhouse/migrations/0018_materialized_psql_persons_table.py
+++ b/ee/clickhouse/migrations/0018_materialized_psql_persons_table.py
@@ -1,0 +1,5 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.person import MATERIALIZED_PSQL_DB_BASE_SQL
+
+operations = [migrations.RunSQL(MATERIALIZED_PSQL_DB_BASE_SQL)]

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -1,5 +1,5 @@
 from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID
-from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, DATABASE_URL
 
 from .clickhouse import (
     COLLAPSING_MERGE_TREE,
@@ -7,6 +7,7 @@ from .clickhouse import (
     REPLACING_MERGE_TREE,
     STORAGE_POLICY,
     kafka_engine,
+    postgresql_database_engine,
     table_engine,
 )
 
@@ -315,3 +316,16 @@ GROUP BY
 LIMIT %(limit)s
 OFFSET %(offset)s
 """
+
+PSQL_TABLES_TO_REPLICATE = ["posthog_person"]
+
+# needs setting allow_experimental_database_materialized_postgresql=1
+MATERIALIZED_PSQL_DB_BASE_SQL = """
+CREATE DATABASE {database_name}
+ENGINE = {engine}
+SETTINGS materialized_postgresql_tables_list = '{tables}'
+""".format(
+    database_name="materialized_postgres",
+    engine=postgresql_database_engine(DATABASE_URL),
+    tables=",".join(PSQL_TABLES_TO_REPLICATE),
+)

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -17,6 +17,7 @@ services:
             - db
     db:
         image: postgres:12-alpine
+        command: postgres -c wal_level=logical
         environment:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
@@ -30,7 +31,7 @@ services:
     clickhouse:
         # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
         # https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/templates/clickhouse_instance.yaml#L88
-        image: yandex/clickhouse-server:21.6.5
+        image: yandex/clickhouse-server:21.8.5.7
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
## ⚠️ WIP

This is a WIP for example purposes only. Testing out a setup with ClickHouse's `MaterializedPostgresql` database engine.

## TL;DR

I know others have been down this rabbit hole before, but I had to do it myself. The good news is I got it working. The bad news is that it would take a few things for us to use this in prod.

## Note

This PR shows how things might work but **best is to try this out manually.**

Run the following on CH (also see the section about how to run below):

```sql
SET allow_experimental_database_materialized_postgresql=1
```

and:

```sql
CREATE DATABASE materialized_postgres
ENGINE = MaterializedPostgreSQL('host:port', 'posthog', 'username', 'password')
SETTINGS materialized_postgresql_tables_list = 'posthog_person'
```

If, like me, you run CH in Docker and Postgres outside of it, a nice trick is setting the host to `host.docker.internal`. That will resolve to your local IP from inside the container.

## How to run

This is a bit difficult. You need to make sure that:

- Postgres `wal_level` is set to `logical` and `max_replication_slots` is >= 2

    ```sql
    ALTER SYSTEM SET wal_level TO logical;
    ALTER SYSTEM SET max_replication_slots TO 2;
    ```
 
    And restart the server

- ClickHouse is set to allow the usage of this engine:

    ```sql
     SET allow_experimental_database_materialized_postgresql=1
    ```

## Learnings

- Our current prod setup has `wal_level` set to logical. So this is a setting that is OK for us to use.
- We will never be able to use this on Heroku. They [don't allow `REPLICATION` or `SUPERUSER` access and explicitly block replication attempts](https://help.heroku.com/E10ZZ6IJ/why-can-t-i-use-third-party-tools-to-replicate-my-heroku-postgres-database-to-a-non-heroku-database) ("for our safety", sure, sure)
- ClickHouse Docs mark the `MaterializedPostgresql` **database** engine as experimental but **not** the table engine. In reality, the table engine [doesn't really work will likely be dropped](https://github.com/ClickHouse/ClickHouse/issues/30495#issuecomment-948591016). The DB engine with the setting `materialized_postgresql_tables_list` is the way to go.

## Story

We're struggling to keep Postgres and CH in sync. We found problems with distinct IDs (fixed now), and the latest issue on my plate is persons.

Persons is a tough one. Unlike distinct IDs, where we essentially have a key value mapping and we just add mappings and "delete" (via insertion) them, with persons we are always inserting a new version of the person. The problem is when we run into equal timestamps. With our setup, this is not as trivial a problem to solve as one would think. 

Either way, it's also annoying to have to handle all this producing to Kafka ourselves (prone to error, race conditions, etc), when we could just have some tool read off the WAL and do it for us.

Thus, I just studied the options a bit:

- **We keep producing to Kafka ourselves:** We currently do this, so it works (somewhat)
- **We build a `pg_notify` system to listen for updates and have a listener running in the plugin server to only produce when there are changes**: Not possible because of PgBouncer. Also probably flaky and a bit dangerous.
- **We use [Debezium](https://debezium.io/):** This would read off the WAL and produce to Kafka when Postgres tables are updated. It's a great solution that I wouldn't want to completely kill just yet. However, it adds another service, so best to avoid for now at least.
- **ClickHouse Postgres engines:** Hence this PR. This would be fantastic. Currently the one blocker to giving this a try in prod is Heroku Postgres. Given we've considered moving away from that anyway, I'd like to give a +1 to that. Would love to get this in prod side-by-side with the current persons table and [help speed up the development of this engine](https://github.com/ClickHouse/ClickHouse/issues/30495#issuecomment-948597770). It would be perfect for our needs.
