### PR TITLE
dev(clickhouse): use prebuild arm64 clickhouse image

### DIFF
--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -14,8 +14,8 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        # Build with: yarn arm64:build:clickhouse
-        image: clickhouse-dev-arm64:latest
+        # Built with: yarn arm64:build:clickhouse
+        image: posthog/clickhouse:v21.9.2.17-stable
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
I built this image a while ago, it's built with `yarn
arm64:build:clickhouse`, then I did a multipart build to copy only one
binary over and symlinking the various incantations (eg. server, client
etc) to keep the size down.

Note I didn't actually save this multistage 🤔  so.... it's a little messy. I 
can recreate if desired.