### PR TITLE
Make project based permissioning an enterprise feature

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -56,7 +56,6 @@ class License(models.Model):
     SCALE_FEATURES = [
         AvailableFeature.ZAPIER,
         AvailableFeature.ORGANIZATIONS_PROJECTS,
-        AvailableFeature.PROJECT_BASED_PERMISSIONING,
         AvailableFeature.GOOGLE_LOGIN,
         AvailableFeature.DASHBOARD_COLLABORATION,
         AvailableFeature.INGESTION_TAXONOMY,
@@ -66,6 +65,7 @@ class License(models.Model):
 
     ENTERPRISE_PLAN = "enterprise"
     ENTERPRISE_FEATURES = SCALE_FEATURES + [
+        AvailableFeature.PROJECT_BASED_PERMISSIONING,
         AvailableFeature.SAML,
     ]
     PLANS = {SCALE_PLAN: SCALE_FEATURES, ENTERPRISE_PLAN: ENTERPRISE_FEATURES}


### PR DESCRIPTION
## Changes

Make project based permissioning an enterprise feature. This shouldn't affect any existing 'scale' customers as they technically have enterprise licenses.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- create 'scale' license on license.posthog.com
- Add to local instance, verify I can't use project based permissioning
- Remove license
- create & add enterprise license, verify i _can_ use project based permissioning
