### PR TITLE
404 on static assets

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -50,6 +50,10 @@ def authorize_and_redirect(request):
     )
 
 
+def static_not_found(request):
+    return HttpResponse("Static file not found", status=404)
+
+
 # Try to include EE endpoints
 ee_urlpatterns: List[Any] = []
 if settings.EE_AVAILABLE:
@@ -132,4 +136,5 @@ frontend_unauthenticated_routes = [
 for route in frontend_unauthenticated_routes:
     urlpatterns.append(re_path(route, home))
 
+urlpatterns.append(re_path(r"static/.*", static_not_found))
 urlpatterns.append(re_path(r"^.*", login_required(home)))


### PR DESCRIPTION
## Changes

Changes `curl --head http://localhost:8000/static/chunk-NONO.js` from:

```http
HTTP/1.1 302 Found
Date: Tue, 09 Nov 2021 22:27:19 GMT
Server: WSGIServer/0.2 CPython/3.9.7
Content-Type: text/html; charset=utf-8
Location: /login?next=/static/chunk-NONO.js
X-Frame-Options: DENY
Content-Length: 0
Vary: Cookie
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
```

to

```http
HTTP/1.1 404 Not Found
Date: Tue, 09 Nov 2021 22:30:31 GMT
Server: WSGIServer/0.2 CPython/3.9.7
Content-Type: text/html; charset=utf-8
X-Frame-Options: DENY
Content-Length: 21
Vary: Cookie
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
```

Static files that exist still get served... I assume [directly by django](https://stackoverflow.com/questions/14408017/does-django-staticfiles-skip-the-middleware), so only serving files that were not there changed.

## Why?

I found a issue with edge caching `/static/chunk-*.js` files that were not there. 

- If you requested `/static/chunk-NOPE.js` and were logged out, you'd get a 302 to the login page. Bad, but fine compared to the alternative.
- If you requested `/static/chunk-STILL-NOPE.js`, and were logged in, you'd get a `200` response with some HTML. Cloudflare would then edge cache this file for a day, so that whoever else later tried opening `chunk-STILL-NOPE.js`, would get some HTML.

Basically, request a file too early (could this happen?) and the file is broken for everyone. 

## Proof of concept

Try this, `curl --head https://app.posthog.com/static/testing-CHANGEME.js` and see a `302`. Visit the same page in the browser and later the same command responds with a `200`

## How did you test this code?

Tested locally by making requests both before and after fixes. I assume this behaviour is consistent with how production does it, but I'm not 100% sure.
