### PR TITLE
Reset insight if opening new insight

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_EXCLUDED_PERSON_PROPERTIES, funnelLogic } from './funnelLogic'
 import { api, defaultAPIMocks, mockAPI, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
 import posthog from 'posthog-js'
-import { expectLogic } from 'kea-test-utils'
+import { expectLogic, partial } from 'kea-test-utils'
 import { initKeaTestLogic } from '~/test/init'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -150,7 +150,7 @@ describe('funnelLogic', () => {
             await expectLogic(logic)
                 .toDispatchActions(['loadResults'])
                 .toMatchValues({
-                    insight: expect.objectContaining({
+                    insight: partial({
                         id: 12,
                         filters: {},
                         result: null,
@@ -166,7 +166,7 @@ describe('funnelLogic', () => {
                 })
                 .toDispatchActions(['loadResultsSuccess'])
                 .toMatchValues({
-                    insight: expect.objectContaining({
+                    insight: partial({
                         filters: {
                             insight: ViewType.FUNNELS,
                             actions: [
@@ -231,7 +231,7 @@ describe('funnelLogic', () => {
         })
             .toDispatchActions(['setFilters', 'loadResults', 'loadResultsSuccess'])
             .toMatchValues({
-                apiParams: expect.objectContaining({
+                apiParams: partial({
                     actions: [],
                     events: [
                         { id: '$pageview', order: 0 },
@@ -245,7 +245,7 @@ describe('funnelLogic', () => {
 
         expect(api.create).toBeCalledWith(
             `api/projects/${MOCK_TEAM_ID}/insights/funnel/`,
-            expect.objectContaining({
+            partial({
                 actions: [],
                 events: [
                     { id: '$pageview', order: 0 },
@@ -278,12 +278,12 @@ describe('funnelLogic', () => {
                         action.payload.filters?.events?.[0]?.id === 42,
                 ])
                 .toMatchValues(logic, {
-                    filters: expect.objectContaining({
+                    filters: partial({
                         events: [{ id: 42 }],
                     }),
                 })
                 .toMatchValues(insightLogic(props), {
-                    filters: expect.objectContaining({
+                    filters: partial({
                         events: [{ id: 42 }],
                     }),
                 })
@@ -294,12 +294,12 @@ describe('funnelLogic', () => {
                 insightLogic(props).actions.setFilters({ events: [{ id: 42 }] })
             })
                 .toMatchValues(logic, {
-                    filters: expect.objectContaining({
+                    filters: partial({
                         events: [{ id: 42 }],
                     }),
                 })
                 .toMatchValues(insightLogic(props), {
-                    filters: expect.objectContaining({
+                    filters: partial({
                         events: [{ id: 42 }],
                     }),
                 })

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -109,7 +109,7 @@ describe('funnelLogic', () => {
     initKeaTestLogic({
         logic: funnelLogic,
         props: {
-            dashboardItemId: undefined,
+            dashboardItemId: 12,
             filters: {
                 insight: ViewType.FUNNELS,
                 actions: [
@@ -125,7 +125,7 @@ describe('funnelLogic', () => {
         it('mounts all sorts of logics', async () => {
             await expectLogic(logic).toMount([
                 eventUsageLogic,
-                insightLogic({ dashboardItemId: undefined }),
+                insightLogic({ dashboardItemId: 12 }),
                 insightHistoryLogic,
                 preflightLogic,
                 funnelsModel,
@@ -151,7 +151,7 @@ describe('funnelLogic', () => {
                 .toDispatchActions(['loadResults'])
                 .toMatchValues({
                     insight: expect.objectContaining({
-                        id: undefined,
+                        id: 12,
                         filters: {},
                         result: null,
                     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -86,9 +86,9 @@ export const DEFAULT_EXCLUDED_PERSON_PROPERTIES = [
 ]
 
 export const funnelLogic = kea<funnelLogicType>({
-    path: (key) => ['scenes', 'funnels', 'funnelLogic', key],
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('insight_funnel'),
+    path: (key) => ['scenes', 'funnels', 'funnelLogic', key],
 
     connect: (props: InsightLogicProps) => ({
         values: [

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -100,9 +100,34 @@ describe('insightLogic', () => {
     })
 
     describe('analytics', () => {
-        it('reports insight changes on setFilter', async () => {
+        it('reports insight changes on setFilter, synced with URL', async () => {
             logic = insightLogic({
                 dashboardItemId: undefined,
+                syncWithUrl: true,
+                filters: { insight: 'TRENDS' },
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ insight: 'FUNNELS' })
+            }).toDispatchActions([
+                eventUsageLogic.actionCreators.reportInsightViewed(
+                    cleanFilters({ insight: 'TRENDS' }),
+                    true,
+                    false,
+                    0,
+                    {}
+                ),
+                eventUsageLogic.actionCreators.reportInsightViewed({ insight: 'FUNNELS' }, true, false, 0, {
+                    changed_insight: 'TRENDS',
+                }),
+            ])
+        })
+
+        it('reports insight changes on setFilter, not synced with URL', async () => {
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                syncWithUrl: false,
                 filters: { insight: 'TRENDS' },
             })
             logic.mount()

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -118,7 +118,7 @@ describe('insightLogic', () => {
                     0,
                     {}
                 ),
-                eventUsageLogic.actionCreators.reportInsightViewed({ insight: 'FUNNELS' }, true, false, 0, {
+                eventUsageLogic.actionCreators.reportInsightViewed({ insight: 'FUNNELS' }, false, false, 0, {
                     changed_insight: 'TRENDS',
                 }),
             ])

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -59,7 +59,7 @@ describe('insightLogic', () => {
             }
         } else if (pathname === `api/projects/${MOCK_TEAM_ID}/insights`) {
             return {
-                id: url.data?.filters.funnel_window_interval,
+                id: 50,
                 filters: url.data?.filters,
                 result: ['result from api'],
             }
@@ -374,7 +374,7 @@ describe('insightLogic', () => {
                     insight: partial({ id: 43, result: ['result from api'] }),
                 })
 
-            router.actions.push(combineUrl('/insights', { insight: 'FUNNELS', funnel_window_interval: 45 }).url)
+            router.actions.push(combineUrl('/insights', { insight: 'FUNNELS' }).url)
             await expectLogic(logic)
                 .toDispatchActions(['setInsight', 'setInsightMode', 'loadResults', 'loadResultsSuccess'])
                 .toMatchValues({
@@ -383,7 +383,7 @@ describe('insightLogic', () => {
                 })
                 .toDispatchActions(['setInsight'])
                 .toMatchValues({
-                    insight: partial({ id: 45, result: ['result from api'] }),
+                    insight: partial({ id: 50, result: ['result from api'] }),
                 })
         })
 

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -85,7 +85,6 @@ export const insightLogic = kea<insightLogicType>({
             options,
         }),
         setInsightMode: (mode: ItemMode, source: InsightEventSource | null) => ({ mode, source }),
-        setInsightDescription: (description: string) => ({ description }),
         saveInsight: true,
         setTagLoading: (tagLoading: boolean) => ({ tagLoading }),
         fetchedResults: (filters: Partial<FilterType>) => ({ filters }),
@@ -624,11 +623,10 @@ export const insightLogic = kea<insightLogicType>({
         '/insights': (_: any, searchParams: Record<string, any>, hashParams: Record<string, any>) => {
             if (props.syncWithUrl) {
                 let loadedFromAnotherLogic = false
-                if (searchParams.insight === 'HISTORY' || !hashParams.fromItem) {
-                    if (values.insightMode !== ItemMode.Edit) {
-                        actions.setInsightMode(ItemMode.Edit, null)
-                    }
-                } else if (hashParams.fromItem) {
+                if (searchParams.insight === 'HISTORY') {
+                    return
+                }
+                if (hashParams.fromItem) {
                     const insightIdChanged = !values.insight.id || values.insight.id !== hashParams.fromItem
 
                     if (
@@ -652,6 +650,22 @@ export const insightLogic = kea<insightLogicType>({
                     const insightModeFromUrl = hashParams.edit ? ItemMode.Edit : ItemMode.View
                     if (insightModeFromUrl !== values.insightMode) {
                         actions.setInsightMode(insightModeFromUrl, null)
+                    }
+                } else {
+                    if (values.insight?.id) {
+                        actions.setInsight(
+                            {
+                                id: undefined,
+                                name: '',
+                                description: '',
+                                tags: [],
+                                filters: cleanFilters(searchParams, values.filters),
+                                result: null,
+                            },
+                            { overrideFilter: true, shouldMergeWithExisting: false }
+                        )
+                        actions.setInsightMode(ItemMode.Edit, null)
+                        return
                     }
                 }
 

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -87,7 +87,10 @@ export const insightLogic = kea<insightLogicType>({
         }),
         setInsightMode: (mode: ItemMode, source: InsightEventSource | null) => ({ mode, source }),
         saveInsight: true,
-        createInsight: (insight: Partial<DashboardItemType>) => ({ insight }),
+        createInsight: (insight: Partial<DashboardItemType>, options: { fromLoadResults?: boolean } = {}) => ({
+            ...options,
+            insight,
+        }),
         setTagLoading: (tagLoading: boolean) => ({ tagLoading }),
         fetchedResults: (filters: Partial<FilterType>) => ({ filters }),
         loadInsight: (id: number, { doNotLoadResults }: { doNotLoadResults?: boolean } = {}) => ({
@@ -545,7 +548,7 @@ export const insightLogic = kea<insightLogicType>({
                 return
             }
             if (!insight.id) {
-                actions.createInsight({ filters: values.filters })
+                actions.createInsight({ filters: values.filters }, { fromLoadResults: true })
             } else if (insight.filters) {
                 // This auto-saves new filters into the insight.
                 // Exceptions:
@@ -588,7 +591,7 @@ export const insightLogic = kea<insightLogicType>({
                 actions.updateInsight(metadata)
             }
         },
-        createInsight: async ({ insight }, breakpoint) => {
+        createInsight: async ({ insight, fromLoadResults }, breakpoint) => {
             actions.setInsight(
                 { id: undefined, name: '', description: '', tags: [], filters: {}, result: null, ...insight },
                 { overrideFilter: true }
@@ -604,7 +607,7 @@ export const insightLogic = kea<insightLogicType>({
                 },
                 { overrideFilter: true, fromPersistentApi: true }
             )
-            if (!values.insight.result) {
+            if (!values.insight.result && !fromLoadResults) {
                 actions.loadResults()
             }
             if (props.syncWithUrl) {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -48,6 +48,7 @@ export const defaultFilterTestAccounts = (): boolean => {
 export const insightLogic = kea<insightLogicType>({
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('new'),
+    path: (key) => ['scenes', 'insights', 'insightLogic', key],
 
     connect: {
         values: [teamLogic, ['currentTeamId']],

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -604,6 +604,9 @@ export const insightLogic = kea<insightLogicType>({
                 },
                 { overrideFilter: true, fromPersistentApi: true }
             )
+            if (!values.insight.result) {
+                actions.loadResults()
+            }
             if (props.syncWithUrl) {
                 router.actions.replace('/insights', values.filters, {
                     ...router.values.hashParams,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -610,6 +610,7 @@ export const insightLogic = kea<insightLogicType>({
             if (props.syncWithUrl) {
                 router.actions.replace('/insights', values.filters, {
                     ...router.values.hashParams,
+                    edit: true,
                     fromItem: createdInsight.id,
                 })
             }

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -602,10 +602,10 @@ export const insightLogic = kea<insightLogicType>({
                     filters: cleanFilters(createdInsight.filters || insight.filters),
                     result: createdInsight.result || insight.result,
                 },
-                {}
+                { overrideFilter: true, fromPersistentApi: true }
             )
             if (props.syncWithUrl) {
-                router.actions.replace('/insights', router.values.searchParams, {
+                router.actions.replace('/insights', values.filters, {
                     ...router.values.hashParams,
                     fromItem: createdInsight.id,
                 })
@@ -676,7 +676,7 @@ export const insightLogic = kea<insightLogicType>({
                             name: '',
                             description: '',
                             tags: [],
-                            filters: cleanFilters(searchParams, values.filters),
+                            filters: cleanFilters(searchParams, {}),
                             result: null,
                         })
                         actions.setInsightMode(ItemMode.Edit, null)

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -33,6 +33,8 @@ const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 export const retentionTableLogic = kea<retentionTableLogicType>({
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
+    path: (key) => ['scenes', 'retention', 'retentionTableLogic', key],
+
     connect: (props: InsightLogicProps) => ({
         values: [insightLogic(props), ['filters', 'insight', 'insightLoading'], actionsModel, ['actions']],
         actions: [insightLogic(props), ['loadResultsSuccess']],

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -150,7 +150,9 @@ export const sceneLogic = kea<sceneLogicType>({
         for (const path of Object.keys(redirects)) {
             mapping[path] = (params) => {
                 const redirect = redirects[path]
-                router.actions.replace(typeof redirect === 'function' ? redirect(params) : redirect)
+                router.actions.replace(
+                    typeof redirect === 'function' ? redirect(params, featureFlagLogic.values.featureFlags) : redirect
+                )
             }
         }
         for (const [path, scene] of Object.entries(routes)) {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -3,6 +3,7 @@ import { Error404 as Error404Component } from '~/layout/Error404'
 import { ErrorNetwork as ErrorNetworkComponent } from '~/layout/ErrorNetwork'
 import { ErrorProjectUnavailable as ErrorProjectUnavailableComponent } from '~/layout/ErrorProjectUnavailable'
 import { urls } from 'scenes/urls'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 
@@ -125,8 +126,8 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
     },
 }
 
-export const redirects: Record<string, string | ((params: Params) => string)> = {
-    '/': urls.insights(),
+export const redirects: Record<string, string | ((params: Params, featureFlags: Record<string, any>) => string)> = {
+    '/': (_, featureFlags) => (featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] ? urls.savedInsights() : urls.insights()),
     '/dashboards': urls.dashboards(),
     '/plugins': urls.plugins(),
     '/actions': '/events/actions',

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -10,6 +10,7 @@ import { isTrendsInsight, keyForInsightLogicProps } from 'scenes/insights/shared
 export const trendsLogic = kea<trendsLogicType>({
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('all_trends'),
+    path: (key) => ['scenes', 'trends', 'trendsLogic', key],
 
     connect: (props: InsightLogicProps) => ({
         values: [insightLogic(props), ['filters', 'insight', 'insightLoading']],

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,3 @@
 import 'whatwg-fetch'
+
+global.scrollTo = jest.fn()


### PR DESCRIPTION
## Changes

- Final TODO before saved insights could be released to the world.
- Previously when you had an insight open, and then clicked "new insight", nothing would happen. 
- This was made worse with Turbo Mode, where you can have a saved insight open, click back to a random page, click "new insight", and still see that previously open insight, but with some bugs.

## How did you test this code?

- Tried in the browser and made some tests

![2021-11-05 12 54 45](https://user-images.githubusercontent.com/53387/140506811-17b8387c-55cd-4d0b-ba4f-befbeb788c34.gif)
