### PR TITLE
Groups/Funnels: Use `GroupType` instead of users in wordings

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -78,6 +78,7 @@ interface BreakdownBarGroupProps {
     onBarClick?: (breakdown_value: string | undefined | number) => void
     isClickable: boolean
     isSingleSeries?: boolean
+    aggregationTargetLabel: { singular: string; plural: string }
 }
 
 export function BreakdownVerticalBarGroup({
@@ -88,6 +89,7 @@ export function BreakdownVerticalBarGroup({
     onBarClick,
     isClickable,
     isSingleSeries = false,
+    aggregationTargetLabel,
 }: BreakdownBarGroupProps): JSX.Element {
     const ref = useRef<HTMLDivElement | null>(null)
     const [, height] = useSize(ref)
@@ -193,8 +195,8 @@ export function BreakdownVerticalBarGroup({
                                 {breakdown.count > 0
                                     ? `${humanizeStepCount(breakdown.count)} ${pluralize(
                                           breakdown.count,
-                                          'user',
-                                          undefined,
+                                          aggregationTargetLabel.singular,
+                                          aggregationTargetLabel.singular,
                                           false
                                       )}`
                                     : ''}
@@ -452,6 +454,7 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
         stepReference,
         barGraphLayout: layout,
         clickhouseFeaturesEnabled,
+        aggregationTargetLabel,
     } = useValues(logic)
     const { openPersonsModal } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -566,7 +569,11 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                     popoverMetrics={[
                                                         {
                                                             title: 'Completed step',
-                                                            value: pluralize(breakdown.count, 'user', undefined),
+                                                            value: pluralize(
+                                                                breakdown.count,
+                                                                aggregationTargetLabel.singular,
+                                                                aggregationTargetLabel.plural
+                                                            ),
                                                         },
                                                         {
                                                             title: 'Conversion rate (total)',
@@ -589,8 +596,8 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                             title: 'Dropped off',
                                                             value: pluralize(
                                                                 breakdown.droppedOffFromPrevious,
-                                                                'user',
-                                                                undefined
+                                                                aggregationTargetLabel.singular,
+                                                                aggregationTargetLabel.plural
                                                             ),
                                                             visible:
                                                                 step.order !== 0 &&
@@ -646,7 +653,11 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                             popoverMetrics={[
                                                 {
                                                     title: 'Completed step',
-                                                    value: pluralize(step.count, 'user', undefined),
+                                                    value: pluralize(
+                                                        step.count,
+                                                        aggregationTargetLabel.singular,
+                                                        aggregationTargetLabel.plural
+                                                    ),
                                                 },
                                                 {
                                                     title: 'Conversion rate (total)',
@@ -663,7 +674,11 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                 },
                                                 {
                                                     title: 'Dropped off',
-                                                    value: pluralize(step.droppedOffFromPrevious, 'user', undefined),
+                                                    value: pluralize(
+                                                        step.droppedOffFromPrevious,
+                                                        aggregationTargetLabel.singular,
+                                                        aggregationTargetLabel.plural
+                                                    ),
                                                     visible: step.order !== 0 && step.droppedOffFromPrevious > 0,
                                                 },
                                                 {
@@ -713,7 +728,12 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                 </span>
                                                 <b>
                                                     {humanizeStepCount(step.count)}{' '}
-                                                    {pluralize(step.count, 'user', undefined, false)}
+                                                    {pluralize(
+                                                        step.count,
+                                                        aggregationTargetLabel.singular,
+                                                        aggregationTargetLabel.plural,
+                                                        false
+                                                    )}
                                                 </b>
                                             </ValueInspectorButton>
                                             <span className="text-muted-alt">
@@ -749,7 +769,12 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                 </span>
                                                 <b>
                                                     {humanizeStepCount(dropOffCount)}{' '}
-                                                    {pluralize(dropOffCount, 'user', undefined, false)}
+                                                    {pluralize(
+                                                        dropOffCount,
+                                                        aggregationTargetLabel.singular,
+                                                        aggregationTargetLabel.plural,
+                                                        false
+                                                    )}
                                                 </b>
                                             </ValueInspectorButton>
                                             <span className="text-muted-alt">

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -1,7 +1,7 @@
 import React, { ForwardRefRenderFunction, useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import useSize from '@react-hook/size'
-import { humanFriendlyDuration, pluralize } from 'lib/utils'
+import { capitalizeFirstLetter, humanFriendlyDuration, pluralize } from 'lib/utils'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { Button, ButtonProps, Popover } from 'antd'
 import { ArrowRightOutlined, InfoCircleOutlined } from '@ant-design/icons'
@@ -45,6 +45,7 @@ interface BarProps {
     breakdownSumPercentage?: number
     popoverTitle?: string | JSX.Element | null
     popoverMetrics?: { title: string; value: number | string; visible?: boolean }[]
+    aggregationTargetLabel: { singular: string; plural: string }
 }
 
 type LabelPosition = 'inside' | 'outside'
@@ -221,6 +222,7 @@ function Bar({
     breakdownSumPercentage,
     popoverTitle = null,
     popoverMetrics = [],
+    aggregationTargetLabel,
 }: BarProps): JSX.Element {
     const barRef = useRef<HTMLDivElement | null>(null)
     const labelRef = useRef<HTMLDivElement | null>(null)
@@ -320,7 +322,9 @@ function Bar({
                     <div
                         ref={labelRef}
                         className={`funnel-bar-percentage ${labelPosition}`}
-                        title={name ? `Users who did ${name}` : undefined}
+                        title={
+                            name ? `${capitalizeFirstLetter(aggregationTargetLabel.plural)} who did ${name}` : undefined
+                        }
                         role="progressbar"
                         aria-valuemin={0}
                         aria-valuemax={100}
@@ -623,6 +627,7 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                             visible: !!breakdown.average_conversion_time,
                                                         },
                                                     ]}
+                                                    aggregationTargetLabel={aggregationTargetLabel}
                                                 />
                                             )
                                         })}
@@ -696,6 +701,7 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                                     visible: !!step.average_conversion_time,
                                                 },
                                             ]}
+                                            aggregationTargetLabel={aggregationTargetLabel}
                                         />
                                         <div
                                             className="funnel-bar-empty-space"

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -197,7 +197,7 @@ export function BreakdownVerticalBarGroup({
                                     ? `${humanizeStepCount(breakdown.count)} ${pluralize(
                                           breakdown.count,
                                           aggregationTargetLabel.singular,
-                                          aggregationTargetLabel.singular,
+                                          aggregationTargetLabel.plural,
                                           false
                                       )}`
                                     : ''}

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -45,7 +45,9 @@ export function FunnelCanvasLabel(): JSX.Element | null {
             ? [
                   <>
                       <span className="text-muted-alt">
-                          <Tooltip title="Average (arithmetic mean) of the total time each user spent in the entire funnel.">
+                          <Tooltip
+                              title={`Average (arithmetic mean) of the total time each ${aggregationTargetLabel.singular} spent in the entire funnel.`}
+                          >
                               <InfoCircleOutlined className="info-indicator left" />
                           </Tooltip>
                           Average time to convert{' '}

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -15,7 +15,9 @@ import { FunnelStepsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelS
 
 export function FunnelCanvasLabel(): JSX.Element | null {
     const { insightProps, filters, activeView } = useValues(insightLogic)
-    const { conversionMetrics, clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
+    const { conversionMetrics, clickhouseFeaturesEnabled, aggregationTargetLabel } = useValues(
+        funnelLogic(insightProps)
+    )
     const { setChartFilter } = useActions(chartFilterLogic)
 
     if (activeView !== InsightType.FUNNELS) {
@@ -27,7 +29,9 @@ export function FunnelCanvasLabel(): JSX.Element | null {
             ? [
                   <>
                       <span className="text-muted-alt">
-                          <Tooltip title="Overall conversion rate for all users on the entire funnel.">
+                          <Tooltip
+                              title={`Overall conversion rate for all ${aggregationTargetLabel.plural} on the entire funnel.`}
+                          >
                               <InfoCircleOutlined className="info-indicator left" />
                           </Tooltip>
                           Total conversion rate

--- a/frontend/src/scenes/funnels/FunnelPeople.tsx
+++ b/frontend/src/scenes/funnels/FunnelPeople.tsx
@@ -12,7 +12,9 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function People(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { stepsWithCount, peopleSorted, peopleLoading, areFiltersValid } = useValues(funnelLogic(insightProps))
+    const { stepsWithCount, peopleSorted, peopleLoading, areFiltersValid, aggregationTargetLabel } = useValues(
+        funnelLogic(insightProps)
+    )
 
     if (!stepsWithCount && !areFiltersValid) {
         return null
@@ -23,7 +25,9 @@ export function People(): JSX.Element | null {
             {peopleLoading ? (
                 <Loading style={{ minHeight: 50 }} />
             ) : !peopleSorted || peopleSorted.length === 0 ? (
-                <div style={{ textAlign: 'center', margin: '3rem 0' }}>No users found for this funnel.</div>
+                <div style={{ textAlign: 'center', margin: '3rem 0' }}>
+                    No {aggregationTargetLabel.plural} found for this funnel.
+                </div>
             ) : (
                 <table className="table-bordered full-width">
                     <tbody>

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1024,12 +1024,12 @@ export const funnelLogic = kea<funnelLogicType>({
         ],
         aggregationTargetLabel: [
             (s) => [s.filters, s.groupTypes],
-            (filters, groupTypes): string => {
+            (filters, groupTypes): { singular: string; plural: string } => {
                 if (filters.aggregation_group_type_index != undefined && groupTypes.length > 0) {
                     const groupType = groupTypes[filters.aggregation_group_type_index]
-                    return `${groupType.group_type}(s)`
+                    return { singular: groupType.group_type, plural: `${groupType.group_type}(s)` }
                 }
-                return 'users'
+                return { singular: 'user', plural: 'users' }
             },
         ],
     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -58,6 +58,7 @@ import { personPropertiesModel } from '~/models/personPropertiesModel'
 import { userLogic } from 'scenes/userLogic'
 import { visibilitySensorLogic } from 'lib/components/VisibilitySensor/visibilitySensorLogic'
 import { elementsToAction } from 'scenes/events/createActionFromEvent'
+import { groupsModel } from '~/models/groupsModel'
 
 const DEVIATION_SIGNIFICANCE_MULTIPLIER = 1.5
 // Chosen via heuristics by eyeballing some values
@@ -105,6 +106,8 @@ export const funnelLogic = kea<funnelLogicType>({
             ['hasAvailableFeature'],
             featureFlagLogic,
             ['featureFlags'],
+            groupsModel,
+            ['groupTypes'],
         ],
         actions: [insightLogic(props), ['loadResults', 'loadResultsSuccess']],
         logic: [eventUsageLogic, dashboardsModel],
@@ -1017,6 +1020,16 @@ export const funnelLogic = kea<funnelLogicType>({
             (s) => [s.inversePropertyNames, s.excludedPropertyNames],
             (inversePropertyNames, excludedPropertyNames): string[] => {
                 return inversePropertyNames(excludedPropertyNames || [])
+            },
+        ],
+        aggregationTargetLabel: [
+            (s) => [s.filters, s.groupTypes],
+            (filters, groupTypes): string => {
+                if (filters.aggregation_group_type_index != undefined && groupTypes.length > 0) {
+                    const groupType = groupTypes[filters.aggregation_group_type_index]
+                    return `${groupType.group_type}(s)`
+                }
+                return 'users'
             },
         ],
     }),

--- a/frontend/src/scenes/insights/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/FunnelCorrelation.tsx
@@ -23,6 +23,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
         correlationDetailedFeedbackVisible,
         correlationFeedbackRating,
         correlationAnalysisAvailable,
+        aggregationTargetLabel,
     } = useValues(funnelLogic(insightProps))
     const {
         sendCorrelationAnalysisFeedback,
@@ -43,8 +44,8 @@ export const FunnelCorrelation = (): JSX.Element | null => {
         return (
             <PayCard
                 identifier={AvailableFeature.CORRELATION_ANALYSIS}
-                title="Get a deeper understanding of why your users are not converting"
-                caption="Correlation analysis automatically finds signals for why users are converting or dropping off."
+                title={`Get a deeper understanding of why your ${aggregationTargetLabel.plural} are not converting`}
+                caption={`Correlation analysis automatically finds signals for why ${aggregationTargetLabel.plural} are converting or dropping off.`}
             />
         )
     }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
@@ -49,9 +49,8 @@ export function FunnelConversionWindowFilter(): JSX.Element {
                     title={
                         <>
                             <b>Recommended!</b> Limit to {aggregationTargetLabel.plural} who converted within a specific
-                            time frame.
-                            {capitalizeFirstLetter(aggregationTargetLabel.plural)} who do not convert in this time frame
-                            will be considered as drop-offs.
+                            time frame. {capitalizeFirstLetter(aggregationTargetLabel.plural)} who do not convert in
+                            this time frame will be considered as drop-offs.
                         </>
                     }
                 >

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelConversionWindowFilter.tsx
@@ -1,6 +1,6 @@
 import { InputNumber, Row, Select } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
-import { pluralize } from 'lib/utils'
+import { capitalizeFirstLetter, pluralize } from 'lib/utils'
 import React, { useRef, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
@@ -20,7 +20,7 @@ const TIME_INTERVAL_BOUNDS: Record<FunnelConversionWindowTimeUnit, number[]> = {
 
 export function FunnelConversionWindowFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { conversionWindow } = useValues(funnelLogic(insightProps))
+    const { conversionWindow, aggregationTargetLabel } = useValues(funnelLogic(insightProps))
     const { setFilters } = useActions(funnelLogic(insightProps))
     const [localConversionWindow, setLocalConversionWindow] = useState<FunnelConversionWindow>(conversionWindow)
     const timeUnitRef: React.RefObject<RefSelectProps> | null = useRef(null)
@@ -48,8 +48,10 @@ export function FunnelConversionWindowFilter(): JSX.Element {
                 <Tooltip
                     title={
                         <>
-                            <b>Recommended!</b> Limit to users who converted within a specific time frame. Users who do
-                            not convert in this time frame will be considered as drop-offs.
+                            <b>Recommended!</b> Limit to {aggregationTargetLabel.plural} who converted within a specific
+                            time frame.
+                            {capitalizeFirstLetter(aggregationTargetLabel.plural)} who do not convert in this time frame
+                            will be considered as drop-offs.
                         </>
                     }
                 >

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -134,7 +134,7 @@ export function FunnelStepTable(): JSX.Element | null {
                         <InsightLabel
                             seriesColor={color}
                             fallbackName={formatBreakdownLabel(
-                                isOnlySeries ? `Unique ${aggregationTargetLabel}` : breakdown.breakdown_value,
+                                isOnlySeries ? `Unique ${aggregationTargetLabel.plural}` : breakdown.breakdown_value,
                                 cohorts
                             )}
                             hasMultipleSeries={steps.length > 1}
@@ -203,7 +203,9 @@ export function FunnelStepTable(): JSX.Element | null {
                             ),
                             renderSubColumnTitle(
                                 <>
-                                    <UserOutlined title={`Unique ${aggregationTargetLabel} who completed this step`} />{' '}
+                                    <UserOutlined
+                                        title={`Unique ${aggregationTargetLabel.plural} who completed this step`}
+                                    />{' '}
                                     Completed
                                 </>
                             ),
@@ -286,7 +288,7 @@ export function FunnelStepTable(): JSX.Element | null {
                                 renderSubColumnTitle(
                                     <>
                                         <UserDeleteOutlined
-                                            title={`Unique ${aggregationTargetLabel} who dropped off on this step`}
+                                            title={`Unique ${aggregationTargetLabel.plural} who dropped off on this step`}
                                         />{' '}
                                         Dropped
                                     </>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -50,6 +50,7 @@ export function FunnelStepTable(): JSX.Element | null {
         flattenedStepsByBreakdown,
         flattenedBreakdowns,
         clickhouseFeaturesEnabled,
+        aggregationTargetLabel,
     } = useValues(logic)
     const { openPersonsModal, toggleVisibilityByBreakdown, setHiddenById } = useActions(logic)
     const { cohorts } = useValues(cohortsModel)
@@ -133,7 +134,7 @@ export function FunnelStepTable(): JSX.Element | null {
                         <InsightLabel
                             seriesColor={color}
                             fallbackName={formatBreakdownLabel(
-                                isOnlySeries ? 'Unique users' : breakdown.breakdown_value,
+                                isOnlySeries ? `Unique ${aggregationTargetLabel}` : breakdown.breakdown_value,
                                 cohorts
                             )}
                             hasMultipleSeries={steps.length > 1}
@@ -202,7 +203,8 @@ export function FunnelStepTable(): JSX.Element | null {
                             ),
                             renderSubColumnTitle(
                                 <>
-                                    <UserOutlined title="Unique users who completed this step" /> Completed
+                                    <UserOutlined title={`Unique ${aggregationTargetLabel} who completed this step`} />{' '}
+                                    Completed
                                 </>
                             ),
                             showLabels,
@@ -283,7 +285,10 @@ export function FunnelStepTable(): JSX.Element | null {
                                 ),
                                 renderSubColumnTitle(
                                     <>
-                                        <UserDeleteOutlined title="Unique users who dropped off on this step" /> Dropped
+                                        <UserDeleteOutlined
+                                            title={`Unique ${aggregationTargetLabel} who dropped off on this step`}
+                                        />{' '}
+                                        Dropped
                                     </>
                                 ),
                                 showLabels,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
@@ -56,6 +56,7 @@ function BreakdownBarGroupWrapper({
         visibleStepsWithConversionMetrics: steps,
         clickhouseFeaturesEnabled,
         flattenedBreakdowns,
+        aggregationTargetLabel,
     } = useValues(logic)
     const { openPersonsModal } = useActions(logic)
     const basisStep = getReferenceStep(steps, stepReference, step.order)
@@ -76,6 +77,7 @@ function BreakdownBarGroupWrapper({
                 }}
                 isClickable={isClickable}
                 isSingleSeries={flattenedBreakdowns.length === 1}
+                aggregationTargetLabel={aggregationTargetLabel}
             />
             <div className="funnel-bar-empty-space" />
             <div className="funnel-bar-axis">


### PR DESCRIPTION
## Changes

This avoids confusion if user switches wordings around

## How did you test this code?

Manually clicking through flows and checking codebase
