### PR TITLE
Improve correlation analysis feedback

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -274,6 +274,8 @@ export const eventUsageLogic = kea<
         ) => ({ recordingData, source, loadTime, delay }),
         reportHelpButtonViewed: true,
         reportHelpButtonUsed: (help_type: HelpType) => ({ help_type }),
+        reportCorrelationAnalysisFeedback: (rating: number) => ({ rating }),
+        reportCorrelationAnalysisDetailedFeedback: (rating: number, comments: string) => ({ rating, comments }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -644,6 +646,12 @@ export const eventUsageLogic = kea<
         },
         reportHelpButtonUsed: (props) => {
             posthog.capture('help button used', props)
+        },
+        reportCorrelationAnalysisFeedback: (props) => {
+            posthog.capture('correlation analysis feedback', props)
+        },
+        reportCorrelationAnalysisDetailedFeedback: (props) => {
+            posthog.capture('correlation analysis detailed feedback', props)
         },
     },
 })

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1033,7 +1033,10 @@ export const funnelLogic = kea<funnelLogicType>({
         setCorrelationFeedbackRating: ({ rating }) => {
             const feedbackBoxVisible = rating > 0
             actions.setCorrelationDetailedFeedbackVisible(feedbackBoxVisible)
-            eventUsageLogic.actions.reportCorrelationAnalysisFeedback(rating)
+            if (feedbackBoxVisible) {
+                // Don't send event when resetting reducer
+                eventUsageLogic.actions.reportCorrelationAnalysisFeedback(rating)
+            }
         },
     }),
 })

--- a/frontend/src/scenes/insights/FunnelCorrelation.scss
+++ b/frontend/src/scenes/insights/FunnelCorrelation.scss
@@ -36,39 +36,44 @@
 
     .correlation-feedback {
         margin-top: $default_spacing;
-        line-height: 2em;
-        border-radius: 4px;
-        align-items: center;
 
         .ant-card-body {
             padding: $default_spacing / 2 $default_spacing;
         }
 
         h4 {
-            font-size: 1.1em;
-            align-items: center;
-            padding: $default_spacing / 2 $default_spacing;
-            margin-left: -$default_spacing;
-            margin-right: -$default_spacing;
-            position: relative;
+            padding: 0;
+            margin: 0;
+            font-weight: bold;
+            color: $text_muted_alt;
+        }
 
-            .emoji-button {
-                margin-left: 2px;
-            }
-
-            .close-button {
-                position: absolute;
-                right: 16px;
-                top: 16px;
-                color: $text_muted !important;
-                cursor: pointer;
-                z-index: $z_raised;
+        .emoji-button {
+            margin-right: 4px;
+            &:last-of-type {
+                margin-right: 0;
             }
         }
 
+        .row-initial {
+            display: flex;
+            align-items: center;
+            .ant-col {
+                text-align: right;
+                &:first-of-type {
+                    text-align: left;
+                }
+            }
+        }
+
+        .close-button {
+            color: $text_muted !important;
+            cursor: pointer;
+            z-index: $z_raised;
+        }
+
         .feedback-button {
-            margin-top: $default_spacing/2;
-            margin-right: $default_spacing/2;
+            margin: $default_spacing 0;
         }
     }
 }

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Row, Col } from 'antd'
 import { CommentOutlined } from '@ant-design/icons'
 import TextArea from 'antd/lib/input/TextArea'
 import { useActions, useValues } from 'kea'
-import React from 'react'
+import React, { useRef } from 'react'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic } from './insightLogic'
 import './FunnelCorrelation.scss'
@@ -27,6 +27,8 @@ export const FunnelCorrelation = (): JSX.Element | null => {
         setCorrelationFeedbackRating,
         setCorrelationDetailedFeedback,
     } = useActions(funnelLogic(insightProps))
+
+    const detailedFeedbackRef = useRef<HTMLTextAreaElement>(null)
 
     if (stepsWithCount.length <= 1) {
         return null
@@ -53,6 +55,8 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                     </div>
                 </Card>
             )}
+
+            <FunnelCorrelationTable />
 
             {/* Feedback Form */}
             {!correlationFeedbackHidden && (
@@ -92,6 +96,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                                             setCorrelationFeedbackRating(0)
                                         } else {
                                             setCorrelationFeedbackRating(content[0])
+                                            setTimeout(() => detailedFeedbackRef.current?.focus(), 100)
                                         }
                                     }}
                                 >
@@ -109,6 +114,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                             onBlur={(e) => setCorrelationDetailedFeedback(e.target.value)}
                             placeholder="Optional. Help us by sharing details around your experience..."
                             style={{ marginTop: 16 }}
+                            ref={detailedFeedbackRef}
                         />
                         <div className="text-right">
                             <Button
@@ -126,7 +132,6 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                 </Card>
             )}
 
-            <FunnelCorrelationTable />
             <FunnelPropertyCorrelationTable />
         </div>
     )

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -57,62 +57,73 @@ export const FunnelCorrelation = (): JSX.Element | null => {
             {/* Feedback Form */}
             {!correlationFeedbackHidden && (
                 <Card className="correlation-feedback">
-                    <h4>
-                        <CloseOutlined className="close-button" onClick={hideCorrelationAnalysisFeedback} />
-                        <Row>
-                            <Col span={16}>
-                                <CommentOutlined style={{ paddingRight: 8 }} />
-                                Is the new feature, Corrrelation analysis, working well for you?
-                            </Col>
-                            <Col span={8} style={{ alignContent: 'right' }}>
-                                {(
-                                    [
-                                        [1, '😍'],
-                                        [2, '😀'],
-                                        [3, '😴'],
-                                        [4, '👎'],
-                                        [5, '👍'],
-                                    ] as const
-                                ).map((content, index) => (
-                                    <Button
-                                        key={index}
-                                        className="emoji-button"
-                                        style={
-                                            correlationFeedbackRating === content[0] ? { background: '#5375FF' } : {}
-                                        }
-                                        onClick={() => {
+                    <Row className="row-initial">
+                        <Col span={15}>
+                            <h4>
+                                <CommentOutlined style={{ marginRight: 4 }} />
+                                Was this correlation analysis report useful?
+                            </h4>
+                        </Col>
+                        <Col span={8} style={{ alignContent: 'right' }}>
+                            {!!correlationFeedbackRating && (
+                                <span style={{ color: 'var(--success)', marginRight: 8 }}>
+                                    Thanks for your feedback!
+                                </span>
+                            )}
+                            {(
+                                [
+                                    [5, '😍'],
+                                    [4, '😀'],
+                                    [3, '😴'],
+                                    [2, '😔'],
+                                    [1, '👎'],
+                                ] as const
+                            ).map((content, index) => (
+                                <Button
+                                    key={index}
+                                    className="emoji-button"
+                                    style={
+                                        correlationFeedbackRating === content[0]
+                                            ? { background: '#5375FF' }
+                                            : correlationFeedbackRating
+                                            ? { display: 'none' }
+                                            : {}
+                                    }
+                                    onClick={() => {
+                                        if (correlationFeedbackRating === content[0]) {
+                                            setCorrelationFeedbackRating(0)
+                                        } else {
                                             setCorrelationFeedbackRating(content[0])
-                                        }}
-                                    >
-                                        {content[1]}
-                                    </Button>
-                                ))}
-                            </Col>
-                        </Row>
-                    </h4>
-                    <div style={{ display: correlationDetailedFeedbackVisible ? undefined : 'None' }}>
-                        <hr />
-                        Tell us more <i>(optional)</i>
-                        <TextArea onBlur={(e) => setCorrelationDetailedFeedback(e.target.value)} />
-                        <Row style={{ justifyContent: 'flex-end' }}>
+                                        }
+                                    }}
+                                >
+                                    {content[1]}
+                                </Button>
+                            ))}
+                        </Col>
+                        <Col span={1}>
+                            <CloseOutlined className="close-button" onClick={hideCorrelationAnalysisFeedback} />
+                        </Col>
+                    </Row>
+
+                    <div style={{ display: correlationDetailedFeedbackVisible ? undefined : 'none' }}>
+                        <TextArea
+                            onBlur={(e) => setCorrelationDetailedFeedback(e.target.value)}
+                            placeholder="Optional. Help us by sharing details around your experience..."
+                            style={{ marginTop: 16 }}
+                        />
+                        <div className="text-right">
                             <Button
                                 className="feedback-button"
-                                onClick={() => {
-                                    setCorrelationFeedbackRating(0)
-                                }}
-                            >
-                                Cancel
-                            </Button>
-                            <Button
-                                className="feedback-button"
+                                data-attr="correlation-analysis-share-feedback"
                                 type="primary"
                                 onClick={() => {
                                     sendCorrelationAnalysisFeedback()
                                 }}
                             >
-                                Share Feedback
+                                Share feedback
                             </Button>
-                        </Row>
+                        </div>
                     </div>
                 </Card>
             )}

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -66,9 +66,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                         </Col>
                         <Col span={8} style={{ alignContent: 'right' }}>
                             {!!correlationFeedbackRating && (
-                                <span style={{ color: 'var(--success)', marginRight: 8 }}>
-                                    Thanks for your feedback!
-                                </span>
+                                <i style={{ color: 'var(--success)', marginRight: 8 }}>Thanks for your feedback!</i>
                             )}
                             {(
                                 [

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -110,24 +110,30 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                     </Row>
 
                     <div style={{ display: correlationDetailedFeedbackVisible ? undefined : 'none' }}>
-                        <TextArea
-                            onBlur={(e) => setCorrelationDetailedFeedback(e.target.value)}
-                            placeholder="Optional. Help us by sharing details around your experience..."
-                            style={{ marginTop: 16 }}
-                            ref={detailedFeedbackRef}
-                        />
-                        <div className="text-right">
-                            <Button
-                                className="feedback-button"
-                                data-attr="correlation-analysis-share-feedback"
-                                type="primary"
-                                onClick={() => {
-                                    sendCorrelationAnalysisFeedback()
+                        <form onSubmit={sendCorrelationAnalysisFeedback}>
+                            <TextArea
+                                onBlur={(e) => setCorrelationDetailedFeedback(e.target.value)}
+                                placeholder="Optional. Help us by sharing details around your experience..."
+                                style={{ marginTop: 16 }}
+                                ref={detailedFeedbackRef}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && e.metaKey) {
+                                        detailedFeedbackRef.current?.blur()
+                                        sendCorrelationAnalysisFeedback()
+                                    }
                                 }}
-                            >
-                                Share feedback
-                            </Button>
-                        </div>
+                            />
+                            <div className="text-right">
+                                <Button
+                                    className="feedback-button"
+                                    data-attr="correlation-analysis-share-feedback"
+                                    type="primary"
+                                    htmlType="submit"
+                                >
+                                    Share feedback
+                                </Button>
+                            </div>
+                        </form>
                     </div>
                 </Card>
             )}


### PR DESCRIPTION
## Changes

- Updates the UI/UX of correlation feedback 
- We now submit a report as soon as a 1-5 score is sent (if user wants to give quick feedback, it’s just 1 click). We only submit a detailed feedback event if the user types further comments.
- The feedback box is now shown between events & properties correlation.
- Submit comments on cmd/ctrl + enter.

![image](https://user-images.githubusercontent.com/5864173/139165123-e822043d-dad8-4a16-b10e-f06d8e0f33a1.gif)


## How did you test this code?

As shown on the recording above.
