### PR TITLE
Don't GET licenses endpoint every time `SitePopover` is opened

### DIFF
--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { CaretDownOutlined } from '@ant-design/icons'
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { userLogic } from '../../../scenes/userLogic'
 import { ProfilePicture } from '../../../lib/components/ProfilePicture'
 import { LemonButton } from '../../../lib/components/LemonButton'
@@ -236,6 +236,7 @@ export function SitePopover(): JSX.Element {
     const { isSitePopoverOpen } = useValues(lemonadeLogic)
     const { toggleSitePopover, closeSitePopover } = useActions(lemonadeLogic)
     const { systemStatus } = useValues(navigationLogic) // TODO: Don't use navigationLogic in Lemonade
+    useMountedLogic(licenseLogic)
 
     return (
         <Popup

--- a/frontend/src/scenes/instance/Licenses/logic.ts
+++ b/frontend/src/scenes/instance/Licenses/logic.ts
@@ -3,8 +3,12 @@ import { kea } from 'kea'
 import { toast } from 'react-toastify'
 import { licenseLogicType } from './logicType'
 import { APIErrorType, LicenseType } from '~/types'
+import { preflightLogic } from '../../PreflightCheck/logic'
 
 export const licenseLogic = kea<licenseLogicType>({
+    connect: {
+        values: [preflightLogic, ['preflight']],
+    },
     actions: {
         setError: (error: APIErrorType | null) => ({ error }),
         addLicense: (license: LicenseType) => ({ license }),
@@ -14,7 +18,7 @@ export const licenseLogic = kea<licenseLogicType>({
             [] as LicenseType[],
             {
                 loadLicenses: async () => {
-                    return (await api.get('api/license')).results
+                    return values.preflight?.cloud ? [] : (await api.get('api/license')).results
                 },
                 createLicense: async (payload: { key: string }) => {
                     try {


### PR DESCRIPTION
## Changes

Making sure `licenseLogic` is not remounted in the new navigation to avoiding hitting the API needlessly.