### PR TITLE
Remove "posthog-toolbar-feature-flags" flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -238,7 +238,6 @@ export const FEATURE_FLAGS = {
     DIVE_DASHBOARDS: 'hackathon-dive-dashboards', // owner: @tiina303
     NEW_PATHS_UI: 'new-paths-ui', // owner: @EDsCODE
     NEW_PATHS_UI_EDGE_WEIGHTS: 'new-paths-ui-edge-weights', // owner: @neilkakkar
-    TOOLBAR_FEATURE_FLAGS: 'posthog-toolbar-feature-flags', // owner: @mariusandra
     REMOVE_SESSIONS: '6050-remove-sessions', // owner: @rcmarron
     FUNNEL_VERTICAL_BREAKDOWN: '5733-funnel-vertical-breakdown', // owner: @alexkim
     RENAME_FILTERS: '6063-rename-filters', // owner: @alexkim

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -18,7 +18,6 @@ import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { Close } from '~/toolbar/button/icons/Close'
 import { AimOutlined, QuestionOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 const HELP_URL =
     'https://posthog.com/docs/tutorials/toolbar?utm_medium=in-product&utm_source=in-product&utm_campaign=toolbar-help-button'
@@ -58,19 +57,12 @@ export function ToolbarButton(): JSX.Element {
     const { enableHeatmap, disableHeatmap } = useActions(heatmapLogic)
     const { heatmapEnabled, heatmapLoading, elementCount, showHeatmapTooltip } = useValues(heatmapLogic)
 
-    const { isAuthenticated, featureFlags, posthog } = useValues(toolbarLogic)
+    const { isAuthenticated } = useValues(toolbarLogic)
     const { authenticate, logout } = useActions(toolbarLogic)
 
     const globalMouseMove = useRef((e: MouseEvent) => {
         e
     })
-
-    // Tricky: the feature flag's used here are not PostHog's normal feature flags, rather they're
-    // the feature flags of the user. The toolbar does not have access to posthog's feature flags because
-    // it uses Posthog-js-lite. As a result, this feature flag can only be turned on for posthog internal
-    // (or any other posthog customer that has a flag with the name `posthog-toolbar-feature-flags` set).
-    // (Should be removed when we want to roll this out broadly)
-    const showFeatureFlags = featureFlags[FEATURE_FLAGS.TOOLBAR_FEATURE_FLAGS] && !!posthog
 
     useEffect(() => {
         globalMouseMove.current = function (e: MouseEvent): void {
@@ -324,32 +316,30 @@ export function ToolbarButton(): JSX.Element {
                             />
                         ) : null}
                     </Circle>
-                    {showFeatureFlags ? (
-                        <Circle
-                            width={buttonWidth}
-                            x={side === 'left' ? 80 : -80}
-                            y={toolbarListVerticalPadding + n++ * 60}
-                            extensionPercentage={featureFlagsExtensionPercentage}
-                            rotationFixer={(r) => (side === 'right' && r < 0 ? 360 : 0)}
-                            label="Feature Flags"
-                            labelPosition={side === 'left' ? 'right' : 'left'}
-                            labelStyle={{
-                                opacity:
-                                    featureFlagsExtensionPercentage > 0.8
-                                        ? (featureFlagsExtensionPercentage - 0.8) / 0.2
-                                        : 0,
-                            }}
-                            content={<Flag style={{ height: 29 }} engaged={flagsVisible} />}
-                            zIndex={1}
-                            onClick={flagsVisible ? hideFlags : showFlags}
-                            style={{
-                                cursor: 'pointer',
-                                transform: `scale(${0.2 + 0.8 * featureFlagsExtensionPercentage})`,
-                                background: flagsVisible ? '#94D674' : '#D6EBCC',
-                                borderRadius,
-                            }}
-                        />
-                    ) : null}
+                    <Circle
+                        width={buttonWidth}
+                        x={side === 'left' ? 80 : -80}
+                        y={toolbarListVerticalPadding + n++ * 60}
+                        extensionPercentage={featureFlagsExtensionPercentage}
+                        rotationFixer={(r) => (side === 'right' && r < 0 ? 360 : 0)}
+                        label="Feature Flags"
+                        labelPosition={side === 'left' ? 'right' : 'left'}
+                        labelStyle={{
+                            opacity:
+                                featureFlagsExtensionPercentage > 0.8
+                                    ? (featureFlagsExtensionPercentage - 0.8) / 0.2
+                                    : 0,
+                        }}
+                        content={<Flag style={{ height: 29 }} engaged={flagsVisible} />}
+                        zIndex={1}
+                        onClick={flagsVisible ? hideFlags : showFlags}
+                        style={{
+                            cursor: 'pointer',
+                            transform: `scale(${0.2 + 0.8 * featureFlagsExtensionPercentage})`,
+                            background: flagsVisible ? '#94D674' : '#D6EBCC',
+                            borderRadius,
+                        }}
+                    />
                 </>
             ) : null}
         </Circle>

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -118,11 +118,6 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             actions.getUserFlags()
             const { posthog } = toolbarLogic.values
             if (posthog) {
-                posthog.onFeatureFlags((_, variants) => {
-                    if (variants) {
-                        toolbarLogic.actions.updateFeatureFlags(variants)
-                    }
-                })
                 const locallyOverrideFeatureFlags = posthog.get_property('$override_feature_flags')
                 if (locallyOverrideFeatureFlags) {
                     actions.setShowLocalFeatureFlagWarning(true)

--- a/frontend/src/toolbar/toolbarLogic.ts
+++ b/frontend/src/toolbar/toolbarLogic.ts
@@ -18,7 +18,6 @@ export const toolbarLogic = kea<toolbarLogicType>({
         clearUserIntent: true,
         showButton: true,
         hideButton: true,
-        updateFeatureFlags: (flags: Record<string, string | boolean>) => ({ flags }),
     }),
 
     reducers: ({ props }) => ({
@@ -29,10 +28,6 @@ export const toolbarLogic = kea<toolbarLogicType>({
         userIntent: [props.userIntent || null, { logout: () => null, clearUserIntent: () => null }],
         buttonVisible: [true, { showButton: () => true, hideButton: () => false, logout: () => false }],
         dataAttributes: [(props.dataAttributes || []) as string[]],
-        featureFlags: [
-            (props.featureFlags || {}) as Record<string, string | boolean>,
-            { updateFeatureFlags: (_, { flags }) => flags },
-        ],
         posthog: [(props.posthog ?? null) as PostHog | null],
     }),
 


### PR DESCRIPTION
## Changes

- This enables feature flags on the toolbar to everyone
- We can't just roll out this feature due to the following comment:
```js
// Tricky: the feature flag's used here are not PostHog's normal feature flags, rather they're
// the feature flags of the user. The toolbar does not have access to posthog's feature flags because
// it uses Posthog-js-lite. As a result, this feature flag can only be turned on for posthog internal
// (or any other posthog customer that has a flag with the name `posthog-toolbar-feature-flags` set).
// (Should be removed when we want to roll this out broadly)
```


## How did you test this code?

- Disabled the flag for myself locally, reloaded the page, the toolbar still came up and had the flags button:
![image](https://user-images.githubusercontent.com/53387/140198285-4cfaafdd-1b5b-40d5-984b-51130acb664e.png)

