### PR TITLE
Don't log errors into sentry

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
+import logging
 import os
 import sys
 from datetime import timedelta
@@ -23,6 +24,7 @@ from django.core.exceptions import ImproperlyConfigured
 from kombu import Exchange, Queue
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
 from posthog.constants import AnalyticsDBMS
@@ -138,9 +140,10 @@ if not TEST:
     if os.getenv("SENTRY_DSN"):
         sentry_sdk.utils.MAX_STRING_LENGTH = 10_000_000
         # https://docs.sentry.io/platforms/python/
+        sentry_logging = sentry_logging = LoggingIntegration(level=logging.INFO, event_level=None)
         sentry_sdk.init(
             dsn=os.environ["SENTRY_DSN"],
-            integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],
+            integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration(), sentry_logging],
             request_bodies="always",
             send_default_pii=True,
             environment=os.getenv("SENTRY_ENVIRONMENT", "production"),


### PR DESCRIPTION
See https://docs.sentry.io/platforms/python/guides/logging/, previously
all error logs were getting piped into sentry. @guidoiaquinti  added structured
logging support which causes each of these log lines to be treated as
unique, not collapsed by sentry, causing untold spam

This is likely not the best fix, but it's an urgent one.

## How did you test this code?

Starts cleanly with SENTRY_DSN set
