### PR TITLE
chore(mypy): update version from 0.790 to 0.910

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -71,10 +71,10 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.8
+            - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
 
             - uses: syphar/restore-virtualenv@v1.2
               id: cache-backend-tests

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -56,16 +56,6 @@ jobs:
         name: Code quality checks
         runs-on: ubuntu-latest
 
-        services:
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_USER: posthog
-                    POSTGRES_PASSWORD: posthog
-                    POSTGRES_DB: posthog
-                ports: ['5432:5432']
-                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
         steps:
             - uses: actions/checkout@v1
               with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -97,7 +97,7 @@ mypy-extensions==0.4.3
     # via
     #   -r requirements-dev.in
     #   mypy
-mypy==0.790
+mypy==0.910
     # via
     #   -r requirements-dev.in
     #   django-stubs
@@ -177,12 +177,11 @@ syrupy==1.4.6
 toml==0.10.1
     # via
     #   black
+    #   mypy
     #   pytest
     #   pytest-cov
 typed-ast==1.4.1
-    # via
-    #   black
-    #   mypy
+    # via black
 typing-extensions==3.7.4.2
     # via
     #   django-stubs


### PR DESCRIPTION
We're quite far behind on mypy version. I noticed that when I tried get
exhaustive checking of Enum types
[here](https://github.com/PostHog/posthog/pull/6951/commits/8d88ab22ff6e536e12cb0cc965786f8e5c13cc2b#diff-3bab9d18653e15b01cd920dbabe0a9adbd61b08743d71520d0cfe33176f6c8c8R560)
it fails to narrow the type, although this works in the most recent
version.