### PR TITLE
Modify action order for graph series in the query builder

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -396,11 +396,11 @@ export function ActionFilterRow({
                                 )}
                             </>
                         )}
-                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{duplicateRowButton}</Col>}
+                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{propertyFiltersButton}</Col>}
                         {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && (horizontalUI || fullWidth) && !hideRename && (
                             <Col>{renameRowButton}</Col>
                         )}
-                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{propertyFiltersButton}</Col>}
+                        {(horizontalUI || fullWidth) && !hideFilter && <Col>{duplicateRowButton}</Col>}
                         {!hideDeleteBtn && !horizontalUI && !singleFilter && (
                             <Col className="column-delete-btn">{deleteButton}</Col>
                         )}


### PR DESCRIPTION
## Changes

Resolves https://github.com/PostHog/posthog/issues/6771.

| Before | After |
| --- | --- |
| ![Zrzut ekranu 2021-11-8 o 20 11 39](https://user-images.githubusercontent.com/4550621/140803318-544ba04d-793c-4850-8cdf-d703b4b6eec9.png) | ![Zrzut ekranu 2021-11-8 o 20 11 17](https://user-images.githubusercontent.com/4550621/140803325-f4cc072f-f6c8-4d6b-af3a-7359be2ed31f.png) |

Though one other thing I noticed is that Trends have a very different delete button. Is that fine or should it be unified?
![Zrzut ekranu 2021-11-8 o 20 11 08](https://user-images.githubusercontent.com/4550621/140803431-3687b08e-e296-4853-ad19-58d63dd63b79.png)

