### PR TITLE
Remove unused imports from tests

### DIFF
--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -1,6 +1,6 @@
 import dataclasses
 from datetime import datetime
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List
 from uuid import uuid4
 
 from django.conf import settings

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -1,5 +1,4 @@
 import random
-import uuid
 from unittest.mock import patch
 
 from django.core import mail

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -7,7 +7,6 @@ from rest_framework import status
 
 from posthog.constants import AnalyticsDBMS
 from posthog.models.organization import Organization, OrganizationInvite
-from posthog.settings import DEBUG_QUERIES
 from posthog.test.base import APIBaseTest
 from posthog.version import VERSION
 

--- a/posthog/api/test/test_retention.py
+++ b/posthog/api/test/test_retention.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Optional
 from unittest.mock import ANY
 
 import pytest

--- a/posthog/api/test/test_trends.py
+++ b/posthog/api/test/test_trends.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
 from datetime import datetime
-from typing import Any, Dict, List, TypedDict, Union
+from typing import Any, Dict, List, Union
 
 import pytest
 from django.test import Client


### PR DESCRIPTION
As the title says, this PR removes unused imports from tests.


Around the code base, there seems to be multiple places where this problem occurs, so I am thinking about maybe cleaning those up and enabling [the flake8 check - F401](https://flake8.pycqa.org/en/latest/user/error-codes.html) to prevent future regressions. 
This is up to the maintainers of this project, please provide me with feedback about this, and if this makes sense I am happy to put up a PR to deal with both issues (cleaning up all unused imports and adding the CI check for that)
