### PR TITLE
Make dashboard item shadow look sleek

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -97,10 +97,7 @@ export function DateFilter({
             id="daterange_selector"
             value={parsedValue}
             onChange={_onChange}
-            style={{
-                marginRight: 4,
-                ...style,
-            }}
+            style={style}
             open={open || dateRangeOpen}
             onBlur={onBlur}
             onClick={onClick}

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -8,6 +8,7 @@
     position: relative;
     box-shadow: $shadow_elevation;
     border-radius: var(--radius);
+    border: 1px solid $border;
     overflow: hidden;
     z-index: 3;
 

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -6,14 +6,10 @@
     height: 100%;
     padding: 0;
     position: relative;
-    box-shadow: 0 8px 10px rgba(0, 0, 0, 0.1);
-    border-radius: 5px;
+    box-shadow: $shadow_elevation;
+    border-radius: var(--radius);
     overflow: hidden;
     z-index: 3;
-
-    &.react-draggable-dragging {
-        box-shadow: 0 20px 20px rgba(0, 0, 0, 0.3);
-    }
 
     .dashboard-item-container {
         display: flex;

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -155,8 +155,7 @@ $z_city_background_content: 1;
 $z_city_background_image: 0;
 
 // Shadows
-$shadow_elevation: 0 0 1px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.06), 0 3px 4px rgba(0, 0, 0, 0.07),
-    0 5px 14px rgba(0, 0, 0, 0.1);
+$shadow_elevation: 0px 16px 16px -16px rgba(0, 0, 0, 0.25);
 $shadow_popup: 0 3px 6px -4px rgb(0 0 0 / 12%), 0 6px 16px 0 rgb(0 0 0 / 8%), 0 9px 28px 8px rgb(0 0 0 / 5%);
 
 // Breakpoints (from AntD)

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -155,6 +155,8 @@ $z_city_background_content: 1;
 $z_city_background_image: 0;
 
 // Shadows
+$shadow_elevation: 0 0 1px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.06), 0 3px 4px rgba(0, 0, 0, 0.07),
+    0 5px 14px rgba(0, 0, 0, 0.1);
 $shadow_popup: 0 3px 6px -4px rgb(0 0 0 / 12%), 0 6px 16px 0 rgb(0 0 0 / 8%), 0 9px 28px 8px rgb(0 0 0 / 5%);
 
 // Breakpoints (from AntD)


### PR DESCRIPTION
## Changes

Shadows - so fleeting but so important to get right if the UI is to look sleek. I've been really put off by our dashboard item shadows, so this makes them look significantly nicer.

### Before
![Zrzut ekranu 2021-11-11 o 13 08 04](https://user-images.githubusercontent.com/4550621/141295756-02e907d7-3fb8-4efe-9084-223dffc90647.png)

### After
![Zrzut ekranu 2021-11-11 o 13 07 30](https://user-images.githubusercontent.com/4550621/141295758-7978d257-b4e6-4e2b-984a-3a5dcff8f9ee.png)
