### PR TITLE
Fix help button alignment

### DIFF
--- a/frontend/src/lib/components/HelpButton/HelpButton.scss
+++ b/frontend/src/lib/components/HelpButton/HelpButton.scss
@@ -1,12 +1,18 @@
 @import '~/vars';
 
 .help-button {
-    display: flex;
     align-items: center;
     height: 2.5rem;
     cursor: pointer;
-    display: inline-block;
-    margin-left: 1.25rem !important;
+    display: flex;
+
+    &:not(.custom-component) {
+        margin-left: 1.25rem !important;
+    }
+
+    &.inline {
+        display: inline-flex;
+    }
 
     .help-icon {
         color: var(--bg-navy);

--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -9,6 +9,7 @@ import { Popup } from '../Popup/Popup'
 import { Placement } from '@popperjs/core'
 import { LemonButton } from '../LemonButton'
 import { IconArticle, IconGithub, IconMail, IconQuestionAnswer } from '../icons'
+import clsx from 'clsx'
 
 const HELP_UTM_TAGS = '?utm_medium=in-product&utm_campaign=help-button-top'
 
@@ -46,9 +47,10 @@ export const helpButtonLogic = kea<helpButtonLogicType>({
 export interface HelpButtonProps {
     placement?: Placement
     customComponent?: JSX.Element
+    inline?: boolean // Whether the component should be an inline element as opposed to a block element
 }
 
-export function HelpButton({ placement, customComponent }: HelpButtonProps): JSX.Element {
+export function HelpButton({ placement, customComponent, inline }: HelpButtonProps): JSX.Element {
     const { reportHelpButtonUsed } = useActions(eventUsageLogic)
     const { isHelpVisible } = useValues(helpButtonLogic)
     const { toggleHelp, hideHelp } = useActions(helpButtonLogic)
@@ -116,7 +118,10 @@ export function HelpButton({ placement, customComponent }: HelpButtonProps): JSX
             placement={placement}
             actionable
         >
-            <div className="help-button" onClick={toggleHelp}>
+            <div
+                className={clsx('help-button', customComponent && 'custom-component', inline && 'inline')}
+                onClick={toggleHelp}
+            >
                 {customComponent || (
                     <>
                         <QuestionCircleOutlined className="help-icon" />

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -48,7 +48,3 @@
         right: 0.5rem;
     }
 }
-
-.LemonButton--block {
-    width: 100%;
-}

--- a/frontend/src/lib/components/LemonButton/index.tsx
+++ b/frontend/src/lib/components/LemonButton/index.tsx
@@ -13,7 +13,6 @@ export interface LemonButtonPropsBase extends Omit<LemonRowPropsBase<'button'>, 
     /** URL to link to. */
     to?: string
     popup?: LemonButtonPopup
-    block?: boolean
 }
 
 /** Note that a LemonButton can be compact OR have a sideIcon, but not both at once. */
@@ -29,12 +28,12 @@ export type LemonButtonProps =
 
 /** Styled button. */
 function LemonButtonInternal(
-    { children, type = 'default', className, popup, to, block, ...buttonProps }: LemonButtonProps,
+    { children, type = 'default', className, popup, to, ...buttonProps }: LemonButtonProps,
     ref: React.Ref<JSX.IntrinsicElements['button']>
 ): JSX.Element {
     const rowProps: LemonRowProps<'button'> = {
         tag: 'button',
-        className: clsx('LemonButton', type !== 'default' && `LemonButton--${type}`, className, block && 'block'),
+        className: clsx('LemonButton', type !== 'default' && `LemonButton--${type}`, className),
         type: 'button',
         ...buttonProps,
     }

--- a/frontend/src/scenes/billing/BillingSubscribed.tsx
+++ b/frontend/src/scenes/billing/BillingSubscribed.tsx
@@ -29,7 +29,7 @@ export function BillingSubscribed(): JSX.Element {
                         <div className="inner">
                             {status === SubscriptionStatus.Success ? <SubscriptionSuccess /> : <SubscriptionFailure />}
                             <div className="support-footer">
-                                Have questions? <HelpButton customComponent={<a href="#">Get help</a>} />
+                                Have questions? <HelpButton inline customComponent={<a href="#">Get help</a>} />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Changes

Fixes #6954. Help button is now properly aligned depending on the context.

**On the main navbar**
<img width="367" alt="" src="https://user-images.githubusercontent.com/5864173/140796782-dfed4d8f-9b5a-4c40-b53c-8c275d473f77.png">

**On the billing subscription page**
<img width="470" alt="" src="https://user-images.githubusercontent.com/5864173/140796767-0b0d948d-19f9-4896-8b22-7ca70fcab6c7.png">

## How did you test this code?

- Manually as shown on the screenshots above.
