### PR TITLE
Fix feature flag sync script with local deleted flags

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -31,8 +31,14 @@ class Command(BaseCommand):
         first_user = User.objects.first()
         for team in Team.objects.all():
             existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
+            deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
             for flag in flags:
-                if flag not in existing_flags:
+                if flag in deleted_flags:
+                    f = FeatureFlag.objects.filter(team=team, key=flag)[0]
+                    f.deleted = False
+                    f.save()
+                    print(f"Undeleted feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
+                elif flag not in existing_flags:
                     FeatureFlag.objects.create(
                         team=team, rollout_percentage=100, name=flag, key=flag, created_by=first_user
                     )


### PR DESCRIPTION
## Changes

- Apparently I had deleted a flag, and `python manage.py sync_feature_flags` didn't bring it back. 
- Now it does

## How did you test this code?

- By being a unix command line ninja
