### PR TITLE
No name override

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -149,7 +149,7 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             },
         ],
     },
-    loaders: () => ({
+    loaders: {
         latestVersion: [
             null as string | null,
             {
@@ -174,7 +174,7 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
                 },
             },
         ],
-    }),
+    },
     listeners: ({ values, actions }) => ({
         collapseMenu: () => {
             if (!values.menuCollapsed && window.innerWidth <= 991) {

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -149,7 +149,7 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             },
         ],
     },
-    loaders: {
+    loaders: () => ({
         latestVersion: [
             null as string | null,
             {
@@ -174,7 +174,7 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
                 },
             },
         ],
-    },
+    }),
     listeners: ({ values, actions }) => ({
         collapseMenu: () => {
             if (!values.menuCollapsed && window.innerWidth <= 991) {

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -18,13 +18,14 @@ export const propertyDefinitionsModel = kea<
 >({
     path: ['models', 'propertyDefinitionsModel'],
     actions: () => ({
+        loadPropertyDefinitions: (initial = false) => ({ initial }),
         updatePropertyDefinition: (property: PropertyDefinition) => ({ property }),
     }),
     loaders: ({ values }) => ({
         propertyStorage: [
             { results: [], next: null, count: 0 } as PropertyDefinitionStorage,
             {
-                loadPropertyDefinitions: async (initial?: boolean) => {
+                loadPropertyDefinitions: async ({ initial }, breakpoint) => {
                     const url = initial
                         ? 'api/projects/@current/property_definitions/?limit=5000'
                         : values.propertyStorage.next
@@ -32,6 +33,7 @@ export const propertyDefinitionsModel = kea<
                         throw new Error('Incorrect call to propertyDefinitionsLogic.loadPropertyDefinitions')
                     }
                     const propertyStorage = await api.get(url)
+                    breakpoint()
                     return {
                         count: propertyStorage.count,
                         results: [...values.propertyStorage.results, ...propertyStorage.results],

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -132,6 +132,25 @@ export const insightLogic = kea<insightLogicType>({
                     savedInsightsLogic.findMounted()?.actions.loadInsights()
                     return updatedInsight
                 },
+                setInsightMetadata: async ({ metadata }, breakpoint) => {
+                    if (values.insightMode === ItemMode.Edit) {
+                        return { ...values.insight, ...metadata }
+                    }
+
+                    const response = await api.update(
+                        `api/projects/${teamLogic.values.currentTeamId}/insights/${values.insight.id}`,
+                        metadata
+                    )
+                    breakpoint()
+
+                    // only update the fields that we changed
+                    const updatedInsight = { ...values.insight }
+                    for (const key of Object.keys(metadata)) {
+                        updatedInsight[key] = response[key]
+                    }
+                    savedInsightsLogic.findMounted()?.actions.loadInsights()
+                    return updatedInsight
+                },
                 // using values.filters, query for new insight results
                 loadResults: async ({ refresh, queryId }, breakpoint) => {
                     // fetch this now, as it might be different when we report below
@@ -566,13 +585,6 @@ export const insightLogic = kea<insightLogicType>({
                         fromItem: createdInsight.id,
                     })
                 }
-            }
-        },
-        setInsightMetadata: ({ metadata }) => {
-            if (values.insightMode === ItemMode.Edit) {
-                actions.setInsight(metadata, { shouldMergeWithExisting: true })
-            } else {
-                actions.updateInsight(metadata)
             }
         },
     }),

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -281,6 +281,7 @@ export const insightLogic = kea<insightLogicType>({
                 ...(shouldMergeWithExisting ? state : {}),
                 ...insight,
             }),
+            setInsightMetadata: (state, { metadata }) => ({ ...state, ...metadata }),
         },
         /* filters contains the in-flight filters, might not (yet?) be the same as insight.filters */
         filters: [

--- a/frontend/src/scenes/session-recordings/player/eventsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/eventsListLogic.ts
@@ -6,6 +6,7 @@ import { colonDelimitedDuration } from 'lib/utils'
 import { CellMeasurerCache } from 'react-virtualized/dist/commonjs/CellMeasurer'
 
 export const eventsListLogic = kea<eventsListLogicType>({
+    path: ['scenes', 'session-recordings', 'player', 'eventsListLogic'],
     connect: {
         actions: [sessionRecordingLogic, ['setFilters']],
         values: [sessionRecordingLogic, ['eventsToShow']],


### PR DESCRIPTION
## Changes

First batch of fixes to the bugs you've been reporting ❤️ 

- Fixes https://github.com/PostHog/posthog/issues/7120
- Fixes https://github.com/PostHog/posthog/issues/7119
  - The error `[KEA] Can not find path "models.propertyDefinitionsModel" in the store.` happened because we were reading a value after the logic had unmounted. Adding a `breakpoint` solved that. The logic had unmounted since react had crashed earlier on, hopefully by the "dayjs().utc is undefined" import order error that I also fixed here.
- Adds a missing path to a logic that was merged to master.

## How did you test this code?

*Please describe.*
