### PR TITLE
BE (Groups/Retention): Support filtering by group properties

### DIFF
--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -61,10 +61,14 @@ class RetentionEventsQuery(ClickhouseEventQuery):
         person_query, person_params = self._get_person_query()
         self.params.update(person_params)
 
+        groups_query, groups_params = self._get_groups_query()
+        self.params.update(groups_params)
+
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
             {self._get_disintct_id_query()}
             {person_query}
+            {groups_query}
             WHERE team_id = %(team_id)s
             {f"AND {entity_query}"}
             {f"AND {date_query}" if self._event_query_type != RetentionQueryType.TARGET_FIRST_TIME else ''}

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -1,0 +1,239 @@
+# name: TestClickhouseRetention.test_groups_filtering
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), reference_event.event_date) as base_interval,
+         datediff('Week', reference_event.event_date, toStartOfWeek(toDateTime(event_date))) as intervals_from_base,
+         COUNT(DISTINCT event.person_id) count
+  FROM
+    (SELECT e.timestamp AS event_date,
+            pdi.person_id as person_id,
+            e.uuid AS uuid,
+            e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND has(['technology'], trim(BOTH '"'
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) event
+  JOIN
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     pdi.person_id as person_id,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND has(['technology'], trim(BOTH '"'
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) reference_event ON (event.person_id = reference_event.person_id)
+  WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
+  GROUP BY base_interval,
+           intervals_from_base
+  ORDER BY base_interval,
+           intervals_from_base
+  '
+---
+# name: TestClickhouseRetention.test_groups_filtering.1
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), event_date) event_date,
+         count(DISTINCT person_id)
+  FROM
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     pdi.person_id as person_id,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND has(['technology'], trim(BOTH '"'
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) )
+  GROUP BY event_date
+  ORDER BY event_date
+  '
+---
+# name: TestClickhouseRetention.test_groups_filtering.2
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), reference_event.event_date) as base_interval,
+         datediff('Week', reference_event.event_date, toStartOfWeek(toDateTime(event_date))) as intervals_from_base,
+         COUNT(DISTINCT event.person_id) count
+  FROM
+    (SELECT e.timestamp AS event_date,
+            pdi.person_id as person_id,
+            e.uuid AS uuid,
+            e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND JSONHas(group_properties_0, 'industry') ) event
+  JOIN
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     pdi.person_id as person_id,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND JSONHas(group_properties_0, 'industry') ) reference_event ON (event.person_id = reference_event.person_id)
+  WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
+  GROUP BY base_interval,
+           intervals_from_base
+  ORDER BY base_interval,
+           intervals_from_base
+  '
+---
+# name: TestClickhouseRetention.test_groups_filtering.3
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), event_date) event_date,
+         count(DISTINCT person_id)
+  FROM
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     pdi.person_id as person_id,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND JSONHas(group_properties_0, 'industry') )
+  GROUP BY event_date
+  ORDER BY event_date
+  '
+---

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -4,11 +4,14 @@ from uuid import uuid4
 import pytz
 
 from ee.clickhouse.models.event import create_event
+from ee.clickhouse.models.group import create_group
 from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
-from ee.clickhouse.util import ClickhouseTestMixin
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 from posthog.models.action import Action
 from posthog.models.action_step import ActionStep
 from posthog.models.filters import Filter
+from posthog.models.filters.retention_filter import RetentionFilter
+from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.person import Person
 from posthog.queries.test.test_retention import retention_test_factory
 
@@ -32,4 +35,68 @@ def _create_person(**kwargs):
 
 
 class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(ClickhouseRetention, _create_event, _create_person, _create_action)):  # type: ignore
-    pass
+    @snapshot_clickhouse_queries
+    def test_groups_filtering(self):
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
+
+        Person.objects.create(team=self.team, distinct_ids=["person1", "alias1"])
+        Person.objects.create(team=self.team, distinct_ids=["person2"])
+        Person.objects.create(team=self.team, distinct_ids=["person3"])
+
+        self._create_events(
+            [
+                ("person1", self._date(0), {"$group_0": "org:5"}),
+                ("person2", self._date(0), {"$group_0": "org:6"}),
+                ("person3", self._date(0)),
+                ("person1", self._date(1), {"$group_0": "org:5"}),
+                ("person2", self._date(1), {"$group_0": "org:6"}),
+                ("person1", self._date(7), {"$group_0": "org:5"}),
+                ("person2", self._date(7), {"$group_0": "org:6"}),
+                ("person1", self._date(14), {"$group_0": "org:5"}),
+                ("person1", self._date(month=1, day=-6), {"$group_0": "org:5"}),
+                ("person2", self._date(month=1, day=-6), {"$group_0": "org:6"}),
+                ("person2", self._date(month=1, day=1), {"$group_0": "org:6"}),
+                ("person1", self._date(month=1, day=1), {"$group_0": "org:5"}),
+                ("person2", self._date(month=1, day=15), {"$group_0": "org:6"}),
+            ]
+        )
+
+        result = ClickhouseRetention().run(
+            RetentionFilter(
+                data={
+                    "date_to": self._date(10, month=1, hour=0),
+                    "period": "Week",
+                    "total_intervals": 7,
+                    "properties": [{"key": "industry", "value": "technology", "type": "group", "group_type_index": 0}],
+                }
+            ),
+            self.team,
+        )
+
+        self.assertEqual(
+            self.pluck(result, "values", "count"),
+            [[1, 1, 0, 1, 1, 0, 1], [1, 0, 1, 1, 0, 1], [0, 0, 0, 0, 0], [1, 1, 0, 1], [1, 0, 1], [0, 0], [1],],
+        )
+
+        result = ClickhouseRetention().run(
+            RetentionFilter(
+                data={
+                    "date_to": self._date(10, month=1, hour=0),
+                    "period": "Week",
+                    "total_intervals": 7,
+                    "properties": [
+                        {"key": "industry", "value": "", "type": "group", "group_type_index": 0, "operator": "is_set"}
+                    ],
+                }
+            ),
+            self.team,
+        )
+
+        self.assertEqual(
+            self.pluck(result, "values", "count"),
+            [[2, 2, 1, 2, 2, 0, 1], [2, 1, 2, 2, 0, 1], [1, 1, 1, 0, 0], [2, 2, 0, 1], [2, 0, 1], [0, 0], [1],],
+        )

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -900,8 +900,11 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
 
         def _create_events(self, user_and_timestamps, event="$pageview"):
             i = 0
-            for distinct_id, timestamp in user_and_timestamps:
+            for (distinct_id, timestamp, *properties_args) in user_and_timestamps:
                 properties = {"$some_property": "value"} if i % 2 == 0 else {}
+                if len(properties_args) == 1:
+                    properties.update(properties_args[0])
+
                 event_factory(
                     team=self.team, event=event, distinct_id=distinct_id, timestamp=timestamp, properties=properties,
                 )


### PR DESCRIPTION
## Changes

Depends on https://github.com/PostHog/posthog/pull/6899

Straight-forward change to support filtering retention by group properties

API changes: None

## How did you test this code?

See unit tests
