### PR TITLE
Batch insert events in the test journey helper

### DIFF
--- a/ee/clickhouse/test/test_journeys.py
+++ b/ee/clickhouse/test/test_journeys.py
@@ -1,7 +1,11 @@
+import dataclasses
+import json
 from typing import Any, Dict, List
 from uuid import uuid4
 
-from ee.clickhouse.models.event import create_event
+from django.utils import timezone
+
+from ee.clickhouse.client import sync_execute
 from posthog.models import Person, PersonDistinctId, Team
 
 
@@ -29,23 +33,55 @@ def journeys_for(events_by_person: Dict[str, List[Dict[str, Any]]], team: Team) 
     """
 
     people = {}
+    events_to_create = []
     for distinct_id, events in events_by_person.items():
         people[distinct_id] = update_or_create_person(distinct_ids=[distinct_id], team_id=team.pk)
         for event in events:
-            _create_event(
-                team=team,
-                distinct_id=distinct_id,
-                event=event["event"],
-                timestamp=event["timestamp"],
-                properties=event.get("properties", {}),
+            events_to_create.append(
+                _create_event(
+                    team=team,
+                    distinct_id=distinct_id,
+                    event=event["event"],
+                    timestamp=event["timestamp"],
+                    properties=event.get("properties", {}),
+                )
             )
+
+    _create_all_events(events_to_create)
 
     return people
 
 
-def _create_event(**kwargs):
-    kwargs.update({"event_uuid": uuid4()})
-    create_event(**kwargs)
+def _create_all_events(all_events: List[Dict]):
+    parsed = ""
+    for event in all_events:
+        data: Dict[str, Any] = {"properties": {}, "timestamp": timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f")}
+        data.update(event)
+        in_memory_event = InMemoryEvent(**data)
+        parsed += f"""
+        ('{str(uuid4())}', '{in_memory_event.event}', '{json.dumps(in_memory_event.properties)}', '{in_memory_event.timestamp}', {in_memory_event.team.pk}, '{in_memory_event.distinct_id}', '', '{timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f")}', now(), 0)
+        """
+
+    sync_execute(
+        f"""
+    INSERT INTO events (uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, _timestamp, _offset) VALUES
+    {parsed}
+    """
+    )
+
+
+# We collect all events per test into an array and batch create the events to reduce creation time
+@dataclasses.dataclass
+class InMemoryEvent:
+    event: str
+    distinct_id: str
+    team: Team
+    timestamp: str
+    properties: Dict
+
+
+def _create_event(**event):
+    return {**event}
 
 
 def update_or_create_person(distinct_ids: List[str], team_id: int, **kwargs):


### PR DESCRIPTION
## Changes

Copies the approach from `test_paths.py`, accumulates a list of in memory events, and then inserts them in one operation

Before: `24 passed in 63.62s`

After: `24 passed in 46.34s`

## How did you test this code?

It is tests :)
