### PR TITLE
Use session_id in recordings query when possible

### DIFF
--- a/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
+++ b/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
@@ -203,7 +203,7 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
         aggregate_having_clause = ""
         where_conditions = "AND event IN %(event_names)s"
         # Always include $pageview events so the start_url and end_url can be extracted
-        event_names_to_filter: Set[Union[int, str]] = set(["$pageview"])
+        event_names_to_filter: List[Union[int, str]] = ["$pageview"]
 
         params: Dict = {}
 
@@ -211,9 +211,11 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
                 for action_step in action.steps.all():
-                    event_names_to_filter.add(action_step.event)
+                    if action_step.event not in event_names_to_filter:
+                        event_names_to_filter.append(action_step.event)
             else:
-                event_names_to_filter.add(entity.id)
+                if entity.id not in event_names_to_filter:
+                    event_names_to_filter.append(entity.id)
 
             condition_sql, filter_params = self.format_event_filter(entity, prepend=f"event_matcher_{index}")
             aggregate_select_clause += f", sum(if({condition_sql}, 1, 0)) as count_event_match_{index}"

--- a/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
+++ b/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
@@ -50,6 +50,7 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
     RIGHT OUTER JOIN (
         SELECT
             session_id,
+            any(window_id) as window_id,
             MIN(timestamp) AS start_time,
             MAX(timestamp) AS end_time,
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
@@ -71,12 +72,24 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
     ON pdi.distinct_id = session_recordings.distinct_id
     {person_query}
     WHERE
-        (
-            empty(events.event) OR
+        (   
+            -- If there is a window_id on the recording, then it is newer data and we can match
+            -- the recording and events on session_id
             (
-                events.timestamp >= session_recordings.start_time
-                AND events.timestamp <= session_recordings.end_time
-            )
+                notEmpty(session_recordings.window_id) AND
+                events.session_id == session_recordings.session_id
+            ) OR
+            -- If there is no window_id on the recording, then it is older data and we should match
+            -- events and recordings on timestamps
+            (
+                empty(session_recordings.window_id) AND
+                (
+                    events.timestamp >= session_recordings.start_time
+                    AND events.timestamp <= session_recordings.end_time
+                )
+            ) OR
+            -- If there are no event matches, we don't want to filter out the recording itself
+            empty(events.event)
         )
         {prop_filter_clause}
         {person_id_clause}
@@ -104,7 +117,11 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
 
     def _get_properties_select_clause(self) -> str:
         current_url_clause, _ = get_property_string_expr("events", "$current_url", "'$current_url'", "properties")
-        clause = f", {current_url_clause} as current_url "
+        session_id_clause, _ = get_property_string_expr("events", "$session_id", "'$session_id'", "properties")
+        clause = f""",
+            {current_url_clause} as current_url, 
+            {session_id_clause} as session_id
+        """
         clause += (
             f", events.elements_chain as elements_chain"
             if self._column_optimizer.should_query_elements_chain_column

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -178,7 +178,9 @@
             team_id,
             timestamp ,
             trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$current_url')) as current_url
+                 FROM JSONExtractRaw(properties, '$current_url')) as current_url,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$session_id')) as session_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -186,6 +188,7 @@
        AND timestamp <= '2021-08-22 08:00:00' ) AS events
   RIGHT OUTER JOIN
     (SELECT session_id,
+            any(window_id) as window_id,
             MIN(timestamp) AS start_time,
             MAX(timestamp) AS end_time,
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
@@ -220,9 +223,12 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-  WHERE (empty(events.event)
-         OR (events.timestamp >= session_recordings.start_time
-             AND events.timestamp <= session_recordings.end_time))
+  WHERE ((notEmpty(session_recordings.window_id)
+          AND events.session_id == session_recordings.session_id)
+         OR (empty(session_recordings.window_id)
+             AND (events.timestamp >= session_recordings.start_time
+                  AND events.timestamp <= session_recordings.end_time))
+         OR empty(events.event))
     AND person_id IN
       (SELECT person_id
        FROM cohortpeople
@@ -255,7 +261,9 @@
             team_id,
             timestamp ,
             trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$current_url')) as current_url
+                 FROM JSONExtractRaw(properties, '$current_url')) as current_url,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$session_id')) as session_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -263,6 +271,7 @@
        AND timestamp <= '2021-01-22 08:00:00' ) AS events
   RIGHT OUTER JOIN
     (SELECT session_id,
+            any(window_id) as window_id,
             MIN(timestamp) AS start_time,
             MAX(timestamp) AS end_time,
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
@@ -299,9 +308,12 @@
      HAVING max(is_deleted) = 0
      AND has(['bla'], trim(BOTH '"'
                            FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')))) person ON person.id = pdi.person_id
-  WHERE (empty(events.event)
-         OR (events.timestamp >= session_recordings.start_time
-             AND events.timestamp <= session_recordings.end_time))
+  WHERE ((notEmpty(session_recordings.window_id)
+          AND events.session_id == session_recordings.session_id)
+         OR (empty(session_recordings.window_id)
+             AND (events.timestamp >= session_recordings.start_time
+                  AND events.timestamp <= session_recordings.end_time))
+         OR empty(events.event))
   GROUP BY session_recordings.session_id
   HAVING 1 = 1
   ORDER BY start_time DESC

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -337,7 +337,7 @@
                  FROM JSONExtractRaw(properties, '$session_id')) as session_id
      FROM events
      WHERE team_id = 2
-       AND event IN ['$autocapture', '$pageview']
+       AND event IN ['$pageview', '$autocapture']
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00' ) AS events
   RIGHT OUTER JOIN

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -245,6 +245,146 @@
   OFFSET 0
   '
 ---
+# name: TestClickhouseSessionRecordingsList.test_event_filter_with_matching_on_session_id
+  '
+  
+  SELECT session_recordings.session_id,
+         any(session_recordings.start_time) as start_time,
+         any(session_recordings.end_time) as end_time,
+         any(session_recordings.duration) as duration,
+         any(session_recordings.distinct_id) as distinct_id,
+         arrayElement(groupArray(current_url), 1) as start_url,
+         arrayElement(groupArray(current_url), -1) as end_url ,
+         sum(if(event = '$pageview', 1, 0)) as count_event_match_0
+  FROM
+    (SELECT distinct_id,
+            event,
+            team_id,
+            timestamp ,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$current_url')) as current_url,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$session_id')) as session_id
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00' ) AS events
+  RIGHT OUTER JOIN
+    (SELECT session_id,
+            any(window_id) as window_id,
+            MIN(timestamp) AS start_time,
+            MAX(timestamp) AS end_time,
+            dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
+            any(distinct_id) as distinct_id,
+            COUNT((JSONExtractInt(snapshot_data, 'type') = 2
+                   OR JSONExtractBool(snapshot_data, 'has_full_snapshot')) ? 1 : NULL) as full_snapshots
+     FROM session_recording_events
+     WHERE team_id = 2
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+     GROUP BY session_id
+     HAVING full_snapshots > 0
+     AND start_time >= '2021-01-14 00:00:00'
+     AND start_time <= '2021-01-21 20:00:00') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, _timestamp) as person_id
+     FROM
+       (SELECT distinct_id,
+               person_id,
+               max(_timestamp) as _timestamp
+        FROM person_distinct_id
+        WHERE team_id = 2
+        GROUP BY person_id,
+                 distinct_id,
+                 team_id
+        HAVING max(is_deleted) = 0)
+     GROUP BY distinct_id) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+  WHERE ((notEmpty(session_recordings.window_id)
+          AND events.session_id == session_recordings.session_id)
+         OR (empty(session_recordings.window_id)
+             AND (events.timestamp >= session_recordings.start_time
+                  AND events.timestamp <= session_recordings.end_time))
+         OR empty(events.event))
+  GROUP BY session_recordings.session_id
+  HAVING 1 = 1
+  AND count_event_match_0 > 0
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsList.test_event_filter_with_matching_on_session_id.1
+  '
+  
+  SELECT session_recordings.session_id,
+         any(session_recordings.start_time) as start_time,
+         any(session_recordings.end_time) as end_time,
+         any(session_recordings.duration) as duration,
+         any(session_recordings.distinct_id) as distinct_id,
+         arrayElement(groupArray(current_url), 1) as start_url,
+         arrayElement(groupArray(current_url), -1) as end_url ,
+         sum(if(event = '$autocapture', 1, 0)) as count_event_match_0
+  FROM
+    (SELECT distinct_id,
+            event,
+            team_id,
+            timestamp ,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$current_url')) as current_url,
+            trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$session_id')) as session_id
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$autocapture', '$pageview']
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00' ) AS events
+  RIGHT OUTER JOIN
+    (SELECT session_id,
+            any(window_id) as window_id,
+            MIN(timestamp) AS start_time,
+            MAX(timestamp) AS end_time,
+            dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
+            any(distinct_id) as distinct_id,
+            COUNT((JSONExtractInt(snapshot_data, 'type') = 2
+                   OR JSONExtractBool(snapshot_data, 'has_full_snapshot')) ? 1 : NULL) as full_snapshots
+     FROM session_recording_events
+     WHERE team_id = 2
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+     GROUP BY session_id
+     HAVING full_snapshots > 0
+     AND start_time >= '2021-01-14 00:00:00'
+     AND start_time <= '2021-01-21 20:00:00') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, _timestamp) as person_id
+     FROM
+       (SELECT distinct_id,
+               person_id,
+               max(_timestamp) as _timestamp
+        FROM person_distinct_id
+        WHERE team_id = 2
+        GROUP BY person_id,
+                 distinct_id,
+                 team_id
+        HAVING max(is_deleted) = 0)
+     GROUP BY distinct_id) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+  WHERE ((notEmpty(session_recordings.window_id)
+          AND events.session_id == session_recordings.session_id)
+         OR (empty(session_recordings.window_id)
+             AND (events.timestamp >= session_recordings.start_time
+                  AND events.timestamp <= session_recordings.end_time))
+         OR empty(events.event))
+  GROUP BY session_recordings.session_id
+  HAVING 1 = 1
+  AND count_event_match_0 > 0
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
 # name: TestClickhouseSessionRecordingsList.test_event_filter_with_person_properties
   '
   

--- a/ee/clickhouse/queries/session_recordings/test/test_clickhouse_session_recording_list.py
+++ b/ee/clickhouse/queries/session_recordings/test/test_clickhouse_session_recording_list.py
@@ -76,3 +76,28 @@ class TestClickhouseSessionRecordingsList(ClickhouseTestMixin, factory_session_r
                 (session_recordings, _) = session_recording_list_instance.run()
                 self.assertEqual(len(session_recordings), 1)
                 self.assertEqual(session_recordings[0]["session_id"], "2")
+
+    @freeze_time("2021-01-21T20:00:00.000Z")
+    @snapshot_clickhouse_queries
+    @test_with_materialized_columns(["$current_url", "$session_id"], verify_no_jsonextract=False)
+    def test_event_filter_with_matching_on_session_id(self):
+        Person.objects.create(team=self.team, distinct_ids=["user"], properties={"email": "bla"})
+        self.create_snapshot("user", "1", self.base_time, window_id="1")
+        self.create_event("user", self.base_time, properties={"$session_id": "1"})
+        self.create_event("user", self.base_time, event_name="$autocapture", properties={"$session_id": "2"})
+        self.create_snapshot("user", "1", self.base_time + relativedelta(seconds=30), window_id="1")
+        filter = SessionRecordingsFilter(
+            team=self.team, data={"events": [{"id": "$pageview", "type": "events", "order": 0, "name": "$pageview"}]},
+        )
+        session_recording_list_instance = ClickhouseSessionRecordingList(filter=filter, team_id=self.team.pk)
+        (session_recordings, _) = session_recording_list_instance.run()
+        self.assertEqual(len(session_recordings), 1)
+        self.assertEqual(session_recordings[0]["session_id"], "1")
+
+        filter = SessionRecordingsFilter(
+            team=self.team,
+            data={"events": [{"id": "$autocapture", "type": "events", "order": 0, "name": "$autocapture"}]},
+        )
+        session_recording_list_instance = ClickhouseSessionRecordingList(filter=filter, team_id=self.team.pk)
+        (session_recordings, _) = session_recording_list_instance.run()
+        self.assertEqual(len(session_recordings), 0)

--- a/ee/clickhouse/queries/session_recordings/test/test_clickhouse_session_recording_list.py
+++ b/ee/clickhouse/queries/session_recordings/test/test_clickhouse_session_recording_list.py
@@ -86,6 +86,9 @@ class TestClickhouseSessionRecordingsList(ClickhouseTestMixin, factory_session_r
         self.create_event("user", self.base_time, properties={"$session_id": "1"})
         self.create_event("user", self.base_time, event_name="$autocapture", properties={"$session_id": "2"})
         self.create_snapshot("user", "1", self.base_time + relativedelta(seconds=30), window_id="1")
+
+        # Filter for recordings that contain a pageview event - will get recording because the $pageview event
+        # and recording share a session id
         filter = SessionRecordingsFilter(
             team=self.team, data={"events": [{"id": "$pageview", "type": "events", "order": 0, "name": "$pageview"}]},
         )
@@ -94,6 +97,8 @@ class TestClickhouseSessionRecordingsList(ClickhouseTestMixin, factory_session_r
         self.assertEqual(len(session_recordings), 1)
         self.assertEqual(session_recordings[0]["session_id"], "1")
 
+        # Filter for recordings that contain an autocapture event - will not get the recording because the $autocapture event
+        # and recording have different session ids
         filter = SessionRecordingsFilter(
             team=self.team,
             data={"events": [{"id": "$autocapture", "type": "events", "order": 0, "name": "$autocapture"}]},

--- a/posthog/queries/session_recordings/test/test_session_recording_list.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list.py
@@ -177,31 +177,6 @@ def factory_session_recordings_list_test(
             (session_recordings, _) = session_recording_list_instance.run()
             self.assertEqual(len(session_recordings), 0)
 
-        @test_with_materialized_columns(["$current_url", "$session_id"], verify_no_jsonextract=False)
-        @freeze_time("2021-01-21T20:00:00.000Z")
-        def test_event_filter_with_matching_on_session_id(self):
-            Person.objects.create(team=self.team, distinct_ids=["user"], properties={"email": "bla"})
-            self.create_snapshot("user", "1", self.base_time, window_id="1")
-            self.create_event("user", self.base_time, properties={"$session_id": "1"})
-            self.create_event("user", self.base_time, event_name="$autocapture", properties={"$session_id": "2"})
-            self.create_snapshot("user", "1", self.base_time + relativedelta(seconds=30), window_id="1")
-            filter = SessionRecordingsFilter(
-                team=self.team,
-                data={"events": [{"id": "$pageview", "type": "events", "order": 0, "name": "$pageview"}]},
-            )
-            session_recording_list_instance = session_recording_list(filter=filter, team_id=self.team.pk)
-            (session_recordings, _) = session_recording_list_instance.run()
-            self.assertEqual(len(session_recordings), 1)
-            self.assertEqual(session_recordings[0]["session_id"], "1")
-
-            filter = SessionRecordingsFilter(
-                team=self.team,
-                data={"events": [{"id": "$autocapture", "type": "events", "order": 0, "name": "$autocapture"}]},
-            )
-            session_recording_list_instance = session_recording_list(filter=filter, team_id=self.team.pk)
-            (session_recordings, _) = session_recording_list_instance.run()
-            self.assertEqual(len(session_recordings), 0)
-
         @freeze_time("2021-01-21T20:00:00.000Z")
         def test_multiple_event_filters(self):
             Person.objects.create(team=self.team, distinct_ids=["user"], properties={"email": "bla"})


### PR DESCRIPTION
## Changes

This PR takes advantage of the session_id in the recordings query. Now, if a recording was created since the advent of `session_id` and `window_id`, then we only look at events that match the `session_id` when filtering. Previously, if a user had simultaneous sessions, the recordings list could show a recording that did not actually include the event being filtered for.

## How did you test this code?

Added a unit test + tested locally by:
* Create a recording - do some stuff
* Open private browsing + login with the same account as above (creates a simultaneous session with a diff session_id)
* Do something new (not done in the original session)
* Filter recordings list by that new event
* See only one recording in the list.
