### PR TITLE
Dayjs plugins

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -5,8 +5,6 @@ import { loadersPlugin } from 'kea-loaders'
 import { windowValuesPlugin } from 'kea-window-values'
 import { errorToast, identifierToHuman } from 'lib/utils'
 import { waitForPlugin } from 'kea-waitfor'
-import dayjs from 'dayjs'
-import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 
 /*
 Actions for which we don't want to show error alerts,
@@ -31,10 +29,6 @@ interface InitKeaProps {
 }
 
 export function initKea({ state, routerHistory, routerLocation, beforePlugins }: InitKeaProps = {}): void {
-    // necessary for any localised date formatting to work
-    // doesn't matter if it is called multiple times but must be called once
-    dayjs.extend(LocalizedFormat)
-
     resetContext({
         plugins: [
             ...(beforePlugins || []),

--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -23,7 +23,6 @@ import { organizationLogic } from '../../../scenes/organizationLogic'
 import { preflightLogic } from '../../../scenes/PreflightCheck/logic'
 import { navigationLogic } from '../../navigation/navigationLogic'
 import { licenseLogic } from '../../../scenes/instance/Licenses/logic'
-import dayjs from 'dayjs'
 import { identifierToHuman } from '../../../lib/utils'
 import { Lettermark } from '../../../lib/components/Lettermark/Lettermark'
 import {
@@ -31,6 +30,7 @@ import {
     NewOrganizationButton,
     OtherOrganizationButton,
 } from '~/layout/lemonade/OrganizationSwitcher'
+import { dayjs } from 'lib/dayjs'
 
 function SitePopoverSection({ title, children }: { title?: string; children: any }): JSX.Element {
     return (

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -4,13 +4,11 @@ import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogi
 import { navigationLogicType } from './navigationLogicType'
 import { SystemStatus, VersionType } from '~/types'
 import { organizationLogic } from 'scenes/organizationLogic'
-import dayjs from 'dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
-import utc from 'dayjs/plugin/utc'
-dayjs.extend(utc)
+import { dayjs } from 'lib/dayjs'
 
 type WarningType =
     | 'welcome'

--- a/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
@@ -5,7 +5,6 @@ import { Button, Popover, Row, Input, Checkbox } from 'antd'
 import { humanFriendlyDetailedTime } from '~/lib/utils'
 import { DeleteOutlined, PlusOutlined, ProjectOutlined, DeploymentUnitOutlined, CloseOutlined } from '@ant-design/icons'
 import { annotationsLogic } from './annotationsLogic'
-import dayjs from 'dayjs'
 import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import { dashboardColors } from 'lib/colors'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -14,6 +13,7 @@ import { AnnotationScope, AnnotationType } from '~/types'
 import { styles } from '../../../vars'
 import { teamLogic } from '../../../scenes/teamLogic'
 import { organizationLogic } from '../../../scenes/organizationLogic'
+import { dayjs } from 'lib/dayjs'
 
 const { TextArea } = Input
 

--- a/frontend/src/lib/components/Annotations/Annotations.tsx
+++ b/frontend/src/lib/components/Annotations/Annotations.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import dayjs from 'dayjs'
 import { annotationsLogic } from './annotationsLogic'
 import { useValues, useActions } from 'kea'
 import { AnnotationMarker } from './AnnotationMarker'
 import { AnnotationType, AnnotationScope } from '~/types'
+import { dayjs } from 'lib/dayjs'
 
 interface AnnotationsProps {
     dates: string[]

--- a/frontend/src/lib/components/AppEditorLink/appUrlsLogic.ts
+++ b/frontend/src/lib/components/AppEditorLink/appUrlsLogic.ts
@@ -2,10 +2,10 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { appEditorUrl } from 'lib/components/AppEditorLink/utils'
-import dayjs from 'dayjs'
 import { appUrlsLogicType } from './appUrlsLogicType'
 import { TrendResult } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
+import { dayjs } from 'lib/dayjs'
 
 const defaultValue = 'https://'
 

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { Modal, Table } from 'antd'
 import api from 'lib/api'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
-dayjs.extend(relativeTime)
+import { dayjs } from 'lib/dayjs'
 
 export async function debugCHQueries(): Promise<void> {
     const results = await api.get('api/debug_ch_queries/')

--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs'
+import { dayjs } from 'lib/dayjs'
 import React from 'react'
 import { IntervalType } from '~/types'
 import './DateDisplay.scss'

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react'
 import { Select } from 'antd'
-import dayjs from 'dayjs'
 import { dateMapping, isDate, dateFilterToText } from 'lib/utils'
 import { DateFilterRange } from 'lib/components/DateFilter/DateFilterRange'
+import { dayjs } from 'lib/dayjs'
 
 export interface DateFilterProps {
     defaultValue: string

--- a/frontend/src/lib/components/DateFilter/DateFilterRange.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilterRange.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react'
-import dayjs from 'dayjs'
 import { Button } from 'antd'
 
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs'
 import generatePicker from 'antd/lib/date-picker/generatePicker'
+import { dayjs } from 'lib/dayjs'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 

--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -1,11 +1,6 @@
 import React from 'react'
 import './index.scss'
-import dayjs from 'dayjs'
 import { Col, Popover, Row } from 'antd'
-import relativeTime from 'dayjs/plugin/relativeTime'
-import LocalizedFormat from 'dayjs/plugin/localizedFormat'
-import utc from 'dayjs/plugin/utc'
-import timezone from 'dayjs/plugin/timezone'
 import { useActions, useValues } from 'kea'
 import { ProjectOutlined, LaptopOutlined, GlobalOutlined, SettingOutlined } from '@ant-design/icons'
 import { Link } from '../Link'
@@ -13,13 +8,9 @@ import { humanTzOffset, shortTimeZone } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { TooltipPlacement } from 'antd/lib/tooltip'
 import { teamLogic } from '../../../scenes/teamLogic'
+import { dayjs } from 'lib/dayjs'
 
 const BASE_OUTPUT_FORMAT = 'ddd, MMM D, YYYY HH:mm'
-
-dayjs.extend(LocalizedFormat)
-dayjs.extend(relativeTime)
-dayjs.extend(utc)
-dayjs.extend(timezone)
 
 function TZConversionHeader(): JSX.Element {
     return (

--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -3,6 +3,7 @@ import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 
 // necessary for any localized date formatting to work
@@ -11,5 +12,6 @@ dayjs.extend(relativeTime)
 dayjs.extend(isSameOrAfter)
 dayjs.extend(isSameOrBefore)
 dayjs.extend(utc)
+dayjs.extend(timezone)
 
 export { dayjs }

--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -1,0 +1,15 @@
+import dayjs from 'dayjs'
+import LocalizedFormat from 'dayjs/plugin/localizedFormat'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import utc from 'dayjs/plugin/utc'
+
+// necessary for any localized date formatting to work
+dayjs.extend(LocalizedFormat)
+dayjs.extend(relativeTime)
+dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrBefore)
+dayjs.extend(utc)
+
+export { dayjs }

--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -9,7 +9,7 @@ import { npsLogicType } from './NPSPromptType'
 import posthog from 'posthog-js'
 import nps from './nps.svg'
 import { userLogic } from 'scenes/userLogic'
-import dayjs from 'dayjs'
+import { dayjs } from 'lib/dayjs'
 
 const NPS_APPEAR_TIMEOUT = 10000
 const NPS_HIDE_TIMEOUT = 3500

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import {
     areObjectValuesEmpty,
     average,
@@ -21,6 +20,7 @@ import {
     eventToDescription,
 } from './utils'
 import { ActionFilter, PropertyOperator } from '~/types'
+import { dayjs } from 'lib/dayjs'
 
 describe('toParams', () => {
     it('handles unusual input', () => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -2,7 +2,6 @@ import React, { CSSProperties, PropsWithChildren } from 'react'
 import api from './api'
 import { toast } from 'react-toastify'
 import { Button, Spin } from 'antd'
-import dayjs from 'dayjs'
 import { EventType, FilterType, ActionFilter, IntervalType, ItemMode, DashboardMode } from '~/types'
 import { tagColors } from 'lib/colors'
 import { CustomerServiceOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
@@ -11,6 +10,7 @@ import { KeyMappingInterface } from 'lib/components/PropertyKeyInfo'
 import { AlignType } from 'rc-trigger/lib/interface'
 import { DashboardEventSource } from './utils/eventUsageLogic'
 import { helpButtonLogic } from './components/HelpButton/HelpButton'
+import { dayjs } from 'lib/dayjs'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -6,12 +6,12 @@ import { eventsTableLogic } from 'scenes/events/eventsTableLogic'
 import api from 'lib/api'
 import { Spin } from 'antd'
 import { EventsTable } from 'scenes/events'
-import dayjs from 'dayjs'
 import { urls } from 'scenes/urls'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { ActionType } from '~/types'
 
 import { actionLogicType } from './ActionType'
+import { dayjs } from 'lib/dayjs'
 interface ActionLogicProps {
     id?: ActionType['id']
     onComplete: () => void

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -11,10 +11,10 @@ import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { actionsModel } from '~/models/actionsModel'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
-import dayjs from 'dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import api from '../../lib/api'
+import { dayjs } from 'lib/dayjs'
 
 export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }: ActionEditLogicProps): JSX.Element {
     const relevantActionEditLogic = actionEditLogic({

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, HTMLAttributes } from 'react'
 import { useValues, useActions } from 'kea'
 import { Table, Tag, Button, Modal, Input, Row, Spin, Menu, Dropdown } from 'antd'
 import { humanFriendlyDetailedTime } from 'lib/utils'
-import dayjs from 'dayjs'
 import { annotationsModel } from '~/models/annotationsModel'
 import { annotationsTableLogic } from './logic'
 import { DeleteOutlined, RedoOutlined, ProjectOutlined, DeploymentUnitOutlined, DownOutlined } from '@ant-design/icons'
@@ -12,12 +11,13 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { PlusOutlined } from '@ant-design/icons'
 import { createdByColumn } from 'lib/components/Table/Table'
 import { AnnotationType, AnnotationScope } from '~/types'
-
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs'
 import generatePicker from 'antd/lib/date-picker/generatePicker'
 import { normalizeColumnTitle, useIsTableScrolling } from 'lib/components/Table/utils'
 import { teamLogic } from '../teamLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { dayjs } from 'lib/dayjs'
+
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
 const { TextArea } = Input

--- a/frontend/src/scenes/cohorts/CohortDetailsRow.tsx
+++ b/frontend/src/scenes/cohorts/CohortDetailsRow.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Row, Col } from 'antd'
 import { CohortType } from '~/types'
-import dayjs from 'dayjs'
 import { TeamMemberID } from 'lib/components/TeamMemberID'
 import { useValues } from 'kea'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { dayjs } from 'lib/dayjs'
 
 export function CohortDetailsRow({ cohort }: { cohort: CohortType }): JSX.Element {
     const { preflight } = useValues(preflightLogic)

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import dayjs from 'dayjs'
 import { DeleteWithUndo, toParams } from 'lib/utils'
 import { Table, Spin, Button, Input } from 'antd'
 import { ExportOutlined, DeleteOutlined, InfoCircleOutlined, ClockCircleOutlined } from '@ant-design/icons'
@@ -15,13 +14,11 @@ import './Cohorts.scss'
 import Fuse from 'fuse.js'
 import { createdAtColumn, createdByColumn } from 'lib/components/Table/Table'
 import { Tooltip } from 'lib/components/Tooltip'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { cohortsUrlLogicType } from './CohortsType'
 import { Link } from 'lib/components/Link'
 import { PROPERTY_MATCH_TYPE } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
-
-dayjs.extend(relativeTime)
+import { dayjs } from 'lib/dayjs'
 
 const NEW_COHORT: CohortType = {
     id: 'new',

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -17,7 +17,6 @@ import {
     CopyOutlined,
 } from '@ant-design/icons'
 import { FullScreen } from 'lib/components/FullScreen'
-import dayjs from 'dayjs'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { AvailableFeature, DashboardMode, DashboardType } from '~/types'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -29,6 +28,7 @@ import { urls } from 'scenes/urls'
 import { Description } from 'lib/components/Description/Description'
 import { userLogic } from 'scenes/userLogic'
 import { Tooltip } from 'lib/components/Tooltip'
+import { dayjs } from 'lib/dayjs'
 
 export function DashboardHeader(): JSX.Element {
     const { dashboard, dashboardMode, lastDashboardModeSource } = useValues(dashboardLogic)

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -13,8 +13,6 @@ import { EllipsisOutlined, SaveOutlined } from '@ant-design/icons'
 import { dashboardColorNames, dashboardColors } from 'lib/colors'
 import { useLongPress } from 'lib/hooks/useLongPress'
 import { usePrevious } from 'lib/hooks/usePrevious'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { SaveModal } from 'scenes/insights/SaveModal'
@@ -46,8 +44,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { LinkButton } from 'lib/components/LinkButton'
 import { DiveIcon } from 'lib/components/icons'
 import { teamLogic } from '../teamLogic'
-
-dayjs.extend(relativeTime)
+import { dayjs } from 'lib/dayjs'
 
 interface Props {
     item: DashboardItemType

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -3,10 +3,10 @@ import { Checkbox, Dropdown, Menu, Radio, Space } from 'antd'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { DownOutlined, LoadingOutlined, ReloadOutlined } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
-import dayjs from 'dayjs'
 import { humanFriendlyDuration } from 'lib/utils'
 import clsx from 'clsx'
 import { Tooltip } from 'lib/components/Tooltip'
+import { dayjs } from 'lib/dayjs'
 
 export const LastRefreshText = (): JSX.Element => {
     const { lastRefreshed } = useValues(dashboardLogic)

--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
-import dayjs from 'dayjs'
 import { EventElements } from 'scenes/events/EventElements'
 import { Tabs, Button } from 'antd'
 
@@ -11,6 +10,7 @@ import { EventType } from '../../types'
 import { Properties } from '@posthog/plugin-scaffold'
 import { useValues } from 'kea'
 import { teamLogic } from '../teamLogic'
+import { dayjs } from 'lib/dayjs'
 
 const { TabPane } = Tabs
 

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react'
 import { useActions, useValues } from 'kea'
-import dayjs from 'dayjs'
 import { EventDetails } from 'scenes/events/EventDetails'
 import { DownloadOutlined, ExportOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
@@ -11,8 +10,6 @@ import { autoCaptureEventToDescription, toParams } from 'lib/utils'
 import './EventsTable.scss'
 import { eventsTableLogic } from './eventsTableLogic'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
-import relativeTime from 'dayjs/plugin/relativeTime'
-import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { ResizableColumnType, ResizableTable, TableConfig } from 'lib/components/ResizableTable'
@@ -29,10 +26,6 @@ import clsx from 'clsx'
 import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic'
 import { EventsTab, EventsTabs } from 'scenes/events/EventsTabs'
 import { urls } from 'scenes/urls'
-
-dayjs.extend(LocalizedFormat)
-dayjs.extend(relativeTime)
-
 export interface FixedFilters {
     action_id?: ActionType['id']
     person_id?: string | number

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -2,13 +2,13 @@ import { kea } from 'kea'
 import { errorToast, toParams } from 'lib/utils'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import dayjs from 'dayjs'
 import { eventsTableLogicType } from './eventsTableLogicType'
 import { FixedFilters } from 'scenes/events/EventsTable'
 import { AnyPropertyFilter, EventsTableRowItem, EventType, PropertyFilter } from '~/types'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { teamLogic } from '../teamLogic'
 import { urls } from 'scenes/urls'
+import { dayjs } from 'lib/dayjs'
 
 const POLL_TIMEOUT = 5000
 

--- a/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
@@ -1,12 +1,9 @@
 import { Button } from 'antd'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import React, { useEffect, useState } from 'react'
 import { Tooltip } from 'antd'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
-
-dayjs.extend(relativeTime)
+import { dayjs } from 'lib/dayjs'
 
 export function ComputationTimeWithRefresh(): JSX.Element {
     const { lastRefresh } = useValues(insightLogic)

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -1,8 +1,6 @@
 import './Insights.scss'
 import React from 'react'
 import { useActions, useMountedLogic, useValues, BindLogic } from 'kea'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { Row, Col, Card, Button, Popconfirm } from 'antd'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { router } from 'kea-router'
@@ -25,8 +23,6 @@ import { HotkeyButton } from 'lib/components/HotkeyButton/HotkeyButton'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ObjectTags } from 'lib/components/ObjectTags'
 import { UNNAMED_INSIGHT_NAME } from './EmptyStates'
-
-dayjs.extend(relativeTime)
 
 export const scene: SceneExport = {
     component: Insights,

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -16,12 +16,7 @@ import { InsightLabel } from 'lib/components/InsightLabel'
 import { InsightTooltip } from '../InsightTooltip/InsightTooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import dayjs from 'dayjs'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
-
-dayjs.extend(isSameOrAfter)
-dayjs.extend(isSameOrBefore)
+import { dayjs } from 'lib/dayjs'
 
 //--Chart Style Options--//
 Chart.defaults.global.legend.display = false

--- a/frontend/src/scenes/insights/RetentionDatePicker.tsx
+++ b/frontend/src/scenes/insights/RetentionDatePicker.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import dayjs from 'dayjs'
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs'
 import generatePicker from 'antd/lib/date-picker/generatePicker'
 import { useActions, useValues } from 'kea'
@@ -7,6 +6,7 @@ import { retentionTableLogic } from 'scenes/retention/retentionTableLogic'
 import { CalendarOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { dayjs } from 'lib/dayjs'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -10,13 +10,10 @@ import './Persons.scss'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { midEllipsis } from 'lib/utils'
 import { DownOutlined, DeleteOutlined, MergeCellsOutlined, LoadingOutlined } from '@ant-design/icons'
-import dayjs from 'dayjs'
 import { MergeSplitPerson } from './MergeSplitPerson'
 import { PersonCohorts } from './PersonCohorts'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { NewPropertyComponent } from './NewPropertyComponent'
-
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { PersonsTabType } from '~/types'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -24,8 +21,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
-
-dayjs.extend(relativeTime)
 
 const { TabPane } = Tabs
 

--- a/frontend/src/scenes/persons/PersonsTable.tsx
+++ b/frontend/src/scenes/persons/PersonsTable.tsx
@@ -1,8 +1,6 @@
 import React, { useRef } from 'react'
 import { Button } from 'antd'
 import { combineUrl } from 'kea-router'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { Link } from 'lib/components/Link'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
@@ -13,9 +11,6 @@ import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { midEllipsis } from 'lib/utils'
 import { PersonHeader } from './PersonHeader'
 import { ResizableColumnType, ResizableTable } from 'lib/components/ResizableTable'
-
-dayjs.extend(relativeTime)
-
 interface PersonsTableType {
     people: PersonType[]
     loading?: boolean

--- a/frontend/src/scenes/plugins/plugin/PluginError.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginError.tsx
@@ -1,9 +1,9 @@
 import { Button, Popover, Tag } from 'antd'
-import dayjs from 'dayjs'
 import React from 'react'
 import { ClearOutlined } from '@ant-design/icons'
 import { PluginErrorType } from '~/types'
 import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
+import { dayjs } from 'lib/dayjs'
 
 export function PluginError({ error, reset }: { error: PluginErrorType; reset?: () => void }): JSX.Element | null {
     if (!error) {

--- a/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
@@ -1,13 +1,13 @@
 import { Button, Checkbox, Row, Space } from 'antd'
 import Search from 'antd/lib/input/Search'
 import { LoadingOutlined } from '@ant-design/icons'
-import dayjs from 'dayjs'
 import { useActions, useValues } from 'kea'
 import React from 'react'
 import { ResizableColumnType, ResizableTable } from '../../../lib/components/ResizableTable'
 import { pluralize } from '../../../lib/utils'
 import { PluginLogEntry, PluginLogEntryType } from '../../../types'
 import { LOGS_PORTION_LIMIT, pluginLogsLogic, PluginLogsProps } from './pluginLogsLogic'
+import { dayjs } from 'lib/dayjs'
 
 function PluginLogEntryTypeDisplay(type: PluginLogEntryType): JSX.Element {
     let color: string | undefined

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import dayjs from 'dayjs'
 import { retentionTableLogic } from './retentionTableLogic'
 import { LineGraph } from '../insights/LineGraph'
 import { useActions, useValues } from 'kea'
@@ -10,6 +9,7 @@ import { PersonType } from '~/types'
 import { RetentionTrendPayload, RetentionTrendPeoplePayload } from 'scenes/retention/types'
 import { router } from 'kea-router'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { dayjs } from 'lib/dayjs'
 
 interface RetentionLineGraphProps {
     dashboardItemId?: number | null

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -12,13 +12,11 @@ import {
 } from 'scenes/retention/types'
 
 import './RetentionTable.scss'
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-dayjs.extend(utc)
 
 import { ColumnsType } from 'antd/lib/table'
 import clsx from 'clsx'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { dayjs } from 'lib/dayjs'
 
 export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: number | null }): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -24,7 +24,6 @@ import { DashboardItem, displayMap, getDisplayedType } from 'scenes/dashboard/Da
 import { membersLogic } from 'scenes/organization/Settings/membersLogic'
 import { normalizeColumnTitle } from 'lib/components/Table/utils'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import dayjs from 'dayjs'
 
 import { PageHeader } from 'lib/components/PageHeader'
 import { SavedInsightsEmptyState, UNNAMED_INSIGHT_NAME } from 'scenes/insights/EmptyStates'
@@ -45,6 +44,7 @@ import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { urls } from 'scenes/urls'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { LemonButton } from '../../lib/components/LemonButton'
+import { dayjs } from 'lib/dayjs'
 
 const { TabPane } = Tabs
 

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
@@ -150,8 +150,8 @@ describe('sessionRecordingLogic', () => {
                 .toDispatchActions(['loadRecordingMeta', 'loadRecordingMetaSuccess', 'loadEvents'])
                 .toMatchValues({
                     eventsApiParams: {
-                        after: '2021-10-12T05:12:42+00:00',
-                        before: '2021-10-12T18:48:47+00:00',
+                        after: '2021-10-12T05:12:42Z',
+                        before: '2021-10-12T18:48:47Z',
                         person_id: 1,
                         orderBy: ['timestamp'],
                     },

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -15,11 +15,8 @@ import {
 import { eventUsageLogic, RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from '../teamLogic'
 import { eventWithTime } from 'rrweb/typings/types'
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
 import { getKeyMapping } from 'lib/components/PropertyKeyInfo'
-
-dayjs.extend(utc)
+import { dayjs } from 'lib/dayjs'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -12,10 +12,10 @@ import {
 } from '~/types'
 import { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
 import { router } from 'kea-router'
-import dayjs from 'dayjs'
 import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
 import { teamLogic } from '../teamLogic'
+import { dayjs } from 'lib/dayjs'
 
 export type SessionRecordingId = string
 export type PersonUUID = string

--- a/frontend/src/scenes/sessions/LEGACY_sessionsPlayLogic.ts
+++ b/frontend/src/scenes/sessions/LEGACY_sessionsPlayLogic.ts
@@ -8,7 +8,6 @@ import {
     SessionRecordingUsageType,
     SessionType,
 } from '~/types'
-import dayjs from 'dayjs'
 import { LEGACY_sessionsPlayLogicType } from './LEGACY_sessionsPlayLogicType'
 import { EventIndex } from '@posthog/react-rrweb-player'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
@@ -16,6 +15,8 @@ import { toast } from 'react-toastify'
 import { eventUsageLogic, RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from '../teamLogic'
 import { eventWithTime } from 'rrweb/typings/types'
+import { dayjs } from 'lib/dayjs'
+
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
 const convertToNewSessionPlayerDataType = (legacyData: LEGACY_SessionPlayerData): SessionPlayerData => {

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -7,7 +7,6 @@ import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDetailedTime, stripHTTP, pluralize, humanFriendlyDuration } from '~/lib/utils'
 import { SessionDetails } from './SessionDetails'
-import dayjs from 'dayjs'
 import { SessionType } from '~/types'
 import {
     CaretLeftOutlined,
@@ -32,6 +31,7 @@ import { ExpandIcon } from 'lib/components/ExpandIcon'
 import { urls } from 'scenes/urls'
 import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDrawer'
 import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
+import { dayjs } from 'lib/dayjs'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 

--- a/frontend/src/scenes/trends/personsModalLogic.tsx
+++ b/frontend/src/scenes/trends/personsModalLogic.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Link } from 'lib/components/Link'
-import dayjs from 'dayjs'
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import api, { PaginatedResponse } from 'lib/api'
@@ -24,6 +23,7 @@ import { filterTrendsClientSideParams } from 'scenes/insights/sharedUtils'
 import { ACTIONS_LINE_GRAPH_CUMULATIVE } from 'lib/constants'
 import { toast } from 'react-toastify'
 import { cohortsModel } from '~/models/cohortsModel'
+import { dayjs } from 'lib/dayjs'
 
 export interface PersonModalParams {
     action: ActionFilter | 'session' // todo, refactor this session string param out


### PR DESCRIPTION
## Changes

Closes #7155. In a local module we now load `dayjs` and all plugins used across the app. 

## How did you test this code?
- Manually went through pages that uses the `dayjs` library (and particularly custom plugins) to make sure everything works as expected. Examples: dashboards table (time ago), timezone conversion component on insights (timezone / UTC), insight filters, retention table (utc), recordings (before/after plugins).
