### PR TITLE
Pushes a particular session recording error to sentry for investigation

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -4,6 +4,7 @@ from rest_framework import exceptions, request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from sentry_sdk import capture_exception, push_scope
 
 from posthog.api.person import PersonSerializer
 from posthog.api.routing import StructuredViewSetMixin
@@ -14,8 +15,6 @@ from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.session_recordings.session_recording import SessionRecording
 from posthog.queries.session_recordings.session_recording_list import SessionRecordingList
-
-from sentry_sdk import capture_exception, push_scope
 
 
 class SessionRecordingSerializer(serializers.Serializer):


### PR DESCRIPTION
## Changes

A customer is reporting an error viewing session recordings. They are getting a generic error from the API when loading session recordings. We are not seeing logs in Sentry which hampers investigation

This change adds a catch block at the most likely source of the error. Tags the exception with the session recording id, pushes it to Sentry, and the rethrows the error so the API behaviour remains the same

## How did you test this code?

running tests to check it didn't break them
