### PR TITLE
wip(e2e): don't start plugin server for e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,8 +94,6 @@ jobs:
               run: |
                   yarn install --frozen-lockfile
                   yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
-                  cd plugin-server
-                  yarn install --frozen-lockfile
             - name: Yarn build
               env:
                   GENERATE_SOURCEMAP: 'false'
@@ -120,7 +118,7 @@ jobs:
                   python manage.py setup_dev
                   mkdir -p cypress/screenshots
                   ./bin/docker-worker &
-                  ./bin/docker-server &
+                  ./bin/docker-worker-celery --with-scheduler &
             - name: Cypress run
               uses: cypress-io/github-action@v2
               with:


### PR DESCRIPTION
Looks like it's using `PRIMARY_DB=postgres` which I think means that
plugin-server is irrelevant? Anyway, this is my test for that.

Doesn't looks true actually, seems plugin server reads the celery queue