### PR TITLE
Fix seekbar dragging outside of click handler boundaries

### DIFF
--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -13,6 +13,7 @@ $tick_hover_size: 5px;
     .slider {
         z-index: 2;
         position: relative;
+        height: 100%;
 
         .thumb {
             z-index: 5;
@@ -69,6 +70,7 @@ $tick_hover_size: 5px;
         z-index: 1;
         position: relative;
         width: 100%;
+        bottom: 100%;
 
         .tick-hover-box {
             cursor: pointer;


### PR DESCRIPTION
## Changes

Clicking on the region above and below a seekbar initiates a pointer cursor but doesn't track the seekbar upon clicking. Fixes one of the bugs in #6483.

Before:

https://user-images.githubusercontent.com/13460330/140814834-2594821a-6bc2-4588-b9ba-ace8d4681e86.mov

After:

https://user-images.githubusercontent.com/13460330/140815067-2b1d9ce1-279c-40ad-873e-b86de9511925.mov

## How did you test this code?

Don't need to test this specific behavior
