### PR TITLE
New insight through insightRouter

### DIFF
--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -238,7 +238,7 @@ function Pages(): JSX.Element {
                 to={urls.savedInsights()}
                 sideAction={{
                     icon: <IconPlus />,
-                    to: urls.insightView(ViewType.TRENDS),
+                    to: urls.newInsight(ViewType.TRENDS),
                     tooltip: 'New insight',
                     identifier: 'insights',
                 }}

--- a/frontend/src/layout/navigation/MainNavigation.tsx
+++ b/frontend/src/layout/navigation/MainNavigation.tsx
@@ -221,7 +221,7 @@ function MenuItems(): JSX.Element {
                     title="New Insight"
                     icon={<IconExplore />}
                     identifier="insights"
-                    to={urls.insightView(ViewType.TRENDS)}
+                    to={urls.newInsight(ViewType.TRENDS)}
                     hotkey="x"
                     tooltip="Answers to all your analytics questions"
                 />
@@ -231,9 +231,7 @@ function MenuItems(): JSX.Element {
                 icon={<IconInsights />}
                 identifier={featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] ? 'savedInsights' : 'insights'}
                 to={
-                    featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS]
-                        ? urls.savedInsights()
-                        : urls.insightView(ViewType.TRENDS)
+                    featureFlags[FEATURE_FLAGS.SAVED_INSIGHTS] ? urls.savedInsights() : urls.newInsight(ViewType.TRENDS)
                 }
                 hotkey="i"
                 tooltip={

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -429,7 +429,7 @@ export const commandPaletteLogic = kea<
                         display: 'Go to Trends',
                         executor: () => {
                             // TODO: Don't reset insight on change
-                            push(urls.insightView(ViewType.TRENDS))
+                            push(urls.newInsight(ViewType.TRENDS))
                         },
                     },
                     {
@@ -437,7 +437,7 @@ export const commandPaletteLogic = kea<
                         display: 'Go to Sessions',
                         executor: () => {
                             // TODO: Don't reset insight on change
-                            push(urls.insightView(ViewType.SESSIONS))
+                            push(urls.newInsight(ViewType.SESSIONS))
                         },
                     },
                     {
@@ -445,7 +445,7 @@ export const commandPaletteLogic = kea<
                         display: 'Go to Funnels',
                         executor: () => {
                             // TODO: Don't reset insight on change
-                            push(urls.insightView(ViewType.FUNNELS))
+                            push(urls.newInsight(ViewType.FUNNELS))
                         },
                     },
                     {
@@ -453,7 +453,7 @@ export const commandPaletteLogic = kea<
                         display: 'Go to Retention',
                         executor: () => {
                             // TODO: Don't reset insight on change
-                            push(urls.insightView(ViewType.RETENTION))
+                            push(urls.newInsight(ViewType.RETENTION))
                         },
                     },
                     {
@@ -461,7 +461,7 @@ export const commandPaletteLogic = kea<
                         display: 'Go to User Paths',
                         executor: () => {
                             // TODO: Don't reset insight on change
-                            push(urls.insightView(ViewType.PATHS))
+                            push(urls.newInsight(ViewType.PATHS))
                         },
                     },
                     {

--- a/frontend/src/scenes/insights/InsightRouter.tsx
+++ b/frontend/src/scenes/insights/InsightRouter.tsx
@@ -1,58 +1,11 @@
 import { Card, Col, Row, Skeleton } from 'antd'
-import { kea, useValues } from 'kea'
-import { router, combineUrl } from 'kea-router'
-import api from 'lib/api'
+import { useValues } from 'kea'
 import { NotFound } from 'lib/components/NotFound'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import React from 'react'
-import { DashboardItemType } from '~/types'
-import { teamLogic } from '../teamLogic'
-import { insightRouterLogicType } from './InsightRouterType'
 import { SceneExport } from 'scenes/sceneTypes'
+import { insightRouterLogic } from 'scenes/insights/insightRouterLogic'
 
-const insightRouterLogic = kea<insightRouterLogicType>({
-    actions: {
-        loadInsight: (id: string) => ({ id }),
-        setError: true,
-    },
-    reducers: {
-        error: [
-            false,
-            {
-                setError: () => true,
-            },
-        ],
-    },
-    listeners: ({ actions }) => ({
-        loadInsight: async ({ id }) => {
-            const response = await api.get(`api/projects/${teamLogic.values.currentTeamId}/insights/?short_id=${id}`)
-            if (response.results.length) {
-                const item = response.results[0] as DashboardItemType
-                eventUsageLogic.actions.reportInsightShortUrlVisited(true, item.filters.insight || null)
-                router.actions.replace(
-                    combineUrl('/insights', item.filters, {
-                        fromItem: item.id,
-                        fromItemName: item.name,
-                        fromDashboard: item.dashboard,
-                        id: item.short_id,
-                    }).url
-                )
-            } else {
-                eventUsageLogic.actions.reportInsightShortUrlVisited(false, null)
-                actions.setError()
-            }
-        },
-    }),
-    urlToAction: ({ actions }) => ({
-        '/i/:id': ({ id }) => {
-            if (id) {
-                actions.loadInsight(id)
-            }
-        },
-    }),
-})
-
-/* Handles insights short links `/i/{id}` */
+/* Handles insights links `/i/{id}` and `/insights/new` */
 export function InsightRouter(): JSX.Element {
     const { error } = useValues(insightRouterLogic)
     return (

--- a/frontend/src/scenes/insights/insightRouterLogic.test.ts
+++ b/frontend/src/scenes/insights/insightRouterLogic.test.ts
@@ -1,0 +1,50 @@
+import { initKeaTests } from '~/test/init'
+import { insightRouterLogic } from 'scenes/insights/insightRouterLogic'
+import { router } from 'kea-router'
+import { defaultAPIMocks, MOCK_TEAM_ID, mockAPI } from 'lib/api.mock'
+import { expectLogic, partial } from 'kea-test-utils'
+jest.mock('lib/api')
+
+describe('insightRouterLogic', () => {
+    let logic: ReturnType<typeof insightRouterLogic.build>
+
+    mockAPI(async (url) => {
+        const { pathname, data } = url
+        console.log(pathname)
+        if (pathname === `api/projects/${MOCK_TEAM_ID}/insights`) {
+            return {
+                ...data,
+                result: ['result from api'],
+                id: 42,
+                filters: data?.filters || {},
+            }
+        }
+        return defaultAPIMocks(url)
+    })
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = insightRouterLogic()
+        logic.mount()
+    })
+
+    it('redirects when opening /insight/new', async () => {
+        router.actions.push('/insights/new')
+        await expectLogic(router)
+            .delay(1)
+            .toMatchValues({
+                location: partial({ pathname: '/insights' }),
+                searchParams: partial({ insight: 'TRENDS' }),
+                hashParams: partial({ edit: true, fromItem: 42 }),
+            })
+
+        router.actions.push('/insights/new?insight=FUNNELS')
+        await expectLogic(router)
+            .delay(1)
+            .toMatchValues({
+                location: partial({ pathname: '/insights' }),
+                searchParams: partial({ insight: 'FUNNELS' }),
+                hashParams: partial({ edit: true, fromItem: 42 }),
+            })
+    })
+})

--- a/frontend/src/scenes/insights/insightRouterLogic.ts
+++ b/frontend/src/scenes/insights/insightRouterLogic.ts
@@ -1,0 +1,69 @@
+import { kea } from 'kea'
+import { DashboardItemType } from '~/types'
+import api from 'lib/api'
+import { teamLogic } from 'scenes/teamLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { combineUrl, router } from 'kea-router'
+import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
+import { insightRouterLogicType } from './insightRouterLogicType'
+
+export const insightRouterLogic = kea<insightRouterLogicType>({
+    actions: {
+        loadInsight: (id: string) => ({ id }),
+        setError: true,
+        createInsight: (insight: Partial<DashboardItemType>) => ({ insight }),
+    },
+    reducers: {
+        error: [
+            false,
+            {
+                setError: () => true,
+            },
+        ],
+    },
+    listeners: ({ actions }) => ({
+        loadInsight: async ({ id }) => {
+            const response = await api.get(`api/projects/${teamLogic.values.currentTeamId}/insights/?short_id=${id}`)
+            if (response.results.length) {
+                const item = response.results[0] as DashboardItemType
+                eventUsageLogic.actions.reportInsightShortUrlVisited(true, item.filters.insight || null)
+                router.actions.replace(
+                    combineUrl('/insights', item.filters, {
+                        fromItem: item.id,
+                        fromItemName: item.name,
+                        fromDashboard: item.dashboard,
+                        id: item.short_id,
+                    }).url
+                )
+            } else {
+                eventUsageLogic.actions.reportInsightShortUrlVisited(false, null)
+                actions.setError()
+            }
+        },
+        createInsight: async ({ insight }, breakpoint) => {
+            const newInsight = { name: '', description: '', tags: [], filters: {}, result: null, ...insight }
+            const createdInsight = await api.create(
+                `api/projects/${teamLogic.values.currentTeamId}/insights`,
+                newInsight
+            )
+            breakpoint()
+            router.actions.replace('/insights', createdInsight.filters, {
+                ...router.values.hashParams,
+                edit: true,
+                fromItem: createdInsight.id,
+            })
+        },
+    }),
+    urlToAction: ({ actions }) => ({
+        '/i/:id': ({ id }) => {
+            if (id) {
+                actions.loadInsight(id)
+            }
+        },
+        '/insights/new': (_, searchParams) => {
+            // console.log(searchParams)
+            // debugger
+            actions.createInsight({ filters: cleanFilters(searchParams) })
+        },
+    }),
+})

--- a/frontend/src/scenes/insights/insightRouterLogic.ts
+++ b/frontend/src/scenes/insights/insightRouterLogic.ts
@@ -61,8 +61,6 @@ export const insightRouterLogic = kea<insightRouterLogicType>({
             }
         },
         '/insights/new': (_, searchParams) => {
-            // console.log(searchParams)
-            // debugger
             actions.createInsight({ filters: cleanFilters(searchParams) })
         },
     }),

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -320,7 +320,7 @@ export function SavedInsights(): JSX.Element {
                                 .map((menuItem) => (
                                     <Menu.Item key={menuItem.type}>
                                         <Link
-                                            to={urls.insightView(menuItem.type)}
+                                            to={urls.newInsight(menuItem.type)}
                                             data-attr="saved-insights-create-new-insight"
                                             data-attr-insight-type={menuItem.type}
                                             onClick={() =>

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -138,6 +138,7 @@ export const routes: Record<string, Scene> = {
     [urls.dashboard(':id')]: Scene.Dashboard,
     [urls.createAction()]: Scene.Action,
     [urls.action(':id')]: Scene.Action,
+    [urls.newInsight()]: Scene.InsightRouter,
     [urls.insights()]: Scene.Insights,
     [urls.insightRouter(':id')]: Scene.InsightRouter,
     [urls.actions()]: Scene.Actions,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -13,7 +13,7 @@ export const urls = {
     eventPropertyStats: () => '/events/properties',
     events: () => '/events',
     insights: () => '/insights',
-    insightView: (view: ViewType) => `/insights?insight=${view}`,
+    newInsight: (insight?: ViewType) => `/insights/new${insight ? `?insight=${encodeURIComponent(insight)}` : ``}`,
     insightRouter: (id: string) => `/i/${id}`,
     savedInsights: () => '/saved_insights',
     sessions: () => '/sessions',


### PR DESCRIPTION
## Changes

- This fixes the last "blockerish" issue with Saved Insights.
- It's FMC: Friday Merge Compatible.
- I have two draft PRs to clean up insight routes, both with a lot of changes:
  - https://github.com/PostHog/posthog/pull/6903
  - https://github.com/PostHog/posthog/pull/6918
- They tend to get really really tricky and complicated if I can't rewrite core pieces due to needing to support both saved insights and the previous view. Both of them are too flakey to merge.
- This is the first piece of a new approach. I'm just using the exsitsting, yet underused, `insightRouter` to create a new insight when `/insights/new` is loaded, and redirect (`replace`) the edit page after.


## How did you test this code?

- Wrote a logic test, which felt so much cleaner than all the tests I had to patch for the PRs before.
- Also tested locally in the browser.
