### PR TITLE
Show a CTA when there are no pinned dashboards

### DIFF
--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { Link } from 'lib/components/Link'
 import React, { useState } from 'react'
 import { sceneConfigurations } from 'scenes/scenes'
+import { PushpinOutlined } from '@ant-design/icons'
 import { ProjectSwitcherOverlay } from '~/layout/lemonade/ProjectSwitcher'
 import {
     IconArrowDropDown,
@@ -17,15 +19,10 @@ import {
     IconRecording,
     IconSettings,
     IconTools,
-} from '../../../lib/components/icons'
-import {
-    LemonButton,
-    LemonButtonProps,
-    LemonButtonWithSideAction,
-    SideAction,
-} from '../../../lib/components/LemonButton'
-import { LemonSpacer } from '../../../lib/components/LemonRow'
-import { Lettermark } from '../../../lib/components/Lettermark/Lettermark'
+} from 'lib/components/icons'
+import { LemonButton, LemonButtonProps, LemonButtonWithSideAction, SideAction } from 'lib/components/LemonButton'
+import { LemonSpacer } from 'lib/components/LemonRow'
+import { Lettermark } from 'lib/components/Lettermark/Lettermark'
 import { dashboardsModel } from '../../../models/dashboardsModel'
 import { organizationLogic } from '../../../scenes/organizationLogic'
 import { canViewPlugins } from '../../../scenes/plugins/access'
@@ -156,15 +153,13 @@ function Pages(): JSX.Element {
                                         />
                                     ))
                                 ) : (
-                                    <LemonButton
-                                        fullWidth
-                                        onClick={() => setArePinnedDashboardsShown(false)}
-                                        to={urls.dashboards()}
-                                    >
-                                        <span style={{ color: 'var(--muted)' }}>
-                                            Pin some dashboards for quick access
-                                        </span>
-                                    </LemonButton>
+                                    <div className="text-muted text-center" style={{ maxWidth: 220 }}>
+                                        <PushpinOutlined style={{ marginRight: 4 }} /> Pinned dashboards will show here.{' '}
+                                        <Link onClick={() => setArePinnedDashboardsShown(false)} to={urls.dashboards()}>
+                                            Go to dashboards
+                                        </Link>
+                                        .
+                                    </div>
                                 )}
                             </div>
                         ),

--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -161,7 +161,9 @@ function Pages(): JSX.Element {
                                         onClick={() => setArePinnedDashboardsShown(false)}
                                         to={urls.dashboards()}
                                     >
-                                        <i>Pin dashboards for quick access</i>
+                                        <span style={{ color: 'var(--muted)' }}>
+                                            Pin some dashboards for quick access
+                                        </span>
                                     </LemonButton>
                                 )}
                             </div>

--- a/frontend/src/layout/lemonade/SideBar/SideBar.tsx
+++ b/frontend/src/layout/lemonade/SideBar/SideBar.tsx
@@ -145,15 +145,25 @@ function Pages(): JSX.Element {
                             <div className="SideBar__pinned-dashboards">
                                 <h5>Pinned dashboards</h5>
                                 <LemonSpacer />
-                                {pinnedDashboards.map((dashboard) => (
-                                    <PageButton
-                                        key={dashboard.id}
-                                        title={dashboard.name}
-                                        identifier={dashboard.id}
+                                {pinnedDashboards.length > 0 ? (
+                                    pinnedDashboards.map((dashboard) => (
+                                        <PageButton
+                                            key={dashboard.id}
+                                            title={dashboard.name}
+                                            identifier={dashboard.id}
+                                            onClick={() => setArePinnedDashboardsShown(false)}
+                                            to={urls.dashboard(dashboard.id)}
+                                        />
+                                    ))
+                                ) : (
+                                    <LemonButton
+                                        fullWidth
                                         onClick={() => setArePinnedDashboardsShown(false)}
-                                        to={urls.dashboard(dashboard.id)}
-                                    />
-                                ))}
+                                        to={urls.dashboards()}
+                                    >
+                                        <i>Pin dashboards for quick access</i>
+                                    </LemonButton>
+                                )}
                             </div>
                         ),
                     },


### PR DESCRIPTION
## Changes

This says it:

| Before | After |
| --- | --- |
| ![Zrzut ekranu 2021-11-17 o 15 21 45](https://user-images.githubusercontent.com/4550621/142218402-22d71af9-2801-4339-a9e5-69dd60446082.png) | ![Zrzut ekranu 2021-11-17 o 15 20 53](https://user-images.githubusercontent.com/4550621/142218403-88473523-5a57-4a1d-a8fb-c4ee2d83920e.png) |

The button takes you to the Dashboards page.