### PR TITLE
Allow wildcard app urls

### DIFF
--- a/frontend/src/lib/components/AppEditorLink/UrlRow.tsx
+++ b/frontend/src/lib/components/AppEditorLink/UrlRow.tsx
@@ -28,6 +28,14 @@ export function UrlRow({ actionId, url, saveUrl, deleteUrl, allowNavigation }: U
                         if (editedValue === defaultUrl) {
                             deleteUrl()
                         } else {
+                            // Validate that the wildcard is valid and we're not trying to match subdomains
+                            // See https://regex101.com/r/UMBc9g/1 for tests
+                            if (editedValue.indexOf('*') > -1 && !editedValue.match(/^(.*)\*[^\*]*\.[^\*]+\.[^\*]+$/)) {
+                                alert(
+                                    'You can only wildcard subdomains. If you wildcard the domain or TLD, people might be able to gain access to your PostHog data.'
+                                )
+                                return
+                            }
                             saveUrl(editedValue)
                             setIsEditing(false)
                             setSavedValue(editedValue)

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -208,6 +208,10 @@ export function ProjectSettings({ user }: { user: UserType }): JSX.Element {
                     These are the domains and URLs where the <b>Toolbar will automatically launch</b> (if you're logged
                     in) and where we'll <a href="#session-recording">record sessions</a> (if enabled).
                 </p>
+                <p>
+                    Wilcard subdomains are permitted: <pre>https://*.example.com</pre>. You cannot wildcard domains or
+                    top-level domains as this could present a security risk.
+                </p>
                 <EditAppUrls />
                 <Divider />
                 <h2 className="subtitle" id="attributes">

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
@@ -26,9 +27,17 @@ def on_permitted_domain(team: Team, request: HttpRequest) -> bool:
         if hostname:
             permitted_domains.append(hostname)
 
-    return (parse_domain(request.headers.get("Origin")) in permitted_domains) or (
-        parse_domain(request.headers.get("Referer")) in permitted_domains
-    )
+    origin = parse_domain(request.headers.get("Origin"))
+    referer = parse_domain(request.headers.get("Referer"))
+    for permitted_domain in permitted_domains:
+        if "*" in permitted_domain:
+            pattern = "^{}$".format(permitted_domain.replace(".", "\\.").replace("*", "(.*)"))
+            if re.search(pattern, origin) or (referer and re.search(pattern, referer)):
+                return True
+        else:
+            if permitted_domain == origin or permitted_domain == referer:
+                return True
+    return False
 
 
 def decide_editor_params(request: HttpRequest) -> Tuple[Dict[str, Any], bool]:

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -32,7 +32,7 @@ def on_permitted_domain(team: Team, request: HttpRequest) -> bool:
     for permitted_domain in permitted_domains:
         if "*" in permitted_domain:
             pattern = "^{}$".format(permitted_domain.replace(".", "\\.").replace("*", "(.*)"))
-            if re.search(pattern, origin) or (referer and re.search(pattern, referer)):
+            if (origin and re.search(pattern, origin)) or (referer and re.search(pattern, referer)):
                 return True
         else:
             if permitted_domain == origin or permitted_domain == referer:

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -92,6 +92,23 @@ class TestDecide(BaseTest):
         self.assertEqual(response["sessionRecording"], {"endpoint": "/s/"})
         self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
 
+    def test_user_session_recording_opt_in_wildcard_domain(self):
+        # :TRICKY: Test for regression around caching
+        response = self._post_decide().json()
+        self.assertEqual(response["sessionRecording"], False)
+
+        self.team.session_recording_opt_in = True
+        self.team.app_urls = ["https://*.example.com"]
+        self.team.save()
+
+        response = self._post_decide(origin="https://random.example.com").json()
+        self.assertEqual(response["sessionRecording"], {"endpoint": "/s/"})
+        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+
+        # Make sure the domain matches exactly
+        response = self._post_decide(origin="https://random.example.com.evilsite.com").json()
+        self.assertEqual(response["sessionRecording"], False)
+
     def test_user_session_recording_evil_site(self):
         self.team.app_urls = ["https://example.com"]
         self.team.session_recording_opt_in = True


### PR DESCRIPTION
## Changes

Allow wildcards on permitted urls

Closes #6546

## How did you test this code?

- Unit tests for the decide functionality
- Manual testing
  - added `127.0.0.1   test.example.com` to my /etc/hosts file
  - Went to test.example.com/demo, verified that /decide returns false for sessionRecording
  - Set permitted domain to *.example.com
  - Verified /decide returns the endpoint