### PR TITLE
Fix clicking in command palette

### DIFF
--- a/frontend/src/lib/components/CommandPalette/CommandResults.tsx
+++ b/frontend/src/lib/components/CommandPalette/CommandResults.tsx
@@ -15,6 +15,7 @@ function CommandResult({ result, focused }: CommandResultProps): JSX.Element {
     const ref = useRef<HTMLDivElement | null>(null)
 
     const isExecutable = !!result.executor
+
     useEffect(() => {
         if (focused) {
             ref.current?.scrollIntoView()

--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -7,7 +7,7 @@ export function useOutsideClickHandler(
     handleClickOutside?: (event: Event) => void,
     extraDeps: any[] = []
 ): void {
-    const allRefs = (Array.isArray(refOrRefs) ? refOrRefs : [refOrRefs]).map((f) => f)
+    const allRefs = Array.isArray(refOrRefs) ? refOrRefs : [refOrRefs]
 
     useEffect(
         () => {
@@ -22,9 +22,9 @@ export function useOutsideClickHandler(
             }
 
             if (allRefs.length > 0) {
-                // only attach event listeners if there's something to track
-                document.addEventListener('mousedown', handleClick)
-                return () => document.removeEventListener('mousedown', handleClick)
+                // Only attach event listeners if there's something to track
+                document.addEventListener('click', handleClick)
+                return () => document.removeEventListener('click', handleClick)
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Changes

Noticed that only Enter works on command palette results and clicking sadly does nothing. Some issue with event handling, fixed by this.

## How did you test this code?

Manually checked clicking on command palette results and clicking outside of it.