### PR TITLE
Fix funnelLogic key

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -86,7 +86,7 @@ export const DEFAULT_EXCLUDED_PERSON_PROPERTIES = [
 ]
 
 export const funnelLogic = kea<funnelLogicType>({
-    path: ['scenes', 'funnels', 'funnelLogic'],
+    path: (key) => ['scenes', 'funnels', 'funnelLogic', key],
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('insight_funnel'),
 


### PR DESCRIPTION
## Changes

- Fixes a problem with dashboards, where any funnel took the filters of the first insight (of any type) in the dashboard. If that insight wasn't a funnel, no funnel would show up. If it was, all funnels would be weird.

## How did you test this code?

- Fixed an obvious bug from the esbuild days, and reloaded all locally broken dashboards to see it worked
