### PR TITLE
Fix new chunk loading error with esbuild, add reload guard

### DIFF
--- a/frontend/src/layout/ErrorNetwork.tsx
+++ b/frontend/src/layout/ErrorNetwork.tsx
@@ -5,7 +5,7 @@ import { ReloadOutlined } from '@ant-design/icons'
 export function ErrorNetwork(): JSX.Element {
     return (
         <div>
-            <h2>Network Error</h2>
+            <h1 className="page-title">Network Error</h1>
             <p>There was an issue loading the requested resource.</p>
             <p>
                 <Button onClick={() => window.location.reload()}>

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -238,7 +238,10 @@ export const sceneLogic = kea<sceneLogicType>({
                 try {
                     importedScene = await props.scenes[scene]()
                 } catch (error) {
-                    if (error.name === 'ChunkLoadError') {
+                    if (
+                        error.name === 'ChunkLoadError' || // webpack
+                        error.message?.includes('Failed to fetch dynamically imported module') // esbuild
+                    ) {
                         if (scene !== null) {
                             // We were on another page (not the first loaded scene)
                             console.error('App assets regenerated. Reloading this page.')

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -45,6 +45,7 @@ export const sceneLogic = kea<sceneLogicType>({
         ) => ({ featureKey, featureName, featureCaption, featureAvailableCallback, guardOn }),
         hideUpgradeModal: true,
         takeToPricing: true,
+        reloadBrowserDueToImportError: true,
     },
     reducers: {
         scene: [
@@ -82,6 +83,13 @@ export const sceneLogic = kea<sceneLogicType>({
                 showUpgradeModal: (_, { featureName, featureCaption }) => [featureName, featureCaption],
                 hideUpgradeModal: () => null,
                 takeToPricing: () => null,
+            },
+        ],
+        lastReloadAt: [
+            null as number | null,
+            { persist: true },
+            {
+                reloadBrowserDueToImportError: () => new Date().valueOf(),
             },
         ],
     },
@@ -242,16 +250,18 @@ export const sceneLogic = kea<sceneLogicType>({
                         error.name === 'ChunkLoadError' || // webpack
                         error.message?.includes('Failed to fetch dynamically imported module') // esbuild
                     ) {
-                        if (scene !== null) {
-                            // We were on another page (not the first loaded scene)
-                            console.error('App assets regenerated. Reloading this page.')
-                            window.location.reload()
-                            return
-                        } else {
-                            // First scene, show an error page
+                        // Reloaded once in the last 20 seconds and now reloading again? Show network error
+                        if (
+                            values.lastReloadAt &&
+                            parseInt(String(values.lastReloadAt)) > new Date().valueOf() - 20000
+                        ) {
                             console.error('App assets regenerated. Showing error page.')
                             actions.setScene(Scene.ErrorNetwork, emptySceneParams)
+                        } else {
+                            console.error('App assets regenerated. Reloading this page.')
+                            actions.reloadBrowserDueToImportError()
                         }
+                        return
                     } else {
                         throw error
                     }
@@ -300,6 +310,9 @@ export const sceneLogic = kea<sceneLogicType>({
                 }
             }
             actions.setScene(scene, params)
+        },
+        reloadBrowserDueToImportError: () => {
+            window.location.reload()
         },
     }),
 })


### PR DESCRIPTION
## Changes

- Fixes [the new esbuild chunk loading error](https://sentry.io/organizations/posthog/issues/2765409713/?referrer=slack)
- Expands on https://github.com/PostHog/posthog/pull/6196 and adds a guard that only reloads once
- Even adds half a test for this.

![2021-11-03 11 28 02](https://user-images.githubusercontent.com/53387/140044932-a609a5fd-f3da-4b9b-ba4a-7525dbe07342.gif)

## How did you test this code?

- In the browser (see gif above) and added a partial test to the reload function. However no E2E logic test for the full reload since mocking `async import('file.tsx')` was tricky. Can add later if needed.
