### PR TITLE
Fix: Include elements_chain in recordings query when needed

### DIFF
--- a/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
+++ b/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
@@ -105,6 +105,11 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
     def _get_properties_select_clause(self) -> str:
         current_url_clause, _ = get_property_string_expr("events", "$current_url", "'$current_url'", "properties")
         clause = f", {current_url_clause} as current_url "
+        clause += (
+            f", events.elements_chain as elements_chain"
+            if self._column_optimizer.should_query_elements_chain_column
+            else ""
+        )
         clause += " ".join(
             f", events.{column_name} as {column_name}" for column_name in self._column_optimizer.event_columns_to_query
         )


### PR DESCRIPTION
## Changes

This PR solves this bug: https://sentry.io/organizations/posthog/issues/2793213912/?project=1899813&referrer=slack

When you filtered for session recordings with a specific type of `elements_chain`, it was erroring out because the `elements_chain` was never being extracted from the events table.


## How did you test this code?

Tested locally - reproduced the bug, made the change, verified it didn't repro' anymore
