### PR TITLE
Add `libpq-dev` to `production.Dockerfile`

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # install base dependencies, including node & yarn; remove unneeded build deps
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.*' \
+    && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.*' 'libpq-dev=13.*' \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y --no-install-recommends 'nodejs=14.*' \
     && npm install -g yarn@1 \


### PR DESCRIPTION
## Changes
Add `libpq-dev` to `production.Dockerfile`.

ℹ️ **Disclaimer**

I'm probably a bit fried but I don't see how this `Dockerfile` can work without the `pg_config` executable installed. The executable is needed as it's a requirement of the PIP package `psycopg2-binary==2.8.6` that we install via `pip install -r requirements.txt --no-cache-dir --compile`. Builds are not failing so I'm not sure what I am missing. Anyway, adding the package explicitly I don't think is a bad idea.


Note: this file will be heavily changed soon as part of https://github.com/PostHog/posthog/pull/6575

## How did you test this code?

**Current `master` branch**
```
➜  posthog git:(master) docker build -f production.Dockerfile .
[+] Building 19.4s (11/21)
[...]
 => CACHED [ 4/17] RUN apt-get update     && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.*'     && curl -sL https://deb.nodesource.com/setup_14.x | bash -   0.0s
[...]
 => ERROR [ 7/17] RUN pip install -r requirements.txt --no-cache-dir --compile                                                                                                                        17.4s
[...]
#11 16.52 Collecting psycopg2-binary==2.8.6
#11 16.53   Downloading psycopg2-binary-2.8.6.tar.gz (384 kB)
#11 16.81     ERROR: Command errored out with exit status 1:
#11 16.81      command: /usr/local/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0r4_cgja/psycopg2-binary_89cc329da071408cb4b84439e57c541c/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0r4_cgja/psycopg2-binary_89cc329da071408cb4b84439e57c541c/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-aljy1w6t
#11 16.81          cwd: /tmp/pip-install-0r4_cgja/psycopg2-binary_89cc329da071408cb4b84439e57c541c/
#11 16.81     Complete output (23 lines):
#11 16.81     running egg_info
#11 16.81     creating /tmp/pip-pip-egg-info-aljy1w6t/psycopg2_binary.egg-info
#11 16.81     writing /tmp/pip-pip-egg-info-aljy1w6t/psycopg2_binary.egg-info/PKG-INFO
#11 16.81     writing dependency_links to /tmp/pip-pip-egg-info-aljy1w6t/psycopg2_binary.egg-info/dependency_links.txt
#11 16.81     writing top-level names to /tmp/pip-pip-egg-info-aljy1w6t/psycopg2_binary.egg-info/top_level.txt
#11 16.81     writing manifest file '/tmp/pip-pip-egg-info-aljy1w6t/psycopg2_binary.egg-info/SOURCES.txt'
#11 16.81
#11 16.81     Error: pg_config executable not found.
#11 16.81
#11 16.81     pg_config is required to build psycopg2 from source.  Please add the directory
#11 16.81     containing pg_config to the $PATH or specify the full executable path with the
#11 16.81     option:
#11 16.81
#11 16.81         python setup.py build_ext --pg-config /path/to/pg_config build ...
#11 16.81
#11 16.81     or with the pg_config option in 'setup.cfg'.
#11 16.81
#11 16.81     If you prefer to avoid building psycopg2 from source, please install the PyPI
#11 16.81     'psycopg2-binary' package instead.
#11 16.81
#11 16.81     For further information please check the 'doc/src/install.rst' file (also at
#11 16.81     <https://www.psycopg.org/docs/install.html>).
#11 16.81
#11 16.81     ----------------------------------------
#11 16.81 WARNING: Discarding https://files.pythonhosted.org/packages/fc/51/0f2c6aec5c59e5640f507b59567f63b9d73a9317898810b4db311da32dfc/psycopg2-binary-2.8.6.tar.gz#sha256=11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0 (from https://pypi.org/simple/psycopg2-binary/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
#11 16.81 ERROR: Could not find a version that satisfies the requirement psycopg2-binary==2.8.6 (from versions: 2.7.4, 2.7.5, 2.7.6, 2.7.6.1, 2.7.7, 2.8, 2.8.1, 2.8.2, 2.8.3, 2.8.4, 2.8.5, 2.8.6, 2.9, 2.9.1)
#11 16.81 ERROR: No matching distribution found for psycopg2-binary==2.8.6
#11 16.93 WARNING: You are using pip version 21.2.4; however, version 21.3 is available.
#11 16.93 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```

**After**
```
➜  posthog git:(master) ✗ docker build -f production.Dockerfile .
[+] Building 18.0s (7/21)
 [...]
 => [ 4/17] RUN apt-get update     && apt-get install -y --no-install-recommends 'curl=7.*' 'git=1:2.*' 'build-essential=12.*' 'libpq-dev=13.*'     && curl -sL https://deb.nodesource.com/setup_14.  39.9s
 => [ 5/17] RUN if [[ -z "${SAML_DISABLED}" ]] && [[ -z "$saml_disabled" ]] ; then     apt-get update     && apt-get install -y --no-install-recommends 'pkg-config=0.*' 'libxml2-dev=2.*' 'libxmlse  26.4s
 => [ 6/17] COPY requirements.txt /code/.                                                                                                                                                              0.0s
 => [ 7/17] RUN pip install -r requirements.txt --no-cache-dir --compile                                                                                                                             471.6s
 => [ 8/17] RUN pip uninstall ipython-genutils pip wheel -y                                                                                                                                            1.5s
 => [ 9/17] RUN  apt-get purge -y git curl build-essential && apt-get autoremove -y                                                                                                                    [...]
```