### PR TITLE
Proposal: Don't index shared dashboards

### DIFF
--- a/frontend/src/shared_dashboard.html
+++ b/frontend/src/shared_dashboard.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta name="robots" content="noindex">
     <script>
       window.__SHARED_DASHBOARD__ = {
         id: {{dashboard.id}},


### PR DESCRIPTION
Not 100% sure this is the right fix, got it from https://stackoverflow.com/questions/26288329/exclude-directory-completely-from-google-search

## How did you test this code?

*Please describe.*
