### PR TITLE
Add top level danger `TopBar` indicator for potential system issues

### DIFF
--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -12,7 +12,7 @@ import {
     IconSignOut,
     IconUpdate,
     IconExclamation,
-} from '../../../lib/components/icons'
+} from 'lib/components/icons'
 import { Popup } from '../../../lib/components/Popup/Popup'
 import { Link } from '../../../lib/components/Link'
 import { urls } from '../../../scenes/urls'

--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -5,14 +5,7 @@ import { userLogic } from '../../../scenes/userLogic'
 import { ProfilePicture } from '../../../lib/components/ProfilePicture'
 import { LemonButton } from '../../../lib/components/LemonButton'
 import { LemonRow } from '../../../lib/components/LemonRow'
-import {
-    IconCheckmark,
-    IconOffline,
-    IconPlus,
-    IconSignOut,
-    IconUpdate,
-    IconExclamation,
-} from 'lib/components/icons'
+import { IconCheckmark, IconOffline, IconPlus, IconSignOut, IconUpdate, IconExclamation } from 'lib/components/icons'
 import { Popup } from '../../../lib/components/Popup/Popup'
 import { Link } from '../../../lib/components/Link'
 import { urls } from '../../../scenes/urls'

--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -5,7 +5,14 @@ import { userLogic } from '../../../scenes/userLogic'
 import { ProfilePicture } from '../../../lib/components/ProfilePicture'
 import { LemonButton } from '../../../lib/components/LemonButton'
 import { LemonRow } from '../../../lib/components/LemonRow'
-import { IconCheckmark, IconOffline, IconPlus, IconSignOut, IconUpdate } from '../../../lib/components/icons'
+import {
+    IconCheckmark,
+    IconOffline,
+    IconPlus,
+    IconSignOut,
+    IconUpdate,
+    IconExclamation,
+} from '../../../lib/components/icons'
 import { Popup } from '../../../lib/components/Popup/Popup'
 import { Link } from '../../../lib/components/Link'
 import { urls } from '../../../scenes/urls'
@@ -228,6 +235,7 @@ export function SitePopover(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { isSitePopoverOpen } = useValues(lemonadeLogic)
     const { toggleSitePopover, closeSitePopover } = useActions(lemonadeLogic)
+    const { systemStatus } = useValues(navigationLogic) // TODO: Don't use navigationLogic in Lemonade
 
     return (
         <Popup
@@ -263,7 +271,13 @@ export function SitePopover(): JSX.Element {
             }
         >
             <div className="SitePopover__crumb" onClick={toggleSitePopover}>
-                <ProfilePicture name={user?.first_name} email={user?.email} size="md" />
+                <div
+                    className="SitePopover__profile-picture"
+                    title={systemStatus ? undefined : 'Potential system issue'}
+                >
+                    <ProfilePicture name={user?.first_name} email={user?.email} size="md" />
+                    {!systemStatus && <IconExclamation className="SitePopover__danger" />}
+                </div>
                 <CaretDownOutlined />
             </div>
         </Popup>

--- a/frontend/src/layout/lemonade/TopBar/index.scss
+++ b/frontend/src/layout/lemonade/TopBar/index.scss
@@ -132,6 +132,22 @@
     cursor: pointer;
 }
 
+.SitePopover__profile-picture {
+    position: relative;
+}
+
+.SitePopover__danger {
+    position: absolute;
+    top: -0.375rem;
+    right: -0.375rem;
+    color: var(--white);
+    background: var(--danger);
+    font-size: 0.75rem;
+    box-sizing: content-box;
+    border-radius: 100%;
+    border: 2px solid var(--bg-bridge);
+}
+
 .SitePopover__section {
     width: 100%;
     padding: 0.5rem 0;

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -610,6 +610,18 @@ export function IconOffline(): JSX.Element {
     )
 }
 
+/** Material Design Priority High icon. */
+export function IconExclamation(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+            <g fill="currentColor">
+                <path d="m12 21c1.1046 0 2-.8954 2-2s-.8954-2-2-2-2 .8954-2 2 .8954 2 2 2z" />
+                <path d="m10 3h4v12h-4z" />
+            </g>
+        </svg>
+    )
+}
+
 // AntD arrows rotated at convenient angles
 
 export function ArrowBottomRightOutlined({ style }: { style?: CSSProperties }): JSX.Element {


### PR DESCRIPTION
## Changes

Adds a helpful indicator to the top right of the profile picture, shown only if there's a problem.

<img width="340" alt="Screen Shot 2021-11-02 at 16 20 04" src="https://user-images.githubusercontent.com/4550621/139876869-c2c29144-a46d-47ba-85e4-2649cc16c098.png">

