### PR TITLE
Session recordings logic unmounted when accessing values

### DIFF
--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -168,23 +168,23 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
     }),
     loaders: ({ values }) => ({
         sessionPlayerData: {
-            loadRecordingMeta: async ({ sessionRecordingId }): Promise<SessionPlayerData> => {
+            loadRecordingMeta: async ({ sessionRecordingId }, breakpoint): Promise<SessionPlayerData> => {
                 const params = toParams({ save_view: true })
                 const response = await api.get(
                     `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}?${params}`
                 )
-
+                breakpoint()
                 return {
                     ...response.result,
                     session_recording: parseMetadataResponse(response.result?.session_recording),
                     snapshots: values.sessionPlayerData?.snapshots ?? [],
                 }
             },
-            loadRecordingSnapshots: async ({ sessionRecordingId, url }): Promise<SessionPlayerData> => {
+            loadRecordingSnapshots: async ({ sessionRecordingId, url }, breakpoint): Promise<SessionPlayerData> => {
                 const apiUrl =
                     url || `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}/snapshots`
                 const response = await api.get(apiUrl)
-
+                breakpoint()
                 const currData = values.sessionPlayerData
                 return {
                     ...currData,
@@ -194,13 +194,14 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
             },
         },
         sessionEventsData: {
-            loadEvents: async ({ url }) => {
+            loadEvents: async ({ url }, breakpoint) => {
                 if (!values.eventsApiParams) {
                     return values.sessionEventsData
                 }
                 // Use `url` if there is a `next` url to fetch
                 const apiUrl = url || `api/projects/${values.currentTeamId}/events?${toParams(values.eventsApiParams)}`
                 const response = await api.get(apiUrl)
+                breakpoint()
 
                 return {
                     ...values.sessionEventsData,

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -100,11 +100,11 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
             cache.eventsStartTime = performance.now()
             actions.loadEvents()
         },
-        loadRecordingSnapshotsSuccess: async () => {
+        loadRecordingSnapshotsSuccess: () => {
             // If there is more data to poll for load the next batch.
             // This will keep calling loadRecording until `next` is empty.
             if (!!values.sessionPlayerData?.next) {
-                await actions.loadRecordingSnapshots(undefined, values.sessionPlayerData.next)
+                actions.loadRecordingSnapshots(undefined, values.sessionPlayerData.next)
             }
             // Finished loading entire recording. Now make it known!
             else {


### PR DESCRIPTION
## Changes

- Hopefully fixes [this sentry bug](https://sentry.io/organizations/posthog/issues/2794164856/?project=1899813&referrer=slack)
- We can't `await` for actions, so this `loadRecordingSnapshotsSuccess` listener had unintended consequences, where it would access `values` after the logic had unmounted (due to the await, otherwise would have ran sequentially)
- Adds breakpoints to other loaders that might return when the scene logic is unmounted.

## How did you test this code?

- I don't have any recordings locally (not sure what's up now?), so I couldn't really test this.
