### PR TITLE
Lemonade polish

### DIFF
--- a/frontend/src/layout/lemonade/RedesignOptIn.scss
+++ b/frontend/src/layout/lemonade/RedesignOptIn.scss
@@ -7,8 +7,9 @@
         font-weight: 600;
         color: var(--primary-alt);
         margin-right: 0.5rem;
+        text-align: right;
     }
-    @media screen and (min-width: $sm) {
+    @media screen and (min-width: $md) {
         display: flex;
         align-items: center;
     }

--- a/frontend/src/layout/lemonade/TopBar/SearchBox.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SearchBox.tsx
@@ -8,7 +8,7 @@ export function SearchBox(): JSX.Element {
     const { showPalette } = useActions(commandPaletteLogic)
 
     return (
-        <div className="SearchBox" onClick={showPalette}>
+        <div className="SearchBox" onClick={showPalette} data-attr="command-palette-toggle">
             <div className="SearchBox__primary-area">
                 <SearchOutlined className="SearchBox__magnifier" />
                 Search

--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -5,7 +5,15 @@ import { userLogic } from '../../../scenes/userLogic'
 import { ProfilePicture } from '../../../lib/components/ProfilePicture'
 import { LemonButton } from '../../../lib/components/LemonButton'
 import { LemonRow } from '../../../lib/components/LemonRow'
-import { IconCheckmark, IconOffline, IconPlus, IconLogout, IconUpdate, IconExclamation } from 'lib/components/icons'
+import {
+    IconCheckmark,
+    IconOffline,
+    IconPlus,
+    IconLogout,
+    IconUpdate,
+    IconExclamation,
+    IconBill,
+} from 'lib/components/icons'
 import { Popup } from '../../../lib/components/Popup/Popup'
 import { Link } from '../../../lib/components/Link'
 import { urls } from '../../../scenes/urls'
@@ -250,6 +258,16 @@ export function SitePopover(): JSX.Element {
                     </SitePopoverSection>
                     <SitePopoverSection title="Current organization">
                         {currentOrganization && <CurrentOrganization organization={currentOrganization} />}
+                        {preflight?.cloud && (
+                            <LemonButton
+                                onClick={closeSitePopover}
+                                to={urls.organizationBilling()}
+                                icon={<IconBill />}
+                                fullWidth
+                            >
+                                Billing
+                            </LemonButton>
+                        )}
                         <InviteMembersButton />
                     </SitePopoverSection>
                     {(otherOrganizations.length > 0 || preflight?.can_create_org) && (

--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -51,7 +51,12 @@ function AccountInfo(): JSX.Element {
                     {user?.email}
                 </div>
             </div>
-            <Link to={urls.mySettings()} onClick={closeSitePopover} className="SitePopover__side-link">
+            <Link
+                to={urls.mySettings()}
+                onClick={closeSitePopover}
+                className="SitePopover__side-link"
+                data-attr="top-menu-item-me"
+            >
                 Manage account
             </Link>
         </div>
@@ -76,7 +81,12 @@ function CurrentOrganization({ organization }: { organization: OrganizationBasic
                     <strong>{organization.name}</strong>
                     <AccessLevelIndicator organization={organization} />
                 </div>
-                <Link to={urls.organizationSettings()} onClick={closeSitePopover} className="SitePopover__side-link">
+                <Link
+                    to={urls.organizationSettings()}
+                    onClick={closeSitePopover}
+                    className="SitePopover__side-link"
+                    data-attr="top-menu-item-org-settings"
+                >
                     Settings
                 </Link>
             </>
@@ -113,6 +123,7 @@ function InviteMembersButton(): JSX.Element {
                 showInviteModal()
             }}
             fullWidth
+            data-attr="top-menu-invite-team-members"
         >
             Invite members
         </LemonButton>
@@ -165,7 +176,12 @@ function License(): JSX.Element {
                         </div>
                     )}
                 </div>
-                <Link to={urls.instanceLicenses()} onClick={closeSitePopover} className="SitePopover__side-link">
+                <Link
+                    to={urls.instanceLicenses()}
+                    onClick={closeSitePopover}
+                    className="SitePopover__side-link"
+                    data-attr="top-menu-item-licenses"
+                >
                     Manage license
                 </Link>
             </>
@@ -187,7 +203,12 @@ function SystemStatus(): JSX.Element {
                 <div className="SitePopover__main-info">
                     {systemStatus ? 'All systems operational' : 'Potential system issue'}
                 </div>
-                <Link to={urls.systemStatus()} onClick={closeSitePopover} className="SitePopover__side-link">
+                <Link
+                    to={urls.systemStatus()}
+                    onClick={closeSitePopover}
+                    className="SitePopover__side-link"
+                    data-attr="system-status-badge"
+                >
                     System status
                 </Link>
             </>
@@ -219,6 +240,7 @@ function Version(): JSX.Element {
                         closeSitePopover()
                     }}
                     className="SitePopover__side-link"
+                    data-attr="update-indicator-badge"
                 >
                     Release notes
                 </Link>
@@ -231,7 +253,7 @@ function SignOutButton(): JSX.Element {
     const { logout } = useActions(userLogic)
 
     return (
-        <LemonButton onClick={logout} icon={<IconLogout />} type="stealth" fullWidth>
+        <LemonButton onClick={logout} icon={<IconLogout />} type="stealth" fullWidth data-attr="top-menu-item-logout">
             Sign out
         </LemonButton>
     )
@@ -264,6 +286,7 @@ export function SitePopover(): JSX.Element {
                                 to={urls.organizationBilling()}
                                 icon={<IconBill />}
                                 fullWidth
+                                data-attr="top-menu-item-billing"
                             >
                                 Billing
                             </LemonButton>

--- a/frontend/src/layout/lemonade/TopBar/index.tsx
+++ b/frontend/src/layout/lemonade/TopBar/index.tsx
@@ -19,6 +19,7 @@ import { CreateProjectModal } from '../../../scenes/project/CreateProjectModal'
 export function TopBar(): JSX.Element {
     const {
         isSideBarShown,
+        isSideBarForciblyHidden,
         announcementMessage,
         isAnnouncementShown,
         isInviteModalShown,
@@ -42,9 +43,11 @@ export function TopBar(): JSX.Element {
             )}
             <header className="TopBar">
                 <div className="TopBar__segment TopBar__segment--left">
-                    <div className="TopBar__hamburger" onClick={toggleSideBar}>
-                        {isSideBarShown ? <IconMenuOpen /> : <IconMenu />}
-                    </div>
+                    {!isSideBarForciblyHidden && (
+                        <div className="TopBar__hamburger" onClick={toggleSideBar}>
+                            {isSideBarShown ? <IconMenuOpen /> : <IconMenu />}
+                        </div>
+                    )}
                     <Link to="/" className="TopBar__logo">
                         <FriendlyLogo />
                     </Link>

--- a/frontend/src/layout/lemonade/lemonadeLogic.ts
+++ b/frontend/src/layout/lemonade/lemonadeLogic.ts
@@ -1,10 +1,6 @@
 import { kea } from 'kea'
 import { FEATURE_FLAGS } from '../../lib/constants'
 import { featureFlagLogic } from '../../lib/logic/featureFlagLogic'
-import { dashboardLogic } from '../../scenes/dashboard/dashboardLogic'
-import { sceneLogic } from '../../scenes/sceneLogic'
-import { Scene } from '../../scenes/sceneTypes'
-import { DashboardMode } from '../../types'
 import { lemonadeLogicType } from './lemonadeLogicType'
 
 export const lemonadeLogic = kea<lemonadeLogicType>({

--- a/frontend/src/layout/lemonade/lemonadeLogic.ts
+++ b/frontend/src/layout/lemonade/lemonadeLogic.ts
@@ -1,6 +1,10 @@
 import { kea } from 'kea'
 import { FEATURE_FLAGS } from '../../lib/constants'
 import { featureFlagLogic } from '../../lib/logic/featureFlagLogic'
+import { dashboardLogic } from '../../scenes/dashboard/dashboardLogic'
+import { sceneLogic } from '../../scenes/sceneLogic'
+import { Scene } from '../../scenes/sceneTypes'
+import { DashboardMode } from '../../types'
 import { lemonadeLogicType } from './lemonadeLogicType'
 
 export const lemonadeLogic = kea<lemonadeLogicType>({
@@ -28,7 +32,7 @@ export const lemonadeLogic = kea<lemonadeLogicType>({
         hideProjectSwitcher: true,
     },
     reducers: {
-        isSideBarShown: [
+        isSideBarShownRaw: [
             window.innerWidth >= 576, // Sync width threshold with Sass variable $sm!
             {
                 toggleSideBar: (state) => !state,
@@ -93,6 +97,11 @@ export const lemonadeLogic = kea<lemonadeLogicType>({
         ],
     },
     selectors: {
+        isSideBarForciblyHidden: [() => [() => document.fullscreenElement], (fullscreenElement) => !!fullscreenElement],
+        isSideBarShown: [
+            (s) => [s.isSideBarShownRaw, s.isSideBarForciblyHidden],
+            (isSideBarShownRaw, isSideBarForciblyHidden) => isSideBarShownRaw && !isSideBarForciblyHidden,
+        ],
         announcementMessage: [
             (s) => [s.featureFlags],
             (featureFlags): string | null => {

--- a/frontend/src/layout/navigation/Navigation.scss
+++ b/frontend/src/layout/navigation/Navigation.scss
@@ -282,6 +282,7 @@
 
     .menu-toggle {
         cursor: pointer;
+        font-size: 1.5rem;
         svg {
             height: 22px;
         }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -823,6 +823,21 @@ export function IconGithub(): JSX.Element {
     )
 }
 
+/** Material Design Receipt icon. */
+export function IconBill(): JSX.Element {
+    return (
+        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <g fill="currentColor">
+                <path d="m18.85 4.35-1.35-1.35-1.35 1.35-1.35-1.35-1.35 1.35-1.35-1.35-1.35 1.35-1.35-1.35-1.35 1.35-1.35-1.35v12.6h-2.7v2.7c0 1.494 1.206 2.7 2.7 2.7h10.8c1.494 0 2.7-1.206 2.7-2.7v-15.3zm-4.05 14.85h-8.1c-.495 0-.9-.405-.9-.9v-.9h9zm3.6-.9c0 .495-.405.9-.9.9s-.9-.405-.9-.9v-2.7h-8.1v-9.9h9.9z" />
+                <path d="m14.8001 7.5h-5.39995v1.8h5.39995z" />
+                <path d="m17.5001 7.5h-1.8v1.8h1.8z" />
+                <path d="m14.8001 10.1996h-5.39995v1.8h5.39995z" />
+                <path d="m17.5001 10.1996h-1.8v1.8h1.8z" />
+            </g>
+        </svg>
+    )
+}
+
 // AntD arrows rotated at convenient angles
 
 export function ArrowBottomRightOutlined({ style }: { style?: CSSProperties }): JSX.Element {


### PR DESCRIPTION
## Changes

A bit of polish for the new UI:
- Billing button on Cloud
- `data-attr`s same as in old UI to track usage
- new sidebar now hidden in fullscreen mode
- properly sized old nav hamburger
- redesign opt-in hidden on tablet-size screens