### PR TITLE
Fix issues with correlation instrumentation

### DIFF
--- a/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
@@ -39,11 +39,10 @@ export const visibilitySensorLogic = kea<visibilitySensorLogicType>({
         },
     }),
 
-    selectors: ({ props }) => ({
+    selectors: () => ({
         checkIsVisible: [
-            (selectors) => [selectors.innerHeight],
-            (windowHeight) => (element: HTMLElement) => {
-                const offset = props.offset || 0
+            (selectors) => [selectors.innerHeight, (_, props) => props.offset || 0],
+            (windowHeight, offset) => (element: HTMLElement) => {
                 if (!element) {
                     return false
                 }

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -690,7 +690,6 @@ export const eventUsageLogic = kea<
             posthog.capture('correlation interaction', { correlation_type: correlationType, action, ...props })
         },
         reportCorrelationViewed: ({ delay, filters, propertiesTable }) => {
-            // TODO: This event is still buggy (see relevant PR #6788 for details)
             if (delay === 0) {
                 posthog.capture(`beta - correlation${propertiesTable ? ' properties' : ''} viewed`, { filters })
             } else {

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -13,7 +13,6 @@ import { CloseOutlined } from '@ant-design/icons'
 import { PayCard } from 'lib/components/PayCard/PayCard'
 import { AvailableFeature } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
-import { VisibilitySensor } from 'lib/components/VisibilitySensor/VisibilitySensor'
 
 export const FunnelCorrelation = (): JSX.Element | null => {
     const { insightProps } = useValues(insightLogic)
@@ -24,7 +23,6 @@ export const FunnelCorrelation = (): JSX.Element | null => {
         correlationDetailedFeedbackVisible,
         correlationFeedbackRating,
         correlationAnalysisAvailable,
-        correlationPropKey,
     } = useValues(funnelLogic(insightProps))
     const {
         sendCorrelationAnalysisFeedback,

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -52,7 +52,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
     }
 
     return (
-        <VisibilitySensor id={correlationPropKey} offset={150}>
+        <>
             <div className="funnel-correlation">
                 {isSkewed && (
                     <Card className="skew-warning">
@@ -158,6 +158,6 @@ export const FunnelCorrelation = (): JSX.Element | null => {
 
                 <FunnelPropertyCorrelationTable />
             </div>
-        </VisibilitySensor>
+        </>
     )
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -21,6 +21,7 @@ import './FunnelCorrelationTable.scss'
 import { Tooltip } from 'lib/components/Tooltip'
 import { elementsToAction } from 'scenes/events/createActionFromEvent'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { VisibilitySensor } from 'lib/components/VisibilitySensor/VisibilitySensor'
 
 export function FunnelCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -35,7 +36,9 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         correlationsLoading,
         eventWithPropertyCorrelationsLoading,
         nestedTableExpandedKeys,
+        correlationPropKey,
     } = useValues(logic)
+
     const {
         setCorrelationTypes,
         loadEventWithPropertyCorrelations,
@@ -221,121 +224,123 @@ export function FunnelCorrelationTable(): JSX.Element | null {
     }
 
     return stepsWithCount.length > 1 ? (
-        <div className="funnel-correlation-table">
-            <span className="funnel-correlation-header">
-                <span className="table-header">
-                    <IconSelectEvents style={{ marginRight: 4 }} />
-                    CORRELATED EVENTS
-                </span>
-                <span className="table-options">
-                    <p className="title">CORRELATION</p>
-                    <div
-                        className="tab-btn ant-btn"
-                        style={{ marginRight: '2px', paddingTop: '1px', paddingBottom: '1px' }}
-                        onClick={() => onClickCorrelationType(FunnelCorrelationType.Success)}
-                    >
-                        <Checkbox
-                            checked={correlationTypes.includes(FunnelCorrelationType.Success)}
-                            style={{
-                                pointerEvents: 'none',
-                            }}
+        <VisibilitySensor id={correlationPropKey} offset={152}>
+            <div className="funnel-correlation-table">
+                <span className="funnel-correlation-header">
+                    <span className="table-header">
+                        <IconSelectEvents style={{ marginRight: 4 }} />
+                        CORRELATED EVENTS
+                    </span>
+                    <span className="table-options">
+                        <p className="title">CORRELATION</p>
+                        <div
+                            className="tab-btn ant-btn"
+                            style={{ marginRight: '2px', paddingTop: '1px', paddingBottom: '1px' }}
+                            onClick={() => onClickCorrelationType(FunnelCorrelationType.Success)}
                         >
-                            Success
-                        </Checkbox>
-                    </div>
-                    <div
-                        className="tab-btn ant-btn"
-                        style={{ marginRight: '5px', paddingTop: '1px', paddingBottom: '1px' }}
-                        onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
-                    >
-                        <Checkbox
-                            checked={correlationTypes.includes(FunnelCorrelationType.Failure)}
-                            style={{
-                                pointerEvents: 'none',
-                            }}
+                            <Checkbox
+                                checked={correlationTypes.includes(FunnelCorrelationType.Success)}
+                                style={{
+                                    pointerEvents: 'none',
+                                }}
+                            >
+                                Success
+                            </Checkbox>
+                        </div>
+                        <div
+                            className="tab-btn ant-btn"
+                            style={{ marginRight: '5px', paddingTop: '1px', paddingBottom: '1px' }}
+                            onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
                         >
-                            Dropoff
-                        </Checkbox>
-                    </div>
+                            <Checkbox
+                                checked={correlationTypes.includes(FunnelCorrelationType.Failure)}
+                                style={{
+                                    pointerEvents: 'none',
+                                }}
+                            >
+                                Dropoff
+                            </Checkbox>
+                        </div>
+                    </span>
                 </span>
-            </span>
-            <Table
-                dataSource={correlationValues}
-                loading={correlationsLoading}
-                size="small"
-                scroll={{ x: 'max-content' }}
-                rowKey={(record: FunnelCorrelation) => record.event.event}
-                pagination={{
-                    pageSize: 5,
-                    hideOnSinglePage: true,
-                    onChange: () => reportCorrelationInteraction(FunnelCorrelationResultsType.Events, 'load more'),
-                }}
-                style={{ marginTop: '1rem' }}
-                expandable={{
-                    expandedRowRender: (record) => renderNestedTable(record.event.event),
-                    expandedRowKeys: nestedTableExpandedKeys,
-                    rowExpandable: () => true,
-                    /* eslint-disable react/display-name */
-                    expandIcon: ({ expanded, onExpand, record }) =>
-                        expanded ? (
-                            <Tooltip title="Collapse">
-                                <div
-                                    style={{ cursor: 'pointer', opacity: 0.5, fontSize: 24 }}
-                                    onClick={(e) => {
-                                        removeNestedTableExpandedKey(record.event.event)
-                                        onExpand(record, e)
-                                    }}
-                                >
-                                    <IconUnfoldLess />
-                                </div>
-                            </Tooltip>
-                        ) : (
-                            <Tooltip title="Expand to see correlated properties for this event">
-                                <div
-                                    style={{ cursor: 'pointer', opacity: 0.5, fontSize: 24 }}
-                                    onClick={(e) => {
-                                        !eventHasPropertyCorrelations(record.event.event) &&
-                                            loadEventWithPropertyCorrelations(record.event.event)
-                                        addNestedTableExpandedKey(record.event.event)
-                                        onExpand(record, e)
-                                    }}
-                                >
-                                    <IconUnfoldMore />
-                                </div>
-                            </Tooltip>
-                        ),
-                    /* eslint-enable react/display-name */
-                }}
-            >
-                <Column
-                    title="Event"
-                    key="eventName"
-                    render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
-                    align="left"
-                    width="60%"
-                    ellipsis
-                />
-                <Column
-                    title="Completed"
-                    key="success_count"
-                    render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
-                    width={90}
-                    align="center"
-                />
-                <Column
-                    title="Dropped off"
-                    key="failure_count"
-                    render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
-                    width={100}
-                    align="center"
-                />
-                <Column
-                    title="Actions"
-                    key="operation"
-                    render={(_, record: FunnelCorrelation) => <CorrelationActionsCell record={record} />}
-                />
-            </Table>
-        </div>
+                <Table
+                    dataSource={correlationValues}
+                    loading={correlationsLoading}
+                    size="small"
+                    scroll={{ x: 'max-content' }}
+                    rowKey={(record: FunnelCorrelation) => record.event.event}
+                    pagination={{
+                        pageSize: 5,
+                        hideOnSinglePage: true,
+                        onChange: () => reportCorrelationInteraction(FunnelCorrelationResultsType.Events, 'load more'),
+                    }}
+                    style={{ marginTop: '1rem' }}
+                    expandable={{
+                        expandedRowRender: (record) => renderNestedTable(record.event.event),
+                        expandedRowKeys: nestedTableExpandedKeys,
+                        rowExpandable: () => true,
+                        /* eslint-disable react/display-name */
+                        expandIcon: ({ expanded, onExpand, record }) =>
+                            expanded ? (
+                                <Tooltip title="Collapse">
+                                    <div
+                                        style={{ cursor: 'pointer', opacity: 0.5, fontSize: 24 }}
+                                        onClick={(e) => {
+                                            removeNestedTableExpandedKey(record.event.event)
+                                            onExpand(record, e)
+                                        }}
+                                    >
+                                        <IconUnfoldLess />
+                                    </div>
+                                </Tooltip>
+                            ) : (
+                                <Tooltip title="Expand to see correlated properties for this event">
+                                    <div
+                                        style={{ cursor: 'pointer', opacity: 0.5, fontSize: 24 }}
+                                        onClick={(e) => {
+                                            !eventHasPropertyCorrelations(record.event.event) &&
+                                                loadEventWithPropertyCorrelations(record.event.event)
+                                            addNestedTableExpandedKey(record.event.event)
+                                            onExpand(record, e)
+                                        }}
+                                    >
+                                        <IconUnfoldMore />
+                                    </div>
+                                </Tooltip>
+                            ),
+                        /* eslint-enable react/display-name */
+                    }}
+                >
+                    <Column
+                        title="Event"
+                        key="eventName"
+                        render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
+                        align="left"
+                        width="60%"
+                        ellipsis
+                    />
+                    <Column
+                        title="Completed"
+                        key="success_count"
+                        render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
+                        width={90}
+                        align="center"
+                    />
+                    <Column
+                        title="Dropped off"
+                        key="failure_count"
+                        render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
+                        width={100}
+                        align="center"
+                    />
+                    <Column
+                        title="Actions"
+                        key="operation"
+                        render={(_, record: FunnelCorrelation) => <CorrelationActionsCell record={record} />}
+                    />
+                </Table>
+            </div>
+        </VisibilitySensor>
     ) : null
 }
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -153,7 +153,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     }
 
     return stepsWithCount.length > 1 ? (
-        <VisibilitySensor offset={300} id={`${correlationPropKey}-properties`}>
+        <VisibilitySensor offset={150} id={`${correlationPropKey}-properties`}>
             <div className="funnel-correlation-table">
                 <span className="funnel-correlation-header">
                     <span className="table-header">


### PR DESCRIPTION
## Changes

Issues from: https://github.com/PostHog/posthog/pull/6788#pullrequestreview-796785608

> The offset in the visibility sensor is not working. props.offset is never set. Couldn't figure out why this is the case, it's just not being passed to the logic correctly.

> We report correlation viewed (and related events) multiple times even if it's the same analysis. We should only report once and re-report only on refreshes/navigation, or if the funnel filters change.

> We only report correlation analyzed if the user does not scroll again at all in the 10s period, yet it's a pretty common case that you scroll a little bit while still "analyzing" the correlation analysis table. We should report the analyzed events if the table stays within the view for 10 seconds.

## How did you test this code?

Manually check events are fired
