### PR TITLE
Align dashboard title style with other page titles

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -1,7 +1,5 @@
 @import '~/vars';
 
-$dashboard-title-size: 32px;
-
 .dashboard {
     margin-top: $default_spacing * 2;
 
@@ -125,27 +123,29 @@ $dashboard-title-size: 32px;
 
         .ant-select-single {
             max-width: 100%;
-            line-height: $dashboard-title-size;
+            line-height: 40px;
 
             .ant-select-selector {
+                align-items: center;
                 padding-left: 0;
                 padding-right: 8px;
-                line-height: $dashboard-title-size;
-                height: $dashboard-title-size;
+                line-height: 40px;
+                height: 40px;
 
                 .ant-select-selection-item {
-                    font-size: $dashboard-title-size;
-                    line-height: $dashboard-title-size;
+                    font-size: 28px;
+                    font-weight: 600;
+                    line-height: 40px;
                     width: 100%;
                     height: 35px;
-                    display: block;
+                    display: flex;
+                    align-items: center;
 
                     .anticon-share-alt {
-                        font-size: $dashboard-title-size * 0.65;
+                        font-size: 16px;
                         color: $success;
                         margin-left: 6px !important;
                         margin-right: 4px;
-                        margin-top: $default_spacing / 2;
                     }
                 }
             }
@@ -156,7 +156,7 @@ $dashboard-title-size: 32px;
             }
             .ant-select-arrow {
                 color: $text_default;
-                font-size: 0.5 * $dashboard-title-size;
+                font-size: 14px;
             }
         }
     }


### PR DESCRIPTION
## Changes

The dashboard title loooked jarringly different from all other page titles. See:
| Before | After |
| --- | --- |
| ![2021-11-11 12 36 07](https://user-images.githubusercontent.com/4550621/141291892-ae415a8e-f27a-4568-ab99-5c475d41071c.gif) | ![2021-11-11 12 35 43](https://user-images.githubusercontent.com/4550621/141291902-5c69bfb5-783c-4887-8d07-ce75bb54bae4.gif) |