### PR TITLE
Groups: Use materialized columns for groups

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -39,14 +39,14 @@ def get_materialized_columns(table: TableWithProperties) -> Dict[PropertyName, C
         return {}
 
 
-def materialize(table: TableWithProperties, property: PropertyName) -> None:
+def materialize(table: TableWithProperties, property: PropertyName, column_name=None) -> None:
     if property in get_materialized_columns(table, use_cache=False):
         if TEST:
             return
 
         raise ValueError(f"Property already materialized. table={table}, property={property}")
 
-    column_name = materialized_column_name(table, property)
+    column_name = column_name or materialized_column_name(table, property)
     # :TRICKY: On cloud, we ON CLUSTER updates to events/sharded_events but not to persons. Why? ¯\_(ツ)_/¯
     execute_on_cluster = f"ON CLUSTER {CLICKHOUSE_CLUSTER}" if table == "events" else ""
 

--- a/ee/clickhouse/migrations/0019_group_analytics_materialized_columns.py
+++ b/ee/clickhouse/migrations/0019_group_analytics_materialized_columns.py
@@ -1,9 +1,18 @@
+from infi.clickhouse_orm import migrations
+
 from ee.clickhouse.materialized_columns.columns import materialize
 
-materialize("events", "$group_0", "$group_0")
-materialize("events", "$group_1", "$group_1")
-materialize("events", "$group_2", "$group_2")
-materialize("events", "$group_3", "$group_3")
-materialize("events", "$group_4", "$group_4")
 
-operations = []  # type: ignore
+def create_materialized_columns(database):
+    try:
+        materialize("events", "$group_0", "$group_0")
+        materialize("events", "$group_1", "$group_1")
+        materialize("events", "$group_2", "$group_2")
+        materialize("events", "$group_3", "$group_3")
+        materialize("events", "$group_4", "$group_4")
+    except ValueError:
+        # Group is already materialized, skip
+        pass
+
+
+operations = [migrations.RunPython(create_materialized_columns)]

--- a/ee/clickhouse/migrations/0019_group_analytics_materialized_columns.py
+++ b/ee/clickhouse/migrations/0019_group_analytics_materialized_columns.py
@@ -1,0 +1,9 @@
+from ee.clickhouse.materialized_columns.columns import materialize
+
+materialize("events", "$group_0", "$group_0")
+materialize("events", "$group_1", "$group_1")
+materialize("events", "$group_2", "$group_2")
+materialize("events", "$group_3", "$group_3")
+materialize("events", "$group_4", "$group_4")
+
+operations = []  # type: ignore

--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -36,10 +36,6 @@ def get_aggregation_target_field(
     aggregation_group_type_index: Optional[int], event_table_alias: str, distinct_id_table_alias: str
 ) -> str:
     if aggregation_group_type_index is not None:
-        prop_var = f"$group_{aggregation_group_type_index}"
-        group_expression, _ = get_property_string_expr(
-            "events", prop_var, f"'{prop_var}'", f"{event_table_alias}.properties"
-        )
-        return group_expression
+        return f"$group_{aggregation_group_type_index}"
     else:
         return f"{distinct_id_table_alias}.person_id"

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -45,9 +45,8 @@
                            e.team_id as team_id,
                            e.distinct_id as distinct_id,
                            e.timestamp as timestamp,
-                           trim(BOTH '"'
-                                FROM JSONExtractRaw(e.properties, '$group_0')) as aggregation_target,
-                           e.properties as properties
+                           $group_0 as aggregation_target,
+                           e.$group_0 as $group_0
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
@@ -67,8 +66,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND NOT has([''], trim(BOTH '"'
-                                             FROM JSONExtractRaw(properties, '$group_0')))
+                      AND NOT has([''], $group_0)
                       AND team_id = 2 ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -42,8 +42,7 @@
                            e.team_id as team_id,
                            e.distinct_id as distinct_id,
                            e.timestamp as timestamp,
-                           trim(BOTH '"'
-                                FROM JSONExtractRaw(e.properties, '$group_0')) as aggregation_target
+                           $group_0 as aggregation_target
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
@@ -92,8 +91,7 @@
                            e.team_id as team_id,
                            e.distinct_id as distinct_id,
                            e.timestamp as timestamp,
-                           trim(BOTH '"'
-                                FROM JSONExtractRaw(e.properties, '$group_0')) as aggregation_target
+                           $group_0 as aggregation_target
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,

--- a/ee/clickhouse/queries/groups_join_query.py
+++ b/ee/clickhouse/queries/groups_join_query.py
@@ -44,7 +44,7 @@ class GroupsJoinQuery:
                     WHERE team_id = %(team_id)s AND group_type_index = %({var})s
                     GROUP BY group_key
                 ) groups_{group_type_index}
-                ON JSONExtractString(properties, '$group_{group_type_index}') == groups_{group_type_index}.group_key
+                ON $group_{group_type_index} == groups_{group_type_index}.group_key
                 """
             )
 

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -13,7 +13,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -269,14 +269,14 @@
      FROM groups
      WHERE team_id = 2
        AND group_type_index = 0
-     GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
   INNER JOIN
     (SELECT group_key,
             argMax(group_properties, _timestamp) AS group_properties_1
      FROM groups
      WHERE team_id = 2
        AND group_type_index = 1
-     GROUP BY group_key) groups_1 ON JSONExtractString(properties, '$group_1') == groups_1.group_key
+     GROUP BY group_key) groups_1 ON $group_1 == groups_1.group_key
   WHERE team_id = 2
     AND event = '$pageview'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
@@ -321,7 +321,7 @@
      FROM groups
      WHERE team_id = 2
        AND group_type_index = 0
-     GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+     GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
   WHERE team_id = 2
     AND event = '$pageview'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))

--- a/ee/clickhouse/queries/test/__snapshots__/test_groups_join_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_groups_join_query.ambr
@@ -10,7 +10,7 @@
                           WHERE team_id = %(team_id)s AND group_type_index = %(group_index_0)s
                           GROUP BY group_key
                       ) groups_0
-                      ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+                      ON $group_0 == groups_0.group_key
                       
     ',
     <class 'dict'> {

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -6,8 +6,7 @@
          COUNT(DISTINCT event.target) count
   FROM
     (SELECT e.timestamp AS event_date,
-            trim(BOTH '"'
-                 FROM JSONExtractRaw(e.properties, '$group_0')) as target,
+            $group_0 as target,
             e.uuid AS uuid,
             e.event AS event
      FROM events e
@@ -29,13 +28,11 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, '$group_0')))
+       AND NOT has([''], $group_0)
        AND team_id = 2 ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     trim(BOTH '"'
-                          FROM JSONExtractRaw(e.properties, '$group_0')) as target,
+                     $group_0 as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -57,8 +54,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, '$group_0')))
+       AND NOT has([''], $group_0)
        AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
@@ -74,8 +70,7 @@
          count(DISTINCT target)
   FROM
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     trim(BOTH '"'
-                          FROM JSONExtractRaw(e.properties, '$group_0')) as target,
+                     $group_0 as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -97,8 +92,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, '$group_0')))
+       AND NOT has([''], $group_0)
        AND team_id = 2 )
   GROUP BY event_date
   ORDER BY event_date
@@ -112,8 +106,7 @@
          COUNT(DISTINCT event.target) count
   FROM
     (SELECT e.timestamp AS event_date,
-            trim(BOTH '"'
-                 FROM JSONExtractRaw(e.properties, '$group_1')) as target,
+            $group_1 as target,
             e.uuid AS uuid,
             e.event AS event
      FROM events e
@@ -135,13 +128,11 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, '$group_1')))
+       AND NOT has([''], $group_1)
        AND team_id = 2 ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     trim(BOTH '"'
-                          FROM JSONExtractRaw(e.properties, '$group_1')) as target,
+                     $group_1 as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -163,8 +154,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, '$group_1')))
+       AND NOT has([''], $group_1)
        AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
@@ -180,8 +170,7 @@
          count(DISTINCT target)
   FROM
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
-                     trim(BOTH '"'
-                          FROM JSONExtractRaw(e.properties, '$group_1')) as target,
+                     $group_1 as target,
                      e.uuid AS uuid,
                      e.event AS event
      FROM events e
@@ -203,8 +192,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, '$group_1')))
+       AND NOT has([''], $group_1)
        AND team_id = 2 )
   GROUP BY event_date
   ORDER BY event_date
@@ -242,7 +230,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
@@ -275,7 +263,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
@@ -320,7 +308,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
@@ -363,7 +351,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
@@ -395,7 +383,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
@@ -439,7 +427,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -12,18 +12,17 @@
         FROM numbers(dateDiff('day', toDateTime('2020-01-01 00:00:00'), toDateTime('2020-01-12 23:59:59')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2020-01-01 00:00:00'))
-        UNION ALL SELECT count(DISTINCT JSONExtractString(properties, '$group_0')) as data,
+        UNION ALL SELECT count(DISTINCT $group_0) as data,
                          toDateTime(toStartOfDay(timestamp), 'UTC') as date
         FROM
           (SELECT e.timestamp as timestamp,
-                  e.properties as properties
+                  e.$group_0 as $group_0
            FROM events e
            WHERE team_id = 2
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND NOT has([''], trim(BOTH '"'
-                                    FROM JSONExtractRaw(properties, '$group_0')))
+             AND NOT has([''], $group_0)
              AND team_id = 2 )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
@@ -44,18 +43,17 @@
         FROM numbers(dateDiff('day', toDateTime('2020-01-01 00:00:00'), toDateTime('2020-01-12 23:59:59')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2020-01-01 00:00:00'))
-        UNION ALL SELECT count(DISTINCT JSONExtractString(properties, '$group_1')) as data,
+        UNION ALL SELECT count(DISTINCT $group_1) as data,
                          toDateTime(toStartOfDay(timestamp), 'UTC') as date
         FROM
           (SELECT e.timestamp as timestamp,
-                  e.properties as properties
+                  e.$group_1 as $group_1
            FROM events e
            WHERE team_id = 2
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND NOT has([''], trim(BOTH '"'
-                                    FROM JSONExtractRaw(properties, '$group_1')))
+             AND NOT has([''], $group_1)
              AND team_id = 2 )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
@@ -77,7 +75,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2020-01-01 00:00:00'
@@ -126,7 +124,7 @@
               FROM groups
               WHERE team_id = 2
                 AND group_type_index = 0
-              GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+              GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
            WHERE e.team_id = 2
              AND event = 'sign up'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
@@ -179,7 +177,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2020-01-01 00:00:00'
@@ -250,7 +248,7 @@
               FROM groups
               WHERE team_id = 2
                 AND group_type_index = 0
-              GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+              GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
            WHERE e.team_id = 2
              AND event = 'sign up'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
@@ -281,7 +279,7 @@
         FROM groups
         WHERE team_id = 2
           AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2020-01-01 00:00:00'
@@ -332,7 +330,7 @@
               FROM groups
               WHERE team_id = 2
                 AND group_type_index = 0
-              GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+              GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
            WHERE e.team_id = 2
              AND event = 'sign up'
              AND has(['finance'], trim(BOTH '"'
@@ -398,7 +396,7 @@
               FROM groups
               WHERE team_id = 2
                 AND group_type_index = 0
-              GROUP BY group_key) groups_0 ON JSONExtractString(properties, '$group_0') == groups_0.group_key
+              GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
            WHERE team_id = 2
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -33,9 +33,7 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Any]]:
     elif entity.math == "unique_group":
         validate_group_type_index("math_group_type_index", entity.math_group_type_index, required=True)
 
-        key = f"e_{entity.index}_math_group"
-        aggregate_operation = f"count(DISTINCT JSONExtractString(properties, %({key})s))"
-        params[key] = f"$group_{entity.math_group_type_index}"
+        aggregate_operation = f"count(DISTINCT $group_{entity.math_group_type_index})"
     elif entity.math in MATH_FUNCTIONS:
         if entity.math_property is None:
             raise ValidationError({"math_property": "This field is required when `math` is set."}, code="required")

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -25,11 +25,11 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
 """
 
 EVENTS_TABLE_MATERIALIZED_COLUMNS = """
-    , $group_0 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_0'))
-    , $group_1 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_1'))
-    , $group_2 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_2'))
-    , $group_3 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_3'))
-    , $group_4 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_4'))
+    , $group_0 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_0')) COMMENT 'column_materializer::$group_0'
+    , $group_1 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_1')) COMMENT 'column_materializer::$group_1'
+    , $group_2 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_2')) COMMENT 'column_materializer::$group_2'
+    , $group_3 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_3')) COMMENT 'column_materializer::$group_3'
+    , $group_4 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_4')) COMMENT 'column_materializer::$group_4'
 """
 
 EVENTS_TABLE_SQL = (

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -21,14 +21,15 @@ CREATE TABLE {table_name} ON CLUSTER {cluster}
     created_at DateTime64(6, 'UTC')
     {materialized_columns}
     {extra_fields}
-) ENGINE = {engine} 
+) ENGINE = {engine}
 """
 
 EVENTS_TABLE_MATERIALIZED_COLUMNS = """
-    , properties_issampledevent VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'isSampledEvent'))
-    , properties_currentscreen VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'currentScreen'))
-    , properties_objectname VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'objectName'))
-    , properties_test_prop VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, 'test_prop'))
+    , $group_0 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_0'))
+    , $group_1 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_1'))
+    , $group_2 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_2'))
+    , $group_3 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_3'))
+    , $group_4 VARCHAR materialized trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_4'))
 """
 
 EVENTS_TABLE_SQL = (
@@ -60,7 +61,7 @@ KAFKA_EVENTS_TABLE_SQL = EVENTS_TABLE_BASE_SQL.format(
 # related to https://github.com/ClickHouse/ClickHouse/issues/10471
 EVENTS_TABLE_MV_SQL = """
 CREATE MATERIALIZED VIEW {table_name}_mv ON CLUSTER {cluster}
-TO {database}.{table_name} 
+TO {database}.{table_name}
 AS SELECT
 uuid,
 event,
@@ -144,7 +145,7 @@ SELECT
     elements_chain,
     created_at
 FROM events
-WHERE 
+WHERE
 team_id = %(team_id)s
 {conditions}
 {filters}
@@ -177,22 +178,22 @@ SELECT toUInt16(0) AS total, {trunc_func}(toDateTime(%(date_to)s) - {interval_fu
 -- NOTE: for week there is some unusual behavior, see:
 --       https://github.com/ClickHouse/ClickHouse/issues/7322
 --
---       This actually aligns with what we want, as they are assuming Sunday week starts, 
---       and we'd rather have the relative week num difference. Likewise the same for 
+--       This actually aligns with what we want, as they are assuming Sunday week starts,
+--       and we'd rather have the relative week num difference. Likewise the same for
 --       "month" intervals
 --
---       To ensure we get all relevant intervals, we add in the truncated "date_from" 
+--       To ensure we get all relevant intervals, we add in the truncated "date_from"
 --       value.
 --
---       This behaviour of dateDiff is different to our handling of "week" and "month" 
+--       This behaviour of dateDiff is different to our handling of "week" and "month"
 --       differences we are performing in python, which just considers seconds between
 --       date_from and date_to
 --
--- TODO: Ths pattern of generating intervals is repeated in several places. Reuse this 
+-- TODO: Ths pattern of generating intervals is repeated in several places. Reuse this
 --       `ticks` query elsewhere.
 FROM numbers(dateDiff(%(interval)s, toDateTime(%(date_from)s), toDateTime(%(date_to)s)))
 
-UNION ALL 
+UNION ALL
 
 -- Make sure we capture the interval date_from falls into.
 SELECT toUInt16(0) AS total, {trunc_func}(toDateTime(%(date_from)s))
@@ -203,7 +204,7 @@ INNER JOIN ({GET_TEAM_PERSON_DISTINCT_IDS}) as pdi ON events.distinct_id = pdi.d
 """
 
 GET_EVENTS_WITH_PROPERTIES = """
-SELECT * FROM events WHERE 
+SELECT * FROM events WHERE
 team_id = %(team_id)s
 {filters}
 {order_by}

--- a/ee/clickhouse/sql/groups.py
+++ b/ee/clickhouse/sql/groups.py
@@ -53,7 +53,7 @@ FROM {CLICKHOUSE_DATABASE}.kafka_{GROUPS_TABLE}
 """
 
 # { ..., "group_0": 1325 }
-# To join with events join using JSONExtractString(events.properties, "$group_{group_type_index}")
+# To join with events join using $group_{group_type_index} column
 
 DROP_GROUPS_TABLE_SQL = f"DROP TABLE IF EXISTS {GROUPS_TABLE} ON CLUSTER {CLICKHOUSE_CLUSTER}"
 


### PR DESCRIPTION
## Changes

Use materialized columns for groups.

This supercedes https://github.com/PostHog/posthog/issues/6422. On the positive, it will speed up queries a ton and some query-building becomes easier.

On the negative, we'll need to exclude the group properties in property definitions, it adds general bloat to event payloads.

## How did you test this code?

Existing unit tests