### PR TITLE
Trying to build ClickHouse 21.6 for running on M1 macs

### DIFF
--- a/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
+++ b/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:focal AS clickhouse_codebase
-ARG GIT_TAG="v21.6.5.37-stable"
+ARG CLICKHOUSE_TAG="v21.6.5.37-stable"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
@@ -35,7 +35,7 @@ tar xJf gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz -C build-aarch64/cma
 
 WORKDIR build-arm64
 # "v21.6.5.37-stable" does not build with llvm 13. later versions do
-RUN CC=clang-$LLVM_VERSION CXX=clang++-$LLVM_VERSION cmake .. && \
+RUN CC=clang-$LLVM_VERSION CXX=clang++-$LLVM_VERSION cmake .. -DGLIBC_COMPATIBILITY=OFF && \
 ninja  -j $(nproc)
 
 FROM arm64v8/ubuntu:focal

--- a/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
+++ b/docker/clickhouse-builder/assets/arm64.compile.Dockerfile
@@ -1,12 +1,49 @@
-FROM arm64v8/ubuntu:focal
+FROM ubuntu:focal AS clickhouse_codebase
+ARG GIT_TAG="v21.6.5.37-stable"
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --shallow-submodules --branch "${CLICKHOUSE_TAG}" --recursive https://github.com/ClickHouse/ClickHouse.git
+
+
+FROM  arm64v8/ubuntu:focal as builder
 
 ARG gosu_ver=1.10
 ARG DEBIAN_FRONTEND=noninteractive
-ARG GIT_TAG="v21.9.2.17-stable"
+
+COPY --from=clickhouse_codebase /ClickHouse /ClickHouse
+
+ENV LLVM_VERSION 10
+
+RUN apt-get update && apt-get -y install cmake python ninja-build lsb-release wget software-properties-common build-essential libc6-dev
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh $LLVM_VERSION
+RUN apt-get update && apt-get -y install llvm-$LLVM_VERSION
+
+WORKDIR /ClickHouse
+RUN mkdir -p build-aarch64/cmake/toolchain/linux-aarch64 && \
+wget 'https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz?revision=2e88a73f-d233-4f96-b1f4-d8b36e9bb0b9&la=en' -O gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz && \
+tar xJf gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz -C build-aarch64/cmake/toolchain/linux-aarch64 --strip-components=1
+#cp -r build-aarch64/cmake/toolchain/linux-aarch64/ cmake/toolchain/
+
+WORKDIR build-arm64
+# "v21.6.5.37-stable" does not build with llvm 13. later versions do
+RUN CC=clang-$LLVM_VERSION CXX=clang++-$LLVM_VERSION cmake .. && \
+ninja  -j $(nproc)
+
+FROM arm64v8/ubuntu:focal
 
 RUN groupadd -r clickhouse --gid=101 \
-    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
-    && apt-get update \
+    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse
+
+RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         apt-transport-https \
         ca-certificates \
@@ -15,8 +52,6 @@ RUN groupadd -r clickhouse --gid=101 \
         locales \
         wget \
         tzdata \
-    && wget --progress=bar:force:noscroll "https://github.com/tianon/gosu/releases/download/$gosu_ver/gosu-$(dpkg --print-architecture)" -O /bin/gosu \
-    && chmod +x /bin/gosu
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -24,16 +59,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV TZ UTC
 
-RUN apt-get -y install git cmake python ninja-build
-RUN git clone --depth 1 --shallow-submodules --branch $GIT_TAG --recursive https://github.com/ClickHouse/ClickHouse.git
-
-RUN apt-get -y install clang-12 build-essential
-ENV CC clang-12
-ENV CXX clang++-12
-
-RUN cd ClickHouse && mkdir build && cd build && cmake ..
-RUN cd ClickHouse/build && ninja -j $(nproc)
-RUN mv ClickHouse/build/programs/clickhouse* /usr/bin/
+COPY --from=builder /ClickHouse/build-arm64/programs/clickhouse* /usr/bin/
 
 RUN mkdir /docker-entrypoint-initdb.d
 COPY ./docker_related_config.xml /etc/clickhouse-server/config.d/

--- a/docker/clickhouse-builder/build.sh
+++ b/docker/clickhouse-builder/build.sh
@@ -8,4 +8,5 @@
 
 cd "$(dirname "$0")"
 
-docker build assets -f assets/arm64.compile.Dockerfile -t clickhouse-dev-arm64:latest
+# DOCKER_BUILDKIT=0 and --progress=plain are just to help debugging
+DOCKER_BUILDKIT=0 docker build assets -f assets/arm64.compile.Dockerfile -t clickhouse-dev-arm64:pauld --progress=plain


### PR DESCRIPTION
## Changes

On versions higher than ClickHouse 21.6 the test suite fails

This attempts to build CH 21.6 in Docker

## How did you test this code?

By running it many many times
