### PR TITLE
Fix static/dynamic cohort dropdown

### DIFF
--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -2,20 +2,25 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 import { CohortNameInput } from './CohortNameInput'
 import { CohortDescriptionInput } from './CohortDescriptionInput'
-import { Button, Col, Divider, Row, Spin } from 'antd'
+import { Button, Col, Divider, Row, Spin, Tooltip } from 'antd'
 import { CohortMatchingCriteriaSection } from './CohortMatchingCriteriaSection'
 import { AvailableFeature, CohortType } from '~/types'
 import { COHORT_DYNAMIC, COHORT_STATIC } from 'lib/constants'
-import { InboxOutlined, SaveOutlined, LoadingOutlined } from '@ant-design/icons'
+import {
+    InboxOutlined,
+    SaveOutlined,
+    LoadingOutlined,
+    CalculatorOutlined,
+    OrderedListOutlined,
+} from '@ant-design/icons'
 import Dragger from 'antd/lib/upload/Dragger'
 import { CohortDetailsRow } from './CohortDetailsRow'
 import { Persons } from 'scenes/persons/Persons'
 import { cohortLogic } from './cohortLogic'
 import { UploadFile } from 'antd/lib/upload/interface'
-import { CalculatorOutlined, OrderedListOutlined } from '@ant-design/icons'
 import { DropdownSelector } from 'lib/components/DropdownSelector/DropdownSelector'
-import { Tooltip } from 'antd'
 import { userLogic } from 'scenes/userLogic'
+import 'antd/lib/dropdown/style/index.css'
 
 export function Cohort(props: { cohort: CohortType }): JSX.Element {
     const logic = cohortLogic(props)


### PR DESCRIPTION
## Changes

This selector used to mess up CSS for the whole app:

<img width="344" alt="Screen Shot 2021-11-09 at 11 22 45" src="https://user-images.githubusercontent.com/4550621/140906959-7a002353-48b0-450d-b835-bac32d8e9f70.png">

Then it stopped doing that, but it also stopped working.
Now it's fine.

## How did you test this code?

Made sure that the dropdown works – without https://github.com/PostHog/posthog/pull/6685 reappearing.