### PR TITLE
New UI shows status as danger 

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -98,8 +98,8 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
                 }
 
                 // On cloud non staff users don't have status metrics to review
-                const hasStatusMetrics = !statusMetrics || statusMetrics.length === 0
-                if (hasStatusMetrics && preflightLogic.values.preflight?.cloud && !userLogic.values.user?.is_staff) {
+                const hasNoStatusMetrics = !statusMetrics || statusMetrics.length === 0
+                if (hasNoStatusMetrics && preflightLogic.values.preflight?.cloud && !userLogic.values.user?.is_staff) {
                     return true
                 }
 

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -8,6 +8,7 @@ import dayjs from 'dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
 
 type WarningType =
     | 'welcome'
@@ -96,17 +97,18 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
                     return false
                 }
 
-                const aliveMetrics = ['redis_alive', 'db_alive', 'plugin_sever_alive']
-                let aliveSignals = 0
-                for (const metric of statusMetrics) {
-                    if (metric.key && aliveMetrics.includes(metric.key) && metric.value) {
-                        aliveSignals = aliveSignals + 1
-                    }
-                    if (aliveSignals >= aliveMetrics.length) {
-                        return true
-                    }
+                // On cloud non staff users don't have status metrics to review
+                const hasStatusMetrics = !statusMetrics || statusMetrics.length === 0
+                if (hasStatusMetrics && preflightLogic.values.preflight?.cloud && !userLogic.values.user?.is_staff) {
+                    return true
                 }
-                return false
+
+                // if you have status metrics these three must have `value: true`
+                const aliveMetrics = ['redis_alive', 'db_alive', 'plugin_sever_alive']
+                const aliveSignals = statusMetrics
+                    .filter((sm) => sm.key && aliveMetrics.includes(sm.key))
+                    .filter((sm) => sm.value).length
+                return aliveSignals >= aliveMetrics.length
             },
         ],
         updateAvailable: [


### PR DESCRIPTION
Because status check assumes only people with access to the status metrics will see it

<img width="344" alt="Screenshot 2021-11-05 at 19 42 48" src="https://user-images.githubusercontent.com/984817/140572046-7acbc256-895c-4a41-b564-61fd05e4c970.png">

## Changes

The new UI puts system status front and centre. However, the method which calculates system status defaults to the status being bad. Previously only people with access to system metrics would have seen it, so this was correct

This change checks if we're running on the cloud and if the person is not staff then skips the status metrics check (which would otherwise fail)

## How did you test this code?

It is already not tested, so I have lazily left it that way :'(
