### PR TITLE
Fix `Cohort` component importing raw AntD CSS

### DIFF
--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -12,12 +12,10 @@ import { CohortDetailsRow } from './CohortDetailsRow'
 import { Persons } from 'scenes/persons/Persons'
 import { cohortLogic } from './cohortLogic'
 import { UploadFile } from 'antd/lib/upload/interface'
-
 import { CalculatorOutlined, OrderedListOutlined } from '@ant-design/icons'
 import { DropdownSelector } from 'lib/components/DropdownSelector/DropdownSelector'
 import { Tooltip } from 'antd'
 import { userLogic } from 'scenes/userLogic'
-import 'antd/lib/dropdown/style/css'
 
 export function Cohort(props: { cohort: CohortType }): JSX.Element {
     const logic = cohortLogic(props)


### PR DESCRIPTION
## Changes

Noticed that whenever I visit the Cohorts page, suddenly our AntD customizations stop working, and this then persists on other pages:
![2021-10-27 09 39 37](https://user-images.githubusercontent.com/4550621/139021870-b006ff53-4582-4f1a-9119-df8e75255e5e.gif)
This fixes the CSS weirdness.