### PR TITLE
Standard empty states

### DIFF
--- a/frontend/src/lib/components/ErrorMessage/ErrorMessage.scss
+++ b/frontend/src/lib/components/ErrorMessage/ErrorMessage.scss
@@ -5,7 +5,7 @@
     border-radius: $radius;
     padding: $default_spacing / 2 $default_spacing;
     color: $danger;
-    font-weight: medium;
+    font-weight: $medium;
     display: flex;
     align-items: center;
 

--- a/frontend/src/lib/components/InfoMessage/InfoMessage.scss
+++ b/frontend/src/lib/components/InfoMessage/InfoMessage.scss
@@ -5,7 +5,7 @@
     border-radius: $radius;
     padding: $default_spacing / 2 $default_spacing;
     color: $primary_alt;
-    font-weight: medium;
+    font-weight: $medium;
     display: flex;
     align-items: center;
 

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -293,9 +293,9 @@ export function IconExternalLink({ style }: { style?: CSSProperties }): JSX.Elem
     )
 }
 
-export function IconExternalLinkBold(): JSX.Element {
+export function IconExternalLinkBold({ style }: { style?: CSSProperties }): JSX.Element {
     return (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="1em" height="1em" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style={style}>
             <path
                 d="M14.2222 14.2222H1.77778V1.77778H8V0H1.77778C0.791111 0 0 0.8 0 1.77778V14.2222C0 15.2 0.791111 16 1.77778 16H14.2222C15.2 16 16 15.2 16 14.2222V8H14.2222V14.2222ZM9.77778 0V1.77778H12.9689L4.23111 10.5156L5.48444 11.7689L14.2222 3.03111V6.22222H16V0H9.77778Z"
                 fill="currentColor"

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -33,7 +33,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import {
     FunnelEmptyState,
     FunnelInvalidExclusionFiltersEmptyState,
-    FunnelInvalidFiltersEmptyState,
+    FunnelSingleStepState,
     InsightErrorState,
     InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
@@ -263,7 +263,7 @@ export function DashboardItem({
         // Insight specific empty states - note order is important here
         if (item.filters.insight === InsightType.FUNNELS) {
             if (!areFiltersValid) {
-                return <FunnelInvalidFiltersEmptyState />
+                return <FunnelSingleStepState />
             }
             if (!areExclusionFiltersValid) {
                 return <FunnelInvalidExclusionFiltersEmptyState />

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -31,8 +31,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
 import { Tooltip } from 'lib/components/Tooltip'
 import {
-    FunnelEmptyState,
-    FunnelInvalidExclusionFiltersEmptyState,
+    InsightEmptyState,
+    FunnelInvalidExclusionState,
     FunnelSingleStepState,
     InsightErrorState,
     InsightTimeoutState,
@@ -266,10 +266,10 @@ export function DashboardItem({
                 return <FunnelSingleStepState />
             }
             if (!areExclusionFiltersValid) {
-                return <FunnelInvalidExclusionFiltersEmptyState />
+                return <FunnelInvalidExclusionState />
             }
             if (!isValidFunnel && !(insightLoading || isLoading)) {
-                return <FunnelEmptyState />
+                return <InsightEmptyState />
             }
         }
 

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -31,11 +31,11 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
 import { Tooltip } from 'lib/components/Tooltip'
 import {
-    ErrorMessage,
     FunnelEmptyState,
     FunnelInvalidExclusionFiltersEmptyState,
     FunnelInvalidFiltersEmptyState,
-    TimeOut,
+    InsightErrorState,
+    InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -275,10 +275,10 @@ export function DashboardItem({
 
         // Insight agnostic empty states
         if (showErrorMessage) {
-            return <ErrorMessage />
+            return <InsightErrorState />
         }
         if (showTimeoutMessage) {
-            return <TimeOut isLoading={isLoading} />
+            return <InsightTimeoutState isLoading={isLoading} />
         }
 
         return null

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -149,8 +149,8 @@
         display: flex;
         height: 100%;
         align-items: center;
+        border-radius: $radius;
 
-        .illustration-main,
         .ant-btn {
             display: none;
         }

--- a/frontend/src/scenes/funnels/Funnel.scss
+++ b/frontend/src/scenes/funnels/Funnel.scss
@@ -1,30 +1,5 @@
 @import '~/vars';
 
-.funnels-empty-state {
-    text-align: center;
-    h2.funnels-empty-state__title {
-        font-weight: bold;
-        font-size: 1.5rem;
-        line-height: 1.6rem;
-    }
-
-    .funnels-empty-state__description {
-        font-weight: medium;
-        font-size: 1rem;
-        line-height: 1.7rem;
-        color: $text_muted;
-    }
-
-    button.add-action-event-button {
-        height: 50px;
-    }
-
-    .funnels-empty-state__help {
-        font-size: 0.9rem;
-        margin-top: 1rem;
-    }
-}
-
 .funnel-bin-filter-dropdown {
     .funnel-bins-custom-picker {
         width: 43px; // enough to hold two characters

--- a/frontend/src/scenes/funnels/Funnel.scss
+++ b/frontend/src/scenes/funnels/Funnel.scss
@@ -55,15 +55,3 @@
         }
     }
 }
-
-.insights-graph-container.funnels {
-    .ant-card-body {
-        padding: 0;
-    }
-
-    .graph-container {
-        // hacky because container not respecting position: relative;
-        width: calc(100% - 48px);
-        height: calc(100% - 48px);
-    }
-}

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.scss
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.scss
@@ -1,13 +1,6 @@
 @import '~/vars';
 
 .insights-graph-header {
-    &.funnels {
-        margin-top: 0 !important;
-        margin-bottom: 0 !important;
-        padding: 8px 24px;
-        border-bottom: 1px solid var(--border);
-    }
-
     .funnel-canvas-label {
         .ant-btn-link {
             padding: 0;

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -9,12 +9,13 @@ import { Button, Empty } from 'antd'
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { SavedInsightsTabs } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import clsx from 'clsx'
 
 export const UNNAMED_INSIGHT_NAME = 'Unnamed insight'
 
 export function InsightEmptyState({ color, isDashboard }: { color?: string; isDashboard?: boolean }): JSX.Element {
     return (
-        <div className="insight-empty-state">
+        <div className={clsx('insight-empty-state', { 'is-dashboard': isDashboard }, color)}>
             <div className="empty-state-inner">
                 <div className="illustration-main">
                     <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -48,7 +48,7 @@ export function InsightTimeoutState({ isLoading }: { isLoading: boolean }): JSX.
     const { preflight } = useValues(preflightLogic)
     return (
         <div className="insight-empty-state timeout">
-            <div className="insight-empty-state__wrapper">
+            <div className="empty-state-inner">
                 <div className="illustration-main">{isLoading ? <LoadingOutlined spin /> : <IllustrationDanger />}</div>
                 <h2>{isLoading ? 'Looks like things are a little slow…' : 'Your query took too long to complete'}</h2>
                 {isLoading ? (
@@ -117,7 +117,7 @@ export function InsightTimeoutState({ isLoading }: { isLoading: boolean }): JSX.
 export function InsightErrorState(): JSX.Element {
     return (
         <div className="insight-empty-state error">
-            <div className="insight-empty-state__wrapper">
+            <div className="empty-state-inner">
                 <div className="illustration-main">
                     <IllustrationDanger />
                 </div>
@@ -169,7 +169,7 @@ export function InsightErrorState(): JSX.Element {
     )
 }
 
-export function FunnelInvalidFiltersEmptyState(): JSX.Element {
+export function FunnelSingleStepState(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { filters, clickhouseFeaturesEnabled } = useValues(funnelLogic(insightProps))
     const { setFilters } = useActions(funnelLogic(insightProps))
@@ -177,7 +177,7 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
 
     return (
         <div className="insight-empty-state funnels-empty-state">
-            <div className="insight-empty-state__wrapper">
+            <div className="empty-state-inner">
                 <div className="illustration-main">
                     <PlusCircleOutlined />
                 </div>
@@ -185,21 +185,23 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
                 <p className="funnels-empty-state__description">
                     You’re almost there! Funnels require at least two steps before calculating.
                     {clickhouseFeaturesEnabled
-                        ? ' Once you have two steps defined, additional steps will automatically recalculate and update the funnel.'
+                        ? ' Once you have two steps defined, additional changes will recalculate automatically.'
                         : ''}
                 </p>
-                <Button
-                    size="large"
-                    onClick={() => addFilter()}
-                    data-attr="add-action-event-button-empty-state"
-                    icon={<PlusCircleOutlined />}
-                    className="add-action-event-button"
-                >
-                    Add funnel step
-                </Button>
-                <div className="funnels-empty-state__help">
+                <div className="mt text-center">
+                    <Button
+                        size="large"
+                        onClick={() => addFilter()}
+                        data-attr="add-action-event-button-empty-state"
+                        icon={<PlusCircleOutlined />}
+                        className="add-action-event-button"
+                    >
+                        Add funnel step
+                    </Button>
+                </div>
+                <div className="mt text-center">
                     <a
-                        data-attr="insight-funnels-emptystate-help"
+                        data-attr="funnels-single-step-help"
                         href="https://posthog.com/docs/user-guides/funnels?utm_medium=in-product&utm_campaign=funnel-empty-state"
                         target="_blank"
                         rel="noopener"
@@ -217,7 +219,7 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
 export function FunnelEmptyState(): JSX.Element {
     return (
         <div className="insight-empty-state funnels-empty-state">
-            <div className="insight-empty-state__wrapper">
+            <div className="empty-state-inner">
                 <div className="illustration-main">
                     <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
                 </div>
@@ -233,7 +235,7 @@ export function FunnelEmptyState(): JSX.Element {
 export function FunnelInvalidExclusionFiltersEmptyState(): JSX.Element {
     return (
         <div className="insight-empty-state funnels-empty-state">
-            <div className="insight-empty-state__wrapper">
+            <div className="empty-state-inner">
                 <div className="illustration-main">
                     <IllustrationDanger />
                 </div>
@@ -288,7 +290,7 @@ export function SavedInsightsEmptyState(): JSX.Element {
 
     return (
         <div className="saved-insight-empty-state">
-            <div className="insight-empty-state__wrapper">
+            <div className="empty-state-inner">
                 <div className="illustration-main">
                     <IconTrendUp />
                 </div>

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import imgEmptyLineGraph from 'public/empty-line-graph.svg'
 import imgEmptyLineGraphDark from 'public/empty-line-graph-dark.svg'
 import { QuestionCircleOutlined, LoadingOutlined, PlusCircleOutlined } from '@ant-design/icons'
-import { IllustrationDanger, IconTrendUp } from 'lib/components/icons'
+import { IllustrationDanger, IconTrendUp, IconExternalLinkBold } from 'lib/components/icons'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { entityFilterLogic } from 'scenes/insights/ActionFilter/entityFilterLogic'
@@ -44,10 +44,10 @@ export function LineGraphEmptyState({ color, isDashboard }: { color: string; isD
     )
 }
 
-export function TimeOut({ isLoading }: { isLoading: boolean }): JSX.Element {
+export function InsightTimeoutState({ isLoading }: { isLoading: boolean }): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     return (
-        <div className="insight-empty-state timeout-message">
+        <div className="insight-empty-state timeout">
             <div className="insight-empty-state__wrapper">
                 <div className="illustration-main">{isLoading ? <LoadingOutlined spin /> : <IllustrationDanger />}</div>
                 <h2>{isLoading ? 'Looks like things are a little slow…' : 'Your query took too long to complete'}</h2>
@@ -114,9 +114,9 @@ export function TimeOut({ isLoading }: { isLoading: boolean }): JSX.Element {
     )
 }
 
-export function ErrorMessage(): JSX.Element {
+export function InsightErrorState(): JSX.Element {
     return (
-        <div className="insight-empty-state error-message">
+        <div className="insight-empty-state error">
             <div className="insight-empty-state__wrapper">
                 <div className="illustration-main">
                     <IllustrationDanger />
@@ -176,7 +176,7 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
     const { addFilter } = useActions(entityFilterLogic({ setFilters, filters, typeKey: 'EditFunnel-action' }))
 
     return (
-        <div className="insight-empty-state funnels-empty-state info-message">
+        <div className="insight-empty-state funnels-empty-state">
             <div className="insight-empty-state__wrapper">
                 <div className="illustration-main">
                     <PlusCircleOutlined />
@@ -203,8 +203,10 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
                         href="https://posthog.com/docs/user-guides/funnels?utm_medium=in-product&utm_campaign=funnel-empty-state"
                         target="_blank"
                         rel="noopener"
+                        className="flex-center"
                     >
-                        Learn more about funnels in our support documentation.
+                        Learn more about funnels in our support documentation
+                        <IconExternalLinkBold style={{ marginLeft: 4, fontSize: '0.85em' }} />
                     </a>
                 </div>
             </div>
@@ -214,7 +216,7 @@ export function FunnelInvalidFiltersEmptyState(): JSX.Element {
 
 export function FunnelEmptyState(): JSX.Element {
     return (
-        <div className="insight-empty-state funnels-empty-state info-message">
+        <div className="insight-empty-state funnels-empty-state">
             <div className="insight-empty-state__wrapper">
                 <div className="illustration-main">
                     <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
@@ -230,7 +232,7 @@ export function FunnelEmptyState(): JSX.Element {
 
 export function FunnelInvalidExclusionFiltersEmptyState(): JSX.Element {
     return (
-        <div className="insight-empty-state funnels-empty-state info-message">
+        <div className="insight-empty-state funnels-empty-state">
             <div className="insight-empty-state__wrapper">
                 <div className="illustration-main">
                     <IllustrationDanger />
@@ -244,11 +246,12 @@ export function FunnelInvalidExclusionFiltersEmptyState(): JSX.Element {
                 <div className="funnels-empty-state__help">
                     <a
                         data-attr="insight-funnels-emptystate-help"
-                        href="https://posthog.com/docs/user-guides/funnels?utm_medium=in-product&utm_campaign=funnel-empty-state"
+                        href="https://posthog.com/docs/user-guides/funnels?utm_medium=in-product&utm_campaign=funnel-exclusion-filter-state"
                         target="_blank"
                         rel="noopener"
                     >
-                        Learn more about funnels in our support documentation.
+                        Learn more about funnels in our support documentation
+                        <IconExternalLinkBold style={{ marginLeft: 4, fontSize: '0.85em' }} />
                     </a>
                 </div>
             </div>

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import React from 'react'
 import imgEmptyLineGraph from 'public/empty-line-graph.svg'
 import imgEmptyLineGraphDark from 'public/empty-line-graph-dark.svg'
-import { QuestionCircleOutlined, LoadingOutlined, PlusCircleOutlined } from '@ant-design/icons'
+import { QuestionCircleOutlined, LoadingOutlined, PlusCircleOutlined, WarningOutlined } from '@ant-design/icons'
 import { IllustrationDanger, IconTrendUp, IconExternalLinkBold } from 'lib/components/icons'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
@@ -47,7 +47,7 @@ export function LineGraphEmptyState({ color, isDashboard }: { color: string; isD
 export function InsightTimeoutState({ isLoading }: { isLoading: boolean }): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     return (
-        <div className="insight-empty-state timeout">
+        <div className="insight-empty-state warning">
             <div className="empty-state-inner">
                 <div className="illustration-main">{isLoading ? <LoadingOutlined spin /> : <IllustrationDanger />}</div>
                 <h2>{isLoading ? 'Looks like things are a little slow…' : 'Your query took too long to complete'}</h2>
@@ -218,15 +218,13 @@ export function FunnelSingleStepState(): JSX.Element {
 
 export function FunnelEmptyState(): JSX.Element {
     return (
-        <div className="insight-empty-state funnels-empty-state">
+        <div className="insight-empty-state">
             <div className="empty-state-inner">
                 <div className="illustration-main">
                     <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
                 </div>
-                <h2 className="funnels-empty-state__title">There are no matching events for this query.</h2>
-                <p className="funnels-empty-state__description">
-                    Try changing dates or pick another action, event, or breakdown.
-                </p>
+                <h2>There are no matching events for this query</h2>
+                <p className="text-center">Try changing the date range or pick another action, event, or breakdown.</p>
             </div>
         </div>
     )
@@ -234,18 +232,17 @@ export function FunnelEmptyState(): JSX.Element {
 
 export function FunnelInvalidExclusionFiltersEmptyState(): JSX.Element {
     return (
-        <div className="insight-empty-state funnels-empty-state">
+        <div className="insight-empty-state warning">
             <div className="empty-state-inner">
                 <div className="illustration-main">
-                    <IllustrationDanger />
+                    <WarningOutlined />
                 </div>
-                <h2 className="funnels-empty-state__title">
-                    Exclusion filters cannot exclude events or actions in the funnel steps.
-                </h2>
-                <p className="funnels-empty-state__description">
-                    Try changing your funnel step filters, or removing the overlapping exclusion event.
+                <h2>Invalid exclusion filters</h2>
+                <p>
+                    You're excluding events or actions that are part of the funnel steps. Try changing your funnel step
+                    filters, or removing the overlapping exclusion event.
                 </p>
-                <div className="funnels-empty-state__help">
+                <div className="mt text-center">
                     <a
                         data-attr="insight-funnels-emptystate-help"
                         href="https://posthog.com/docs/user-guides/funnels?utm_medium=in-product&utm_campaign=funnel-exclusion-filter-state"

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -1,8 +1,6 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
-import imgEmptyLineGraph from 'public/empty-line-graph.svg'
-import imgEmptyLineGraphDark from 'public/empty-line-graph-dark.svg'
-import { QuestionCircleOutlined, LoadingOutlined, PlusCircleOutlined, WarningOutlined } from '@ant-design/icons'
+import { LoadingOutlined, PlusCircleOutlined, WarningOutlined } from '@ant-design/icons'
 import { IllustrationDanger, IconTrendUp, IconExternalLinkBold } from 'lib/components/icons'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
@@ -14,33 +12,17 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 export const UNNAMED_INSIGHT_NAME = 'Unnamed insight'
 
-export function LineGraphEmptyState({ color, isDashboard }: { color: string; isDashboard?: boolean }): JSX.Element {
+export function InsightEmptyState({ color, isDashboard }: { color?: string; isDashboard?: boolean }): JSX.Element {
     return (
-        <>
-            {isDashboard ? (
-                <div className="text-center" style={{ height: '100%' }}>
-                    <img
-                        src={color === 'white' ? imgEmptyLineGraphDark : imgEmptyLineGraph}
-                        alt=""
-                        style={{ maxHeight: '100%', maxWidth: '80%', opacity: 0.5 }}
-                    />
-                    <div style={{ textAlign: 'center', fontWeight: 'bold', marginTop: 16 }}>
-                        Seems like there's no data to show this graph yet{' '}
-                        <a
-                            target="_blank"
-                            href="https://posthog.com/docs/features/trends?utm_campaign=dashboard-empty-state&utm_medium=in-product"
-                            style={{ color: color === 'white' ? 'rgba(0, 0, 0, 0.85)' : 'white' }}
-                        >
-                            <QuestionCircleOutlined />
-                        </a>
-                    </div>
+        <div className="insight-empty-state">
+            <div className="empty-state-inner">
+                <div className="illustration-main">
+                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
                 </div>
-            ) : (
-                <p style={{ textAlign: 'center', paddingTop: '4rem' }}>
-                    We couldn't find any matching events. Try changing dates or pick another action or event.
-                </p>
-            )}
-        </>
+                <h2>There are no matching events for this query</h2>
+                <p className="text-center">Try changing the date range or pick another action, event, or breakdown.</p>
+            </div>
+        </div>
     )
 }
 
@@ -216,21 +198,7 @@ export function FunnelSingleStepState(): JSX.Element {
     )
 }
 
-export function FunnelEmptyState(): JSX.Element {
-    return (
-        <div className="insight-empty-state">
-            <div className="empty-state-inner">
-                <div className="illustration-main">
-                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
-                </div>
-                <h2>There are no matching events for this query</h2>
-                <p className="text-center">Try changing the date range or pick another action, event, or breakdown.</p>
-            </div>
-        </div>
-    )
-}
-
-export function FunnelInvalidExclusionFiltersEmptyState(): JSX.Element {
+export function FunnelInvalidExclusionState(): JSX.Element {
     return (
         <div className="insight-empty-state warning">
             <div className="empty-state-inner">

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -20,7 +20,7 @@ import { router } from 'kea-router'
 import {
     FunnelEmptyState,
     FunnelInvalidExclusionFiltersEmptyState,
-    FunnelInvalidFiltersEmptyState,
+    FunnelSingleStepState,
     InsightErrorState,
     InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
@@ -72,7 +72,7 @@ export function InsightContainer(): JSX.Element {
         // Insight specific empty states - note order is important here
         if (loadedView === InsightType.FUNNELS) {
             if (!areFiltersValid) {
-                return <FunnelInvalidFiltersEmptyState />
+                return <FunnelSingleStepState />
             }
             if (!areExclusionFiltersValid) {
                 return <FunnelInvalidExclusionFiltersEmptyState />
@@ -176,10 +176,6 @@ export function InsightContainer(): JSX.Element {
                         })}
                         align="middle"
                         justify="space-between"
-                        style={{
-                            marginTop: -8,
-                            marginBottom: 16,
-                        }}
                     >
                         <Col>
                             <FunnelCanvasLabel />

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -165,9 +165,7 @@ export function InsightContainer(): JSX.Element {
                     />
                 }
                 data-attr="insights-graph"
-                className={clsx('insights-graph-container', {
-                    funnels: activeView === InsightType.FUNNELS,
-                })}
+                className="insights-graph-container"
             >
                 <div>
                     <Row

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -18,11 +18,11 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { annotationsLogic } from 'lib/components/Annotations'
 import { router } from 'kea-router'
 import {
-    ErrorMessage,
     FunnelEmptyState,
     FunnelInvalidExclusionFiltersEmptyState,
     FunnelInvalidFiltersEmptyState,
-    TimeOut,
+    InsightErrorState,
+    InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
 import { Loading } from 'lib/utils'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
@@ -84,10 +84,10 @@ export function InsightContainer(): JSX.Element {
 
         // Insight agnostic empty states
         if (showErrorMessage) {
-            return <ErrorMessage />
+            return <InsightErrorState />
         }
         if (showTimeoutMessage) {
-            return <TimeOut isLoading={isLoading} />
+            return <InsightTimeoutState isLoading={isLoading} />
         }
 
         return null

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -18,9 +18,9 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { annotationsLogic } from 'lib/components/Annotations'
 import { router } from 'kea-router'
 import {
-    FunnelEmptyState,
-    FunnelInvalidExclusionFiltersEmptyState,
+    FunnelInvalidExclusionState,
     FunnelSingleStepState,
+    InsightEmptyState,
     InsightErrorState,
     InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
@@ -75,10 +75,10 @@ export function InsightContainer(): JSX.Element {
                 return <FunnelSingleStepState />
             }
             if (!areExclusionFiltersValid) {
-                return <FunnelInvalidExclusionFiltersEmptyState />
+                return <FunnelInvalidExclusionState />
             }
             if (!isValidFunnel && !(insightLoading || isLoading)) {
-                return <FunnelEmptyState />
+                return <InsightEmptyState />
             }
         }
 

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -217,6 +217,25 @@ $funnel_canvas_background: #fafafa;
         }
     }
 
+    &.is-dashboard:not(.white) {
+        background-color: var(--item-darker);
+        color: rgba(#ffffff, 0.7);
+        h2 {
+            color: rgba(#ffffff, 0.9);
+        }
+        .ant-empty-img-simple-ellipse {
+            fill: var(--item-darkest);
+        }
+
+        .ant-empty-img-simple-g {
+            stroke: var(--item-lighter);
+
+            .ant-empty-img-simple-path {
+                fill: var(--item-lighter);
+            }
+        }
+    }
+
     h2 {
         font-weight: bold;
         font-size: 1.5rem;

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -172,7 +172,7 @@ $funnel_canvas_background: #fafafa;
     padding-top: $default_spacing * 2;
     padding-bottom: $default_spacing * 2;
 
-    &.error-message {
+    &.error {
         .illustration-main {
             color: $danger;
         }
@@ -182,7 +182,7 @@ $funnel_canvas_background: #fafafa;
         }
     }
 
-    &.timeout-message {
+    &.timeout {
         .illustration-main {
             color: $warning;
         }
@@ -192,16 +192,8 @@ $funnel_canvas_background: #fafafa;
         }
     }
 
-    &.info-message {
-        .illustration-main {
-            color: $border;
-        }
-    }
-
-    &.action-message {
-        .illustration-main {
-            color: $primary;
-        }
+    .illustration-main {
+        color: $border;
     }
 
     .insight-empty-state__wrapper {

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -79,8 +79,10 @@ $funnel_canvas_background: #fafafa;
     }
 
     .insights-graph-container {
+        margin-bottom: $default_spacing;
+
         .ant-card-head {
-            border-bottom: 1px solid var(--border);
+            border-bottom: 1px solid $border;
             min-height: unset;
             background-color: $bg_mid;
             padding-right: $default_spacing / 4;
@@ -100,6 +102,10 @@ $funnel_canvas_background: #fafafa;
             @media screen and (max-width: $md) {
                 overflow-x: auto;
             }
+        }
+
+        .ant-card-body {
+            padding: 0;
         }
     }
 
@@ -162,6 +168,14 @@ $funnel_canvas_background: #fafafa;
             margin-top: 0 !important;
         }
     }
+
+    .insights-graph-header {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        padding: 8px 24px;
+        border-bottom: 1px solid $border;
+        min-height: 48px;
+    }
 }
 
 .insight-empty-state {
@@ -171,10 +185,13 @@ $funnel_canvas_background: #fafafa;
     align-items: center;
     padding-top: $default_spacing * 2;
     padding-bottom: $default_spacing * 2;
+    background-color: $bg_mid;
+    color: $text_muted;
+    font-size: 1.1em;
 
     &.error {
         .illustration-main {
-            color: $danger;
+            color: #fb8c6a; // $danger with increased lightness
         }
 
         h2 {
@@ -184,7 +201,7 @@ $funnel_canvas_background: #fafafa;
 
     &.timeout {
         .illustration-main {
-            color: $warning;
+            color: rgba($warning, 0.5);
         }
 
         h2 {
@@ -192,11 +209,22 @@ $funnel_canvas_background: #fafafa;
         }
     }
 
-    .illustration-main {
-        color: $border;
+    h2 {
+        font-weight: bold;
+        font-size: 1.5rem;
+        line-height: 1.6rem;
+        color: $primary_alt;
     }
 
-    .insight-empty-state__wrapper {
+    .illustration-main {
+        color: rgba($primary_alt, 0.3);
+    }
+
+    button.ant-btn-lg {
+        height: 42px;
+    }
+
+    .empty-state-inner {
         max-width: 600px;
 
         .illustration-main {

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -199,9 +199,9 @@ $funnel_canvas_background: #fafafa;
         }
     }
 
-    &.timeout {
+    &.warning {
         .illustration-main {
-            color: rgba($warning, 0.5);
+            color: #fec34d; // $warning with increased lightness
         }
 
         h2 {

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -107,6 +107,13 @@ $funnel_canvas_background: #fafafa;
         .ant-card-body {
             padding: 0;
         }
+
+        .graph-container {
+            // hacky because container not respecting position: relative;
+            width: calc(100% - 48px);
+            height: calc(100% - 48px);
+            margin-top: $default_spacing * 2;
+        }
     }
 
     .insight-title-container {
@@ -188,6 +195,7 @@ $funnel_canvas_background: #fafafa;
     background-color: $bg_mid;
     color: $text_muted;
     font-size: 1.1em;
+    flex-grow: 1;
 
     &.error {
         .illustration-main {
@@ -258,6 +266,8 @@ $funnel_canvas_background: #fafafa;
 .trends-insights-container {
     position: relative;
     min-height: min(calc(90vh - 16rem), 36rem);
+    display: flex;
+    justify-content: center;
 }
 
 .funnel-insights-container {

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { retentionTableLogic } from './retentionTableLogic'
 import { LineGraph } from '../insights/LineGraph'
 import { useActions, useValues } from 'kea'
-import { LineGraphEmptyState } from '../insights/EmptyStates'
+import { InsightEmptyState } from '../insights/EmptyStates'
 import { Modal, Button } from 'antd'
 import { PersonsTable } from 'scenes/persons/PersonsTable'
 import { PersonType } from '~/types'
@@ -104,6 +104,6 @@ export function RetentionLineGraph({
             </Modal>
         </>
     ) : (
-        <LineGraphEmptyState color={color} isDashboard={!!dashboardItemId} />
+        <InsightEmptyState color={color} isDashboard={!!dashboardItemId} />
     )
 }

--- a/frontend/src/scenes/trends/viz/ActionsBarValueGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsBarValueGraph.tsx
@@ -3,7 +3,7 @@ import { LineGraph } from '../../insights/LineGraph'
 import { getChartColors } from 'lib/colors'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { LineGraphEmptyState } from '../../insights/EmptyStates'
+import { InsightEmptyState } from '../../insights/EmptyStates'
 import { FilterType, TrendResultWithAggregate } from '~/types'
 import { personsModalLogic } from '../personsModalLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -109,6 +109,6 @@ export function ActionsBarValueGraph({
             }
         />
     ) : (
-        <LineGraphEmptyState color={color} isDashboard={!!dashboardItemId} />
+        <InsightEmptyState color={color} isDashboard={!!dashboardItemId} />
     )
 }

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { LineGraph } from '../../insights/LineGraph'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { LineGraphEmptyState } from '../../insights/EmptyStates'
+import { InsightEmptyState } from '../../insights/EmptyStates'
 import { ACTIONS_BAR_CHART } from 'lib/constants'
 import { ChartParams } from '~/types'
 import { InsightType } from '~/types'
@@ -68,6 +68,6 @@ export function ActionsLineGraph({
             }
         />
     ) : (
-        <LineGraphEmptyState color={color} isDashboard={!!dashboardItemId} />
+        <InsightEmptyState color={color} isDashboard={!!dashboardItemId} />
     )
 }

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -11,7 +11,7 @@ $primary_bg_active: rgba($primary, 0.2);
 $success: #77b96c;
 $warning: #f7a501;
 $danger: #f96132;
-$danger_bridge: #df4313; // Used for bridge pages
+$danger_bridge: #df4313; // Used for bridge pages (posthog.com to PostHog App transition)
 
 // Brand colors, as in logo
 $brand_blue: #1d4aff;
@@ -91,7 +91,7 @@ $hc_navy: #35416b; // paired with $hc_light_lilac or $hc_yellow
 $hc_light_lilac: #ead1ee; // paired with $hc_navy
 $hc_yellow: #fbd577;
 
-// Gradients
+// Gradients - DEPRECATED
 $sky: linear-gradient(180deg, #373088 0%, #d05783 60.94%, #ffb269 100%);
 $dusk_sky: linear-gradient(180deg, #20305a 0%, #373088 33.85%, #d05783 100%);
 $night_sky: linear-gradient(180deg, #200c39 0%, #373088 75%, #4a3587 100%);
@@ -136,7 +136,7 @@ $default_spacing: 1rem;
 $radius: 4px;
 $top_nav_height: 50px;
 
-// Session Recording
+// Recordings
 $recording_spacing: $default_spacing * 2 / 3;
 
 .text-ellipsis {
@@ -146,7 +146,7 @@ $recording_spacing: $default_spacing * 2 / 3;
     max-width: calc(100% - 8px);
 }
 
-// Z-indexes, sync with vars.ts
+// z-indexes, synced with vars.ts
 $z_nps_overlay: 5200;
 $z_bottom_notice: 5100;
 $z_command_palette: 1875;


### PR DESCRIPTION
## Changes

Supposed to be a quick fix, but standardizing all graph empty states was convoluted. All empty states now follow the same style. Insights now have a secondary header the same way we had it for funnels. 🖼️ worth more than a thousand words.

**Before (funnels)**
<img width="788" alt="" src="https://user-images.githubusercontent.com/5864173/142458834-fc2c020f-0005-4ad3-9a7c-a52676f05b6e.png">

**Funnels - single step**
<img width="779" alt="" src="https://user-images.githubusercontent.com/5864173/142458899-3cb45e4f-7b36-4f31-b2ca-fd1065523bb0.png">

**Error in query**
<img width="1184" alt="" src="https://user-images.githubusercontent.com/5864173/142458983-ca0df1c0-77a3-4a7c-9369-de7a38191123.png">


**Funnels - invalid exclusion filters**
<img width="794" alt="" src="https://user-images.githubusercontent.com/5864173/142459036-92a057ad-b4ef-4c30-b962-02b02ec31f58.png">

**No matching events (same for trends & funnels)**
<img width="787" alt="" src="https://user-images.githubusercontent.com/5864173/142459140-2ac31340-1c89-42d9-8a06-a15f35244a09.png">

**No matching events (dashboards)**
<img width="1222" alt="" src="https://user-images.githubusercontent.com/5864173/142459167-3989d3d8-824f-4030-ad50-6cab121a6696.png">




 ## How did you test this code?
- Manually triggered all the empty states (by selecting an event in a timeframe were it wasn't received) & error states (by raising an error on Python).
- Tested all different visualization options for trends.
