### PR TITLE
GH actions for FOSS

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -20,6 +20,7 @@ jobs:
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
         runs-on: ubuntu-latest
+        if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
         # Set job outputs to values from filter step
         outputs:
@@ -50,7 +51,7 @@ jobs:
     backend-code-quality:
         needs: changes
         # Make sure we only run on backend changes
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Code quality checks
         runs-on: ubuntu-latest
@@ -108,7 +109,7 @@ jobs:
 
     django:
         needs: changes
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – Py ${{ matrix.python-version }}
         runs-on: ubuntu-latest
@@ -179,7 +180,7 @@ jobs:
 
     saml:
         needs: changes
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – with SAML
         runs-on: ubuntu-latest
@@ -235,7 +236,7 @@ jobs:
 
     cloud:
         needs: changes
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – Cloud
         runs-on: ubuntu-latest
@@ -337,7 +338,7 @@ jobs:
 
     foss:
         needs: changes
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – FOSS
         runs-on: ubuntu-latest

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     build-push:
         name: Build Docker images and push them
+        if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-20.04
         steps:
             - name: Checkout default branch

--- a/.github/workflows/docker-unstable-image.yml
+++ b/.github/workflows/docker-unstable-image.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     build-release-push:
         name: Build & push Docker release image
+        if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-20.04
         steps:
             - name: Checkout default branch

--- a/.github/workflows/docker-vuln-scan.yml
+++ b/.github/workflows/docker-vuln-scan.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     build:
         name: Vulnerabilty Scan
+        if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-latest
 
         steps:
@@ -22,7 +23,6 @@ jobs:
               uses: docker/setup-buildx-action@v1
 
             - name: Login to DockerHub
-              if: github.repository == 'PostHog/posthog'
               uses: docker/login-action@v1
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -30,14 +30,12 @@ jobs:
 
             - name: Build image
               uses: docker/build-push-action@v2
-              if: github.repository == 'PostHog/posthog'
               with:
                   push: true
                   tags: posthog/posthog:vuln-scan-${{ github.sha }}
 
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@master
-              if: github.repository == 'PostHog/posthog'
               with:
                   image-ref: 'posthog/posthog:vuln-scan-${{ github.sha }}'
                   ignore-unfixed: true
@@ -49,6 +47,5 @@ jobs:
 
             - name: Upload Trivy scan results to GitHub Security tab
               uses: github/codeql-action/upload-sarif@v1
-              if: github.repository == 'PostHog/posthog'
               with:
                   sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -51,5 +51,6 @@ jobs:
               with:
                   message: 'Sync and remove all non-FOSS parts'
                   remove: '["-r ee/"]'
+                  default_author: github_actions
                   github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - run: echo # Empty step so that GitHub doesn't complain about an empty job on forks

--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -9,10 +9,10 @@ on:
 jobs:
     repo-sync:
         name: Sync posthog-foss with posthog
+        if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-latest
         steps:
             - name: Sync repositories 1 to 1 - master branch
-              if: github.repository == 'PostHog/posthog'
               uses: wei/git-sync@v3
               with:
                   source_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog.git'
@@ -20,7 +20,6 @@ jobs:
                   destination_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog-foss.git'
                   destination_branch: 'master'
             - name: Sync repositories 1 to 1 – tags
-              if: github.repository == 'PostHog/posthog'
               uses: wei/git-sync@v3
               with:
                   source_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog.git'
@@ -28,25 +27,21 @@ jobs:
                   destination_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog-foss.git'
                   destination_branch: 'refs/tags/*'
             - name: Checkout posthog-foss
-              if: github.repository == 'PostHog/posthog'
               uses: actions/checkout@v2
               with:
                   repository: 'posthog/posthog-foss'
                   ref: master
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Change LICENSE to pure MIT
-              if: github.repository == 'PostHog/posthog'
               run: |
                   sed -i -e '/PostHog Inc\./,/Permission is hereby granted/c\Copyright (c) 2020-2021 PostHog Inc\.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy' LICENSE
                   echo -e "MIT License\n\n$(cat LICENSE)" > LICENSE
             - name: Remove unused GitHub workflows
-              if: github.repository == 'PostHog/posthog'
               run: |
                   cd .github/workflows
                   ls | grep -v foss-release-image-publish.yml | xargs rm
 
             - name: Commit "Sync and remove all non-FOSS parts"
-              if: github.repository == 'PostHog/posthog'
               uses: EndBug/add-and-commit@v7
               with:
                   message: 'Sync and remove all non-FOSS parts'

--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -124,11 +124,11 @@ jobs:
     sentry:
         name: Notify Sentry of a production release
         runs-on: ubuntu-20.04
+        if: github.repository == 'PostHog/posthog'
         steps:
             - name: Checkout master
               uses: actions/checkout@v2
             - name: Notify Sentry
-              if: github.repository == 'PostHog/posthog'
               uses: getsentry/action-release@v1
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     storybook-deployment:
         runs-on: ubuntu-latest
+        if: github.repository == 'PostHog/posthog'
         steps:
             - name: Check out PostHog/posthog repo
               uses: actions/checkout@v2
@@ -37,7 +38,6 @@ jobs:
                   cp -a posthog/storybook-static storybook-build/docs
 
             - name: Commit update
-              if: github.repository == 'PostHog/posthog'
               uses: stefanzweifel/git-auto-commit-action@v4
               with:
                   repository: storybook-build


### PR DESCRIPTION
## Changes

We're now enabling actions on the `posthog-foss` repo so the `posthog-foss` Docker images can be built from there. The way we sync the PostHog FOSS repo (through `wei/git-sync@v3`) causes actions from the main repo that should run on pushes to master to run automatically. This adds a conditional so the actions only run on the main repo.

## How did you test this code?

Testing after merge as we need to execute the entire workflow of GH actions.
