### PR TITLE
Persist view/edit for insight in URL + refactor insightLogic tests

### DIFF
--- a/frontend/src/lib/api.mock.ts
+++ b/frontend/src/lib/api.mock.ts
@@ -68,6 +68,7 @@ export function defaultAPIMocks(
             `api/projects/${MOCK_TEAM_ID}/actions/`,
             `api/projects/${MOCK_TEAM_ID}/event_definitions/`,
             `api/projects/${MOCK_TEAM_ID}/dashboards/`,
+            `api/projects/${MOCK_TEAM_ID}/dashboards`,
             'api/projects/@current/event_definitions/',
         ].includes(pathname)
     ) {

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -1,6 +1,6 @@
-import { defaultAPIMocks, mockAPI, MOCK_TEAM_ID } from 'lib/api.mock'
+import { defaultAPIMocks, MOCK_TEAM_ID, mockAPI } from 'lib/api.mock'
 import { expectLogic, partial } from 'kea-test-utils'
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { insightLogic } from './insightLogic'
 import { AvailableFeature, PropertyOperator, ViewType } from '~/types'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -13,6 +13,7 @@ jest.mock('lib/api')
 
 describe('insightLogic', () => {
     let logic: ReturnType<typeof insightLogic.build>
+    beforeEach(initKeaTests)
 
     mockAPI(async (url) => {
         const { pathname, searchParams } = url
@@ -20,7 +21,11 @@ describe('insightLogic', () => {
             throw { status: 0, statusText: 'error from the API' }
         }
         if (
-            [`api/projects/${MOCK_TEAM_ID}/insights/42`, `api/projects/${MOCK_TEAM_ID}/insights/43`].includes(pathname)
+            [
+                `api/projects/${MOCK_TEAM_ID}/insights/42`,
+                `api/projects/${MOCK_TEAM_ID}/insights/43`,
+                `api/projects/${MOCK_TEAM_ID}/insights/44`,
+            ].includes(pathname)
         ) {
             return {
                 result: pathname.endsWith('42') ? ['result from api'] : null,
@@ -39,7 +44,7 @@ describe('insightLogic', () => {
                     { id: 42, result: 'result!', filters: { insight: 'TRENDS', interval: 'month' }, tags: ['bla'] },
                 ],
             }
-        } else if ([`api/projects/${MOCK_TEAM_ID}/insights/44`].includes(pathname)) {
+        } else if ([`api/projects/${MOCK_TEAM_ID}/insights/500`].includes(pathname)) {
             throwAPIError()
         } else if (
             [
@@ -64,27 +69,22 @@ describe('insightLogic', () => {
     })
 
     describe('when there is no props id', () => {
-        initKeaTestLogic({
-            logic: insightLogic,
-            props: {
-                dashboardItemId: undefined,
-            },
-            onLogic: (l) => (logic = l),
-        })
-
         it('has the key set to "new"', () => {
+            logic = insightLogic({
+                dashboardItemId: undefined,
+            })
             expect(logic.key).toEqual('new')
         })
     })
 
     describe('analytics', () => {
-        initKeaTestLogic({
-            logic: insightLogic,
-            props: { dashboardItemId: undefined, filters: { insight: 'TRENDS' } },
-            onLogic: (l) => (logic = l),
-        })
-
         it('reports insight changes on setFilter', async () => {
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                filters: { insight: 'TRENDS' },
+            })
+            logic.mount()
+
             await expectLogic(logic, () => {
                 logic.actions.setFilters({ insight: 'FUNNELS' })
             }).toDispatchActions([
@@ -97,9 +97,8 @@ describe('insightLogic', () => {
 
     describe('as dashboard item', () => {
         describe('props with filters and cached results', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
+            beforeEach(() => {
+                logic = insightLogic({
                     dashboardItemId: 42,
                     cachedResults: ['cached result'],
                     filters: {
@@ -107,8 +106,8 @@ describe('insightLogic', () => {
                         events: [{ id: 2 }],
                         properties: [{ value: 'lol', operator: PropertyOperator.Exact, key: 'lol', type: 'lol' }],
                     },
-                },
-                onLogic: (l) => (logic = l),
+                })
+                logic.mount()
             })
 
             it('has the key set to the id', () => {
@@ -117,10 +116,10 @@ describe('insightLogic', () => {
             it('no query to load results', async () => {
                 await expectLogic(logic)
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 42, result: ['cached result'] }),
-                        filters: expect.objectContaining({
+                        insight: partial({ id: 42, result: ['cached result'] }),
+                        filters: partial({
                             events: [{ id: 2 }],
-                            properties: [expect.objectContaining({ type: 'lol' })],
+                            properties: [partial({ type: 'lol' })],
                         }),
                     })
                     .toNotHaveDispatchedActions(['loadResultsSuccess']) // this took the cached results
@@ -128,9 +127,8 @@ describe('insightLogic', () => {
         })
 
         describe('props with filters, no cached results', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
+            it('makes a query to load the results', async () => {
+                logic = insightLogic({
                     dashboardItemId: 42,
                     cachedResults: undefined,
                     filters: {
@@ -138,18 +136,16 @@ describe('insightLogic', () => {
                         events: [{ id: 3 }],
                         properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' }],
                     },
-                },
-                onLogic: (l) => (logic = l),
-            })
+                })
+                logic.mount()
 
-            it('makes a query to load the results', async () => {
                 await expectLogic(logic)
                     .toDispatchActions(['loadResults', 'loadResultsSuccess'])
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 42, result: ['result from api'] }),
-                        filters: expect.objectContaining({
+                        insight: partial({ id: 42, result: ['result from api'] }),
+                        filters: partial({
                             events: [{ id: 3 }],
-                            properties: [expect.objectContaining({ value: 'a' })],
+                            properties: [partial({ value: 'a' })],
                         }),
                     })
                     .toDispatchActions(['updateInsight', 'updateInsightSuccess'])
@@ -157,9 +153,8 @@ describe('insightLogic', () => {
         })
 
         describe('props with filters, no cached results, error from API', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
+            it('makes a query to load the results', async () => {
+                logic = insightLogic({
                     dashboardItemId: 42,
                     cachedResults: undefined,
                     filters: {
@@ -167,18 +162,16 @@ describe('insightLogic', () => {
                         events: [{ id: 3, throw: true }],
                         properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' }],
                     },
-                },
-                onLogic: (l) => (logic = l),
-            })
+                })
+                logic.mount()
 
-            it('makes a query to load the results', async () => {
                 await expectLogic(logic)
                     .toDispatchActions(['loadResults', 'loadResultsFailure'])
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 42, result: null }),
-                        filters: expect.objectContaining({
-                            events: [expect.objectContaining({ id: 3 })],
-                            properties: [expect.objectContaining({ value: 'a' })],
+                        insight: partial({ id: 42, result: null }),
+                        filters: partial({
+                            events: [partial({ id: 3 })],
+                            properties: [partial({ value: 'a' })],
                         }),
                     })
                     .delay(1)
@@ -187,9 +180,8 @@ describe('insightLogic', () => {
         })
 
         describe('props with filters, no cached results, respects doNotLoad', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
+            it('does not make a query', async () => {
+                logic = insightLogic({
                     dashboardItemId: 42,
                     cachedResults: undefined,
                     filters: {
@@ -198,17 +190,15 @@ describe('insightLogic', () => {
                         properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' }],
                     },
                     doNotLoad: true,
-                },
-                onLogic: (l) => (logic = l),
-            })
+                })
+                logic.mount()
 
-            it('does not make a query', async () => {
                 await expectLogic(logic)
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 42, result: null }),
-                        filters: expect.objectContaining({
-                            events: [expect.objectContaining({ id: 3 })],
-                            properties: [expect.objectContaining({ value: 'a' })],
+                        insight: partial({ id: 42, result: null }),
+                        filters: partial({
+                            events: [partial({ id: 3 })],
+                            properties: [partial({ value: 'a' })],
                         }),
                     })
                     .delay(1)
@@ -217,24 +207,21 @@ describe('insightLogic', () => {
         })
 
         describe('props with no filters, no cached results, results from API', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
+            it('makes a query to load the results', async () => {
+                logic = insightLogic({
                     dashboardItemId: 42,
                     cachedResults: undefined,
                     filters: undefined,
-                },
-                onLogic: (l) => (logic = l),
-            })
+                })
+                logic.mount()
 
-            it('makes a query to load the results', async () => {
                 await expectLogic(logic)
                     .toDispatchActions(['loadInsight', 'loadInsightSuccess'])
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 42, result: ['result from api'] }),
-                        filters: expect.objectContaining({
+                        insight: partial({ id: 42, result: ['result from api'] }),
+                        filters: partial({
                             events: [{ id: 3 }],
-                            properties: [expect.objectContaining({ value: 'a' })],
+                            properties: [partial({ value: 'a' })],
                         }),
                     })
                     .toNotHaveDispatchedActions(['loadResults']) // does not fetch results as there was no filter
@@ -242,53 +229,47 @@ describe('insightLogic', () => {
         })
 
         describe('props with no filters, no cached results, no results from API', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
+            it('makes a query to load the results', async () => {
+                logic = insightLogic({
                     dashboardItemId: 43, // 43 --> result: null
                     cachedResults: undefined,
                     filters: undefined,
-                },
-                onLogic: (l) => (logic = l),
-            })
+                })
+                logic.mount()
 
-            it('makes a query to load the results', async () => {
                 await expectLogic(logic)
                     .toDispatchActions(['loadInsight', 'loadInsightSuccess'])
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 43, result: null }),
-                        filters: expect.objectContaining({
+                        insight: partial({ id: 43, result: null }),
+                        filters: partial({
                             events: [{ id: 3 }],
-                            properties: [expect.objectContaining({ value: 'a' })],
+                            properties: [partial({ value: 'a' })],
                         }),
                     })
                     .toDispatchActions(['loadResults', 'loadResultsSuccess'])
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 43, result: ['result from api'] }),
-                        filters: expect.objectContaining({
+                        insight: partial({ id: 43, result: ['result from api'] }),
+                        filters: partial({
                             events: [{ id: 3 }],
-                            properties: [expect.objectContaining({ value: 'a' })],
+                            properties: [partial({ value: 'a' })],
                         }),
                     })
             })
         })
 
         describe('props with no filters, no cached results, API throws', () => {
-            initKeaTestLogic({
-                logic: insightLogic,
-                props: {
-                    dashboardItemId: 44, // 44 --> result: throws
+            it('makes a query to load the results', async () => {
+                logic = insightLogic({
+                    dashboardItemId: 500, // 500 --> result: throws
                     cachedResults: undefined,
                     filters: undefined,
-                },
-                onLogic: (l) => (logic = l),
-            })
+                })
+                logic.mount()
 
-            it('makes a query to load the results', async () => {
                 await expectLogic(logic)
                     .toDispatchActions(['loadInsight', 'loadInsightFailure'])
                     .toMatchValues({
-                        insight: expect.objectContaining({ id: 44, result: null, filters: {} }),
+                        insight: partial({ id: 500, result: null, filters: {} }),
                         filters: {},
                     })
                     .delay(1)
@@ -297,17 +278,15 @@ describe('insightLogic', () => {
         })
     })
 
-    describe('reacts to the URL', () => {
-        initKeaTestLogic({
-            logic: insightLogic,
-            props: {
+    describe('syncWithUrl: true persists state in the URL', () => {
+        beforeEach(async () => {
+            logic = insightLogic({
                 syncWithUrl: true,
-                dashboardItemId: undefined,
-            },
-            onLogic: (l) => (logic = l),
+                dashboardItemId: 44,
+            })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners().clearHistory()
         })
-
-        beforeEach(async () => await expectLogic(logic).toFinishAllListeners())
 
         it('sets filters from the URL', async () => {
             const url = combineUrl('/insights', { insight: 'TRENDS', interval: 'minute' }).url
@@ -315,7 +294,7 @@ describe('insightLogic', () => {
             await expectLogic(logic)
                 .toDispatchActions([router.actionCreators.push(url), 'setFilters'])
                 .toMatchValues({
-                    filters: expect.objectContaining({ insight: 'TRENDS', interval: 'minute' }),
+                    filters: partial({ insight: 'TRENDS', interval: 'minute' }),
                 })
 
             // setting the same URL twice doesn't call `setFilters`
@@ -324,7 +303,7 @@ describe('insightLogic', () => {
                 .toDispatchActions([router.actionCreators.push(url)])
                 .toNotHaveDispatchedActions(['setFilters'])
                 .toMatchValues({
-                    filters: expect.objectContaining({ insight: 'TRENDS', interval: 'minute' }),
+                    filters: partial({ insight: 'TRENDS', interval: 'minute' }),
                 })
 
             // calls when the values changed
@@ -333,7 +312,7 @@ describe('insightLogic', () => {
             await expectLogic(logic)
                 .toDispatchActions([router.actionCreators.push(url2), 'setFilters'])
                 .toMatchValues({
-                    filters: expect.objectContaining({ insight: 'TRENDS', interval: 'week' }),
+                    filters: partial({ insight: 'TRENDS', interval: 'week' }),
                 })
         })
 
@@ -344,8 +323,8 @@ describe('insightLogic', () => {
                 .toDispatchActions([router.actionCreators.push(url), 'loadInsight', 'loadInsightSuccess'])
                 .toNotHaveDispatchedActions(['loadResults'])
                 .toMatchValues({
-                    filters: expect.objectContaining({ insight: 'TRENDS' }),
-                    insight: expect.objectContaining({ id: 42, result: ['result from api'] }),
+                    filters: partial({ insight: 'TRENDS' }),
+                    insight: partial({ id: 42, result: ['result from api'] }),
                 })
 
             // changing the ID, does not query twice
@@ -353,13 +332,13 @@ describe('insightLogic', () => {
             await expectLogic(logic)
                 .toDispatchActions(['loadInsight', 'setFilters', 'loadResults', 'loadInsightSuccess'])
                 .toMatchValues({
-                    filters: expect.objectContaining({ insight: 'FUNNELS' }),
-                    insight: expect.objectContaining({ id: 43, result: null }),
+                    filters: partial({ insight: 'FUNNELS' }),
+                    insight: partial({ id: 43, result: null }),
                 })
                 .toNotHaveDispatchedActions(['loadResults']) // don't load twice!
                 .toDispatchActions(['loadResultsSuccess'])
                 .toMatchValues({
-                    insight: expect.objectContaining({ id: 43, result: ['result from api'] }),
+                    insight: partial({ id: 43, result: ['result from api'] }),
                 })
         })
 
@@ -368,26 +347,25 @@ describe('insightLogic', () => {
             await expectLogic()
                 .toDispatchActions(logic, [logic.actionCreators.setFilters({ insight: 'TRENDS', interval: 'minute' })])
                 .toDispatchActions(router, ['replace', 'locationChanged'])
-                .toMatchValues(router, { searchParams: expect.objectContaining({ interval: 'minute' }) })
+                .toMatchValues(router, { searchParams: partial({ interval: 'minute' }) })
 
             // no change in filters, doesn't change the URL
             logic.actions.setFilters({ insight: 'TRENDS', interval: 'minute' })
             await expectLogic()
                 .toDispatchActions(logic, [logic.actionCreators.setFilters({ insight: 'TRENDS', interval: 'minute' })])
                 .toNotHaveDispatchedActions(router, ['replace', 'locationChanged'])
-                .toMatchValues(router, { searchParams: expect.objectContaining({ interval: 'minute' }) })
+                .toMatchValues(router, { searchParams: partial({ interval: 'minute' }) })
 
             logic.actions.setFilters({ insight: 'TRENDS', interval: 'month' })
             await expectLogic()
                 .toDispatchActions(router, ['replace', 'locationChanged'])
                 .toMatchValues(router, {
-                    searchParams: expect.objectContaining({ insight: 'TRENDS', interval: 'month' }),
+                    searchParams: partial({ insight: 'TRENDS', interval: 'month' }),
                 })
         })
     })
 
     describe('takes data from dashboardLogic if available', () => {
-        initKeaTestLogic()
         it('works if all conditions match', async () => {
             // 0. the feature flag must be set
             featureFlagLogic.mount()

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -573,6 +573,18 @@ export const insightLogic = kea<insightLogicType>({
                 return ['/insights', values.filters, router.values.hashParams, { replace: true }]
             }
         },
+        setInsightMode: () => {
+            if (props.syncWithUrl) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { edit: _discard, ...otherHashParams } = router.values.hashParams
+                return [
+                    '/insights',
+                    router.values.searchParams,
+                    values.insightMode === ItemMode.View ? otherHashParams : { ...otherHashParams, edit: true },
+                    { replace: true },
+                ]
+            }
+        },
     }),
     urlToAction: ({ actions, values, props }) => ({
         '/insights': (_: any, searchParams: Record<string, any>, hashParams: Record<string, any>) => {
@@ -605,6 +617,11 @@ export const insightLogic = kea<insightLogicType>({
                     if (!loadedFromDashboard && insightIdChanged) {
                         // Do not load the result if missing, as setFilters below will do so anyway.
                         actions.loadInsight(hashParams.fromItem, { doNotLoadResults: true })
+                    }
+
+                    const insightModeFromUrl = hashParams.edit ? ItemMode.Edit : ItemMode.View
+                    if (insightModeFromUrl !== values.insightMode) {
+                        actions.setInsightMode(insightModeFromUrl, null)
                     }
                 }
 


### PR DESCRIPTION
## Changes

- Adds `edit=true` to the URL when in edit mode
- Also refactored a bunch of tests inside `insightLogic` as a bit of a dependency. I think we should deprecate `initKeaTestLogic` that runs a `beforeEach` block inside the function itself, which causes if you want to use it inside a test, and not inside a `describe` block. Because of this I created a simpler `initKeaTests`. So I propose to use that, plus explicitly calling `logic = blaLogic(props) && logic.mount()` is not *that* bad. It makes the variable easier to follow, and can be simplified further down, e.g. `logic = blaLogic(props).mountAndReturnTheSameThingDamnit()`

## How did you test this code?

- Wrote a test for it, and checked in the browser myself.
