### PR TITLE
Refine shadows further

### DIFF
--- a/frontend/src/lib/components/Popup/Popup.scss
+++ b/frontend/src/lib/components/Popup/Popup.scss
@@ -2,7 +2,7 @@
 
 .Popup {
     z-index: $z_popup;
-    box-shadow: $shadow_popup;
+    box-shadow: var(--shadow-z-8);
     background: #fff;
     padding: 0.5rem;
     border-radius: var(--radius);

--- a/frontend/src/lib/components/SelectBox.scss
+++ b/frontend/src/lib/components/SelectBox.scss
@@ -1,9 +1,9 @@
-/* This is a temporary comment to see if we can get Webpack to rebundle this file. */
 .select-box {
     position: absolute;
     width: 620px;
-    box-shadow: 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 9px 28px 8px rgba(0, 0, 0, 0.05);
-    border-radius: 2px;
+    box-shadow: var(--shadow-z-8);
+    border: 1px solid var(--border);
+    border-radius: var(--border);
     height: 400px;
     background: #fff;
     z-index: 999;

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -6,7 +6,7 @@
     height: 100%;
     padding: 0;
     position: relative;
-    box-shadow: $shadow_elevation;
+    box-shadow: var(--shadow-z-2);
     border-radius: var(--radius);
     border: 1px solid $border;
     overflow: hidden;

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -2,7 +2,7 @@
 
 .ph-graph-tooltip,
 .ant-popover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-z-2);
     font-size: 14px;
     overflow-x: hidden;
     z-index: $z_graph_tooltip;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -35,6 +35,9 @@ NOTE: $medium is a SCSS var; not a keyword
     --border-dark: #{$border_dark};
     --border-active: #{$border_active};
     --radius: #{$radius};
+    // Shadows
+    --shadow-z-2: #{$shadow_z_2};
+    --shadow-z-8: #{$shadow_z_8};
     // Used for graph series
     --blue: #{$blue_500};
     --blue-light: #{$blue_300};

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -155,8 +155,8 @@ $z_city_background_content: 1;
 $z_city_background_image: 0;
 
 // Shadows
-$shadow_elevation: 0px 16px 16px -16px rgba(0, 0, 0, 0.25);
-$shadow_popup: 0 3px 6px -4px rgb(0 0 0 / 12%), 0 6px 16px 0 rgb(0 0 0 / 8%), 0 9px 28px 8px rgb(0 0 0 / 5%);
+$shadow_z_2: 0 4px 12px -4px rgba(0, 0, 0, 0.1), 0 16px 16px -16px rgba(0, 0, 0, 0.2);
+$shadow_z_8: 0 4px 16px -4px rgb(0, 0, 0, 0.15), 0 16px 24px -4px rgb(0, 0, 0, 0.1);
 
 // Breakpoints (from AntD)
 $sm: 576px;


### PR DESCRIPTION
## Changes

A few tweaks to shadows in general:
- switched to a z-index based scheme inspired by Material Design's guidelines (https://material.io/design/environment/elevation.html#default-elevations)
- generally switched to CSS vars
- brought `$shadow_popup` (now `var(--shadow-z-8)`) more in line with https://github.com/PostHog/posthog/pull/7062#pullrequestreview-803974114
- added a second layer to `$shadow_elevation` (now `var(--shadow-z-2)`) that give a slight shadow to the sides as well – this is almost unnoticeable but really enhances the impression that this is a bit elevated for me
- updated `SelectBox`'s style to use this stuff

Here's a comparison, though you will need to open the screenshots in a new tab and switch between them to see:
| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/4550621/141371186-b733eb38-7cf6-418e-baab-bcd76556b2d0.png) | ![after](https://user-images.githubusercontent.com/4550621/141371196-6ab8492e-ac78-4aab-8a26-dca5938e260e.png) |
