### PR TITLE
Fix error in recordings table

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -106,10 +106,10 @@ export function EventsTable({ fixedFilters, filtersEnabled = true, pageKey }: Ev
                         }
                         return showLinkToPerson && event.person?.distinct_ids?.length ? (
                             <Link to={`/person/${encodeURIComponent(event.person.distinct_ids[0])}`}>
-                                <PersonHeader person={event.person} />
+                                <PersonHeader withIcon person={event.person} />
                             </Link>
                         ) : (
-                            <PersonHeader person={event.person} />
+                            <PersonHeader withIcon person={event.person} />
                         )
                     },
                 },

--- a/frontend/src/scenes/events/definitions/EventsTableSnippet.tsx
+++ b/frontend/src/scenes/events/definitions/EventsTableSnippet.tsx
@@ -14,7 +14,7 @@ export function EventsTableSnippet(): JSX.Element {
             title: 'Person',
             key: 'person',
             render: function renderPerson({ person }: { person: PersonType }) {
-                return person ? <PersonHeader person={person} /> : { props: { colSpan: 0 } }
+                return person ? <PersonHeader withIcon person={person} /> : { props: { colSpan: 0 } }
             },
         },
         {

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -120,7 +120,7 @@ export function Person(): JSX.Element {
                     <Card className="card-elevated person-detail" data-test-person-details>
                         {person && (
                             <>
-                                <PersonHeader person={person} />
+                                <PersonHeader withIcon person={person} />
                                 <div className="item-group">
                                     <label>IDs</label>
                                     <div style={{ display: 'flex' }}>

--- a/frontend/src/scenes/persons/PersonHeader.scss
+++ b/frontend/src/scenes/persons/PersonHeader.scss
@@ -22,4 +22,8 @@
             color: $purple_700;
         }
     }
+
+    &:hover {
+        text-decoration: underline;
+    }
 }

--- a/frontend/src/scenes/persons/PersonsTable.tsx
+++ b/frontend/src/scenes/persons/PersonsTable.tsx
@@ -65,7 +65,7 @@ export function PersonsTable({
             key: 'identification',
             span: 6,
             render: function Render(person: PersonType) {
-                return <PersonHeader person={person} />
+                return <PersonHeader withIcon person={person} />
             },
         },
         {

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -88,7 +88,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
             title: 'Person',
             key: 'person',
             render: function RenderPersonLink(sessionRecording: SessionRecordingType) {
-                return <PersonHeader person={sessionRecording.person} />
+                return <PersonHeader withIcon person={sessionRecording.person} />
             },
             ellipsis: true,
             span: 3,

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -268,9 +268,9 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
                 }
             }
         }
+        const urlPattern = props.personUUID ? '/person/*' : '/recordings'
         return {
-            '/person/*': props.personUUID ? urlToAction : () => {},
-            '/recordings': props.personUUID ? () => {} : urlToAction,
+            [urlPattern]: urlToAction,
         }
     },
 })

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -239,7 +239,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
         }
     },
 
-    urlToAction: ({ actions, values }) => {
+    urlToAction: ({ actions, values, props }) => {
         const urlToAction = (_: any, params: Params): void => {
             const nulledSessionRecordingId = params.sessionRecordingId ?? null
             if (nulledSessionRecordingId !== values.sessionRecordingId) {
@@ -268,10 +268,9 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
                 }
             }
         }
-
         return {
-            '/recordings': urlToAction,
-            '/person/*': urlToAction,
+            '/person/*': props.personUUID ? urlToAction : () => {},
+            '/recordings': props.personUUID ? () => {} : urlToAction,
         }
     },
 })


### PR DESCRIPTION
## Changes

Small fix for: https://sentry.io/organizations/posthog/issues/2733918347/?referrer=slack

The recording table logic exists on both the person + recordings page, so as a user moved between the two pages, urlToAction was triggering actions on both logics even though one was un-mounting.

I think users were hitting this issue by moving back and forth from the person page to the recording page. Pretty sure this is because the person header didn't look very click-able, so they're accidentally clicking it. So, this PR also makes the PersonHeader seem more click-able by:
* Adding the icon back (looks like we recently lost it by accident)
* Makes the text underline on hover

![image](https://user-images.githubusercontent.com/4813045/138332916-4f96a5ac-3223-4a5e-8e84-62a5d715cb9e.png)


## How did you test this code?

Clicked from the recordings page to a person's page, and then hit the back button. Verified the error is no longer in the console.
