### PR TITLE
Take posthog-js from the props to the toolbar

### DIFF
--- a/frontend/src/toolbar/ToolbarApp.tsx
+++ b/frontend/src/toolbar/ToolbarApp.tsx
@@ -4,12 +4,12 @@ import root from 'react-shadow'
 import { ToolbarContainer } from '~/toolbar/ToolbarContainer'
 import { useMountedLogic } from 'kea'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
-import { EditorProps } from '~/types'
+import { ToolbarProps } from '~/types'
 import { Slide, ToastContainer } from 'react-toastify'
 
 type HTMLElementWithShadowRoot = HTMLElement & { shadowRoot: ShadowRoot }
 
-export function ToolbarApp(props: EditorProps = {}): JSX.Element {
+export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
     useMountedLogic(toolbarLogic(props))
 
     const shadowRef = useRef<HTMLElementWithShadowRoot | null>(null)

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -58,7 +58,7 @@ export function ToolbarButton(): JSX.Element {
     const { enableHeatmap, disableHeatmap } = useActions(heatmapLogic)
     const { heatmapEnabled, heatmapLoading, elementCount, showHeatmapTooltip } = useValues(heatmapLogic)
 
-    const { isAuthenticated, featureFlags } = useValues(toolbarLogic)
+    const { isAuthenticated, featureFlags, posthog } = useValues(toolbarLogic)
     const { authenticate, logout } = useActions(toolbarLogic)
 
     const globalMouseMove = useRef((e: MouseEvent) => {
@@ -70,7 +70,7 @@ export function ToolbarButton(): JSX.Element {
     // it uses Posthog-js-lite. As a result, this feature flag can only be turned on for posthog internal
     // (or any other posthog customer that has a flag with the name `posthog-toolbar-feature-flags` set).
     // (Should be removed when we want to roll this out broadly)
-    const showFeatureFlags = featureFlags[FEATURE_FLAGS.TOOLBAR_FEATURE_FLAGS]
+    const showFeatureFlags = featureFlags[FEATURE_FLAGS.TOOLBAR_FEATURE_FLAGS] && !!posthog
 
     useEffect(
         () => {

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -5,7 +5,6 @@ import { useActions, useValues } from 'kea'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 import { Radio, Switch, Row, Typography, List, Button, Input } from 'antd'
 import { AnimatedCollapsible } from './AnimatedCollapsible'
-import { PostHog } from 'posthog-js'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { urls } from 'scenes/urls'
 import { IconExternalLinkBold } from 'lib/components/icons'
@@ -14,7 +13,7 @@ export function FeatureFlags(): JSX.Element {
     const { showLocalFeatureFlagWarning, searchTerm, filteredFlags } = useValues(featureFlagsLogic)
     const { setOverriddenUserFlag, deleteOverriddenUserFlag, setShowLocalFeatureFlagWarning, setSearchTerm } =
         useActions(featureFlagsLogic)
-    const { apiURL } = useValues(toolbarLogic)
+    const { apiURL, posthog } = useValues(toolbarLogic)
 
     return (
         <div className="toolbar-block">
@@ -31,7 +30,7 @@ export function FeatureFlags(): JSX.Element {
                         <Button
                             type="primary"
                             onClick={() => {
-                                ;(window['posthog'] as PostHog).feature_flags.override(false)
+                                posthog?.feature_flags.override(false)
                                 setShowLocalFeatureFlagWarning(false)
                             }}
                         >

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -1,7 +1,6 @@
 import { kea } from 'kea'
 import { CombinedFeatureFlagAndOverrideType } from '~/types'
 import { featureFlagsLogicType } from './featureFlagsLogicType'
-import { PostHog } from 'posthog-js'
 import { toolbarFetch } from '~/toolbar/utils'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import Fuse from 'fuse.js'
@@ -42,7 +41,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                     }
                     const results = await response.json()
 
-                    ;(window['posthog'] as PostHog).featureFlags.reloadFeatureFlags()
+                    toolbarLogic.values.posthog?.featureFlags.reloadFeatureFlags()
                     return [...values.userFlags].map((userFlag) =>
                         userFlag.feature_flag.id === results.feature_flag
                             ? { ...userFlag, override: results }
@@ -59,7 +58,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                         return []
                     }
 
-                    ;(window['posthog'] as PostHog).featureFlags.reloadFeatureFlags()
+                    toolbarLogic.values.posthog?.featureFlags.reloadFeatureFlags()
                     return [...values.userFlags].map((userFlag) =>
                         userFlag?.override?.id === overrideId ? { ...userFlag, override: null } : userFlag
                     )
@@ -117,15 +116,14 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
     events: ({ actions }) => ({
         afterMount: () => {
             actions.getUserFlags()
-            if (window && window['posthog']) {
-                ;(window['posthog'] as PostHog).onFeatureFlags((_, variants) => {
+            const { posthog } = toolbarLogic.values
+            if (posthog) {
+                posthog.onFeatureFlags((_, variants) => {
                     if (variants) {
                         toolbarLogic.actions.updateFeatureFlags(variants)
                     }
                 })
-                const locallyOverrideFeatureFlags = (window['posthog'] as PostHog).get_property(
-                    '$override_feature_flags'
-                )
+                const locallyOverrideFeatureFlags = posthog.get_property('$override_feature_flags')
                 if (locallyOverrideFeatureFlags) {
                     actions.setShowLocalFeatureFlagWarning(true)
                 }

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -10,12 +10,19 @@ import { Provider } from 'react-redux'
 import { initKea } from '~/initKea'
 import { ToolbarApp } from '~/toolbar/ToolbarApp'
 import { EditorProps } from '~/types'
+import { PostHog } from 'posthog-js'
 
 initKea()
 ;(window as any)['simmer'] = new Simmer(window, { depth: 8 })
-;(window as any)['ph_load_editor'] = function (editorParams: EditorProps) {
+;(window as any)['ph_load_editor'] = function (editorParams: EditorProps, posthog: PostHog) {
     const container = document.createElement('div')
     document.body.appendChild(container)
+
+    if (!posthog) {
+        console.warn(
+            '⚠️⚠️⚠️ Loaded toolbar via old version of posthog-js that does not support feature flags. Please upgrade! ⚠️⚠️⚠️'
+        )
+    }
 
     ReactDOM.render(
         <Provider store={getContext().store}>
@@ -25,6 +32,7 @@ initKea()
                     typeof editorParams.actionId === 'string' ? parseInt(editorParams.actionId) : editorParams.actionId
                 }
                 jsURL={editorParams.jsURL || editorParams.apiURL}
+                posthog={posthog}
             />
         </Provider>,
         container

--- a/frontend/src/toolbar/toolbarLogic.ts
+++ b/frontend/src/toolbar/toolbarLogic.ts
@@ -33,7 +33,7 @@ export const toolbarLogic = kea<toolbarLogicType>({
             (props.featureFlags || {}) as Record<string, string | boolean>,
             { updateFeatureFlags: (_, { flags }) => flags },
         ],
-        posthog: [props.posthog as PostHog | null],
+        posthog: [props.posthog ?? (null as PostHog | null)],
     }),
 
     selectors: ({ selectors }) => ({

--- a/frontend/src/toolbar/toolbarLogic.ts
+++ b/frontend/src/toolbar/toolbarLogic.ts
@@ -33,7 +33,7 @@ export const toolbarLogic = kea<toolbarLogicType>({
             (props.featureFlags || {}) as Record<string, string | boolean>,
             { updateFeatureFlags: (_, { flags }) => flags },
         ],
-        posthog: [props.posthog ?? (null as PostHog | null)],
+        posthog: [(props.posthog ?? null) as PostHog | null],
     }),
 
     selectors: ({ selectors }) => ({
@@ -41,7 +41,7 @@ export const toolbarLogic = kea<toolbarLogicType>({
             () => [selectors.rawApiURL],
             (apiURL) => `${apiURL.endsWith('/') ? apiURL.replace(/\/+$/, '') : apiURL}`,
         ],
-        jsURL: [() => [selectors.rawJsURL], (jsURL) => `${jsURL.endsWith('/') ? jsURL.replace(/\/+$/, '') : jsURL}`],
+        jsURL: [() => [selectors.rawJsURL], (jsURL) => `${jsURL.endsWith('/') ? jsURL.replace(/\/+$/, '') : jsURL} `],
         isAuthenticated: [() => [selectors.temporaryToken], (temporaryToken) => !!temporaryToken],
     }),
 
@@ -49,7 +49,7 @@ export const toolbarLogic = kea<toolbarLogicType>({
         authenticate: () => {
             posthog.capture('toolbar authenticate', { is_authenticated: values.isAuthenticated })
             const encodedUrl = encodeURIComponent(window.location.href)
-            window.location.href = `${values.apiURL}/authorize_and_redirect/?redirect=${encodedUrl}`
+            window.location.href = `${values.apiURL} /authorize_and_redirect/ ? redirect = ${encodedUrl} `
             clearSessionToolbarToken()
         },
         logout: () => {

--- a/frontend/src/toolbar/toolbarLogic.ts
+++ b/frontend/src/toolbar/toolbarLogic.ts
@@ -1,14 +1,15 @@
 import { kea } from 'kea'
 import { toolbarLogicType } from './toolbarLogicType'
-import { EditorProps } from '~/types'
+import { ToolbarProps } from '~/types'
 import { clearSessionToolbarToken } from '~/toolbar/utils'
 import { posthog } from '~/toolbar/posthog'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { toolbarButtonLogic } from '~/toolbar/button/toolbarButtonLogic'
+import { PostHog } from 'posthog-js'
 
 // input: props = all editorProps
 export const toolbarLogic = kea<toolbarLogicType>({
-    props: {} as EditorProps,
+    props: {} as ToolbarProps,
 
     actions: () => ({
         authenticate: true,
@@ -20,7 +21,7 @@ export const toolbarLogic = kea<toolbarLogicType>({
         updateFeatureFlags: (flags: Record<string, string | boolean>) => ({ flags }),
     }),
 
-    reducers: ({ props }: { props: EditorProps }) => ({
+    reducers: ({ props }) => ({
         rawApiURL: [props.apiURL as string],
         rawJsURL: [(props.jsURL || props.apiURL) as string],
         temporaryToken: [props.temporaryToken || null, { logout: () => null }],
@@ -32,6 +33,7 @@ export const toolbarLogic = kea<toolbarLogicType>({
             (props.featureFlags || {}) as Record<string, string | boolean>,
             { updateFeatureFlags: (_, { flags }) => flags },
         ],
+        posthog: [props.posthog as PostHog | null],
     }),
 
     selectors: ({ selectors }) => ({

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -18,6 +18,7 @@ import { PluginInstallationType } from 'scenes/plugins/types'
 import { PROPERTY_MATCH_TYPE } from 'lib/constants'
 import { UploadFile } from 'antd/lib/upload/interface'
 import { eventWithTime } from 'rrweb/typings/types'
+import { PostHog } from 'posthog-js'
 
 export type Optional<T, K extends string | number | symbol> = Omit<T, K> & { [K in keyof T]?: T[K] }
 
@@ -234,7 +235,7 @@ export interface ElementType {
 
 export type ToolbarUserIntent = 'add-action' | 'edit-action'
 
-export type EditorProps = {
+export interface EditorProps {
     apiURL?: string
     jsURL?: string
     temporaryToken?: string
@@ -245,6 +246,10 @@ export type EditorProps = {
     userEmail?: string
     dataAttributes?: string[]
     featureFlags?: Record<string, string | boolean>
+}
+
+export interface ToolbarProps extends EditorProps {
+    posthog?: PostHog
 }
 
 export type PropertyFilterValue = string | number | (string | number)[] | null


### PR DESCRIPTION
## Changes

- Takes `posthog-js` directly from the props passed to the toolbar, not from the `window` object.
- Depends on https://github.com/PostHog/posthog-js/pull/327

## How did you test this code?

- Ran locally, everything still worked. The toolbar does not have tests to begin with, so :yolo:
