### PR TITLE
Rename series in insights table

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -32,6 +32,7 @@ interface InsightsLabelProps {
     showCountedByTag?: boolean // Force 'counted by' tag to show (always shown when action.math is set)
     allowWrap?: boolean // Allow wrapping to multiple lines (useful for long values like URLs)
     useCustomName?: boolean // Whether to show new custom name (FF `6063-rename-filters`). `{custom_name} ({id})`.
+    hideSeriesSubtitle?: boolean // Whether to show the base event/action name (if a custom name is set) in the insight label
 }
 
 function MathTag({ math, mathProperty }: Record<string, string | undefined>): JSX.Element {
@@ -74,6 +75,7 @@ export function InsightLabel({
     showCountedByTag,
     allowWrap = false,
     useCustomName = false,
+    hideSeriesSubtitle,
 }: InsightsLabelProps): JSX.Element {
     const showEventName = !breakdownValue || hasMultipleSeries
     const eventName = seriesStatus ? capitalizeFirstLetter(seriesStatus) : action?.name || fallbackName || ''
@@ -107,7 +109,7 @@ export function InsightLabel({
                     {showEventName && (
                         <>
                             {useCustomName && action ? (
-                                <EntityFilterInfo filter={action} />
+                                <EntityFilterInfo filter={action} showSubTitle={!hideSeriesSubtitle} />
                             ) : (
                                 <PropertyKeyInfo disableIcon disablePopover value={eventName} ellipsis={!allowWrap} />
                             )}

--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -33,6 +33,7 @@ interface InsightsLabelProps {
     allowWrap?: boolean // Allow wrapping to multiple lines (useful for long values like URLs)
     useCustomName?: boolean // Whether to show new custom name (FF `6063-rename-filters`). `{custom_name} ({id})`.
     hideSeriesSubtitle?: boolean // Whether to show the base event/action name (if a custom name is set) in the insight label
+    onLabelClick?: () => void // Click handler for inner label
 }
 
 function MathTag({ math, mathProperty }: Record<string, string | undefined>): JSX.Element {
@@ -75,6 +76,7 @@ export function InsightLabel({
     allowWrap = false,
     useCustomName = false,
     hideSeriesSubtitle,
+    onLabelClick,
 }: InsightsLabelProps): JSX.Element {
     const showEventName = !breakdownValue || hasMultipleSeries
     const eventName = seriesStatus ? capitalizeFirstLetter(seriesStatus) : action?.name || fallbackName || ''
@@ -104,7 +106,7 @@ export function InsightLabel({
                         hasBreakdown={!!breakdownValue}
                     />
                 )}
-                <div className={allowWrap ? '' : 'protect-width'}>
+                <div className={allowWrap ? '' : 'protect-width'} onClick={onLabelClick}>
                     {showEventName && (
                         <>
                             {useCustomName && action ? (

--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -7,6 +7,7 @@ import './InsightLabel.scss'
 import { MATHS } from 'lib/constants'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
+import clsx from 'clsx'
 
 export enum IconSize {
     Small = 'small',
@@ -19,8 +20,7 @@ interface InsightsLabelProps {
     seriesColor?: string
     action?: ActionFilter
     value?: string
-    style?: React.CSSProperties
-    innerStyle?: React.CSSProperties // Style for the inner component, the actual value content
+    className?: string
     breakdownValue?: string | number
     hideBreakdown?: boolean // Whether to hide the breakdown detail in the label
     hideIcon?: boolean // Whether to hide the icon that showcases the color of the series
@@ -62,8 +62,7 @@ export function InsightLabel({
     seriesColor = '#000000',
     action,
     value,
-    style,
-    innerStyle,
+    className,
     breakdownValue,
     hideBreakdown,
     hideIcon,
@@ -82,7 +81,7 @@ export function InsightLabel({
     const iconSizePx = iconSize === IconSize.Large ? 14 : iconSize === IconSize.Medium ? 12 : 10
 
     return (
-        <Row className="insights-label" wrap={false} style={style}>
+        <Row className={clsx('insights-label', className)} wrap={false}>
             <Col style={{ display: 'flex', alignItems: 'center' }} flex="auto">
                 {!(hasMultipleSeries && !breakdownValue) && !hideIcon && (
                     <div
@@ -105,7 +104,7 @@ export function InsightLabel({
                         hasBreakdown={!!breakdownValue}
                     />
                 )}
-                <div className={allowWrap ? '' : 'protect-width'} style={innerStyle}>
+                <div className={allowWrap ? '' : 'protect-width'}>
                     {showEventName && (
                         <>
                             {useCustomName && action ? (

--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -19,6 +19,8 @@ interface InsightsLabelProps {
     seriesColor?: string
     action?: ActionFilter
     value?: string
+    style?: React.CSSProperties
+    innerStyle?: React.CSSProperties // Style for the inner component, the actual value content
     breakdownValue?: string | number
     hideBreakdown?: boolean // Whether to hide the breakdown detail in the label
     hideIcon?: boolean // Whether to hide the icon that showcases the color of the series
@@ -59,6 +61,8 @@ export function InsightLabel({
     seriesColor = '#000000',
     action,
     value,
+    style,
+    innerStyle,
     breakdownValue,
     hideBreakdown,
     hideIcon,
@@ -76,7 +80,7 @@ export function InsightLabel({
     const iconSizePx = iconSize === IconSize.Large ? 14 : iconSize === IconSize.Medium ? 12 : 10
 
     return (
-        <Row className="insights-label" wrap={false}>
+        <Row className="insights-label" wrap={false} style={style}>
             <Col style={{ display: 'flex', alignItems: 'center' }} flex="auto">
                 {!(hasMultipleSeries && !breakdownValue) && !hideIcon && (
                     <div
@@ -99,7 +103,7 @@ export function InsightLabel({
                         hasBreakdown={!!breakdownValue}
                     />
                 )}
-                <div className={allowWrap ? '' : 'protect-width'}>
+                <div className={allowWrap ? '' : 'protect-width'} style={innerStyle}>
                     {showEventName && (
                         <>
                             {useCustomName && action ? (

--- a/frontend/src/scenes/insights/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/RenameModal.tsx
@@ -42,8 +42,8 @@ export function RenameModal({ typeKey, view }: RenameModalProps): JSX.Element {
             }
             onCancel={hideModal}
         >
-            Query steps can be renamed to provide a more meaningful label for your insight. Renamed steps are also shown
-            on dashboards.
+            Query series/steps can be renamed to provide a more <b>meaningful label for you and your team members</b>.
+            Custom names are also shown on dashboards.
             <br />
             <div className="l4 mt-05 mb-05">Name</div>
             <Input

--- a/frontend/src/scenes/insights/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/RenameModal.tsx
@@ -42,8 +42,8 @@ export function RenameModal({ typeKey, view }: RenameModalProps): JSX.Element {
             }
             onCancel={hideModal}
         >
-            Query series/steps can be renamed to provide a more <b>meaningful label for you and your team members</b>.
-            Custom names are also shown on dashboards.
+            Query series/steps can be renamed to provide a more{' '}
+            <strong>meaningful label for you and your team members</strong>. Custom names are also shown on dashboards.
             <br />
             <div className="l4 mt-05 mb-05">Name</div>
             <Input

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -138,7 +138,11 @@ export function InsightContainer(): JSX.Element {
                 <Card style={{ marginTop: 8 }}>
                     <BindLogic logic={trendsLogic} props={insightProps}>
                         <h3 className="l3">Details table</h3>
-                        <InsightsTable showTotalCount={activeView !== ViewType.SESSIONS} />
+                        <InsightsTable
+                            showTotalCount={activeView !== ViewType.SESSIONS}
+                            typeKey={activeView === ViewType.TRENDS ? `trends_${activeView}` : ''}
+                            canEditSeriesNameInline={activeView === ViewType.TRENDS}
+                        />
                     </BindLogic>
                 </Card>
             )

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -2,7 +2,7 @@ import { Card, Col, Row } from 'antd'
 import { InsightDisplayConfig } from 'scenes/insights/InsightTabs/InsightDisplayConfig'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { ComputationTimeWithRefresh } from 'scenes/insights/ComputationTimeWithRefresh'
-import { FunnelVizType, ViewType } from '~/types'
+import { FunnelVizType, ItemMode, ViewType } from '~/types'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { FunnelInsight } from 'scenes/insights/FunnelInsight'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
@@ -141,7 +141,7 @@ export function InsightContainer(): JSX.Element {
                         <InsightsTable
                             showTotalCount={activeView !== ViewType.SESSIONS}
                             typeKey={activeView === ViewType.TRENDS ? `trends_${activeView}` : ''}
-                            canEditSeriesNameInline={activeView === ViewType.TRENDS}
+                            canEditSeriesNameInline={activeView === ViewType.TRENDS && insightMode === ItemMode.Edit}
                         />
                     </BindLogic>
                 </Card>

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -140,7 +140,7 @@ export function InsightContainer(): JSX.Element {
                         <h3 className="l3">Details table</h3>
                         <InsightsTable
                             showTotalCount={activeView !== ViewType.SESSIONS}
-                            typeKey={activeView === ViewType.TRENDS ? `trends_${activeView}` : ''}
+                            filterKey={activeView === ViewType.TRENDS ? `trends_${activeView}` : ''}
                             canEditSeriesNameInline={activeView === ViewType.TRENDS && insightMode === ItemMode.Edit}
                         />
                     </BindLogic>

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -51,7 +51,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         horizontalUI
                         filters={filters}
                         setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
-                        typeKey={'trends_' + view}
+                        typeKey={`trends_${view}`}
                         buttonCopy="Add graph series"
                         showSeriesIndicator
                         singleFilter={filters.insight === ViewType.LIFECYCLE}

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
@@ -1,0 +1,16 @@
+@import '~/vars';
+
+.series-name-wrapper-col {
+    display: flex;
+    align-items: center;
+    .insights-label {
+        flex-grow: 1;
+        &.editable {
+            cursor: pointer;
+            .ant-typography {
+                color: $primary;
+                font-weight: $medium;
+            }
+        }
+    }
+}

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
@@ -3,6 +3,13 @@
 .series-name-wrapper-col {
     display: flex;
     align-items: center;
+
+    .edit-icon {
+        color: $primary;
+        cursor: pointer;
+        padding-right: 4px;
+    }
+
     .insights-label {
         flex-grow: 1;
         &.editable {

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -156,6 +156,7 @@ export function InsightsTable({
                                   }
                                 : undefined
                         }
+                        hideSeriesSubtitle
                     />
                 </div>
             )

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -12,7 +12,7 @@ import { average, median, maybeAddCommasToInteger } from 'lib/utils'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
-import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
+import { DownOutlined, InfoCircleOutlined, EditOutlined } from '@ant-design/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesToggleWrapper } from './components/SeriesToggleWrapper'
@@ -21,6 +21,8 @@ import { IndexedTrendResult } from 'scenes/trends/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { entityFilterLogic } from '../ActionFilter/entityFilterLogic'
+import './InsightsTable.scss'
+import clsx from 'clsx'
 
 interface InsightsTableProps {
     isLegend?: boolean // `true` -> Used as a supporting legend at the bottom of another graph; `false` -> used as it's own display
@@ -137,7 +139,9 @@ export function InsightsTable({
                             showModal()
                         }
                     }}
+                    className="series-name-wrapper-col"
                 >
+                    <EditOutlined style={{ color: 'var(--primary)', marginRight: 4 }} />
                     <InsightLabel
                         seriesColor={colorList[item.id]}
                         action={item.action}
@@ -148,14 +152,7 @@ export function InsightsTable({
                         hideBreakdown
                         hideIcon
                         useCustomName={!!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]}
-                        innerStyle={
-                            canEditSeriesNameInline
-                                ? {
-                                      cursor: 'pointer',
-                                      borderBottom: '1px dashed var(--primary)',
-                                  }
-                                : undefined
-                        }
+                        className={clsx(canEditSeriesNameInline && 'editable')}
                         hideSeriesSubtitle
                     />
                 </div>

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -27,7 +27,7 @@ import clsx from 'clsx'
 interface InsightsTableProps {
     isLegend?: boolean // `true` -> Used as a supporting legend at the bottom of another graph; `false` -> used as it's own display
     showTotalCount?: boolean
-    typeKey: string // key for the entityFilterLogic
+    filterKey: string // key for the entityFilterLogic
     canEditSeriesNameInline?: boolean
 }
 
@@ -40,7 +40,7 @@ const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
 export function InsightsTable({
     isLegend = true,
     showTotalCount = false,
-    typeKey,
+    filterKey,
     canEditSeriesNameInline,
 }: InsightsTableProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -52,7 +52,7 @@ export function InsightsTable({
     const _entityFilterLogic = entityFilterLogic({
         setFilters,
         filters,
-        typeKey,
+        typeKey: filterKey,
     })
     const { showModal, selectFilter } = useActions(_entityFilterLogic)
 

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -68,7 +68,7 @@ export function InsightsTable({
     const colorList = getChartColors('white')
     const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
 
-    const handleEditClick = (item: IndexedTrendResult) => {
+    const handleEditClick = (item: IndexedTrendResult): void => {
         if (canEditSeriesNameInline) {
             selectFilter(item.action)
             showModal()

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -68,6 +68,13 @@ export function InsightsTable({
     const colorList = getChartColors('white')
     const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
 
+    const handleEditClick = (item: IndexedTrendResult) => {
+        if (canEditSeriesNameInline) {
+            selectFilter(item.action)
+            showModal()
+        }
+    }
+
     const calcColumnMenu = (
         <Menu>
             {Object.keys(CALC_COLUMN_LABELS).map((key) => (
@@ -132,16 +139,10 @@ export function InsightsTable({
         title: 'Event or Action',
         render: function RenderLabel({}, item: IndexedTrendResult): JSX.Element {
             return (
-                <div
-                    onClick={() => {
-                        if (canEditSeriesNameInline) {
-                            selectFilter(item.action)
-                            showModal()
-                        }
-                    }}
-                    className="series-name-wrapper-col"
-                >
-                    <EditOutlined style={{ color: 'var(--primary)', marginRight: 4 }} />
+                <div className="series-name-wrapper-col">
+                    <div className="edit-icon" onClick={() => handleEditClick(item)}>
+                        <EditOutlined />
+                    </div>
                     <InsightLabel
                         seriesColor={colorList[item.id]}
                         action={item.action}
@@ -154,6 +155,7 @@ export function InsightsTable({
                         useCustomName={!!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]}
                         className={clsx(canEditSeriesNameInline && 'editable')}
                         hideSeriesSubtitle
+                        onLabelClick={() => handleEditClick(item)}
                     />
                 </div>
             )

--- a/frontend/src/scenes/insights/utils.ts
+++ b/frontend/src/scenes/insights/utils.ts
@@ -2,6 +2,7 @@ import { EntityFilter, ActionFilter, FilterType, DashboardItemType } from '~/typ
 import { ensureStringIsNotBlank, objectsEqual } from 'lib/utils'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
+import { keyMapping } from 'lib/components/PropertyKeyInfo'
 
 export const getDisplayNameFromEntityFilter = (
     filter: EntityFilter | ActionFilter | null,
@@ -9,7 +10,10 @@ export const getDisplayNameFromEntityFilter = (
 ): string | null => {
     // Make sure names aren't blank strings
     const customName = ensureStringIsNotBlank(filter?.custom_name)
-    const name = ensureStringIsNotBlank(filter?.name)
+    let name = ensureStringIsNotBlank(filter?.name)
+    if (name && keyMapping.event[name]) {
+        name = keyMapping.event[name].label
+    }
 
     // Return custom name. If that doesn't exist then the name, then the id, then just null.
     return (isCustom ? customName : null) ?? name ?? (filter?.id ? `${filter?.id}` : null)

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -52,7 +52,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                     <InsightsTable
                         isLegend={false}
                         showTotalCount={view !== ViewType.SESSIONS}
-                        typeKey={`trends_${view}`}
+                        filterKey={`trends_${view}`}
                         canEditSeriesNameInline
                     />
                 </BindLogic>

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -33,6 +33,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
     const { showingPeople } = useValues(personsModalLogic)
     const { saveCohortWithFilters } = useActions(personsModalLogic)
     const { reportCohortCreatedFromPersonModal } = useActions(eventUsageLogic)
+
     const renderViz = (): JSX.Element | undefined => {
         if (
             !_filters.display ||
@@ -48,7 +49,12 @@ export function TrendInsight({ view }: Props): JSX.Element {
             }
             return (
                 <BindLogic logic={trendsLogic} props={{ dashboardItemId: null, view, filters: null }}>
-                    <InsightsTable isLegend={false} showTotalCount={view !== ViewType.SESSIONS} />
+                    <InsightsTable
+                        isLegend={false}
+                        showTotalCount={view !== ViewType.SESSIONS}
+                        typeKey={`trends_${view}`}
+                        canEditSeriesNameInline
+                    />
                 </BindLogic>
             )
         }


### PR DESCRIPTION
## Changes

As requested by some users, we now allow series to be renamed from the insights table.


![image](https://user-images.githubusercontent.com/5864173/140833885-e83b7adf-01ab-4bed-88ef-7ee540a5a01b.gif)


### Additionally
- We fix how we display names for PostHog events in the rename modal (e.g. `$pageview` becomes "Pageview")

**Before**
<img width="520" alt="" src="https://user-images.githubusercontent.com/5864173/140833686-bee16d7f-c8f4-41e0-b9b9-c6719a4dacc6.png">

**After**
<img width="518" alt="" src="https://user-images.githubusercontent.com/5864173/140833699-b61ad57e-8054-4fea-bde7-ae92ff259fa3.png">

- In the insights table, we now only show the custom name (as opposed to showing the raw event name too, users can click on the label to see the underlying event)
<img width="1146" alt="" src="https://user-images.githubusercontent.com/5864173/140833861-e8a903ff-b4f8-4d89-a716-a7595b889a3a.png">

- For breakdown values we now show a browser-based tooltip with the full value in case is too large to fit in the cell (as a temporary patch while we address #6965).


## How did you test this code?

- As shown in the recording above, manually changing a series name.
- Also tested having a table with multiple breakdown values.
- Tested view & edit mode.
- Tested trends & sessions to make sure no weird behavior leaked to sessions.
