### PR TITLE
closes #6581 funnel conversion window not updating

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -183,7 +183,7 @@ export function FunnelTab(): JSX.Element {
                     )}
                     <hr />
                     <h4 className="secondary">Options</h4>
-                    <FunnelConversionWindowFilter />
+                    <FunnelConversionWindowFilter filters={filters} />
                     {!featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] && (
                         <>
                             <hr />


### PR DESCRIPTION
## Changes

- Fixes #6581 
- Display funnel_window_interval and funnel_window_interval_unit returned by api.

*If this affects the frontend, include screenshots.*  


https://user-images.githubusercontent.com/69707565/139281957-9b029e1b-2fac-45e8-ab84-b18671004d8c.mp4


## How did you test this code?
Please check the video.

**Describe**
Hello sir. As per i understand what happening here is FunnelConversionWindowFilter component is always rendering default interval as 14 and default unit as day, and not the data returned by api. That's why if you navigate between saved funnels the conversion window does not change.
