### PR TITLE
Limit auto height of trends graph

### DIFF
--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -188,9 +188,7 @@ export function InsightContainer(): JSX.Element {
                         {lastRefresh && <ComputationTimeWithRefresh />}
                     </Row>
                     {!BlockingEmptyState && CoexistingEmptyState}
-                    <div style={{ display: 'block' }}>
-                        {!!BlockingEmptyState ? BlockingEmptyState : VIEW_MAP[activeView]}
-                    </div>
+                    {!!BlockingEmptyState ? BlockingEmptyState : VIEW_MAP[activeView]}
                 </div>
             </Card>
             {renderTable()}

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -234,6 +234,11 @@ $funnel_canvas_background: #fafafa;
     }
 }
 
+.trends-insights-container {
+    position: relative;
+    min-height: min(calc(90vh - 16rem), 36rem);
+}
+
 .funnel-insights-container {
     padding: 24px;
     background-color: $funnel_canvas_background;

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -9,7 +9,6 @@ import {
     ACTIONS_BAR_CHART,
     ACTIONS_BAR_CHART_VALUE,
 } from 'lib/constants'
-
 import { ActionsPie, ActionsLineGraph, ActionsBarValueGraph, ActionsTable } from './viz'
 import { SaveCohortModal } from './SaveCohortModal'
 import { trendsLogic } from './trendsLogic'
@@ -74,14 +73,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
     return (
         <>
             {(_filters.actions || _filters.events || _filters.session) && (
-                <div
-                    style={{
-                        minHeight: 'calc(90vh - 16rem)',
-                        position: 'relative',
-                    }}
-                >
-                    {renderViz()}
-                </div>
+                <div className="trends-insights-container">{renderViz()}</div>
             )}
             {_filters.breakdown && (
                 <div className="mt text-center">


### PR DESCRIPTION
## Changes

Effectively sets the maximum height of the graph to 576 px, so that we don't waste a ton of space on large/tall viewports. Also a bit of styling cleanup. Resolves #6801.
See below comparison taken at 2560x1400:

### Before
![before](https://user-images.githubusercontent.com/4550621/141302349-f45c885f-5305-4988-9da1-99101ed62d6a.png) 

### After
![after](https://user-images.githubusercontent.com/4550621/141302344-878708f3-50a9-40db-9a55-297ebe36b780.png)