### PR TITLE
Remove cohort filtering from recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -15,6 +15,7 @@ import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { Tooltip } from 'lib/components/Tooltip'
 import './SessionRecordingTable.scss'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 interface SessionRecordingsTableProps {
     personUUID?: string
     isPersonPage?: boolean
@@ -138,6 +139,11 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                         showOr
                         renderRow={(props) => <FilterRow {...props} />}
                         showNestedArrow={false}
+                        propertiesTaxonomicGroupTypes={[
+                            TaxonomicFilterGroupType.EventProperties,
+                            TaxonomicFilterGroupType.PersonProperties,
+                            TaxonomicFilterGroupType.Elements,
+                        ]}
                     />
                 </div>
                 <Button


### PR DESCRIPTION
## Changes

Removes the broken cohort filtering on the recordings page.

## How did you test this code?

Tested locally