### PR TITLE
Hide table filter renaming behind FF and more fixes

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -140,9 +140,11 @@ export function InsightsTable({
         render: function RenderLabel({}, item: IndexedTrendResult): JSX.Element {
             return (
                 <div className="series-name-wrapper-col">
-                    <div className="edit-icon" onClick={() => handleEditClick(item)}>
-                        <EditOutlined />
-                    </div>
+                    {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && canEditSeriesNameInline && (
+                        <div className="edit-icon" onClick={() => handleEditClick(item)}>
+                            <EditOutlined />
+                        </div>
+                    )}
                     <InsightLabel
                         seriesColor={colorList[item.id]}
                         action={item.action}
@@ -153,9 +155,15 @@ export function InsightsTable({
                         hideBreakdown
                         hideIcon
                         useCustomName={!!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]}
-                        className={clsx(canEditSeriesNameInline && 'editable')}
+                        className={clsx({
+                            editable: featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && canEditSeriesNameInline,
+                        })}
                         hideSeriesSubtitle
-                        onLabelClick={() => handleEditClick(item)}
+                        onLabelClick={
+                            featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && canEditSeriesNameInline
+                                ? () => handleEditClick(item)
+                                : undefined
+                        }
                     />
                 </div>
             )

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -58,7 +58,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                         isLegend={false}
                         showTotalCount={view !== InsightType.SESSIONS}
                         filterKey={`trends_${view}`}
-                        canEditSeriesNameInline
+                        canEditSeriesNameInline={_filters.session !== 'avg'}
                     />
                 </BindLogic>
             )


### PR DESCRIPTION
## Bugs introduced in #6968

- Rename capability is exposed in dashboard view mode. Clicking edit icon doesn't do anything.

https://user-images.githubusercontent.com/13460330/141200775-9462acfd-484c-458e-a3e3-1b63caf626c0.mov

- The new functionality not being behind the existing `6063-rename-filters` FF means users can try to rename filters from the table while `6063-rename-filters` is turned off. This obviously breaks when the modal isn't loaded because it's protected behind the FF.

https://user-images.githubusercontent.com/13460330/141201463-8bc2b12c-99ac-4c9c-9beb-2e20f9253486.mov

- Editable icon shows in tables in contexts where it shouldn't. i.e., sessions table

https://user-images.githubusercontent.com/13460330/141200940-b1b472d5-7690-4952-b4e0-b93e17fc917d.mov


## Changes

- Hide edit icons in dashboard view mode.
- Hide new functionality behind pre-existing FF `6063-rename-filters`.
- Disable `canEditSeriesNameInline` for sessions tables

## How did you test this code?

N/A