### PR TITLE
Person creation to set properties

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -722,3 +722,8 @@ export enum CeleryTriggeredJobOperation {
 }
 
 export type GroupTypeToColumnIndex = Record<string, number>
+
+export enum PersonPropertyUpdateOperation {
+    Set = 'set',
+    SetOnce = 'set_once',
+}

--- a/plugin-server/tests/clickhouse/postgres-parity.test.ts
+++ b/plugin-server/tests/clickhouse/postgres-parity.test.ts
@@ -81,7 +81,7 @@ describe('postgres parity', () => {
                 id: uuid,
                 created_at: expect.any(String), // '2021-02-04 00:18:26.472',
                 team_id: team.id,
-                properties: '{"userProp":"propValue", "userPropOnce":"propOnceValue"}',
+                properties: '{"userPropOnce":"propOnceValue", "userProp":"propValue"}',
                 is_identified: 1,
                 is_deleted: 0,
                 _timestamp: expect.any(String),

--- a/plugin-server/tests/clickhouse/postgres-parity.test.ts
+++ b/plugin-server/tests/clickhouse/postgres-parity.test.ts
@@ -54,10 +54,16 @@ describe('postgres parity', () => {
 
     test('createPerson', async () => {
         const uuid = new UUIDT().toString()
-        const person = await hub.db.createPerson(DateTime.utc(), { userProp: 'propValue' }, team.id, null, true, uuid, [
-            'distinct1',
-            'distinct2',
-        ])
+        const person = await hub.db.createPerson(
+            DateTime.utc(),
+            { userProp: 'propValue' },
+            {},
+            team.id,
+            null,
+            true,
+            uuid,
+            ['distinct1', 'distinct2']
+        )
         await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
 

--- a/plugin-server/tests/clickhouse/postgres-parity.test.ts
+++ b/plugin-server/tests/clickhouse/postgres-parity.test.ts
@@ -111,6 +111,7 @@ describe('postgres parity', () => {
         const person = await hub.db.createPerson(
             DateTime.utc(),
             { userProp: 'propValue' },
+            {},
             team.id,
             null,
             false,
@@ -168,12 +169,20 @@ describe('postgres parity', () => {
     test('addDistinctId', async () => {
         const uuid = new UUIDT().toString()
         const uuid2 = new UUIDT().toString()
-        const person = await hub.db.createPerson(DateTime.utc(), { userProp: 'propValue' }, team.id, null, true, uuid, [
-            'distinct1',
-        ])
+        const person = await hub.db.createPerson(
+            DateTime.utc(),
+            { userProp: 'propValue' },
+            {},
+            team.id,
+            null,
+            true,
+            uuid,
+            ['distinct1']
+        )
         const anotherPerson = await hub.db.createPerson(
             DateTime.utc(),
             { userProp: 'propValue' },
+            {},
             team.id,
             null,
             true,
@@ -240,6 +249,7 @@ describe('postgres parity', () => {
         const person = await hub.db.createPerson(
             DateTime.utc(),
             { userProp: 'propValue' },
+            {},
             team.id,
             null,
             false,
@@ -249,6 +259,7 @@ describe('postgres parity', () => {
         const anotherPerson = await hub.db.createPerson(
             DateTime.utc(),
             { userProp: 'propValue' },
+            {},
             team.id,
             null,
             true,

--- a/plugin-server/tests/clickhouse/postgres-parity.test.ts
+++ b/plugin-server/tests/clickhouse/postgres-parity.test.ts
@@ -2,7 +2,15 @@ import { DateTime } from 'luxon'
 import { PoolClient } from 'pg'
 
 import { startPluginsServer } from '../../src/main/pluginsServer'
-import { Database, Hub, LogLevel, PluginsServerConfig, Team, TimestampFormat } from '../../src/types'
+import {
+    Database,
+    Hub,
+    LogLevel,
+    PersonPropertyUpdateOperation,
+    PluginsServerConfig,
+    Team,
+    TimestampFormat,
+} from '../../src/types'
 import { castTimestampOrNow, delay, UUIDT } from '../../src/utils/utils'
 import { makePiscina } from '../../src/worker/piscina'
 import { createPosthog, DummyPostHog } from '../../src/worker/vm/extensions/posthog'
@@ -57,7 +65,7 @@ describe('postgres parity', () => {
         const person = await hub.db.createPerson(
             DateTime.utc(),
             { userProp: 'propValue' },
-            {},
+            { userPropOnce: 'propOnceValue' },
             team.id,
             null,
             true,
@@ -73,7 +81,7 @@ describe('postgres parity', () => {
                 id: uuid,
                 created_at: expect.any(String), // '2021-02-04 00:18:26.472',
                 team_id: team.id,
-                properties: '{"userProp":"propValue"}',
+                properties: '{"userProp":"propValue", "userPropOnce":"propOnceValue"}',
                 is_identified: 1,
                 is_deleted: 0,
                 _timestamp: expect.any(String),
@@ -90,9 +98,13 @@ describe('postgres parity', () => {
                 created_at: expect.any(DateTime),
                 properties: {
                     userProp: 'propValue',
+                    userPropOnce: 'userPropOnceValue',
                 },
-                properties_last_updated_at: {},
-                properties_last_operation: null,
+                properties_last_updated_at: {
+                    userProp: PersonPropertyUpdateOperation.Set,
+                    userPropOnce: PersonPropertyUpdateOperation.SetOnce,
+                },
+                properties_last_operation: { userProp: expect.any(String), userPropOnce: expect.any(String) },
                 team_id: 2,
                 is_user_id: null,
                 is_identified: true,

--- a/plugin-server/tests/clickhouse/postgres-parity.test.ts
+++ b/plugin-server/tests/clickhouse/postgres-parity.test.ts
@@ -81,7 +81,7 @@ describe('postgres parity', () => {
                 id: uuid,
                 created_at: expect.any(String), // '2021-02-04 00:18:26.472',
                 team_id: team.id,
-                properties: '{"userPropOnce":"propOnceValue", "userProp":"propValue"}',
+                properties: '{"userPropOnce":"propOnceValue","userProp":"propValue"}',
                 is_identified: 1,
                 is_deleted: 0,
                 _timestamp: expect.any(String),
@@ -98,13 +98,16 @@ describe('postgres parity', () => {
                 created_at: expect.any(DateTime),
                 properties: {
                     userProp: 'propValue',
-                    userPropOnce: 'userPropOnceValue',
+                    userPropOnce: 'propOnceValue',
                 },
                 properties_last_updated_at: {
+                    userProp: expect.any(String),
+                    userPropOnce: expect.any(String),
+                },
+                properties_last_operation: {
                     userProp: PersonPropertyUpdateOperation.Set,
                     userPropOnce: PersonPropertyUpdateOperation.SetOnce,
                 },
-                properties_last_operation: { userProp: expect.any(String), userPropOnce: expect.any(String) },
                 team_id: 2,
                 is_user_id: null,
                 is_identified: true,

--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -94,6 +94,9 @@ describe('DB', () => {
             expect(fetched_person.properties_last_updated_at).toEqual({})
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
+
+            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
+            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
 
         test('without properties indentified true', async () => {
@@ -105,6 +108,9 @@ describe('DB', () => {
             expect(fetched_person.properties_last_updated_at).toEqual({})
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
+
+            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
+            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
 
         test('with properties', async () => {
@@ -133,6 +139,9 @@ describe('DB', () => {
             })
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
+
+            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
+            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
 
         test('with set and set_once for the same key', async () => {
@@ -146,6 +155,9 @@ describe('DB', () => {
             expect(fetched_person.properties_last_updated_at).toEqual({ a: TIMESTAMP.toISO() })
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
+
+            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
+            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
     })
 

--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -94,9 +94,6 @@ describe('DB', () => {
             expect(fetched_person.properties_last_updated_at).toEqual({})
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
-
-            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
-            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
 
         test('without properties indentified true', async () => {
@@ -108,9 +105,6 @@ describe('DB', () => {
             expect(fetched_person.properties_last_updated_at).toEqual({})
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
-
-            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
-            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
 
         test('with properties', async () => {
@@ -139,9 +133,6 @@ describe('DB', () => {
             })
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
-
-            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
-            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
 
         test('with set and set_once for the same key', async () => {
@@ -155,9 +146,6 @@ describe('DB', () => {
             expect(fetched_person.properties_last_updated_at).toEqual({ a: TIMESTAMP.toISO() })
             expect(fetched_person.uuid).toEqual(uuid)
             expect(fetched_person.team_id).toEqual(team.id)
-
-            const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
-            expect(updatePersonSpy).not.toHaveBeenCalled()
         })
     })
 

--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -84,7 +84,7 @@ describe('DB', () => {
             team = await getFirstTeam(hub)
         })
 
-        test('witout properties', async () => {
+        test('without properties', async () => {
             const person = await db.createPerson(TIMESTAMP, {}, {}, team.id, null, false, uuid, [distinctId])
             const fetched_person = await fetchPersonByPersonId(team.id, person.id)
 
@@ -96,7 +96,7 @@ describe('DB', () => {
             expect(fetched_person.team_id).toEqual(team.id)
         })
 
-        test('witout properties indentified true', async () => {
+        test('without properties indentified true', async () => {
             const person = await db.createPerson(TIMESTAMP, {}, {}, team.id, null, true, uuid, [distinctId])
             const fetched_person = await fetchPersonByPersonId(team.id, person.id)
             expect(fetched_person.is_identified).toEqual(true)

--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -1,8 +1,11 @@
-import { Hub, PropertyOperator } from '../../src/types'
+import { DateTime } from 'luxon'
+
+import { Hub, Person, PersonPropertyUpdateOperation, PropertyOperator, Team } from '../../src/types'
 import { DB } from '../../src/utils/db/db'
 import { createHub } from '../../src/utils/db/hub'
+import { UUIDT } from '../../src/utils/utils'
 import { ActionManager } from '../../src/worker/ingestion/action-manager'
-import { resetTestDatabase } from '../helpers/sql'
+import { getFirstTeam, resetTestDatabase } from '../helpers/sql'
 
 jest.mock('../../src/utils/status')
 
@@ -56,6 +59,93 @@ describe('DB', () => {
                     ],
                 },
             },
+        })
+    })
+
+    async function fetchPersonByPersonId(teamId: number, personId: number): Promise<Person> {
+        const selectResult = await db.postgresQuery(
+            `SELECT * FROM posthog_person WHERE team_id = $1 AND id = $2`,
+            [teamId, personId],
+            'fetchPersonByPersonId'
+        )
+
+        return selectResult.rows[0]
+    }
+
+    describe('createPerson', () => {
+        let team: Team
+        let person: Person
+        const uuid = new UUIDT().toString()
+        const distinctId = 'distinct_id1'
+
+        const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z')
+
+        beforeEach(async () => {
+            team = await getFirstTeam(hub)
+        })
+
+        test('witout properties', async () => {
+            const person = await db.createPerson(TIMESTAMP, {}, {}, team.id, null, false, uuid, [distinctId])
+            const fetched_person = await fetchPersonByPersonId(team.id, person.id)
+
+            expect(fetched_person.is_identified).toEqual(false)
+            expect(fetched_person.properties).toEqual({})
+            expect(fetched_person.properties_last_operation).toEqual({})
+            expect(fetched_person.properties_last_updated_at).toEqual({})
+            expect(fetched_person.uuid).toEqual(uuid)
+            expect(fetched_person.team_id).toEqual(team.id)
+        })
+
+        test('witout properties indentified true', async () => {
+            const person = await db.createPerson(TIMESTAMP, {}, {}, team.id, null, true, uuid, [distinctId])
+            const fetched_person = await fetchPersonByPersonId(team.id, person.id)
+            expect(fetched_person.is_identified).toEqual(true)
+            expect(fetched_person.properties).toEqual({})
+            expect(fetched_person.properties_last_operation).toEqual({})
+            expect(fetched_person.properties_last_updated_at).toEqual({})
+            expect(fetched_person.uuid).toEqual(uuid)
+            expect(fetched_person.team_id).toEqual(team.id)
+        })
+
+        test('with properties', async () => {
+            const person = await db.createPerson(
+                TIMESTAMP,
+                { a: 123, b: false },
+                { c: 'bbb' },
+                team.id,
+                null,
+                false,
+                uuid,
+                [distinctId]
+            )
+            const fetched_person = await fetchPersonByPersonId(team.id, person.id)
+            expect(fetched_person.is_identified).toEqual(false)
+            expect(fetched_person.properties).toEqual({ a: 123, b: false, c: 'bbb' })
+            expect(fetched_person.properties_last_operation).toEqual({
+                a: PersonPropertyUpdateOperation.Set,
+                b: PersonPropertyUpdateOperation.Set,
+                c: PersonPropertyUpdateOperation.SetOnce,
+            })
+            expect(fetched_person.properties_last_updated_at).toEqual({
+                a: TIMESTAMP.toISO(),
+                b: TIMESTAMP.toISO(),
+                c: TIMESTAMP.toISO(),
+            })
+            expect(fetched_person.uuid).toEqual(uuid)
+            expect(fetched_person.team_id).toEqual(team.id)
+        })
+
+        test('with set and set_once for the same key', async () => {
+            const person = await db.createPerson(TIMESTAMP, { a: 1 }, { a: 2 }, team.id, null, false, uuid, [
+                distinctId,
+            ])
+            const fetched_person = await fetchPersonByPersonId(team.id, person.id)
+            expect(fetched_person.is_identified).toEqual(false)
+            expect(fetched_person.properties).toEqual({ a: 1 })
+            expect(fetched_person.properties_last_operation).toEqual({ a: PersonPropertyUpdateOperation.Set })
+            expect(fetched_person.properties_last_updated_at).toEqual({ a: TIMESTAMP.toISO() })
+            expect(fetched_person.uuid).toEqual(uuid)
+            expect(fetched_person.team_id).toEqual(team.id)
         })
     })
 

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -335,7 +335,7 @@ export const createProcessEventTests = (
 
         // TODO: Make this test actually useful and not flaky
         if (database === 'clickhouse') {
-            expect(queryCounter).toBe(11 + 14 /* event & prop definitions */)
+            expect(queryCounter).toBe(9 + 14 /* event & prop definitions */)
         } else if (database === 'postgresql') {
             expect(queryCounter).toBe(12 + 14 /* event & prop definitions */)
         }

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -288,6 +288,7 @@ export const createProcessEventTests = (
     })
 
     test('capture new person', async () => {
+        const updatePersonSpy = jest.spyOn(hub.db, 'updatePerson')
         await hub.db.postgresQuery(
             `UPDATE posthog_team
              SET ingested_event = $1
@@ -328,6 +329,7 @@ export const createProcessEventTests = (
             DateTime.now(),
             new UUIDT().toString()
         )
+        expect(updatePersonSpy).not.toHaveBeenCalled()
 
         let persons = await hub.db.fetchPersons()
         let events = await hub.db.fetchEvents()
@@ -390,6 +392,7 @@ export const createProcessEventTests = (
             DateTime.now(),
             new UUIDT().toString()
         )
+        expect(updatePersonSpy).toHaveBeenCalledTimes(1)
 
         events = await hub.db.fetchEvents()
         persons = await hub.db.fetchPersons()

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -45,7 +45,16 @@ export async function createPerson(
     distinctIds: string[],
     properties: Record<string, any> = {}
 ): Promise<Person> {
-    return server.db.createPerson(DateTime.utc(), properties, team.id, null, false, new UUIDT().toString(), distinctIds)
+    return server.db.createPerson(
+        DateTime.utc(),
+        properties,
+        {},
+        team.id,
+        null,
+        false,
+        new UUIDT().toString(),
+        distinctIds
+    )
 }
 
 export type ReturnWithHub = { hub?: Hub; closeHub?: () => Promise<void> }
@@ -328,7 +337,7 @@ export const createProcessEventTests = (
         if (database === 'clickhouse') {
             expect(queryCounter).toBe(11 + 14 /* event & prop definitions */)
         } else if (database === 'postgresql') {
-            expect(queryCounter).toBe(14 + 14 /* event & prop definitions */)
+            expect(queryCounter).toBe(12 + 14 /* event & prop definitions */)
         }
 
         let persons = await hub.db.fetchPersons()

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -87,7 +87,6 @@ export const createProcessEventTests = (
     extraServerConfig?: Partial<PluginsServerConfig>,
     createTests?: (response: ReturnWithHub) => void
 ): ReturnWithHub => {
-    let queryCounter = 0
     let processEventCounter = 0
     let mockClientEventCounter = 0
     let team: Team
@@ -110,8 +109,6 @@ export const createProcessEventTests = (
 
         await redis.del(hub.PLUGINS_CELERY_QUEUE)
         await redis.del(hub.CELERY_DEFAULT_QUEUE)
-
-        onQuery(hub, () => queryCounter++)
 
         return [hub, closeHub]
     }
@@ -145,7 +142,6 @@ export const createProcessEventTests = (
         returned.hub = hub
         returned.closeHub = closeHub
         eventsProcessor = new EventsProcessor(hub)
-        queryCounter = 0
         processEventCounter = 0
         mockClientEventCounter = 0
         team = await getFirstTeam(hub)
@@ -332,13 +328,6 @@ export const createProcessEventTests = (
             DateTime.now(),
             new UUIDT().toString()
         )
-
-        // TODO: Make this test actually useful and not flaky
-        if (database === 'clickhouse') {
-            expect(queryCounter).toBe(9 + 14 /* event & prop definitions */)
-        } else if (database === 'postgresql') {
-            expect(queryCounter).toBe(12 + 14 /* event & prop definitions */)
-        }
 
         let persons = await hub.db.fetchPersons()
         let events = await hub.db.fetchEvents()


### PR DESCRIPTION
## Changes

Helping make collisions less probable by setting properties during person creation if we can.

## How did you test this code?

unittests added + ran process_event tests too
