### PR TITLE
Change insight URL only if scene active

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -357,6 +357,9 @@ describe('insightLogic', () => {
         })
 
         it('sets the URL when changing filters', async () => {
+            // make sure we're on the right page
+            router.actions.push('/insights')
+
             logic.actions.setFilters({ insight: 'TRENDS', interval: 'minute' })
             await expectLogic()
                 .toDispatchActions(logic, [logic.actionCreators.setFilters({ insight: 'TRENDS', interval: 'minute' })])

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -381,6 +381,10 @@ export const insightLogic = kea<insightLogicType>({
                     user?.organization?.available_features?.includes(AvailableFeature.DASHBOARD_COLLABORATION)
                 ),
         ],
+        syncWithUrl: [
+            () => [(_, props: InsightLogicProps) => props.syncWithUrl, router.selectors.location],
+            (syncWithUrl, { pathname }) => syncWithUrl && pathname.startsWith('/insights'),
+        ],
     },
     listeners: ({ actions, selectors, values, props }) => ({
         setFilters: async ({ filters }, breakpoint, _, previousState) => {
@@ -553,7 +557,7 @@ export const insightLogic = kea<insightLogicType>({
                     { ...insight, ...createdInsight, result: createdInsight.result || insight.result },
                     {}
                 )
-                if (props.syncWithUrl) {
+                if (values.syncWithUrl) {
                     router.actions.replace('/insights', router.values.searchParams, {
                         ...router.values.hashParams,
                         fromItem: createdInsight.id,
@@ -602,14 +606,14 @@ export const insightLogic = kea<insightLogicType>({
             }
         },
     }),
-    actionToUrl: ({ values, props }) => ({
+    actionToUrl: ({ values }) => ({
         setFilters: () => {
-            if (props.syncWithUrl) {
+            if (values.syncWithUrl) {
                 return ['/insights', values.filters, router.values.hashParams, { replace: true }]
             }
         },
         setInsightMode: () => {
-            if (props.syncWithUrl) {
+            if (values.syncWithUrl) {
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { edit: _discard, ...otherHashParams } = router.values.hashParams
                 return [
@@ -621,9 +625,9 @@ export const insightLogic = kea<insightLogicType>({
             }
         },
     }),
-    urlToAction: ({ actions, values, props }) => ({
+    urlToAction: ({ actions, values }) => ({
         '/insights': (_: any, searchParams: Record<string, any>, hashParams: Record<string, any>) => {
-            if (props.syncWithUrl) {
+            if (values.syncWithUrl) {
                 let loadedFromAnotherLogic = false
                 if (searchParams.insight === 'HISTORY' || !hashParams.fromItem) {
                     if (values.insightMode !== ItemMode.Edit) {


### PR DESCRIPTION
## Changes

- Fixes bug where you would navigate away from the insight page, only to be redirected back there when the insight finally loaded.

## How did you test this code?

- Made added network throttling, loaded a new insight, navigated away and watched it NOT change the URL back to the insight that was just loaded.
- Edited the insight's filters to make sure the `urlToAction` code still works with a value that's selecting from the router.
