### PR TITLE
Open modals for everything in correlation events

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -87,6 +87,10 @@ export const funnelLogic = kea<funnelLogicType>({
             stepNumber,
             breakdown_value,
         }),
+        openCorrelationPersonsModal: (entity: Record<string, any>, converted: 'true' | 'false') => ({
+            entity,
+            converted,
+        }),
         setStepReference: (stepReference: FunnelStepReference) => ({ stepReference }),
         changeStepRange: (funnel_from_step?: number, funnel_to_step?: number) => ({
             funnel_from_step,
@@ -860,6 +864,19 @@ export const funnelLogic = kea<funnelLogicType>({
                 filters: values.filters,
                 saveOriginal: true,
                 funnelStep: stepNumber,
+            })
+        },
+        openCorrelationPersonsModal: ({ entity, converted }) => {
+            personsModalLogic.actions.loadPeople({
+                action: { id: entity.id, name: entity.name, properties: entity.properties, type: entity.type },
+                label: entity.id,
+                date_from: '',
+                date_to: '',
+                filters: {
+                    ...values.filters,
+                    funnel_correlation_person_converted: converted,
+                    funnel_correlation_person_entity: entity,
+                },
             })
         },
         changeStepRange: ({ funnel_from_step, funnel_to_step }) => {

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -87,7 +87,7 @@ export const funnelLogic = kea<funnelLogicType>({
             stepNumber,
             breakdown_value,
         }),
-        openCorrelationPersonsModal: (entity: Record<string, any>, converted: 'true' | 'false') => ({
+        openCorrelationPersonsModal: (entity: Record<string, any>, converted: boolean) => ({
             entity,
             converted,
         }),
@@ -874,7 +874,7 @@ export const funnelLogic = kea<funnelLogicType>({
                 date_to: '',
                 filters: {
                     ...values.filters,
-                    funnel_correlation_person_converted: converted,
+                    funnel_correlation_person_converted: converted ? 'true' : 'false',
                     funnel_correlation_person_entity: entity,
                 },
             })

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -4,9 +4,10 @@ import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
 import { RiseOutlined, FallOutlined } from '@ant-design/icons'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import { FunnelCorrelation, FunnelCorrelationType } from '~/types'
+import { EntityTypes, FunnelCorrelation, FunnelCorrelationType, PropertyFilter, PropertyOperator } from '~/types'
 import Checkbox from 'antd/lib/checkbox/Checkbox'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { ValueInspectorButton } from 'scenes/funnels/FunnelBarGraph'
 
 export function FunnelCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -18,7 +19,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         eventHasPropertyCorrelations,
         eventWithPropertyCorrelationsValues,
     } = useValues(logic)
-    const { setCorrelationTypes, loadEventWithPropertyCorrelations } = useActions(logic)
+    const { setCorrelationTypes, loadEventWithPropertyCorrelations, openCorrelationPersonsModal } = useActions(logic)
 
     const onClickCorrelationType = (correlationType: FunnelCorrelationType): void => {
         if (correlationTypes) {
@@ -65,6 +66,51 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         )
     }
 
+    const parseEventAndProperty = (item: string): { name: string; property?: PropertyFilter } => {
+        const components = item.split('::')
+        if (components.length === 1) {
+            return { name: components[0] }
+        } else {
+            return {
+                name: components[0],
+                property: { key: components[1], operator: PropertyOperator.Exact, value: components[2], type: 'event' },
+            }
+        }
+    }
+    const renderSuccessCount = (record: FunnelCorrelation): JSX.Element => {
+        const { name, property } = parseEventAndProperty(record.event || '')
+
+        return (
+            <ValueInspectorButton
+                onClick={() => {
+                    openCorrelationPersonsModal(
+                        { id: name, type: EntityTypes.EVENTS, properties: property ? [property] : [] },
+                        'true'
+                    )
+                }}
+            >
+                {record.success_count}
+            </ValueInspectorButton>
+        )
+    }
+
+    const renderFailureCount = (record: FunnelCorrelation): JSX.Element => {
+        const { name, property } = parseEventAndProperty(record.event || '')
+
+        return (
+            <ValueInspectorButton
+                onClick={() => {
+                    openCorrelationPersonsModal(
+                        { id: name, type: EntityTypes.EVENTS, properties: property ? [property] : [] },
+                        'false'
+                    )
+                }}
+            >
+                {record.failure_count}
+            </ValueInspectorButton>
+        )
+    }
+
     const renderNestedTable = (eventName?: string): JSX.Element => {
         if (!eventName) {
             return <p>Unable to find property correlations for event.</p>
@@ -83,8 +129,20 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                     render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
                     align="left"
                 />
-                <Column title="Completed" dataIndex="success_count" width={90} align="center" />
-                <Column title="Dropped off" dataIndex="failure_count" width={100} align="center" />
+                <Column
+                    title="Completed"
+                    key="success_count"
+                    render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
+                    width={90}
+                    align="center"
+                />
+                <Column
+                    title="Dropped off"
+                    key="failure_count"
+                    render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
+                    width={100}
+                    align="center"
+                />
             </Table>
         )
     }
@@ -148,9 +206,22 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                 key="eventName"
                 render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
                 align="left"
+                ellipsis
             />
-            <Column title="Completed" dataIndex="success_count" width={90} align="center" />
-            <Column title="Dropped off" dataIndex="failure_count" width={100} align="center" />
+            <Column
+                title="Completed"
+                key="success_count"
+                render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
+                width={90}
+                align="center"
+            />
+            <Column
+                title="Dropped off"
+                key="failure_count"
+                render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
+                width={100}
+                align="center"
+            />
             <Column
                 title="Property correlations"
                 key="operation"

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -85,7 +85,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                 onClick={() => {
                     openCorrelationPersonsModal(
                         { id: name, type: EntityTypes.EVENTS, properties: property ? [property] : [] },
-                        'true'
+                        true
                     )
                 }}
             >
@@ -102,7 +102,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                 onClick={() => {
                     openCorrelationPersonsModal(
                         { id: name, type: EntityTypes.EVENTS, properties: property ? [property] : [] },
-                        'false'
+                        false
                     )
                 }}
             >

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -72,6 +72,8 @@ export function cleanFilters(filters: Partial<FilterType>, oldFilters?: Partial<
             interval: autocorrectInterval(filters),
             breakdown: breakdownEnabled ? filters.breakdown || undefined : undefined,
             breakdown_type: breakdownEnabled ? filters.breakdown_type || undefined : undefined,
+            funnel_correlation_person_entity: filters.funnel_correlation_person_entity || undefined,
+            funnel_correlation_person_converted: filters.funnel_correlation_person_converted || undefined,
         }
 
         // if we came from an URL with just `#q={insight:TRENDS}` (no `events`/`actions`), add the default states `[]`

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -176,7 +176,10 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                 } = peopleParams
                 const searchTermParam = searchTerm ? `&search=${encodeURIComponent(searchTerm)}` : ''
 
-                if (filters.insight === ViewType.LIFECYCLE) {
+                if (filters.funnel_correlation_person_entity) {
+                    const cleanedParams = cleanFilters(filters)
+                    people = await api.create(`api/person/funnel/correlation/?${searchTermParam}`, cleanedParams)
+                } else if (filters.insight === ViewType.LIFECYCLE) {
                     const filterParams = parsePeopleParams(
                         { label, action, target_date: date_from, lifecycle_type: breakdown_value },
                         filters

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -811,6 +811,8 @@ export interface FilterType {
     edge_limit?: number | undefined // Paths edge limit
     min_edge_weight?: number | undefined // Paths
     max_edge_weight?: number | undefined // Paths
+    funnel_correlation_person_entity?: Record<string, any> // Funnel Correlation Persons Filter
+    funnel_correlation_person_converted?: 'true' | 'false' // Funnel Correlation Persons Converted - success or failure counts
 }
 
 export interface SystemStatusSubrows {


### PR DESCRIPTION
## Changes

Allows for searching people by their correlated events in the UI.

![image](https://user-images.githubusercontent.com/7115141/138297993-ab43d8a9-55af-4358-91f2-c7d76b6241e5.png)

![image](https://user-images.githubusercontent.com/7115141/138298045-29e6b2cb-6ba7-4ab6-8415-ea423febb230.png)


## How did you test this code?

Click on numbers, see modals pop up.
