### PR TITLE
Make "Release notes" point to latest version instead of currently running

### DIFF
--- a/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/lemonade/TopBar/SitePopover.tsx
@@ -182,21 +182,20 @@ function Version(): JSX.Element {
                     </div>
                     {updateAvailable && <div className="supplement">{latestVersion} is available</div>}
                 </div>
-                <Link
-                    href={`https://posthog.com/blog/the-posthog-array-${preflight?.posthog_version?.replace(
-                        /\./g,
-                        '-'
-                    )}`}
-                    target="_blank"
-                    rel="noopener"
-                    onClick={() => {
-                        closeSitePopover()
-                    }}
-                    className="SitePopover__side-link"
-                    data-attr="update-indicator-badge"
-                >
-                    Release notes
-                </Link>
+                {latestVersion && (
+                    <Link
+                        href={`https://posthog.com/blog/the-posthog-array-${latestVersion.replace(/\./g, '-')}`}
+                        target="_blank"
+                        rel="noopener"
+                        onClick={() => {
+                            closeSitePopover()
+                        }}
+                        className="SitePopover__side-link"
+                        data-attr="update-indicator-badge"
+                    >
+                        Release notes
+                    </Link>
+                )}
             </>
         </LemonRow>
     )


### PR DESCRIPTION
## Changes

So I clicked this:
![Zrzut ekranu 2021-11-17 o 16 34 41](https://user-images.githubusercontent.com/4550621/142231054-ffc06012-42d0-45e4-b1b9-1df845f14699.png)
I missed this when approving #7045, but this is a suboptimal experience: I wasn't redirected to 1.30.0 notes to find out what's new, only to 1.29.0 ones – for the version I'm _already_ running.
This makes the link point to the latest version in existence.

