### PR TITLE
Update pycharm configs with new plugin server scripts

### DIFF
--- a/.run/Plugin Server - ClickHouse.run.xml
+++ b/.run/Plugin Server - ClickHouse.run.xml
@@ -3,7 +3,7 @@
     <package-json value="$PROJECT_DIR$/plugin-server/package.json" />
     <command value="run" />
     <scripts>
-      <script value="start" />
+      <script value="start:dev:ee" />
     </scripts>
     <node-interpreter value="project" />
     <envs>

--- a/.run/Plugin Server - ClickHouse.run.xml
+++ b/.run/Plugin Server - ClickHouse.run.xml
@@ -3,7 +3,7 @@
     <package-json value="$PROJECT_DIR$/plugin-server/package.json" />
     <command value="run" />
     <scripts>
-      <script value="start:dev:ee" />
+      <script value="start:dev" />
     </scripts>
     <node-interpreter value="project" />
     <envs>

--- a/.run/Plugin Server - Postgres.run.xml
+++ b/.run/Plugin Server - Postgres.run.xml
@@ -3,7 +3,7 @@
     <package-json value="$PROJECT_DIR$/plugin-server/package.json" />
     <command value="run" />
     <scripts>
-      <script value="start" />
+      <script value="start:dev" />
     </scripts>
     <node-interpreter value="project" />
     <envs>


### PR DESCRIPTION
## Changes

Plugin server scripts were changed in #6784 so that `yarn start` serves the distribution version of plugin-server, not dev. Old PyCharm configs don't work with this, so making this small fix.

## How did you test this code?

Tried it out on my local Pycharm env.
