### PR TITLE
Fix whitescreen on PersonsModal: add nullish coercion for empty string

### DIFF
--- a/frontend/src/scenes/trends/PersonModal.tsx
+++ b/frontend/src/scenes/trends/PersonModal.tsx
@@ -63,7 +63,7 @@ export function PersonModal({ visible, view, filters, onSaveCohort }: PersonModa
             ) : (
                 <>
                     <PropertyKeyInfo value={people?.label || ''} disablePopover /> on{' '}
-                    <DateDisplay interval={filters.interval || 'day'} date={people?.day.toString() || ''} />
+                    <DateDisplay interval={filters.interval || 'day'} date={people?.day?.toString() || ''} />
                 </>
             ),
         [filters, people, isInitialLoad]


### PR DESCRIPTION
## Changes

`day` here is `string | number | undefined`, and I ran into a case where `TypeError: Cannot read properties of undefined (reading 'toString')` was thrown and whitescreened the app.


## How did you test this code?

*Please describe.*
