### PR TITLE
Ingest groups into separate columns on events table

### DIFF
--- a/ee/clickhouse/migrations/0019_group_analytics_events.py
+++ b/ee/clickhouse/migrations/0019_group_analytics_events.py
@@ -1,0 +1,24 @@
+# Note: This migrations works on self-hosted only. Changes will be applied manually on cloud
+
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.events import EVENTS_TABLE, EVENTS_TABLE_MV_SQL, KAFKA_EVENTS_TABLE_SQL
+from posthog.constants import GROUP_TYPES_LIMIT
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_REPLICATION
+
+if CLICKHOUSE_REPLICATION:
+    raise NotImplementedError("Can't handle replication yet")
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE events_mv ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+    migrations.RunSQL(f"DROP TABLE kafka_events ON CLUSTER {CLICKHOUSE_CLUSTER}"),
+]
+
+operations.extend(
+    migrations.RunSQL(
+        f"ALTER TABLE {EVENTS_TABLE} ON CLUSTER {CLICKHOUSE_CLUSTER} ADD COLUMN IF NOT EXISTS group_{index} VARCHAR"
+    )
+    for index in range(GROUP_TYPES_LIMIT)
+)
+
+operations.extend([migrations.RunSQL(KAFKA_EVENTS_TABLE_SQL), migrations.RunSQL(EVENTS_TABLE_MV_SQL)])

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -19,16 +19,8 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     distinct_id VARCHAR,
     elements_chain VARCHAR,
     created_at DateTime64(6, 'UTC')
-    {materialized_columns}
     {extra_fields}
-) ENGINE = {engine} 
-"""
-
-EVENTS_TABLE_MATERIALIZED_COLUMNS = """
-    , properties_issampledevent VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'isSampledEvent'))
-    , properties_currentscreen VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'currentScreen'))
-    , properties_objectname VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'objectName'))
-    , properties_test_prop VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'test_prop'))
+) ENGINE = {engine}
 """
 
 EVENTS_TABLE_SQL = (
@@ -43,7 +35,6 @@ ORDER BY (team_id, toDate(timestamp), distinct_id, uuid)
     cluster=CLICKHOUSE_CLUSTER,
     engine=table_engine(EVENTS_TABLE, "_timestamp", REPLACING_MERGE_TREE),
     extra_fields=KAFKA_COLUMNS,
-    materialized_columns=EVENTS_TABLE_MATERIALIZED_COLUMNS,
     sample_by_uuid="SAMPLE BY uuid" if not DEBUG else "",  # https://github.com/PostHog/posthog/issues/5684
     storage_policy=STORAGE_POLICY,
 )
@@ -53,14 +44,13 @@ KAFKA_EVENTS_TABLE_SQL = EVENTS_TABLE_BASE_SQL.format(
     cluster=CLICKHOUSE_CLUSTER,
     engine=kafka_engine(topic=KAFKA_EVENTS, serialization="Protobuf", proto_schema="events:Event"),
     extra_fields="",
-    materialized_columns="",
 )
 
 # You must include the database here because of a bug in clickhouse
 # related to https://github.com/ClickHouse/ClickHouse/issues/10471
 EVENTS_TABLE_MV_SQL = """
 CREATE MATERIALIZED VIEW {table_name}_mv ON CLUSTER {cluster}
-TO {database}.{table_name} 
+TO {database}.{table_name}
 AS SELECT
 uuid,
 event,
@@ -144,7 +134,7 @@ SELECT
     elements_chain,
     created_at
 FROM events
-WHERE 
+WHERE
 team_id = %(team_id)s
 {conditions}
 {filters}
@@ -177,22 +167,22 @@ SELECT toUInt16(0) AS total, {trunc_func}(toDateTime(%(date_to)s) - {interval_fu
 -- NOTE: for week there is some unusual behavior, see:
 --       https://github.com/ClickHouse/ClickHouse/issues/7322
 --
---       This actually aligns with what we want, as they are assuming Sunday week starts, 
---       and we'd rather have the relative week num difference. Likewise the same for 
+--       This actually aligns with what we want, as they are assuming Sunday week starts,
+--       and we'd rather have the relative week num difference. Likewise the same for
 --       "month" intervals
 --
---       To ensure we get all relevant intervals, we add in the truncated "date_from" 
+--       To ensure we get all relevant intervals, we add in the truncated "date_from"
 --       value.
 --
---       This behaviour of dateDiff is different to our handling of "week" and "month" 
+--       This behaviour of dateDiff is different to our handling of "week" and "month"
 --       differences we are performing in python, which just considers seconds between
 --       date_from and date_to
 --
--- TODO: Ths pattern of generating intervals is repeated in several places. Reuse this 
+-- TODO: Ths pattern of generating intervals is repeated in several places. Reuse this
 --       `ticks` query elsewhere.
 FROM numbers(dateDiff(%(interval)s, toDateTime(%(date_from)s), toDateTime(%(date_to)s)))
 
-UNION ALL 
+UNION ALL
 
 -- Make sure we capture the interval date_from falls into.
 SELECT toUInt16(0) AS total, {trunc_func}(toDateTime(%(date_from)s))
@@ -203,7 +193,7 @@ INNER JOIN ({GET_TEAM_PERSON_DISTINCT_IDS}) as pdi ON events.distinct_id = pdi.d
 """
 
 GET_EVENTS_WITH_PROPERTIES = """
-SELECT * FROM events WHERE 
+SELECT * FROM events WHERE
 team_id = %(team_id)s
 {filters}
 {order_by}

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -1,4 +1,5 @@
 from ee.kafka_client.topics import KAFKA_EVENTS
+from posthog.constants import GROUP_TYPES_LIMIT
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, DEBUG
 
 from .clickhouse import KAFKA_COLUMNS, REPLACING_MERGE_TREE, STORAGE_POLICY, kafka_engine, table_engine
@@ -7,6 +8,9 @@ from .person import GET_TEAM_PERSON_DISTINCT_IDS
 EVENTS_TABLE = "events"
 
 DROP_EVENTS_TABLE_SQL = f"DROP TABLE IF EXISTS {EVENTS_TABLE} ON CLUSTER {CLICKHOUSE_CLUSTER}"
+
+GROUP_TYPE_COLUMN_DEFINITIONS = "".join(f", group_{index} VARCHAR" for index in range(GROUP_TYPES_LIMIT))
+GROUP_TYPE_COLUMN_NAMES = "".join(f"group_{index}," for index in range(GROUP_TYPES_LIMIT))
 
 EVENTS_TABLE_BASE_SQL = """
 CREATE TABLE {table_name} ON CLUSTER {cluster}
@@ -19,6 +23,7 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     distinct_id VARCHAR,
     elements_chain VARCHAR,
     created_at DateTime64(6, 'UTC')
+    {groups_fields}
     {extra_fields}
 ) ENGINE = {engine}
 """
@@ -34,6 +39,7 @@ ORDER BY (team_id, toDate(timestamp), distinct_id, uuid)
     table_name=EVENTS_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
     engine=table_engine(EVENTS_TABLE, "_timestamp", REPLACING_MERGE_TREE),
+    groups_fields=GROUP_TYPE_COLUMN_DEFINITIONS,
     extra_fields=KAFKA_COLUMNS,
     sample_by_uuid="SAMPLE BY uuid" if not DEBUG else "",  # https://github.com/PostHog/posthog/issues/5684
     storage_policy=STORAGE_POLICY,
@@ -43,6 +49,7 @@ KAFKA_EVENTS_TABLE_SQL = EVENTS_TABLE_BASE_SQL.format(
     table_name="kafka_" + EVENTS_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
     engine=kafka_engine(topic=KAFKA_EVENTS, serialization="Protobuf", proto_schema="events:Event"),
+    groups_fields=GROUP_TYPE_COLUMN_DEFINITIONS,
     extra_fields="",
 )
 
@@ -60,11 +67,15 @@ team_id,
 distinct_id,
 elements_chain,
 created_at,
+{group_columns}
 _timestamp,
 _offset
 FROM {database}.kafka_{table_name}
 """.format(
-    table_name=EVENTS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE,
+    table_name=EVENTS_TABLE,
+    cluster=CLICKHOUSE_CLUSTER,
+    database=CLICKHOUSE_DATABASE,
+    group_columns=GROUP_TYPE_COLUMN_NAMES
 )
 
 INSERT_EVENT_SQL = """

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -75,7 +75,7 @@ FROM {database}.kafka_{table_name}
     table_name=EVENTS_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
     database=CLICKHOUSE_DATABASE,
-    group_columns=GROUP_TYPE_COLUMN_NAMES
+    group_columns=GROUP_TYPE_COLUMN_NAMES,
 )
 
 INSERT_EVENT_SQL = """

--- a/ee/idl/events.proto
+++ b/ee/idl/events.proto
@@ -12,4 +12,9 @@ message Event {
   string elements_chain = 8;
   google.protobuf.Timestamp proto_created_at = 9;
   google.protobuf.Timestamp proto_timestamp = 10;
+  optional string group_0 = 11;
+  optional string group_1 = 12;
+  optional string group_2 = 13;
+  optional string group_3 = 14;
+  optional string group_4 = 15;
 }

--- a/plugin-server/src/config/idl/events.proto
+++ b/plugin-server/src/config/idl/events.proto
@@ -12,4 +12,9 @@ message Event {
   string elements_chain = 8;
   google.protobuf.Timestamp proto_created_at = 9;
   google.protobuf.Timestamp proto_timestamp = 10;
+  optional string group_0 = 11;
+  optional string group_1 = 12;
+  optional string group_2 = 13;
+  optional string group_3 = 14;
+  optional string group_4 = 15;
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -445,6 +445,11 @@ export interface Event {
 export interface ClickHouseEvent extends Omit<Event, 'id' | 'elements' | 'elements_hash'> {
     uuid: string
     elements_chain: string
+    group_0: string
+    group_1: string
+    group_2: string
+    group_3: string
+    group_4: string
 }
 
 export interface DeadLetterQueueEvent {

--- a/plugin-server/src/worker/ingestion/groups.ts
+++ b/plugin-server/src/worker/ingestion/groups.ts
@@ -1,19 +1,29 @@
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TeamId } from '../../types'
+import { status } from '../../utils/status'
 import { GroupTypeManager } from './group-type-manager'
 
-export async function addGroupProperties(
+export async function getGroupColumns(
     teamId: TeamId,
     properties: Properties,
     groupTypeManager: GroupTypeManager
-): Promise<Properties> {
-    for (const [groupType, groupIdentifier] of Object.entries(properties.$groups || {})) {
+): Promise<Record<string, string>> {
+    const result: Record<string, string> = {}
+
+    if (typeof properties.$groups !== 'object') {
+        status.info('🔔', "Couldn't event parse properties.$groups information, likely malformed. Ignoring", {
+            properties,
+        })
+        return {}
+    }
+
+    for (const [groupType, groupIdentifier] of Object.entries(properties.$groups)) {
         const columnIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
         if (columnIndex !== null) {
-            // :TODO: Update event column instead
-            properties[`$group_${columnIndex}`] = groupIdentifier
+            result[`group_${columnIndex}`] = (groupIdentifier as any).toString()
         }
     }
-    return properties
+
+    return result
 }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -31,7 +31,7 @@ import {
 import { status } from '../../utils/status'
 import { castTimestampOrNow, RaceConditionError, UUID, UUIDT } from '../../utils/utils'
 import { GroupTypeManager } from './group-type-manager'
-import { addGroupProperties } from './groups'
+import { getGroupColumns } from './groups'
 import { PersonManager } from './person-manager'
 import { TeamManager } from './team-manager'
 
@@ -485,7 +485,7 @@ export class EventsProcessor {
         await this.createPersonIfDistinctIdIsNew(teamId, distinctId, sentAt || DateTime.utc(), personUuid)
 
         properties = personInitialAndUTMProperties(properties)
-        properties = await addGroupProperties(teamId, properties, this.groupTypeManager)
+        const groupsColumns = await getGroupColumns(teamId, properties, this.groupTypeManager)
 
         if (event === '$groupidentify') {
             await this.upsertGroup(teamId, properties)
@@ -506,7 +506,8 @@ export class EventsProcessor {
             properties,
             timestamp,
             elementsList,
-            siteUrl
+            siteUrl,
+            groupsColumns
         )
     }
 
@@ -518,7 +519,8 @@ export class EventsProcessor {
         properties?: Properties,
         timestamp?: DateTime | string,
         elements?: Element[],
-        siteUrl?: string
+        siteUrl?: string,
+        groupsColumns?: Record<string, string>
     ): Promise<[IEvent, Event['id'] | undefined, Element[] | undefined]> {
         const timestampString = castTimestampOrNow(
             timestamp,
@@ -535,6 +537,7 @@ export class EventsProcessor {
             distinctId,
             elementsChain,
             createdAt: castTimestampOrNow(),
+            ...groupsColumns,
         }
 
         let eventId: Event['id'] | undefined


### PR DESCRIPTION
Compared to properties, this will be much faster overall without bloating event properties further.

Migration only works on self-hosted, see https://github.com/PostHog/posthog/issues/6422 for details on the migration on cloud.

- Remove default materialized columns from events schema
- Update event proto files
- Add a migration for new group types columns
- Ingest group keys into group_X columns in plugin-server

## How did you test this code?

See unit tests.
