### PR TITLE
Spinner UI

### DIFF
--- a/frontend/src/lib/components/AppEditorLink/EditAppUrls.tsx
+++ b/frontend/src/lib/components/AppEditorLink/EditAppUrls.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
 import { useActions, useValues } from 'kea'
-import { Spin, Button, List } from 'antd'
+import { Button, List } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import { appUrlsLogic } from './appUrlsLogic'
 import { UrlRow } from './UrlRow'
+import { Spinner } from '../Spinner/Spinner'
 
 export function EditAppUrls({
     actionId,
@@ -38,10 +39,10 @@ export function EditAppUrls({
                     />
                 ))}
                 {appUrls.length === 0 && (
-                    <List.Item>
+                    <List.Item className="flex-center">
                         No URLs added yet.
                         {!suggestions ||
-                            (suggestions.length > 0 && <> Suggestions: {suggestionsLoading && <Spin />}</>)}
+                            (suggestions.length > 0 && <> Suggestions: {suggestionsLoading && <Spinner />}</>)}
                     </List.Item>
                 )}
                 {suggestions &&

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -66,12 +66,3 @@
         transform: translateX(1rem) scale(1.1);
     }
 }
-
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
-}

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -17,6 +17,7 @@
     transform: translateZ(0);
     -webkit-animation: loadSpinner 1.25s infinite linear;
     animation: loadSpinner 1.25s infinite linear;
+    display: inline-block;
 
     &.sm {
         width: 16px;

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -1,50 +1,55 @@
 @import '~/vars';
 
-.loader-spinner,
-.loader-spinner:after {
-    border-radius: 50%;
+.spinner {
+    animation: spin 1s infinite linear;
+    display: inline-block;
     width: 32px;
     height: 32px;
-}
-
-.loader-spinner {
-    border-top: 4px solid $primary_hover;
-    border-right: 4px solid $primary;
-    border-bottom: 4px solid $primary;
-    border-left: 4px solid $primary;
-    transform: translateZ(0);
-    animation: loadSpinner 1.25s infinite linear;
-    display: inline-block;
-
+    flex-shrink: 0;
+    .base,
+    .overlay {
+        display: block;
+        fill: transparent;
+        stroke: var(--primary);
+        stroke-width: 8px;
+        transform-origin: center;
+    }
+    .base {
+        opacity: 0.25;
+    }
+    .overlay {
+        animation: writhe 1s infinite ease both;
+        stroke-linecap: round;
+        stroke-dashoffset: -30;
+        stroke-dasharray: 60;
+    }
+    &.inverse {
+        .base,
+        .overlay {
+            stroke: #fff;
+        }
+    }
     &.sm {
         width: 16px;
         height: 16px;
-        border-top-width: 2px;
-        border-bottom-width: 2px;
-        border-right-width: 2px;
-        border-left-width: 2px;
     }
-
     &.lg {
         width: 64px;
         height: 64px;
-        border-top-width: 8px;
-        border-bottom-width: 8px;
-        border-right-width: 8px;
-        border-left-width: 8px;
-    }
-
-    &.inverse {
-        border-color: #fff;
-        border-top-color: rgba(255, 255, 255, 0.4);
     }
 }
 
-@keyframes loadSpinner {
+@keyframes writhe {
     0% {
-        transform: rotate(0deg);
+        stroke-dashoffset: -40;
+        stroke-dasharray: 50;
+    }
+    50% {
+        stroke-dashoffset: -30;
+        stroke-dasharray: 70;
     }
     100% {
-        transform: rotate(360deg);
+        stroke-dashoffset: -40;
+        stroke-dasharray: 50;
     }
 }

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -36,6 +36,11 @@
         border-right-width: 8px;
         border-left-width: 8px;
     }
+
+    &.inverse {
+        border-color: #fff;
+        border-top-color: rgba(255, 255, 255, 0.4);
+    }
 }
 
 @-webkit-keyframes loadSpinner {

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -12,10 +12,7 @@
     border-right: 4px solid $primary;
     border-bottom: 4px solid $primary;
     border-left: 4px solid $primary;
-    -webkit-transform: translateZ(0);
-    -ms-transform: translateZ(0);
     transform: translateZ(0);
-    -webkit-animation: loadSpinner 1.25s infinite linear;
     animation: loadSpinner 1.25s infinite linear;
     display: inline-block;
 
@@ -43,23 +40,11 @@
     }
 }
 
-@-webkit-keyframes loadSpinner {
-    0% {
-        -webkit-transform: rotate(0deg);
-        transform: rotate(0deg);
-    }
-    100% {
-        -webkit-transform: rotate(360deg);
-        transform: rotate(360deg);
-    }
-}
 @keyframes loadSpinner {
     0% {
-        -webkit-transform: rotate(0deg);
         transform: rotate(0deg);
     }
     100% {
-        -webkit-transform: rotate(360deg);
         transform: rotate(360deg);
     }
 }

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -1,0 +1,59 @@
+@import '~/vars';
+
+.loader-spinner,
+.loader-spinner:after {
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+}
+
+.loader-spinner {
+    border-top: 4px solid $primary_hover;
+    border-right: 4px solid $primary;
+    border-bottom: 4px solid $primary;
+    border-left: 4px solid $primary;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation: loadSpinner 1.25s infinite linear;
+    animation: loadSpinner 1.25s infinite linear;
+
+    &.sm {
+        width: 16px;
+        height: 16px;
+        border-top-width: 2px;
+        border-bottom-width: 2px;
+        border-right-width: 2px;
+        border-left-width: 2px;
+    }
+
+    &.lg {
+        width: 64px;
+        height: 64px;
+        border-top-width: 8px;
+        border-bottom-width: 8px;
+        border-right-width: 8px;
+        border-left-width: 8px;
+    }
+}
+
+@-webkit-keyframes loadSpinner {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+@keyframes loadSpinner {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}

--- a/frontend/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { ComponentMeta } from '@storybook/react'
+
+import { Spinner as SpinnerComponent } from './Spinner'
+
+export default {
+    title: 'PostHog/Components/Spinner',
+    component: SpinnerComponent,
+    parameters: { options: { showPanel: true } },
+} as ComponentMeta<typeof Spinner>
+
+export function Spinner(): JSX.Element {
+    return (
+        <>
+            <h2>Small – primary</h2>
+            <SpinnerComponent size="sm" />
+            <h2>Medium – primary (default)</h2>
+            <SpinnerComponent />
+            <h2>Large – primary</h2>
+            <SpinnerComponent size="lg" />
+            <h2>Medium – inverse</h2>
+            <div style={{ display: 'flex', background: 'black', width: 'fit-content', padding: 8 }}>
+                <SpinnerComponent type="inverse" />
+            </div>
+        </>
+    )
+}

--- a/frontend/src/lib/components/Spinner/Spinner.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.tsx
@@ -1,0 +1,11 @@
+import clsx from 'clsx'
+import React from 'react'
+import './Spinner.scss'
+
+interface SpinnerProps {
+    size?: 'sm' | 'md' | 'lg'
+}
+
+export function Spinner({ size = 'md' }: SpinnerProps): JSX.Element {
+    return <div className={clsx('loader-spinner', size)} />
+}

--- a/frontend/src/lib/components/Spinner/Spinner.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.tsx
@@ -4,9 +4,10 @@ import './Spinner.scss'
 
 interface SpinnerProps {
     size?: 'sm' | 'md' | 'lg'
+    type?: 'primary' | 'inverse'
     style?: React.CSSProperties
 }
 
-export function Spinner({ size = 'md', style }: SpinnerProps): JSX.Element {
-    return <div className={clsx('loader-spinner', size)} style={style} />
+export function Spinner({ size = 'md', type = 'primary', style }: SpinnerProps): JSX.Element {
+    return <div className={clsx('loader-spinner', size, type)} style={style} />
 }

--- a/frontend/src/lib/components/Spinner/Spinner.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.tsx
@@ -2,12 +2,22 @@ import clsx from 'clsx'
 import React from 'react'
 import './Spinner.scss'
 
-interface SpinnerProps {
+export interface SpinnerProps {
     size?: 'sm' | 'md' | 'lg'
     type?: 'primary' | 'inverse'
     style?: React.CSSProperties
 }
 
 export function Spinner({ size = 'md', type = 'primary', style }: SpinnerProps): JSX.Element {
-    return <div className={clsx('loader-spinner', size, type)} style={style} />
+    return (
+        <svg
+            className={clsx('spinner', size, type)}
+            style={style}
+            viewBox="0 0 48 48"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <circle className="base" cx="24" cy="24" r="20" />
+            <circle className="overlay" cx="24" cy="24" r="20" />
+        </svg>
+    )
 }

--- a/frontend/src/lib/components/Spinner/Spinner.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.tsx
@@ -4,8 +4,9 @@ import './Spinner.scss'
 
 interface SpinnerProps {
     size?: 'sm' | 'md' | 'lg'
+    style?: React.CSSProperties
 }
 
-export function Spinner({ size = 'md' }: SpinnerProps): JSX.Element {
-    return <div className={clsx('loader-spinner', size)} />
+export function Spinner({ size = 'md', style }: SpinnerProps): JSX.Element {
+    return <div className={clsx('loader-spinner', size)} style={style} />
 }

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, PropsWithChildren } from 'react'
 import api from './api'
 import { toast } from 'react-toastify'
-import { Button, Spin } from 'antd'
+import { Button } from 'antd'
 import { EventType, FilterType, ActionFilter, IntervalType, ItemMode, DashboardMode } from '~/types'
 import { tagColors } from 'lib/colors'
 import { CustomerServiceOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
@@ -11,6 +11,7 @@ import { AlignType } from 'rc-trigger/lib/interface'
 import { DashboardEventSource } from './utils/eventUsageLogic'
 import { helpButtonLogic } from './components/HelpButton/HelpButton'
 import { dayjs } from 'lib/dayjs'
+import { Spinner } from './components/Spinner/Spinner'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
@@ -225,7 +226,7 @@ export function successToast(title?: string, message?: string): void {
 export function Loading(props: Record<string, any>): JSX.Element {
     return (
         <div className="loading-overlay" style={props.style}>
-            <Spin />
+            <Spinner size="lg" />
         </div>
     )
 }
@@ -240,7 +241,7 @@ export function TableRowLoading({
     return (
         <tr className={asOverlay ? 'loading-overlay over-table' : ''}>
             <td colSpan={colSpan} style={{ padding: 50, textAlign: 'center' }}>
-                <Spin />
+                <Spinner />
             </td>
         </tr>
     )
@@ -249,7 +250,7 @@ export function TableRowLoading({
 export function SceneLoading(): JSX.Element {
     return (
         <div style={{ textAlign: 'center', marginTop: '20vh' }}>
-            <Spin />
+            <Spinner size="lg" />
         </div>
     )
 }

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -4,14 +4,13 @@ import { kea, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { eventsTableLogic } from 'scenes/events/eventsTableLogic'
 import api from 'lib/api'
-import { Spin } from 'antd'
 import { EventsTable } from 'scenes/events'
 import { urls } from 'scenes/urls'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { ActionType } from '~/types'
-
 import { actionLogicType } from './ActionType'
 import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 interface ActionLogicProps {
     id?: ActionType['id']
     onComplete: () => void
@@ -79,7 +78,7 @@ export function Action({ id }: { id: ActionType['id'] }): JSX.Element {
 
     const { push } = useActions(router)
     const { fetchEvents } = useActions(eventsTableLogic({ fixedFilters, sceneUrl: urls.action(id) }))
-    const { isComplete, action } = useValues(actionLogic({ id, onComplete: fetchEvents }))
+    const { action, isComplete } = useValues(actionLogic({ id, onComplete: fetchEvents }))
     const { loadAction } = useActions(actionLogic({ id, onComplete: fetchEvents }))
     const { preflight } = useValues(preflightLogic)
     const isClickHouseEnabled = !!preflight?.is_clickhouse_enabled
@@ -101,8 +100,10 @@ export function Action({ id }: { id: ActionType['id'] }): JSX.Element {
             {id && !isComplete && (
                 <div style={{ marginBottom: '10rem' }}>
                     <h2 className="subtitle">Events</h2>
-                    <Spin style={{ marginRight: 12 }} />
-                    Calculating action, please hold on.
+                    <div className="flex-center">
+                        <Spinner style={{ marginRight: 12 }} />
+                        Calculating action, please hold on.
+                    </div>
                 </div>
             )}
             {isComplete && (

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, HTMLAttributes } from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Tag, Button, Modal, Input, Row, Spin, Menu, Dropdown } from 'antd'
+import { Table, Tag, Button, Modal, Input, Row, Menu, Dropdown } from 'antd'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { annotationsModel } from '~/models/annotationsModel'
 import { annotationsTableLogic } from './logic'
@@ -17,6 +17,7 @@ import { normalizeColumnTitle, useIsTableScrolling } from 'lib/components/Table/
 import { teamLogic } from '../teamLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -134,7 +135,7 @@ export function Annotations(): JSX.Element {
                     }}
                 >
                     {loadingNext ? (
-                        <Spin />
+                        <Spinner size="sm" />
                     ) : (
                         <Button
                             type="primary"

--- a/frontend/src/scenes/billing/BillingEnrollment.tsx
+++ b/frontend/src/scenes/billing/BillingEnrollment.tsx
@@ -1,9 +1,10 @@
-import { Button, Card, Col, Row, Skeleton, Spin } from 'antd'
+import { Button, Card, Col, Row, Skeleton } from 'antd'
 import { useActions, useValues } from 'kea'
 import React, { useEffect, useState } from 'react'
 import { PlanInterface } from '~/types'
 import { billingLogic } from './billingLogic'
 import defaultImg from 'public/plan-default.svg'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 function Plan({ plan, onSubscribe }: { plan: PlanInterface; onSubscribe: (plan: PlanInterface) => void }): JSX.Element {
     const [detail, setDetail] = useState('')
@@ -73,9 +74,7 @@ export function BillingEnrollment(): JSX.Element | null {
                         {plans.map((plan: PlanInterface) => (
                             <Col sm={8} key={plan.key} className="text-center">
                                 {billingSubscriptionLoading ? (
-                                    <Spin>
-                                        <Plan plan={plan} onSubscribe={handleBillingSubscribe} />
-                                    </Spin>
+                                    <Spinner />
                                 ) : (
                                     <Plan plan={plan} onSubscribe={handleBillingSubscribe} />
                                 )}

--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -2,17 +2,11 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 import { CohortNameInput } from './CohortNameInput'
 import { CohortDescriptionInput } from './CohortDescriptionInput'
-import { Button, Col, Divider, Row, Spin, Tooltip } from 'antd'
+import { Button, Col, Divider, Row, Tooltip } from 'antd'
 import { CohortMatchingCriteriaSection } from './CohortMatchingCriteriaSection'
 import { AvailableFeature, CohortType } from '~/types'
 import { COHORT_DYNAMIC, COHORT_STATIC } from 'lib/constants'
-import {
-    InboxOutlined,
-    SaveOutlined,
-    LoadingOutlined,
-    CalculatorOutlined,
-    OrderedListOutlined,
-} from '@ant-design/icons'
+import { InboxOutlined, SaveOutlined, CalculatorOutlined, OrderedListOutlined } from '@ant-design/icons'
 import Dragger from 'antd/lib/upload/Dragger'
 import { CohortDetailsRow } from './CohortDetailsRow'
 import { Persons } from 'scenes/persons/Persons'
@@ -21,6 +15,7 @@ import { UploadFile } from 'antd/lib/upload/interface'
 import { DropdownSelector } from 'lib/components/DropdownSelector/DropdownSelector'
 import { userLogic } from 'scenes/userLogic'
 import 'antd/lib/dropdown/style/index.css'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export function Cohort(props: { cohort: CohortType }): JSX.Element {
     const logic = cohortLogic(props)
@@ -148,9 +143,10 @@ export function Cohort(props: { cohort: CohortType }): JSX.Element {
                         <h3 className="l3">Matched Users</h3>
                         <span>List of users that currently match the criteria defined</span>
                         {cohort.is_calculating ? (
-                            <div className="cohort-recalculating">
-                                <Spin indicator={<LoadingOutlined style={{ fontSize: 24 }} spin />} /> We're
-                                recalculating who belongs to this cohort. This could take up to a couple of minutes.
+                            <div className="cohort-recalculating flex-center">
+                                <Spinner size="sm" style={{ marginRight: 4 }} />
+                                We're recalculating who belongs to this cohort. This could take up to a couple of
+                                minutes.
                             </div>
                         ) : (
                             <div style={{ marginTop: 15 }}>

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -21,8 +21,6 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 
-dayjs.extend(relativeTime)
-
 const NEW_COHORT: CohortType = {
     id: 'new',
     groups: [

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { DeleteWithUndo, toParams } from 'lib/utils'
-import { Table, Spin, Button, Input } from 'antd'
+import { Table, Button, Input } from 'antd'
 import { ExportOutlined, DeleteOutlined, InfoCircleOutlined, ClockCircleOutlined } from '@ant-design/icons'
 import { cohortsModel } from '../../models/cohortsModel'
 import { useValues, useActions, kea } from 'kea'
@@ -19,6 +19,9 @@ import { Link } from 'lib/components/Link'
 import { PROPERTY_MATCH_TYPE } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
 import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/components/Spinner/Spinner'
+
+dayjs.extend(relativeTime)
 
 const NEW_COHORT: CohortType = {
     id: 'new',
@@ -113,8 +116,8 @@ export function Cohorts(): JSX.Element {
                     return <>N/A</>
                 }
                 return cohort.is_calculating ? (
-                    <span>
-                        Calculating <Spin />
+                    <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+                        Calculating <Spinner size="sm" />
                     </span>
                 ) : (
                     dayjs(cohort.last_calculation).fromNow()

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { Button, Card, Col, Drawer, Input, Row, Spin, Table } from 'antd'
+import { Button, Card, Col, Drawer, Input, Row, Table } from 'antd'
 import { dashboardsLogic } from 'scenes/dashboard/dashboardsLogic'
 import { Link } from 'lib/components/Link'
 import {
@@ -22,6 +22,7 @@ import { ColumnType } from 'antd/lib/table'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
 import { SceneExport } from 'scenes/sceneTypes'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export const scene: SceneExport = {
     component: Dashboards,
@@ -186,7 +187,12 @@ export function Dashboards(): JSX.Element {
             </Drawer>
 
             {dashboardsLoading ? (
-                <Spin />
+                <div className="flex-center" style={{ flexDirection: 'column' }}>
+                    <Spinner />
+                    <div className="mt">
+                        <b>Loading dashboards</b>
+                    </div>
+                </div>
             ) : dashboards.length > 0 || searchTerm ? (
                 <Table
                     dataSource={dashboards}

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { EventDetails } from 'scenes/events/EventDetails'
 import { DownloadOutlined, ExportOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
-import { Button, Col, Row, Spin } from 'antd'
+import { Button, Col, Row } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { autoCaptureEventToDescription, toParams } from 'lib/utils'
@@ -26,6 +26,7 @@ import clsx from 'clsx'
 import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic'
 import { EventsTab, EventsTabs } from 'scenes/events/EventsTabs'
 import { urls } from 'scenes/urls'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 export interface FixedFilters {
     action_id?: ActionType['id']
     person_id?: string | number
@@ -394,8 +395,13 @@ export function EventsTable({
                             textAlign: 'center',
                         }}
                     >
-                        <Button type="primary" onClick={fetchNextEvents}>
-                            {isLoadingNext ? <Spin /> : 'Load more events'}
+                        <Button
+                            type="primary"
+                            onClick={fetchNextEvents}
+                            disabled={isLoadingNext}
+                            style={{ display: 'inline-flex', alignItems: 'center' }}
+                        >
+                            {isLoadingNext ? <Spinner size="sm" /> : 'Load more events'}
                         </Button>
                     </div>
                 </div>

--- a/frontend/src/scenes/ingestion/IngestionWizard.scss
+++ b/frontend/src/scenes/ingestion/IngestionWizard.scss
@@ -1,10 +1,5 @@
 .background {
-    background-color: hsla(210, 6%, 95%, 1);
-}
-
-.prompt-text {
-    font-size: 16px;
-    font-weight: bold;
+    background-color: $bg_bridge;
 }
 
 .platform-item {

--- a/frontend/src/scenes/ingestion/IngestionWizard.scss
+++ b/frontend/src/scenes/ingestion/IngestionWizard.scss
@@ -1,3 +1,5 @@
+@import '~/vars.scss';
+
 .background {
     background-color: $bg_bridge;
 }

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { useInterval } from 'lib/hooks/useInterval'
 import { CardContainer } from 'scenes/ingestion/CardContainer'
-import { Button, Row, Spin, Space, Popconfirm, Dropdown, Menu, Typography } from 'antd'
+import { Button, Row, Space, Popconfirm, Dropdown, Menu, Typography } from 'antd'
 import { ingestionLogic } from 'scenes/ingestion/ingestionLogic'
 import { DownOutlined, SlackSquareOutlined, ReadOutlined } from '@ant-design/icons'
 import { CreateInviteModalWithButton } from 'scenes/organization/Settings/CreateInviteModal'
 import { teamLogic } from 'scenes/teamLogic'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 const { Text } = Typography
 
@@ -112,14 +113,15 @@ export function VerificationPanel(): JSX.Element {
         <CardContainer index={index} totalSteps={totalSteps} onBack={() => setVerify(false)}>
             {!currentTeam?.ingested_event ? (
                 <>
-                    <Row align="middle">
-                        <Spin />
-                        <h2 className="ml-3">Listening for events!</h2>
+                    <Row className="flex-center">
+                        <Spinner style={{ marginRight: 4 }} />
+                        <h2 className="ml-3" style={{ marginBottom: 0, color: 'var(--primary-alt)' }}>
+                            Listening for events...
+                        </h2>
                     </Row>
-                    <p className="prompt-text">
-                        {' '}
-                        Once you have integrated the snippet and sent an event, we will verify it sent properly and
-                        continue.
+                    <p className="prompt-text mt-05">
+                        Once you have integrated the snippet and sent an event, we will verify it was properly received
+                        and continue.
                     </p>
                     <HelperButtonRow />
                 </>

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Modal, Button, Spin } from 'antd'
+import { Table, Modal, Button } from 'antd'
 import { percentage } from 'lib/utils'
 import { Link } from 'lib/components/Link'
 import { retentionTableLogic } from './retentionTableLogic'
@@ -17,6 +17,7 @@ import { ColumnsType } from 'antd/lib/table'
 import clsx from 'clsx'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: number | null }): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -118,7 +119,7 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
                     }}
                     title={results[selectedRow] ? dayjs(results[selectedRow].date).format('MMMM D, YYYY') : ''}
                 >
-                    {results && !peopleLoading ? (
+                    {!peopleLoading ? (
                         <div>
                             {results[selectedRow]?.values[0]?.count === 0 ? (
                                 <span>No persons during this period.</span>
@@ -203,7 +204,7 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
                             )}
                         </div>
                     ) : (
-                        <Spin />
+                        <Spinner size="sm" />
                     )}
                 </Modal>
             )}

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef } from 'react'
 import { useValues, useActions, BindLogic } from 'kea'
 import { decodeParams } from 'kea-router'
-import { Button, Spin, Space, Badge, Switch, Row } from 'antd'
+import { Button, Space, Badge, Switch, Row } from 'antd'
 import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDetailedTime, stripHTTP, pluralize, humanFriendlyDuration } from '~/lib/utils'
@@ -32,6 +32,7 @@ import { urls } from 'scenes/urls'
 import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDrawer'
 import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -300,8 +301,13 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 }}
             >
                 {(pagination || isLoadingNext) && (
-                    <Button type="primary" onClick={fetchNextSessions} data-attr="load-more-sessions">
-                        {isLoadingNext ? <Spin> </Spin> : 'Load more sessions'}
+                    <Button
+                        type="primary"
+                        onClick={fetchNextSessions}
+                        data-attr="load-more-sessions"
+                        disabled={isLoadingNext}
+                    >
+                        {isLoadingNext ? <Spinner /> : 'Load more sessions'}
                     </Button>
                 )}
             </div>

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -346,12 +346,23 @@ code.code {
     animation: highlight 2000ms ease-out;
 }
 
+// Highlight background blink
 @keyframes highlight {
     0% {
         background-color: $yellow_50;
     }
     100% {
         background-color: initial;
+    }
+}
+
+// Generic 360 spin
+@keyframes spin {
+    0% {
+        transform: rotateZ(0deg);
+    }
+    100% {
+        transform: rotateZ(360deg);
     }
 }
 

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -296,6 +296,11 @@ code.code {
     justify-content: space-between;
 }
 
+.flex-center {
+    display: flex;
+    align-items: center;
+}
+
 .main-app-content {
     min-width: 0;
     padding: 0 2rem 2rem;

--- a/frontend/src/toolbar/actions/ActionsList.tsx
+++ b/frontend/src/toolbar/actions/ActionsList.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { actionsLogic } from '~/toolbar/actions/actionsLogic'
-import { Button, Spin, Row, Input } from 'antd'
+import { Button, Row, Input } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { ActionsListView } from '~/toolbar/actions/ActionsListView'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export function ActionsList(): JSX.Element {
     const { allActions, sortedActions, allActionsLoading, searchTerm } = useValues(actionsLogic)
@@ -30,7 +31,13 @@ export function ActionsList(): JSX.Element {
                         <PlusOutlined /> New Action
                     </Button>
                 </Row>
-                {allActions.length === 0 && allActionsLoading ? <Spin /> : <ActionsListView actions={sortedActions} />}
+                {true || (allActions.length === 0 && allActionsLoading) ? (
+                    <div className="text-center mt mb">
+                        <Spinner />
+                    </div>
+                ) : (
+                    <ActionsListView actions={sortedActions} />
+                )}
             </div>
         </>
     )

--- a/frontend/src/toolbar/stats/HeatmapStats.tsx
+++ b/frontend/src/toolbar/stats/HeatmapStats.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
-import { List, Space, Spin } from 'antd'
+import { List, Space } from 'antd'
 import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { getShadowRootPopupContainer } from '~/toolbar/utils'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export function HeatmapStats(): JSX.Element {
     const { countedElements, clickCount, heatmapEnabled, heatmapLoading, heatmapFilter } = useValues(heatmapLogic)
@@ -15,7 +16,7 @@ export function HeatmapStats(): JSX.Element {
         <div style={{ margin: 8 }}>
             {heatmapEnabled ? (
                 <>
-                    <div style={{ marginTop: 0, marginBottom: 10 }}>
+                    <div style={{ marginTop: 0, marginBottom: 10 }} className="flex-center">
                         <DateFilter
                             defaultValue="Last 7 days"
                             dateFrom={heatmapFilter.date_from}
@@ -23,7 +24,7 @@ export function HeatmapStats(): JSX.Element {
                             onChange={(date_from, date_to) => setHeatmapFilter({ date_from, date_to })}
                             getPopupContainer={getShadowRootPopupContainer}
                         />
-                        {heatmapLoading ? <Spin style={{ marginLeft: 8 }} /> : null}
+                        {heatmapLoading ? <Spinner size="sm" style={{ marginLeft: 8 }} /> : null}
                     </div>
                     <div style={{ marginTop: 20, marginBottom: 10 }}>
                         Found: {countedElements.length} elements / {clickCount} clicks!


### PR DESCRIPTION
## Changes

Initial pass at the new loading spinner. Starts using it in some places (not everywhere just yet).

**Spinner component**
![image](https://user-images.githubusercontent.com/5864173/142350539-9ab6e972-7d18-4be9-ac27-14100e1eea88.gif)

**In the wild**
<img width="1198" alt="" src="https://user-images.githubusercontent.com/5864173/142350592-8734cda0-b34f-4d12-a35a-48120932e170.png">
<img width="757" alt="" src="https://user-images.githubusercontent.com/5864173/142350597-e1405abc-f7cc-4259-bf6a-e38c1a83e59c.png">
<img width="1188" alt="" src="https://user-images.githubusercontent.com/5864173/142350604-22a26c17-fc5d-478a-bb04-f75762e3bbbd.png">
<img width="1193" alt="" src="https://user-images.githubusercontent.com/5864173/142350612-36205cfc-bfbf-41de-9fb9-08b9952c8bc6.png">
<img width="911" alt="" src="https://user-images.githubusercontent.com/5864173/142350626-9e9daebb-f1cf-4742-9638-33c9d1b81c28.png">

## How did you test this code?
- Manually set states as loading in all places where the Ant component was being replaced.
