### PR TITLE
Fix `teamId` usage in `pluginsLogsLogic`

### DIFF
--- a/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
+++ b/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
@@ -1,6 +1,7 @@
 import { kea } from 'kea'
 import api from '~/lib/api'
 import { PluginLogEntry } from '~/types'
+import { teamLogic } from '../../teamLogic'
 import { pluginLogsLogicType } from './pluginLogsLogicType'
 
 export interface PluginLogsProps {
@@ -9,20 +10,24 @@ export interface PluginLogsProps {
 
 export const LOGS_PORTION_LIMIT = 50
 
-export const pluginLogsLogic = kea<pluginLogsLogicType>({
-    key: ({ teamId, pluginConfigId }) => `${teamId}-${pluginConfigId}`,
+export const pluginLogsLogic = kea<pluginLogsLogicType<PluginLogsProps>>({
+    props: {} as PluginLogsProps,
+    key: ({ pluginConfigId }: PluginLogsProps) => pluginConfigId,
+    connect: {
+        values: [teamLogic, ['currentTeamId']],
+    },
 
     actions: {
         clearPluginLogsBackground: true,
         markLogsEnd: true,
     },
 
-    loaders: ({ props: { teamId, pluginConfigId }, values, actions, cache }) => ({
+    loaders: ({ props: { pluginConfigId }, values, actions, cache }) => ({
         pluginLogs: {
             __default: [] as PluginLogEntry[],
             loadPluginLogsInitially: async () => {
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}`
+                    `api/projects/${values.currentTeamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}`
                 )
                 cache.pollingInterval = setInterval(actions.loadPluginLogsBackgroundPoll, 2000)
                 actions.clearPluginLogsBackground()
@@ -30,7 +35,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
             },
             loadPluginLogsSearch: async (searchTerm: string) => {
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}&search=${searchTerm}`
+                    `api/projects/${values.currentTeamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}&search=${searchTerm}`
                 )
                 actions.clearPluginLogsBackground()
                 return response.results
@@ -39,7 +44,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
                 const before = values.trailingEntry ? '&before=' + values.trailingEntry.timestamp : ''
                 const search = values.searchTerm ? `&search=${values.searchTerm}` : ''
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}${before}${search}`
+                    `api/projects/${values.currentTeamId}/plugin_configs/${pluginConfigId}/logs?limit=${LOGS_PORTION_LIMIT}${before}${search}`
                 )
                 if (response.count < LOGS_PORTION_LIMIT) {
                     actions.markLogsEnd()
@@ -61,7 +66,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
                 const after = values.leadingEntry ? 'after=' + values.leadingEntry.timestamp : ''
                 const search = values.searchTerm ? `search=${values.searchTerm}` : ''
                 const response = await api.get(
-                    `api/projects/${teamId}/plugin_configs/${pluginConfigId}/logs?${[after, search]
+                    `api/projects/${values.currentTeamId}/plugin_configs/${pluginConfigId}/logs?${[after, search]
                         .filter(Boolean)
                         .join('&')}`
                 )


### PR DESCRIPTION
## Changes

Closes #6633.
The plugin logs UI has been using an approach where `teamId` is passed via logic props. With the recent avalanche of logic refactors that I've been doing, I applied the same style initially, but Marius suggested it'd be faster to just connect all logics to `teamLogic.values.currentTeamId`, which is less flexible BUT requires a less fundamental rework of most logics. So I ended up moving things to the simpler approach. However it looks like I also moved `pluginLogsLogic`… which was not correct, as `pluginLogsLogic` was _not_ part of this refactoring wave. I missed that the logic is no longer used correctly, because logic props were not set up with typechecking (`props: {} as LogicPropsType`).

This PR adds props typechecking to `pluginLogsLogic` and actually removes the need to pass `teamId` to it (by connecting to `teamLogic` instead, like other recently updated logics).

## How did you test this code?

Tried the fixed plugin logs pane out locally.