### PR TITLE
Minor fixes to `dev.Dockerfile`

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,8 @@
 #
 # This Dockerfile is used for self-hosted development builds.
 #
+# Note: for 'posthog/posthog-cloud' remember to update 'dev.Dockerfile' as appropriate
+#
 FROM python:3.8-alpine3.14
 
 ENV PYTHONUNBUFFERED 1
@@ -17,13 +19,13 @@ RUN apk --update --no-cache add \
     "bash~=5.1" \
     "g++~=10.3" \
     "gcc~=10.3" \
+    "libxml2-dev~=2.9" \
+    "libxslt~=1.1" \
+    "libxslt-dev~=1.1" \
     "make~=4.3" \
     "nodejs~=14" \
     "npm~=7" \
-    "postgresql-client~=13" \
-    "libxslt~=1.1" \
-    "libxslt-dev~=1.1" \
-    "libxml2-dev~=2.9" \
+    "libpq~=13.4" \
     && npm install -g yarn@1
 
 # Compile and install Python dependencies.
@@ -37,13 +39,13 @@ RUN apk --update --no-cache add \
 #   and then uninstall them when the compilation is completed.
 COPY requirements.txt requirements-dev.txt ./
 RUN apk --update --no-cache --virtual .build-deps add \
-    "linux-headers~=5.10" \
-    "musl-dev~=1.2" \
+    "cargo~=1.52" \
     "git~=2" \
     "libffi-dev~=3.3" \
-    "postgresql-dev~=13" \
+    "linux-headers~=5.10" \
+    "musl-dev~=1.2" \
     "openssl-dev~=1.1" \
-    "cargo~=1.52" \
+    "postgresql-dev~=13" \
     && \
     pip install -r requirements-dev.txt --compile --no-cache-dir && \
     pip install -r requirements.txt --compile --no-cache-dir \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -19,13 +19,13 @@ RUN apk --update --no-cache add \
     "bash~=5.1" \
     "g++~=10.3" \
     "gcc~=10.3" \
+    "libpq~=13.4" \
     "libxml2-dev~=2.9" \
     "libxslt~=1.1" \
     "libxslt-dev~=1.1" \
     "make~=4.3" \
     "nodejs~=14" \
     "npm~=7" \
-    "libpq~=13.4" \
     && npm install -g yarn@1
 
 # Compile and install Python dependencies.


### PR DESCRIPTION
## Changes
This is mostly a cosmetic change: 
* alphabetically sort the packages
* swap `postgresql-client~=13` with `libpq~=13.4` (that works for what we need and it's way smaller)

## How did you test this code?

1. `docker-compose -f docker-compose.dev.yml up --build` (build and execution) still works:
    ```
    posthog-backend-1   | Django version 3.2.5, using settings 'posthog.settings'
    posthog-backend-1   | Starting development server at http://0.0.0.0:8000/
    posthog-backend-1   | Quit the server with CONTROL-C.
    ```
    ```
    posthog-worker-1    | [MAIN] 11:15:35 🚀 All systems go
    posthog-worker-1    | [core] INFO: Worker connected and looking for jobs... (task names: 'pluginJob')
    ```

1. Image size and build time are like before
