### PR TITLE
metrics - add Prometheus endpoint

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -260,13 +260,13 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.postgres",
     "django.contrib.staticfiles",
-    "django_prometheus",
     "posthog.apps.PostHogConfig",
     "rest_framework",
     "loginas",
     "corsheaders",
     "social_django",
     "django_filters",
+    "django_prometheus",
     "axes",
 ]
 

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -260,6 +260,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.postgres",
     "django.contrib.staticfiles",
+    "django_prometheus",
     "posthog.apps.PostHogConfig",
     "rest_framework",
     "loginas",
@@ -271,6 +272,7 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django_structlog.middlewares.RequestMiddleware",
     "django_structlog.middlewares.CeleryMiddleware",
     "django.middleware.security.SecurityMiddleware",
@@ -286,6 +288,7 @@ MIDDLEWARE = [
     "posthog.middleware.CSVNeverCacheMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "axes.middleware.AxesMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 if STATSD_HOST is not None:

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect
 from django.urls import URLPattern, include, path, re_path
 from django.urls.base import reverse
 from django.views.decorators.csrf import csrf_exempt
+from django_prometheus import exports
 
 from posthog.api import (
     api_not_found,
@@ -69,6 +70,7 @@ urlpatterns = [
     # internals
     opt_slash_path("_health", health),
     opt_slash_path("_stats", stats),
+    opt_slash_path("_metrics", exports.ExportToDjangoView),
     opt_slash_path("_preflight", preflight_check),
     # admin
     path("admin/", include("loginas.urls")),

--- a/requirements.in
+++ b/requirements.in
@@ -17,6 +17,7 @@ django-deprecate-fields==0.1.1
 django-extensions==3.1.2
 django-filter==2.4.0
 django-loginas==0.3.9
+django-prometheus==2.1.0
 django-redis==4.12.1
 django-statsd==2.5.2
 django-structlog==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,8 @@ django-ipware==3.0.2
     #   django-structlog
 django-loginas==0.3.9
     # via -r requirements.in
+django-prometheus==2.1.0
+    # via -r requirements.in
 django-redis==4.12.1
     # via -r requirements.in
 git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
@@ -144,6 +146,8 @@ pickleshare==0.7.5
     # via -r requirements.in
 posthoganalytics==1.4.2
     # via -r requirements.in
+prometheus-client==0.11.0
+    # via django-prometheus
 protobuf==3.13.0
     # via -r requirements.in
 psycopg2-binary==2.8.6


### PR DESCRIPTION
## Changes
This PR adds the `django-prometheus` library and adds a new route to our app to expose them at `/_metrics`. As you can see below, the default lib config already includes few nice metrics regarding Python GC and the Django framework. 
 
In future PRs we'll start adding custom metrics.  

## How did you test this code?
```
➜  posthog git:(prometheus_client) ✗ curl -s http://127.0.0.1:8000/_metrics | head -n 50
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 41203.0
python_gc_objects_collected_total{generation="1"} 6569.0
python_gc_objects_collected_total{generation="2"} 1030.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 370.0
python_gc_collections_total{generation="1"} 33.0
python_gc_collections_total{generation="2"} 3.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="8",patchlevel="9",version="3.8.9"} 1.0
# HELP django_model_inserts_total Number of insert operations by model.
# TYPE django_model_inserts_total counter
# HELP django_model_updates_total Number of update operations by model.
# TYPE django_model_updates_total counter
# HELP django_model_deletes_total Number of delete operations by model.
# TYPE django_model_deletes_total counter
# HELP django_migrations_unapplied_total Count of unapplied migrations by database connection
# TYPE django_migrations_unapplied_total gauge
django_migrations_unapplied_total{connection="default"} 0.0
# HELP django_migrations_applied_total Count of applied migrations by database connection
# TYPE django_migrations_applied_total gauge
django_migrations_applied_total{connection="default"} 233.0
# HELP posthog_capture_endpoint_to_kafka_success_total Total count of captured events successfully sent to Kafka
# TYPE posthog_capture_endpoint_to_kafka_success_total counter
# HELP posthog_capture_endpoint_to_kafka_failures_total Total count of captured events unsuccessfully sent to Kafka
# TYPE posthog_capture_endpoint_to_kafka_failures_total counter
# HELP django_http_requests_before_middlewares_total Total count of requests before middlewares run.
# TYPE django_http_requests_before_middlewares_total counter
django_http_requests_before_middlewares_total 7.0
# HELP django_http_requests_before_middlewares_created Total count of requests before middlewares run.
# TYPE django_http_requests_before_middlewares_created gauge
django_http_requests_before_middlewares_created 1.6354256230487292e+09
# HELP django_http_responses_before_middlewares_total Total count of responses before middlewares run.
# TYPE django_http_responses_before_middlewares_total counter
django_http_responses_before_middlewares_total 6.0
# HELP django_http_responses_before_middlewares_created Total count of responses before middlewares run.
# TYPE django_http_responses_before_middlewares_created gauge
django_http_responses_before_middlewares_created 1.6354256230487418e+09
# HELP django_http_requests_latency_including_middlewares_seconds Histogram of requests processing time (including middleware processing time).
# TYPE django_http_requests_latency_including_middlewares_seconds histogram
django_http_requests_latency_including_middlewares_seconds_bucket{le="0.005"} 1.0
django_http_requests_latency_including_middlewares_seconds_bucket{le="0.01"} 5.0
```