### PR TITLE
Add data-attrs to new sidebar

### DIFF
--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -183,7 +183,7 @@ function PageButton({ title, sideAction, identifier, ...buttonProps }: PageButto
         <LemonButton
             fullWidth
             type={isActive ? 'highlighted' : 'stealth'}
-            data-attr={`menu-item-dashboard-${identifier.toString().toLowerCase()}`}
+            data-attr={`menu-item-${identifier.toString().toLowerCase()}`}
             {...buttonProps}
         >
             {title}

--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -169,13 +169,23 @@ function PageButton({ title, sideAction, identifier, ...buttonProps }: PageButto
         <LemonButtonWithSideAction
             fullWidth
             type={isActive ? 'highlighted' : 'stealth'}
-            sideAction={{ ...sideAction, type: isActiveSide ? 'highlighted' : isActive ? undefined : 'stealth' }}
+            sideAction={{
+                ...sideAction,
+                type: isActiveSide ? 'highlighted' : isActive ? undefined : 'stealth',
+                'data-attr': sideAction.identifier ? `menu-item-${sideAction.identifier.toLowerCase()}` : undefined,
+            }}
+            data-attr={`menu-item-${identifier.toString().toLowerCase()}`}
             {...buttonProps}
         >
             {title}
         </LemonButtonWithSideAction>
     ) : (
-        <LemonButton fullWidth type={isActive ? 'highlighted' : 'stealth'} {...buttonProps}>
+        <LemonButton
+            fullWidth
+            type={isActive ? 'highlighted' : 'stealth'}
+            data-attr={`menu-item-dashboard-${identifier.toString().toLowerCase()}`}
+            {...buttonProps}
+        >
             {title}
         </LemonButton>
     )

--- a/frontend/src/lib/components/LemonButton/index.tsx
+++ b/frontend/src/lib/components/LemonButton/index.tsx
@@ -64,9 +64,7 @@ function LemonButtonInternal(
 }
 export const LemonButton = React.forwardRef(LemonButtonInternal)
 
-export interface SideAction extends Pick<LemonButtonProps, 'onClick' | 'popup' | 'to' | 'icon' | 'type' | 'tooltip'> {
-    'data-attr'?: string
-}
+export type SideAction = Pick<LemonButtonProps, 'onClick' | 'popup' | 'to' | 'icon' | 'type' | 'tooltip' | 'data-attr'>
 
 /** A LemonButtonWithSideAction can neither be compact nor have a sideIcon - instead it has a clickable sideAction. */
 export interface LemonButtonWithSideActionProps extends LemonButtonPropsBase {

--- a/frontend/src/lib/components/LemonButton/index.tsx
+++ b/frontend/src/lib/components/LemonButton/index.tsx
@@ -64,7 +64,9 @@ function LemonButtonInternal(
 }
 export const LemonButton = React.forwardRef(LemonButtonInternal)
 
-export type SideAction = Pick<LemonButtonProps, 'onClick' | 'popup' | 'to' | 'icon' | 'type' | 'tooltip'>
+export interface SideAction extends Pick<LemonButtonProps, 'onClick' | 'popup' | 'to' | 'icon' | 'type' | 'tooltip'> {
+    'data-attr'?: string
+}
 
 /** A LemonButtonWithSideAction can neither be compact nor have a sideIcon - instead it has a clickable sideAction. */
 export interface LemonButtonWithSideActionProps extends LemonButtonPropsBase {

--- a/frontend/src/lib/components/LemonRow/index.tsx
+++ b/frontend/src/lib/components/LemonRow/index.tsx
@@ -18,6 +18,7 @@ export interface LemonRowPropsBase<T extends keyof JSX.IntrinsicElements>
     status?: 'success' | 'warning' | 'danger' | 'highlighted'
     tooltip?: string
     fullWidth?: boolean
+    'data-attr'?: string
 }
 
 // This is a union so that a LemonRow can be compact OR have a sideIcon, but not both at once


### PR DESCRIPTION
## Changes

Data-attrs in the new sidebar. Now available. This will make tests possible (didn't notice as currently tests run with the old UI).