### PR TITLE
Disable Storybook previews on forks

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
     storybook-chromatic:
         runs-on: ubuntu-latest
+        if: github.repository == 'PostHog/posthog'
         steps:
             - uses: actions/checkout@v1
 


### PR DESCRIPTION
## Changes

Running Storybook previews with Chromatic requires a secret token to be passed. To avoid potential secret leaks, we disable this check if running from an external fork. This will unblock contributors PR's tests from passing (though we still have the Cypress parallelization issue). 
 
## How did you test this code?

Testing as workflow runs.
