### PR TITLE
Handling for plugin server restarts in historical exports

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -63,7 +63,7 @@ export function addHistoricalEventsExportCapability(
         exec: async (payload) => {
             const storedTimestampCursor = await meta.storage.get(TIMESTAMP_CURSOR_KEY, null)
 
-            // if the cursor hasn't been incremented within 5 minutes of the restart
+            // if the cursor hasn't been incremented within 10 minutes of the restart
             // that means we didn't pick up from where we left off automatically
             // thus, kick off a new export chain with a new batchId
             if (payload && payload.storedTimestampCursor === storedTimestampCursor) {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/utils.ts
@@ -28,6 +28,9 @@ export interface ExportEventsJobPayload extends Record<string, any> {
 
     // tells us we're ready to pick up a new interval
     incrementTimestampCursor: boolean
+
+    // used for ensuring only one "export task" is running if the server restarts
+    batchId: number
 }
 
 export interface HistoricalExportEvent extends PluginEvent {


### PR DESCRIPTION
## Changes

So historical exports currently rely on our jobs mechanism for handling plugin server restarts. Essentially, if a job is in the queue by the time the server goes down, we will pick back up from where we left off.

However (and this was a known problem that we punted on), this approach isn't perfect. Users have reported jobs _not_ picking back up on restarts.

The reason for this is that there is a reasonable chunk of time during which no jobs are in the queue (we're talking small in human time, but long in computer time - milliseconds, maybe a few seconds).

Users have logs and a timestamp is stored in Postgres, so they can start things back up manually, but this is not ideal.

The ultimate solution for this is long running tasks (see #6870). #7133 would also help. However, as users are doing migrations, I quickly chopped something together that helps us in this front and we can get into 1.30.0.

Essentially, after a restart, we schedule a job for 10min from now to check if we've picked up where we left off. If not, we kick off the export chain again, with handling for duplicates via batch ids.

This:

a) **Is not the final solution**
b) Is still untested, will do this tomorrow ASAP, but putting out for a review during your work day @tiina303 
c) Can lead to some duplicates, but this is something that's accepted and has been discussed before with multiple people. Historical exports should export on a "at least once" basis. Docs should be updated to reflect this.

## How did you test this code?

Currently untested. Draft until tomorrow.