### PR TITLE
[paths] Moving limits and conditions to accurately reflect full paths

### DIFF
--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1028,6 +1028,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
                 {"id": "step two", "order": 1},
                 {"id": "step three", "order": 2},
             ],
+            "edge_limit": 200,
         }
         funnel_filter = Filter(data=data)
         path_filter = PathFilter(data=data)
@@ -2331,156 +2332,6 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             0, len(self._get_people_at_path(filter, path_start="4_step four"))
         )  # 0 total reach after step 4
 
-    def test_paths_start_dropping_orphaned_edges(self):
-        events = []
-        for i in range(5):
-            # 5 people going through this route to increase weights
-            Person.objects.create(team_id=self.team.pk, distinct_ids=[f"person_{i}"])
-            special_route = [
-                _create_event(
-                    properties={"$current_url": "/1"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:01:00",
-                ),
-                _create_event(
-                    properties={"$current_url": "/2"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:02:00",
-                ),
-                _create_event(
-                    properties={"$current_url": "/3"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:03:00",
-                ),
-                _create_event(
-                    properties={"$current_url": "/4"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:04:00",
-                ),
-                _create_event(
-                    properties={"$current_url": "/5"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:05:00",
-                ),
-                _create_event(
-                    properties={"$current_url": "/about"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:06:00",
-                ),
-                _create_event(
-                    properties={"$current_url": "/after"},
-                    distinct_id=f"person_{i}",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2021-05-01 00:07:00",
-                ),
-            ]
-            events.extend(special_route)
-
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_r_2"])
-        events_p2 = [
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="person_r_2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/a"},
-                distinct_id="person_r_2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:30",
-            ),
-            _create_event(
-                properties={"$current_url": "/x"},
-                distinct_id="person_r_2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:02:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_r_2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:03:00",
-            ),
-        ]
-        events.extend(events_p2)
-
-        p3 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_r_3"])
-        event_p3 = [
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="person_r_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/b"},
-                distinct_id="person_r_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:30",
-            ),
-            _create_event(
-                properties={"$current_url": "/x"},
-                distinct_id="person_r_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:02:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_r_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:03:00",
-            ),
-        ]
-
-        events.extend(event_p3)
-        _create_all_events(events)
-
-        # /x -> /about has higher weight than /2 -> /a -> /x and /2 -> /b -> /x
-
-        filter = PathFilter(
-            data={
-                "path_type": "$pageview",
-                "start_point": "/2",
-                "date_from": "2021-05-01 00:00:00",
-                "date_to": "2021-05-07 00:00:00",
-                "edge_limit": "6",
-            }
-        )
-        response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter,)
-        self.assertEqual(
-            response,
-            [
-                {"source": "1_/2", "target": "2_/3", "value": 5, "average_conversion_time": 60000.0},
-                {"source": "2_/3", "target": "3_/4", "value": 5, "average_conversion_time": 60000.0},
-                {"source": "3_/4", "target": "4_/5", "value": 5, "average_conversion_time": 60000.0},
-                {"source": "4_/5", "target": "5_/about", "value": 5, "average_conversion_time": 60000.0},
-                # {'source': '3_/x', 'target': '4_/about', 'value': 2, 'average_conversion_time': 60000.0}, # gets deleted by validation since dangling
-                {"source": "1_/2", "target": "2_/a", "value": 1, "average_conversion_time": 30000.0},
-            ],
-        )
-
     def test_path_min_edge_weight(self):
         # original data from test_path_by_grouping.py
         self._create_sample_data_multiple_dropoffs()
@@ -2521,31 +2372,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             ],
         )
 
-        path_filter = path_filter.with_data({"edge_limit": 2})
-        response = ClickhousePaths(team=self.team, filter=path_filter).run()
-        self.assertCountEqual(
-            response,
-            [
-                {
-                    "source": "1_step one",
-                    "target": "2_step drop*",
-                    "value": 20,
-                    "average_conversion_time": 2 * ONE_MINUTE,
-                },
-                # when we group events for a single user, these effectively become duplicate events, and we choose the last event from
-                # a list of duplicate events.
-                {
-                    "source": "1_step one",
-                    "target": "2_between_step_1_*",
-                    "value": 15,
-                    "average_conversion_time": (5 * 3 + 10 * 2)
-                    * ONE_MINUTE
-                    / 15,  # first 5 go till between_step_1_c, next 10 go till between_step_1_b
-                },
-            ],
-        )
-
-        path_filter = path_filter.with_data({"edge_limit": 20, "max_edge_weight": 11, "min_edge_weight": 6})
+        path_filter = path_filter.with_data({"max_edge_weight": 11, "min_edge_weight": 6})
         response = ClickhousePaths(team=self.team, filter=path_filter).run()
         self.assertCountEqual(
             response,

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1229,7 +1229,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             5, len(self._get_people_at_path(path_filter, "4_between_step_1_c", "5_step two", funnel_filter))
         )
 
-    @test_with_materialized_columns(["$current_url"])
+    @test_with_materialized_columns(["$current_url", "$screen_name"])
     def test_paths_end(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"])
         p1 = [
@@ -1867,7 +1867,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             ],
         )
 
-    @test_with_materialized_columns(["$current_url"])
+    @test_with_materialized_columns(["$current_url", "$screen_name"])
     def test_paths_start_and_end(self):
         p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"])
         events_p1 = [

--- a/ee/clickhouse/sql/paths/path.py
+++ b/ee/clickhouse/sql/paths/path.py
@@ -41,5 +41,6 @@ PATH_ARRAY_QUERY = """
             )
             ARRAY JOIN limited_path_timings AS joined_path_tuple, arrayEnumerate(limited_path_timings) AS event_in_session_index
             {boundary_event_filter}
+            {limit_clause}
             )
 """

--- a/ee/clickhouse/sql/paths/path.py
+++ b/ee/clickhouse/sql/paths/path.py
@@ -30,17 +30,17 @@ PATH_ARRAY_QUERY = """
                     , arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple
                     , {session_threshold_clause} as session_paths
                 FROM (
-                        SELECT person_id,
-                                groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
-                                groupArray(path_item) as paths
-                        FROM ({path_event_query})
-                        GROUP BY person_id
+                            SELECT * {target_index_clause} FROM (
+                                SELECT person_id,
+                                    groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                                    groupArray(path_item) as paths
+                                FROM ({path_event_query})
+                                GROUP BY person_id
+                            ) {boundary_event_filter} {limit_clause}
                         )
                 /* this array join splits paths for a single personID per session */
                 ARRAY JOIN session_paths AS path_time_tuple, arrayEnumerate(session_paths) AS session_index
             )
             ARRAY JOIN limited_path_timings AS joined_path_tuple, arrayEnumerate(limited_path_timings) AS event_in_session_index
-            {boundary_event_filter}
-            {limit_clause}
             )
 """

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/NewPathTab.tsx
@@ -426,52 +426,6 @@ export function NewPathTab(): JSX.Element {
                                                             />
                                                         </Col>
                                                     </Row>
-                                                    <Row gutter={8} align="middle" className="mt-05">
-                                                        <Col>Number of people on each Path between</Col>
-                                                        <Col>
-                                                            <InputNumber
-                                                                style={{
-                                                                    paddingTop: 2,
-                                                                    width: '80px',
-                                                                    marginLeft: 5,
-                                                                    marginRight: 5,
-                                                                }}
-                                                                size="small"
-                                                                min={0}
-                                                                max={100000}
-                                                                onChange={(value): void =>
-                                                                    setLocalEdgeParameters((state) => ({
-                                                                        ...state,
-                                                                        min_edge_weight: Number(value),
-                                                                    }))
-                                                                }
-                                                                onBlur={updateEdgeParameters}
-                                                                onPressEnter={updateEdgeParameters}
-                                                            />
-                                                        </Col>
-                                                        <Col>and</Col>
-                                                        <Col>
-                                                            <InputNumber
-                                                                style={{
-                                                                    paddingTop: 2,
-                                                                    width: '80px',
-                                                                    marginLeft: 5,
-                                                                    marginRight: 5,
-                                                                }}
-                                                                size="small"
-                                                                onChange={(value): void =>
-                                                                    setLocalEdgeParameters((state) => ({
-                                                                        ...state,
-                                                                        max_edge_weight: Number(value),
-                                                                    }))
-                                                                }
-                                                                min={0}
-                                                                max={100000}
-                                                                onBlur={updateEdgeParameters}
-                                                                onPressEnter={updateEdgeParameters}
-                                                            />
-                                                        </Col>
-                                                    </Row>
                                                     <hr />
                                                     <Row align="middle" justify="space-between">
                                                         <Col>


### PR DESCRIPTION
## Changes

*Please describe.*  
- address #6800 by considering number of full paths rather than edges with limit
- The problem currently is that the edge_limit is causing later steps in a path to be excluded from the final visualization. So a person who went from `step 1 -> step 2 -> step 3 -> step 4` might be missing the `step 3 -> step 4`. This edge isn't considered dangling, but since it's not shown, the visualization denotes this user as dropping off. However, our path person query does a true query without limits and will return null on the person modal since it doesn't designate this user as having dropped off
- My solution is to remove some of the advanced controls based on edge weights. Change the limiting to be based on the number of full paths. There's a bit of guesstimating in terms of number of edges but as long as there's a `step count + path limit` provided, assuming maximum variability in path types, there will be `step count * path limit` possible edges. Most cases should prove to be much less so I'm not too concerned about overwhelming number of edges on the visualization
*If this affects the frontend, include screenshots.*  

## How did you test this code?
*Please describe.*
- update tests