### PR TITLE
Feature flags: Refactor & Simplify variant matching

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -147,9 +147,8 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
             if len(my_overrides) > 0:
                 override = my_overrides[0]
 
-            value_for_user_without_override: Union[bool, str, None] = feature_flag.matches(request.user.distinct_id)
-            if len(feature_flag.variants) > 0 and value_for_user_without_override:
-                value_for_user_without_override = feature_flag.get_variant(request.user.distinct_id)
+            match = feature_flag.matches(request.user.distinct_id)
+            value_for_user_without_override = match.variant if match else None
 
             flags.append(
                 {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -147,11 +147,9 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
             if len(my_overrides) > 0:
                 override = my_overrides[0]
 
-            value_for_user_without_override: Union[bool, str, None] = feature_flag.distinct_id_matches(
-                request.user.distinct_id
-            )
+            value_for_user_without_override: Union[bool, str, None] = feature_flag.matches(request.user.distinct_id)
             if len(feature_flag.variants) > 0 and value_for_user_without_override:
-                value_for_user_without_override = feature_flag.get_variant_for_distinct_id(request.user.distinct_id)
+                value_for_user_without_override = feature_flag.get_variant(request.user.distinct_id)
 
             flags.append(
                 {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -41,13 +41,13 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
     # Simple flags are ones that only have rollout_percentage
     #  That means server side libraries are able to gate these flags without calling to the server
     def get_is_simple_flag(self, feature_flag: FeatureFlag) -> bool:
-        return len(feature_flag.groups) == 1 and all(
-            len(group.get("properties", [])) == 0 for group in feature_flag.groups
+        return len(feature_flag.match_groups) == 1 and all(
+            len(group.get("properties", [])) == 0 for group in feature_flag.match_groups
         )
 
     def get_rollout_percentage(self, feature_flag: FeatureFlag) -> Optional[int]:
         if self.get_is_simple_flag(feature_flag):
-            return feature_flag.groups[0].get("rollout_percentage")
+            return feature_flag.match_groups[0].get("rollout_percentage")
         else:
             return None
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -148,7 +148,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
                 override = my_overrides[0]
 
             match = feature_flag.matches(request.user.distinct_id)
-            value_for_user_without_override = match.variant if match else None
+            value_for_user_without_override = (match.variant or True) if match else False
 
             flags.append(
                 {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -41,13 +41,13 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
     # Simple flags are ones that only have rollout_percentage
     #  That means server side libraries are able to gate these flags without calling to the server
     def get_is_simple_flag(self, feature_flag: FeatureFlag) -> bool:
-        return len(feature_flag.match_groups) == 1 and all(
-            len(group.get("properties", [])) == 0 for group in feature_flag.match_groups
+        return len(feature_flag.conditions) == 1 and all(
+            len(group.get("properties", [])) == 0 for group in feature_flag.conditions
         )
 
     def get_rollout_percentage(self, feature_flag: FeatureFlag) -> Optional[int]:
         if self.get_is_simple_flag(feature_flag):
-            return feature_flag.match_groups[0].get("rollout_percentage")
+            return feature_flag.conditions[0].get("rollout_percentage")
         else:
             return None
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -265,7 +265,7 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         instance.refresh_from_db()
         self.assertEqual(instance.name, "Updated name")
-        self.assertEqual(instance.match_groups[0]["rollout_percentage"], 65)
+        self.assertEqual(instance.conditions[0]["rollout_percentage"], 65)
 
         # Assert analytics are sent
         mock_capture.assert_called_once_with(

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -265,7 +265,7 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         instance.refresh_from_db()
         self.assertEqual(instance.name, "Updated name")
-        self.assertEqual(instance.groups[0]["rollout_percentage"], 65)
+        self.assertEqual(instance.match_groups[0]["rollout_percentage"], 65)
 
         # Assert analytics are sent
         mock_capture.assert_called_once_with(

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -38,10 +38,10 @@ class FeatureFlag(models.Model):
     deleted: models.BooleanField = models.BooleanField(default=False)
     active: models.BooleanField = models.BooleanField(default=True)
 
-    def distinct_id_matches(self, distinct_id: str) -> bool:
+    def matches(self, distinct_id: str) -> bool:
         return FeatureFlagMatcher(distinct_id, self).is_match()
 
-    def get_variant_for_distinct_id(self, distinct_id: str) -> Optional[str]:
+    def get_variant(self, distinct_id: str) -> Optional[str]:
         return FeatureFlagMatcher(distinct_id, self).get_matching_variant()
 
     def get_analytics_metadata(self) -> Dict:
@@ -199,10 +199,10 @@ def get_active_feature_flags(team: Team, distinct_id: str) -> Dict[str, Union[bo
 
     for feature_flag in feature_flags:
         try:
-            if not feature_flag.distinct_id_matches(distinct_id):
+            if not feature_flag.matches(distinct_id):
                 continue
             if len(feature_flag.variants) > 0:
-                variant = feature_flag.get_variant_for_distinct_id(distinct_id)
+                variant = feature_flag.get_variant(distinct_id)
                 if variant is not None:
                     flags_enabled[feature_flag.key] = variant
             else:

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -126,9 +126,9 @@ class FeatureFlagMatcher:
                 return variant["key"]
         return None
 
-    def is_group_match(self, group: Dict, match_group_index: int):
-        rollout_percentage = group.get("rollout_percentage")
-        if len(group.get("properties", [])) > 0:
+    def is_group_match(self, match_group: Dict, match_group_index: int):
+        rollout_percentage = match_group.get("rollout_percentage")
+        if len(match_group.get("properties", [])) > 0:
             if not self._match_distinct_id(match_group_index):
                 return False
             elif not rollout_percentage:

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -6,22 +6,22 @@ class TestFeatureFlag(BaseTest):
     def test_blank_flag(self):
         # Blank feature flags now default to be released for everyone
         feature_flag = self.create_feature_flag()
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertTrue(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertTrue(feature_flag.matches("another_id"))
 
     def test_rollout_percentage(self):
         feature_flag = self.create_feature_flag(filters={"groups": [{"rollout_percentage": 50}]})
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
 
     def test_empty_group(self):
         feature_flag = self.create_feature_flag(filters={"groups": [{}]})
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertTrue(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertTrue(feature_flag.matches("another_id"))
 
     def test_null_rollout_percentage(self):
         feature_flag = self.create_feature_flag(filters={"groups": [{"properties": [], "rollout_percentage": None}]})
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
 
     def test_complicated_flag(self):
         Person.objects.create(
@@ -42,9 +42,9 @@ class TestFeatureFlag(BaseTest):
             }
         )
 
-        self.assertTrue(feature_flag.distinct_id_matches("test_id"))
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("test_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
 
     def test_multi_property_filters(self):
         Person.objects.create(
@@ -62,10 +62,10 @@ class TestFeatureFlag(BaseTest):
             }
         )
         with self.assertNumQueries(1):
-            self.assertTrue(feature_flag.distinct_id_matches("example_id"))
+            self.assertTrue(feature_flag.matches("example_id"))
         with self.assertNumQueries(1):
-            self.assertTrue(feature_flag.distinct_id_matches("another_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("false_id"))
+            self.assertTrue(feature_flag.matches("another_id"))
+        self.assertFalse(feature_flag.matches("false_id"))
 
     def test_user_in_cohort(self):
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"})
@@ -78,13 +78,13 @@ class TestFeatureFlag(BaseTest):
             filters={"groups": [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}]}
         )
 
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
 
     def test_legacy_rollout_percentage(self):
         feature_flag = self.create_feature_flag(rollout_percentage=50)
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
 
     def test_legacy_property_filters(self):
         Person.objects.create(
@@ -94,8 +94,8 @@ class TestFeatureFlag(BaseTest):
             team=self.team, distinct_ids=["another_id"], properties={"email": "example@example.com"},
         )
         feature_flag = self.create_feature_flag(filters={"properties": [{"key": "email", "value": "tim@posthog.com"}]},)
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
 
     def test_legacy_rollout_and_property_filter(self):
         Person.objects.create(
@@ -112,9 +112,9 @@ class TestFeatureFlag(BaseTest):
             filters={"properties": [{"key": "email", "value": "tim@posthog.com", "type": "person"}]},
         )
         with self.assertNumQueries(1):
-            self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("id_number_3"))
+            self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertFalse(feature_flag.matches("id_number_3"))
 
     def test_legacy_user_in_cohort(self):
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"})
@@ -127,8 +127,8 @@ class TestFeatureFlag(BaseTest):
             filters={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}
         )
 
-        self.assertTrue(feature_flag.distinct_id_matches("example_id"))
-        self.assertFalse(feature_flag.distinct_id_matches("another_id"))
+        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertFalse(feature_flag.matches("another_id"))
 
     def create_feature_flag(self, **kwargs):
         return FeatureFlag.objects.create(

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1,4 +1,5 @@
 from posthog.models import Cohort, FeatureFlag, Person
+from posthog.models.feature_flag import FeatureFlagMatch
 from posthog.test.base import BaseTest
 
 
@@ -6,22 +7,22 @@ class TestFeatureFlag(BaseTest):
     def test_blank_flag(self):
         # Blank feature flags now default to be released for everyone
         feature_flag = self.create_feature_flag()
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertTrue(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertEqual(feature_flag.matches("another_id"), FeatureFlagMatch())
 
     def test_rollout_percentage(self):
         feature_flag = self.create_feature_flag(filters={"groups": [{"rollout_percentage": 50}]})
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
 
     def test_empty_group(self):
         feature_flag = self.create_feature_flag(filters={"groups": [{}]})
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertTrue(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertEqual(feature_flag.matches("another_id"), FeatureFlagMatch())
 
     def test_null_rollout_percentage(self):
         feature_flag = self.create_feature_flag(filters={"groups": [{"properties": [], "rollout_percentage": None}]})
-        self.assertTrue(feature_flag.matches("example_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
 
     def test_complicated_flag(self):
         Person.objects.create(
@@ -42,9 +43,9 @@ class TestFeatureFlag(BaseTest):
             }
         )
 
-        self.assertTrue(feature_flag.matches("test_id"))
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("test_id"), FeatureFlagMatch())
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
 
     def test_multi_property_filters(self):
         Person.objects.create(
@@ -62,10 +63,10 @@ class TestFeatureFlag(BaseTest):
             }
         )
         with self.assertNumQueries(1):
-            self.assertTrue(feature_flag.matches("example_id"))
+            self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
         with self.assertNumQueries(1):
-            self.assertTrue(feature_flag.matches("another_id"))
-        self.assertFalse(feature_flag.matches("false_id"))
+            self.assertEqual(feature_flag.matches("another_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("false_id"))
 
     def test_user_in_cohort(self):
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"})
@@ -78,13 +79,13 @@ class TestFeatureFlag(BaseTest):
             filters={"groups": [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}]}
         )
 
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
 
     def test_legacy_rollout_percentage(self):
         feature_flag = self.create_feature_flag(rollout_percentage=50)
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
 
     def test_legacy_property_filters(self):
         Person.objects.create(
@@ -94,8 +95,8 @@ class TestFeatureFlag(BaseTest):
             team=self.team, distinct_ids=["another_id"], properties={"email": "example@example.com"},
         )
         feature_flag = self.create_feature_flag(filters={"properties": [{"key": "email", "value": "tim@posthog.com"}]},)
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
 
     def test_legacy_rollout_and_property_filter(self):
         Person.objects.create(
@@ -112,9 +113,9 @@ class TestFeatureFlag(BaseTest):
             filters={"properties": [{"key": "email", "value": "tim@posthog.com", "type": "person"}]},
         )
         with self.assertNumQueries(1):
-            self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
-        self.assertFalse(feature_flag.matches("id_number_3"))
+            self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
+        self.assertIsNone(feature_flag.matches("id_number_3"))
 
     def test_legacy_user_in_cohort(self):
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"$some_prop": "something"})
@@ -127,8 +128,26 @@ class TestFeatureFlag(BaseTest):
             filters={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}
         )
 
-        self.assertTrue(feature_flag.matches("example_id"))
-        self.assertFalse(feature_flag.matches("another_id"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch())
+        self.assertIsNone(feature_flag.matches("another_id"))
+
+    def test_variants(self):
+        feature_flag = self.create_feature_flag(
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": None}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                        {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                        {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(feature_flag.matches("11"), FeatureFlagMatch(variant="first-variant"))
+        self.assertEqual(feature_flag.matches("example_id"), FeatureFlagMatch(variant="second-variant"))
+        self.assertEqual(feature_flag.matches("3"), FeatureFlagMatch(variant="third-variant"))
 
     def create_feature_flag(self, **kwargs):
         return FeatureFlag.objects.create(


### PR DESCRIPTION
## Changes

This is in preparation for https://github.com/PostHog/posthog/issues/7010. Alongside variant matching and overrides a lot of cruft has crept into feature flags, which makes both using and implementing group analytics support harder.

This PR tries to refactor a few things for a cleaner future.

## How did you test this code?

See unit tests.