### PR TITLE
fix plugin-server db test

### DIFF
--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -34,7 +34,7 @@ describe('DB', () => {
                     id: ACTION_ID,
                     name: 'Test Action',
                     deleted: false,
-                    post_to_slack: false,
+                    post_to_slack: true,
                     slack_message_format: '',
                     is_calculating: false,
                     steps: [


### PR DESCRIPTION
## Changes



I suspect it comes from https://github.com/PostHog/posthog/blob/5f6e77ce89f9c77d2d3af5f32f6e589d36089ba0/plugin-server/tests/helpers/sql.ts#L86

## How did you test this code?

ran the plugin server test locally
``` 
PASS  tests/shared/db.test.ts (40.943 s)
  DB
    ✓ fetchAllActionsGroupedByTeam (1495 ms)
    fetchGroupTypes() and insertGroupType()
      ✓ fetches group types that have been inserted (1167 ms)
      ✓ handles conflicting by index when inserting and limits (1548 ms)
      ✓ handles conflict by name when inserting (1543 ms)
```
