### PR TITLE
BE: Allow filtering by group properties in trends

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -6,7 +6,7 @@ from ee.clickhouse.models.util import PersonPropertiesMode
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Action, Entity, Filter
 from posthog.models.action_step import ActionStep
-from posthog.models.property import Property, PropertyName, PropertyType
+from posthog.models.property import Property, PropertyIdentifier, PropertyName, PropertyType
 
 
 def format_action_filter(
@@ -106,14 +106,14 @@ def format_entity_filter(entity: Entity, prepend: str = "action", filter_by_team
     return entity_filter, params
 
 
-def get_action_tables_and_properties(action: Action) -> Counter[Tuple[PropertyName, PropertyType]]:
+def get_action_tables_and_properties(action: Action) -> Counter[PropertyIdentifier]:
     from ee.clickhouse.models.property import extract_tables_and_properties
 
-    result: Counter[Tuple[PropertyName, PropertyType]] = Counter()
+    result: Counter[PropertyIdentifier] = Counter()
 
     for action_step in action.steps.all():
         if action_step.url:
-            result[("$current_url", "event")] += 1
+            result[("$current_url", "event", None)] += 1
         result += extract_tables_and_properties(Filter(data={"properties": action_step.properties or []}).properties)
 
     return result

--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -1,0 +1,31 @@
+import datetime
+import json
+from typing import Dict, Optional
+
+from django.utils.timezone import now
+
+from ee.clickhouse.sql.groups import INSERT_GROUP_SQL
+from ee.kafka_client.client import ClickhouseProducer
+from ee.kafka_client.topics import KAFKA_GROUPS
+
+
+def create_group(
+    team_id: int,
+    group_type_index: int,
+    group_key: str,
+    properties: Optional[Dict] = {},
+    timestamp: Optional[datetime.datetime] = None,
+):
+    if not timestamp:
+        timestamp = now()
+
+    data = {
+        "group_type_index": group_type_index,
+        "group_key": group_key,
+        "team_id": team_id,
+        "group_properties": json.dumps(properties),
+        "created_at": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
+        "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    p = ClickhouseProducer()
+    p.produce(topic=KAFKA_GROUPS, sql=INSERT_GROUP_SQL, data=data)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -25,7 +25,14 @@ from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_
 from ee.clickhouse.sql.person import GET_DISTINCT_IDS_BY_PERSON_ID_FILTER, GET_DISTINCT_IDS_BY_PROPERTY_SQL
 from posthog.models.cohort import Cohort
 from posthog.models.event import Selector
-from posthog.models.property import NEGATED_OPERATORS, OperatorType, Property, PropertyName, PropertyType
+from posthog.models.property import (
+    NEGATED_OPERATORS,
+    OperatorType,
+    Property,
+    PropertyIdentifier,
+    PropertyName,
+    PropertyType,
+)
 from posthog.models.team import Team
 from posthog.utils import is_valid_regex, relative_date_parse
 
@@ -382,5 +389,5 @@ def build_selector_regex(selector: Selector) -> str:
     return regex
 
 
-def extract_tables_and_properties(props: List[Property]) -> Counter[Tuple[PropertyName, PropertyType]]:
-    return Counter((prop.key, prop.type) for prop in props)
+def extract_tables_and_properties(props: List[Property]) -> Counter[PropertyIdentifier]:
+    return Counter((prop.key, prop.type, prop.group_type_index) for prop in props)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -106,6 +106,14 @@ def parse_prop_clauses(
 
             final.append(f"{filter_query} AND {table_name}team_id = %(team_id)s" if team_id else filter_query)
             params.update(filter_params)
+        elif prop.type == "group":
+            # :TRICKY: This assumes group properties have already been joined, as in trends query
+            filter_query, filter_params = prop_filter_json_extract(
+                prop, idx, prepend, prop_var=f"group_properties_{prop.group_type_index}", allow_denormalized_props=False
+            )
+
+            final.append(filter_query)
+            params.update(filter_params)
         elif prop.type in ("static-cohort", "precalculated-cohort"):
             cohort_id = cast(int, prop.value)
 
@@ -240,6 +248,8 @@ def property_table(property: Property) -> TableWithProperties:
         return "events"
     elif property.type == "person":
         return "person"
+    elif property.type == "group":
+        return "groups"
     else:
         raise ValueError(f"Property type does not have a table: {property.type}")
 

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -46,6 +46,11 @@ class ColumnOptimizer:
         return len(self._used_properties_with_type("person")) > 0
 
     @cached_property
+    def group_types_to_query(self) -> Set[GroupTypeIndex]:
+        used_properties = self._used_properties_with_type("group")
+        return set(group_type_index for _, _, group_type_index in used_properties)
+
+    @cached_property
     def should_query_elements_chain_column(self) -> bool:
         "Returns whether this query uses elements_chain"
         has_element_type_property = lambda properties: any(prop.type == "element" for prop in properties)

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -1,4 +1,4 @@
-from typing import Counter, List, Set, Tuple, Union, cast
+from typing import Counter, List, Set, Union, cast
 
 from ee.clickhouse.materialized_columns.columns import ColumnName, get_materialized_columns
 from ee.clickhouse.models.action import get_action_tables_and_properties, uses_elements_chain
@@ -9,7 +9,7 @@ from posthog.models.filters import Filter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
-from posthog.models.property import PropertyName, PropertyType, TableWithProperties
+from posthog.models.property import GroupTypeIndex, PropertyIdentifier, PropertyType, TableWithProperties
 
 
 class ColumnOptimizer:
@@ -35,13 +35,11 @@ class ColumnOptimizer:
 
         return self.columns_to_query("person", set(self._used_properties_with_type("person")))
 
-    def columns_to_query(
-        self, table: TableWithProperties, used_properties: Set[Tuple[PropertyName, PropertyType]]
-    ) -> Set[ColumnName]:
+    def columns_to_query(self, table: TableWithProperties, used_properties: Set[PropertyIdentifier]) -> Set[ColumnName]:
         "Transforms a list of property names to what columns are needed for that query"
 
         materialized_columns = get_materialized_columns(table)
-        return set(materialized_columns.get(property_name, "properties") for property_name, _ in used_properties)
+        return set(materialized_columns.get(property_name, "properties") for property_name, _, _ in used_properties)
 
     @cached_property
     def is_using_person_properties(self) -> bool:
@@ -70,9 +68,9 @@ class ColumnOptimizer:
         return False
 
     @cached_property
-    def properties_used_in_filter(self) -> Counter[Tuple[PropertyName, PropertyType]]:
+    def properties_used_in_filter(self) -> Counter[PropertyIdentifier]:
         "Returns collection of properties + types that this query would use"
-        counter: Counter[Tuple[PropertyName, PropertyType]] = extract_tables_and_properties(self.filter.properties)
+        counter: Counter[PropertyIdentifier] = extract_tables_and_properties(self.filter.properties)
 
         # Some breakdown types read properties
         #
@@ -81,7 +79,7 @@ class ColumnOptimizer:
         if self.filter.breakdown_type in ["event", "person"]:
             # :TRICKY: We only support string breakdown for event/person properties
             assert isinstance(self.filter.breakdown, str)
-            counter[(self.filter.breakdown, self.filter.breakdown_type)] += 1
+            counter[(self.filter.breakdown, self.filter.breakdown_type, None)] += 1
 
         # Both entities and funnel exclusions can contain nested property filters
         for entity in self.filter.entities + cast(List[Entity], self.filter.exclusions):
@@ -91,7 +89,7 @@ class ColumnOptimizer:
             #
             # See ee/clickhouse/queries/trends/util.py#process_math
             if entity.math_property:
-                counter[(entity.math_property, "event")] += 1
+                counter[(entity.math_property, "event", None)] += 1
 
             # :TRICKY: If action contains property filters, these need to be included
             #
@@ -101,15 +99,15 @@ class ColumnOptimizer:
 
         if self.filter.correlation_type == FunnelCorrelationType.PROPERTIES and self.filter.correlation_property_names:
             for prop_value in self.filter.correlation_property_names:
-                counter[(prop_value, "person")] += 1
+                counter[(prop_value, "person", None)] += 1
 
         return counter
 
-    def _used_properties_with_type(self, property_type: PropertyType) -> Counter[Tuple[PropertyName, PropertyType]]:
+    def _used_properties_with_type(self, property_type: PropertyType) -> Counter[PropertyIdentifier]:
         return Counter(
             {
-                (name, type): count
-                for (name, type), count in self.properties_used_in_filter.items()
+                (name, type, group_type_index): count
+                for (name, type, group_type_index), count in self.properties_used_in_filter.items()
                 if type == property_type
             }
         )

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -48,7 +48,7 @@ class ColumnOptimizer:
     @cached_property
     def group_types_to_query(self) -> Set[GroupTypeIndex]:
         used_properties = self._used_properties_with_type("group")
-        return set(group_type_index for _, _, group_type_index in used_properties)
+        return set(cast(int, group_type_index) for _, _, group_type_index in used_properties)
 
     @cached_property
     def should_query_elements_chain_column(self) -> bool:

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -1,0 +1,101 @@
+# name: TestEventQuery.test_basic_event_filter
+  '
+  
+  SELECT e.timestamp as timestamp
+  FROM events e
+  WHERE team_id = %(team_id)s
+    AND event = %(event)s
+    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime(%(date_from)s))
+    AND timestamp <= %(date_to)s
+  '
+---
+# name: TestEventQuery.test_basic_event_filter.1
+  <class 'dict'> {
+    'date_from': '2021-05-01 00:00:00',
+    'date_to': '2021-05-07 23:59:59',
+    'event': 'viewed',
+  }
+---
+# name: TestEventQuery.test_denormalised_props
+  '
+  
+  SELECT e.timestamp as timestamp,
+         e.mat_test_prop as mat_test_prop
+  FROM events e
+  WHERE team_id = %(team_id)s
+    AND event = %(event)s
+    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime(%(date_from)s))
+    AND timestamp <= %(date_to)s
+    AND has(%(vglobal_0_0)s, mat_test_prop)
+    AND team_id = %(team_id)s
+    AND has(%(vglobal_1_0)s, mat_test_prop)
+    AND team_id = %(team_id)s
+  '
+---
+# name: TestEventQuery.test_denormalised_props.1
+  <class 'dict'> {
+    'date_from': '2020-01-01 00:00:00',
+    'date_to': '2020-01-14 23:59:59',
+    'event': 'user signed up',
+    'kglobal_0_0': 'test_prop',
+    'kglobal_1_0': 'test_prop',
+    'vglobal_0_0': <class 'list'> [
+      'hi',
+    ],
+    'vglobal_1_0': <class 'list'> [
+      'hi',
+    ],
+  }
+---
+# name: TestEventQuery.test_groups_filters
+  '
+  
+  SELECT e.timestamp as timestamp
+  FROM events e
+  INNER JOIN
+    (SELECT group_key,
+            argMax(group_properties, _timestamp) AS group_properties_0
+     FROM groups
+     WHERE team_id = %(team_id)s
+       AND group_type_index = %(group_index_0)s
+     GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+  INNER JOIN
+    (SELECT group_key,
+            argMax(group_properties, _timestamp) AS group_properties_1
+     FROM groups
+     WHERE team_id = %(team_id)s
+       AND group_type_index = %(group_index_1)s
+     GROUP BY group_key) groups_1 ON JSONExtractString(properties, '$group_1') == groups_1.group_key
+  WHERE team_id = %(team_id)s
+    AND event = %(event)s
+    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime(%(date_from)s))
+    AND timestamp <= %(date_to)s
+    AND has(%(vglobal_0_0)s, trim(BOTH '"'
+                                  FROM JSONExtractRaw(group_properties_0, %(kglobal_0_0)s)))
+    AND has(%(vglobal_1_0)s, trim(BOTH '"'
+                                  FROM JSONExtractRaw(group_properties_0, %(kglobal_1_0)s)))
+    AND has(%(vglobal_2_0)s, trim(BOTH '"'
+                                  FROM JSONExtractRaw(group_properties_1, %(kglobal_2_0)s)))
+  '
+---
+# name: TestEventQuery.test_groups_filters.1
+  <class 'dict'> {
+    'date_from': '2020-01-01 00:00:00',
+    'date_to': '2020-01-12 23:59:59',
+    'event': '$pageview',
+    'group_index_0': 0,
+    'group_index_1': 1,
+    'kglobal_0_0': 'industry',
+    'kglobal_1_0': 'key',
+    'kglobal_2_0': 'another',
+    'vglobal_0_0': <class 'list'> [
+      'finance',
+    ],
+    'vglobal_1_0': <class 'list'> [
+      'value',
+    ],
+    'vglobal_2_0': <class 'list'> [
+      'value',
+    ],
+  }
+---

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -163,3 +163,11 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             ColumnOptimizer(filter, self.team.id).should_query_elements_chain_column, True,
         )
+
+    def group_types_to_query(self):
+        group_types_to_query = lambda filter: ColumnOptimizer(
+            filter, self.team.id
+        ).group_types_to_query
+
+        self.assertEqual(group_types_to_query(BASE_FILTER), set())
+        self.assertEqual(group_types_to_query(FILTER_WITH_PROPERTIES), {2})

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -165,9 +165,7 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         )
 
     def group_types_to_query(self):
-        group_types_to_query = lambda filter: ColumnOptimizer(
-            filter, self.team.id
-        ).group_types_to_query
+        group_types_to_query = lambda filter: ColumnOptimizer(filter, self.team.id).group_types_to_query
 
         self.assertEqual(group_types_to_query(BASE_FILTER), set())
         self.assertEqual(group_types_to_query(FILTER_WITH_PROPERTIES), {2})

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -10,6 +10,7 @@ PROPERTIES_OF_ALL_TYPES = [
     {"key": "person_prop", "value": "efg", "type": "person"},
     {"key": "id", "value": 1, "type": "cohort"},
     {"key": "tag_name", "value": ["label"], "operator": "exact", "type": "element"},
+    {"key": "group_prop", "value": ["value"], "operator": "exact", "type": "group", "group_type_index": 2},
 ]
 
 BASE_FILTER = Filter({"events": [{"id": "$pageview", "type": "events", "order": 0}]})
@@ -28,15 +29,21 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(properties_used_in_filter(BASE_FILTER), {})
         self.assertEqual(
             properties_used_in_filter(FILTER_WITH_PROPERTIES),
-            {("event_prop", "event"): 1, ("person_prop", "person"): 1, ("id", "cohort"): 1, ("tag_name", "element"): 1},
+            {
+                ("event_prop", "event", None): 1,
+                ("person_prop", "person", None): 1,
+                ("id", "cohort", None): 1,
+                ("tag_name", "element", None): 1,
+                ("group_prop", "group", 2): 1,
+            },
         )
 
         # Breakdown cases
         filter = BASE_FILTER.with_data({"breakdown": "some_prop", "breakdown_type": "person"})
-        self.assertEqual(properties_used_in_filter(filter), {("some_prop", "person"): 1})
+        self.assertEqual(properties_used_in_filter(filter), {("some_prop", "person", None): 1})
 
         filter = BASE_FILTER.with_data({"breakdown": "some_prop", "breakdown_type": "event"})
-        self.assertEqual(properties_used_in_filter(filter), {("some_prop", "event"): 1})
+        self.assertEqual(properties_used_in_filter(filter), {("some_prop", "event", None): 1})
 
         filter = BASE_FILTER.with_data({"breakdown": [11], "breakdown_type": "cohort"})
         self.assertEqual(properties_used_in_filter(filter), {})
@@ -50,7 +57,9 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         filter = BASE_FILTER.with_data(
             {"funnel_correlation_type": "properties", "funnel_correlation_names": ["random_column", "$browser"]}
         )
-        self.assertEqual(properties_used_in_filter(filter), {("random_column", "person"): 1, ("$browser", "person"): 1})
+        self.assertEqual(
+            properties_used_in_filter(filter), {("random_column", "person", None): 1, ("$browser", "person", None): 1}
+        )
 
         filter = BASE_FILTER.with_data({"funnel_correlation_type": "properties"})
         self.assertEqual(properties_used_in_filter(filter), {})
@@ -72,11 +81,12 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             properties_used_in_filter(filter),
             {
-                ("numeric_prop", "event"): 1,
-                ("event_prop", "event"): 1,
-                ("person_prop", "person"): 1,
-                ("id", "cohort"): 1,
-                ("tag_name", "element"): 1,
+                ("numeric_prop", "event", None): 1,
+                ("event_prop", "event", None): 1,
+                ("person_prop", "person", None): 1,
+                ("id", "cohort", None): 1,
+                ("tag_name", "element", None): 1,
+                ("group_prop", "group", 2): 1,
             },
         )
 
@@ -96,13 +106,13 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
         filter = Filter(data={"actions": [{"id": action.id, "math": "dau"}]})
         self.assertEqual(
             ColumnOptimizer(filter, self.team.id).properties_used_in_filter,
-            {("$current_url", "event"): 1, ("$browser", "person"): 1},
+            {("$current_url", "event", None): 1, ("$browser", "person", None): 1},
         )
 
         filter = BASE_FILTER.with_data({"exclusions": [{"id": action.id, "type": "actions"}]})
         self.assertEqual(
             ColumnOptimizer(filter, self.team.id).properties_used_in_filter,
-            {("$current_url", "event"): 1, ("$browser", "person"): 1},
+            {("$current_url", "event", None): 1, ("$browser", "person", None): 1},
         )
 
     def test_materialized_columns_checks(self):

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.models.event import create_event
+from ee.clickhouse.models.group import create_group
 from ee.clickhouse.models.person import create_person_distinct_id
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
 from ee.clickhouse.queries.trends.person import TrendsPersonQuery
@@ -14,6 +15,7 @@ from posthog.models.action import Action
 from posthog.models.action_step import ActionStep
 from posthog.models.cohort import Cohort
 from posthog.models.filters import Filter
+from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.person import Person
 from posthog.queries.test.test_trends import trend_test_factory
 from posthog.test.base import test_with_materialized_columns
@@ -827,3 +829,48 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             ClickhouseTrends().run(
                 Filter(data={"events": [{"id": "sign up", "math": "sum"}]}), self.team,
             )
+
+    def test_filtering_with_group_props(self):
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
+        create_group(
+            team_id=self.team.pk, group_type_index=1, group_key="company:10", properties={"industry": "finance"}
+        )
+
+        _create_event(
+            event="$pageview",
+            distinct_id="person1",
+            team=self.team,
+            properties={"$group_0": "org:5"},
+            timestamp="2020-01-02T12:00:00Z",
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="person1",
+            team=self.team,
+            properties={"$group_0": "org:6"},
+            timestamp="2020-01-02T12:00:00Z",
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="person1",
+            team=self.team,
+            properties={"$group_0": "org:6", "$group_1": "company:10"},
+            timestamp="2020-01-02T12:00:00Z",
+        )
+
+        filter = Filter(
+            {
+                "date_from": "2020-01-01T00:00:00Z",
+                "date_to": "2020-01-12T00:00:00Z",
+                "events": [{"id": "$pageview", "type": "events", "order": 0}],
+                "properties": [{"key": "industry", "value": "finance", "type": "group", "group_type_index": 0}],
+            },
+            team=self.team,
+        )
+
+        response = ClickhouseTrends().run(filter, self.team)
+        self.assertEqual(response[0]["count"], 1)

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -61,10 +61,14 @@ class TrendsEventQuery(ClickhouseEventQuery):
         person_query, person_params = self._get_person_query()
         self.params.update(person_params)
 
+        groups_query, groups_params = self._get_groups_query()
+        self.params.update(groups_params)
+
         query = f"""
             SELECT {_fields} FROM events {self.EVENT_TABLE_ALIAS}
             {self._get_disintct_id_query()}
             {person_query}
+            {groups_query}
             WHERE team_id = %(team_id)s
             {entity_query}
             {date_query}

--- a/ee/clickhouse/sql/groups.py
+++ b/ee/clickhouse/sql/groups.py
@@ -54,3 +54,9 @@ FROM {CLICKHOUSE_DATABASE}.kafka_{GROUPS_TABLE}
 
 # { ..., "group_0": 1325 }
 # To join with events join using JSONExtractString(events.properties, "$group_{group_type_index}")
+
+DROP_GROUPS_TABLE_SQL = f"DROP TABLE IF EXISTS {GROUPS_TABLE} ON CLUSTER {CLICKHOUSE_CLUSTER}"
+
+INSERT_GROUP_SQL = """
+INSERT INTO groups (group_type_index, group_key, team_id, group_properties, created_at, _timestamp, _offset) SELECT %(group_type_index)s, %(group_key)s, %(team_id)s, %(group_properties)s, %(created_at)s, %(_timestamp)s, 0
+"""

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -25,6 +25,7 @@ def reset_clickhouse_tables():
     from ee.clickhouse.sql.cohort import CREATE_COHORTPEOPLE_TABLE_SQL, DROP_COHORTPEOPLE_TABLE_SQL
     from ee.clickhouse.sql.dead_letter_queue import DEAD_LETTER_QUEUE_TABLE_SQL, DROP_DEAD_LETTER_QUEUE_TABLE_SQL
     from ee.clickhouse.sql.events import DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
+    from ee.clickhouse.sql.groups import DROP_GROUPS_TABLE_SQL, GROUPS_TABLE_SQL
     from ee.clickhouse.sql.person import (
         DROP_PERSON_DISTINCT_ID_TABLE_SQL,
         DROP_PERSON_STATIC_COHORT_TABLE_SQL,
@@ -51,6 +52,7 @@ def reset_clickhouse_tables():
         (DROP_KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL, KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL),
         (DROP_DEAD_LETTER_QUEUE_TABLE_SQL, DEAD_LETTER_QUEUE_TABLE_SQL),
         (DROP_DEAD_LETTER_QUEUE_TABLE_MV_SQL, DEAD_LETTER_QUEUE_TABLE_MV_SQL),
+        (DROP_GROUPS_TABLE_SQL, GROUPS_TABLE_SQL),
     ]
     for item in TABLES_TO_CREATE_DROP:
         sync_execute(item[0])

--- a/ee/conftest.py
+++ b/ee/conftest.py
@@ -103,3 +103,9 @@ def base_test_mixin_fixture():
 @pytest.fixture
 def team(base_test_mixin_fixture):
     return base_test_mixin_fixture.team
+
+
+# :TRICKY: Integrate syrupy with unittest test cases
+@pytest.fixture
+def unittest_snapshot(request, snapshot):
+    request.cls.snapshot = snapshot

--- a/posthog/models/entity.py
+++ b/posthog/models/entity.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, Counter, Dict, Literal, Optional, Union
 
 from django.conf import settings
 from rest_framework.exceptions import ValidationError
@@ -89,12 +89,10 @@ class Entity(PropertyMixin):
     def is_superset(self, other) -> bool:
         """ Checks if this entity is a superset version of other. The ids match and the properties of (this) is a subset of the properties of (other)"""
 
-        self_properties = sorted([str(prop) for prop in self.properties])
-        other_properties = sorted([str(prop) for prop in other.properties])
+        self_properties = Counter([str(prop) for prop in self.properties])
+        other_properties = Counter([str(prop) for prop in other.properties])
 
-        num_matched_props = sum([1 for x, y in zip(self_properties, other_properties) if x == y])
-
-        return self.id == other.id and num_matched_props == len(self_properties)
+        return self.id == other.id and len(self_properties - other_properties) == 0
 
     def get_action(self) -> Action:
         if self.type != TREND_FILTER_TYPE_ACTIONS:

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 from django.db.models import Exists, OuterRef, Q
 
@@ -13,9 +13,10 @@ OperatorType = Literal[
     "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
 ]
 
+GroupTypeIndex = Optional[int]
+PropertyIdentifier = Tuple[PropertyName, PropertyType, GroupTypeIndex]
+
 NEGATED_OPERATORS = ["is_not", "not_icontains", "not_regex", "is_not_set"]
-
-
 CLICKHOUSE_ONLY_PROPERTY_TYPES = ["static-cohort", "precalculated-cohort", "group"]
 
 

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -73,6 +73,9 @@ class Property:
     def property_to_Q(self) -> Q:
         from .cohort import CohortPeople
 
+        if self.type in CLICKHOUSE_ONLY_PROPERTY_TYPES:
+            raise ValueError(f"property_to_Q: type is not supported: {repr(self.type)}")
+
         value = self._parse_value(self.value)
         if self.type == "cohort":
             cohort_id = int(cast(Union[str, int], value))

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -18,6 +18,7 @@ NEGATED_OPERATORS = ["is_not", "not_icontains", "not_regex", "is_not_set"]
 
 CLICKHOUSE_ONLY_PROPERTY_TYPES = ["static-cohort", "precalculated-cohort", "group"]
 
+
 class Property:
     key: str
     operator: Optional[OperatorType]
@@ -42,7 +43,7 @@ class Property:
         self.group_type_index = group_type_index
 
     def __repr__(self):
-        params_repr = ", ".join(f"{key}={repr(value)}" for key, value in self.to_dict())
+        params_repr = ", ".join(f"{key}={repr(value)}" for key, value in self.to_dict().items())
         return f"Property({params_repr})"
 
     def to_dict(self) -> Dict[str, Any]:

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -8,7 +8,7 @@ from posthog.utils import is_valid_regex
 ValueT = Union[str, int, List[str]]
 PropertyType = Literal["event", "person", "cohort", "element", "static-cohort", "precalculated-cohort", "group"]
 PropertyName = str
-TableWithProperties = Literal["events", "person"]
+TableWithProperties = Literal["events", "person", "groups"]
 OperatorType = Literal[
     "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
 ]

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -13,8 +13,8 @@ OperatorType = Literal[
     "exact", "is_not", "icontains", "not_icontains", "regex", "not_regex", "gt", "lt", "is_set", "is_not_set",
 ]
 
-GroupTypeIndex = Optional[int]
-PropertyIdentifier = Tuple[PropertyName, PropertyType, GroupTypeIndex]
+GroupTypeIndex = int
+PropertyIdentifier = Tuple[PropertyName, PropertyType, Optional[GroupTypeIndex]]
 
 NEGATED_OPERATORS = ["is_not", "not_icontains", "not_regex", "is_not_set"]
 CLICKHOUSE_ONLY_PROPERTY_TYPES = ["static-cohort", "precalculated-cohort", "group"]

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -1,5 +1,14 @@
 import json
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from django.db.models import Exists, OuterRef, Q
 


### PR DESCRIPTION
## Changes

This PR allows FE to send properties with `type: 'group'` and `group_type_index: N` to backend and get back results for trends.

## How did you test this code?

See unit tests