### PR TITLE
Reload localhost _after_ build is complete

### DIFF
--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -56,7 +56,7 @@ export function copyIndexHtml(from = 'src/index.html', to = 'dist/index.html', e
         fse.readFileSync(path.resolve(__dirname, from), { encoding: 'utf-8' }).replace(
             '</head>',
             `   <script type="application/javascript">
-                    window.ESBUILD_LOADED_CHUNKS = new Set(); 
+                    window.ESBUILD_LOADED_CHUNKS = new Set();
                     window.ESBUILD_LOAD_SCRIPT = async function (file) {
                         try {
                             await import('${isDev ? jsURL : ''}/static/' + file)
@@ -64,14 +64,14 @@ export function copyIndexHtml(from = 'src/index.html', to = 'dist/index.html', e
                             console.error('Error loading chunk: "' + file + '"')
                         }
                     }
-                    window.ESBUILD_LOAD_CHUNKS = function(name) { 
+                    window.ESBUILD_LOAD_CHUNKS = function(name) {
                         const chunks = ${JSON.stringify(chunks)}[name] || [];
-                        for (const chunk of chunks) { 
-                            if (!window.ESBUILD_LOADED_CHUNKS.has(chunk)) { 
-                                window.ESBUILD_LOAD_SCRIPT('chunk-'+chunk+'.js'); 
+                        for (const chunk of chunks) {
+                            if (!window.ESBUILD_LOADED_CHUNKS.has(chunk)) {
+                                window.ESBUILD_LOAD_SCRIPT('chunk-'+chunk+'.js');
                                 window.ESBUILD_LOADED_CHUNKS.add(chunk);
-                            } 
-                        } 
+                            }
+                        }
                     }
                     window.ESBUILD_LOAD_SCRIPT("${entry}.js?t=" + new Date().valueOf())
                     window.ESBUILD_LOAD_CHUNKS('index');
@@ -161,9 +161,9 @@ export async function buildOrWatch(config) {
         }
         buildAgain = false
         onBuildStart?.()
-        reloadLiveServer()
         buildPromise = runBuild()
         const chunks = await buildPromise
+        reloadLiveServer()
         buildPromise = null
         onBuildComplete?.(chunks)
         if (isDev && buildAgain) {


### PR DESCRIPTION
When developing the frontend I kept running into a problem where the
code being executed was not what I had on disk. I traced this down to us
reloading the site _before_ the build was complete, which returned the
previous assets for me.

To repro, add `console.log('v1')` to navigationLogic afterMount, save
and check console. Change the string and try again. It should be always
_behind_.

This small patch fixes the issue I was having.

## How did you test this code?

Manual testing

