### PR TITLE
you always need DEBUG=1 when running tests

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -24,5 +24,6 @@ fi
 
 export REDIS_URL='redis:///'
 export TEST=1
+export DEBUG=1
 psql posthog -c "drop database if exists test_posthog"
 nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db -s $*; mypy posthog ee"


### PR DESCRIPTION
## Changes

there is no situation where you want to run `./bin/tests` without DEBUG=1 so this sets it

## How did you test this code?

it _is_tests :P 

(and ran it)
