### PR TITLE
Fix broken docs link for secret key

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -605,7 +605,7 @@ if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
         (
             "You are using the default SECRET_KEY in a production environment!",
             "For the safety of your instance, you must generate and set a unique key.",
-            "More information on https://posthog.com/docs/deployment/securing-posthog#secret-key",
+            "More information on https://posthog.com/docs/self-host/configure/securing-posthog",
         )
     )
     sys.exit("[ERROR] Default SECRET_KEY in production. Stopping Django server…\n")


### PR DESCRIPTION
Noticed that [this link](https://posthog.com/docs/deployment/securing-posthog#secret-key) is broken:
<img width="1245" alt="Screen Shot 2021-10-21 at 9 55 43 AM" src="https://user-images.githubusercontent.com/1268088/138323070-c7867c47-6309-4089-a17a-600087ae4e47.png">

so I think [this is](https://posthog.com/docs/self-host/configure/securing-posthog) the proper place to link to.
