### PR TITLE
Duplicate filters on insights

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -53,16 +53,16 @@ export enum InsightEventSource {
 }
 
 export enum RecordingWatchedSource {
-    Direct = 'direct',
+    Direct = 'direct', // Visiting the URL directly
     Unknown = 'unknown',
-    RecordingsList = 'recordings_list',
-    SessionsList = 'sessions_list',
-    SessionsListPlayAll = 'sessions_list_play_all',
+    RecordingsList = 'recordings_list', // New recordings list page
+    SessionsList = 'sessions_list', // DEPRECATED sessions list page
+    SessionsListPlayAll = 'sessions_list_play_all', // DEPRECATED play all button on sessions list
 }
 
 export enum GraphSeriesAddedSource {
-    Main = 'Main',
-    Duplicate = 'Duplicate',
+    Default = 'default',
+    Duplicate = 'duplicate',
 }
 
 interface RecordingViewedProps {
@@ -138,7 +138,7 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
         properties_global_custom_count: properties_global.filter((item) => item === 'custom').length,
         properties_local,
         properties_local_custom_count: properties_local.filter((item) => item === 'custom').length,
-        properties_all: properties_global.concat(properties_local),
+        properties_all: properties_global.concat(properties_local), // Global and local properties together©155
     }
 }
 
@@ -153,7 +153,7 @@ export const eventUsageLogic = kea<
             filters: Partial<FilterType>,
             isFirstLoad: boolean,
             fromDashboard: boolean,
-            delay?: number,
+            delay?: number, // Number of delayed seconds to report event (useful to measure insights where users don't navigate immediately away)
             changedFilters?: Record<string, any>
         ) => ({
             filters,
@@ -343,7 +343,7 @@ export const eventUsageLogic = kea<
                 ...sanitizeFilterParams(filters),
                 report_delay: delay,
                 is_first_component_load: isFirstLoad,
-                from_dashboard: fromDashboard,
+                from_dashboard: fromDashboard, // Whether the insight is on a dashboard
             }
 
             properties.total_event_actions_count = (properties.events_count || 0) + (properties.actions_count || 0)
@@ -399,8 +399,8 @@ export const eventUsageLogic = kea<
                 has_breakdown_value: Boolean(breakdown_value),
                 save_original: saveOriginal,
                 has_search_term: Boolean(searchTerm),
-                count,
-                has_next: hasNext,
+                count, // Total count of persons
+                has_next: hasNext, // Whether there are other persons to be loaded (pagination)
             }
             posthog.capture('insight person modal viewed', properties)
         },

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -138,7 +138,7 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
         properties_global_custom_count: properties_global.filter((item) => item === 'custom').length,
         properties_local,
         properties_local_custom_count: properties_local.filter((item) => item === 'custom').length,
-        properties_all: properties_global.concat(properties_local), // Global and local properties together©155
+        properties_all: properties_global.concat(properties_local), // Global and local properties together
     }
 }
 
@@ -153,13 +153,13 @@ export const eventUsageLogic = kea<
             filters: Partial<FilterType>,
             isFirstLoad: boolean,
             fromDashboard: boolean,
-            delay?: number, // Number of delayed seconds to report event (useful to measure insights where users don't navigate immediately away)
+            delay?: number,
             changedFilters?: Record<string, any>
         ) => ({
             filters,
             isFirstLoad,
             fromDashboard,
-            delay,
+            delay, // Number of delayed seconds to report event (useful to measure insights where users don't navigate immediately away)
             changedFilters,
         }),
         reportPersonModalViewed: (params: PersonModalParams, count: number, hasNext: boolean) => ({

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -14,7 +14,14 @@ import {
 } from '~/types'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { EVENT_MATH_TYPE, FEATURE_FLAGS, MATHS, PROPERTY_MATH_TYPE } from 'lib/constants'
-import { CloseSquareOutlined, DeleteOutlined, DownOutlined, EditOutlined, FilterOutlined } from '@ant-design/icons'
+import {
+    CloseSquareOutlined,
+    DeleteOutlined,
+    DownOutlined,
+    EditOutlined,
+    FilterOutlined,
+    CopyOutlined,
+} from '@ant-design/icons'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { BareEntity, entityFilterLogic } from '../entityFilterLogic'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -131,6 +138,7 @@ export function ActionFilterRow({
         removeLocalFilter,
         updateFilterProperty,
         setEntityFilterVisibility,
+        duplicateFilter,
     } = useActions(logic)
     const { numericalPropertyNames } = useValues(propertyDefinitionsModel)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -267,9 +275,23 @@ export function ActionFilterRow({
             }}
             className={`row-action-btn show-rename`}
             data-attr={'show-prop-rename-' + index}
-            title="Rename"
+            title="Rename graph series"
         >
             <EditOutlined />
+        </Button>
+    )
+
+    const duplicateRowButton = (
+        <Button
+            type="link"
+            onClick={() => {
+                duplicateFilter(filter)
+            }}
+            className={`row-action-btn show-duplicabe`}
+            data-attr={'show-prop-duplicate-' + index}
+            title="Duplicate graph series"
+        >
+            <CopyOutlined />
         </Button>
     )
 
@@ -374,6 +396,7 @@ export function ActionFilterRow({
                                 )}
                             </>
                         )}
+                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{duplicateRowButton}</Col>}
                         {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && (horizontalUI || fullWidth) && !hideRename && (
                             <Col>{renameRowButton}</Col>
                         )}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -374,10 +374,10 @@ export function ActionFilterRow({
                                 )}
                             </>
                         )}
-                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{propertyFiltersButton}</Col>}
                         {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && (horizontalUI || fullWidth) && !hideRename && (
                             <Col>{renameRowButton}</Col>
                         )}
+                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{propertyFiltersButton}</Col>}
                         {!hideDeleteBtn && !horizontalUI && !singleFilter && (
                             <Col className="column-delete-btn">{deleteButton}</Col>
                         )}

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -204,12 +204,12 @@ export const entityFilterLogic = kea<entityFilterLogicType<BareEntity, EntityFil
                 {
                     id: '$pageview',
                     type: 'events',
-                    order: values.localFilters[previousLength - 1].order,
+                    order: values.localFilters[previousLength - 1].order + 1,
                     name: '$pageview',
                     ...props.addFilterDefaultOptions,
                 },
             ])
-            eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Main)
+            eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Default)
         },
         duplicateFilter: async ({ filter }) => {
             const previousLength = values.localFilters.length

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -198,25 +198,16 @@ export const entityFilterLogic = kea<entityFilterLogicType<BareEntity, EntityFil
         addFilter: async () => {
             const previousLength = values.localFilters.length
             const newLength = previousLength + 1
-            if (values.localFilters.length > 0) {
-                const lastFilter: LocalFilter = {
-                    ...values.localFilters[previousLength - 1],
-                    custom_name: undefined, // Remove custom name
-                }
-                const order = lastFilter.order + 1
-                actions.setFilters([...values.localFilters, { ...lastFilter, order }])
-                actions.setEntityFilterVisibility(order, values.entityFilterVisible[lastFilter.order])
-            } else {
-                actions.setFilters([
-                    {
-                        id: '$pageview',
-                        type: 'events',
-                        order: 0,
-                        name: '$pageview',
-                        ...props.addFilterDefaultOptions,
-                    },
-                ])
-            }
+            actions.setFilters([
+                ...values.localFilters,
+                {
+                    id: '$pageview',
+                    type: 'events',
+                    order: values.localFilters[previousLength - 1].order,
+                    name: '$pageview',
+                    ...props.addFilterDefaultOptions,
+                },
+            ])
             eventUsageLogic.actions.reportInsightFilterAdded(newLength)
         },
         setFilters: async ({ filters }) => {


### PR DESCRIPTION
## Changes

- Reorganizes the order in which actions are displayed in the graph series.
- Adds duplicate functionality to filters.
- Clicking on add graph series creates a blank series.

![image](https://user-images.githubusercontent.com/5864173/138979066-3802613a-fea3-48f4-89e9-235aff9415b8.gif)


## How did you test this code?
As shown by the recording.
