### PR TITLE
handle dates better in plugin server

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -34,6 +34,7 @@ import { GroupTypeManager } from './group-type-manager'
 import { addGroupProperties } from './groups'
 import { PersonManager } from './person-manager'
 import { TeamManager } from './team-manager'
+import { parseDate } from './utils'
 
 const MAX_FAILED_PERSON_MERGE_ATTEMPTS = 3
 
@@ -195,26 +196,18 @@ export class EventsProcessor {
                 try {
                     // timestamp and sent_at must both be in the same format: either both with or both without timezones
                     // otherwise we can't get a diff to add to now
-                    return now.plus(this.parseDate(data['timestamp']).diff(sentAt))
+                    return now.plus(parseDate(data['timestamp']).diff(sentAt))
                 } catch (error) {
                     status.error('⚠️', 'Error when handling timestamp:', error)
                     Sentry.captureException(error, { extra: { data, now, sentAt } })
                 }
             }
-            return this.parseDate(data['timestamp'])
+            return parseDate(data['timestamp'])
         }
         if (data['offset']) {
             return now.minus(Duration.fromMillis(data['offset']))
         }
         return now
-    }
-
-    private parseDate(supposedIsoString: string): DateTime {
-        const jsDate = new Date(supposedIsoString)
-        if (Number.isNaN(jsDate.getTime())) {
-            return DateTime.fromISO(supposedIsoString)
-        }
-        return DateTime.fromJSDate(jsDate)
     }
 
     private async updatePersonProperties(

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -46,3 +46,11 @@ export function generateEventDeadLetterQueueMessage(
     }
     return message
 }
+
+export function parseDate(supposedIsoString: string): DateTime {
+    const jsDate = new Date(supposedIsoString)
+    if (Number.isNaN(jsDate.getTime())) {
+        return DateTime.fromISO(supposedIsoString)
+    }
+    return DateTime.fromJSDate(jsDate)
+}

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -2121,31 +2121,6 @@ export const createProcessEventTests = (
         })
     })
 
-    test('handleTimestamp', () => {
-        const timestamps = [
-            '2021-10-29',
-            '2021-10-29 00:00:00',
-            '2021-10-29T00:00:00.000Z',
-            '2021-10-29 00:00:00+00:00',
-            '2021-10-29T00:00:00.000-00:00',
-            '2021-10-29T00:00:00.000',
-            '2021-10-29T00:00:00.000+00:00',
-            '2021-W43-5',
-            '2021-302',
-        ]
-
-        for (const timestamp of timestamps) {
-            const parsedTimestamp = eventsProcessor.handleTimestamp({ timestamp } as PluginEvent, DateTime.now(), null)
-            expect(parsedTimestamp.year).toBe(2021)
-            expect(parsedTimestamp.month).toBe(10)
-            expect(parsedTimestamp.day).toBe(29)
-            expect(parsedTimestamp.hour).toBe(0)
-            expect(parsedTimestamp.minute).toBe(0)
-            expect(parsedTimestamp.second).toBe(0)
-            expect(parsedTimestamp.millisecond).toBe(0)
-        }
-    })
-
     if (database == 'clickhouse') {
         test('groupidentify', async () => {
             await createPerson(hub, team, ['distinct_id1'])

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -2121,6 +2121,31 @@ export const createProcessEventTests = (
         })
     })
 
+    test('handleTimestamp', () => {
+        const timestamps = [
+            '2021-10-29',
+            '2021-10-29 00:00:00',
+            '2021-10-29T00:00:00.000Z',
+            '2021-10-29 00:00:00+00:00',
+            '2021-10-29T00:00:00.000-00:00',
+            '2021-10-29T00:00:00.000',
+            '2021-10-29T00:00:00.000+00:00',
+            '2021-W43-5',
+            '2021-302',
+        ]
+
+        for (const timestamp of timestamps) {
+            const parsedTimestamp = eventsProcessor.handleTimestamp({ timestamp } as PluginEvent, DateTime.now(), null)
+            expect(parsedTimestamp.year).toBe(2021)
+            expect(parsedTimestamp.month).toBe(10)
+            expect(parsedTimestamp.day).toBe(29)
+            expect(parsedTimestamp.hour).toBe(0)
+            expect(parsedTimestamp.minute).toBe(0)
+            expect(parsedTimestamp.second).toBe(0)
+            expect(parsedTimestamp.millisecond).toBe(0)
+        }
+    })
+
     if (database == 'clickhouse') {
         test('groupidentify', async () => {
             await createPerson(hub, team, ['distinct_id1'])

--- a/plugin-server/tests/utils.test.ts
+++ b/plugin-server/tests/utils.test.ts
@@ -15,6 +15,7 @@ import {
     UUID,
     UUIDT,
 } from '../src/utils/utils'
+import { parseDate } from '../src/worker/ingestion/utils'
 
 // .zip in Base64: github repo posthog/helloworldplugin
 const zip =
@@ -369,5 +370,31 @@ describe('stringify', () => {
     it('transforms object values into strings', () => {
         expect(stringify({})).toStrictEqual('{}')
         expect(stringify([])).toStrictEqual('[]')
+    })
+})
+
+describe('parseDate', () => {
+    const timestamps = [
+        '2021-10-29',
+        '2021-10-29 00:00:00',
+        '2021-10-29 00:00:00.000000',
+        '2021-10-29T00:00:00.000Z',
+        '2021-10-29 00:00:00+00:00',
+        '2021-10-29T00:00:00.000-00:00',
+        '2021-10-29T00:00:00.000',
+        '2021-10-29T00:00:00.000+00:00',
+        '2021-W43-5',
+        '2021-302',
+    ]
+
+    test.each(timestamps)('parses %s', (timestamp) => {
+        const parsedTimestamp = parseDate(timestamp)
+        expect(parsedTimestamp.year).toBe(2021)
+        expect(parsedTimestamp.month).toBe(10)
+        expect(parsedTimestamp.day).toBe(29)
+        expect(parsedTimestamp.hour).toBe(0)
+        expect(parsedTimestamp.minute).toBe(0)
+        expect(parsedTimestamp.second).toBe(0)
+        expect(parsedTimestamp.millisecond).toBe(0)
     })
 })


### PR DESCRIPTION
## Changes

Here's a more neat and uncompromising solution to plugin server dates.

We can now handle date formats that we couldn't before (like CH date formats), without sacrificing some additional ISO8601 formats that `DateTime` can parse

## How did you test this code?

Added tests for a variety of ISO8601 timestamps