### PR TITLE
Chromatic storybook action needs the git history or errors

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -8,6 +8,8 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         steps:
             - uses: actions/checkout@v2
+              with:
+                fetch-depth: '0' # chromatic needs Git history
 
             - name: Install dependencies and chromatic
               run: yarn add --dev chromatic


### PR DESCRIPTION
## Changes

Chromatic actions started erroring

```
Chromatic CLI v6.0.5
https://www.chromatic.com/docs/cli

Authenticating with Chromatic
    → Connecting to https://index.chromatic.com
Could not retrieve package info from registry; skipping update check
Authenticated with Chromatic
    → Using project token '********9108'
Retrieving git information
    → ✖ Found only one commit
This typically means you've checked out a shallow copy of the Git repository, which some CI systems do by default.
In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
In {bold GitHub Actions}, you can enable this by setting \`fetch-depth: 0\`.
ℹ Read more at https://www.chromatic.com/docs/github-actions
```

## How did you test this code?

by pushing it to let the action run
