### PR TITLE
Some more test speed improvements

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -156,8 +156,7 @@ jobs:
 
             - name: Start stack with Docker Compose
               run: |
-                docker-compose -f ee/docker-compose.ch.yml up -d db
-                ${{ matrix.foss && '' || 'docker-compose -f ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka &' }}
+                docker-compose -f ee/docker-compose.ch.yml up -d ${{ matrix.foss && 'db' || 'clickhouse zookeeper kafka' }}
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
@@ -275,8 +274,7 @@ jobs:
                   cat requirements.txt >> deploy/requirements.txt
             - name: Start stack with Docker Compose
               run: |
-                docker-compose -f ee/docker-compose.ch.yml up -d db
-                docker-compose -f ee/docker-compose.ch.yml up -d clickhouse zookeeper kafka &
+                docker-compose -f ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
             - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -80,13 +80,12 @@ jobs:
               run: sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - uses: syphar/restore-virtualenv@v1.2
-              id: cache-backend-tests-saml
+              id: cache-backend-tests
 
             - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests-saml.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests-saml.outputs.cache-hit != 'true'
               run: |
                   python -m pip install -r requirements-dev.txt
                   python -m pip install -r requirements.txt
@@ -156,8 +155,9 @@ jobs:
                   fetch-depth: 1
 
             - name: Start stack with Docker Compose
-              run: docker-compose -f ee/docker-compose.ch.yml up -d ${{ matrix.foss && 'db' || 'db clickhouse zookeeper kafka' }}
-
+              run: |
+                docker-compose -f ee/docker-compose.ch.yml up -d db
+                ${{ matrix.foss && '' || 'docker-compose -f ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka &' }}
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
@@ -274,7 +274,9 @@ jobs:
                   cat multi_tenancy_settings.py >> deploy/posthog/settings.py
                   cat requirements.txt >> deploy/requirements.txt
             - name: Start stack with Docker Compose
-              run: docker-compose -f deploy/ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
+              run: |
+                docker-compose -f ee/docker-compose.ch.yml up -d db
+                docker-compose -f ee/docker-compose.ch.yml up -d clickhouse zookeeper kafka &
             - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,17 +49,16 @@ jobs:
                   python-version: 3.8
 
             - uses: syphar/restore-virtualenv@v1.2
-              id: cache-virtualenv
+              id: cache-backend-tests
               with:
                   requirement_files: requirements.txt # this is optional
             - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
             - name: Install python dependencies
-              if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  python -m pip install --upgrade pip
-                  python -m pip install $(grep -ivE "psycopg2" requirements.txt | cut -d'#' -f1) --no-cache-dir --compile
-                  python -m pip install psycopg2-binary --no-cache-dir --compile
+                  python -m pip install -r requirements-dev.txt
+                  python -m pip install -r requirements.txt
             - uses: actions/setup-node@v1
               with:
                   node-version: 14


### PR DESCRIPTION
## Changes

Salvaged from #6171. 
- ~Don't wait for clickhouse, kafka and zookeeper for a speed bump~ this didn't work
- The github cache is super small so to increase cache hits remove the saml cache and use the one cache as a cache filler
- Don't have a separate virtualenv cache for e2e either.
## How did you test this code?

See if tests pass quicker than other prs
