### PR TITLE
Session Recording buffering race bug

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -195,10 +195,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             const currentEvents = values.replayer?.service.state.context.events ?? []
             const eventsToAdd = values.snapshots.slice(currentEvents.length) ?? []
 
-            if (eventsToAdd.length < 1) {
-                return
-            }
-
             // If replayer isn't initialized, it will be initialized with the already loaded snapshots
             if (!!values.replayer) {
                 eventsToAdd.forEach((event: eventWithTime) => {
@@ -206,8 +202,14 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 })
             }
 
+            // replayer should be updated with new events.
+            const finalEvents = [...currentEvents, ...eventsToAdd]
+            if (finalEvents.length < 1) {
+                return
+            }
+
             // Update last buffered point
-            const lastEvent = eventsToAdd[eventsToAdd.length - 1]
+            const lastEvent = finalEvents[finalEvents.length - 1]
             actions.setLastBufferedTime(lastEvent.timestamp)
 
             // If buffering has completed, resume last playing state
@@ -226,7 +228,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 // Sometimes replayer doesn't update with events we recently added.
                 const endTime = Math.max(
                     meta.endTime,
-                    eventsToAdd.length ? eventsToAdd[eventsToAdd.length - 1]?.timestamp : 0
+                    finalEvents.length ? finalEvents[finalEvents.length - 1]?.timestamp : 0
                 )
                 const finalMeta = {
                     ...meta,
@@ -268,7 +270,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             actions.setCurrentTime(time ?? 0)
 
             // If next time is greater than last buffered time, set to buffering
-            if (nextTime > values.zeroOffsetTime.lastBuffered) {
+            if (!values.zeroOffsetTime.lastBuffered || nextTime > values.zeroOffsetTime.lastBuffered) {
                 values.replayer?.pause()
                 actions.setBuffer()
             }


### PR DESCRIPTION
## Changes

There's a race condition where buffering states/times aren't being updated when rrweb Replayer is initialized after snapshots are successfully loaded.

We initialize rrweb's replayer with a set of snapshots that are fetched from the snapshots endpoint. We perform a comparison [here](https://github.com/PostHog/posthog/blob/23ce7aaf163563717193e1942421ad08931f4921/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts#L198-L200) to see if we should enter or exit from buffer mode. In the failure case, snapshots are fetched before the replayer is initialized and the replayer is initialized with these snapshots, which means we never execute the block of code that sets the last buffered time. This will forever keep the player in a buffer state. 

Changes in this PR:
- If last time/buffer time is NaN or 0, set buffering. This is later updated to exit buffering on animation loop. 
- Don't noop if `eventsToAdd` is empty. Rather return if `[...replayerEvents, ...eventsToAdd]` is empty. This handles the race condition where replayer can already be initialized with `eventsToAdd`.

This PR addresses several bugs (as part of squashing stuff here #6483):
- [x] Hard to repro, but sometimes the player gets stuck in a "always buffering" state (the recording is playing in the background, but the buffering sign is still shown). I think it only happens on recordings where the entire recording is returned in a single request.
- [x] If you click on recent recording (<1min ago and <1min duration), timestamp is NaN:NaN:NaN

## How did you test this code?

Here's a [real life example](https://app.posthog.com/recordings?sessionRecordingId=17d01b05405750-0401d28a389c86-1c306851-1ea000-17d01b05406bdb&filters=%7B%22actions%22%3A%5B%5D%2C%22events%22%3A%5B%7B%22id%22%3A%22recording%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22name%22%3A%22recording%20viewed%22%7D%5D%2C%22date_from%22%3A%222021-10-09%22%2C%22date_to%22%3Anull%2C%22offset%22%3A0%2C%22session_recording_duration%22%3A%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22duration%22%2C%22value%22%3A60%2C%22operator%22%3A%22gt%22%7D%7D) of where this bug shows up (Try hard refreshing a few times and the bug will show inconsistently).

It's difficult to reproduce this in local dev environments, but the way I triggered the bug was to create a short recording that would require a single snapshot chunk load. Then you can click the recording to see it stuck in buffering forever. Hard refreshes will work correctly because this reinitializes the replayer so make sure to enter the playback modal from the recordings list page.
