### PR TITLE
Proposal: Use unique topic names for kafka in test

### DIFF
--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -1,8 +1,12 @@
-KAFKA_EVENTS = "clickhouse_events_proto"
-KAFKA_PERSON = "clickhouse_person"
-KAFKA_PERSON_UNIQUE_ID = "clickhouse_person_unique_id"
-KAFKA_SESSION_RECORDING_EVENTS = "clickhouse_session_recording_events"
-KAFKA_EVENTS_PLUGIN_INGESTION = "events_plugin_ingestion"
-KAFKA_PLUGIN_LOG_ENTRIES = "plugin_log_entries"
-KAFKA_DEAD_LETTER_QUEUE = "events_dead_letter_queue"
-KAFKA_GROUPS = "clickhouse_groups"
+from posthog.settings import TEST
+
+suffix = "_test" if TEST else ""
+
+KAFKA_EVENTS = f"clickhouse_events_proto{suffix}"
+KAFKA_PERSON = f"clickhouse_person{suffix}"
+KAFKA_PERSON_UNIQUE_ID = f"clickhouse_person_unique_id{suffix}"
+KAFKA_SESSION_RECORDING_EVENTS = f"clickhouse_session_recording_events{suffix}"
+KAFKA_EVENTS_PLUGIN_INGESTION = f"events_plugin_ingestion{suffix}"
+KAFKA_PLUGIN_LOG_ENTRIES = f"plugin_log_entries{suffix}"
+KAFKA_DEAD_LETTER_QUEUE = f"events_dead_letter_queue{suffix}"
+KAFKA_GROUPS = f"clickhouse_groups{suffix}"

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -1,8 +1,13 @@
-export const KAFKA_EVENTS = 'clickhouse_events_proto'
-export const KAFKA_PERSON = 'clickhouse_person'
-export const KAFKA_PERSON_UNIQUE_ID = 'clickhouse_person_unique_id'
-export const KAFKA_SESSION_RECORDING_EVENTS = 'clickhouse_session_recording_events'
-export const KAFKA_EVENTS_PLUGIN_INGESTION = 'events_plugin_ingestion'
-export const KAFKA_PLUGIN_LOG_ENTRIES = 'plugin_log_entries'
-export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = 'events_dead_letter_queue'
-export const KAFKA_GROUPS = 'clickhouse_groups'
+import { determineNodeEnv, NodeEnv } from '../utils/utils'
+
+const isTestEnv = determineNodeEnv() === NodeEnv.Test
+const suffix = isTestEnv ? '_test' : ''
+
+export const KAFKA_EVENTS = `clickhouse_events_proto${suffix}`
+export const KAFKA_PERSON = `clickhouse_person${suffix}`
+export const KAFKA_PERSON_UNIQUE_ID = `clickhouse_person_unique_id${suffix}`
+export const KAFKA_SESSION_RECORDING_EVENTS = `clickhouse_session_recording_events${suffix}`
+export const KAFKA_EVENTS_PLUGIN_INGESTION = `events_plugin_ingestion${suffix}`
+export const KAFKA_PLUGIN_LOG_ENTRIES = `plugin_log_entries${suffix}`
+export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = `events_dead_letter_queue${suffix}`
+export const KAFKA_GROUPS = `clickhouse_groups${suffix}`


### PR DESCRIPTION
Without this, to run plugin-server tests you need to reset all
containers every time since otherwise both test- and non-test clickhouse
would attempt to read from the same topic.

## How did you test this code?

I ran plugin-server tests after `yarn setup:test:ee`