### PR TITLE
[groups bug] fix issue when breaking down on group property 

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -140,6 +140,69 @@
   GROUP BY breakdown_value
   '
 ---
+# name: TestClickhouseTrends.test_breakdown_by_group_props.2
+  '
+  
+  SELECT person_id,
+         created_at,
+         team_id,
+         person_props,
+         is_identified,
+         arrayReduce('groupUniqArray', groupArray(distinct_id)) AS distinct_ids
+  FROM
+    (SELECT e.timestamp as timestamp,
+            pdi.person_id as person_id,
+            e.distinct_id as distinct_id,
+            e.team_id as team_id,
+            person.created_at as created_at,
+            person.person_props as person_props,
+            person.is_identified as is_identified
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, _timestamp) as person_id
+        FROM
+          (SELECT distinct_id,
+                  person_id,
+                  max(_timestamp) as _timestamp
+           FROM person_distinct_id
+           WHERE team_id = 2
+           GROUP BY person_id,
+                    distinct_id,
+                    team_id
+           HAVING max(is_deleted) = 0)
+        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(created_at, _timestamp) as created_at,
+               argMax(is_identified, _timestamp) as is_identified,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
+       (SELECT group_key,
+               argMax(group_properties, _timestamp) AS group_properties_0
+        FROM groups
+        WHERE team_id = 2
+          AND group_type_index = 0
+        GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
+     WHERE team_id = 2
+       AND event = 'sign up'
+       AND timestamp >= '2020-01-02 00:00:00'
+       AND timestamp <= '2020-01-02 23:59:59'
+       AND has(['technology'], trim(BOTH '"'
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) )
+  GROUP BY person_id,
+           created_at,
+           team_id,
+           person_props,
+           is_identified
+  LIMIT 200
+  OFFSET 0
+  '
+---
 # name: TestClickhouseTrends.test_breakdown_by_group_props_with_person_filter
   '
   

--- a/ee/clickhouse/queries/trends/person.py
+++ b/ee/clickhouse/queries/trends/person.py
@@ -56,9 +56,18 @@ class TrendsPersonQuery:
             and isinstance(self.filter.breakdown, str)
             and isinstance(self.filter.breakdown_value, str)
         ):
-            breakdown_prop = Property(
-                key=self.filter.breakdown, value=self.filter.breakdown_value, type=self.filter.breakdown_type
-            )
+            if self.filter.breakdown_type == "group":
+                breakdown_prop = Property(
+                    key=self.filter.breakdown,
+                    value=self.filter.breakdown_value,
+                    type=self.filter.breakdown_type,
+                    group_type_index=self.filter.breakdown_group_type_index,
+                )
+            else:
+                breakdown_prop = Property(
+                    key=self.filter.breakdown, value=self.filter.breakdown_value, type=self.filter.breakdown_type
+                )
+
             self.filter = self.filter.with_data({"properties": self.filter.properties + [breakdown_prop]})
 
         events_query, params = TrendsEventQuery(


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses [this sentry error](https://sentry.io/organizations/posthog/issues/2792789792/?project=1899813&referrer=slack) where the query was failing if you tried to query for persons when a group breakdown was applied
- The property was missing an extra field
*If this affects the frontend, include screenshots.*  

## How did you test this code?

*Please describe.*
- added test