### PR TITLE
dev.Dockerfile `COPY` fix

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -61,7 +61,8 @@ RUN apk --update --no-cache --virtual .build-deps add \
 #
 # - we need few additional OS packages for this. Let's install
 #   and then uninstall them when the compilation is completed.
-COPY package.json yarn.lock plugins/package.json plugins/yarn.lock ./
+COPY package.json yarn.lock ./
+COPY plugins/package.json plugins/yarn.lock ./plugins/
 RUN apk --update --no-cache --virtual .build-deps add \
     "gcc~=10.3" \
     && \


### PR DESCRIPTION
## Changes
Those should be 2 distinct `COPY` actions otherwise `plugins/package.json` will overwrite `package.json`

## How did you test this code?
`docker-compose -f docker-compose.dev.yml up --build` (build and execution) still works:

    ```
    posthog-backend-1   | Django version 3.2.5, using settings 'posthog.settings'
    posthog-backend-1   | Starting development server at http://0.0.0.0:8000/
    ```

    ```
    posthog-worker-1    | [MAIN] 09:25:46 🚀 All systems go
    posthog-worker-1    | [core] INFO: Worker connected and looking for jobs... (task names: 'pluginJob')
    ```

    ```
    posthog-frontend-1  | ℹ ｢wds｣: Project is running at http://127.0.0.1:8234/
    posthog-frontend-1  | ℹ ｢wds｣: webpack output is served from http://127.0.0.1:8234/static/
    posthog-frontend-1  | ℹ ｢wds｣: Content not from webpack is served from /code/frontend/dist
    ```