### PR TITLE
Plugin-server: Always use db.postgresQuery

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -150,12 +150,17 @@ export class DB {
     public postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
         queryTextOrConfig: string | QueryConfig<I>,
         values: I | undefined,
-        tag: string
+        tag: string,
+        client?: PoolClient
     ): Promise<QueryResult<R>> {
         return instrumentQuery(this.statsd, 'query.postgres', tag, async () => {
             const timeout = timeoutGuard('Postgres slow query warning after 30 sec', { queryTextOrConfig, values })
             try {
-                return await this.postgres.query(queryTextOrConfig, values)
+                if (client) {
+                    return await client.query(queryTextOrConfig, values)
+                } else {
+                    return await this.postgres.query(queryTextOrConfig, values)
+                }
             } finally {
                 clearTimeout(timeout)
             }
@@ -443,12 +448,7 @@ export class DB {
         }
         const values = [teamId, distinctId]
 
-        let selectResult: QueryResult | null = null
-        if (client) {
-            selectResult = await client.query(queryString, values)
-        } else {
-            selectResult = await this.postgresQuery(queryString, values, 'fetchPerson')
-        }
+        const selectResult: QueryResult = await this.postgresQuery(queryString, values, 'fetchPerson', client)
 
         if (selectResult.rows.length > 0) {
             const rawPerson: RawPerson = selectResult.rows[0]
@@ -485,7 +485,7 @@ export class DB {
         })
 
         const person = await this.postgresTransaction(async (client) => {
-            const insertResult = await client.query(
+            const insertResult = await this.postgresQuery(
                 'INSERT INTO posthog_person (created_at, properties, properties_last_updated_at, properties_last_operation, team_id, is_user_id, is_identified, uuid, version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *',
                 [
                     createdAt.toISO(),
@@ -497,7 +497,9 @@ export class DB {
                     isIdentified,
                     uuid,
                     0,
-                ]
+                ],
+                'insertPerson',
+                client
             )
             const personCreated = insertResult.rows[0] as RawPerson
             const person = {
@@ -870,9 +872,11 @@ export class DB {
 
         try {
             await this.postgresTransaction(async (client) => {
-                const insertResult = await client.query(
+                const insertResult = await this.postgresQuery(
                     'INSERT INTO posthog_elementgroup (hash, team_id) VALUES ($1, $2) ON CONFLICT DO NOTHING RETURNING *',
-                    [hash, teamId]
+                    [hash, teamId],
+                    'createElementGroup',
+                    client
                 )
 
                 if (insertResult.rows.length > 0) {
@@ -912,11 +916,13 @@ export class DB {
                         )
                     }
 
-                    await client.query(
+                    await this.postgresQuery(
                         `INSERT INTO posthog_element (text, tag_name, href, attr_id, nth_child, nth_of_type, attributes, "order", event_id, attr_class, group_id) VALUES ${rowStrings.join(
                             ', '
                         )}`,
-                        values
+                        values,
+                        'insertElement',
+                        client
                     )
                 }
             })

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -672,7 +672,7 @@ export class DB {
         }
     }
 
-    public async moveDistinctIds(source: Person, target: Person): Promise<ProducerRecord[]> {
+    public async moveDistinctIds(source: Person, target: Person, client?: PoolClient): Promise<ProducerRecord[]> {
         let movedDistinctIdResult: QueryResult<any> | null = null
         try {
             movedDistinctIdResult = await this.postgresQuery(
@@ -684,7 +684,8 @@ export class DB {
                     RETURNING *
                 `,
                 [target.id, source.id, target.team_id],
-                'updateDistinctIdPerson'
+                'updateDistinctIdPerson',
+                client
             )
         } catch (error) {
             if (

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -556,7 +556,7 @@ export class DB {
         }
         RETURNING version`
 
-        const updateResult: QueryResult = this.postgresQuery(queryString, values, 'updatePerson', client)
+        const updateResult: QueryResult = await this.postgresQuery(queryString, values, 'updatePerson', client)
 
         const updatedPersonVersion: Person['version'] = Number(updateResult.rows[0].version)
         const updatedPerson: Person = { ...person, ...update, version: updatedPersonVersion }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -439,7 +439,7 @@ export class EventsProcessor {
                     client
                 )
 
-                const distinctIdMessages = await this.db.moveDistinctIds(otherPerson, mergeInto)
+                const distinctIdMessages = await this.db.moveDistinctIds(otherPerson, mergeInto, client)
 
                 const deletePersonMessages = await this.db.deletePerson(otherPerson, client)
 

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -432,10 +432,12 @@ export class EventsProcessor {
                 )
 
                 // Merge the distinct IDs
-                await client.query('UPDATE posthog_cohortpeople SET person_id = $1 WHERE person_id = $2', [
-                    mergeInto.id,
-                    otherPerson.id,
-                ])
+                await this.db.postgresQuery(
+                    'UPDATE posthog_cohortpeople SET person_id = $1 WHERE person_id = $2',
+                    [mergeInto.id, otherPerson.id],
+                    'updateCohortPeople',
+                    client
+                )
 
                 const distinctIdMessages = await this.db.moveDistinctIds(otherPerson, mergeInto)
 

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -32,7 +32,7 @@ export async function updatePersonProperties(
             return
         }
 
-        const updateResult: QueryResult = await client.query(
+        const updateResult: QueryResult = await db.postgresQuery(
             `UPDATE posthog_person SET
                 properties = $1,
                 properties_last_updated_at = $2,
@@ -45,7 +45,9 @@ export async function updatePersonProperties(
                 JSON.stringify(person.properties_last_updated_at),
                 JSON.stringify(person.properties_last_operation || {}),
                 person.id,
-            ]
+            ],
+            'updatePersonProperties',
+            client
         )
         person.version = Number(updateResult.rows[0].version)
     })


### PR DESCRIPTION
## Changes

We've been leveraging postges transactions more and more recently. However we haven't been paying attention to code patterns and problems have emerged:
1. We don't track all postgres queries in our metrics anymore, meaning when performance problems arise we don't have proper tools to debug them
2. There were transactions where some queries did not make use of transactions

This PR unifies the two querying approaches by always _always_ using postgresQuery.

## How did you test this code?

Unit tests :)
