### PR TITLE
Un-authorise the toolbar when we can't load feature flags

### DIFF
--- a/frontend/src/toolbar/actions/actionsLogic.test.ts
+++ b/frontend/src/toolbar/actions/actionsLogic.test.ts
@@ -18,7 +18,7 @@ global.fetch = jest.fn(() =>
     } as any as Response)
 )
 
-describe('actions logic', () => {
+describe('toolbar actionsLogic', () => {
     let logic: ReturnType<typeof actionsLogic.build>
 
     initKeaTestLogic()

--- a/frontend/src/toolbar/actions/actionsLogic.ts
+++ b/frontend/src/toolbar/actions/actionsLogic.ts
@@ -1,9 +1,9 @@
 import { kea } from 'kea'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
-import { encodeParams } from 'kea-router'
 import { actionsLogicType } from './actionsLogicType'
 import { ActionType } from '~/types'
 import Fuse from 'fuse.js'
+import { toolbarFetch } from '~/toolbar/utils'
 
 export const actionsLogic = kea<actionsLogicType>({
     actions: {
@@ -23,14 +23,7 @@ export const actionsLogic = kea<actionsLogicType>({
             {
                 // eslint-disable-next-line
                 getActions: async (_ = null, breakpoint: () => void) => {
-                    const params = {
-                        temporary_token: toolbarLogic.values.temporaryToken,
-                    }
-                    const url = `${toolbarLogic.values.apiURL}/api/projects/@current/actions/${encodeParams(
-                        params,
-                        '?'
-                    )}`
-                    const response = await fetch(url)
+                    const response = await toolbarFetch('/api/projects/@current/actions/')
                     const results = await response.json()
 
                     if (response.status === 403) {

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -2,7 +2,7 @@
 import { kea } from 'kea'
 import { encodeParams } from 'kea-router'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
-import { elementToActionStep, elementToSelector, trimElement } from '~/toolbar/utils'
+import { elementToActionStep, elementToSelector, toolbarFetch, trimElement } from '~/toolbar/utils'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { heatmapLogicType } from './heatmapLogicType'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
@@ -64,12 +64,9 @@ export const heatmapLogic = kea<heatmapLogicType>({
                 ) => {
                     const params: Record<string, any> = {
                         properties: [{ key: '$current_url', value: $current_url }],
-                        temporary_token: toolbarLogic.values.temporaryToken,
                         ...values.heatmapFilter,
                     }
-
-                    const url = `${toolbarLogic.values.apiURL}/api/element/stats/${encodeParams(params, '?')}`
-                    const response = await fetch(url)
+                    const response = await toolbarFetch(`/api/element/stats/${encodeParams(params, '?')}`)
                     const results = await response.json()
 
                     if (response.status === 403) {

--- a/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
@@ -1,5 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { CombinedFeatureFlagAndOverrideType } from '~/types'
@@ -14,19 +14,20 @@ const featureFlagsWithExtraInfo = [
     { currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 2' } },
 ]
 
-global.fetch = jest.fn(() =>
-    Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(featureFlags),
-    } as any as Response)
-)
-
-describe('feature flags logic', () => {
+describe('toolbar featureFlagsLogic', () => {
     let logic: ReturnType<typeof featureFlagsLogic.build>
-
-    initKeaTestLogic()
+    beforeEach(() => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve(featureFlags),
+            } as any as Response)
+        )
+    })
 
     beforeEach(() => {
+        initKeaTests()
         toolbarLogic({ apiURL: 'http://localhost' }).mount()
         logic = featureFlagsLogic()
         logic.mount()
@@ -46,5 +47,18 @@ describe('feature flags logic', () => {
         }).toMatchValues({
             filteredFlags: [{ currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 2' } }],
         })
+    })
+
+    it('expires the token if request failed', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: false,
+                status: 401,
+                json: () => Promise.resolve(featureFlags),
+            } as any as Response)
+        )
+        await expectLogic(logic, () => {
+            logic.actions.getUserFlags()
+        }).toDispatchActions([toolbarLogic.actionTypes.tokenExpired])
     })
 })

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -20,6 +20,12 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             {
                 getUserFlags: async (_, breakpoint) => {
                     const response = await toolbarFetch('/api/projects/@current/feature_flags/my_flags')
+
+                    if (response.status >= 400) {
+                        toolbarLogic.actions.tokenExpired()
+                        return []
+                    }
+
                     breakpoint()
                     if (!response.ok) {
                         return []

--- a/frontend/src/toolbar/toolbarLogic.test.ts
+++ b/frontend/src/toolbar/toolbarLogic.test.ts
@@ -1,0 +1,26 @@
+import { toolbarLogic } from '~/toolbar/toolbarLogic'
+import { initKeaTests } from '~/test/init'
+import { expectLogic } from 'kea-test-utils'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
+
+global.fetch = jest.fn(() =>
+    Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+    } as any as Response)
+)
+
+describe('toolbar toolbarLogic', () => {
+    let logic: ReturnType<typeof toolbarLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = toolbarLogic({ apiURL: 'http://localhost' })
+        logic.mount()
+    })
+
+    it('mounts feature flags', () => {
+        expectLogic(logic).toMount([featureFlagsLogic])
+    })
+})

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -4,7 +4,7 @@ import { ActionStepType, ActionStepUrlMatching, ElementType } from '~/types'
 import { ActionStepForm, BoxColor } from '~/toolbar/types'
 import { querySelectorAllDeep } from 'query-selector-shadow-dom'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
-import { encodeParams } from 'kea-router'
+import { combineUrl, encodeParams } from 'kea-router'
 
 // these plus any element with cursor:pointer will be click targets
 const CLICK_TARGET_SELECTOR = `a, button, input, select, textarea, label`
@@ -408,8 +408,9 @@ export async function toolbarFetch(
     method: string = 'GET',
     payload?: Record<string, any>
 ): Promise<Response> {
-    const params = { temporary_token: toolbarLogic.values.temporaryToken }
-    const fullUrl = `${toolbarLogic.values.apiURL}${url}${encodeParams(params, '?')}`
+    const { pathname, searchParams } = combineUrl(url)
+    const params = { ...searchParams, temporary_token: toolbarLogic.values.temporaryToken }
+    const fullUrl = `${toolbarLogic.values.apiURL}${pathname}${encodeParams(params, '?')}`
 
     const payloadData = payload
         ? {


### PR DESCRIPTION
## Changes

- Clears the toolbar's session if we're unauthorized when loading the feature flags. Clicking the toolbar will then re-trigger the authorization flow.
- Before when you clicked on "actions" or "heatmap" to make an API request that then invalidated the session and triggered the authorization flow. The feature flags request is done always, even if you don't interact with the toolbar. Thus we couldn't really redirect you.

## How did you test this code?

Made tests, and also locally I edited my temporary token in the db, and reloaded the page. I was kicked out from expanding the buttons when these changes were enabled.