### PR TITLE
Garbage collect replayer

### DIFF
--- a/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
@@ -202,7 +202,7 @@ export const seekbarLogic = kea<seekbarLogicType>({
         afterMount: () => {
             window.addEventListener('resize', () => actions.setCurrentTime(values.time.current))
         },
-        afterUnmount: () => {
+        beforeUnmount: () => {
             window.removeEventListener('resize', () => actions.setCurrentTime(values.time.current))
         },
     }),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -176,7 +176,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             actions.setReplayer(replayer)
         },
         setReplayer: ({ replayer }) => {
-            if (!replayer) {
+            if (replayer) {
                 actions.setPlay()
             }
         },

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -175,8 +175,10 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
             actions.setReplayer(replayer)
         },
-        setReplayer: () => {
-            actions.setPlay()
+        setReplayer: ({ replayer }) => {
+            if (!replayer) {
+                actions.setPlay()
+            }
         },
         loadRecordingMetaSuccess: async ({ sessionPlayerData }, breakpoint) => {
             // Set meta timestamps when first chunk loads. The first time is a guesstimate that's later corrected by

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -30,7 +30,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
     },
     actions: {
         initReplayer: (frame: HTMLDivElement) => ({ frame }),
-        setReplayer: (replayer: Replayer) => ({ replayer }),
+        setReplayer: (replayer: Replayer | null) => ({ replayer }),
         setPlay: true,
         setPause: true,
         setBuffer: true,
@@ -335,4 +335,10 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
     windowValues: {
         isSmallScreen: (window) => window.innerWidth < getBreakpoint('md'),
     },
+    events: ({ values, actions }) => ({
+        beforeUnmount: () => {
+            values.replayer?.pause()
+            actions.setReplayer(null)
+        },
+    }),
 })


### PR DESCRIPTION
## Changes

Closes #7193. Garbage collecting `replayer` before unmounting recordingPlayerLogic will prevent replayer calls from firing even when the drawer is closed.

## How did you test this code?

Observe that we don't see console errors anymore.
