### PR TITLE
Corrects the path to search for in list of feature flags

### DIFF
--- a/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
@@ -5,13 +5,13 @@ import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { CombinedFeatureFlagAndOverrideType } from '~/types'
 
 const featureFlags = [
-    { feature_flag: { name: 'flag 1' } },
-    { feature_flag: { name: 'flag 2' } },
+    { feature_flag: { key: 'flag 1' } },
+    { feature_flag: { key: 'flag 2' } },
 ] as CombinedFeatureFlagAndOverrideType[]
 
 const featureFlagsWithExtraInfo = [
-    { currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 1' } },
-    { currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 2' } },
+    { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 1' } },
+    { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } },
 ]
 
 describe('toolbar featureFlagsLogic', () => {
@@ -45,7 +45,7 @@ describe('toolbar featureFlagsLogic', () => {
         await expectLogic(logic, () => {
             logic.actions.setSearchTerm('2')
         }).toMatchValues({
-            filteredFlags: [{ currentValue: undefined, hasVariants: false, feature_flag: { name: 'flag 2' } }],
+            filteredFlags: [{ currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } }],
         })
     })
 

--- a/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
@@ -7,11 +7,13 @@ import { CombinedFeatureFlagAndOverrideType } from '~/types'
 const featureFlags = [
     { feature_flag: { key: 'flag 1' } },
     { feature_flag: { key: 'flag 2' } },
+    { feature_flag: { key: 'flag 3', name: 'mentions 2' } },
 ] as CombinedFeatureFlagAndOverrideType[]
 
 const featureFlagsWithExtraInfo = [
     { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 1' } },
     { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } },
+    { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 3', name: 'mentions 2' } },
 ]
 
 describe('toolbar featureFlagsLogic', () => {
@@ -45,7 +47,17 @@ describe('toolbar featureFlagsLogic', () => {
         await expectLogic(logic, () => {
             logic.actions.setSearchTerm('2')
         }).toMatchValues({
-            filteredFlags: [{ currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } }],
+            filteredFlags: [
+                { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } },
+                {
+                    currentValue: undefined,
+                    feature_flag: {
+                        key: 'flag 3',
+                        name: 'mentions 2',
+                    },
+                    hasVariants: false,
+                },
+            ],
         })
     })
 

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -114,7 +114,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                 return searchTerm
                     ? new Fuse(userFlagsWithCalculatedInfo, {
                           threshold: 0.3,
-                          keys: ['feature_flag.name'],
+                          keys: ['feature_flag.key'],
                       })
                           .search(searchTerm)
                           .map(({ item }) => item)

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -114,7 +114,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
                 return searchTerm
                     ? new Fuse(userFlagsWithCalculatedInfo, {
                           threshold: 0.3,
-                          keys: ['feature_flag.key'],
+                          keys: ['feature_flag.key', 'feature_flag.name'],
                       })
                           .search(searchTerm)
                           .map(({ item }) => item)


### PR DESCRIPTION
## Changes

Feature flag search in the toolbar was using flag `name`. And not searching correctly

The flag `name` is the property that holds the description. The correct property to search is `key`

### Before

![2021-11-10 15 43 40](https://user-images.githubusercontent.com/984817/141144834-d7974115-b1c5-4af4-9f3f-9b0a38c72eae.gif)

### After

![2021-11-10 15 41 55](https://user-images.githubusercontent.com/984817/141144519-004181cf-9b69-40d3-8a56-1ec84cfb53d5.gif)


## How did you test this code?

*Please describe.*
