### PR TITLE
Refactor taxonomy selector/property naming

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
@@ -17,7 +17,7 @@ interface PropertyFiltersProps {
     popoverPlacement?: TooltipPlacement | null
     taxonomicPopoverPlacement?: Placement
     style?: CSSProperties
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     showNestedArrow?: boolean
 }
 

--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -17,7 +17,7 @@ interface PropertyFiltersProps {
     onChange?: null | ((filters: AnyPropertyFilter[]) => void)
     pageKey: string
     style?: CSSProperties
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     wildcardOptions?: SimpleOption[]
 }
 
@@ -26,7 +26,7 @@ export function PathItemFilters({
     onChange = null,
     pageKey,
     style = {},
-    groupTypes,
+    taxonomicGroupTypes,
     wildcardOptions,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, urlOverride: 'exclude_events' }
@@ -54,7 +54,7 @@ export function PathItemFilters({
                                     pathItem={filter.value as string | undefined}
                                     onChange={(pathItem) => setFilter(index, pathItem, pathItem, null, 'event')}
                                     index={index}
-                                    groupTypes={groupTypes}
+                                    taxonomicGroupTypes={taxonomicGroupTypes}
                                     wildcardOptions={wildcardOptions}
                                 >
                                     {!filter.value ? (

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -19,7 +19,7 @@ interface PropertyFiltersProps {
     popoverPlacement?: TooltipPlacement | null
     taxonomicPopoverPlacement?: Placement
     style?: CSSProperties
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     showNestedArrow?: boolean
 }
 
@@ -31,7 +31,7 @@ export function PropertyFilters({
     disablePopover = false, // use bare PropertyFilter without popover
     popoverPlacement = null,
     taxonomicPopoverPlacement = undefined,
-    groupTypes,
+    taxonomicGroupTypes,
     style = {},
     showNestedArrow = false,
 }: PropertyFiltersProps): JSX.Element {
@@ -66,7 +66,7 @@ export function PropertyFilters({
                                         index,
                                         onComplete,
                                         selectProps: {},
-                                        groupTypes,
+                                        taxonomicGroupTypes,
                                     }
                                     return (
                                         <PropertyFilter

--- a/frontend/src/lib/components/PropertyFilters/components/PathItemSelector.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PathItemSelector.tsx
@@ -8,7 +8,7 @@ interface PathItemSelectorProps {
     onChange: (item: string) => void
     children: JSX.Element
     index: number
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     disabled?: boolean
     wildcardOptions?: SimpleOption[]
 }
@@ -17,7 +17,7 @@ export function PathItemSelector({
     pathItem,
     onChange,
     children,
-    groupTypes,
+    taxonomicGroupTypes,
     disabled,
     wildcardOptions,
 }: PathItemSelectorProps): JSX.Element {
@@ -36,7 +36,7 @@ export function PathItemSelector({
                         onChange(value as string)
                         setVisible(false)
                     }}
-                    groupTypes={groupTypes}
+                    taxonomicGroupTypes={taxonomicGroupTypes}
                     optionsFromProp={{ wildcard: wildcardOptions }}
                 />
             }

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilter.tsx
@@ -9,7 +9,7 @@ export interface PropertyFilterInternalProps {
     selectProps: Partial<SelectGradientOverflowProps>
     onComplete: () => void
     disablePopover: boolean
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
 }
 export function PropertyFilter({ ...props }: PropertyFilterInternalProps): JSX.Element {
     return <TaxonomicPropertyFilter {...props} />

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -24,7 +24,7 @@ export function TaxonomicPropertyFilter({
     index,
     onComplete,
     disablePopover, // inside a dropdown if this is false
-    groupTypes,
+    taxonomicGroupTypes,
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
     const { setFilter } = useActions(propertyFilterLogic)
@@ -51,8 +51,8 @@ export function TaxonomicPropertyFilter({
                     onComplete?.()
                 }
             }}
-            groupTypes={
-                groupTypes || [
+            taxonomicGroupTypes={
+                taxonomicGroupTypes || [
                     TaxonomicFilterGroupType.EventProperties,
                     TaxonomicFilterGroupType.PersonProperties,
                     TaxonomicFilterGroupType.Cohorts,

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -19,10 +19,10 @@ function TabTitle({
     taxonomicFilterLogicProps: TaxonomicFilterLogicProps
 }): JSX.Element {
     const logic = infiniteListLogic({ ...taxonomicFilterLogicProps, listGroupType: groupType })
-    const { groups } = useValues(taxonomicFilterLogic)
+    const { taxonomicGroups } = useValues(taxonomicFilterLogic)
     const { totalCount } = useValues(logic)
 
-    const group = groups.find((g) => g.type === groupType)
+    const group = taxonomicGroups.find((g) => g.type === groupType)
 
     return (
         <div data-attr={`taxonomic-tab-${groupType}`}>
@@ -35,7 +35,7 @@ export function InfiniteSelectResults({
     focusInput,
     taxonomicFilterLogicProps,
 }: InfiniteSelectResultsProps): JSX.Element {
-    const { activeTab, groups, groupTypes } = useValues(taxonomicFilterLogic)
+    const { activeTab, taxonomicGroups, groupTypes } = useValues(taxonomicFilterLogic)
     const { setActiveTab } = useActions(taxonomicFilterLogic)
 
     if (groupTypes.length === 1) {
@@ -48,7 +48,7 @@ export function InfiniteSelectResults({
 
     return (
         <Tabs
-            activeKey={activeTab || groups[0].type}
+            activeKey={activeTab || taxonomicGroups[0].type}
             onChange={(value) => {
                 setActiveTab(value as TaxonomicFilterGroupType)
                 focusInput()

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -35,12 +35,15 @@ export function InfiniteSelectResults({
     focusInput,
     taxonomicFilterLogicProps,
 }: InfiniteSelectResultsProps): JSX.Element {
-    const { activeTab, taxonomicGroups, groupTypes } = useValues(taxonomicFilterLogic)
+    const { activeTab, taxonomicGroups, taxonomicGroupTypes } = useValues(taxonomicFilterLogic)
     const { setActiveTab } = useActions(taxonomicFilterLogic)
 
-    if (groupTypes.length === 1) {
+    if (taxonomicGroupTypes.length === 1) {
         return (
-            <BindLogic logic={infiniteListLogic} props={{ ...taxonomicFilterLogicProps, listGroupType: groupTypes[0] }}>
+            <BindLogic
+                logic={infiniteListLogic}
+                props={{ ...taxonomicFilterLogicProps, listGroupType: taxonomicGroupTypes[0] }}
+            >
                 <InfiniteList />
             </BindLogic>
         )
@@ -56,7 +59,7 @@ export function InfiniteSelectResults({
             tabPosition="top"
             animated={false}
         >
-            {groupTypes.map((groupType) => {
+            {taxonomicGroupTypes.map((groupType) => {
                 return (
                     <Tabs.TabPane
                         key={groupType}

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -18,7 +18,7 @@ export function TaxonomicFilter({
     value,
     onChange,
     onClose,
-    groupTypes = [
+    taxonomicGroupTypes = [
         TaxonomicFilterGroupType.EventProperties,
         TaxonomicFilterGroupType.PersonProperties,
         TaxonomicFilterGroupType.Cohorts,
@@ -39,7 +39,7 @@ export function TaxonomicFilter({
         groupType,
         value,
         onChange,
-        groupTypes,
+        taxonomicGroupTypes,
         optionsFromProp,
     }
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)
@@ -50,16 +50,18 @@ export function TaxonomicFilter({
         window.setTimeout(() => focusInput(), 1)
     }, [])
 
-    const placeholder = groupTypes
+    const placeholder = taxonomicGroupTypes
         .map(
             (type, index) =>
-                `${index !== 0 ? (index === groupTypes.length - 1 ? ' or ' : ', ') : ''}${type.split('_').join(' ')}`
+                `${index !== 0 ? (index === taxonomicGroupTypes.length - 1 ? ' or ' : ', ') : ''}${type
+                    .split('_')
+                    .join(' ')}`
         )
         .join('')
 
     return (
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>
-            <div className={`taxonomic-filter${groupTypes.length === 1 ? ' one-taxonomic-tab' : ''}`}>
+            <div className={`taxonomic-filter${taxonomicGroupTypes.length === 1 ? ' one-taxonomic-tab' : ''}`}>
                 <Input
                     data-attr="taxonomic-filter-searchfield"
                     placeholder={`Search ${placeholder}`}

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -38,7 +38,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
     key: (props) => `${props.taxonomicFilterLogicKey}-${props.listGroupType}`,
 
     connect: (props: InfiniteListLogicProps) => ({
-        values: [taxonomicFilterLogic(props), ['searchQuery', 'value', 'groupType', 'groups']],
+        values: [taxonomicFilterLogic(props), ['searchQuery', 'value', 'groupType', 'taxonomicGroups']],
         actions: [taxonomicFilterLogic(props), ['setSearchQuery', 'selectItem']],
     }),
 
@@ -163,16 +163,16 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
         listGroupType: [() => [(_, props) => props.listGroupType], (listGroupType) => listGroupType],
         isLoading: [(s) => [s.remoteItemsLoading], (remoteItemsLoading) => remoteItemsLoading],
         group: [
-            (s) => [s.listGroupType, s.groups],
-            (listGroupType, groups) => groups.find((g) => g.type === listGroupType),
+            (s) => [s.listGroupType, s.taxonomicGroups],
+            (listGroupType, taxonomicGroups) => taxonomicGroups.find((g) => g.type === listGroupType),
         ],
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
         isRemoteDataSource: [(s) => [s.remoteEndpoint], (remoteEndpoint) => !!remoteEndpoint],
         rawLocalItems: [
             (selectors) => [
                 (state, props) => {
-                    const groups = selectors.groups(state)
-                    const group = groups.find((g) => g.type === props.listGroupType)
+                    const taxonomicGroups = selectors.taxonomicGroups(state)
+                    const group = taxonomicGroups.find((g) => g.type === props.listGroupType)
                     if (group?.logic && group?.value) {
                         return group.logic.selectors[group.value]?.(state) || null
                     }

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -69,7 +69,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             () => [(_, props) => props.taxonomicFilterLogicKey],
             (taxonomicFilterLogicKey) => taxonomicFilterLogicKey,
         ],
-        groups: [
+        taxonomicGroups: [
             (selectors) => [selectors.currentTeamId],
             (teamId): TaxonomicFilterGroup[] => [
                 {
@@ -161,8 +161,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             ],
         ],
         groupTypes: [
-            (selectors) => [(_, props) => props.groupTypes, selectors.groups],
-            (groupTypes, groups): TaxonomicFilterGroupType[] => groupTypes || groups.map((g) => g.type),
+            (selectors) => [(_, props) => props.groupTypes, selectors.taxonomicGroups],
+            (groupTypes, taxonomicGroups): TaxonomicFilterGroupType[] =>
+                groupTypes || taxonomicGroups.map((g) => g.type),
         ],
         value: [() => [(_, props) => props.value], (value) => value],
         groupType: [() => [(_, props) => props.groupType], (groupType) => groupType],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -45,7 +45,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
         ],
         activeTab: [
             (state: any): TaxonomicFilterGroupType => {
-                return selectors.groupType(state) || selectors.groupTypes(state)[0]
+                return selectors.groupType(state) || selectors.taxonomicGroupTypes(state)[0]
             },
             {
                 setActiveTab: (_, { activeTab }) => activeTab,
@@ -160,15 +160,15 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                 },
             ],
         ],
-        groupTypes: [
-            (selectors) => [(_, props) => props.groupTypes, selectors.taxonomicGroups],
+        taxonomicGroupTypes: [
+            (selectors) => [(_, props) => props.taxonomicGroupTypes, selectors.taxonomicGroups],
             (groupTypes, taxonomicGroups): TaxonomicFilterGroupType[] =>
                 groupTypes || taxonomicGroups.map((g) => g.type),
         ],
         value: [() => [(_, props) => props.value], (value) => value],
         groupType: [() => [(_, props) => props.groupType], (groupType) => groupType],
         currentTabIndex: [
-            (s) => [s.groupTypes, s.activeTab],
+            (s) => [s.taxonomicGroupTypes, s.activeTab],
             (groupTypes, activeTab) => Math.max(groupTypes.indexOf(activeTab || ''), 0),
         ],
     },
@@ -214,15 +214,15 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
         },
 
         tabLeft: () => {
-            const { currentTabIndex, groupTypes } = values
-            const newIndex = (currentTabIndex - 1 + groupTypes.length) % groupTypes.length
-            actions.setActiveTab(groupTypes[newIndex])
+            const { currentTabIndex, taxonomicGroupTypes } = values
+            const newIndex = (currentTabIndex - 1 + taxonomicGroupTypes.length) % taxonomicGroupTypes.length
+            actions.setActiveTab(taxonomicGroupTypes[newIndex])
         },
 
         tabRight: () => {
-            const { currentTabIndex, groupTypes } = values
-            const newIndex = (currentTabIndex + 1) % groupTypes.length
-            actions.setActiveTab(groupTypes[newIndex])
+            const { currentTabIndex, taxonomicGroupTypes } = values
+            const newIndex = (currentTabIndex + 1) % taxonomicGroupTypes.length
+            actions.setActiveTab(taxonomicGroupTypes[newIndex])
         },
     }),
 })

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -11,7 +11,7 @@ export interface TaxonomicFilterProps {
     value?: TaxonomicFilterValue
     onChange?: (groupType: TaxonomicFilterGroupType, value: TaxonomicFilterValue, item: any) => void
     onClose?: () => void
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     taxonomicFilterLogicKey?: string
     optionsFromProp?: Partial<Record<TaxonomicFilterGroupType, SimpleOption[]>>
 }

--- a/frontend/src/scenes/cohorts/CohortGroup.tsx
+++ b/frontend/src/scenes/cohorts/CohortGroup.tsx
@@ -85,7 +85,7 @@ export function CohortGroup({
                                 )
                             }}
                             propertyFilters={group.properties || {}}
-                            groupTypes={[
+                            taxonomicGroupTypes={[
                                 TaxonomicFilterGroupType.PersonProperties,
                                 TaxonomicFilterGroupType.CohortsWithAllUsers,
                             ]}

--- a/frontend/src/scenes/cohorts/CohortMatchingCriteriaSection/MatchCriteriaSelector.tsx
+++ b/frontend/src/scenes/cohorts/CohortMatchingCriteriaSection/MatchCriteriaSelector.tsx
@@ -111,7 +111,7 @@ function PropertyCriteriaRow({
                     }}
                     propertyFilters={group.properties}
                     style={{ margin: '1rem 0 0' }}
-                    groupTypes={[
+                    taxonomicGroupTypes={[
                         TaxonomicFilterGroupType.PersonProperties,
                         TaxonomicFilterGroupType.CohortsWithAllUsers,
                     ]}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
@@ -51,7 +51,7 @@ export interface ActionFilterProps {
     horizontalUI?: boolean
     fullWidth?: boolean
     showNestedArrow?: boolean // show nested arrows to the left of property filter buttons
-    groupTypes?: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     hideDeleteBtn?: boolean
     renderRow?: ({
         seriesIndicator,
@@ -91,7 +91,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             stripeActionRow = true,
             customActions,
             showNestedArrow = false,
-            groupTypes,
+            taxonomicGroupTypes,
             hideDeleteBtn,
             renderRow,
         },
@@ -145,7 +145,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             stripeActionRow,
             hasBreakdown: !!filters.breakdown,
             fullWidth,
-            groupTypes,
+            taxonomicGroupTypes,
             hideDeleteBtn,
             disabled,
             renderRow,

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -87,7 +87,7 @@ export interface ActionFilterRowProps {
     stripeActionRow?: boolean // Whether or not to alternate the color behind the action rows
     hasBreakdown: boolean // Whether the current graph has a breakdown filter applied
     showNestedArrow?: boolean // Show nested arrows to the left of property filter buttons
-    groupTypes?: TaxonomicFilterGroupType[] // Specify which tabs to show, used in taxonomic filter
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[] // Specify which tabs to show, used in taxonomic filter
     hideDeleteBtn?: boolean // Choose to hide delete btn. You can use the onClose function passed into customRow{Pre|Suf}fix to render the delete btn anywhere
     disabled?: boolean
     renderRow?: ({
@@ -126,7 +126,7 @@ export function ActionFilterRow({
     hasBreakdown,
     showNestedArrow = false,
     hideDeleteBtn = false,
-    groupTypes = [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+    taxonomicGroupTypes = [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
     disabled = false,
     renderRow,
 }: ActionFilterRowProps): JSX.Element {
@@ -216,7 +216,7 @@ export function ActionFilterRow({
                         })
                     }}
                     onClose={() => selectFilter(null)}
-                    groupTypes={groupTypes}
+                    taxonomicGroupTypes={taxonomicGroupTypes}
                 />
             }
             visible={dropDownCondition}

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -30,7 +30,7 @@ export function TaxonomicBreakdownButton({
                             setOpen(false)
                         }
                     }}
-                    groupTypes={
+                    taxonomicGroupTypes={
                         onlyCohorts
                             ? [TaxonomicFilterGroupType.CohortsWithAllUsers]
                             : [

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
@@ -154,7 +154,7 @@ export function FunnelExclusionsFilter(): JSX.Element | null {
             }}
             disabled={!areFiltersValid}
             buttonCopy="Add exclusion"
-            groupTypes={[TaxonomicFilterGroupType.Events]}
+            taxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
             hideMathSelector
             hidePropertySelector
             hideFilter

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -45,7 +45,7 @@ export function NewPathTab(): JSX.Element {
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)
-    const groupTypes: TaxonomicFilterGroupType[] = filter.include_event_types
+    const taxonomicGroupTypes: TaxonomicFilterGroupType[] = filter.include_event_types
         ? [
               ...filter.include_event_types.map((item) => {
                   if (item === PathType.Screen) {
@@ -269,7 +269,7 @@ export function NewPathTab(): JSX.Element {
                                             start_point: pathItem,
                                         })
                                     }
-                                    groupTypes={groupTypes}
+                                    taxonomicGroupTypes={taxonomicGroupTypes}
                                     disabled={overrideStartInput || overrideEndInput}
                                     wildcardOptions={wildcards}
                                 >
@@ -337,7 +337,7 @@ export function NewPathTab(): JSX.Element {
                                                     end_point: pathItem,
                                                 })
                                             }
-                                            groupTypes={groupTypes}
+                                            taxonomicGroupTypes={taxonomicGroupTypes}
                                             disabled={overrideEndInput || overrideStartInput}
                                             wildcardOptions={wildcards}
                                         >
@@ -535,7 +535,7 @@ export function NewPathTab(): JSX.Element {
                                 </Tooltip>
                             </h4>
                             <PathItemFilters
-                                groupTypes={groupTypes}
+                                taxonomicGroupTypes={taxonomicGroupTypes}
                                 pageKey={'exclusion'}
                                 propertyFilters={
                                     filter.exclude_events &&


### PR DESCRIPTION
Pulling out a tiny (but potentially conflict-causing) change from a larger group analytics change.

Renaming things to avoid confusion with groups going forward

- Rename groups => taxonomicGroups
- Rename groupTypes => taxonomicGroupTypes

## How did you test this code?

*Please describe.*
