### PR TITLE
Fix 'Load more People' on Paths and Correlations

### DIFF
--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -178,7 +178,10 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
 
                 if (filters.funnel_correlation_person_entity) {
                     const cleanedParams = cleanFilters(filters)
-                    people = await api.create(`api/person/funnel/correlation/?${searchTermParam}`, cleanedParams)
+                    const funnelCorrelationParams = toParams(cleanedParams)
+                    people = await api.create(
+                        `api/person/funnel/correlation/?${funnelCorrelationParams}${searchTermParam}`
+                    )
                 } else if (filters.insight === ViewType.LIFECYCLE) {
                     const filterParams = parsePeopleParams(
                         { label, action, target_date: date_from, lifecycle_type: breakdown_value },
@@ -210,7 +213,8 @@ export const personsModalLogic = kea<personsModalLogicType<PersonModalParams>>({
                     people = await api.create(`api/person/funnel/?${funnelParams}${searchTermParam}`)
                 } else if (filters.insight === ViewType.PATHS) {
                     const cleanedParams = cleanFilters(filters)
-                    people = await api.create(`api/person/path/?${searchTermParam}`, cleanedParams)
+                    const pathParams = toParams(cleanedParams)
+                    people = await api.create(`api/person/path/?${pathParams}${searchTermParam}`)
                 } else {
                     const filterParams = parsePeopleParams(
                         { label, action, date_from, date_to, breakdown_value },


### PR DESCRIPTION
## Changes

We don't support `POST` body data as well as we'd believed earlier. This is because the `next_url` that's generated loses all the filters information in the POST Body.

This ensures things don't error out for now, but a proper fix would involve saving the body params in the modal, because encoding everything in the URL leads to too huge URLs.

## How did you test this code?

Ran locally, see it works
