### PR TITLE
Do not update insights when listing them

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -141,8 +141,10 @@ class InsightSerializer(InsightBasicSerializer):
         result = self.get_result(insight)
         if result is not None:
             return insight.last_refresh
-        insight.last_refresh = None
-        insight.save()
+        if insight.last_refresh is not None:
+            # Update last_refresh without updating "updated_at" (insight edit date)
+            Insight.objects.filter(pk=insight.pk).update(last_refresh=None)
+            insight.refresh_from_db()
         return None
 
     def to_representation(self, instance: Insight):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -289,6 +289,7 @@ def insight_test_factory(event_factory, person_factory):
                 self.assertEqual(spy_update_dashboard_item_cache.call_count, 1)
                 self.assertEqual(response["result"][0]["data"], [0, 0, 0, 0, 0, 0, 2, 0])
                 self.assertEqual(response["last_refresh"], "2012-01-15T04:01:34Z")
+                self.assertEqual(response["updated_at"], "2012-01-15T04:01:34Z")
 
             with freeze_time("2012-01-15T05:01:34.000Z"):
                 event_factory(team=self.team, event="$pageview", distinct_id="1")
@@ -298,6 +299,13 @@ def insight_test_factory(event_factory, person_factory):
                 self.assertEqual(spy_update_dashboard_item_cache.call_count, 2)
                 self.assertEqual(response["result"][0]["data"], [0, 0, 0, 0, 0, 0, 2, 1])
                 self.assertEqual(response["last_refresh"], "2012-01-15T05:01:34Z")
+                self.assertEqual(response["updated_at"], "2012-01-15T04:01:34Z")  # did not change
+
+            with freeze_time("2012-01-25T05:01:34.000Z"):
+                response = self.client.get(f"/api/projects/{self.team.id}/insights/{response['id']}/").json()
+                self.assertEqual(spy_update_dashboard_item_cache.call_count, 2)
+                self.assertEqual(response["last_refresh"], None)
+                self.assertEqual(response["updated_at"], "2012-01-15T04:01:34Z")  # did not change
 
         # BASIC TESTING OF ENDPOINTS. /queries as in depth testing for each insight
 


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/7078
- We used to change the "updated_at" field on an insight in case the cache had expired. No more.

## How did you test this code?

- Made a test
- Tried in the browser locally, used a debugger to see the fix did what it should do.
