### PR TITLE
Fix locking migration

### DIFF
--- a/posthog/management/commands/test_migrations_are_null.py
+++ b/posthog/management/commands/test_migrations_are_null.py
@@ -15,7 +15,11 @@ class Command(BaseCommand):
             try:
                 results = re.findall(r"([a-z]+)\/migrations\/([a-zA-Z_0-9]+)\.py", variable)[0]
                 sql = call_command("sqlmigrate", results[0], results[1])
-                if "NOT NULL" in sql and "Create model" not in sql and "-- not-null-ignore" not in sql:
+                if (
+                    ("NOT NULL" in sql or "DEFAULT" in sql)
+                    and "Create model" not in sql
+                    and "-- not-null-ignore" not in sql
+                ):
                     print(
                         f"\n\n\033[91mFound a non-null field added to an existing model. This will lock up the table while migrating. Please add 'null=True, blank=True' to the field",
                         "red",

--- a/posthog/migrations/0172_person_properties_last_operation.py
+++ b/posthog/migrations/0172_person_properties_last_operation.py
@@ -11,8 +11,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name="person",
-            name="properties_last_operation",
-            field=models.JSONField(blank=True, default=dict, null=True),
+            model_name="person", name="properties_last_operation", field=models.JSONField(blank=True, null=True),
         ),
     ]

--- a/posthog/models/person.py
+++ b/posthog/models/person.py
@@ -70,7 +70,7 @@ class Person(models.Model):
     properties_last_updated_at: models.JSONField = models.JSONField(default=dict, null=True, blank=True)
 
     # used for evaluating if we need to override the value or not (value: set or set_once)
-    properties_last_operation: models.JSONField = models.JSONField(default=dict, null=True, blank=True)
+    properties_last_operation: models.JSONField = models.JSONField(null=True, blank=True)
 
     team: models.ForeignKey = models.ForeignKey("Team", on_delete=models.CASCADE)
     properties: models.JSONField = models.JSONField(default=dict)


### PR DESCRIPTION
## Changes

We [created a migration](https://github.com/PostHog/posthog/pull/6253) that rewrites every row on person, causing people upgrading to 1.29 to get stuck migrating.

1. Rewrite the offending migration
2. Change our automated test to catch this case.

## How did you test this code?

Went back to the commit where this was introduced, ran all migrations up to that point, then switched back to this branch and ran the rest
