### PR TITLE
dev(clickhouse): use altinity docker image

### DIFF
--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -14,8 +14,7 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        # Build with: yarn arm64:build:clickhouse
-        image: clickhouse-dev-arm64:latest
+        image: altinity/clickhouse-server:21.6.1.6734-testing-arm
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
I have no idea if this works, my tests are passing locally, but I've probably failed to kill an old container or something.