### PR TITLE
[trends] don't allow persons on formula

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -409,13 +409,11 @@ export function LineGraph({
                 axis: 'xy',
                 intersect: false,
                 onHover(evt) {
-                    if (onClick) {
-                        const point = this.getElementAtEvent(evt)
-                        if (point.length) {
-                            evt.target.style.cursor = 'pointer'
-                        } else {
-                            evt.target.style.cursor = 'default'
-                        }
+                    const point = this.getElementAtEvent(evt)
+                    if (onClick && point.length) {
+                        evt.target.style.cursor = 'pointer'
+                    } else {
+                        evt.target.style.cursor = 'default'
                     }
                     if (evt.type === 'mouseout') {
                         setTooltipVisible(false)

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -39,7 +39,7 @@ export function ActionsLineGraph({
             showPersonsModal={showPersonsModal}
             tooltipPreferAltTitle={filters.insight === ViewType.STICKINESS}
             onClick={
-                dashboardItemId
+                dashboardItemId || filters.formula
                     ? null
                     : (point) => {
                           const { dataset, day, value: pointValue } = point

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -66,19 +66,28 @@ export function ActionsPie({
                         labels={data[0].labels}
                         inSharedMode={inSharedMode}
                         dashboardItemId={dashboardItemId}
-                        onClick={dashboardItemId || filtersParam.formula
-                            ? null
-                            : (point) => {
-                            const { dataset } = point
-                            const action = dataset.actions[point.index]
-                            const label = dataset.labels[point.index]
-                            const date_from = filtersParam.date_from || ''
-                            const date_to = filtersParam.date_to || ''
-                            const breakdown_value = dataset.breakdownValues[point.index]
-                                ? dataset.breakdownValues[point.index]
-                                : null
-                            loadPeople({ action, label, date_from, date_to, filters: filtersParam, breakdown_value })
-                        }}
+                        onClick={
+                            dashboardItemId || filtersParam.formula
+                                ? null
+                                : (point) => {
+                                      const { dataset } = point
+                                      const action = dataset.actions[point.index]
+                                      const label = dataset.labels[point.index]
+                                      const date_from = filtersParam.date_from || ''
+                                      const date_to = filtersParam.date_to || ''
+                                      const breakdown_value = dataset.breakdownValues[point.index]
+                                          ? dataset.breakdownValues[point.index]
+                                          : null
+                                      loadPeople({
+                                          action,
+                                          label,
+                                          date_from,
+                                          date_to,
+                                          filters: filtersParam,
+                                          breakdown_value,
+                                      })
+                                  }
+                        }
                     />
                 </div>
                 <h1>

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -70,17 +70,28 @@ export function ActionsPie({
                         labels={data[0].labels}
                         inSharedMode={inSharedMode}
                         dashboardItemId={dashboardItemId}
-                        onClick={(point) => {
-                            const { dataset } = point
-                            const action = dataset.actions[point.index]
-                            const label = dataset.labels[point.index]
-                            const date_from = dataset.days[0]
-                            const date_to = dataset.days[dataset.days.length - 1]
-                            const breakdown_value = dataset.breakdownValues[point.index]
-                                ? dataset.breakdownValues[point.index]
-                                : null
-                            loadPeople({ action, label, date_from, date_to, filters: filtersParam, breakdown_value })
-                        }}
+                        onClick={
+                            dashboardItemId || filtersParam.formula
+                                ? null
+                                : (point) => {
+                                      const { dataset } = point
+                                      const action = dataset.actions[point.index]
+                                      const label = dataset.labels[point.index]
+                                      const date_from = dataset.days[0]
+                                      const date_to = dataset.days[dataset.days.length - 1]
+                                      const breakdown_value = dataset.breakdownValues[point.index]
+                                          ? dataset.breakdownValues[point.index]
+                                          : null
+                                      loadPeople({
+                                          action,
+                                          label,
+                                          date_from,
+                                          date_to,
+                                          filters: filtersParam,
+                                          breakdown_value,
+                                      })
+                                  }
+                        }
                     />
                 </div>
                 <h1>


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses #6797 by not allowing persons on formula for now
- conceptually, showing persons based on formula transformed numbers doesnt seem intuitive
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*
manual qa
