### PR TITLE
Don't return/show forbidden projects at all

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -117,6 +117,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         ProjectMembershipNecessaryPermissions,
         PremiumMultiprojectPermissions,
     ]
+    lookup_field = "id"
     ordering = "-created_by"
     organization: Optional[Organization] = None
 

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -117,13 +117,19 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         ProjectMembershipNecessaryPermissions,
         PremiumMultiprojectPermissions,
     ]
-    lookup_field = "id"
     ordering = "-created_by"
     organization: Optional[Organization] = None
 
     def get_queryset(self):
         # This is actually what ensures that a user cannot read/update a project for which they don't have permission
-        return super().get_queryset().filter(organization__in=cast(User, self.request.user).organizations.all())
+        visible_teams_ids = [
+            team.id
+            for team in super()
+            .get_queryset()
+            .filter(organization__in=cast(User, self.request.user).organizations.all())
+            if team.get_effective_membership_level(self.request.user) is not None
+        ]
+        return super().get_queryset().filter(id__in=visible_teams_ids)
 
     def get_serializer_class(self) -> Type[serializers.BaseSerializer]:
         if self.action == "list":


### PR DESCRIPTION
## Changes

This is a quick[^1] change to completely hide restricted projects from users that don't have access, instead of only disallowing access, following a user call discussing project-based permissioning.
I was also considering making this behavior switchable in project settings, but I think that'd have little utility currently. It'll make a ton more sense if we add an actual "request access" flow. 

CC @marcushyett-ph 

[^1]: Quick but not optimal queries-wise – unfortunately there's no way to filter by a `SerializerMethodField` so I opted for something slightly dirty instead of porting `Team.get_effective_membership_level` to Django ORM.

## How did you test this code?

Added a Python test case.
