### PR TITLE
BE (Groups/Retention): Support aggregating by groups

### DIFF
--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -9,6 +9,7 @@ from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.models.cohort import Cohort
 from posthog.models.event import Event
 from posthog.models.filters import Filter
+from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.test.test_filter import TestFilter as PGTestFilters
 from posthog.models.filters.test.test_filter import property_to_Q_test_factory
 from posthog.models.person import Person
@@ -181,6 +182,14 @@ class TestFilters(PGTestFilters):
                     }
                 ],
             },
+        )
+
+    def test_simplify_when_aggregating_by_group(self):
+        filter = RetentionFilter(data={"aggregation_group_type_index": 0})
+
+        self.assertEqual(
+            filter.simplify(self.team).properties_to_dict(),
+            {"properties": [{"key": "$group_0", "operator": "is_not", "value": "", "type": "event"}]},
         )
 
 

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -29,7 +29,7 @@ class RetentionEventsQuery(ClickhouseEventQuery):
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         _fields = [
             self.get_timestamp_field(),
-            (f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as target" if self._should_join_distinct_ids else ""),
+            f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as target",
             (
                 f"argMin(e.uuid, {self._trunc_func}(e.timestamp)) as min_uuid"
                 if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Tuple
 
 from ee.clickhouse.models.action import format_action_filter
+from ee.clickhouse.models.property import get_property_string_expr
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
 from ee.clickhouse.queries.util import get_trunc_func_ch
 from posthog.constants import (
@@ -29,7 +30,7 @@ class RetentionEventsQuery(ClickhouseEventQuery):
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         _fields = [
             self.get_timestamp_field(),
-            f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as target",
+            f"{self.get_target_field()} as target",
             (
                 f"argMin(e.uuid, {self._trunc_func}(e.timestamp)) as min_uuid"
                 if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
@@ -77,6 +78,14 @@ class RetentionEventsQuery(ClickhouseEventQuery):
         """
 
         return query, self.params
+
+    def get_target_field(self) -> str:
+        if self._filter.aggregation_group_type_index is not None:
+            prop_var = f"$group_{self._filter.aggregation_group_type_index}"
+            group_expression, _ = get_property_string_expr("events", prop_var, f"'{prop_var}'", f"{self.EVENT_TABLE_ALIAS}.properties")
+            return group_expression
+        else:
+            return f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"
 
     def get_timestamp_field(self) -> str:
         if self._event_query_type == RetentionQueryType.TARGET:

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, Tuple
+from typing import Any, Dict, Tuple
 
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.queries.event_query import ClickhouseEventQuery
@@ -29,7 +29,7 @@ class RetentionEventsQuery(ClickhouseEventQuery):
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         _fields = [
             self.get_timestamp_field(),
-            (f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id" if self._should_join_distinct_ids else ""),
+            (f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as target" if self._should_join_distinct_ids else ""),
             (
                 f"argMin(e.uuid, {self._trunc_func}(e.timestamp)) as min_uuid"
                 if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
@@ -73,7 +73,7 @@ class RetentionEventsQuery(ClickhouseEventQuery):
             {f"AND {entity_query}"}
             {f"AND {date_query}" if self._event_query_type != RetentionQueryType.TARGET_FIRST_TIME else ''}
             {prop_query}
-            {f"GROUP BY person_id HAVING {date_query}" if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME else ''}
+            {f"GROUP BY target HAVING {date_query}" if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME else ''}
         """
 
         return query, self.params

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -82,7 +82,9 @@ class RetentionEventsQuery(ClickhouseEventQuery):
     def get_target_field(self) -> str:
         if self._filter.aggregation_group_type_index is not None:
             prop_var = f"$group_{self._filter.aggregation_group_type_index}"
-            group_expression, _ = get_property_string_expr("events", prop_var, f"'{prop_var}'", f"{self.EVENT_TABLE_ALIAS}.properties")
+            group_expression, _ = get_property_string_expr(
+                "events", prop_var, f"'{prop_var}'", f"{self.EVENT_TABLE_ALIAS}.properties"
+            )
             return group_expression
         else:
             return f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -3,10 +3,10 @@
   
   SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), reference_event.event_date) as base_interval,
          datediff('Week', reference_event.event_date, toStartOfWeek(toDateTime(event_date))) as intervals_from_base,
-         COUNT(DISTINCT event.person_id) count
+         COUNT(DISTINCT event.target) count
   FROM
     (SELECT e.timestamp AS event_date,
-            pdi.person_id as person_id,
+            pdi.person_id as target,
             e.uuid AS uuid,
             e.event AS event
      FROM events e
@@ -39,7 +39,7 @@
                                     FROM JSONExtractRaw(group_properties_0, 'industry'))) ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     pdi.person_id as person_id,
+                     pdi.person_id as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -69,7 +69,7 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) reference_event ON (event.person_id = reference_event.person_id)
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -81,10 +81,10 @@
   '
   
   SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), event_date) event_date,
-         count(DISTINCT person_id)
+         count(DISTINCT target)
   FROM
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     pdi.person_id as person_id,
+                     pdi.person_id as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -124,10 +124,10 @@
   
   SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), reference_event.event_date) as base_interval,
          datediff('Week', reference_event.event_date, toStartOfWeek(toDateTime(event_date))) as intervals_from_base,
-         COUNT(DISTINCT event.person_id) count
+         COUNT(DISTINCT event.target) count
   FROM
     (SELECT e.timestamp AS event_date,
-            pdi.person_id as person_id,
+            pdi.person_id as target,
             e.uuid AS uuid,
             e.event AS event
      FROM events e
@@ -159,7 +159,7 @@
        AND JSONHas(group_properties_0, 'industry') ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     pdi.person_id as person_id,
+                     pdi.person_id as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -188,7 +188,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry') ) reference_event ON (event.person_id = reference_event.person_id)
+       AND JSONHas(group_properties_0, 'industry') ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -200,10 +200,10 @@
   '
   
   SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), event_date) event_date,
-         count(DISTINCT person_id)
+         count(DISTINCT target)
   FROM
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     pdi.person_id as person_id,
+                     pdi.person_id as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -28,7 +28,10 @@
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
-       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00') ) event
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND NOT has([''], trim(BOTH '"'
+                              FROM JSONExtractRaw(properties, '$group_0')))
+       AND team_id = 2 ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      trim(BOTH '"'
@@ -53,7 +56,10 @@
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
-       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00') ) reference_event ON (event.target = reference_event.target)
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND NOT has([''], trim(BOTH '"'
+                              FROM JSONExtractRaw(properties, '$group_0')))
+       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -90,7 +96,10 @@
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
-       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00') )
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND NOT has([''], trim(BOTH '"'
+                              FROM JSONExtractRaw(properties, '$group_0')))
+       AND team_id = 2 )
   GROUP BY event_date
   ORDER BY event_date
   '

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -104,6 +104,112 @@
   ORDER BY event_date
   '
 ---
+# name: TestClickhouseRetention.test_groups_aggregating.2
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), reference_event.event_date) as base_interval,
+         datediff('Week', reference_event.event_date, toStartOfWeek(toDateTime(event_date))) as intervals_from_base,
+         COUNT(DISTINCT event.target) count
+  FROM
+    (SELECT e.timestamp AS event_date,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(e.properties, '$group_1')) as target,
+            e.uuid AS uuid,
+            e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND NOT has([''], trim(BOTH '"'
+                              FROM JSONExtractRaw(properties, '$group_1')))
+       AND team_id = 2 ) event
+  JOIN
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     trim(BOTH '"'
+                          FROM JSONExtractRaw(e.properties, '$group_1')) as target,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND NOT has([''], trim(BOTH '"'
+                              FROM JSONExtractRaw(properties, '$group_1')))
+       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
+  WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
+  GROUP BY base_interval,
+           intervals_from_base
+  ORDER BY base_interval,
+           intervals_from_base
+  '
+---
+# name: TestClickhouseRetention.test_groups_aggregating.3
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), event_date) event_date,
+         count(DISTINCT target)
+  FROM
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     trim(BOTH '"'
+                          FROM JSONExtractRaw(e.properties, '$group_1')) as target,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
+       AND NOT has([''], trim(BOTH '"'
+                              FROM JSONExtractRaw(properties, '$group_1')))
+       AND team_id = 2 )
+  GROUP BY event_date
+  ORDER BY event_date
+  '
+---
 # name: TestClickhouseRetention.test_groups_filtering
   '
   

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -1,3 +1,100 @@
+# name: TestClickhouseRetention.test_groups_aggregating
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), reference_event.event_date) as base_interval,
+         datediff('Week', reference_event.event_date, toStartOfWeek(toDateTime(event_date))) as intervals_from_base,
+         COUNT(DISTINCT event.target) count
+  FROM
+    (SELECT e.timestamp AS event_date,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(e.properties, '$group_0')) as target,
+            e.uuid AS uuid,
+            e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00') ) event
+  JOIN
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     trim(BOTH '"'
+                          FROM JSONExtractRaw(e.properties, '$group_0')) as target,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00') ) reference_event ON (event.target = reference_event.target)
+  WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
+  GROUP BY base_interval,
+           intervals_from_base
+  ORDER BY base_interval,
+           intervals_from_base
+  '
+---
+# name: TestClickhouseRetention.test_groups_aggregating.1
+  '
+  
+  SELECT datediff('Week', toStartOfWeek(toDateTime('2020-06-07 00:00:00')), event_date) event_date,
+         count(DISTINCT target)
+  FROM
+    (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
+                     trim(BOTH '"'
+                          FROM JSONExtractRaw(e.properties, '$group_0')) as target,
+                     e.uuid AS uuid,
+                     e.event AS event
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND e.event = '$pageview'
+       AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
+       AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00') )
+  GROUP BY event_date
+  ORDER BY event_date
+  '
+---
 # name: TestClickhouseRetention.test_groups_filtering
   '
   

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -75,7 +75,8 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                     "period": "Week",
                     "total_intervals": 7,
                     "properties": [{"key": "industry", "value": "technology", "type": "group", "group_type_index": 0}],
-                }
+                },
+                team=self.team
             ),
             self.team,
         )
@@ -94,7 +95,8 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                     "properties": [
                         {"key": "industry", "value": "", "type": "group", "group_type_index": 0, "operator": "is_set"}
                     ],
-                }
+                },
+                team=self.team
             ),
             self.team,
         )
@@ -115,7 +117,8 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                     "period": "Week",
                     "total_intervals": 7,
                     "aggregation_group_type_index": 0
-                }
+                },
+                team=self.team
             ),
             self.team,
         )

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -76,7 +76,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                     "total_intervals": 7,
                     "properties": [{"key": "industry", "value": "technology", "type": "group", "group_type_index": 0}],
                 },
-                team=self.team
+                team=self.team,
             ),
             self.team,
         )
@@ -96,7 +96,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                         {"key": "industry", "value": "", "type": "group", "group_type_index": 0, "operator": "is_set"}
                     ],
                 },
-                team=self.team
+                team=self.team,
             ),
             self.team,
         )
@@ -116,11 +116,13 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                     "date_to": self._date(10, month=1, hour=0),
                     "period": "Week",
                     "total_intervals": 7,
-                    "aggregation_group_type_index": 0
+                    "aggregation_group_type_index": 0,
                 },
-                team=self.team
+                team=self.team,
             ),
             self.team,
         )
 
-        import pprint; pprint.pprint(result)
+        import pprint
+
+        pprint.pprint(result)

--- a/ee/clickhouse/sql/retention/retention.py
+++ b/ee/clickhouse/sql/retention/retention.py
@@ -2,14 +2,14 @@ RETENTION_SQL = """
 SELECT
     datediff(%(period)s, {trunc_func}(toDateTime(%(start_date)s)), reference_event.event_date) as base_interval,
     datediff(%(period)s, reference_event.event_date, {trunc_func}(toDateTime(event_date))) as intervals_from_base,
-    COUNT(DISTINCT event.person_id) count
+    COUNT(DISTINCT event.target) count
 FROM (
     {returning_event_query}
 ) event
 JOIN (
     {target_event_query}
 ) reference_event
-    ON (event.person_id = reference_event.person_id)
+    ON (event.target = reference_event.target)
 WHERE {trunc_func}(event.event_date) > {trunc_func}(reference_event.event_date)
 GROUP BY base_interval, intervals_from_base
 ORDER BY base_interval, intervals_from_base
@@ -51,7 +51,7 @@ LIMIT 100 OFFSET %(offset)s
 
 INITIAL_INTERVAL_SQL = """
 SELECT datediff(%(period)s, {trunc_func}(toDateTime(%(start_date)s)), event_date) event_date,
-       count(DISTINCT person_id) FROM (
+       count(DISTINCT target) FROM (
     {reference_event_sql}
 ) GROUP BY event_date ORDER BY event_date
 """

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -149,6 +149,7 @@ PATH_DROPOFF_KEY = "path_dropoff_key"
 PATH_EDGE_LIMIT = "edge_limit"
 PATH_MIN_EDGE_WEIGHT = "min_edge_weight"
 PATH_MAX_EDGE_WEIGHT = "max_edge_weight"
+AGGREGATION_GROUP_TYPE_INDEX = "aggregation_group_type_index"
 
 
 class FunnelOrderType(str, Enum):

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -38,6 +38,7 @@ from posthog.constants import (
 )
 from posthog.models.entity import Entity, ExclusionEntity
 from posthog.models.filters.mixins.base import BaseParamMixin, BreakdownType, IntervalType
+from posthog.models.filters.mixins.groups import validate_group_type_index
 from posthog.models.filters.mixins.utils import cached_property, include_dict, process_bool
 from posthog.utils import relative_date_parse
 
@@ -151,12 +152,7 @@ class BreakdownMixin(BaseParamMixin):
     @cached_property
     def breakdown_group_type_index(self) -> Optional[int]:
         value = self._data.get(BREAKDOWN_GROUP_TYPE_INDEX, None)
-        if value is not None and not (isinstance(value, int) and 0 <= value < GROUP_TYPES_LIMIT):
-            raise ValidationError(
-                {
-                    "breakdown_group_type_index": f"This field is required if breakdown_type is group and must be greater than 0 and less than {GROUP_TYPES_LIMIT}"
-                }
-            )
+        validate_group_type_index(BREAKDOWN_GROUP_TYPE_INDEX, value)
 
         return value
 

--- a/posthog/models/filters/mixins/groups.py
+++ b/posthog/models/filters/mixins/groups.py
@@ -26,4 +26,8 @@ class GroupsAggregationMixin(BaseParamMixin):
 
     @include_dict
     def aggregation_group_type_index_to_dict(self):
-        return {AGGREGATION_GROUP_TYPE_INDEX: self.aggregation_group_type_index} if self.aggregation_group_type_index is not None else {}
+        return (
+            {AGGREGATION_GROUP_TYPE_INDEX: self.aggregation_group_type_index}
+            if self.aggregation_group_type_index is not None
+            else {}
+        )

--- a/posthog/models/filters/mixins/groups.py
+++ b/posthog/models/filters/mixins/groups.py
@@ -1,0 +1,29 @@
+from typing import Any, Optional
+
+from rest_framework.exceptions import ValidationError
+
+from posthog.constants import AGGREGATION_GROUP_TYPE_INDEX, GROUP_TYPES_LIMIT
+from posthog.models.filters.mixins.common import BaseParamMixin
+from posthog.models.filters.mixins.utils import cached_property, include_dict
+
+
+def validate_group_type_index(param_name: str, value: Any):
+    if value is not None and not (isinstance(value, int) and 0 <= value < GROUP_TYPES_LIMIT):
+        raise ValidationError(
+            {
+                param_name: f"This field is required if breakdown_type is group and must be greater than 0 and less than {GROUP_TYPES_LIMIT}"
+            }
+        )
+
+
+class GroupsAggregationMixin(BaseParamMixin):
+    @cached_property
+    def aggregation_group_type_index(self) -> Optional[int]:
+        value = self._data.get(AGGREGATION_GROUP_TYPE_INDEX)
+        validate_group_type_index(AGGREGATION_GROUP_TYPE_INDEX, value)
+
+        return value
+
+    @include_dict
+    def aggregation_group_type_index_to_dict(self):
+        return {AGGREGATION_GROUP_TYPE_INDEX: self.aggregation_group_type_index} if self.aggregation_group_type_index is not None else {}

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, TypeVar, cast
 
 from posthog.utils import is_clickhouse_enabled
 
@@ -35,10 +35,14 @@ class SimplifyFilterMixin:
             for entity_type, entities in result.entities_to_dict().items():
                 updated_entities[entity_type] = [self._simplify_entity(team, entity_type, entity, **kwargs) for entity in entities]  # type: ignore
 
+        properties = self._simplify_properties(team, result.properties, **kwargs) # type: ignore
+        if getattr(result, "aggregation_group_type_index", None) is not None:
+            properties.append(self._group_set_property(cast(int, result.aggregation_group_type_index))) # type: ignore
+
         return result.with_data(
             {
                 **updated_entities,
-                "properties": self._simplify_properties(team, result.properties, **kwargs),  # type: ignore
+                "properties": properties,
             }
         )
 
@@ -46,14 +50,13 @@ class SimplifyFilterMixin:
         self, team: "Team", entity_type: Literal["events", "actions", "exclusions"], entity_params: Dict, **kwargs
     ) -> Dict:
         from posthog.models.entity import Entity, ExclusionEntity
-        from posthog.models.property import Property
 
         EntityClass = ExclusionEntity if entity_type == "exclusions" else Entity
 
         entity = EntityClass(entity_params)
         properties = self._simplify_properties(team, entity.properties, **kwargs)
         if entity.math == "unique_group":
-            properties.append(Property(key=f"$group_{entity.math_group_type_index}", value="", operator="is_not",))
+            properties.append(self._group_set_property(cast(int, entity.math_group_type_index)))
 
         return EntityClass({**entity_params, "properties": properties}).to_dict()
 
@@ -79,6 +82,11 @@ class SimplifyFilterMixin:
             return simplified_cohort_filter_properties(cohort, team)
 
         return [property]
+
+    def _group_set_property(self, group_type_index: int) -> "Property":
+        from posthog.models.property import Property
+
+        return Property(key=f"$group_{group_type_index}", value="", operator="is_not",)
 
     @property
     def is_simplified(self) -> bool:

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -35,16 +35,11 @@ class SimplifyFilterMixin:
             for entity_type, entities in result.entities_to_dict().items():
                 updated_entities[entity_type] = [self._simplify_entity(team, entity_type, entity, **kwargs) for entity in entities]  # type: ignore
 
-        properties = self._simplify_properties(team, result.properties, **kwargs) # type: ignore
+        properties = self._simplify_properties(team, result.properties, **kwargs)  # type: ignore
         if getattr(result, "aggregation_group_type_index", None) is not None:
-            properties.append(self._group_set_property(cast(int, result.aggregation_group_type_index))) # type: ignore
+            properties.append(self._group_set_property(cast(int, result.aggregation_group_type_index)))  # type: ignore
 
-        return result.with_data(
-            {
-                **updated_entities,
-                "properties": properties,
-            }
-        )
+        return result.with_data({**updated_entities, "properties": properties,})
 
     def _simplify_entity(
         self, team: "Team", entity_type: Literal["events", "actions", "exclusions"], entity_params: Dict, **kwargs

--- a/posthog/models/filters/mixins/test/test_groups.py
+++ b/posthog/models/filters/mixins/test/test_groups.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.models.filters.mixins.groups import validate_group_type_index
 
+
 def test_validate_group_type_index():
     validate_group_type_index("field", None)
     validate_group_type_index("field", 0)

--- a/posthog/models/filters/mixins/test/test_groups.py
+++ b/posthog/models/filters/mixins/test/test_groups.py
@@ -1,0 +1,18 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from posthog.models.filters.mixins.groups import validate_group_type_index
+
+def test_validate_group_type_index():
+    validate_group_type_index("field", None)
+    validate_group_type_index("field", 0)
+    validate_group_type_index("field", 2)
+    validate_group_type_index("field", 3)
+    validate_group_type_index("field", 4)
+
+    with pytest.raises(ValidationError):
+        validate_group_type_index("field", 5)
+    with pytest.raises(ValidationError):
+        validate_group_type_index("field", "another_type")
+    with pytest.raises(ValidationError):
+        validate_group_type_index("field", -1)

--- a/posthog/models/filters/retention_filter.py
+++ b/posthog/models/filters/retention_filter.py
@@ -12,6 +12,7 @@ from posthog.models.filters.mixins.common import (
     OffsetMixin,
 )
 from posthog.models.filters.mixins.funnel import FunnelCorrelationMixin
+from posthog.models.filters.mixins.groups import GroupsAggregationMixin
 from posthog.models.filters.mixins.property import PropertyMixin
 from posthog.models.filters.mixins.retention import EntitiesDerivedMixin, RetentionDateDerivedMixin, RetentionTypeMixin
 from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
@@ -29,6 +30,7 @@ class RetentionFilter(
     BreakdownMixin,
     InsightMixin,
     OffsetMixin,
+    GroupsAggregationMixin,
     FunnelCorrelationMixin,  # Typing pain because ColumnOptimizer expects a uniform filter
     # TODO: proper fix for EventQuery abstraction, make filters uniform
     SimplifyFilterMixin,


### PR DESCRIPTION
## Changes

Request schema change: new top-level filter property `aggregation_group_type_index` has been added. Undefined if aggregating by people, group type index otherwise.

## How did you test this code?

See tests
