### PR TITLE
refactor(retention): Adds `people_urls` to retention trends response

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -141,7 +141,8 @@ class ClickhouseInsightsViewSet(InsightViewSet):
         if not request.GET.get("date_from"):
             data.update({"date_from": "-11d"})
         filter = RetentionFilter(data=data, request=request, team=self.team)
-        result = ClickhouseRetention().run(filter, team)
+        base_uri = request.build_absolute_uri("/")
+        result = ClickhouseRetention(base_uri=base_uri).run(filter, team)
         return {"result": result}
 
 

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -1,7 +1,7 @@
 import dataclasses
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 from unittest.mock import ANY
 from uuid import uuid4
 
@@ -633,6 +633,7 @@ def create_team(organization):
 
 class EventPattern(TypedDict):
     id: str
+    type: Union[Literal['events'], Literal["actions"]]
 
 
 @dataclasses.dataclass

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -13,6 +13,7 @@ from freezegun import freeze_time
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.queries.funnels.funnel_correlation import EventOddsRatioSerialized, FunnelCorrelation
 from ee.clickhouse.test.test_journeys import journeys_for, update_or_create_person
+from posthog.api.test.test_team import create_team
 from posthog.constants import FunnelCorrelationType
 from posthog.models.element import Element
 from posthog.models.person import Person, PersonDistinctId
@@ -625,10 +626,6 @@ class FunnelCorrelationTest(BaseTest):
 @pytest.fixture(autouse=True)
 def clear_django_cache():
     cache.clear()
-
-
-def create_team(organization):
-    return Team.objects.create(name="Test Team", organization=organization)
 
 
 class EventPattern(TypedDict, total=False):

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -631,7 +631,7 @@ def create_team(organization):
     return Team.objects.create(name="Test Team", organization=organization)
 
 
-class EventPattern(TypedDict):
+class EventPattern(TypedDict, total=False):
     id: str
     type: Union[Literal["events"], Literal["actions"]]
 

--- a/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
+++ b/ee/clickhouse/views/test/test_clickhouse_funnel_correlation.py
@@ -633,7 +633,7 @@ def create_team(organization):
 
 class EventPattern(TypedDict):
     id: str
-    type: Union[Literal['events'], Literal["actions"]]
+    type: Union[Literal["events"], Literal["actions"]]
 
 
 @dataclasses.dataclass

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -1,0 +1,96 @@
+from typing import List, Literal, TypedDict, Union
+import pytest
+import json
+import numbers
+from django.test import TestCase
+from django.test.client import Client
+from ee.clickhouse.test.test_journeys import journeys_for
+from ee.clickhouse.views.test.test_clickhouse_funnel_correlation import EventPattern, create_team
+from posthog.api.test.test_event_definition import create_organization, create_user
+
+
+class RetentionTests(TestCase):
+    def test_can_get_line_chart_and_fetch_people(self):
+        organization = create_organization(name="test")
+        team = create_team(organization=organization)
+        user = create_user(email="test@posthog.com", password="1234", organization=organization)
+
+        self.client.force_login(user)
+
+        journeys_for(events_by_person={
+            "person that stays forever": [
+                {"event": "target event" , "timestamp": "2020-01-01"},
+                {"event": "target event" , "timestamp": "2020-01-02"}
+            ],
+            "person that leaves on 2020-01-02": [
+                {"event": "target event", "timestamp": "2020-01-01"}
+            ]
+        }, team=team)
+
+        retention = get_retention_ok(
+            client=self.client, 
+            team_id=team.pk, 
+            request=RetentionRequest(
+                target_entity={"id": "target event", "type": "events"},
+                returning_entity={"id": "target event", "type": "events"}, 
+                date_from="2020-01-01", 
+                date_to="2020-01-02", 
+                display="ActionsLineGraph",
+                period="Day",
+                retention_type='retention_first_time'
+            )
+        )
+
+        trend_series = retention['result'][0]
+        retention_by_day = get_people_for_retention_trend_series(client=self.client, trend_series=trend_series)
+
+        assert retention_by_day == {
+            "2020-01-01": ["person that stays forever", "person that leaves on 2020-01-02"],
+            "2020-01-01": ["person that stays forever"]
+        }
+
+
+class RetentionRequest(TypedDict):
+    date_from: str
+    date_to: str
+    target_entity: EventPattern
+    returning_entity: EventPattern
+    period: Union[Literal["Hour"], Literal["Day"], Literal["Week"], Literal["Month"]]
+    retention_type: Literal["retention_first_time"]  # probably not an exhaustive list
+    display: Literal["ActionsLineGraph"]  # probably not an exhaustive list
+
+
+class Series(TypedDict):
+    days: List[str]
+    data: List[int]
+    
+    # List of people urls corresponding to `data`
+    people_urls: List[str]
+
+class RetentionTrendResponse(TypedDict):
+    result: List[Series]
+
+
+def get_retention_ok(client: Client, team_id: int, request: RetentionRequest):
+    response = get_retention(client=client, team_id=team_id, request=request)
+    assert response.status_code == 200, response.content
+    return response.json()
+
+
+def get_retention(client: Client, team_id: int, request: RetentionRequest):
+    return client.get(
+        f"/api/projects/{team_id}/insights/retention/",
+        # NOTE: for get requests we need to JSON encode non-scalars
+        data={k: (v if isinstance(v, (str, numbers.Number)) else json.dumps(v)) for k, v in request.items()},
+    )
+
+
+def get_people_for_retention_trend_series(client: Client, trend_series: Series):
+    def get_people_ids_via_url(people_url):
+        response = client.get(people_url)
+        assert response.status_code == 200, response.content
+
+    return {
+        day: get_people_ids_via_url(people_url)  for day, people_url in zip(trend_series['days'], trend_series['people_urls'])
+    }
+        

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -17,37 +17,38 @@ class RetentionTests(TestCase):
 
         self.client.force_login(user)
 
-        journeys_for(events_by_person={
-            "person that stays forever": [
-                {"event": "target event" , "timestamp": "2020-01-01"},
-                {"event": "target event" , "timestamp": "2020-01-02"}
-            ],
-            "person that leaves on 2020-01-02": [
-                {"event": "target event", "timestamp": "2020-01-01"}
-            ]
-        }, team=team)
-
-        retention = get_retention_ok(
-            client=self.client, 
-            team_id=team.pk, 
-            request=RetentionRequest(
-                target_entity={"id": "target event", "type": "events"},
-                returning_entity={"id": "target event", "type": "events"}, 
-                date_from="2020-01-01",
-                total_intervals=2, 
-                date_to="2020-01-02", 
-                display="ActionsLineGraph",
-                period="Day",
-                retention_type='retention_first_time'
-            )
+        journeys_for(
+            events_by_person={
+                "person that stays forever": [
+                    {"event": "target event", "timestamp": "2020-01-01"},
+                    {"event": "target event", "timestamp": "2020-01-02"},
+                ],
+                "person that leaves on 2020-01-02": [{"event": "target event", "timestamp": "2020-01-01"}],
+            },
+            team=team,
         )
 
-        trend_series = retention['result'][0]
+        retention = get_retention_ok(
+            client=self.client,
+            team_id=team.pk,
+            request=RetentionRequest(
+                target_entity={"id": "target event", "type": "events"},
+                returning_entity={"id": "target event", "type": "events"},
+                date_from="2020-01-01",
+                total_intervals=2,
+                date_to="2020-01-02",
+                display="ActionsLineGraph",
+                period="Day",
+                retention_type="retention_first_time",
+            ),
+        )
+
+        trend_series = retention["result"][0]
         retention_by_day = get_people_for_retention_trend_series(client=self.client, trend_series=trend_series)
 
         assert retention_by_day == {
             "2020-01-01": ["person that leaves on 2020-01-02", "person that stays forever"],
-            "2020-01-02": ["person that stays forever"]
+            "2020-01-02": ["person that stays forever"],
         }
 
 
@@ -65,9 +66,10 @@ class RetentionRequest(TypedDict):
 class Series(TypedDict):
     days: List[str]
     data: List[int]
-    
+
     # List of people urls corresponding to `data`
     people_urls: List[str]
+
 
 class RetentionTrendResponse(TypedDict):
     result: List[Series]
@@ -91,9 +93,9 @@ def get_people_for_retention_trend_series(client: Client, trend_series: Series):
     def get_people_ids_via_url(people_url):
         response = client.get(people_url)
         assert response.status_code == 200, response.content
-        return sorted([distinct_id for person in response.json()['result'] for distinct_id in person['distinct_ids']])
+        return sorted([distinct_id for person in response.json()["result"] for distinct_id in person["distinct_ids"]])
 
     return {
-        day: get_people_ids_via_url(people_url) if count else [] for day, count, people_url in zip(trend_series['days'], trend_series['data'], trend_series['people_urls'])
+        day: get_people_ids_via_url(people_url) if count else []
+        for day, count, people_url in zip(trend_series["days"], trend_series["data"], trend_series["people_urls"])
     }
-        

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -1,9 +1,11 @@
-from typing import List, Literal, TypedDict, Union
-import pytest
 import json
 import numbers
+from typing import List, Literal, TypedDict, Union
+
+import pytest
 from django.test import TestCase
 from django.test.client import Client
+
 from ee.clickhouse.test.test_journeys import journeys_for
 from ee.clickhouse.views.test.test_clickhouse_funnel_correlation import EventPattern, create_team
 from posthog.api.test.test_event_definition import create_organization, create_user

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -2,13 +2,14 @@ import json
 import numbers
 from typing import List, Literal, TypedDict, Union
 
-import pytest
 from django.test import TestCase
 from django.test.client import Client
 
 from ee.clickhouse.test.test_journeys import journeys_for
-from ee.clickhouse.views.test.test_clickhouse_funnel_correlation import EventPattern, create_team
-from posthog.api.test.test_event_definition import create_organization, create_user
+from ee.clickhouse.views.test.test_clickhouse_funnel_correlation import EventPattern
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.api.test.test_user import create_user
 
 
 class RetentionTests(TestCase):

--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -14,8 +14,8 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        # Build with: yarn arm64:build:clickhouse
-        image: clickhouse-dev-arm64:latest
+        # Built with: yarn arm64:build:clickhouse
+        image: posthog/clickhouse:v21.9.2.17-stable
         depends_on:
             - kafka
             - zookeeper

--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -14,8 +14,8 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        # Built with: yarn arm64:build:clickhouse
-        image: posthog/clickhouse:v21.9.2.17-stable
+        # Build with: yarn arm64:build:clickhouse
+        image: clickhouse-dev-arm64:latest
         depends_on:
             - kafka
             - zookeeper

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -371,7 +371,8 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if not request.GET.get("date_from"):
             data.update({"date_from": "-11d"})
         filter = RetentionFilter(data=data, request=request)
-        result = retention.Retention().run(filter, team)
+        base_uri = request.build_absolute_uri("/")
+        result = retention.Retention(base_uri=base_uri).run(filter, team)
         return {"result": result}
 
     # ******************************************

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -209,11 +209,12 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 status=400,
             )
         filter = RetentionFilter(request=request)
+        base_uri = request.build_absolute_uri("/")
 
         if display == TRENDS_TABLE:
-            people = self.retention_class().people_in_period(filter, team)
+            people = self.retention_class(base_uri=base_uri).people_in_period(filter, team)
         else:
-            people = self.retention_class().people(filter, team)
+            people = self.retention_class(base_uri=base_uri).people(filter, team)
 
         next_url = paginated_result(people, request, filter.offset)
 

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -7,8 +7,10 @@ from django.conf import settings
 from freezegun.api import freeze_time
 from rest_framework import status
 
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.api.test.test_user import create_user
 from posthog.models import Event, EventDefinition, Organization, Team
-from posthog.models.user import User
 from posthog.tasks.calculate_event_property_usage import calculate_event_property_usage_for_team
 from posthog.test.base import APIBaseTest
 
@@ -143,36 +145,6 @@ class TestEventDefinitionAPI(APIBaseTest):
         self.assertEqual(response.json()["count"], 1)
         for item in response.json()["results"]:
             self.assertIn(item["name"], ["watched_movie"])
-
-
-def create_organization(name: str) -> Organization:
-    return Organization.objects.create(name=name)
-
-
-def create_user(email: str, password: str, organization: Organization):
-    return User.objects.create_and_join(organization, email, password)
-
-
-def create_team(organization: Organization) -> Team:
-    """
-    This is a helper that just creates a team. It currently uses the orm, but we
-    could use either the api, or django admin to create, to get better parity
-    with real world  scenarios.
-
-    Previously these tests were running `posthog.demo.create_demo_team` which
-    also does a lot of creating of other demo data. This is quite complicated
-    and has a couple of downsides:
-
-      1. the tests take 30 seconds just to startup
-      2. it makes it difficult to see what data is being used
-    """
-    return Team.objects.create(
-        organization=organization,
-        name="Test team",
-        ingested_event=True,
-        completed_snippet_onboarding=True,
-        is_demo=True,
-    )
 
 
 @dataclasses.dataclass

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -199,3 +199,12 @@ class TestOrganizationAPI(APIBaseTest):
 
         # Assert nothing was reported
         mock_capture.assert_not_called()
+
+
+def create_organization(name: str) -> Organization:
+    """
+    Helper that just creates an organization. It currently uses the orm, but we
+    could use either the api, or django admin to create, to get better parity
+    with real world scenarios.
+    """
+    return Organization.objects.create(name=name)

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -142,3 +142,14 @@ class TestTeamAPI(APIBaseTest):
         self.assertNotEqual(response_data["api_token"], "xyz")
         self.assertEqual(response_data["api_token"], self.team.api_token)
         self.assertTrue(response_data["api_token"].startswith("phc_"))
+
+
+def create_team(organization: Organization, name: str = "Test team") -> Team:
+    """
+    This is a helper that just creates a team. It currently uses the orm, but we
+    could use either the api, or django admin to create, to get better parity
+    with real world  scenarios.
+    """
+    return Team.objects.create(
+        organization=organization, name=name, ingested_event=True, completed_snippet_onboarding=True, is_demo=True,
+    )

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -498,3 +498,12 @@ class TestLoginViews(APIBaseTest):
         User.objects.all().delete()
         response = self.client.get("/", follow=True)
         self.assertRedirects(response, "/preflight")
+
+
+def create_user(email: str, password: str, organization: Organization):
+    """
+    Helper that just creates a user. It currently uses the orm, but we
+    could use either the api, or django admin to create, to get better parity
+    with real world scenarios.
+    """
+    return User.objects.create_and_join(organization, email, password)

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -84,17 +84,15 @@ class Retention(BaseQuery):
             "count": data[0] if data else 0,
             "days": days,
             "people_urls": [
-                self._construct_people_url_for_trend_interval(
-                    filter=filter, 
-                    selected_interval=index
-                ) for index, _ in enumerate(data)
-            ]
+                self._construct_people_url_for_trend_interval(filter=filter, selected_interval=index)
+                for index, _ in enumerate(data)
+            ],
         }
         return [result]
 
     def _construct_people_url_for_trend_interval(self, filter: RetentionFilter, selected_interval: int):
-        params = filter.with_data({'selected_interval': selected_interval}).to_params()
-        return f'{self._base_uri}api/person/retention/?{urlencode(params)}'
+        params = filter.with_data({"selected_interval": selected_interval}).to_params()
+        return f"{self._base_uri}api/person/retention/?{urlencode(params)}"
 
     def _determine_query_params(self, filter: RetentionFilter, team: Team):
 

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -1,6 +1,6 @@
 import dataclasses
 from typing import Any, Dict, List, Literal, Tuple, Union
-
+from urllib.parse import urlencode
 from django.db import connection
 from django.db.models import Min
 from django.db.models.expressions import Exists, F, OuterRef
@@ -33,6 +33,10 @@ class AppearanceRow:
 
 
 class Retention(BaseQuery):
+    def __init__(self, base_uri, **kwargs):
+        self._base_uri = base_uri
+        super().__init__(**kwargs)
+
     def process_table_result(
         self, resultset: Dict[Tuple[int, int], Dict[str, Any]], filter: RetentionFilter,
     ):
@@ -79,8 +83,18 @@ class Retention(BaseQuery):
             "labels": labels,
             "count": data[0] if data else 0,
             "days": days,
+            "people_urls": [
+                self._construct_people_url_for_trend_interval(
+                    filter=filter, 
+                    selected_interval=index
+                ) for index, _ in enumerate(data)
+            ]
         }
         return [result]
+
+    def _construct_people_url_for_trend_interval(self, filter: RetentionFilter, selected_interval: int):
+        params = filter.with_data({'selected_interval': selected_interval}).to_params()
+        return f'{self._base_uri}api/person/retention/?{urlencode(params)}'
 
     def _determine_query_params(self, filter: RetentionFilter, team: Team):
 

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -1,6 +1,7 @@
 import dataclasses
 from typing import Any, Dict, List, Literal, Tuple, Union
 from urllib.parse import urlencode
+
 from django.db import connection
 from django.db.models import Min
 from django.db.models.expressions import Exists, F, OuterRef

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -34,7 +34,7 @@ class AppearanceRow:
 
 
 class Retention(BaseQuery):
-    def __init__(self, base_uri, **kwargs):
+    def __init__(self, base_uri: str = "/", **kwargs):
         self._base_uri = base_uri
         super().__init__(**kwargs)
 

--- a/posthog/queries/retention.py
+++ b/posthog/queries/retention.py
@@ -36,7 +36,6 @@ class AppearanceRow:
 class Retention(BaseQuery):
     def __init__(self, base_uri: str = "/", **kwargs):
         self._base_uri = base_uri
-        super().__init__(**kwargs)
 
     def process_table_result(
         self, resultset: Dict[Tuple[int, int], Dict[str, Any]], filter: RetentionFilter,


### PR DESCRIPTION
## Changes

As part of https://github.com/PostHog/posthog/issues/6935 we are updating endpoints to return urls to be used for retrieving people corresponding to aggregate counts.

This change, specifically for the retention trend line graph, which corresponds to `display="ActionsLineGraph"` adds an array along side the existing `days` and `data` arrays. I've avoided making any larger changes to the structure, although it would be nice to not have the implicit positional dependencies between these arrays.

## How did you test this code?

automated test