### PR TITLE
Fix breadcrumbs on wider screens

### DIFF
--- a/frontend/src/layout/lemonade/Breadcrumbs/Breadcrumbs.scss
+++ b/frontend/src/layout/lemonade/Breadcrumbs/Breadcrumbs.scss
@@ -3,20 +3,24 @@
 .Breadcrumbs {
     display: flex;
     align-items: center;
-    width: 100vw;
     // Make the container full width to aid horizontal scroll while automatically retaining proper padding
+    width: 100vw;
     padding: 0 calc((100vw - 100%) / 2);
     margin-left: calc((100vw - 100%) / -2);
-    margin-top: 1.5rem;
+    margin-top: 1rem;
     cursor: default;
     overflow-x: auto;
     &--loading {
-        margin-top: 0.75rem;
+        margin-top: 0.25rem;
     }
-    @media (max-width: $md) {
-        margin-top: 1rem;
+    @media screen and (min-width: $lg) {
+        // Disable fullwidth hacks for viewport widths where the sidebar affects layout
+        width: auto;
+        padding: 0;
+        margin-left: 0;
+        margin-top: 1.5rem;
         &--loading {
-            margin-top: 0.25rem;
+            margin-top: 0.75rem;
         }
     }
 }


### PR DESCRIPTION
## Changes

Resolves #7077. Breadcrumbs use some `calc`s to allow automatically full-width horizontal scrolling on mobile for the best experience, but this is not needed on wider screens, and in fact messes with body width then.

## How did you test this code?

Tried to scroll horizontally.
