### PR TITLE
Groups: Allow filtering by group properties under entities in trends/funnels

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
@@ -51,7 +51,8 @@ export interface ActionFilterProps {
     horizontalUI?: boolean
     fullWidth?: boolean
     showNestedArrow?: boolean // show nested arrows to the left of property filter buttons
-    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
+    actionsTaxonomicGroupTypes?: TaxonomicFilterGroupType[] // Which tabs to show for actions selector
+    propertiesTaxonomicGroupTypes?: TaxonomicFilterGroupType[] // Which tabs to show for property filters
     hideDeleteBtn?: boolean
     renderRow?: ({
         seriesIndicator,
@@ -91,7 +92,8 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             stripeActionRow = true,
             customActions,
             showNestedArrow = false,
-            taxonomicGroupTypes,
+            actionsTaxonomicGroupTypes,
+            propertiesTaxonomicGroupTypes,
             hideDeleteBtn,
             renderRow,
         },
@@ -141,7 +143,8 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             stripeActionRow,
             hasBreakdown: !!filters.breakdown,
             fullWidth,
-            taxonomicGroupTypes,
+            actionsTaxonomicGroupTypes,
+            propertiesTaxonomicGroupTypes,
             hideDeleteBtn,
             disabled,
             renderRow,

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -85,7 +85,8 @@ export interface ActionFilterRowProps {
     stripeActionRow?: boolean // Whether or not to alternate the color behind the action rows
     hasBreakdown: boolean // Whether the current graph has a breakdown filter applied
     showNestedArrow?: boolean // Show nested arrows to the left of property filter buttons
-    taxonomicGroupTypes?: TaxonomicFilterGroupType[] // Specify which tabs to show, used in taxonomic filter
+    actionsTaxonomicGroupTypes?: TaxonomicFilterGroupType[] // Which tabs to show for actions selector
+    propertiesTaxonomicGroupTypes?: TaxonomicFilterGroupType[] // Which tabs to show for property filters
     hideDeleteBtn?: boolean // Choose to hide delete btn. You can use the onClose function passed into customRow{Pre|Suf}fix to render the delete btn anywhere
     disabled?: boolean
     renderRow?: ({
@@ -124,7 +125,8 @@ export function ActionFilterRow({
     hasBreakdown,
     showNestedArrow = false,
     hideDeleteBtn = false,
-    taxonomicGroupTypes = [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+    actionsTaxonomicGroupTypes = [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+    propertiesTaxonomicGroupTypes,
     disabled = false,
     renderRow,
 }: ActionFilterRowProps): JSX.Element {
@@ -215,7 +217,7 @@ export function ActionFilterRow({
                         })
                     }}
                     onClose={() => selectFilter(null)}
-                    taxonomicGroupTypes={taxonomicGroupTypes}
+                    taxonomicGroupTypes={actionsTaxonomicGroupTypes}
                 />
             }
             visible={dropDownCondition}
@@ -442,6 +444,7 @@ export function ActionFilterRow({
                         disablePopover={horizontalUI}
                         style={{ marginBottom: 0 }}
                         showNestedArrow={showNestedArrow}
+                        taxonomicGroupTypes={propertiesTaxonomicGroupTypes}
                     />
                 </div>
             )}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
@@ -154,7 +154,7 @@ export function FunnelExclusionsFilter(): JSX.Element | null {
             }}
             disabled={!areFiltersValid}
             buttonCopy="Add exclusion"
-            taxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+            actionsTaxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
             hideMathSelector
             hidePropertySelector
             hideFilter

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -115,6 +115,13 @@ export function FunnelTab(): JSX.Element {
                                 fullWidth
                                 sortable
                                 showNestedArrow={true}
+                                propertiesTaxonomicGroupTypes={[
+                                    TaxonomicFilterGroupType.EventProperties,
+                                    TaxonomicFilterGroupType.PersonProperties,
+                                    ...groupsTaxonomicTypes,
+                                    TaxonomicFilterGroupType.Cohorts,
+                                    TaxonomicFilterGroupType.Elements,
+                                ]}
                             />
 
                             {!clickhouseFeaturesEnabled && (

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -65,6 +65,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         showSeriesIndicator
                         singleFilter={filters.insight === InsightType.LIFECYCLE}
                         hideMathSelector={filters.insight === InsightType.LIFECYCLE}
+                        propertiesTaxonomicGroupTypes={taxonomicTypes}
                         customRowPrefix={
                             filters.insight === InsightType.LIFECYCLE ? (
                                 <>


### PR DESCRIPTION
## Changes

You could previously only filter by group properties at the top level. Not anymore!

![image](https://user-images.githubusercontent.com/148820/141264054-1ea4c370-6de0-402e-ac62-46cf9b991984.png)

![image](https://user-images.githubusercontent.com/148820/141264020-c62d9674-38b8-4c7a-9206-a229ce03f84a.png)

## How did you test this code?

Clickthrough
