### PR TITLE
Improve merge of PropertyValue dropdown options

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -88,19 +88,20 @@ export function PropertyValue({
             return
         }
         const key = propertyKey.split('__')[0]
-        setOptions({ [propertyKey]: { ...options[propertyKey], status: 'loading' }, ...options })
+        setOptions({ ...options, [propertyKey]: { ...options[propertyKey], status: 'loading' } })
         if (outerOptions) {
             setOptions({
+                ...options,
                 [propertyKey]: {
                     values: [...Array.from(new Set(outerOptions))],
                     status: 'loaded',
                 },
-                ...options,
             })
         } else {
             api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
                 (propValues: PropValue[]) => {
                     setOptions({
+                        ...options,
                         [propertyKey]: {
                             values: [...Array.from(new Set(propValues))],
                             status: 'loaded',

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { AutoComplete, Select } from 'antd'
 import { useThrottledCallback } from 'use-debounce'
 import api from 'lib/api'
@@ -105,7 +105,6 @@ export function PropertyValue({
                             values: [...Array.from(new Set(propValues))],
                             status: 'loaded',
                         },
-                        ...options,
                     })
                 }
             )
@@ -130,9 +129,10 @@ export function PropertyValue({
         }
     }, [input, shouldBlur])
 
-    const displayOptions = (options[propertyKey]?.values || []).filter(
-        (option) => input === '' || matchesLowerCase(input, toString(option?.name))
-    )
+    const displayOptions = (options[propertyKey]?.values || []).filter((option) => {
+        console.log({ input, option, matches: matchesLowerCase(input, toString(option?.name)) })
+        return input === '' || matchesLowerCase(input, toString(option?.name))
+    })
 
     const validationError = operator ? getValidationError(operator, value) : null
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -129,10 +129,9 @@ export function PropertyValue({
         }
     }, [input, shouldBlur])
 
-    const displayOptions = (options[propertyKey]?.values || []).filter((option) => {
-        console.log({ input, option, matches: matchesLowerCase(input, toString(option?.name)) })
-        return input === '' || matchesLowerCase(input, toString(option?.name))
-    })
+    const displayOptions = (options[propertyKey]?.values || []).filter(
+        (option) => input === '' || matchesLowerCase(input, toString(option?.name))
+    )
 
     const validationError = operator ? getValidationError(operator, value) : null
 


### PR DESCRIPTION
## Changes

relates to #6762 

When searching in the Property Filter API calls are made as the user types.  When there are API results they are merged with the existing state of the displayable results. With existing state overwriting new results.

This causes unexpected behaviour. In the GIFs below there are 5 results from the API but the current code only shows four of them.

This change allows API results to replace current results

# Before

![2021-11-15 08 55 13](https://user-images.githubusercontent.com/984817/141743574-157f5167-9761-4fb2-b722-152308fd16b7.gif)

# After

![2021-11-15 08 54 24](https://user-images.githubusercontent.com/984817/141743591-df929096-ed70-4544-adb5-dd2e85d621bb.gif)

## How did you test this code?

Running it locally
