### PR TITLE
Make get people test ids sorted, remove flakiness

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_insights.py
+++ b/ee/clickhouse/views/test/test_clickhouse_insights.py
@@ -964,8 +964,8 @@ def get_converted_and_dropped_people(client: Client, step):
 
     return {
         "name": step["name"],
-        "converted": converted_distinct_ids,
-        "dropped": dropped_distinct_ids,
+        "converted": sorted(converted_distinct_ids),
+        "dropped": sorted(dropped_distinct_ids),
     }
 
 


### PR DESCRIPTION
I introduced some flakiness in introducing this, it seems indeterministic so need to sort before compare

## Changes

Sort people ids before compare in funnel tests

## How did you test this code?

*Please describe.*
