### PR TITLE
Fix $active_feature_flags in capture.py

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -18,7 +18,7 @@ from posthog.celery import app as celery_app
 from posthog.exceptions import RequestParsingError, generate_exception_response
 from posthog.helpers.session_recording import preprocess_session_recording_events
 from posthog.models import Team
-from posthog.models.feature_flag import get_active_feature_flags
+from posthog.models.feature_flag import get_overridden_feature_flags
 from posthog.models.utils import UUIDT
 from posthog.utils import cors_response, get_ip_address, is_clickhouse_enabled
 
@@ -136,7 +136,7 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
 def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], team: Team, distinct_id: str):
     """If the event comes from web, ensure that it contains property $active_feature_flags."""
     if event["properties"].get("$lib") == "web" and "$active_feature_flags" not in event["properties"]:
-        flags = get_active_feature_flags(team, distinct_id)
+        flags = get_overridden_feature_flags(team, distinct_id)
         event["properties"]["$active_feature_flags"] = list(flags.keys())
         for k, v in flags.items():
             event["properties"][f"$feature/{k}"] = v

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -13,8 +13,9 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from posthog.api.test.mock_sentry import mock_sentry_context_for_tagging
-from posthog.models import PersonalAPIKey
-from posthog.models.feature_flag import FeatureFlag
+from posthog.models import Person, PersonalAPIKey
+from posthog.models.feature_flag import FeatureFlag, FeatureFlagOverride
+from posthog.models.person import PersonDistinctId
 from posthog.test.base import BaseTest
 
 
@@ -769,6 +770,30 @@ class TestCapture(BaseTest):
             },
         )
         arguments = self._to_arguments(patch_process_event_with_plugins)
+        self.assertEqual(arguments["data"]["properties"]["$active_feature_flags"], ["test-ff"])
+
+    @patch("posthog.api.capture.celery_app.send_task")
+    def test_add_feature_flags_with_overrides_if_missing(self, patch_process_event_with_plugins) -> None:
+        feature_flag_instance = FeatureFlag.objects.create(
+            team=self.team, created_by=self.user, key="test-ff", rollout_percentage=0
+        )
+        Person.objects.create(
+            team=self.team, distinct_ids=[self.user.distinct_id], properties={"email": self.user.email},
+        )
+        FeatureFlagOverride.objects.create(
+            team=self.team, user=self.user, feature_flag=feature_flag_instance, override_value=True
+        )
+        self.client.post(
+            "/track/",
+            data={
+                "data": json.dumps(
+                    [{"event": "purchase", "properties": {"distinct_id": self.user.distinct_id, "$lib": "web"}}]
+                ),
+                "api_key": self.team.api_token,
+            },
+        )
+        arguments = self._to_arguments(patch_process_event_with_plugins)
+        self.assertEqual(arguments["data"]["properties"]["$feature/test-ff"], True)
         self.assertEqual(arguments["data"]["properties"]["$active_feature_flags"], ["test-ff"])
 
     def test_handle_lacking_event_name_field(self):

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -15,7 +15,6 @@ from rest_framework import status
 from posthog.api.test.mock_sentry import mock_sentry_context_for_tagging
 from posthog.models import Person, PersonalAPIKey
 from posthog.models.feature_flag import FeatureFlag, FeatureFlagOverride
-from posthog.models.person import PersonDistinctId
 from posthog.test.base import BaseTest
 
 


### PR DESCRIPTION
## Changes

Resolves https://github.com/PostHog/posthog/issues/7150

If $active_feature_flags isn't in an event's properties, then it gets added in `capture.py`, but `capture.py` didn't account for feature flag overrides.

## How did you test this code?

Tested locally and added a test for the case
