### PR TITLE
Make the API safe to introduce multi-property breakdown

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -548,7 +548,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
 
             # input events have chrome and safari so results is an array with two arrays as its contents
             for i in range(0, 2):
-                for result in result[i]:
+                for result in range[i]:
                     self.assertIsInstance(result["name"], str)
                     self.assertEqual(test_case["expected"][i], result["breakdown"])
                     self.assertEqual(test_case["expected"][i], result["breakdown_value"])

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -548,10 +548,10 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
 
             # input events have chrome and safari so results is an array with two arrays as its contents
             for i in range(0, 2):
-                for result in range[i]:
-                    self.assertIsInstance(result["name"], str)
-                    self.assertEqual(test_case["expected"][i], result["breakdown"])
-                    self.assertEqual(test_case["expected"][i], result["breakdown_value"])
+                for funnel_data in result[i]:
+                    self.assertIsInstance(funnel_data["name"], str)
+                    self.assertEqual(test_case["expected"][i], funnel_data["breakdown"])
+                    self.assertEqual(test_case["expected"][i], funnel_data["breakdown_value"])
 
     @staticmethod
     def as_result(breakdown_properties: Union[str, List[str]]) -> Dict[str, Any]:

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -418,7 +418,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
     def test_funnel_invalid_action_handled(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/funnel/",
-            {"actions": [{"id": 666, "type": "actions", "order": 0}, ]},
+            {"actions": [{"id": 666, "type": "actions", "order": 0},]},
         )
 
         self.assertEqual(response.status_code, 400)
@@ -441,7 +441,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
                     {"id": "step one", "type": "events", "order": 0},
                     {"id": "step two", "type": "events", "order": 1},
                 ],
-                "exclusions": [{"id": "step x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1}, ],
+                "exclusions": [{"id": "step x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1},],
                 "funnel_window_days": 14,
                 "insight": "funnels",
             },

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -418,7 +418,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
     def test_funnel_invalid_action_handled(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/funnel/",
-            {"actions": [{"id": 666, "type": "actions", "order": 0},]},
+            {"actions": [{"id": 666, "type": "actions", "order": 0}, ]},
         )
 
         self.assertEqual(response.status_code, 400)
@@ -441,7 +441,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
                     {"id": "step one", "type": "events", "order": 0},
                     {"id": "step two", "type": "events", "order": 1},
                 ],
-                "exclusions": [{"id": "step x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1},],
+                "exclusions": [{"id": "step x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1}, ],
                 "funnel_window_days": 14,
                 "insight": "funnels",
             },

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -1,6 +1,5 @@
 import json
-
-from typing import List, Any, Union, Dict
+from typing import Any, Dict, List, Union
 from unittest.mock import patch
 from uuid import uuid4
 

--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -548,13 +548,13 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
 
             # input events have chrome and safari so results is an array with two arrays as its contents
             for i in range(0, 2):
-                for r in result[i]:
-                    self.assertIsInstance(r["name"], str)
-                    self.assertEqual(test_case["expected"][i], r["breakdown"])
-                    self.assertEqual(test_case["expected"][i], r["breakdown_value"])
+                for result in result[i]:
+                    self.assertIsInstance(result["name"], str)
+                    self.assertEqual(test_case["expected"][i], result["breakdown"])
+                    self.assertEqual(test_case["expected"][i], result["breakdown_value"])
 
     @staticmethod
-    def as_result(b: Union[str, List[str]]) -> Dict[str, Any]:
+    def as_result(breakdown_properties: Union[str, List[str]]) -> Dict[str, Any]:
         return {
             "action_id": "$pageview",
             "name": "$pageview",
@@ -565,6 +565,6 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
             "type": "events",
             "average_conversion_time": None,
             "median_conversion_time": None,
-            "breakdown": b,
-            "breakdown_value": b,
+            "breakdown": breakdown_properties,
+            "breakdown_value": breakdown_properties,
         }

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Dict, Type, List
+from typing import Any, Dict, List, Type
 
 from django.core.cache import cache
 from django.db.models import QuerySet

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -312,12 +312,12 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
         if is_single_property_breakdown:
             copied_result = copy.deepcopy(result)
-            for i_index, i in enumerate(result):
-                for j_index, j in enumerate(i):
-                    if isinstance(j["breakdown"], List):
-                        copied_result[i_index][j_index]["breakdown"] = j["breakdown"][0]
-                    if isinstance(j["breakdown_value"], List):
-                        copied_result[i_index][j_index]["breakdown_value"] = j["breakdown_value"][0]
+            for series_index, series in enumerate(result):
+                for data_index, data in enumerate(series):
+                    if isinstance(data["breakdown"], List):
+                        copied_result[series_index][data_index]["breakdown"] = data["breakdown"][0]
+                    if isinstance(data["breakdown_value"], List):
+                        copied_result[series_index][data_index]["breakdown_value"] = data["breakdown_value"][0]
             return copied_result
         else:
             return result

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -160,7 +160,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_class(self) -> Type[serializers.BaseSerializer]:
         if (self.action == "list" or self.action == "retrieve") and str_to_bool(
-                self.request.query_params.get("basic", "0"),
+            self.request.query_params.get("basic", "0"),
         ):
             return InsightBasicSerializer
         return super().get_serializer_class()
@@ -290,7 +290,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     @staticmethod
     def protect_old_clients_from_multi_property_default(
-            data: Dict[str, Any], result: List[List[Dict[str, Any]]]
+        data: Dict[str, Any], result: List[List[Dict[str, Any]]]
     ) -> List[List[Dict[str, Any]]]:
         """
         Implementing multi property breakdown will default breakdown to a list even if it is received as a string.
@@ -303,12 +303,12 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         :return:
         """
         is_single_property_breakdown = (
-                "insight" in data
-                and data["insight"] == "FUNNELS"
-                and "breakdown_type" in data
-                and data["breakdown_type"] in ["person", "event"]
-                and "breakdown" in data
-                and isinstance(data["breakdown"], str)
+            "insight" in data
+            and data["insight"] == "FUNNELS"
+            and "breakdown_type" in data
+            and data["breakdown_type"] in ["person", "event"]
+            and "breakdown" in data
+            and isinstance(data["breakdown"], str)
         )
         if is_single_property_breakdown:
             copied_result = copy.deepcopy(result)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -160,7 +160,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_class(self) -> Type[serializers.BaseSerializer]:
         if (self.action == "list" or self.action == "retrieve") and str_to_bool(
-            self.request.query_params.get("basic", "0"),
+                self.request.query_params.get("basic", "0"),
         ):
             return InsightBasicSerializer
         return super().get_serializer_class()
@@ -290,7 +290,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     @staticmethod
     def protect_old_clients_from_multi_property_default(
-        data: Dict[str, Any], result: List[List[Dict[str, Any]]]
+            data: Dict[str, Any], result: List[List[Dict[str, Any]]]
     ) -> List[List[Dict[str, Any]]]:
         """
         Implementing multi property breakdown will default breakdown to a list even if it is received as a string.
@@ -303,12 +303,12 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         :return:
         """
         is_single_property_breakdown = (
-            "insight" in data
-            and data["insight"] == "FUNNELS"
-            and "breakdown_type" in data
-            and data["breakdown_type"] in ["person", "event"]
-            and "breakdown" in data
-            and isinstance(data["breakdown"], str)
+                "insight" in data
+                and data["insight"] == "FUNNELS"
+                and "breakdown_type" in data
+                and data["breakdown_type"] in ["person", "event"]
+                and "breakdown" in data
+                and isinstance(data["breakdown"], str)
         )
         if is_single_property_breakdown:
             copied_result = copy.deepcopy(result)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Type
+import copy
+from typing import Any, Dict, Type, List
 
 from django.core.cache import cache
 from django.db.models import QuerySet
@@ -9,7 +10,6 @@ from rest_framework import request, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from sentry_sdk.api import capture_exception
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -282,9 +282,43 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     # ******************************************
     @action(methods=["GET", "POST"], detail=False)
     def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        result = self.calculate_funnel(request)
+        funnel = self.calculate_funnel(request)
 
-        return Response(result)
+        funnel["result"] = self.protect_old_clients_from_multi_property_default(request.data, funnel["result"])
+
+        return Response(funnel)
+
+    @staticmethod
+    def protect_old_clients_from_multi_property_default(
+        data: Dict[str, Any], result: List[List[Dict[str, Any]]]
+    ) -> List[List[Dict[str, Any]]]:
+        """
+        Implementing multi property breakdown will default breakdown to a list even if it is received as a string.
+        This is a breaking change for clients.
+        Clients which do not have multi property breakdown enabled will send a single breakdown as a string
+        This method checks if the request has come in that format and "unboxes" the list
+        to avoid breaking that client
+        :param data: the data in the request
+        :param result: the query result which may contain an unwanted array breakdown
+        :return:
+        """
+        is_single_property_breakdown = (
+            "insight" in data
+            and data["insight"] == "FUNNELS"
+            and data["breakdown_type"] in ["person", "event"]
+            and isinstance(data["breakdown"], str)
+        )
+        if is_single_property_breakdown:
+            copied_result = copy.deepcopy(result)
+            for i_index, i in enumerate(result):
+                for j_index, j in enumerate(i):
+                    if isinstance(j["breakdown"], List):
+                        copied_result[i_index][j_index]["breakdown"] = j["breakdown"][0]
+                    if isinstance(j["breakdown_value"], List):
+                        copied_result[i_index][j_index]["breakdown_value"] = j["breakdown_value"][0]
+            return copied_result
+        else:
+            return result
 
     @cached_function
     def calculate_funnel(self, request: request.Request) -> Dict[str, Any]:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -305,7 +305,9 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         is_single_property_breakdown = (
             "insight" in data
             and data["insight"] == "FUNNELS"
+            and "breakdown_type" in data
             and data["breakdown_type"] in ["person", "event"]
+            and "breakdown" in data
             and isinstance(data["breakdown"], str)
         )
         if is_single_property_breakdown:


### PR DESCRIPTION
## Changes

For #938 we are going to start accepting and returning arrays of person and event breakdown properties where currently we have only strings

This is a breaking change. 

To minimise its impact we can amend the API so that if it receives a string it returns one.

Currently, API clients expect that:

sending `breakdown: "property"` -> returns `"breakdown: "property"` 

And when sending an array of cohorts - or after this change - API clients will expect that: 

sending `breakdown: ["property"]` -> returns `"breakdown: ["property"]` 

One suggestion for making the code to implement #938 simpler is to convert all inputs to an array. This is avoid multiple instances where the code must check `if isinstance(breakdown, str): oneThing() else: anotherThing()`. 

This would mean the API would change such that

sending `breakdown: "property"` -> returns `"breakdown: ["property"]` 

This would be a breaking change.

However, if we receive a string breakdown property instead of an array, we can assume that the array response will have a single item in it. We can convert that single item array back into a string and avoid the breaking change. 

## How did you test this code?

By writing tests
