### PR TITLE
Backend support for autocapture elements chain in Correlations

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -3,16 +3,25 @@ from os import stat
 from typing import Any, Dict, List, Literal, Tuple, TypedDict, cast
 
 from rest_framework.exceptions import ValidationError
+from rest_framework.utils.serializer_helpers import ReturnList
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.element import chain_to_elements
+from ee.clickhouse.models.event import ElementSerializer
 from ee.clickhouse.models.property import get_property_string_expr
 from ee.clickhouse.queries.column_optimizer import ColumnOptimizer
 from ee.clickhouse.queries.funnels.funnel_persons import ClickhouseFunnelPersons
 from ee.clickhouse.queries.person_query import ClickhousePersonQuery
 from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS
-from posthog.constants import FunnelCorrelationType
+from posthog.constants import AUTOCAPTURE_EVENT, FunnelCorrelationType
 from posthog.models import Filter, Team
 from posthog.models.filters import Filter
+
+
+class EventDefinition(TypedDict):
+    event: str
+    properties: Dict[str, Any]
+    elements: list
 
 
 class EventOddsRatio(TypedDict):
@@ -25,6 +34,14 @@ class EventOddsRatio(TypedDict):
     correlation_type: Literal["success", "failure"]
 
 
+class EventOddsRatioSerialized(TypedDict):
+    event: EventDefinition
+    success_count: int
+    failure_count: int
+    odds_ratio: float
+    correlation_type: Literal["success", "failure"]
+
+
 class FunnelCorrelationResponse(TypedDict):
     """
     The structure that the diagnose response will be returned in.
@@ -32,7 +49,7 @@ class FunnelCorrelationResponse(TypedDict):
     queries, but we could use, for example, a dataclass
     """
 
-    events: List[EventOddsRatio]
+    events: List[EventOddsRatioSerialized]
     skewed: bool
 
 
@@ -61,6 +78,8 @@ class EventContingencyTable:
 class FunnelCorrelation:
 
     TOTAL_IDENTIFIER = "Total_Values_In_Query"
+    ELEMENTS_DIVIDER = "__~~__"
+    AUTOCAPTURE_EVENT_TYPE = "$event_type"
     MIN_PERSON_COUNT = 25
     MIN_PERSON_PERCENTAGE = 0.02
     PRIOR_COUNT = 1
@@ -86,6 +105,14 @@ class FunnelCorrelation:
             include_preceding_timestamp=False,
             no_person_limit=True,
         )
+
+    def _query_elements_chain(self) -> bool:
+        if (
+            self._filter.correlation_type == FunnelCorrelationType.EVENT_WITH_PROPERTIES
+            and AUTOCAPTURE_EVENT in self._filter.correlation_event_names
+        ):
+            return True
+        return False
 
     def get_contingency_table_query(self) -> Tuple[str, Dict[str, Any]]:
         """
@@ -171,6 +198,17 @@ class FunnelCorrelation:
 
         event_join_query = self._get_events_join_query()
 
+        if self._query_elements_chain():
+            array_join_query = f"""
+                arrayPushBack(prop_keys, 'elements_chain') as prop_keys_with_elements,
+                arrayPushBack(prop_values, concat(trim(BOTH '"' FROM JSONExtractRaw(properties, '{self.AUTOCAPTURE_EVENT_TYPE}')), '{self.ELEMENTS_DIVIDER}', elements_chain)) as prop_values_with_elements,
+                arrayJoin(arrayZip(prop_keys_with_elements, prop_values_with_elements)) as prop
+            """
+        else:
+            array_join_query = f"""
+                arrayJoin(arrayZip(prop_keys, prop_values)) as prop
+            """
+
         query = f"""
             WITH
                 funnel_people as ({funnel_persons_query}),
@@ -189,12 +227,8 @@ class FunnelCorrelation:
                     events.event as event_name,
                     -- Same as what we do in $all property queries
                     arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(properties)) as prop_keys,
-                    arrayJoin(
-                        arrayZip(
-                            prop_keys,
-                            arrayMap(x -> trim(BOTH '"' FROM JSONExtractRaw(properties, x)), prop_keys)
-                            )
-                        ) as prop
+                    arrayMap(x -> trim(BOTH '"' FROM JSONExtractRaw(properties, x)), prop_keys) as prop_values,
+                    {array_join_query}
                 FROM events AS event
                     {event_join_query}
                     AND event.event IN %(event_names)s
@@ -385,7 +419,7 @@ class FunnelCorrelation:
                 person_property_params,
             )
 
-    def run(self) -> FunnelCorrelationResponse:
+    def _run(self) -> Tuple[List[EventOddsRatio], bool]:
         """
         Run the diagnose query.
 
@@ -443,13 +477,11 @@ class FunnelCorrelation:
             correlation, e.g. "watched video"
 
         """
-        if not self._filter.entities:
-            return FunnelCorrelationResponse(events=[], skewed=False)
 
         event_contingency_tables, success_total, failure_total = self.get_partial_event_contingency_tables()
 
         if not success_total or not failure_total:
-            return {"events": [], "skewed": True}
+            return [], True
 
         skewed_totals = False
 
@@ -477,10 +509,31 @@ class FunnelCorrelation:
         )
 
         # Return the top ten positively correlated events, and top then negatively correlated events
+        events = positively_correlated_events[:10] + negatively_correlated_events[:10]
+        return events, skewed_totals
+
+    def format_results(self, results: Tuple[List[EventOddsRatio], bool]) -> FunnelCorrelationResponse:
         return {
-            "events": positively_correlated_events[:10] + negatively_correlated_events[:10],
-            "skewed": skewed_totals,
+            "events": list(
+                map(
+                    lambda eventOddsRatio: {
+                        "success_count": eventOddsRatio["success_count"],
+                        "failure_count": eventOddsRatio["failure_count"],
+                        "odds_ratio": eventOddsRatio["odds_ratio"],
+                        "correlation_type": eventOddsRatio["correlation_type"],
+                        "event": self.serialize_event_with_property(eventOddsRatio["event"]),
+                    },
+                    results[0],
+                )
+            ),
+            "skewed": results[1],
         }
+
+    def run(self) -> FunnelCorrelationResponse:
+        if not self._filter.entities:
+            return FunnelCorrelationResponse(events=[], skewed=False)
+
+        return self.format_results(self._run())
 
     def get_partial_event_contingency_tables(self) -> Tuple[List[EventContingencyTable], int, int]:
         """
@@ -539,6 +592,24 @@ class FunnelCorrelation:
             return True
 
         return False
+
+    def serialize_event_with_property(self, event: str) -> EventDefinition:
+        """
+        Format the event name for display.
+        """
+        if not self._query_elements_chain():
+            return EventDefinition(event=event, properties={}, elements=[])
+        event_name, property_name, property_value = event.split("::")
+        if event_name == AUTOCAPTURE_EVENT and property_name == "elements_chain":
+
+            event_type, elements_chain = property_value.split(self.ELEMENTS_DIVIDER)
+            return EventDefinition(
+                event=event,
+                properties={self.AUTOCAPTURE_EVENT_TYPE: event_type},
+                elements=cast(list, ElementSerializer(chain_to_elements(elements_chain), many=True).data),
+            )
+
+        return EventDefinition(event=event, properties={}, elements=[])
 
 
 def get_entity_odds_ratio(event_contingency_table: EventContingencyTable, prior_counts: int) -> EventOddsRatio:

--- a/ee/clickhouse/queries/funnels/test/test_funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_correlation.py
@@ -8,6 +8,7 @@ from ee.clickhouse.queries.funnels.funnel_correlation import EventContingencyTab
 from ee.clickhouse.queries.funnels.funnel_correlation_persons import FunnelCorrelationPersons
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.constants import INSIGHT_FUNNELS
+from posthog.models.element import Element
 from posthog.models.filters import Filter
 from posthog.models.person import Person
 from posthog.test.base import APIBaseTest, test_with_materialized_columns
@@ -81,7 +82,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                     timestamp="2020-01-03T14:00:00Z",
                 )
 
-        result = correlation.run()["events"]
+        result = correlation._run()[0]
 
         odds_ratios = [item.pop("odds_ratio") for item in result]  # type: ignore
         expected_odds_ratios = [11, 1 / 11]
@@ -168,7 +169,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             team=self.team, event="paid", distinct_id=f"user_succ", timestamp="2020-01-04T14:00:00Z",
         )
 
-        result = correlation.run()["events"]
+        result = correlation._run()[0]
 
         odds_ratios = [item.pop("odds_ratio") for item in result]  # type: ignore
 
@@ -252,10 +253,10 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                     timestamp="2020-01-03T14:00:00Z",
                 )
 
-        results = correlation.run()
-        self.assertFalse(results["skewed"])
+        results = correlation._run()
+        self.assertFalse(results[1])
 
-        result = results["events"]
+        result = results[0]
 
         odds_ratios = [item.pop("odds_ratio") for item in result]  # type: ignore
         expected_odds_ratios = [9, 1 / 3]
@@ -308,7 +309,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
         with self.assertRaises(ValidationError):
-            correlation.run()
+            correlation._run()
 
     @test_with_materialized_columns(event_properties=[], person_properties=["$browser"])
     def test_correlation_with_multiple_properties(self):
@@ -375,7 +376,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             team=self.team, event="paid", distinct_id=f"user_succ", timestamp="2020-01-04T14:00:00Z",
         )
 
-        result = correlation.run()["events"]
+        result = correlation._run()[0]
 
         # Success Total = 5 + 10 + 1 = 16
         # Failure Total = 5 + 1 = 6
@@ -442,11 +443,11 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(result, expected_result)
 
-        # Run property correlation with filter on all properties
+        # _run property correlation with filter on all properties
         filter = filter.with_data({"funnel_correlation_names": ["$all"]})
         correlation = FunnelCorrelation(filter, self.team)
 
-        new_result = correlation.run()["events"]
+        new_result = correlation._run()[0]
 
         odds_ratios = [item.pop("odds_ratio") for item in new_result]  # type: ignore
 
@@ -526,7 +527,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         # Discard both due to %
         FunnelCorrelation.MIN_PERSON_PERCENTAGE = 0.11
         FunnelCorrelation.MIN_PERSON_COUNT = 25
-        result = correlation.run()["events"]
+        result = correlation._run()[0]
         self.assertEqual(len(result), 2)
 
     def test_events_within_conversion_window_for_correlation(self):
@@ -568,7 +569,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-02T14:15:00Z",  # event happened outside conversion window
         )
 
-        result = correlation.run()["events"]
+        result = correlation._run()[0]
 
         odds_ratios = [item.pop("odds_ratio") for item in result]  # type: ignore
         expected_odds_ratios = [4]
@@ -639,7 +640,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 )
                 # source: shazam occurs only once, so would be discarded from result set
 
-        result = correlation.run()["events"]
+        result = correlation._run()[0]
 
         odds_ratios = [item.pop("odds_ratio") for item in result]  # type: ignore
         expected_odds_ratios = [11, 5.5, 2 / 11]
@@ -683,6 +684,137 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(
             len(self._get_people_for_event(filter, "negatively_related", {"signup_source": "email"}, False)), 3
+        )
+
+    @test_with_materialized_columns(["$event_type", "signup_source"])
+    def test_funnel_correlation_with_event_properties_autocapture(self):
+        filters = {
+            "events": [
+                {"id": "user signed up", "type": "events", "order": 0},
+                {"id": "paid", "type": "events", "order": 1},
+            ],
+            "insight": INSIGHT_FUNNELS,
+            "date_from": "2020-01-01",
+            "date_to": "2020-01-14",
+            "funnel_correlation_type": "event_with_properties",
+            "funnel_correlation_event_names": ["$autocapture"],
+        }
+
+        filter = Filter(data=filters)
+        correlation = FunnelCorrelation(filter, self.team)
+
+        # Need a minimum of 3 hits to get a correlation result
+        for i in range(6):
+            _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team, event="user signed up", distinct_id=f"user_{i}", timestamp="2020-01-02T14:00:00Z",
+            )
+            _create_event(
+                team=self.team,
+                event="$autocapture",
+                distinct_id=f"user_{i}",
+                elements=[Element(nth_of_type=1, nth_child=0, tag_name="a", href="/movie")],
+                timestamp="2020-01-03T14:00:00Z",
+                properties={"signup_source": "email", "$event_type": "click"},
+            )
+            # Test two different types of autocapture elements, with different counts, so we can accurately test results
+            if i % 2 == 0:
+                _create_event(
+                    team=self.team,
+                    event="$autocapture",
+                    distinct_id=f"user_{i}",
+                    elements=[Element(nth_of_type=1, nth_child=0, tag_name="button", text="Pay $10")],
+                    timestamp="2020-01-03T14:00:00Z",
+                    properties={"signup_source": "facebook", "$event_type": "submit"},
+                )
+
+            _create_event(
+                team=self.team, event="paid", distinct_id=f"user_{i}", timestamp="2020-01-04T14:00:00Z",
+            )
+
+        # Atleast one person that fails, to ensure we get results
+        _create_person(distinct_ids=[f"user_fail"], team_id=self.team.pk)
+        _create_event(
+            team=self.team, event="user signed up", distinct_id=f"user_fail", timestamp="2020-01-02T14:00:00Z",
+        )
+
+        result = correlation._run()[0]
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "event": '$autocapture::elements_chain::click__~~__a:href="/movie"nth-child="0"nth-of-type="1"',
+                    "success_count": 6,
+                    "failure_count": 0,
+                    "odds_ratio": 14.0,
+                    "correlation_type": "success",
+                },
+                {
+                    "event": "$autocapture::signup_source::email",
+                    "success_count": 6,
+                    "failure_count": 0,
+                    "odds_ratio": 14.0,
+                    "correlation_type": "success",
+                },
+                {
+                    "event": "$autocapture::$event_type::click",
+                    "success_count": 6,
+                    "failure_count": 0,
+                    "odds_ratio": 14.0,
+                    "correlation_type": "success",
+                },
+                {
+                    "event": '$autocapture::elements_chain::submit__~~__button:nth-child="0"nth-of-type="1"text="Pay $10"',
+                    "success_count": 3,
+                    "failure_count": 0,
+                    "odds_ratio": 2.0,
+                    "correlation_type": "success",
+                },
+                {
+                    "event": "$autocapture::$event_type::submit",
+                    "success_count": 3,
+                    "failure_count": 0,
+                    "odds_ratio": 2.0,
+                    "correlation_type": "success",
+                },
+                {
+                    "event": "$autocapture::signup_source::facebook",
+                    "success_count": 3,
+                    "failure_count": 0,
+                    "odds_ratio": 2.0,
+                    "correlation_type": "success",
+                },
+            ],
+        )
+
+        self.assertEqual(len(self._get_people_for_event(filter, "$autocapture", {"signup_source": "facebook"})), 3)
+        self.assertEqual(len(self._get_people_for_event(filter, "$autocapture", {"$event_type": "click"})), 6)
+        self.assertEqual(
+            len(
+                self._get_people_for_event(
+                    filter,
+                    "$autocapture",
+                    [
+                        {"key": "tag_name", "operator": "exact", "type": "element", "value": "button"},
+                        {"key": "text", "operator": "exact", "type": "element", "value": "Pay $10"},
+                    ],
+                )
+            ),
+            3,
+        )
+        self.assertEqual(
+            len(
+                self._get_people_for_event(
+                    filter,
+                    "$autocapture",
+                    [
+                        {"key": "tag_name", "operator": "exact", "type": "element", "value": "a"},
+                        {"key": "href", "operator": "exact", "type": "element", "value": "/movie"},
+                    ],
+                )
+            ),
+            6,
         )
 
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -51,7 +51,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                     ) : (
                         <FallOutlined style={{ color: 'red' }} />
                     )}{' '}
-                    {record.event}
+                    {record.event?.event}
                 </h4>
                 <div>
                     People who converted were{' '}
@@ -78,7 +78,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         }
     }
     const renderSuccessCount = (record: FunnelCorrelation): JSX.Element => {
-        const { name, property } = parseEventAndProperty(record.event || '')
+        const { name, property } = parseEventAndProperty(record.event?.event || '')
 
         return (
             <ValueInspectorButton
@@ -95,7 +95,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
     }
 
     const renderFailureCount = (record: FunnelCorrelation): JSX.Element => {
-        const { name, property } = parseEventAndProperty(record.event || '')
+        const { name, property } = parseEventAndProperty(record.event?.event || '')
 
         return (
             <ValueInspectorButton
@@ -152,12 +152,12 @@ export function FunnelCorrelationTable(): JSX.Element | null {
             dataSource={correlationValues}
             scroll={{ x: 'max-content' }}
             size="small"
-            rowKey={(record: FunnelCorrelation) => record.event || 'rowKey'}
+            rowKey={(record: FunnelCorrelation) => record.event?.event || 'rowKey'}
             pagination={{ pageSize: 100, hideOnSinglePage: true }}
             style={{ marginTop: '1rem' }}
             expandable={{
-                expandedRowRender: (record) => renderNestedTable(record.event),
-                rowExpandable: (record) => !!record.event && eventHasPropertyCorrelations(record.event),
+                expandedRowRender: (record) => renderNestedTable(record.event?.event),
+                rowExpandable: (record) => !!record.event?.event && eventHasPropertyCorrelations(record.event?.event),
             }}
             title={() => (
                 <>
@@ -226,7 +226,9 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                 title="Property correlations"
                 key="operation"
                 render={(_, record: FunnelCorrelation) => (
-                    <a onClick={() => record.event && loadEventWithPropertyCorrelations(record.event)}>Run</a>
+                    <a onClick={() => record.event?.event && loadEventWithPropertyCorrelations(record.event?.event)}>
+                        Run
+                    </a>
                 )}
             />
         </Table>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -50,7 +50,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     }
 
     const renderSuccessCount = (record: FunnelCorrelation): JSX.Element => {
-        const { breakdown, breakdown_value } = parseBreakdownValue(record.event || '')
+        const { breakdown, breakdown_value } = parseBreakdownValue(record.event?.event || '')
 
         return (
             <ValueInspectorButton
@@ -71,7 +71,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     }
 
     const renderFailureCount = (record: FunnelCorrelation): JSX.Element => {
-        const { breakdown, breakdown_value } = parseBreakdownValue(record.event || '')
+        const { breakdown, breakdown_value } = parseBreakdownValue(record.event?.event || '')
 
         return (
             <ValueInspectorButton
@@ -158,7 +158,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                                 ) : (
                                     <FallOutlined style={{ color: 'red' }} />
                                 )}{' '}
-                                {record.event}
+                                {record.event?.event}
                             </h4>
                             <div>
                                 People who converted were{' '}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1268,7 +1268,7 @@ export interface PathEdgeParameters {
 }
 
 export interface FunnelCorrelation {
-    event?: string
+    event?: Partial<EventType>
     property?: string
     odds_ratio: number
     success_count: number

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -259,14 +259,14 @@ class FunnelCorrelationMixin(BaseParamMixin):
         return None
 
     @cached_property
-    def correlation_property_names(self) -> Optional[List[str]]:
+    def correlation_property_names(self) -> List[str]:
         property_names = self._data.get(FUNNEL_CORRELATION_NAMES, [])
         if isinstance(property_names, str):
             return json.loads(property_names)
         return property_names
 
     @cached_property
-    def correlation_event_names(self) -> Optional[List[str]]:
+    def correlation_event_names(self) -> List[str]:
         event_names = self._data.get(FUNNEL_CORRELATION_EVENT_NAMES, [])
         if isinstance(event_names, str):
             return json.loads(event_names)


### PR DESCRIPTION
## Changes

I opted to make the smallest Frontend change for now, so things still work as we'd expect them to. Proper frontend handling to follow.

Here, I'm changing the return type of events from string to `Partial<EventType>` , as this allows us to use the existing frontend infra to parse event names out of autocapture events.

I opted to make things uniform: such that we always return an `Partial<EventType>`, vs. doing this only for autocapture / nested breakdowns. This made the entire codebase simpler, albeit "fluffy" with details.

To make this happen, I opted for introducing a `format_results` in the end, vs doing this parsing in the beginning. This was because: It kept existing code as is & simple. It meant the final parsing happens only on the 20 strings we've filtered out, vs the 1000+ the query returns. I also test this formatting only at the API level, and not at the query level (`FunnelCorrelation` class)

## How did you test this code?

Unit test + API tests
