### PR TITLE
Player tweaks and fixes

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -646,6 +646,7 @@ export const eventUsageLogic = kea<
             posthog.capture('saved insights new insight clicked', { insight_type: insightType })
         },
         reportRecording: ({ recordingData, source, loadTime, type }) => {
+            // @ts-ignore
             const eventIndex = new EventIndex(recordingData?.snapshots || [])
             const payload: Partial<RecordingViewedProps> = {
                 load_time: loadTime,

--- a/frontend/src/scenes/session-recordings/player/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerController.tsx
@@ -4,7 +4,7 @@ import {
     PLAYBACK_SPEEDS,
     sessionRecordingPlayerLogic,
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
-import { Select, Switch } from 'antd'
+import { Select } from 'antd'
 import { SessionPlayerState } from '~/types'
 import { IconPause, IconPlay } from 'scenes/session-recordings/player/icons'
 import { Seekbar } from 'scenes/session-recordings/player/Seekbar'
@@ -49,10 +49,6 @@ export function PlayerController(): JSX.Element {
                     ))}
                 </Select.OptGroup>
             </Select>
-            <div className="rrweb-inactivity-toggle">
-                <span className="inactivity-label">Skip inactivity</span>
-                <Switch disabled size="small" />
-            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -92,7 +92,6 @@ $tick_hover_size: 5px;
                 padding: $default_spacing/4 $default_spacing/2;
                 position: absolute;
                 top: -4 * $tick_size;
-                border: 2px solid $recording_player_container_bg;
                 background-color: $bg_charcoal;
                 display: none;
                 color: $text_light;

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayerV2.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayerV2.tsx
@@ -60,7 +60,7 @@ export function SessionRecordingPlayerV2(): JSX.Element {
                 {/*    <PlayerEvents />*/}
                 {/*</Col>*/}
             </Row>
-            <Row className="session-player-controller ph-no-capture" align="middle">
+            <Row className="session-player-controller" align="middle">
                 <PlayerController />
             </Row>
         </Col>

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -151,6 +151,9 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 skipInactive: true,
                 triggerFocus: false,
                 speed: values.speed,
+                insertStyleRules: [
+                    `.ph-no-capture {   background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNOCAwSDE2TDAgMTZWOEw4IDBaIiBmaWxsPSIjMkQyRDJEIi8+CjxwYXRoIGQ9Ik0xNiA4VjE2SDhMMTYgOFoiIGZpbGw9IiMyRDJEMkQiLz4KPC9zdmc+Cg=="); }`,
+                ],
             })
             replayer.on('finish', () => {
                 // Use 500ms buffer because current time is not always exactly identical to end time.

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -13,7 +13,7 @@
 
         .player-container {
             position: relative;
-            padding: $default_spacing * 4 $default_spacing / 2;
+            padding: $default_spacing;
         }
     }
 

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -146,7 +146,6 @@
 
     .rrweb-speed-toggle {
         cursor: pointer;
-        margin-right: $default_spacing;
     }
 
     .rrweb-inactivity-toggle {

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -166,4 +166,7 @@
     .ant-drawer-body {
         padding: 0;
     }
+    .ant-drawer-close {
+        padding: 12px 0px;
+    }
 }

--- a/frontend/src/scenes/sessions/LEGACY_sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/LEGACY_sessionsPlayLogic.ts
@@ -215,6 +215,7 @@ export const LEGACY_sessionsPlayLogic = kea<LEGACY_sessionsPlayLogicType>({
         eventIndex: [
             (selectors) => [selectors.sessionPlayerData],
             (sessionPlayerData: LEGACY_SessionPlayerData): EventIndex =>
+                // @ts-ignore
                 new EventIndex(sessionPlayerData?.snapshots || []),
         ],
         recordingIndex: [

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "redux": "^4.0.5",
         "reselect": "^4.0.0",
         "resize-observer-polyfill": "^1.5.1",
-        "rrweb": "^1.0.2",
+        "rrweb": "^1.0.6",
         "sass": "^1.26.2",
         "screenfull": "^5.1.0",
         "use-debounce": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14601,6 +14601,11 @@ rrweb-snapshot@^1.1.7:
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.7.tgz#92a3b47b1112a1b566c2fae2edb02fa48a6f6653"
   integrity sha512-+f2kCCvIQ1hbEeCWnV7mPVPDEdWEExqwcYqMd/r1nfK52QE7qU52jefUOyTe85Vy67rZGqWnfK/B25e/OTSgYg==
 
+rrweb-snapshot@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.9.tgz#f8d0f560291a37dab00dc5ac6d9368f76208256f"
+  integrity sha512-kpoWi2gx1AmX2PZU8XNKMvIvh5WPSz9lKfyHs9GYvczYE2H7VNrmPf7+rDin8Y+HcJ9Tu7x9id4JOCD2PsSPQA==
+
 rrweb@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.0.2.tgz#da561b829e3729461443966fe5abc745e7d3ebf3"
@@ -14611,6 +14616,17 @@ rrweb@^1.0.2:
     fflate "^0.4.4"
     mitt "^1.1.3"
     rrweb-snapshot "^1.1.7"
+
+rrweb@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.0.6.tgz#381027a4331c610739145dc4142364be680504ba"
+  integrity sha512-uiRpPMNEd1oMqNYRelKBz28WBLXQEirx9u+nlTIaxk65fbTEUyKBr81GhcUSjeZAsTpkUtIAHacS0Gjz35x/Rw==
+  dependencies:
+    "@types/css-font-loading-module" "0.0.4"
+    "@xstate/fsm" "^1.4.0"
+    fflate "^0.4.4"
+    mitt "^1.1.3"
+    rrweb-snapshot "^1.1.9"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Changes

This PR fixes a set of player bugs/styles. Specifically:
* Player close button position
* Padding around the player is reduced (until we add in the events card)
* Removed the 'skip-inactivity' toggle. We can add this back in when we tackle this in full. Right now, rr-player's support is pretty buggy (toggling only works sometimes), so removing for now.
* Add SVG for removed content. Note, there is some odd behavior with the SVG when you scale the player. The bottom image is what the SVG should look like, and the top one is what it looks like when the player is scaled. Closes (https://github.com/PostHog/posthog/issues/2258)

![image](https://user-images.githubusercontent.com/4813045/140584444-a7989ac0-b7f5-4381-8bda-d202c9a75e28.png)

![image](https://user-images.githubusercontent.com/4813045/140584268-b3b68e29-02be-46fe-8587-1364ce333f39.png)

![image](https://user-images.githubusercontent.com/4813045/140584861-dae43971-3bee-46e9-8038-39ac78b10f36.png)


## How did you test this code?

Tested locally - ran logic tests.
