### PR TITLE
Perf improvement on person query in recordings

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -115,7 +115,9 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         distinct_id = session_recording_meta_data["distinct_id"]
 
         try:
-            person: Union[Person, None] = Person.objects.get(persondistinctid__distinct_id=distinct_id, team=self.team)
+            person: Union[Person, None] = Person.objects.get(
+                persondistinctid__distinct_id=distinct_id, persondistinctid__team_id=self.team, team=self.team
+            )
         except Person.DoesNotExist:
             person = None
 


### PR DESCRIPTION
## Changes

Very small change that adds another team filter to the person query (`persondistinctid__team_id=self.team`). It should boost the speed of the recordings endpoint and resolve https://sentry.io/organizations/posthog/issues/2754446558/?project=1899813&referrer=slack

## How did you test this code?

Tested it locally. 
