### PR TITLE
WIP: PostHog ClickHouse (Hobby Edition)

### DIFF
--- a/ee/docker-compose.ch.hobby.yml
+++ b/ee/docker-compose.ch.hobby.yml
@@ -1,0 +1,82 @@
+version: '3'
+
+services:
+    db:
+        image: postgres:12-alpine
+        environment:
+            POSTGRES_USER: posthog
+            POSTGRES_DB: posthog
+            POSTGRES_PASSWORD: posthog
+        ports:
+            - '5432:5432'
+        restart: on-failure
+    redis:
+        image: 'redis:alpine'
+        ports:
+            - '6379:6379'
+        restart: on-failure
+    clickhouse:
+        # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
+        # https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/templates/clickhouse_instance.yaml#L88
+        image: yandex/clickhouse-server:21.6.5
+        depends_on:
+            - kafka
+            - zookeeper
+        ports:
+            - '8123:8123'
+            - '9000:9000'
+            - '9440:9440'
+            - '9009:9009'
+        volumes:
+            - ./idl:/idl
+            - ../docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+            - ../docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
+            - ../docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
+        restart: on-failure
+    zookeeper:
+        image: wurstmeister/zookeeper
+        restart: on-failure
+    kafka:
+        image: wurstmeister/kafka
+        depends_on:
+            - zookeeper
+        ports:
+            - '9092:9092'
+        environment:
+            KAFKA_ADVERTISED_HOST_NAME: kafka
+            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_HEAP_OPTS: -Xmx512M -Xms512M
+        restart: on-failure
+    web: 
+        image: posthog/posthog:latest
+        command: bash -c "python manage.py migrate_clickhouse && ./bin/docker"
+        environment:
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_DATABASE: 'posthog'
+            CLICKHOUSE_SECURE: 'false'
+            CLICKHOUSE_VERIFY: 'false'
+            KAFKA_URL: 'kafka://kafka'
+            REDIS_URL: 'redis://redis:6379/'
+            SECRET_KEY: 'alsdfjiosdajfklalsdjkf'
+            DEBUG: 'true'
+            PRIMARY_DB: 'clickhouse'
+            PGHOST: db
+            PGUSER: posthog
+            PGPASSWORD: posthog
+            KAFKA_ENABLED: 'true'
+            KAFKA_HOSTS: 'kafka:9092'
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+        links:
+            - db:db
+            - redis:redis
+            - clickhouse:clickhouse
+            - kafka:kafka
+        ports:
+            - '8000:8000'
+            - '80:8000'
+        restart: on-failure

--- a/ee/docker-compose.ch.hobby.yml
+++ b/ee/docker-compose.ch.hobby.yml
@@ -7,13 +7,9 @@ services:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
-        ports:
-            - '5432:5432'
         restart: on-failure
     redis:
-        image: 'redis:alpine'
-        ports:
-            - '6379:6379'
+        image: 'redis:6.2.6-alpine'
         restart: on-failure
     clickhouse:
         # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
@@ -22,11 +18,6 @@ services:
         depends_on:
             - kafka
             - zookeeper
-        ports:
-            - '8123:8123'
-            - '9000:9000'
-            - '9440:9440'
-            - '9009:9009'
         volumes:
             - ./idl:/idl
             - ../docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
@@ -34,18 +25,20 @@ services:
             - ../docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
         restart: on-failure
     zookeeper:
-        image: wurstmeister/zookeeper
+        image: bitnami/zookeeper:3.7.0
         restart: on-failure
+        environment:
+            ALLOW_ANONYMOUS_LOGIN: 'Yes'
     kafka:
-        image: wurstmeister/kafka
+        image: bitnami/kafka:2.8.1
         depends_on:
             - zookeeper
-        ports:
-            - '9092:9092'
         environment:
             KAFKA_ADVERTISED_HOST_NAME: kafka
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
             KAFKA_HEAP_OPTS: -Xmx512M -Xms512M
+            KAFKA_BROKER_ID: 1000
+            ALLOW_PLAINTEXT_LISTENER: 'Yes'
         restart: on-failure
     web: 
         image: posthog/posthog:latest
@@ -77,6 +70,5 @@ services:
             - clickhouse:clickhouse
             - kafka:kafka
         ports:
-            - '8000:8000'
             - '80:8000'
         restart: on-failure

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
         "start-https": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve --https",
         "start-docker": "mkdir -p frontend/dist/ && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts && webpack serve --host 0.0.0.0",
         "start-ch-dev": "concurrently -n DOCKER,WEBPACK,TYPEGEN -c red,blue,green \"docker-compose -f ee/docker-compose.ch.yml pull && CH_WEB_SCRIPT=./ee/bin/docker-ch-dev-backend docker-compose -f ee/docker-compose.ch.yml up\" \"yarn run start-http --host 0.0.0.0\" \"yarn run typegen:watch\"",
+        "start-ch-hobby": "docker-compose -f ee/docker-compose.ch.hobby.yml pull && docker-compose -f ee/docker-compose.ch.hobby.yml up --detach",  
+        "stop-ch-hobby": "docker-compose -f ee/docker-compose.ch.hobby.yml stop",    
         "clear-ch-dev": "docker compose -f ee/docker-compose.ch.yml stop && docker compose -f ee/docker-compose.ch.yml rm -v && docker compose -f ee/docker-compose.ch.yml down",
         "build": "echo \"Building Webpack\" && NODE_ENV=production webpack --config webpack.config.js && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts",
         "prettier": "prettier --write \"./**/*.{js,ts,tsx,json,yaml,yml,css,scss}\"",


### PR DESCRIPTION
## Changes

I've created a docker-compose suitable for a $10/mo digitalocean droplet. I could not get it running on a $5 instance - no matter how much I tried - the resources get used up by the number of services running and the instance falls over after a few minutes.

## Where I need help

@guidoiaquinti or @tiina303 I would love your help, I'm struggling to:

- [ ] Get DEBUG = FALSE to work, I don't seem to be able to enable HTTPS on the ClickHouse docker image. I'm not sure if I get that working what other issues I might come across - so would appreciate any foresight here?
- [ ] Making this "hobby ready"
    - [ ] How should I use restarts in docker-compose if this is being used a semi-production instance
    - [ ] Should we remove the dependency on yarn e.g. just document running `docker-compose`?
    - [ ] How do we turn this into a DO one-click install
    - [ ] Other testing should we do to make sure its "good enough"?

## How did you test this code?

Set up a DO droplet with Docker and Node

ran `yarn start-ch-hobby`

Used make some noise plugin to created 10K events using make some noise plugin and performed basic trends queries.

N.B. Although it works with >10K events on a $10/month it starts getting slow quite quickly - I think we should recommend the $20/month as the minimum spec.
