### PR TITLE
Persons table schema migration

### DIFF
--- a/ee/clickhouse/migrations/0019_person_table_version_column.py
+++ b/ee/clickhouse/migrations/0019_person_table_version_column.py
@@ -29,7 +29,7 @@ operations = [
     migrations.RunSQL(
         f"""
         RENAME TABLE
-            {CLICKHOUSE_DATABASE}.{PERSONS_TABLE} to {CLICKHOUSE_DATABASE}.person_backup,
+            {CLICKHOUSE_DATABASE}.{PERSONS_TABLE} to {CLICKHOUSE_DATABASE}.person_backup_0019,
             {CLICKHOUSE_DATABASE}.{TEMPORARY_TABLE_NAME} to {CLICKHOUSE_DATABASE}.{PERSONS_TABLE}
         ON CLUSTER {CLICKHOUSE_CLUSTER}
     """

--- a/ee/clickhouse/migrations/0019_person_table_version_column.py
+++ b/ee/clickhouse/migrations/0019_person_table_version_column.py
@@ -1,0 +1,39 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.person import *
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+TEMPORARY_TABLE_NAME = "person_tmp_migration_0019"
+
+operations = [
+    migrations.RunSQL(PERSONS_TABLE_SQL.replace(PERSONS_TABLE, TEMPORARY_TABLE_NAME, 1)),
+    migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(
+        f"""
+        INSERT INTO {TEMPORARY_TABLE_NAME} (id, team_id, created_at, properties, is_identified, is_deleted, version, _partition, _timestamp, _offset)
+        SELECT
+            id,
+            team_id,
+            created_at,
+            properties,
+            is_identified,
+            is_deleted,
+            0,
+            0,
+            _timestamp,
+            _offset
+        FROM {PERSONS_TABLE}
+    """
+    ),
+    migrations.RunSQL(
+        f"""
+        RENAME TABLE
+            {CLICKHOUSE_DATABASE}.{PERSONS_TABLE} to {CLICKHOUSE_DATABASE}.person_backup,
+            {CLICKHOUSE_DATABASE}.{TEMPORARY_TABLE_NAME} to {CLICKHOUSE_DATABASE}.{PERSONS_TABLE}
+        ON CLUSTER {CLICKHOUSE_CLUSTER}
+    """
+    ),
+    migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
+    migrations.RunSQL(PERSONS_TABLE_MV_SQL),
+]

--- a/ee/clickhouse/migrations/0021_person_table_version_column.py
+++ b/ee/clickhouse/migrations/0021_person_table_version_column.py
@@ -3,7 +3,7 @@ from infi.clickhouse_orm import migrations
 from ee.clickhouse.sql.person import *
 from posthog.settings import CLICKHOUSE_CLUSTER
 
-TEMPORARY_TABLE_NAME = "person_tmp_migration_0019"
+TEMPORARY_TABLE_NAME = "person_tmp_migration_0021"
 
 operations = [
     migrations.RunSQL(
@@ -18,7 +18,7 @@ operations = [
     migrations.RunSQL(
         f"""
         RENAME TABLE
-            {CLICKHOUSE_DATABASE}.{PERSONS_TABLE} to {CLICKHOUSE_DATABASE}.person_backup_0019,
+            {CLICKHOUSE_DATABASE}.{PERSONS_TABLE} to {CLICKHOUSE_DATABASE}.person_backup_0021,
             {CLICKHOUSE_DATABASE}.{TEMPORARY_TABLE_NAME} to {CLICKHOUSE_DATABASE}.{PERSONS_TABLE}
         ON CLUSTER {CLICKHOUSE_CLUSTER}
     """

--- a/ee/clickhouse/migrations/0021_person_table_version_column.py
+++ b/ee/clickhouse/migrations/0021_person_table_version_column.py
@@ -23,7 +23,6 @@ operations = [
         ON CLUSTER {CLICKHOUSE_CLUSTER}
     """
     ),
-    # migrations.RunSQL("OPTIMIZE TABLE person FINAL") # TODO: Investigate - do we need this?
     migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
     migrations.RunSQL(PERSONS_TABLE_MV_SQL),
 ]

--- a/ee/clickhouse/migrations/0021_person_table_version_column.py
+++ b/ee/clickhouse/migrations/0021_person_table_version_column.py
@@ -6,26 +6,15 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 TEMPORARY_TABLE_NAME = "person_tmp_migration_0019"
 
 operations = [
+    migrations.RunSQL(
+        "ALTER TABLE person ADD COLUMN IF NOT EXISTS version UInt64, ADD COLUMN IF NOT EXISTS _partition UInt32"
+    ),
     migrations.RunSQL(PERSONS_TABLE_SQL.replace(PERSONS_TABLE, TEMPORARY_TABLE_NAME, 1)),
     migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
     migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER {CLICKHOUSE_CLUSTER}"),
-    migrations.RunSQL(
-        f"""
-        INSERT INTO {TEMPORARY_TABLE_NAME} (id, team_id, created_at, properties, is_identified, is_deleted, version, _partition, _timestamp, _offset)
-        SELECT
-            id,
-            team_id,
-            created_at,
-            properties,
-            is_identified,
-            is_deleted,
-            0,
-            0,
-            _timestamp,
-            _offset
-        FROM {PERSONS_TABLE}
-    """
-    ),
+    # Check partition names with: `SELECT partition FROM system.parts WHERE table = 'person' and active = 1 GROUP BY partition;`
+    # The persons table currently doesn't have a PARTITION BY clause so tuple() is the default
+    migrations.RunSQL(f"ALTER TABLE {TEMPORARY_TABLE_NAME} ATTACH PARTITION tuple() FROM person"),
     migrations.RunSQL(
         f"""
         RENAME TABLE
@@ -34,6 +23,7 @@ operations = [
         ON CLUSTER {CLICKHOUSE_CLUSTER}
     """
     ),
+    # migrations.RunSQL("OPTIMIZE TABLE person FINAL") # TODO: Investigate - do we need this?
     migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL),
     migrations.RunSQL(PERSONS_TABLE_MV_SQL),
 ]

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -68,6 +68,7 @@ def create_person(
         "is_identified": int(is_identified),
         "created_at": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
         "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "version": 0,
         "is_deleted": 0,
     }
     p = ClickhouseProducer()

--- a/ee/clickhouse/models/person.py
+++ b/ee/clickhouse/models/person.py
@@ -68,6 +68,7 @@ def create_person(
         "is_identified": int(is_identified),
         "created_at": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
         "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "is_deleted": 0,
     }
     p = ClickhouseProducer()
     p.produce(topic=KAFKA_PERSON, sql=INSERT_PERSON_SQL, data=data, sync=sync)

--- a/ee/clickhouse/models/test/test_person.py
+++ b/ee/clickhouse/models/test/test_person.py
@@ -75,7 +75,7 @@ class TestPersonsTable(ClickhouseTestMixin, BaseTest):
         kafka_producer.send(topic=KAFKA_PERSON, value=json.dumps(kafka_person1).encode("utf-8"))
         kafka_producer.send(topic=KAFKA_PERSON, value=json.dumps(kafka_person2).encode("utf-8"))
 
-        delay_until_clickhouse_consumes_from_kafka(PERSONS_TABLE, 1, timeout_seconds=10)
+        delay_until_clickhouse_consumes_from_kafka(PERSONS_TABLE, 1, timeout_seconds=20)
 
         persons = sync_execute("SELECT version, is_deleted FROM person FINAL")
 

--- a/ee/clickhouse/models/test/test_person.py
+++ b/ee/clickhouse/models/test/test_person.py
@@ -60,4 +60,3 @@ class TestPersonsTable(ClickhouseTestMixin, BaseTest):
 
         self.assertEqual(persons[0][0], 4)  # version
         self.assertEqual(persons[0][1], 1)  # is_deleted
-

--- a/ee/clickhouse/models/test/test_person.py
+++ b/ee/clickhouse/models/test/test_person.py
@@ -1,0 +1,88 @@
+import json
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from kafka import KafkaProducer
+
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.test.utils.util import delay_until_clickhouse_consumes_from_kafka
+from ee.clickhouse.sql.person import INSERT_PERSON_SQL, PERSONS_TABLE
+from ee.clickhouse.util import ClickhouseTestMixin
+from ee.kafka_client.topics import KAFKA_PERSON
+from posthog.settings import KAFKA_HOSTS
+from posthog.test.base import BaseTest
+
+TEST_DATA = {
+    "id": str(uuid4()),
+    "team_id": 99,
+    "properties": "{ a: 1 }",
+    "is_identified": 1,
+    "is_deleted": 0,
+    "version": 0,
+    "_timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+}
+
+
+def reset_tables():
+    sync_execute("TRUNCATE TABLE person")
+
+
+class TestPersonsTable(ClickhouseTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        reset_tables()
+
+    def test_replacing_merge_tree(self):
+
+        person1 = TEST_DATA.copy()
+        person1["version"] = 1
+
+        person2 = TEST_DATA.copy()
+        person2["version"] = 2
+
+        person3 = TEST_DATA.copy()
+        person3["version"] = 3
+        person3["is_deleted"] = 1
+
+        person4 = TEST_DATA.copy()
+        person4["version"] = 4
+        person4["is_deleted"] = 1
+
+        sync_execute(INSERT_PERSON_SQL, person1)
+        sync_execute(INSERT_PERSON_SQL, person2)
+        sync_execute(INSERT_PERSON_SQL, person3)
+        sync_execute(INSERT_PERSON_SQL, person4)
+
+        persons = sync_execute("SELECT version, is_deleted FROM person FINAL")
+
+        self.assertEqual(len(persons), 1)
+
+        self.assertEqual(persons[0][0], 4)  # version
+        self.assertEqual(persons[0][1], 1)  # is_deleted
+
+    def test_kafka_insert(self):
+
+        kafka_person1 = TEST_DATA.copy()
+        kafka_person1["version"] = 2
+        kafka_person1["is_deleted"] = 1
+
+        kafka_person2 = TEST_DATA.copy()
+        kafka_person2["version"] = 100
+
+        kafka_producer = KafkaProducer(bootstrap_servers=KAFKA_HOSTS)
+
+        kafka_producer.send(topic=KAFKA_PERSON, value=json.dumps(kafka_person1).encode("utf-8"))
+        kafka_producer.send(topic=KAFKA_PERSON, value=json.dumps(kafka_person2).encode("utf-8"))
+
+        delay_until_clickhouse_consumes_from_kafka(PERSONS_TABLE, 1, timeout_seconds=10)
+
+        persons = sync_execute("SELECT version, is_deleted FROM person FINAL")
+
+        # the person with is_deleted = 1 gets assigned a version = max(uint64)
+        # this ensures all other rows will be collapsed and we'll keep the record
+        # of the person being deleted
+        self.assertEqual(len(persons), 1)
+
+        self.assertEqual(persons[0][0], 2 ** 64 - 1)  # version
+        self.assertEqual(persons[0][1], 1)  # is_deleted

--- a/ee/clickhouse/models/test/utils/util.py
+++ b/ee/clickhouse/models/test/utils/util.py
@@ -9,6 +9,6 @@ def delay_until_clickhouse_consumes_from_kafka(table_name: str, target_row_count
     ts_start = time()
     while time() < ts_start + timeout_seconds:
         result = sync_execute(f"SELECT COUNT(1) FROM {table_name}")
-        if result[0][0] == target_row_count:
+        if result[0][0] >= target_row_count:
             return
         sleep(0.5)

--- a/ee/clickhouse/sql/clickhouse.py
+++ b/ee/clickhouse/sql/clickhouse.py
@@ -37,13 +37,28 @@ GENERATE_UUID_SQL = """
 SELECT generateUUIDv4()
 """
 
-KAFKA_COLUMNS = """
-, _timestamp DateTime
-, _offset UInt64
-"""
 
 COLLAPSING_MERGE_TREE = "collapsing_merge_tree"
 REPLACING_MERGE_TREE = "replacing_merge_tree"
+
+
+def get_kafka_columns(topic=False, key=False, timestamp=False, offset=False, partition=False):
+    columns = []
+    if topic:
+        columns.append(", _topic VARCHAR")
+    if key:
+        columns.append(", _key VARCHAR")
+    if timestamp:
+        columns.append(", _timestamp DateTime")
+    if offset:
+        columns.append(", _offset UInt64")
+    if partition:
+        columns.append(", _partition UInt32")
+
+    return "\n".join(columns)
+
+
+KAFKA_COLUMNS = get_kafka_columns(offset=True, timestamp=True)
 
 
 def table_engine(table: str, ver: Optional[str] = None, engine_type: Optional[str] = None) -> str:


### PR DESCRIPTION
## Changes

~~Still **WIP** as I need to get feedback on this.~~

This is part of the work to ensure CH and Postgres are always in sync.

The approach here is to always increment a version column in Postgres when we make an update (see #6628). This version is then passed to ClickHouse and we'll collapse rows based on this value.

The interesting part comes with `is_deleted`. Initially, I added `is_deleted` to the sort key (`ORDER BY` clause). This would ensure that we couldn't possibly collapse all rows with `is_deleted` (as has happened before), leaving us with a person that is deleted in Postgres but exists in ClickHouse.

The problem here is storage. We'd have to keep around 2x rows for each deleted person. As we'd only ever collapse down to 2 rows: one with `is_deleted=0` and one with `is_deleted=1`. 

The solution here was inspired by what we did with distinct IDs. When reading from Kafka, we can simply assign `version` to the max possible `UInt64` value, ensuring we always keep the `is_deleted` row around without having to add it to the sort key. The way this was done also ensures backwards compatibility.

### Other points/questions

1. I opted for not changing the queries. They currently use `argMax` with `_timestamp` but this should be fine. The case where this could be incorrect is if we have equal timestamps before the collapsing happens. The alternative is to change the queries to use `version`, but we'd run into problems when we first migrate. Happy to get some thoughts here.
2. I also added `_partition` to the table. We currently have `_offset`, which is somewhat helpful, but for it to be truly helpful we need the partition number too.


## How did you test this code?

Added tests for direct insertion ~~and "kafka insertion" into the new table~~ (removed due to flakiness). Confirmed collapsing works as expected.

Also tested manually