### PR TITLE
Show latest version if update available in `SitePopover`

### DIFF
--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -189,7 +189,7 @@ function SystemStatus(): JSX.Element {
 
 function Version(): JSX.Element {
     const { closeSitePopover, showChangelogModal } = useActions(lemonadeLogic)
-    const { updateAvailable } = useValues(navigationLogic) // TODO: Don't use navigationLogic in Lemonade
+    const { updateAvailable, latestVersion } = useValues(navigationLogic) // TODO: Don't use navigationLogic in Lemonade
     const { preflight } = useValues(preflightLogic)
 
     return (
@@ -200,7 +200,10 @@ function Version(): JSX.Element {
         >
             <>
                 <div className="SitePopover__main-info">
-                    Version <strong>{preflight?.posthog_version}</strong>
+                    <div>
+                        Version <strong>{preflight?.posthog_version}</strong>
+                    </div>
+                    {updateAvailable && <div className="supplement">{latestVersion} is available</div>}
                 </div>
                 <Link
                     onClick={() => {


### PR DESCRIPTION
## Changes

Proposal:
I found it not super clear what should I do with an orange update icon as a user, so this adds "X.Y.Z is available" as a clear indicator of what should I upgrade to (or at least consider).

![Zrzut ekranu 2021-11-3 o 13 17 43](https://user-images.githubusercontent.com/4550621/140058860-55b3415e-15e8-410b-8fad-42002b14dcce.png)