### PR TITLE
Breadcrumbs redux

### DIFF
--- a/frontend/src/layout/lemonade/Breadcrumbs/Breadcrumbs.scss
+++ b/frontend/src/layout/lemonade/Breadcrumbs/Breadcrumbs.scss
@@ -32,7 +32,8 @@
     font-weight: 500;
     white-space: pre;
     &--current {
-        font-style: italic;
+        font-weight: bold;
+        color: $text_default;
     }
     > :first-child {
         margin-right: 0.5rem;

--- a/frontend/src/layout/lemonade/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/src/layout/lemonade/Breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,9 @@
 import { useValues } from 'kea'
 import React from 'react'
-import { IconExpandMore } from '../../../lib/components/icons'
-import { Link } from '../../../lib/components/Link'
+import { IconExpandMore } from 'lib/components/icons'
+import { Link } from 'lib/components/Link'
 import './Breadcrumbs.scss'
 import { Breadcrumb as IBreadcrumb, breadcrumbsLogic } from './breadcrumbsLogic'
-import { Tooltip } from '../../../lib/components/Tooltip'
 import clsx from 'clsx'
 import { Skeleton } from 'antd'
 
@@ -17,17 +16,6 @@ function Breadcrumb({ breadcrumb }: { breadcrumb: IBreadcrumb }): JSX.Element {
     )
     if (breadcrumb.path) {
         breadcrumbContent = <Link to={breadcrumb.path}>{breadcrumbContent}</Link>
-    }
-    let { tooltip } = breadcrumb
-    if (!tooltip) {
-        if (breadcrumb.path) {
-            tooltip = `Go to ${breadcrumb.name}`
-        } else if (breadcrumb.here) {
-            tooltip = 'You are here'
-        }
-    }
-    if (tooltip) {
-        breadcrumbContent = <Tooltip title={tooltip}>{breadcrumbContent}</Tooltip>
     }
     return breadcrumbContent
 }

--- a/frontend/src/layout/lemonade/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/lemonade/Breadcrumbs/breadcrumbsLogic.tsx
@@ -102,6 +102,8 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     breadcrumbs.push({
                         name: currentOrganization.name,
                         symbol: <Lettermark name={currentOrganization.name} />,
+                        here: activeScene === Scene.OrganizationSettings,
+                        path: activeScene === Scene.OrganizationSettings ? undefined : urls.organizationSettings(),
                     })
                 }
                 // Project
@@ -111,10 +113,15 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     }
                     breadcrumbs.push({
                         name: currentTeam.name,
+                        here: activeScene === Scene.ProjectSettings,
+                        path: activeScene === Scene.ProjectSettings ? undefined : urls.projectSettings(),
                     })
                 }
                 // Parent page handling
                 switch (activeScene) {
+                    case Scene.ProjectSettings:
+                    case Scene.OrganizationSettings:
+                        break
                     case Scene.Person:
                         breadcrumbs.push({
                             name: 'Persons',

--- a/frontend/src/layout/lemonade/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/lemonade/Breadcrumbs/breadcrumbsLogic.tsx
@@ -1,21 +1,18 @@
 import { kea } from 'kea'
-import { organizationLogic } from '../../../scenes/organizationLogic'
-import { teamLogic } from '../../../scenes/teamLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
 import './Breadcrumbs.scss'
 import { breadcrumbsLogicType } from './breadcrumbsLogicType'
-import { sceneLogic } from '../../../scenes/sceneLogic'
-import { Scene } from '../../../scenes/sceneTypes'
-import { urls } from '../../../scenes/urls'
-import { preflightLogic } from '../../../scenes/PreflightCheck/logic'
-import { identifierToHuman, stripHTTP } from '../../../lib/utils'
-import { userLogic } from '../../../scenes/userLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { Scene } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { identifierToHuman, stripHTTP } from 'lib/utils'
+import { userLogic } from 'scenes/userLogic'
 import React from 'react'
-import { Lettermark } from '../../../lib/components/Lettermark/Lettermark'
-import { ProfilePicture } from '../../../lib/components/ProfilePicture'
-import { dashboardsModel } from '../../../models/dashboardsModel'
-import { featureFlagLogic } from '../../../scenes/feature-flags/featureFlagLogic'
-import { personsLogic } from '../../../scenes/persons/personsLogic'
-import { asDisplay } from '../../../scenes/persons/PersonHeader'
+import { Lettermark } from 'lib/components/Lettermark/Lettermark'
+import { ProfilePicture } from 'lib/components/ProfilePicture'
+import { dashboardsModel } from '~/models/dashboardsModel'
 
 export interface Breadcrumb {
     /** Name to display. */
@@ -24,8 +21,6 @@ export interface Breadcrumb {
     symbol?: React.ReactNode
     /** Path to link to. */
     path?: string
-    /** Tooltip on hover. */
-    tooltip?: string
     /** Whether this breadcrumb refers to the current location. */
     here?: boolean
 }
@@ -51,10 +46,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
             ['currentTeam', 'currentTeamLoading'],
             dashboardsModel,
             ['rawDashboards', 'lastDashboardId'],
-            featureFlagLogic,
-            ['featureFlag'],
-            personsLogic,
-            ['person'],
         ],
     },
     selectors: {
@@ -68,8 +59,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                 s.currentTeam,
                 s.rawDashboards,
                 s.lastDashboardId,
-                s.featureFlag,
-                s.person,
             ],
             (
                 preflight,
@@ -79,9 +68,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                 currentOrganization,
                 currentTeam,
                 rawDashboards,
-                lastDashboardId,
-                featureFlag,
-                person
+                lastDashboardId
             ) => {
                 const breadcrumbs: Breadcrumb[] = []
                 if (!activeScene) {
@@ -94,7 +81,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     }
                     breadcrumbs.push({
                         name: user.first_name,
-                        tooltip: 'You',
                         symbol: <ProfilePicture name={user.first_name} email={user.email} size="md" />,
                     })
                 }
@@ -105,7 +91,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     }
                     breadcrumbs.push({
                         name: stripHTTP(preflight.site_url),
-                        tooltip: 'This PostHog instance',
                         symbol: <Lettermark name="@" />,
                     })
                 }
@@ -117,7 +102,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     breadcrumbs.push({
                         name: currentOrganization.name,
                         symbol: <Lettermark name={currentOrganization.name} />,
-                        tooltip: 'Current organization',
                     })
                 }
                 // Project
@@ -127,7 +111,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     }
                     breadcrumbs.push({
                         name: currentTeam.name,
-                        tooltip: 'Current project',
                     })
                 }
                 // Parent page handling
@@ -139,7 +122,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                         })
                         // Current place
                         breadcrumbs.push({
-                            name: person ? asDisplay(person) : null,
+                            name: 'Person',
                             here: true,
                         })
                         break
@@ -172,7 +155,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                         })
                         // Current place
                         breadcrumbs.push({
-                            name: featureFlag ? featureFlag.key || 'Unnamed flag' : null,
+                            name: 'Feature Flag',
                             here: true,
                         })
                         break

--- a/frontend/src/layout/lemonade/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/lemonade/Breadcrumbs/breadcrumbsLogic.tsx
@@ -82,6 +82,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     breadcrumbs.push({
                         name: user.first_name,
                         symbol: <ProfilePicture name={user.first_name} email={user.email} size="md" />,
+                        path: urls.mySettings(),
                     })
                 }
                 // Instance
@@ -92,6 +93,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                     breadcrumbs.push({
                         name: stripHTTP(preflight.site_url),
                         symbol: <Lettermark name="@" />,
+                        path: urls.systemStatus(),
                     })
                 }
                 // Organization


### PR DESCRIPTION
## Changes

- I closed the [previous breadcrumb update PR](https://github.com/PostHog/posthog/pull/7025) because there's no way we could get everyone on page and merge this in before the code freeze. I don't think we have to be all on the same page as well, @clarkus as Product Designer should have a stronger say in the design of the product.
- This PR does the minimal change needed to get the breadcrumbs looking and behaving like the product design, with one tweak.
- The tweak is that I [converted the first two elements into **simple links**](https://github.com/PostHog/posthog/pull/7025#issuecomment-965821484). Just to make the breadcrumbs visually coherent with a pattern of `[[[blue >] blue] > blue] > black` everywhere... and to remove dropdowns that open when clicking on links.
- The Org and Project **links** in the beginning of the toolbar now open the org and project settings pages. (TODO: missing a check if you have access to these pages...?)
- I removed the "display name" for the feature flags and persons views, because having them there means we load and activate both the feature flags and persons scenes (including pulling in the data) for ALL pages of the site - no matter what other scene you open the app with. That's not OK technically, so removed that. It downgraded the experience because now it's "> Feature flags > Feature flag" instead of having the actual name, but fixing that is **outside the scope of this release**.

![2021-11-12 08 57 10](https://user-images.githubusercontent.com/53387/141431259-5d82b6d0-70f1-4550-b27a-8173d36d109f.gif)

- The person/instance status also got a quick change. Now the first link just links to the page itself. Not ideal because there's a "Blue > Black" pattern, where the blue opens the black link..., but at least it's a consistent pattern of `[[[blue >] blue] > blue] > black` everywhere. We should find a way to improve this **after this PR**.

<img width="674" alt="Screenshot 2021-11-12 at 09 03 08" src="https://user-images.githubusercontent.com/53387/141432075-79dce8d7-3f89-4a35-9aee-e4ee65b0f6bb.png">

<img width="683" alt="Screenshot 2021-11-12 at 09 03 24" src="https://user-images.githubusercontent.com/53387/141432082-02f6112d-a092-42b8-9ac7-6b62a9ce8a23.png">

## How did you test this code?

- Visually in the browser
