### PR TITLE
Add healthcheck endpoint to plugin server

### DIFF
--- a/ee/docker-compose.ch.yml
+++ b/ee/docker-compose.ch.yml
@@ -87,6 +87,7 @@ services:
             - ..:/code
         restart: on-failure
         environment:
+            DEBUG: 1
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_ENABLED: 'true'
             KAFKA_HOSTS: 'kafka:9092'
@@ -102,3 +103,5 @@ services:
             - redis:redis
             - clickhouse:clickhouse
             - kafka:kafka
+        ports:
+            - '5000:5000'

--- a/plugin-server/src/httpserver.ts
+++ b/plugin-server/src/httpserver.ts
@@ -1,0 +1,31 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http'
+
+import { healthcheck } from './healthcheck'
+import { Status } from './utils/status'
+
+const port = 5000
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.url === '/health' && req.method === 'GET') {
+        const status = await healthcheck()
+        if (status) {
+            const responseBody = {
+                status: 'ok',
+            }
+            res.statusCode = 200
+            res.end(JSON.stringify(responseBody))
+        } else {
+            const responseBody = {
+                status: 'error',
+            }
+            res.statusCode = 500
+            res.end(JSON.stringify(responseBody))
+        }
+    }
+})
+
+export function startServer(logger: Status) {
+    server.listen(port, () => {
+        logger.info('🩺', `Status server listening on port ${port}`)
+    })
+}

--- a/plugin-server/src/httpserver.ts
+++ b/plugin-server/src/httpserver.ts
@@ -24,7 +24,7 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     }
 })
 
-export function startServer(logger: Status) {
+export function startServer(logger: Status): void {
     server.listen(port, () => {
         logger.info('🩺', `Status server listening on port ${port}`)
     })

--- a/plugin-server/src/index.ts
+++ b/plugin-server/src/index.ts
@@ -1,5 +1,6 @@
 import { defaultConfig, formatConfigHelp } from './config/config'
 import { healthcheckWithExit } from './healthcheck'
+import { startServer } from './httpserver'
 import { initApp } from './init'
 import { GraphileQueue } from './main/job-queues/concurrent/graphile-queue'
 import { startPluginsServer } from './main/pluginsServer'
@@ -33,6 +34,9 @@ if (argv.includes('--help') || argv.includes('-h')) {
 const status = new Status(alternativeMode)
 
 status.info('⚡', `@posthog/plugin-server v${version}`)
+
+status.info('🩺', 'Starting health check endpoint')
+startServer(status)
 
 switch (alternativeMode) {
     case AlternativeMode.Version:


### PR DESCRIPTION
## Changes

First pass at adding a health endpoint to the plugin server/service

## How did you test this code?

docker-compose -f ee/docker-compose.ch.yaml up
open browser and hit http://127.0.0.1:5000/health


## Note

Note that `healthcheck` function that is already in plugin server is not very great for this use case. The next step in either this PR or the next will be to create a different `healthcheck` endpoint that we can hit that will represent the individual node's health.