### PR TITLE
Wire up `ToolbarModal` in `SideBar`

### DIFF
--- a/frontend/src/layout/ToolbarModal/ToolbarModal.scss
+++ b/frontend/src/layout/ToolbarModal/ToolbarModal.scss
@@ -1,24 +1,4 @@
 .toolbar-modal {
-    padding: 30px;
-    padding-bottom: 40px;
-    min-height: 400px;
+    padding: 2rem;
     position: relative;
-    overflow: hidden;
-
-    .hog-icon {
-        transition: filter 200ms ease;
-        position: absolute;
-        left: 0;
-        width: 300px;
-        height: 175px;
-        bottom: 0;
-        opacity: 0.2;
-    }
-
-    .toolbar-help {
-        position: absolute;
-        bottom: 20px;
-        right: 20px;
-        display: block;
-    }
 }

--- a/frontend/src/layout/ToolbarModal/ToolbarModal.scss
+++ b/frontend/src/layout/ToolbarModal/ToolbarModal.scss
@@ -1,4 +1,0 @@
-.toolbar-modal {
-    padding: 2rem;
-    position: relative;
-}

--- a/frontend/src/layout/ToolbarModal/ToolbarModal.tsx
+++ b/frontend/src/layout/ToolbarModal/ToolbarModal.tsx
@@ -4,29 +4,32 @@ import { useValues } from 'kea'
 import { EditAppUrls } from 'lib/components/AppEditorLink/EditAppUrls'
 import { userLogic } from 'scenes/userLogic'
 import { ToolbarSettings } from 'scenes/project/Settings/ToolbarSettings'
+import { Modal, ModalProps } from 'antd'
 
-export function ToolbarModal(): JSX.Element {
+export function ToolbarModal({ visible, onCancel }: Pick<ModalProps, 'visible' | 'onCancel'>): JSX.Element {
     const { user } = useValues(userLogic)
     const toolbarEnabled = user?.toolbar_mode !== 'disabled'
 
     return (
-        <div className="toolbar-modal">
-            {!toolbarEnabled ? (
-                <>
-                    <h2>Enable the Toolbar to continue</h2>
-                    <ToolbarSettings />
-                </>
-            ) : (
-                <>
-                    <h2>Toolbar – Permitted Domains/URLs</h2>
-                    <p>
-                        Make sure you're using the snippet or the latest <code>posthog-js</code> version.
-                        <br />
-                        Clicking a URL launches it with the Toolbar.
-                    </p>
-                    <EditAppUrls allowNavigation />
-                </>
-            )}
-        </div>
+        <Modal bodyStyle={{ padding: 0 }} visible={visible} onCancel={onCancel} footer={null}>
+            <div className="toolbar-modal">
+                {!toolbarEnabled ? (
+                    <>
+                        <h2>Enable the Toolbar to continue</h2>
+                        <ToolbarSettings />
+                    </>
+                ) : (
+                    <>
+                        <h2>Toolbar – Permitted Domains/URLs</h2>
+                        <p>
+                            Make sure you're using the snippet or the latest <code>posthog-js</code> version.
+                            <br />
+                            Clicking a URL launches it with the Toolbar.
+                        </p>
+                        <EditAppUrls allowNavigation />
+                    </>
+                )}
+            </div>
+        </Modal>
     )
 }

--- a/frontend/src/layout/ToolbarModal/ToolbarModal.tsx
+++ b/frontend/src/layout/ToolbarModal/ToolbarModal.tsx
@@ -1,4 +1,3 @@
-import './ToolbarModal.scss'
 import React from 'react'
 import { useValues } from 'kea'
 import { EditAppUrls } from 'lib/components/AppEditorLink/EditAppUrls'
@@ -11,25 +10,24 @@ export function ToolbarModal({ visible, onCancel }: Pick<ModalProps, 'visible' |
     const toolbarEnabled = user?.toolbar_mode !== 'disabled'
 
     return (
-        <Modal bodyStyle={{ padding: 0 }} visible={visible} onCancel={onCancel} footer={null}>
-            <div className="toolbar-modal">
-                {!toolbarEnabled ? (
-                    <>
-                        <h2>Enable the Toolbar to continue</h2>
-                        <ToolbarSettings />
-                    </>
-                ) : (
-                    <>
-                        <h2>Toolbar – Permitted Domains/URLs</h2>
-                        <p>
-                            Make sure you're using the snippet or the latest <code>posthog-js</code> version.
-                            <br />
-                            Clicking a URL launches it with the Toolbar.
-                        </p>
-                        <EditAppUrls allowNavigation />
-                    </>
-                )}
-            </div>
+        <Modal
+            title={toolbarEnabled ? 'Toolbar – permitted domains/URLs' : 'Enable Toolbar'}
+            visible={visible}
+            onCancel={onCancel}
+            footer={null}
+        >
+            {toolbarEnabled ? (
+                <>
+                    <p>
+                        Make sure you're using the snippet or the latest <code>posthog-js</code> version.
+                        <br />
+                        Clicking a URL launches it with the Toolbar.
+                    </p>
+                    <EditAppUrls allowNavigation />
+                </>
+            ) : (
+                <ToolbarSettings />
+            )}
         </Modal>
     )
 }

--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -22,6 +22,7 @@ import { canViewPlugins } from '../../../scenes/plugins/access'
 import { sceneLogic } from '../../../scenes/sceneLogic'
 import { teamLogic } from '../../../scenes/teamLogic'
 import { urls } from '../../../scenes/urls'
+import { ToolbarModal } from '../../ToolbarModal/ToolbarModal'
 import { lemonadeLogic } from '../lemonadeLogic'
 import './SideBar.scss'
 
@@ -71,6 +72,7 @@ function PageButton({
 
 function Pages(): JSX.Element {
     const { currentOrganization } = useValues(organizationLogic)
+    const { showToolbarModal } = useActions(lemonadeLogic)
 
     return (
         <div className="Pages">
@@ -103,12 +105,7 @@ function Pages(): JSX.Element {
             {canViewPlugins(currentOrganization) && (
                 <PageButton title="Plugins" icon={<IconExtension />} identifier="plugins" to={urls.plugins()} />
             )}
-            <PageButton
-                title="Toolbar"
-                icon={<IconTools />}
-                identifier="toolbar"
-                onClick={() => console.error('TODO')}
-            />
+            <PageButton title="Toolbar" icon={<IconTools />} identifier="toolbar" onClick={showToolbarModal} />
             <PageButton
                 title="Project settings"
                 icon={<IconSettings />}
@@ -120,8 +117,8 @@ function Pages(): JSX.Element {
 }
 
 export function SideBar({ children }: { children: React.ReactNode }): JSX.Element {
-    const { isSideBarShown } = useValues(lemonadeLogic)
-    const { hideSideBar } = useActions(lemonadeLogic)
+    const { isSideBarShown, isToolbarModalShown } = useValues(lemonadeLogic)
+    const { hideSideBar, hideToolbarModal } = useActions(lemonadeLogic)
 
     return (
         <div className={clsx('SideBar', 'SideBar__layout', !isSideBarShown && 'SideBar--hidden')}>
@@ -134,6 +131,7 @@ export function SideBar({ children }: { children: React.ReactNode }): JSX.Elemen
             </div>
             <div className="SideBar__overlay" onClick={hideSideBar} />
             {children}
+            <ToolbarModal visible={isToolbarModalShown} onCancel={hideToolbarModal} />
         </div>
     )
 }

--- a/frontend/src/layout/lemonade/lemonadeLogic.ts
+++ b/frontend/src/layout/lemonade/lemonadeLogic.ts
@@ -20,6 +20,8 @@ export const lemonadeLogic = kea<lemonadeLogicType>({
         hideCreateOrganizationModal: true,
         showChangelogModal: true,
         hideChangelogModal: true,
+        showToolbarModal: true,
+        hideToolbarModal: true,
     },
     reducers: {
         isSideBarShown: [
@@ -62,6 +64,13 @@ export const lemonadeLogic = kea<lemonadeLogicType>({
             {
                 showChangelogModal: () => true,
                 hideChangelogModal: () => false,
+            },
+        ],
+        isToolbarModalShown: [
+            false,
+            {
+                showToolbarModal: () => true,
+                hideToolbarModal: () => false,
             },
         ],
     },

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Layout, Menu, Modal, Popover } from 'antd'
+import { Layout, Menu, Popover } from 'antd'
 import {
     ApiFilled,
     ClockCircleFilled,
@@ -417,14 +417,7 @@ export function MainNavigation(): JSX.Element {
                 </div>
             </Layout.Sider>
 
-            <Modal
-                bodyStyle={{ padding: 0 }}
-                visible={toolbarModalOpen}
-                footer={null}
-                onCancel={() => setToolbarModalOpen(false)}
-            >
-                <ToolbarModal />
-            </Modal>
+            <ToolbarModal visible={toolbarModalOpen} onCancel={() => setToolbarModalOpen(false)} />
         </>
     )
 }


### PR DESCRIPTION
## Changes

Adds the world-famous Toolbar Modal to the new sidebar, with a touch of refactoring.
![2021-11-03 17 53 45](https://user-images.githubusercontent.com/4550621/140111418-3bb17a3b-8d38-4751-8bae-feb57299a7b9.gif)

