### PR TITLE
Show person tooltip in insights

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -229,8 +229,6 @@ export function LineGraph({
             precision: 0,
         }
 
-        const inspectPersonsLabel = !dashboardItemId && onClick && showPersonsModal
-
         const tooltipOptions = {
             enabled: false, // disable builtin tooltip (use custom markup)
             mode: 'nearest',
@@ -339,7 +337,7 @@ export function LineGraph({
                                 referenceDate={referenceDate}
                                 interval={interval}
                                 bodyLines={bodyLines}
-                                inspectPersonsLabel={inspectPersonsLabel}
+                                inspectPersonsLabel={onClick && showPersonsModal}
                                 preferAltTitle={tooltipPreferAltTitle}
                                 hideHeader={type === 'horizontalBar'}
                             />


### PR DESCRIPTION
This was removed by accident with the shared dashboards work I assume? `dashboardId` is now always set by the time we get to LineGraph

Before:
![image](https://user-images.githubusercontent.com/148820/141111929-3a0109d3-d42b-4352-b840-8d6fc74317cc.png)

After:
![image](https://user-images.githubusercontent.com/148820/141111742-859c6be1-517b-42c9-8d2e-d3faa7b5585a.png)

## How did you test this code?

See screenshots
