### PR TITLE
Revert "Update the docker-compose dev environment to reflect prod better (include pgbouncer)"

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -124,7 +124,7 @@ jobs:
                   fetch-depth: 1
 
             - name: Start stack with Docker Compose
-              run: docker-compose -f ee/docker-compose.ch.yml up -d db pgb clickhouse zookeeper kafka
+              run: docker-compose -f ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
 
             - name: Set up Python
               uses: actions/setup-python@v2
@@ -190,7 +190,7 @@ jobs:
                   fetch-depth: 1
 
             - name: Start stack with Docker Compose
-              run: docker-compose -f ee/docker-compose.ch.yml up -d db pgb clickhouse zookeeper kafka
+              run: docker-compose -f ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
 
             - name: Set up Python
               uses: actions/setup-python@v2
@@ -257,7 +257,7 @@ jobs:
                   cat multi_tenancy_settings.py >> deploy/posthog/settings.py
                   cat requirements.txt >> deploy/requirements.txt
             - name: Start stack with Docker Compose
-              run: docker-compose -f deploy/ee/docker-compose.ch.yml up -d db pgb clickhouse zookeeper kafka
+              run: docker-compose -f deploy/ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
             - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:

--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -1,20 +1,6 @@
 version: '3'
 
 services:
-    pgb:
-        image: bitnami/pgbouncer:1.16.0
-        ports:
-            - '6432:6432'
-        environment:
-            PGBOUNCER_POOL_MODE: transaction
-            PGBOUNCER_DATABASE: posthog
-            POSTGRESQL_USERNAME: posthog
-            POSTGRESQL_PASSWORD: posthog
-            POSTGRESQL_DATABASE: posthog
-            POSTGRESQL_HOST: db
-            POSTGRESQL_PORT: 5432
-        depends_on:
-            - db
     db:
         image: postgres:12-alpine
         environment:
@@ -63,7 +49,7 @@ services:
         volumes:
             - ..:/code
         environment:
-            DATABASE_URL: 'postgres://posthog:posthog@pgb:6432/posthog'
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog'
             CLICKHOUSE_SECURE: 'false'
@@ -77,10 +63,15 @@ services:
             PGUSER: posthog
             PGPASSWORD: posthog
         depends_on:
-            - pgb
+            - db
             - redis
             - clickhouse
             - kafka
+        links:
+            - db:db
+            - redis:redis
+            - clickhouse:clickhouse
+            - kafka:kafka
     web:
         <<: *worker
         command: '${CH_WEB_SCRIPT:-./ee/bin/docker-ch-dev-web}'
@@ -96,13 +87,18 @@ services:
             - ..:/code
         restart: on-failure
         environment:
-            DATABASE_URL: 'postgres://posthog:posthog@pgb:6432/posthog'
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_ENABLED: 'true'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
             CLICKHOUSE_HOST: 'clickhouse'
         depends_on:
-            - pgb
+            - db
             - redis
             - clickhouse
             - kafka
+        links:
+            - db:db
+            - redis:redis
+            - clickhouse:clickhouse
+            - kafka:kafka


### PR DESCRIPTION
I'm proposing getting rid of PGB in dev environment. Since introducing this developing locally has been super slow, and PGB is close enough to postgres itself that it doesn't matter.



Reverts PostHog/posthog#6558