### PR TITLE
Correlation analysis UI

### DIFF
--- a/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
+++ b/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .property-names-select-container {
     // Make sure we can absolutely position the popover
     position: relative;
@@ -11,19 +13,19 @@
         display: flex;
         align-items: stretch;
         align-items: center;
-        padding: 8px;
+        padding: 4px 8px;
 
         /* background/clear */
 
         background: #ffffff;
         /* main/primary */
 
-        border: 1px solid var(--primary);
+        border: 1px solid $border;
         border-radius: 4px;
 
         .checkbox-icon {
             font-size: 18px;
-            color: var(--primary);
+            color: $primary;
         }
 
         .selection-status-text {
@@ -33,6 +35,17 @@
 
         &:hover {
             cursor: pointer;
+            .dropdown-icon {
+                border-radius: $radius;
+                background-color: $primary_hover;
+            }
+        }
+
+        .dropdown-icon {
+            font-size: 1.5em;
+            line-height: 0;
+            margin-left: 4px;
+            color: $primary_alt;
         }
     }
 
@@ -54,9 +67,9 @@
         background: #ffffff;
         /* main/primary */
 
-        border: 1px solid var(--primary);
+        border: 1px solid $primary;
         box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-        border-radius: 4px;
+        border-radius: $radius;
 
         .search-box {
             padding: 8px;
@@ -66,12 +79,12 @@
             background: #ffffff;
             /* border/default */
 
-            border: 1px solid #d9d9d9;
+            border: 1px solid $border;
             box-sizing: border-box;
-            border-radius: 4px;
+            border-radius: $radius;
 
             &:focus-within {
-                border-color: var(--primary);
+                border-color: $primary;
             }
         }
 
@@ -89,10 +102,10 @@
                 width: 100%;
 
                 background: #ffffff;
-                border-radius: 4px;
+                border-radius: $radius;
 
                 &.checked {
-                    background: #eef2ff;
+                    background: $primary_hover;
                 }
             }
 
@@ -101,7 +114,7 @@
                 text-align: center;
                 font-size: 14px;
                 line-height: 24px;
-                color: #2d2d2d;
+                color: $text_default;
                 margin: 1em 4px;
             }
         }

--- a/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.tsx
+++ b/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.tsx
@@ -1,10 +1,10 @@
-import CaretDownFilled from '@ant-design/icons/lib/icons/CaretDownFilled'
-import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined'
+import { SearchOutlined } from '@ant-design/icons'
 import { Checkbox, Input } from 'antd'
 import { BindLogic, useActions, useValues } from 'kea'
 import React from 'react'
 import { propertySelectLogic } from './propertyNamesSelectLogic'
-import './styles.scss'
+import './PropertyNamesSelect.scss'
+import { IconArrowDropDown } from '../icons'
 
 // Incrementing counter to ensure uniqueness of logic for each component
 let propertyNameSelectCounter = 0
@@ -119,8 +119,9 @@ export const PropertyNamesSelectBox = ({
                         <div className="selection-status-text">
                             {selectedProperties.size} of {properties.length}
                         </div>
-
-                        <CaretDownFilled />
+                        <span className="dropdown-icon">
+                            <IconArrowDropDown />
+                        </span>
                     </>
                 ) : (
                     'Loading properties'

--- a/frontend/src/lib/components/ResizableTable/TableConfig.scss
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.scss
@@ -26,7 +26,7 @@
         }
 
         &.selected {
-            background-color: #eef2ff;
+            background-color: $primary_hover;
         }
     }
 }

--- a/frontend/src/scenes/insights/FunnelCorrelation.scss
+++ b/frontend/src/scenes/insights/FunnelCorrelation.scss
@@ -1,6 +1,8 @@
 @import '~/vars';
 
 .funnel-correlation {
+    margin-bottom: $default_spacing * 3;
+
     .skew-warning {
         margin-top: $default_spacing;
         line-height: 2em;

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -86,4 +86,18 @@
             border-bottom: 1px solid $border;
         }
     }
+
+    .nested-properties-loading {
+        text-align: center;
+        padding: $default_spacing * 2 0;
+
+        h3 {
+            font-size: 1rem;
+            font-weight: bold;
+            margin-bottom: 0;
+            p {
+                color: $text_muted_alt;
+            }
+        }
+    }
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -2,7 +2,8 @@
 
 .funnel-correlation-table {
     margin-top: $default_spacing;
-    border: 1px solid #d9d9d9;
+    border: 1px solid $border;
+    border-radius: $radius;
 
     .funnel-correlation-header {
         background: #f2f2f2;
@@ -12,22 +13,23 @@
         flex-grow: 1;
         justify-content: space-between;
         align-content: space-between;
-        margin-top: 2px;
+        border-top-left-radius: $radius;
+        border-top-right-radius: $radius;
         padding-bottom: 5px;
 
         .table-header {
-            font-family: Inter;
             font-style: normal;
-            font-weight: 600;
+            font-weight: bold;
             font-size: 11px;
             line-height: 16px;
+            padding-bottom: 4px;
 
             display: flex;
             align-items: center;
             letter-spacing: 0.02em;
             text-transform: uppercase;
 
-            color: #2d2d2d;
+            color: $text_default;
             flex: none;
             flex-grow: 4;
             margin-left: $default_spacing;

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -5,6 +5,12 @@
     border: 1px solid $border;
     border-radius: $radius;
 
+    .ant-table {
+        thead th {
+            border-bottom: 1px solid $border;
+        }
+    }
+
     .funnel-correlation-header {
         background: #f2f2f2;
         display: flex;
@@ -63,6 +69,15 @@
 
                 color: rgba(0, 0, 0, 0.5);
             }
+        }
+    }
+
+    .nested-properties-table {
+        margin: $default_spacing;
+        border: 1px solid $border;
+        border-radius: $radius;
+        thead th {
+            border-bottom: 1px solid $border;
         }
     }
 }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -72,6 +72,12 @@
         }
     }
 
+    .column-info {
+        color: $text_muted_alt;
+        cursor: pointer;
+        padding-left: 4px;
+    }
+
     .nested-properties-table {
         margin: $default_spacing;
         border: 1px solid $border;

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Row, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
-import { RiseOutlined, FallOutlined, EllipsisOutlined } from '@ant-design/icons'
+import { RiseOutlined, FallOutlined, EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { IconSelectEvents, IconUnfoldLess, IconUnfoldMore } from 'lib/components/icons'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType } from '~/types'
@@ -284,17 +284,37 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                         ellipsis
                     />
                     <Column
-                        title="Completed"
+                        title={
+                            <div className="flex-center">
+                                Completed
+                                <Tooltip title="Users who performed the event and completed the entire funnel.">
+                                    <InfoCircleOutlined className="column-info" />
+                                </Tooltip>
+                            </div>
+                        }
                         key="success_count"
                         render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
                         width={90}
                         align="center"
                     />
                     <Column
-                        title="Dropped off"
+                        title={
+                            <div className="flex-center">
+                                Dropped off
+                                <Tooltip
+                                    title={
+                                        <>
+                                            Users who performed the event and did <b>not complete</b> the entire funnel.
+                                        </>
+                                    }
+                                >
+                                    <InfoCircleOutlined className="column-info" />
+                                </Tooltip>
+                            </div>
+                        }
                         key="failure_count"
                         render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
-                        width={100}
+                        width={120}
                         align="center"
                     />
                     <Column

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Row, Table } from 'antd'
+import { Row, Spin, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
 import { RiseOutlined, FallOutlined, EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons'
@@ -124,12 +124,21 @@ export function FunnelCorrelationTable(): JSX.Element | null {
     }
 
     const renderNestedTable = (eventName: string): JSX.Element => {
+        if (eventWithPropertyCorrelationsLoading) {
+            return (
+                <div className="nested-properties-loading">
+                    <Spin />
+                    <h3>Loading correlation results</h3>
+                    <p>This process can take up to 20 seconds. </p>
+                </div>
+            )
+        }
+
         return (
             <div>
                 <h4 style={{ paddingLeft: 16 }}>Correlated properties</h4>
                 <Table
                     dataSource={eventWithPropertyCorrelationsValues[eventName]}
-                    loading={eventWithPropertyCorrelationsLoading}
                     rowKey={(record: FunnelCorrelation) => record.event.event}
                     className="nested-properties-table"
                     scroll={{ x: 'max-content' }}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Row, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
-import { RiseOutlined, FallOutlined, EllipsisOutlined } from '@ant-design/icons'
+import { RiseOutlined, FallOutlined, EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType } from '~/types'
 import Checkbox from 'antd/lib/checkbox/Checkbox'
@@ -16,6 +16,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { VisibilitySensor } from 'lib/components/VisibilitySensor/VisibilitySensor'
 import { Popup } from 'lib/components/Popup/Popup'
 import { LemonButton } from 'lib/components/LemonButton'
+import { Tooltip } from 'lib/components/Tooltip'
 
 export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -202,17 +203,37 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                         width="60%"
                     />
                     <Column
-                        title="Completed"
+                        title={
+                            <div className="flex-center">
+                                Completed
+                                <Tooltip title="Users who have this property and completed the entire funnel.">
+                                    <InfoCircleOutlined className="column-info" />
+                                </Tooltip>
+                            </div>
+                        }
                         key="success_count"
                         render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
                         width={90}
                         align="center"
                     />
                     <Column
-                        title="Dropped off"
+                        title={
+                            <div className="flex-center">
+                                Dropped off
+                                <Tooltip
+                                    title={
+                                        <>
+                                            Users who have this property and did <b>not complete</b> the entire funnel.
+                                        </>
+                                    }
+                                >
+                                    <InfoCircleOutlined className="column-info" />
+                                </Tooltip>
+                            </div>
+                        }
                         key="failure_count"
                         render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
-                        width={100}
+                        width={120}
                         align="center"
                     />
                     <Column

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -149,7 +149,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                         </div>
                         <div
                             className="tab-btn ant-btn"
-                            style={{ marginRight: '5px', paddingTop: '1px', paddingBottom: '1px' }}
+                            style={{ marginRight: '8px', paddingTop: '1px', paddingBottom: '1px' }}
                             onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
                         >
                             <Checkbox
@@ -201,7 +201,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                         align="center"
                     />
                     <Column
-                        title="Actions"
+                        title=""
                         key="actions"
                         render={(_, record: FunnelCorrelation) => <CorrelationActionsCell record={record} />}
                         align="center"

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -132,10 +132,17 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                                 />
                             </>
                         )}
-                        <p className="title">CORRELATION</p>
+                        <p className="title" style={{ marginLeft: 8 }}>
+                            CORRELATION
+                        </p>
                         <div
                             className="tab-btn ant-btn"
-                            style={{ marginRight: '2px', paddingTop: '1px', paddingBottom: '1px' }}
+                            style={{
+                                paddingTop: '1px',
+                                paddingBottom: '1px',
+                                borderTopRightRadius: 0,
+                                borderBottomRightRadius: 0,
+                            }}
                             onClick={() => onClickCorrelationType(FunnelCorrelationType.Success)}
                         >
                             <Checkbox
@@ -149,7 +156,13 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                         </div>
                         <div
                             className="tab-btn ant-btn"
-                            style={{ marginRight: '8px', paddingTop: '1px', paddingBottom: '1px' }}
+                            style={{
+                                marginRight: '8px',
+                                paddingTop: '1px',
+                                paddingBottom: '1px',
+                                borderTopLeftRadius: 0,
+                                borderBottomLeftRadius: 0,
+                            }}
                             onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
                         >
                             <Checkbox
@@ -180,7 +193,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                     }}
                 >
                     <Column
-                        title="Correlated Person Properties"
+                        title="Person property"
                         key="propertName"
                         render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
                         align="left"

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import { Button, Table } from 'antd'
+import React, { useState } from 'react'
+import { Row, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
-import { RiseOutlined, FallOutlined } from '@ant-design/icons'
+import { RiseOutlined, FallOutlined, EllipsisOutlined } from '@ant-design/icons'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelCorrelation, FunnelCorrelationResultsType, FunnelCorrelationType } from '~/types'
 import Checkbox from 'antd/lib/checkbox/Checkbox'
@@ -14,6 +14,8 @@ import { IconSelectProperties } from 'lib/components/icons'
 import './FunnelCorrelationTable.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { VisibilitySensor } from 'lib/components/VisibilitySensor/VisibilitySensor'
+import { Popup } from 'lib/components/Popup/Popup'
+import { LemonButton } from 'lib/components/LemonButton'
 
 export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -232,13 +234,34 @@ const CorrelationActionsCell = ({ record }: { record: FunnelCorrelation }): JSX.
     const { isPropertyExcludedFromProject } = useValues(logic)
     const propertyName = (record.event.event || '').split('::')[0]
 
+    const [popoverOpen, setPopoverOpen] = useState(false)
+
     return (
-        <Button
-            disabled={isPropertyExcludedFromProject(propertyName)}
-            onClick={() => excludePropertyFromProject(propertyName)}
-            type="link"
-        >
-            Exclude from project
-        </Button>
+        <Row style={{ justifyContent: 'flex-end' }}>
+            <Popup
+                visible={popoverOpen}
+                actionable
+                onClickOutside={() => setPopoverOpen(false)}
+                overlay={
+                    <>
+                        <LemonButton
+                            disabled={isPropertyExcludedFromProject(propertyName)}
+                            onClick={() => excludePropertyFromProject(propertyName)}
+                            fullWidth
+                            title="Remove this property from any correlation analysis report in this project."
+                        >
+                            Exclude event from project
+                        </LemonButton>
+                    </>
+                }
+            >
+                <LemonButton type="stealth" style={{ paddingLeft: 0 }} onClick={() => setPopoverOpen(!popoverOpen)}>
+                    <EllipsisOutlined
+                        style={{ color: 'var(--primary)', fontSize: 24 }}
+                        className="insight-dropdown-actions"
+                    />
+                </LemonButton>
+            </Popup>
+        </Row>
     )
 }

--- a/frontend/src/styles/antd.less
+++ b/frontend/src/styles/antd.less
@@ -20,6 +20,7 @@ with SASS, leading to duplicated config. When changing any variable here, please
 @layout-body-background: #fff;
 @font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+@table-expanded-row-bg: #fafaf9;
 
 .hide-gte-lg {
     display: none !important;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -300,6 +300,11 @@ code.code {
     justify-content: space-between;
 }
 
+.flex-center {
+    display: flex;
+    align-items: center;
+}
+
 .main-app-content {
     min-width: 0;
     padding: 0 2rem 2rem;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -176,7 +176,8 @@ body strong {
 }
 
 mark {
-    background-color: $mark_color;
+    background-color: $mark_color !important;
+    border-radius: $radius;
 }
 
 // Supplement text, such as email under user name

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -175,6 +175,10 @@ body strong {
     color: $primary;
 }
 
+mark {
+    background-color: $mark_color;
+}
+
 // Supplement text, such as email under user name
 .supplement {
     text-overflow: ellipsis;

--- a/frontend/src/toolbar/flags/featureFlags.scss
+++ b/frontend/src/toolbar/flags/featureFlags.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .flags-button-window {
     width: min(350px, 100vw);
 }
@@ -41,8 +43,8 @@
             border-left: 2px solid #fafafa;
 
             .ant-radio-wrapper-checked {
-                background-color: #eef2ff;
-                border-radius: 4px;
+                background-color: $primary_hover;
+                border-radius: $radius;
             }
 
             .ant-radio-wrapper-checked > span {

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -4,7 +4,7 @@ when changing any base config here, please remember to update antd.less too  */
 // Main colors
 $primary: #5375ff;
 $primary_alt: #35416b;
-$primary_hover: #7d9bff;
+$primary_hover: #eef2ff;
 $primary_active: #3d57d9;
 $primary_bg_hover: rgba($primary, 0.1);
 $primary_bg_active: rgba($primary, 0.2);

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -23,6 +23,7 @@ $text_default: #2d2d2d;
 $text_light: rgba(255, 255, 255, 0.88);
 $text_muted: rgba(0, 0, 0, 0.5);
 $text_muted_alt: #747ea1;
+$mark_color: #fdedc9;
 
 // Background colors
 $bg_navy: #35416b;


### PR DESCRIPTION
## Changes

Sands some rough edges of correlation analysis's UI to match @clarkus's designs. In addition, this introduces preparation to include the full numbers matrix.

**Correlated events**
<img width="785" alt="" src="https://user-images.githubusercontent.com/5864173/142345104-36984c99-38d8-448f-963a-941f4389ede4.png">

**Correlated person properties**
<img width="791" alt="" src="https://user-images.githubusercontent.com/5864173/142345121-56e7294f-1afb-489e-86d9-fe3ff247d861.png">

**Loading correlated event properties**
<img width="800" alt="" src="https://user-images.githubusercontent.com/5864173/142345158-0840b7ff-504a-4c6e-822a-d9c234da4e14.png">


## How did you test this code?
Enabling correlation analysis and creating a dummy funnel.
