### PR TITLE
Fix running `yarn` in plugin-server/ directory

### DIFF
--- a/plugin-server/.eslintrc.js
+++ b/plugin-server/.eslintrc.js
@@ -31,4 +31,5 @@ module.exports = {
             },
         },
     ],
+    root: true,
 }


### PR DESCRIPTION
This broke with the following error:

```
ESLint: 7.28.0

ESLint couldn't determine the plugin "@typescript-eslint" uniquely.

- /home/macobo/backups/2/projects/posthog/plugin-server/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in "../../../.eslintrc.js")
- /home/macobo/backups/2/projects/posthog/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in "../../../../.eslintrc.js")

Please remove the "plugins" setting from either config or remove either plugin installation.

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.
```

Relate github issue: https://github.com/eslint/eslint/issues/13385

## How did you test this code?

Local env test
