### PR TITLE
Reload saved insights list when going back

### DIFF
--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -51,6 +51,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType<InsightsResult, Sav
         logic: [eventUsageLogic],
     },
     actions: {
+        sceneActivated: true,
         setSavedInsightsFilters: (filters: Partial<SavedInsightFilters>, merge = true) => ({ filters, merge }),
         addGraph: (type: string) => ({ type }),
 
@@ -215,6 +216,11 @@ export const savedInsightsLogic = kea<savedInsightsLogicType<InsightsResult, Sav
         },
         [dashboardItemsModel.actionTypes.renameDashboardItemSuccess]: ({ item }) => {
             actions.setInsight(item)
+        },
+        sceneActivated: () => {
+            if (!values.insights.previous) {
+                actions.loadInsights()
+            }
         },
     }),
     actionToUrl: ({ values }) => {

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -336,6 +336,13 @@ export const sceneLogic = kea<sceneLogicType>({
                         throw e
                     }
                 }
+            } else {
+                if (featureFlagLogic.values.featureFlags[FEATURE_FLAGS.TURBO_MODE] && loadedScene.logic) {
+                    const logic = loadedScene.logic.build(loadedScene.paramsToProps?.(params) || {}, false)
+                    if ('sceneActivated' in logic.actions) {
+                        logic.actions.sceneActivated()
+                    }
+                }
             }
             actions.setScene(scene, params, clickedLink || wasNotLoaded)
         },


### PR DESCRIPTION
## Changes

- Reloads the insights list when activating the scene (except for the first time)
- This makes it so that the insight you added is actually shown.

## How did you test this code?

- In the browser. Will add tests next week when I redo the insight URLs.
