### PR TITLE
Set conversion window on api response when editing a funnel

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -1,5 +1,5 @@
 import { funnelLogic } from './funnelLogic'
-import { api, defaultAPIMocks, mockAPI, MOCK_TEAM_ID } from 'lib/api.mock'
+import { api, defaultAPIMocks, MOCK_TEAM_ID, mockAPI } from 'lib/api.mock'
 import posthog from 'posthog-js'
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTestLogic } from '~/test/init'
@@ -8,7 +8,13 @@ import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { funnelsModel } from '~/models/funnelsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
-import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType, ViewType } from '~/types'
+import {
+    FunnelConversionWindowTimeUnit,
+    FunnelCorrelation,
+    FunnelCorrelationResultsType,
+    FunnelCorrelationType,
+    ViewType,
+} from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 jest.mock('lib/api')
@@ -354,6 +360,38 @@ describe('funnelLogic', () => {
                     second_value: '1.2',
                 })
             })
+        })
+    })
+
+    describe('conversion window filter', () => {
+        it('initially is 14 days', async () => {
+            await expectLogic(logic)
+                .toFinishListeners()
+                .toMatchValues({
+                    conversionWindow: {
+                        funnel_window_interval: 14,
+                        funnel_window_interval_unit: 'day',
+                    },
+                })
+        })
+
+        it('are updated when results are loaded', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadResultsSuccess({
+                    filters: {
+                        insight: ViewType.FUNNELS,
+                        funnel_window_interval: 7,
+                        funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Week,
+                    },
+                })
+            })
+                .toFinishListeners()
+                .toMatchValues({
+                    conversionWindow: {
+                        funnel_window_interval: 7,
+                        funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Week,
+                    },
+                })
         })
     })
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -241,6 +241,11 @@ export const funnelLogic = kea<funnelLogicType>({
                         ...(funnel_window_interval ? { funnel_window_interval } : {}),
                     }
                 },
+                loadResultsSuccess: (state, { insight }) => ({
+                    funnel_window_interval_unit:
+                        insight.filters?.funnel_window_interval_unit || state.funnel_window_interval_unit,
+                    funnel_window_interval: insight.filters?.funnel_window_interval || state.funnel_window_interval,
+                }),
             },
         ],
         stepReference: [

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
@@ -1,7 +1,7 @@
 import { InputNumber, Row, Select } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { pluralize } from 'lib/utils'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelConversionWindow, FunnelConversionWindowTimeUnit } from '~/types'
@@ -23,6 +23,10 @@ export function FunnelConversionWindowFilter(): JSX.Element {
     const { setConversionWindow } = useActions(funnelLogic(insightProps))
     const [localConversionWindow, setLocalConversionWindow] = useState<FunnelConversionWindow>(conversionWindow)
     const timeUnitRef: React.RefObject<RefSelectProps> | null = useRef(null)
+
+    useEffect(() => {
+        setLocalConversionWindow(conversionWindow)
+    }, [conversionWindow])
 
     const options = Object.keys(TIME_INTERVAL_BOUNDS).map((unit) => ({
         label: pluralize(conversionWindow.funnel_window_interval ?? 7, unit, `${unit}s`, false),


### PR DESCRIPTION
## Changes

A user reported that the conversion window limit always showed as fourteen days even though the API response was correct

This change updates the conversion window when the API response succeeds

### Before

![2021-11-01 15 18 09](https://user-images.githubusercontent.com/984817/139695912-70335b27-6c6f-4afd-a25f-6bdfcfc93a63.gif)

### After

![2021-11-01 15 19 13](https://user-images.githubusercontent.com/984817/139695951-36b0560c-a68e-4af7-ba1d-9a819b6215d9.gif)

## How did you test this code?

unit tests and running locally
