### PR TITLE
Only load correlations for Funnels

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1100,7 +1100,7 @@ export const funnelLogic = kea<funnelLogicType>({
 
     events: ({ values, actions }) => ({
         afterMount: () => {
-            if (featureFlagLogic.values.featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS]) {
+            if (featureFlagLogic.values.featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] && values.insight.filters?.insight === ViewType.FUNNELS) {
                 actions.setPropertyNames(values.allProperties)
             }
         },

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1100,7 +1100,10 @@ export const funnelLogic = kea<funnelLogicType>({
 
     events: ({ values, actions }) => ({
         afterMount: () => {
-            if (featureFlagLogic.values.featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] && values.insight.filters?.insight === ViewType.FUNNELS) {
+            if (
+                featureFlagLogic.values.featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] &&
+                values.insight.filters?.insight === ViewType.FUNNELS
+            ) {
                 actions.setPropertyNames(values.allProperties)
             }
         },


### PR DESCRIPTION

Our dashboards currently always load `funnelLogic` ( https://github.com/PostHog/posthog/issues/6118 ) - which means we load property correlations on dashboards, which leads to errors like:

![image (3)](https://user-images.githubusercontent.com/7115141/139691221-6036ca03-a4f1-464c-afaf-5a6dd0f53ce0.png)
 : Property Correlations errors on Dashboards with no funnels


## How did you test this code?

Locally running & seeing no correlation requests
