### PR TITLE
Revert "404 on static assets"

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -50,10 +50,6 @@ def authorize_and_redirect(request):
     )
 
 
-def static_not_found(request):
-    return HttpResponse("Static file not found", status=404)
-
-
 # Try to include EE endpoints
 ee_urlpatterns: List[Any] = []
 if settings.EE_AVAILABLE:
@@ -136,5 +132,4 @@ frontend_unauthenticated_routes = [
 for route in frontend_unauthenticated_routes:
     urlpatterns.append(re_path(route, home))
 
-urlpatterns.append(re_path(r"static/.*", static_not_found))
 urlpatterns.append(re_path(r"^.*", login_required(home)))


### PR DESCRIPTION
Reverts PostHog/posthog#7000

With this change we are seeing a load of 404's for static assets.
![image](https://user-images.githubusercontent.com/391319/141046826-007eb11e-9c00-4551-869d-00ee713de075.png)
