### PR TITLE
Adds basic functionality to filter plugin logs by log type

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import { ActionType, CohortType, FilterType, PersonType, PluginLogEntry, TeamTyp
 import { getCurrentTeamId } from './utils/logics'
 import { CheckboxValueType } from 'antd/lib/checkbox/Group'
 import { LOGS_PORTION_LIMIT } from 'scenes/plugins/plugin/pluginLogsLogic'
+import { toParams } from 'lib/utils'
 
 export interface PaginatedResponse<T> {
     results: T[]
@@ -213,17 +214,21 @@ const api = {
             trailingEntry: PluginLogEntry | null = null,
             leadingEntry: PluginLogEntry | null = null
         ): Promise<PluginLogEntry[]> {
-            const type_filters =
-                typeFilters && typeFilters.length > 0 ? `&type_filter=${typeFilters.join('&type_filter=')}` : ''
-            const search = searchTerm ? `&search=${searchTerm}` : ''
-            const before = trailingEntry ? '&before=' + trailingEntry.timestamp : ''
-            const after = leadingEntry ? '&after=' + leadingEntry.timestamp : ''
-            const queryParams = `?limit=${LOGS_PORTION_LIMIT}${before}${after}${search}${type_filters}`
+            const params = toParams(
+                {
+                    limit: LOGS_PORTION_LIMIT,
+                    type_filter: typeFilters,
+                    search: searchTerm || '',
+                    before: trailingEntry?.timestamp || '',
+                    after: leadingEntry?.timestamp || '',
+                },
+                true
+            )
 
             const response = await new ApiRequest()
                 .projectsDetail(currentTeamId || undefined)
                 .pluginLogs(pluginConfigId)
-                .withQueryString(queryParams)
+                .withQueryString(params)
                 .get()
 
             return response.results

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -218,9 +218,9 @@ const api = {
                 {
                     limit: LOGS_PORTION_LIMIT,
                     type_filter: typeFilters,
-                    search: searchTerm || '',
-                    before: trailingEntry?.timestamp || '',
-                    after: leadingEntry?.timestamp || '',
+                    search: searchTerm || undefined,
+                    before: trailingEntry?.timestamp,
+                    after: leadingEntry?.timestamp,
                 },
                 true
             )

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -35,9 +35,9 @@ describe('toParams', () => {
         expect(left).toEqual(right)
     })
 
-    it('does not send empty string', () => {
-        const actual = toParams({ include: 'tomat', exclude: '' })
-        expect(actual).toEqual('include=tomat')
+    it('can handle numeric values', () => {
+        const actual = toParams({ a: 123 })
+        expect(actual).toEqual('a=123')
     })
 
     it('encodes arrays as a single query param', () => {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -34,6 +34,21 @@ describe('toParams', () => {
         const right = toParams({ a: 'b', ...{}, ...{}, b: 'c' })
         expect(left).toEqual(right)
     })
+
+    it('does not send empty string', () => {
+        const actual = toParams({ include: 'tomat', exclude: '' })
+        expect(actual).toEqual('include=tomat')
+    })
+
+    it('encodes arrays as a single query param', () => {
+        const actual = toParams({ include: ['a', 'b'] })
+        expect(actual).toEqual('include=%5B%22a%22%2C%22b%22%5D')
+    })
+
+    it('can explode arrays to individual parameters', () => {
+        const actual = toParams({ include: ['a', 'b'] }, true)
+        expect(actual).toEqual('include=a&include=b')
+    })
 })
 
 describe('capitalizeFirstLetter()', () => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -67,7 +67,7 @@ export function areObjectValuesEmpty(obj: Record<string, any>): boolean {
     )
 }
 
-export function toParams(obj: Record<string, any>): string {
+export function toParams(obj: Record<string, any>, explodeArrays: boolean = false): string {
     if (!obj) {
         return ''
     }
@@ -79,8 +79,19 @@ export function toParams(obj: Record<string, any>): string {
         val = typeof val === 'object' ? JSON.stringify(val) : val
         return encodeURIComponent(val)
     }
+
     return Object.entries(obj)
         .filter((item) => item[1] != undefined && item[1] != null)
+        .filter((item) => item[1].length > 0)
+        .reduce((acc, [key, val]) => {
+            if (explodeArrays && Array.isArray(val)) {
+                val.forEach((v) => acc.push([key, v]))
+            } else {
+                acc.push([key, val])
+            }
+
+            return acc
+        }, [] as [string, any][])
         .map(([key, val]) => `${key}=${handleVal(val)}`)
         .join('&')
 }

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -82,8 +82,14 @@ export function toParams(obj: Record<string, any>, explodeArrays: boolean = fals
 
     return Object.entries(obj)
         .filter((item) => item[1] != undefined && item[1] != null)
-        .filter((item) => item[1].length > 0)
         .reduce((acc, [key, val]) => {
+            /**
+             *  query parameter arrays can be handled in two ways
+             *  either they are encoded as a single query parameter
+             *    a=[1, 2] => a=%5B1%2C2%5D
+             *  or they are "exploded" so each item in the array is sent separately
+             *    a=[1, 2] => a=1&a=2
+             **/
             if (explodeArrays && Array.isArray(val)) {
                 val.forEach((v) => acc.push([key, v]))
             } else {

--- a/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
@@ -79,14 +79,15 @@ export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
                 />
             </Row>
             <Row>
-                <span>
-                    Show logs of type:&nbsp;
+                <Space>
+                    <span>Show logs of type:&nbsp;</span>
                     <Checkbox.Group
                         options={Object.values(PluginLogEntryType)}
                         value={pluginLogsTypes}
                         onChange={setPluginLogsTypes}
+                        style={{ marginLeft: '8px' }}
                     />
-                </span>
+                </Space>
             </Row>
             <Row>
                 <Button

--- a/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
@@ -1,4 +1,4 @@
-import { Button, Row, Space } from 'antd'
+import { Button, Checkbox, Row, Space } from 'antd'
 import Search from 'antd/lib/input/Search'
 import { LoadingOutlined } from '@ant-design/icons'
 import dayjs from 'dayjs'
@@ -66,7 +66,7 @@ export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
     const logic = pluginLogsLogic({ pluginConfigId })
 
     const { pluginLogs, pluginLogsLoading, pluginLogsBackground, isThereMoreToLoad } = useValues(logic)
-    const { revealBackground, loadPluginLogsMore, loadPluginLogsSearch } = useActions(logic)
+    const { revealBackground, loadPluginLogsMore, loadPluginLogsSearch, loadPluginLogsTypes } = useActions(logic)
 
     return (
         <Space direction="vertical" style={{ flexGrow: 1 }} className="ph-no-capture plugin-logs">
@@ -77,6 +77,16 @@ export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
                     placeholder="Search for messages containing…"
                     allowClear
                 />
+            </Row>
+            <Row>
+                <span>
+                    Show logs of type:&nbsp;
+                    <Checkbox.Group
+                        options={Object.values(PluginLogEntryType)}
+                        defaultValue={Object.values(PluginLogEntryType)}
+                        onChange={loadPluginLogsTypes}
+                    />
+                </span>
             </Row>
             <Row>
                 <Button

--- a/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
@@ -66,14 +66,14 @@ export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
     const logic = pluginLogsLogic({ pluginConfigId })
 
     const { pluginLogs, pluginLogsLoading, pluginLogsBackground, isThereMoreToLoad, pluginLogsTypes } = useValues(logic)
-    const { revealBackground, loadPluginLogsMore, loadPluginLogsSearch, setPluginLogsTypes } = useActions(logic)
+    const { revealBackground, loadPluginLogsMore, setPluginLogsTypes, setSearchTerm } = useActions(logic)
 
     return (
         <Space direction="vertical" style={{ flexGrow: 1 }} className="ph-no-capture plugin-logs">
             <Row>
                 <Search
                     loading={pluginLogsLoading}
-                    onSearch={(term) => loadPluginLogsSearch(term)}
+                    onSearch={setSearchTerm}
                     placeholder="Search for messages containing…"
                     allowClear
                 />

--- a/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
@@ -65,8 +65,8 @@ const columns: ResizableColumnType<PluginLogEntry>[] = [
 export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
     const logic = pluginLogsLogic({ pluginConfigId })
 
-    const { pluginLogs, pluginLogsLoading, pluginLogsBackground, isThereMoreToLoad } = useValues(logic)
-    const { revealBackground, loadPluginLogsMore, loadPluginLogsSearch, loadPluginLogsTypes } = useActions(logic)
+    const { pluginLogs, pluginLogsLoading, pluginLogsBackground, isThereMoreToLoad, pluginLogsTypes } = useValues(logic)
+    const { revealBackground, loadPluginLogsMore, loadPluginLogsSearch, setPluginLogsTypes } = useActions(logic)
 
     return (
         <Space direction="vertical" style={{ flexGrow: 1 }} className="ph-no-capture plugin-logs">
@@ -83,8 +83,8 @@ export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
                     Show logs of type:&nbsp;
                     <Checkbox.Group
                         options={Object.values(PluginLogEntryType)}
-                        defaultValue={Object.values(PluginLogEntryType)}
-                        onChange={loadPluginLogsTypes}
+                        value={pluginLogsTypes}
+                        onChange={setPluginLogsTypes}
                     />
                 </span>
             </Row>

--- a/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
+++ b/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import api from '~/lib/api'
-import { PluginLogEntry } from '~/types'
+import { PluginLogEntry, PluginLogEntryType } from '~/types'
 import { teamLogic } from '../../teamLogic'
 import { pluginLogsLogicType } from './pluginLogsLogicType'
 import { CheckboxValueType } from 'antd/lib/checkbox/Group'
@@ -42,6 +42,9 @@ export const pluginLogsLogic = kea<pluginLogsLogicType<PluginLogsProps>>({
     actions: {
         clearPluginLogsBackground: true,
         markLogsEnd: true,
+        setPluginLogsTypes: (typeFilters: CheckboxValueType[]) => ({
+            typeFilters,
+        }),
     },
 
     loaders: ({ props: { pluginConfigId }, values, actions, cache }) => ({
@@ -115,8 +118,18 @@ export const pluginLogsLogic = kea<pluginLogsLogicType<PluginLogsProps>>({
             },
         },
     }),
-
+    listeners: ({ actions }) => ({
+        setPluginLogsTypes: ({ typeFilters }) => {
+            actions.loadPluginLogsTypes(typeFilters)
+        },
+    }),
     reducers: {
+        pluginLogsTypes: [
+            Object.values(PluginLogEntryType),
+            {
+                setPluginLogsTypes: (_, { typeFilters }) => typeFilters.map((tf) => tf as PluginLogEntryType),
+            },
+        ],
         pluginLogsBackground: [
             [] as PluginLogEntry[],
             {

--- a/posthog/api/plugin_log_entry.py
+++ b/posthog/api/plugin_log_entry.py
@@ -50,6 +50,7 @@ class PluginLogEntryViewSet(StructuredViewSetMixin, mixins.ListModelMixin, views
 
         parents_query_dict = self.get_parents_query_dict()
 
+        type_filter = [PluginLogEntry.Type[t] for t in (self.request.GET.getlist("type_filter", []))]
         return fetch_plugin_log_entries(
             team_id=parents_query_dict["team_id"],
             plugin_config_id=parents_query_dict["plugin_config_id"],
@@ -57,4 +58,5 @@ class PluginLogEntryViewSet(StructuredViewSetMixin, mixins.ListModelMixin, views
             before=before,
             search=self.request.GET.get("search"),
             limit=limit,
+            type_filter=type_filter,
         )

--- a/posthog/test/test_plugin_log_entry.py
+++ b/posthog/test/test_plugin_log_entry.py
@@ -65,6 +65,49 @@ def factory_test_plugin_log_entry(plugin_log_entry_factory: Callable):
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0].message, "Something happened!")
 
+        def test_log_type_filter_works(self):
+            plugin_server_instance_id = str(UUIDT())
+
+            some_plugin: Plugin = Plugin.objects.create(organization=self.organization)
+            some_plugin_config: PluginConfig = PluginConfig.objects.create(plugin=some_plugin, order=1)
+
+            plugin_log_entry_factory(
+                team_id=self.team.pk,
+                plugin_id=some_plugin.pk,
+                plugin_config_id=some_plugin_config.pk,
+                source=PluginLogEntry.Source.CONSOLE,
+                type=PluginLogEntry.Type.INFO,
+                message="Something happened!",
+                instance_id=plugin_server_instance_id,
+            )
+            plugin_log_entry_factory(
+                team_id=self.team.pk,
+                plugin_id=some_plugin.pk,
+                plugin_config_id=some_plugin_config.pk,
+                source=PluginLogEntry.Source.CONSOLE,
+                type=PluginLogEntry.Type.ERROR,
+                message="Random error",
+                instance_id=plugin_server_instance_id,
+            )
+            plugin_log_entry_factory(
+                team_id=self.team.pk,
+                plugin_id=some_plugin.pk,
+                plugin_config_id=some_plugin_config.pk,
+                source=PluginLogEntry.Source.CONSOLE,
+                type=PluginLogEntry.Type.DEBUG,
+                message="debug message",
+                instance_id=plugin_server_instance_id,
+            )
+
+            results = fetch_plugin_log_entries(
+                plugin_config_id=some_plugin_config.pk,
+                type_filter=[PluginLogEntry.Type.ERROR, PluginLogEntry.Type.DEBUG],
+            )
+
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[0].message, "debug message")
+            self.assertEqual(results[1].message, "Random error")
+
         def test_log_limit_works(self):
             plugin_server_instance_id = str(UUIDT())
 


### PR DESCRIPTION
## Changes

A customer reported they found the plugin logs list noisy and suggested that filtering by type would help make the plugin logs view more useful. See #6743

This adds a set of checkboxes to the UI letting a user include or exclude logs based on their type

![2021-11-02 00 04 36](https://user-images.githubusercontent.com/984817/139758370-f9bc063a-bb6a-496c-a640-4bc1f64d641a.gif)

## How did you test this code?

unit tests and running locally
