### PR TITLE
Lower the toast

### DIFF
--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -119,7 +119,7 @@ function AppScene(): JSX.Element | null {
     const essentialElements = (
         // Components that should always be mounted inside Layout
         <>
-            <ToastContainer autoClose={8000} transition={Slide} position="top-right" />
+            <ToastContainer autoClose={8000} transition={Slide} position="bottom-right" />
         </>
     )
 


### PR DESCRIPTION
## Changes

The most serious change to our UX since turbo mode.

- Before:
![2021-10-27 12 15 57](https://user-images.githubusercontent.com/53387/139046990-e385ad6f-8368-41c6-814c-cc25115646d0.gif)

- After:
![2021-10-27 12 14 36](https://user-images.githubusercontent.com/53387/139046841-e580d37c-0119-4c61-ac50-fc8b241263d5.gif)

## How did you test this code?

Changed it, ran it, looked at it, felt satisfied.

## Additional context

This new position seem to be very low and missable when I'm on a huge screen. Not sure if that's an issue though.

![2021-10-27 12 17 31](https://user-images.githubusercontent.com/53387/139047205-c51a35fd-3916-4a99-b277-d97b62634db6.gif)
