### PR TITLE
Align breakdown button correctly

### DIFF
--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.scss
@@ -2,7 +2,7 @@
 
 .taxonomic-breakdown-filter {
     &.tag-button {
-        padding: 8px 12px;
+        padding: 8px 12px 8px 0px;
         line-height: 16px;
         font-size: 14px;
         height: auto;


### PR DESCRIPTION
## Changes

Before:
![image](https://user-images.githubusercontent.com/148820/141100826-cec8c2ce-b6a3-4cec-996b-8b0cad5e2920.png)

After:
![image](https://user-images.githubusercontent.com/148820/141100943-468f7c5b-0e63-4cbe-a653-e0c6384c7a0f.png)

Tagging paul since his last change seems to have caused it: https://github.com/PostHog/posthog/pull/6557

## How did you test this code?

Screenshots