### PR TITLE
Release nav redesign for all Cloud users

### DIFF
--- a/frontend/src/layout/lemonade/TopBar/index.tsx
+++ b/frontend/src/layout/lemonade/TopBar/index.tsx
@@ -12,7 +12,6 @@ import { CreateOrganizationModal } from '../../../scenes/organization/CreateOrga
 import { BulkInviteModal } from '../../../scenes/organization/Settings/BulkInviteModal'
 import { Link } from '../../../lib/components/Link'
 import { IconMenu, IconMenuOpen } from '../../../lib/components/icons'
-import { RedesignOptIn } from '../RedesignOptIn'
 import { CreateProjectModal } from '../../../scenes/project/CreateProjectModal'
 
 export function TopBar(): JSX.Element {

--- a/frontend/src/layout/lemonade/TopBar/index.tsx
+++ b/frontend/src/layout/lemonade/TopBar/index.tsx
@@ -46,7 +46,6 @@ export function TopBar(): JSX.Element {
                     <SearchBox />
                 </div>
                 <div className="TopBar__segment TopBar__segment--right">
-                    <RedesignOptIn />
                     <HelpButton />
                     <SitePopover />
                 </div>

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -44,7 +44,6 @@ import { featureFlagLogic } from '../../lib/logic/featureFlagLogic'
 import { TopBar } from '../lemonade/TopBar'
 import { HelpButton } from 'lib/components/HelpButton/HelpButton'
 import { CommandPalette } from '../../lib/components/CommandPalette'
-import { RedesignOptIn } from '../lemonade/RedesignOptIn'
 
 export function WhoAmI({ user }: { user: UserType }): JSX.Element {
     return (

--- a/frontend/src/layout/navigation/TopNavigation.tsx
+++ b/frontend/src/layout/navigation/TopNavigation.tsx
@@ -347,7 +347,6 @@ function TopNavigationOriginal(): JSX.Element {
                         </div>
                     </Dropdown>
                 </div>
-                <RedesignOptIn />
                 <HelpButton />
                 {user && (
                     <>
@@ -377,5 +376,5 @@ function TopNavigationOriginal(): JSX.Element {
 export function TopNavigation(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
-    return featureFlags[FEATURE_FLAGS.LEMONADE] ? <TopBar /> : <TopNavigationOriginal />
+    return true || featureFlags[FEATURE_FLAGS.LEMONADE] ? <TopBar /> : <TopNavigationOriginal />
 }

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -143,10 +143,10 @@ function AppScene(): JSX.Element | null {
     const layoutContent = activeScene ? (
         <Layout.Content className="main-app-content" data-attr="layout-content">
             {!sceneConfig?.hideDemoWarnings && <DemoWarnings />}
-            {featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT] && !featureFlags[FEATURE_FLAGS.LEMONADE] ? (
+            {featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT] && !(true || featureFlags[FEATURE_FLAGS.LEMONADE]) ? (
                 <CloudAnnouncement message={String(featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT])} />
             ) : null}
-            {featureFlags[FEATURE_FLAGS.LEMONADE] && <Breadcrumbs />}
+            {(true || featureFlags[FEATURE_FLAGS.LEMONADE]) && <Breadcrumbs />}
             <BillingAlerts />
             <BackTo />
             <SceneComponent user={user} {...params} />
@@ -155,7 +155,7 @@ function AppScene(): JSX.Element | null {
 
     return (
         <>
-            {featureFlags[FEATURE_FLAGS.LEMONADE] ? (
+            {true || featureFlags[FEATURE_FLAGS.LEMONADE] ? (
                 <Layout style={{ minHeight: '100vh' }}>
                     {!sceneConfig?.hideTopNav && <TopNavigation />}
                     <SideBar>{layoutContent}</SideBar>


### PR DESCRIPTION
## Changes

It is time.
We released the redesign for all self-hosted users in 1.30.0 and Cloud can't fall behind.
(also, ProductHunt launch, [context](https://posthog.slack.com/archives/C02MTU32X3M/p1637244496038900?thread_ts=1637236751.020900&cid=C02MTU32X3M))