### PR TITLE
Groups/Trends: Allow filtering by group properties

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -44,9 +44,9 @@ export function TaxonomicPropertyFilter({
         <TaxonomicFilter
             groupType={propertyFilterTypeToTaxonomicFilterType(filter?.type)}
             value={cohortOrOtherValue}
-            onChange={(groupType, value) => {
-                selectItem(taxonomicFilterTypeToPropertyFilterType(groupType), value)
-                if (groupType === TaxonomicFilterGroupType.Cohorts) {
+            onChange={(group, value) => {
+                selectItem(taxonomicFilterTypeToPropertyFilterType(group.type), value)
+                if (group.type === TaxonomicFilterGroupType.Cohorts) {
                     onComplete?.()
                 }
             }}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -12,10 +12,7 @@ import { Popup } from 'lib/components/Popup/Popup'
 import { PropertyFilterInternalProps } from 'lib/components/PropertyFilters'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import {
-    propertyFilterTypeToTaxonomicFilterType,
-    taxonomicFilterTypeToPropertyFilterType,
-} from 'lib/components/PropertyFilters/utils'
+import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
 
 let uniqueMemoizedIndex = 0
 
@@ -44,9 +41,9 @@ export function TaxonomicPropertyFilter({
         <TaxonomicFilter
             groupType={propertyFilterTypeToTaxonomicFilterType(filter?.type)}
             value={cohortOrOtherValue}
-            onChange={(group, value) => {
-                selectItem(taxonomicFilterTypeToPropertyFilterType(group.type), value)
-                if (group.type === TaxonomicFilterGroupType.Cohorts) {
+            onChange={(taxonomicGroup, value) => {
+                selectItem(taxonomicGroup, value)
+                if (taxonomicGroup.type === TaxonomicFilterGroupType.Cohorts) {
                     onComplete?.()
                 }
             }}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -39,7 +39,7 @@ export function TaxonomicPropertyFilter({
 
     const taxonomicFilter = (
         <TaxonomicFilter
-            groupType={propertyFilterTypeToTaxonomicFilterType(filter?.type)}
+            groupType={propertyFilterTypeToTaxonomicFilterType(filter?.type, filter?.group_type_index)}
             value={cohortOrOtherValue}
             onChange={(taxonomicGroup, value) => {
                 selectItem(taxonomicGroup, value)
@@ -109,7 +109,14 @@ export function TaxonomicPropertyFilter({
                             placeholder="Enter value..."
                             onChange={(newOperator, newValue) => {
                                 if (filter?.key && filter?.type) {
-                                    setFilter(index, filter?.key, newValue || null, newOperator, filter?.type)
+                                    setFilter(
+                                        index,
+                                        filter?.key,
+                                        newValue || null,
+                                        newOperator,
+                                        filter?.type,
+                                        filter?.group_type_index
+                                    )
                                 }
                                 if (
                                     newOperator &&

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -48,6 +48,7 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
 
     listeners: ({ actions, values, props }) => ({
         selectItem: ({ taxonomicGroup, propertyKey }) => {
+            console.trace('TaxPropFilterLogic.selectItem', { taxonomicGroup, propertyKey })
             const propertyType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type)
             if (propertyKey && propertyType) {
                 if (propertyType === 'cohort') {

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -4,6 +4,8 @@ import { TaxonomicPropertyFilterLogicProps } from 'lib/components/PropertyFilter
 import { AnyPropertyFilter, PropertyFilterValue, PropertyOperator } from '~/types'
 import { taxonomicPropertyFilterLogicType } from './taxonomicPropertyFilterLogicType'
 import { cohortsModel } from '~/models/cohortsModel'
+import { TaxonomicFilterGroup } from 'lib/components/TaxonomicFilter/types'
+import { taxonomicFilterTypeToPropertyFilterType } from 'lib/components/PropertyFilters/utils'
 
 export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType>({
     path: (key) => ['lib', 'components', 'PropertyFilters', 'components', 'taxonomicPropertyFilterLogic', key],
@@ -15,7 +17,10 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
     }),
 
     actions: {
-        selectItem: (propertyType?: string, propertyKey?: PropertyFilterValue) => ({ propertyType, propertyKey }),
+        selectItem: (taxonomicGroup: TaxonomicFilterGroup, propertyKey?: PropertyFilterValue) => ({
+            taxonomicGroup,
+            propertyKey,
+        }),
         openDropdown: true,
         closeDropdown: true,
     },
@@ -42,7 +47,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
     },
 
     listeners: ({ actions, values, props }) => ({
-        selectItem: ({ propertyType, propertyKey }) => {
+        selectItem: ({ taxonomicGroup, propertyKey }) => {
+            const propertyType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type)
             if (propertyKey && propertyType) {
                 if (propertyType === 'cohort') {
                     propertyFilterLogic(props).actions.setFilter(

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -69,7 +69,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                         propertyKey.toString(),
                         null, // Reset value field
                         operator,
-                        propertyType
+                        propertyType,
+                        taxonomicGroup.groupTypeIndex
                     )
                 }
                 actions.closeDropdown()

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -48,7 +48,6 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
 
     listeners: ({ actions, values, props }) => ({
         selectItem: ({ taxonomicGroup, propertyKey }) => {
-            console.trace('TaxPropFilterLogic.selectItem', { taxonomicGroup, propertyKey })
             const propertyType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type)
             if (propertyKey && propertyType) {
                 if (propertyType === 'cohort') {

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -19,8 +19,9 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
             key: PropertyFilter['key'],
             value: PropertyFilter['value'],
             operator: PropertyFilter['operator'],
-            type: PropertyFilter['type']
-        ) => ({ index, key, value, operator, type }),
+            type: PropertyFilter['type'],
+            group_type_index?: PropertyFilter['group_type_index']
+        ) => ({ index, key, value, operator, type, group_type_index }),
         setFilters: (filters: AnyPropertyFilter[]) => ({ filters }),
         newFilter: true,
         remove: (index: number) => ({ index }),
@@ -30,9 +31,9 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
         filters: [
             props.propertyFilters ? parseProperties(props.propertyFilters) : ([] as AnyPropertyFilter[]),
             {
-                setFilter: (state, { index, key, value, operator, type }) => {
+                setFilter: (state, { index, ...property }) => {
                     const newFilters = [...state]
-                    newFilters[index] = { key, value, operator, type }
+                    newFilters[index] = property
                     return newFilters
                 },
                 setFilters: (_, { filters }) => filters,

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -48,18 +48,27 @@ const propertyFilterMapping: Record<string, TaxonomicFilterGroupType> = {
     event: TaxonomicFilterGroupType.EventProperties,
     cohort: TaxonomicFilterGroupType.Cohorts,
     element: TaxonomicFilterGroupType.Elements,
-    groups: TaxonomicFilterGroupType.GroupsPrefix, // :TODO:
 }
 
 export function propertyFilterTypeToTaxonomicFilterType(
-    filterType?: string | null
+    filterType?: string | null,
+    groupTypeIndex?: number | null
 ): TaxonomicFilterGroupType | undefined {
-    return filterType && filterType in propertyFilterMapping ? propertyFilterMapping[filterType] : undefined
+    if (!filterType) {
+        return undefined
+    }
+    if (filterType == 'group') {
+        return `${TaxonomicFilterGroupType.GroupsPrefix}_${groupTypeIndex}` as TaxonomicFilterGroupType
+    }
+    return propertyFilterMapping[filterType]
 }
 
 export function taxonomicFilterTypeToPropertyFilterType(filterType?: TaxonomicFilterGroupType): string | undefined {
     if (filterType === TaxonomicFilterGroupType.CohortsWithAllUsers) {
         return 'cohort'
+    }
+    if (filterType?.startsWith(TaxonomicFilterGroupType.GroupsPrefix)) {
+        return 'group'
     }
     return Object.entries(propertyFilterMapping).find(([, v]) => v === filterType)?.[0]
 }

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -48,7 +48,7 @@ const propertyFilterMapping: Record<string, TaxonomicFilterGroupType> = {
     event: TaxonomicFilterGroupType.EventProperties,
     cohort: TaxonomicFilterGroupType.Cohorts,
     element: TaxonomicFilterGroupType.Elements,
-    groups: TaxonomicFilterGroupType.Groups,
+    groups: TaxonomicFilterGroupType.GroupsPrefix, // :TODO:
 }
 
 export function propertyFilterTypeToTaxonomicFilterType(

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -187,13 +187,7 @@ export function InfiniteList(): JSX.Element {
             <div
                 key={`item_${rowIndex}`}
                 className={`taxonomic-list-row${rowIndex === index ? ' hover' : ''}${isSelected ? ' selected' : ''}`}
-                onClick={() =>
-                    selectItem(
-                        listGroupType?.startsWith('groups') ? TaxonomicFilterGroupType.GroupsPrefix : listGroupType,
-                        itemValue ?? null,
-                        item
-                    )
-                }
+                onClick={() => selectItem(listGroupType, itemValue ?? null, item)}
                 onMouseOver={() => (mouseInteractionsEnabled ? setIndex(rowIndex) : null)}
                 style={style}
                 data-attr={`prop-filter-${listGroupType}-${rowIndex}`}

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -50,8 +50,8 @@ const renderItemContents = ({
     return listGroupType === TaxonomicFilterGroupType.EventProperties ||
         listGroupType === TaxonomicFilterGroupType.PersonProperties ||
         listGroupType === TaxonomicFilterGroupType.Events ||
-        listGroupType === TaxonomicFilterGroupType.Groups ||
-        listGroupType === TaxonomicFilterGroupType.CustomEvents ? (
+        listGroupType === TaxonomicFilterGroupType.CustomEvents ||
+        listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix) ? (
         <PropertyKeyInfo value={item.name ?? ''} disablePopover />
     ) : listGroupType === TaxonomicFilterGroupType.Elements ? (
         <PropertyKeyInfo type="element" value={item.name ?? ''} disablePopover />
@@ -96,8 +96,8 @@ const renderItemPopup = (
             // NB: also update "selectedItemHasPopup" below
             listGroupType === TaxonomicFilterGroupType.Events ||
             listGroupType === TaxonomicFilterGroupType.EventProperties ||
-            listGroupType === TaxonomicFilterGroupType.Groups ||
-            listGroupType === TaxonomicFilterGroupType.PersonProperties
+            listGroupType === TaxonomicFilterGroupType.PersonProperties ||
+            listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix)
         ) {
             data = getKeyMapping(value.toString(), 'event')
         } else if (listGroupType === TaxonomicFilterGroupType.Elements) {
@@ -189,7 +189,7 @@ export function InfiniteList(): JSX.Element {
                 className={`taxonomic-list-row${rowIndex === index ? ' hover' : ''}${isSelected ? ' selected' : ''}`}
                 onClick={() =>
                     selectItem(
-                        listGroupType?.includes('groups') ? TaxonomicFilterGroupType.Groups : listGroupType,
+                        listGroupType?.startsWith('groups') ? TaxonomicFilterGroupType.GroupsPrefix : listGroupType,
                         itemValue ?? null,
                         item
                     )

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -96,8 +96,7 @@ const renderItemPopup = (
             // NB: also update "selectedItemHasPopup" below
             listGroupType === TaxonomicFilterGroupType.Events ||
             listGroupType === TaxonomicFilterGroupType.EventProperties ||
-            listGroupType === TaxonomicFilterGroupType.PersonProperties ||
-            listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix)
+            listGroupType === TaxonomicFilterGroupType.PersonProperties
         ) {
             data = getKeyMapping(value.toString(), 'event')
         } else if (listGroupType === TaxonomicFilterGroupType.Elements) {
@@ -142,7 +141,6 @@ const selectedItemHasPopup = (
             ((listGroupType === TaxonomicFilterGroupType.Elements ||
                 listGroupType === TaxonomicFilterGroupType.Events ||
                 listGroupType === TaxonomicFilterGroupType.EventProperties ||
-                listGroupType?.startsWith(TaxonomicFilterGroupType.GroupsPrefix) || // :TODO: Kill this maybe?
                 listGroupType === TaxonomicFilterGroupType.PersonProperties) &&
                 !!getKeyMapping(
                     group?.getValue(item),

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -142,7 +142,7 @@ const selectedItemHasPopup = (
             ((listGroupType === TaxonomicFilterGroupType.Elements ||
                 listGroupType === TaxonomicFilterGroupType.Events ||
                 listGroupType === TaxonomicFilterGroupType.EventProperties ||
-                listGroupType?.includes(TaxonomicFilterGroupType.Groups) ||
+                listGroupType?.startsWith(TaxonomicFilterGroupType.GroupsPrefix) || // :TODO: Kill this maybe?
                 listGroupType === TaxonomicFilterGroupType.PersonProperties) &&
                 !!getKeyMapping(
                     group?.getValue(item),

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -183,11 +183,11 @@ export function InfiniteList(): JSX.Element {
         const isSelected = listGroupType === groupType && itemValue === value
         const isHighlighted = rowIndex === index && isActiveTab
 
-        return item ? (
+        return item && group ? (
             <div
                 key={`item_${rowIndex}`}
                 className={`taxonomic-list-row${rowIndex === index ? ' hover' : ''}${isSelected ? ' selected' : ''}`}
-                onClick={() => selectItem(listGroupType, itemValue ?? null, item)}
+                onClick={() => selectItem(group, itemValue ?? null, item)}
                 onMouseOver={() => (mouseInteractionsEnabled ? setIndex(rowIndex) : null)}
                 style={style}
                 data-attr={`prop-filter-${listGroupType}-${rowIndex}`}

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -117,7 +117,9 @@ describe('infiniteListLogic', () => {
         expectLogic(logic, () => logic.actions.selectSelected()).toDispatchActions([
             logic.actionCreators.selectSelected(),
             logic.actionCreators.selectItem(
-                TaxonomicFilterGroupType.Events,
+                expect.objectContaining({
+                    type: TaxonomicFilterGroupType.Events,
+                }),
                 'event1',
                 expect.objectContaining({ name: 'event1' })
             ),

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -6,7 +6,13 @@ import { EventDefinitionStorage } from '~/models/eventDefinitionsModel'
 import { infiniteListLogicType } from './infiniteListLogicType'
 import { CohortType, EventDefinition } from '~/types'
 import Fuse from 'fuse.js'
-import { InfiniteListLogicProps, ListFuse, ListStorage, LoaderOptions } from 'lib/components/TaxonomicFilter/types'
+import {
+    InfiniteListLogicProps,
+    ListFuse,
+    ListStorage,
+    LoaderOptions,
+    TaxonomicFilterGroup,
+} from 'lib/components/TaxonomicFilter/types'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 
 function appendAtIndex<T>(array: T[], items: any[], startIndex?: number): T[] {
@@ -125,7 +131,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
         ],
     }),
 
-    listeners: ({ values, actions, props }) => ({
+    listeners: ({ values, actions }) => ({
         onRowsRendered: ({ rowInfo: { startIndex, stopIndex, overscanStopIndex } }) => {
             if (values.isRemoteDataSource) {
                 let loadFrom: number | null = null
@@ -156,7 +162,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
             actions.setIndex((index + 1) % totalCount)
         },
         selectSelected: () => {
-            actions.selectItem(props.listGroupType, values.selectedItemValue, values.selectedItem)
+            actions.selectItem(values.group, values.selectedItemValue, values.selectedItem)
         },
     }),
 
@@ -165,7 +171,8 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
         isLoading: [(s) => [s.remoteItemsLoading], (remoteItemsLoading) => remoteItemsLoading],
         group: [
             (s) => [s.listGroupType, s.taxonomicGroups],
-            (listGroupType, taxonomicGroups) => taxonomicGroups.find((g) => g.type === listGroupType),
+            (listGroupType, taxonomicGroups): TaxonomicFilterGroup =>
+                taxonomicGroups.find((g) => g.type === listGroupType) as TaxonomicFilterGroup,
         ],
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
         isRemoteDataSource: [(s) => [s.remoteEndpoint], (remoteEndpoint) => !!remoteEndpoint],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -16,6 +16,7 @@ import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
 import { teamLogic } from '../../../scenes/teamLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { groupPropertiesModel } from '~/models/groupPropertiesModel'
+import { capitalizeFirstLetter } from 'lib/utils'
 
 export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
     path: (key) => ['lib', 'components', 'TaxonomicFilter', 'taxonomicFilterLogic', key],
@@ -173,11 +174,11 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             (selectors) => [selectors.groupTypes],
             (groupTypes): TaxonomicFilterGroup[] =>
                 groupTypes.map((type, index) => ({
-                    name: type.group_type,
+                    name: capitalizeFirstLetter(type.group_type),
                     type: `${TaxonomicFilterGroupType.GroupsPrefix}_${index}` as TaxonomicFilterGroupType,
                     logic: groupPropertiesModel,
                     value: `groupProperties_${index}`,
-                    getName: (group) => group.name,
+                    getName: (group) => capitalizeFirstLetter(group.name),
                     getValue: (group) => group.name,
                     groupTypeIndex: index,
                 })),

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -174,7 +174,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             (groupTypes): TaxonomicFilterGroup[] =>
                 groupTypes.map((type, index) => ({
                     name: type.group_type,
-                    type: `${TaxonomicFilterGroupType.Groups}_${index}`,
+                    type: `${TaxonomicFilterGroupType.GroupsPrefix}_${index}` as TaxonomicFilterGroupType,
                     logic: groupPropertiesModel,
                     value: `groupProperties_${index}`,
                     getName: (group) => group.name,
@@ -192,8 +192,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
     listeners: ({ actions, values, props }) => ({
         selectItem: ({ groupType, value, item }) => {
             if (item && value) {
-                const groupTypeWithGroupAnalytics = groupType.includes('groups')
-                    ? TaxonomicFilterGroupType.Groups
+                const groupTypeWithGroupAnalytics = groupType.startsWith('groups')
+                    ? TaxonomicFilterGroupType.GroupsPrefix
                     : groupType
                 props.onChange?.(groupTypeWithGroupAnalytics, value, item)
             }

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -179,6 +179,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     value: `groupProperties_${index}`,
                     getName: (group) => group.name,
                     getValue: (group) => group.name,
+                    groupTypeIndex: index,
                 })),
         ],
         value: [() => [(_, props) => props.value], (value) => value],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -194,7 +194,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
     listeners: ({ actions, values, props }) => ({
         selectItem: ({ group, value, item }) => {
             if (item && value) {
-                props.onChange?.(group, value)
+                props.onChange?.(group, value, item)
             }
         },
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -73,54 +73,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             (taxonomicFilterLogicKey) => taxonomicFilterLogicKey,
         ],
         taxonomicGroups: [
-            (selectors) => [selectors.currentTeamId, selectors.groupAnalyticsTypes],
-            (teamId, groupAnalyticsTypes): TaxonomicFilterGroup[] => [
+            (selectors) => [selectors.currentTeamId, selectors.groupAnalyticsTaxonomicGroups],
+            (teamId, groupAnalyticsTaxonomicGroups): TaxonomicFilterGroup[] => [
                 {
                     name: 'Events',
                     type: TaxonomicFilterGroupType.Events,
                     endpoint: `api/projects/${teamId}/event_definitions`,
                     getName: (eventDefinition: EventDefinition): string => eventDefinition.name,
                     getValue: (eventDefinition: EventDefinition): TaxonomicFilterValue => eventDefinition.name,
-                },
-                {
-                    name: groupAnalyticsTypes[0]?.group_type,
-                    type: `${TaxonomicFilterGroupType.Groups}_0`,
-                    logic: groupPropertiesModel,
-                    value: 'groupProperties_0',
-                    getName: (group) => group.name,
-                    getValue: (group) => group.name,
-                },
-                {
-                    name: groupAnalyticsTypes[1]?.group_type,
-                    type: `${TaxonomicFilterGroupType.Groups}_1`,
-                    logic: groupPropertiesModel,
-                    value: 'groupProperties_1',
-                    getName: (group) => group.name,
-                    getValue: (group) => group.name,
-                },
-                {
-                    name: groupAnalyticsTypes[2]?.group_type,
-                    type: `${TaxonomicFilterGroupType.Groups}_2`,
-                    logic: groupPropertiesModel,
-                    value: 'groupProperties_2',
-                    getName: (group) => group.name,
-                    getValue: (group) => group.name,
-                },
-                {
-                    name: groupAnalyticsTypes[3]?.group_type,
-                    type: `${TaxonomicFilterGroupType.Groups}_3`,
-                    logic: groupPropertiesModel,
-                    value: 'groupProperties_3',
-                    getName: (group) => group.name,
-                    getValue: (group) => group.name,
-                },
-                {
-                    name: groupAnalyticsTypes[4]?.group_type,
-                    type: `${TaxonomicFilterGroupType.Groups}_4`,
-                    logic: groupPropertiesModel,
-                    value: 'groupProperties_4',
-                    getName: (group) => group.name,
-                    getValue: (group) => group.name,
                 },
                 {
                     name: 'Actions',
@@ -201,6 +161,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     getName: (option: SimpleOption): string => option.name,
                     getValue: (option: SimpleOption): TaxonomicFilterValue => option.name,
                 },
+                ...groupAnalyticsTaxonomicGroups,
             ],
         ],
         taxonomicGroupTypes: [
@@ -208,13 +169,24 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             (groupTypes, taxonomicGroups): TaxonomicFilterGroupType[] =>
                 groupTypes || taxonomicGroups.map((g) => g.type),
         ],
+        groupAnalyticsTaxonomicGroups: [
+            (selectors) => [selectors.groupTypes],
+            (groupTypes): TaxonomicFilterGroup[] =>
+                groupTypes.map((type, index) => ({
+                    name: type.group_type,
+                    type: `${TaxonomicFilterGroupType.Groups}_${index}`,
+                    logic: groupPropertiesModel,
+                    value: `groupProperties_${index}`,
+                    getName: (group) => group.name,
+                    getValue: (group) => group.name,
+                })),
+        ],
         value: [() => [(_, props) => props.value], (value) => value],
         groupType: [() => [(_, props) => props.groupType], (groupType) => groupType],
         currentTabIndex: [
             (s) => [s.taxonomicGroupTypes, s.activeTab],
             (groupTypes, activeTab) => Math.max(groupTypes.indexOf(activeTab || ''), 0),
         ],
-        groupAnalyticsTypes: [(s) => [s.groupTypes], (groupTypes) => groupTypes],
     },
 
     listeners: ({ actions, values, props }) => ({

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -192,10 +192,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
     listeners: ({ actions, values, props }) => ({
         selectItem: ({ groupType, value, item }) => {
             if (item && value) {
-                const groupTypeWithGroupAnalytics = groupType.startsWith('groups')
-                    ? TaxonomicFilterGroupType.GroupsPrefix
-                    : groupType
-                props.onChange?.(groupTypeWithGroupAnalytics, value, item)
+                props.onChange?.(groupType, value, item)
             }
         },
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.ts
@@ -31,8 +31,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
         tabRight: true,
         setSearchQuery: (searchQuery: string) => ({ searchQuery }),
         setActiveTab: (activeTab: TaxonomicFilterGroupType) => ({ activeTab }),
-        selectItem: (groupType: TaxonomicFilterGroupType, value: TaxonomicFilterValue | null, item: any) => ({
-            groupType,
+        selectItem: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue | null, item: any) => ({
+            group,
             value,
             item,
         }),
@@ -190,9 +190,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
     },
 
     listeners: ({ actions, values, props }) => ({
-        selectItem: ({ groupType, value, item }) => {
+        selectItem: ({ group, value, item }) => {
             if (item && value) {
-                props.onChange?.(groupType, value, item)
+                props.onChange?.(group, value)
             }
         },
 

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -32,6 +32,7 @@ export interface TaxonomicFilterGroup {
     searchAlias?: string
     getName: (instance: any) => string
     getValue: (instance: any) => TaxonomicFilterValue
+    groupTypeIndex?: number
 }
 
 export enum TaxonomicFilterGroupType {

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -24,7 +24,7 @@ export interface TaxonomicFilterLogicProps extends TaxonomicFilterProps {
 
 export interface TaxonomicFilterGroup {
     name: string
-    type: TaxonomicFilterGroupType | string
+    type: TaxonomicFilterGroupType
     endpoint?: string
     options?: Record<string, any>[]
     logic?: LogicWrapper
@@ -46,7 +46,7 @@ export enum TaxonomicFilterGroupType {
     Screens = 'screens',
     CustomEvents = 'custom_events',
     Wildcards = 'wildcard',
-    Groups = 'groups',
+    GroupsPrefix = 'groups',
 }
 
 export interface InfiniteListLogicProps extends TaxonomicFilterLogicProps {

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -9,7 +9,7 @@ export interface SimpleOption {
 export interface TaxonomicFilterProps {
     groupType?: TaxonomicFilterGroupType
     value?: TaxonomicFilterValue
-    onChange?: (groupType: TaxonomicFilterGroupType, value: TaxonomicFilterValue, item: any) => void
+    onChange?: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue) => void
     onClose?: () => void
     taxonomicGroupTypes?: (TaxonomicFilterGroupType | string)[]
     taxonomicFilterLogicKey?: string

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -9,7 +9,7 @@ export interface SimpleOption {
 export interface TaxonomicFilterProps {
     groupType?: TaxonomicFilterGroupType
     value?: TaxonomicFilterValue
-    onChange?: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue) => void
+    onChange?: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue, item: any) => void
     onClose?: () => void
     taxonomicGroupTypes?: (TaxonomicFilterGroupType | string)[]
     taxonomicFilterLogicKey?: string

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -43,7 +43,7 @@ export const groupsModel = kea<groupsModelType>({
             (groupTypes): TaxonomicFilterGroupType[] => {
                 return groupTypes.map(
                     (groupType: GroupType) =>
-                        `${TaxonomicFilterGroupType.Groups}_${groupType.group_type_index}` as TaxonomicFilterGroupType
+                        `${TaxonomicFilterGroupType.GroupsPrefix}_${groupType.group_type_index}` as TaxonomicFilterGroupType
                 )
             },
         ],

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -38,20 +38,13 @@ export const groupsModel = kea<groupsModelType>({
             (s) => [s.featureFlags, s.clickhouseEnabled],
             (featureFlags, clickhouseEnabled) => featureFlags[FEATURE_FLAGS.GROUP_ANALYTICS] && clickhouseEnabled,
         ],
-        taxonomicTypesWithGroups: [
-            (s) => [s.groupsEnabled, s.groupTypes],
-            (groupsEnabled, groupTypes) => {
-                if (groupsEnabled) {
-                    return [
-                        TaxonomicFilterGroupType.EventProperties,
-                        TaxonomicFilterGroupType.PersonProperties,
-                        ...groupTypes.map(
-                            (groupType: GroupType) => `${TaxonomicFilterGroupType.Groups}_${groupType.group_type_index}`
-                        ),
-                        TaxonomicFilterGroupType.Cohorts,
-                        TaxonomicFilterGroupType.Elements,
-                    ] as TaxonomicFilterGroupType[]
-                }
+        groupsTaxonomicTypes: [
+            (s) => [s.groupTypes],
+            (groupTypes): TaxonomicFilterGroupType[] => {
+                return groupTypes.map(
+                    (groupType: GroupType) =>
+                        `${TaxonomicFilterGroupType.Groups}_${groupType.group_type_index}` as TaxonomicFilterGroupType
+                )
             },
         ],
     },

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -207,9 +207,9 @@ export function ActionFilterRow({
                     value={
                         filter.type === 'actions' && typeof value === 'string' ? parseInt(value) : value || undefined
                     }
-                    onChange={(groupType, changedValue, item) => {
+                    onChange={(taxonomicGroup, changedValue, item) => {
                         updateFilter({
-                            type: taxonomicFilterGroupTypeToEntityType(groupType) || undefined,
+                            type: taxonomicFilterGroupTypeToEntityType(taxonomicGroup.type) || undefined,
                             id: `${changedValue}`,
                             name: item?.name,
                             index,

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -24,9 +24,9 @@ export function TaxonomicBreakdownButton({
             overlay={
                 <TaxonomicFilter
                     groupType={breakdownType}
-                    onChange={(groupType, value) => {
+                    onChange={(taxonomicGroup, value) => {
                         if (value) {
-                            onChange(value, groupType)
+                            onChange(value, taxonomicGroup.type)
                             setOpen(false)
                         }
                     }}

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -18,6 +18,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { groupPropertiesModel } from '~/models/groupPropertiesModel'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 export interface TrendTabProps {
     view: string
@@ -29,7 +30,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
     const { setFilters, toggleLifecycle } = useActions(trendsLogic(insightProps))
     const { preflight } = useValues(preflightLogic)
     groupPropertiesModel.mount()
-    const { taxonomicTypesWithGroups } = useValues(groupsModel)
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
     const [isUsingFormulas, setIsUsingFormulas] = useState(filters.formula ? true : false)
     const lifecycles = [
         { name: 'new', tooltip: 'Users that are new.' },
@@ -42,6 +43,17 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
     const formulaAvailable =
         (!filters.insight || filters.insight === ViewType.TRENDS) && preflight?.is_clickhouse_enabled
     const formulaEnabled = (filters.events?.length || 0) + (filters.actions?.length || 0) > 0
+
+    const taxonomicTypes =
+        filters.insight === ViewType.TRENDS
+            ? [
+                  TaxonomicFilterGroupType.EventProperties,
+                  TaxonomicFilterGroupType.PersonProperties,
+                  ...groupsTaxonomicTypes,
+                  TaxonomicFilterGroupType.Cohorts,
+                  TaxonomicFilterGroupType.Elements,
+              ]
+            : undefined
 
     return (
         <>
@@ -94,7 +106,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     {filters.insight !== ViewType.LIFECYCLE && (
                         <>
                             <GlobalFiltersTitle />
-                            <PropertyFilters taxonomicGroupTypes={taxonomicTypesWithGroups} pageKey="trends-filters" />
+                            <PropertyFilters taxonomicGroupTypes={taxonomicTypes} pageKey="trends-filters" />
                             <TestAccountFilter filters={filters} onChange={setFilters} />
                             {formulaAvailable && (
                                 <>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -270,6 +270,7 @@ export interface PropertyFilter {
     operator: PropertyOperator | null
     type: string
     value: PropertyFilterValue
+    group_type_index?: number | null
 }
 
 export type EmptyPropertyFilter = Partial<PropertyFilter>


### PR DESCRIPTION
## Changes

This PR:
- Fixes an issue where group type filters were shown in lifecycle
- Simplifies data flow for groups significantly
- Starts sending data in right format to backend for group properties
- Removes popover logic for groups - we don't have any event definition logic available there yet

## How did you test this code?

Manual testing. Adding filters, checking payloads + generated queries