### PR TITLE
Add event exclusion correlation config to project page

### DIFF
--- a/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
@@ -40,18 +40,21 @@ export const Default = (): JSX.Element => {
                             name: '$autocapture',
                             volume_30_day: null,
                             query_usage_30_day: null,
+                            description: '',
                         },
                         {
                             id: '017ce199-a10e-0000-6783-7167743302f4',
                             name: '$capture_failed_request',
                             volume_30_day: null,
                             query_usage_30_day: null,
+                            description: '',
                         },
                         {
                             id: '017cdbee-0c77-0000-ecf1-bd5a9e253b92',
                             name: '$capture_metrics',
                             volume_30_day: null,
                             query_usage_30_day: null,
+                            description: '',
                         },
                     ],
                 })

--- a/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
@@ -73,7 +73,11 @@ export const Default = (): JSX.Element => {
 
     return (
         <Provider>
-            <EventSelect selectedEvents={selectedEvents} onChange={setSelectedEvents} />
+            <EventSelect
+                selectedEvents={selectedEvents}
+                onChange={setSelectedEvents}
+                addElement={<span>add events</span>}
+            />
         </Provider>
     )
 }

--- a/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
@@ -10,6 +10,17 @@ import { EventSelect } from './EventSelect'
 
 export default {
     title: 'PostHog/Components/EventSelect',
+    decorators: [
+        (Story) => {
+            worker.use(
+                rest.get('/api/projects/:projectId', (_, res, ctx) => {
+                    return res(ctx.json({ id: 2 }))
+                })
+            )
+
+            return <Story />
+        },
+    ],
 } as Meta
 
 export const Default = (): JSX.Element => {
@@ -20,7 +31,7 @@ export const Default = (): JSX.Element => {
             res(
                 ctx.delay(1500),
                 ctx.json({
-                    count: 22,
+                    count: 3,
                     next: null,
                     previous: null,
                     results: [
@@ -68,10 +79,10 @@ type GetEventDefinitionsResponse = EventDefinitionStorage
 type GetEventDefinitionsRequest = undefined
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export const mockGetEventDefinitions = (
+const mockGetEventDefinitions = (
     handler: ResponseResolver<RestRequest<GetEventDefinitionsRequest, any>, RestContext, GetEventDefinitionsResponse>
 ) =>
     rest.get<GetEventDefinitionsRequest, GetEventDefinitionsResponse>(
-        '/api/projects/@current/event_definitions',
+        '/api/projects/:projectId/event_definitions',
         handler
     )

--- a/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
@@ -1,0 +1,77 @@
+import { Meta } from '@storybook/react'
+import { Provider } from 'kea'
+import { ResponseResolver, RestRequest, RestContext, rest } from 'msw'
+import React from 'react'
+import { teamLogic } from 'scenes/teamLogic'
+import { initKea } from '~/initKea'
+import { worker } from '~/mocks/browser'
+import { eventDefinitionsModel, EventDefinitionStorage } from '~/models/eventDefinitionsModel'
+import { EventSelect } from './EventSelect'
+
+export default {
+    title: 'PostHog/Components/EventSelect',
+} as Meta
+
+export const Default = (): JSX.Element => {
+    const [selectedEvents, setSelectedEvents] = React.useState<string[]>([])
+
+    worker.use(
+        mockGetEventDefinitions((_, res, ctx) =>
+            res(
+                ctx.delay(1500),
+                ctx.json({
+                    count: 22,
+                    next: null,
+                    previous: null,
+                    results: [
+                        {
+                            id: '017cdbec-c38f-0000-1479-bc7b9e2b6c77',
+                            name: '$autocapture',
+                            volume_30_day: null,
+                            query_usage_30_day: null,
+                        },
+                        {
+                            id: '017ce199-a10e-0000-6783-7167743302f4',
+                            name: '$capture_failed_request',
+                            volume_30_day: null,
+                            query_usage_30_day: null,
+                        },
+                        {
+                            id: '017cdbee-0c77-0000-ecf1-bd5a9e253b92',
+                            name: '$capture_metrics',
+                            volume_30_day: null,
+                            query_usage_30_day: null,
+                        },
+                    ],
+                })
+            )
+        )
+    )
+
+    initKea()
+    eventDefinitionsModel.mount()
+
+    // Need to mount teamLogic otherwise we get erros regarding not being able
+    // to find the storre for team. It also makes some API calls to
+    // `/api/projects/@current` and `/api/organizations/@current` although I
+    // haven't mocked these as the component still works without doing so
+    teamLogic.mount()
+
+    return (
+        <Provider>
+            <EventSelect selectedEvents={selectedEvents} onChange={setSelectedEvents} />
+        </Provider>
+    )
+}
+
+type GetEventDefinitionsResponse = EventDefinitionStorage
+type GetEventDefinitionsRequest = undefined
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
+export const mockGetEventDefinitions = (
+    handler: ResponseResolver<RestRequest<GetEventDefinitionsRequest, any>, RestContext, GetEventDefinitionsResponse>
+) =>
+    rest.get<GetEventDefinitionsRequest, GetEventDefinitionsResponse>(
+        '/api/projects/@current/event_definitions',
+        handler
+    )

--- a/frontend/src/lib/components/EventSelect/EventSelect.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
+import { Button, Row } from 'antd'
+import { Popup } from 'lib/components/Popup/Popup'
+import PlusCircleOutlined from '@ant-design/icons/lib/icons/PlusCircleOutlined'
+import { CloseButton } from 'lib/components/CloseButton'
+
+interface EventSelectProps {
+    onChange: (names: string[]) => void
+    selectedEvents: string[]
+}
+
+export const EventSelect = ({ onChange, selectedEvents: selectedEvents }: EventSelectProps): JSX.Element => {
+    const { open, toggle, hide } = usePopup()
+
+    const handleChange = (name: string): void => {
+        onChange(Array.from(new Set(selectedEvents.concat([name]))))
+    }
+
+    const handleRemove = (name: string): void => {
+        onChange(selectedEvents.filter((p) => p !== name))
+    }
+
+    return (
+        <div className="mb">
+            {selectedEvents.length > 0 &&
+                selectedEvents.map((name) => {
+                    return (
+                        <Row
+                            key={name}
+                            align="middle"
+                            className="property-filter-row mt-05 mb-05"
+                            style={{
+                                width: '100%',
+                                margin: '0.25rem 0',
+                                padding: '0.25rem 0',
+                            }}
+                        >
+                            <Button type="primary" shape="round">
+                                {name}
+                            </Button>{' '}
+                            <CloseButton
+                                className="ml-1"
+                                onClick={() => handleRemove(name)}
+                                style={{ cursor: 'pointer', float: 'none', marginLeft: 5 }}
+                            />
+                        </Row>
+                    )
+                })}
+            <Row>
+                <Popup
+                    visible={open}
+                    overlay={
+                        <TaxonomicFilter
+                            onChange={(_, value) => {
+                                handleChange(value as string)
+                                hide()
+                            }}
+                            taxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                        />
+                    }
+                >
+                    {({ setRef }) => (
+                        <Button
+                            ref={setRef}
+                            onClick={() => toggle()}
+                            type="link"
+                            className="new-prop-filter"
+                            icon={<PlusCircleOutlined />}
+                        >
+                            Exclude event
+                        </Button>
+                    )}
+                </Popup>
+            </Row>
+        </div>
+    )
+}
+
+const popupLogic = {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    toggle: (open: boolean) => !open,
+
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    hide: () => false,
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const usePopup = () => {
+    const [open, setOpen] = React.useState<boolean>(false)
+
+    return {
+        open,
+        toggle: () => setOpen(popupLogic.toggle(open)),
+        hide: () => setOpen(popupLogic.hide()),
+    }
+}

--- a/frontend/src/lib/components/EventSelect/EventSelect.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.tsx
@@ -2,16 +2,16 @@ import React from 'react'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
-import { Button, Tag } from 'antd'
+import { Tag } from 'antd'
 import { Popup } from 'lib/components/Popup/Popup'
-import PlusCircleOutlined from '@ant-design/icons/lib/icons/PlusCircleOutlined'
 
 interface EventSelectProps {
     onChange: (names: string[]) => void
     selectedEvents: string[]
+    addElement: JSX.Element
 }
 
-export const EventSelect = ({ onChange, selectedEvents }: EventSelectProps): JSX.Element => {
+export const EventSelect = ({ onChange, selectedEvents, addElement }: EventSelectProps): JSX.Element => {
     const { open, toggle, hide } = usePopup()
 
     const handleChange = (name: string): void => {
@@ -22,28 +22,15 @@ export const EventSelect = ({ onChange, selectedEvents }: EventSelectProps): JSX
         onChange(selectedEvents.filter((p) => p !== name))
     }
 
+    // Add in the toggle popup logic for the passed in element
+    const addElementWithToggle = React.cloneElement(addElement, { onClick: toggle })
+
     return (
         <div>
             <div>
-                {selectedEvents.length > 0 &&
-                    selectedEvents.map((name) => {
-                        return (
-                            <Tag
-                                key={name}
-                                closable
-                                onClose={(): void => handleRemove(name)}
-                                style={{
-                                    margin: '0.25rem',
-                                    padding: '0.25rem 0.5em',
-                                    background: '#D9D9D9',
-                                    border: '1px solid #D9D9D9',
-                                    borderRadius: '40px',
-                                }}
-                            >
-                                {name}
-                            </Tag>
-                        )
-                    })}
+                {selectedEvents.map((name) => (
+                    <PropertyTag handleRemove={handleRemove} name={name} key={name} />
+                ))}
 
                 <Popup
                     visible={open}
@@ -57,17 +44,7 @@ export const EventSelect = ({ onChange, selectedEvents }: EventSelectProps): JSX
                         />
                     }
                 >
-                    {({ setRef }) => (
-                        <Button
-                            ref={setRef}
-                            onClick={() => toggle()}
-                            type="link"
-                            className="new-prop-filter"
-                            icon={<PlusCircleOutlined />}
-                        >
-                            Exclude events
-                        </Button>
-                    )}
+                    {addElementWithToggle}
                 </Popup>
             </div>
         </div>
@@ -92,3 +69,25 @@ const usePopup = () => {
         hide: () => setOpen(popupLogic.hide()),
     }
 }
+
+type PropertyTagProps = {
+    name: string
+    handleRemove: (name: string) => void
+}
+
+const PropertyTag = ({ name, handleRemove }: PropertyTagProps): JSX.Element => (
+    <Tag
+        key={name}
+        closable
+        onClose={(): void => handleRemove(name)}
+        style={{
+            margin: '0.25rem',
+            padding: '0.25rem 0.5em',
+            background: '#D9D9D9',
+            border: '1px solid #D9D9D9',
+            borderRadius: '40px',
+        }}
+    >
+        {name}
+    </Tag>
+)

--- a/frontend/src/lib/components/EventSelect/EventSelect.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.tsx
@@ -2,17 +2,16 @@ import React from 'react'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
-import { Button, Row } from 'antd'
+import { Button, Tag } from 'antd'
 import { Popup } from 'lib/components/Popup/Popup'
 import PlusCircleOutlined from '@ant-design/icons/lib/icons/PlusCircleOutlined'
-import { CloseButton } from 'lib/components/CloseButton'
 
 interface EventSelectProps {
     onChange: (names: string[]) => void
     selectedEvents: string[]
 }
 
-export const EventSelect = ({ onChange, selectedEvents: selectedEvents }: EventSelectProps): JSX.Element => {
+export const EventSelect = ({ onChange, selectedEvents }: EventSelectProps): JSX.Element => {
     const { open, toggle, hide } = usePopup()
 
     const handleChange = (name: string): void => {
@@ -24,32 +23,28 @@ export const EventSelect = ({ onChange, selectedEvents: selectedEvents }: EventS
     }
 
     return (
-        <div className="mb">
-            {selectedEvents.length > 0 &&
-                selectedEvents.map((name) => {
-                    return (
-                        <Row
-                            key={name}
-                            align="middle"
-                            className="property-filter-row mt-05 mb-05"
-                            style={{
-                                width: '100%',
-                                margin: '0.25rem 0',
-                                padding: '0.25rem 0',
-                            }}
-                        >
-                            <Button type="primary" shape="round">
+        <div>
+            <div>
+                {selectedEvents.length > 0 &&
+                    selectedEvents.map((name) => {
+                        return (
+                            <Tag
+                                key={name}
+                                closable
+                                onClose={(): void => handleRemove(name)}
+                                style={{
+                                    margin: '0.25rem',
+                                    padding: '0.25rem 0.5em',
+                                    background: '#D9D9D9',
+                                    border: '1px solid #D9D9D9',
+                                    borderRadius: '40px',
+                                }}
+                            >
                                 {name}
-                            </Button>{' '}
-                            <CloseButton
-                                className="ml-1"
-                                onClick={() => handleRemove(name)}
-                                style={{ cursor: 'pointer', float: 'none', marginLeft: 5 }}
-                            />
-                        </Row>
-                    )
-                })}
-            <Row>
+                            </Tag>
+                        )
+                    })}
+
                 <Popup
                     visible={open}
                     overlay={
@@ -70,11 +65,11 @@ export const EventSelect = ({ onChange, selectedEvents: selectedEvents }: EventS
                             className="new-prop-filter"
                             icon={<PlusCircleOutlined />}
                         >
-                            Exclude event
+                            Exclude events
                         </Button>
                     )}
                 </Popup>
-            </Row>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -8,7 +8,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { funnelsModel } from '~/models/funnelsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
-import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType, ViewType } from '~/types'
+import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType, TeamType, ViewType } from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -16,13 +16,9 @@ import { userLogic } from 'scenes/userLogic'
 jest.mock('lib/api')
 jest.mock('posthog-js')
 
-type CorrelationConfig = {
-    excluded_person_property_names?: string[]
-}
-
 describe('funnelLogic', () => {
     let logic: ReturnType<typeof funnelLogic.build>
-    let correlationConfig: CorrelationConfig = {}
+    let correlationConfig: TeamType['correlation_config'] = {}
 
     mockAPI(async (url) => {
         if (['api/projects/@current', `api/projects/${MOCK_TEAM_ID}`].includes(url.pathname)) {
@@ -76,6 +72,33 @@ describe('funnelLogic', () => {
                                 includePropertyNames.includes(correlation.event.event)
                         )
                         .filter((correlation) => !excludePropertyFromProjectNames.includes(correlation.event.event)),
+                },
+                type: 'Funnel',
+            }
+        } else if (
+            url.pathname === `api/projects/${MOCK_TEAM_ID}/insights/funnel/correlation` &&
+            url.data?.funnel_correlation_type === 'events'
+        ) {
+            return {
+                is_cached: true,
+                last_refresh: '2021-09-16T13:41:41.297295Z',
+                result: {
+                    events: [
+                        {
+                            event: { event: 'some event' },
+                            success_count: 1,
+                            failure_count: 1,
+                            odds_ratio: 1,
+                            correlation_type: 'success',
+                        },
+                        {
+                            event: { event: 'another event' },
+                            success_count: 1,
+                            failure_count: 1,
+                            odds_ratio: 1,
+                            correlation_type: 'failure',
+                        },
+                    ],
                 },
                 type: 'Funnel',
             }
@@ -546,7 +569,7 @@ describe('funnelLogic', () => {
             })
         })
 
-        it('loads exclude list from Project settings', async () => {
+        it('loads property exclude list from Project settings', async () => {
             featureFlagLogic.actions.setFeatureFlags(['correlation-analysis'], { 'correlation-analysis': true })
             correlationConfig = { excluded_person_property_names: ['some property'] }
 
@@ -579,6 +602,39 @@ describe('funnelLogic', () => {
                             },
                         ],
                     },
+                })
+        })
+
+        it('loads event exclude list from Project settings', async () => {
+            featureFlagLogic.actions.setFeatureFlags(['correlation-analysis'], { 'correlation-analysis': true })
+            correlationConfig = { excluded_events: ['some event'] }
+
+            // TODO: move api mocking to this test. I couldn't seem to figure
+            // out how that would work with mockApi.
+            await expectLogic(teamLogic, () => teamLogic.actions.loadCurrentTeam())
+                .toFinishListeners()
+                .toMatchValues({
+                    currentTeam: {
+                        ...MOCK_DEFAULT_TEAM,
+                        correlation_config: { excluded_events: ['some event'] },
+                    },
+                })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadResultsSuccess({ filters: { insight: ViewType.FUNNELS } })
+            })
+                .toFinishAllListeners()
+                .toMatchValues({
+                    correlationValues: [
+                        {
+                            event: { event: 'another event' },
+                            success_count: 1,
+                            failure_count: 1,
+                            odds_ratio: 1,
+                            correlation_type: 'failure',
+                            result_type: FunnelCorrelationResultsType.Events,
+                        },
+                    ],
                 })
         })
     })

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -8,7 +8,14 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { funnelsModel } from '~/models/funnelsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightHistoryLogic } from 'scenes/insights/InsightHistoryPanel/insightHistoryLogic'
-import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType, TeamType, ViewType } from '~/types'
+import {
+    AvailableFeature,
+    FunnelCorrelation,
+    FunnelCorrelationResultsType,
+    FunnelCorrelationType,
+    TeamType,
+    ViewType,
+} from '~/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -126,7 +133,7 @@ describe('funnelLogic', () => {
                 { name: 'third property', count: 5 },
             ]
         }
-        return defaultAPIMocks(url)
+        return defaultAPIMocks(url, { availableFeatures: [AvailableFeature.CORRELATION_ANALYSIS] })
     })
 
     initKeaTestLogic({
@@ -621,6 +628,7 @@ describe('funnelLogic', () => {
                 })
 
             await expectLogic(logic, () => {
+                logic.actions.setPropertyNames(logic.values.allProperties)
                 logic.actions.loadResultsSuccess({ filters: { insight: ViewType.FUNNELS } })
             })
                 .toFinishAllListeners()

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -100,6 +100,8 @@ export const funnelLogic = kea<funnelLogicType>({
             ['personProperties'],
             userLogic,
             ['hasAvailableFeature'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
         actions: [insightLogic(props), ['loadResults', 'loadResultsSuccess'], funnelsModel, ['loadFunnels']],
         logic: [eventUsageLogic, dashboardsModel],
@@ -985,9 +987,9 @@ export const funnelLogic = kea<funnelLogicType>({
             },
         ],
         correlationAnalysisAvailable: [
-            (s) => [s.hasAvailableFeature, s.clickhouseFeaturesEnabled],
-            (hasAvailableFeature, clickhouseFeaturesEnabled) =>
-                featureFlagLogic.values.featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] &&
+            (s) => [s.hasAvailableFeature, s.clickhouseFeaturesEnabled, s.featureFlags],
+            (hasAvailableFeature, clickhouseFeaturesEnabled, featureFlags) =>
+                featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] &&
                 clickhouseFeaturesEnabled &&
                 hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
         ],

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -3,6 +3,8 @@ import { useActions, useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { PersonPropertySelect } from 'lib/components/PersonPropertySelect/PersonPropertySelect'
 import { EventSelect } from 'lib/components/EventSelect/EventSelect'
+import PlusCircleOutlined from '@ant-design/icons/lib/icons/PlusCircleOutlined'
+import { Button } from 'antd'
 
 export function CorrelationConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
@@ -45,6 +47,11 @@ export function CorrelationConfig(): JSX.Element {
                         <EventSelect
                             onChange={handleEventsChange}
                             selectedEvents={currentTeam.correlation_config.excluded_events || []}
+                            addElement={
+                                <Button type="link" className="new-prop-filter" icon={<PlusCircleOutlined />}>
+                                    Add exclusion
+                                </Button>
+                            }
                         />
                     </>
                 )}

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -36,7 +36,6 @@ export function CorrelationConfig(): JSX.Element {
                 {currentTeam && (
                     <>
                         <h3>Excluded person properties:</h3>
-
                         <PersonPropertySelect
                             onChange={handlePersonPropertiesChange}
                             selectedProperties={currentTeam.correlation_config.excluded_person_property_names || []}

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -2,13 +2,32 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { PersonPropertySelect } from 'lib/components/PersonPropertySelect/PersonPropertySelect'
+import { EventSelect } from 'lib/components/EventSelect/EventSelect'
 
 export function CorrelationConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
 
-    const handleChange = (excludedProperties: string[]): void => {
-        updateCurrentTeam({ correlation_config: { excluded_person_property_names: excludedProperties } })
+    const handlePersonPropertiesChange = (excludedProperties: string[]): void => {
+        if (currentTeam) {
+            updateCurrentTeam({
+                correlation_config: {
+                    ...currentTeam.correlation_config,
+                    excluded_person_property_names: excludedProperties,
+                },
+            })
+        }
+    }
+
+    const handleEventsChange = (excludedEvents: string[]): void => {
+        if (currentTeam) {
+            updateCurrentTeam({
+                correlation_config: {
+                    ...currentTeam.correlation_config,
+                    excluded_events: excludedEvents,
+                },
+            })
+        }
     }
 
     return (
@@ -16,10 +35,17 @@ export function CorrelationConfig(): JSX.Element {
             <div style={{ marginBottom: 8 }}>
                 <h3>Excluded person properties:</h3>
                 {currentTeam && (
-                    <PersonPropertySelect
-                        onChange={handleChange}
-                        selectedProperties={currentTeam.correlation_config.excluded_person_property_names || []}
-                    />
+                    <>
+                        <PersonPropertySelect
+                            onChange={handlePersonPropertiesChange}
+                            selectedProperties={currentTeam.correlation_config.excluded_person_property_names || []}
+                        />
+
+                        <EventSelect
+                            onChange={handleEventsChange}
+                            selectedEvents={currentTeam.correlation_config.excluded_events || []}
+                        />
+                    </>
                 )}
             </div>
         </div>

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -33,14 +33,16 @@ export function CorrelationConfig(): JSX.Element {
     return (
         <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 8 }}>
-                <h3>Excluded person properties:</h3>
                 {currentTeam && (
                     <>
+                        <h3>Excluded person properties:</h3>
+
                         <PersonPropertySelect
                             onChange={handlePersonPropertiesChange}
                             selectedProperties={currentTeam.correlation_config.excluded_person_property_names || []}
                         />
 
+                        <h3>Excluded events:</h3>
                         <EventSelect
                             onChange={handleEventsChange}
                             selectedEvents={currentTeam.correlation_config.excluded_events || []}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -190,8 +190,8 @@ export interface TeamType extends TeamBasicType {
     // Uses to exclude person properties from correlation analysis results, for
     // example can be used to exclude properties that have trivial causation
     correlation_config: {
-        excluded_person_property_names: string[]
-        excluded_events: string[]
+        excluded_person_property_names?: string[]
+        excluded_events?: string[]
     }
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -191,6 +191,7 @@ export interface TeamType extends TeamBasicType {
     // example can be used to exclude properties that have trivial causation
     correlation_config: {
         excluded_person_property_names: string[]
+        excluded_events: string[]
     }
 }
 
@@ -1246,7 +1247,7 @@ export interface LicenseType {
 export interface EventDefinition {
     id: string
     name: string
-    description: string
+    description?: string
     tags?: string[]
     volume_30_day: number | null
     query_usage_30_day: number | null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1247,7 +1247,7 @@ export interface LicenseType {
 export interface EventDefinition {
     id: string
     name: string
-    description?: string
+    description: string
     tags?: string[]
     volume_30_day: number | null
     query_usage_30_day: number | null


### PR DESCRIPTION
Add ability to select events to exclude from correlation analysis. This change:

 1. adds a new multi select to the project settings page for specifying the events you wish to not include in the funnel correlations
 2. adds logic for pulling in the settings from the team correlations config to the funnels logic.

![2021-11-04 12 06 25](https://user-images.githubusercontent.com/128561/140310698-4f578772-da3f-422c-861f-12fe8277f93c.gif)
