### PR TITLE
Make historical exports even more robust

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -17,12 +17,17 @@ import {
     fetchTimestampBoundariesForTeam,
 } from './utils'
 
-const EVENTS_TIME_INTERVAL = 10 * 60 * 1000 // 10 minutes
+const TEN_MINUTES = 1000 * 60 * 10
+const EVENTS_TIME_INTERVAL = TEN_MINUTES
 const EVENTS_PER_RUN = 100
+
 const TIMESTAMP_CURSOR_KEY = 'timestamp_cursor'
 const MAX_UNIX_TIMESTAMP_KEY = 'max_timestamp'
 const MIN_UNIX_TIMESTAMP_KEY = 'min_timestamp'
 const EXPORT_RUNNING_KEY = 'is_export_running'
+const RUN_EVERY_MINUTE_LAST_RUN_KEY = 'run_every_minute_last'
+const BATCH_ID_CURSOR_KEY = 'batch_id'
+const OLD_TIMESTAMP_CURSOR_KEY = 'old_timestamp_cursor'
 
 const INTERFACE_JOB_NAME = 'Export historical events'
 
@@ -38,6 +43,8 @@ export function addHistoricalEventsExportCapability(
 
     const oldSetupPlugin = methods.setupPlugin
 
+    const oldRunEveryMinute = tasks.schedule.runEveryMinute?.exec
+
     methods.setupPlugin = async () => {
         // Fetch the max and min timestamps for a team's events
         const timestampBoundaries = await fetchTimestampBoundariesForTeam(hub.db, pluginConfig.team_id)
@@ -47,31 +54,48 @@ export function addHistoricalEventsExportCapability(
         // the historical export to duplicate them
         meta.global.timestampBoundariesForTeam = timestampBoundaries
 
-        await meta.utils.cursor.init('batch_id')
+        await meta.utils.cursor.init(BATCH_ID_CURSOR_KEY)
 
         const storedTimestampCursor = await meta.storage.get(TIMESTAMP_CURSOR_KEY, null)
-        if (storedTimestampCursor) {
-            await meta.jobs.restartExportIfNeeded({ storedTimestampCursor }).runIn(10, 'minutes')
-        }
+        await meta.storage.set(OLD_TIMESTAMP_CURSOR_KEY, storedTimestampCursor || 0)
+        await meta.storage.set(RUN_EVERY_MINUTE_LAST_RUN_KEY, Date.now() + TEN_MINUTES)
 
         await oldSetupPlugin?.()
     }
 
-    tasks.job['restartExportIfNeeded'] = {
-        name: 'restartExportIfNeeded',
-        type: PluginTaskType.Job,
-        exec: async (payload) => {
-            const storedTimestampCursor = await meta.storage.get(TIMESTAMP_CURSOR_KEY, null)
+    tasks.schedule.runEveryMinute = {
+        name: 'runEveryMinute',
+        type: PluginTaskType.Schedule,
+        exec: async () => {
+            const lastRun = await meta.storage.get(RUN_EVERY_MINUTE_LAST_RUN_KEY, 0)
+            const exportShouldBeRunning = await meta.storage.get(EXPORT_RUNNING_KEY, false)
 
-            // if the cursor hasn't been incremented within 10 minutes of the restart
-            // that means we didn't pick up from where we left off automatically
+            const have10MinutesPassed = Date.now() - Number(lastRun) < TEN_MINUTES
+
+            // only run every 10 minutes _if_ an export is in progress
+            if (!exportShouldBeRunning || !have10MinutesPassed) {
+                return
+            }
+
+            const oldTimestampCursor = await meta.storage.get(OLD_TIMESTAMP_CURSOR_KEY, 0)
+            const currentTimestampCursor = await meta.storage.get(TIMESTAMP_CURSOR_KEY, 0)
+
+            // if the cursor hasn't been incremented after 10 minutes that means we didn't pick up from
+            // where we left off  automatically after a restart, or something else has gone wrong
             // thus, kick off a new export chain with a new batchId
-            if (payload && payload.storedTimestampCursor === storedTimestampCursor) {
-                const batchId = await meta.utils.cursor.increment('batch_id')
+            if (exportShouldBeRunning && oldTimestampCursor === currentTimestampCursor) {
+                const batchId = await meta.utils.cursor.increment(BATCH_ID_CURSOR_KEY)
                 await meta.jobs
                     .exportHistoricalEvents({ retriesPerformedSoFar: 0, incrementTimestampCursor: true, batchId })
                     .runNow()
             }
+
+            // set the old timestamp cursor to the current one so we can see if it changed in 10 minutes
+            await meta.storage.set(OLD_TIMESTAMP_CURSOR_KEY, currentTimestampCursor)
+
+            await meta.storage.set(RUN_EVERY_MINUTE_LAST_RUN_KEY, Date.now())
+
+            await oldRunEveryMinute?.()
         },
     }
 
@@ -91,6 +115,8 @@ export function addHistoricalEventsExportCapability(
             if (exportAlreadyRunning) {
                 return
             }
+
+            await meta.storage.set(RUN_EVERY_MINUTE_LAST_RUN_KEY, Date.now() + TEN_MINUTES)
             await meta.storage.set(EXPORT_RUNNING_KEY, true)
 
             // get rid of all state pertaining to a previous run
@@ -102,7 +128,7 @@ export function addHistoricalEventsExportCapability(
 
             await meta.global.initTimestampsAndCursor(payload)
 
-            const batchId = await meta.utils.cursor.increment('batch_id')
+            const batchId = await meta.utils.cursor.increment(BATCH_ID_CURSOR_KEY)
 
             await meta.jobs
                 .exportHistoricalEvents({ retriesPerformedSoFar: 0, incrementTimestampCursor: true, batchId: batchId })
@@ -117,7 +143,7 @@ export function addHistoricalEventsExportCapability(
         }
 
         // this is handling for duplicates when the plugin server restarts
-        const currentBatchId = await meta.storage.get('batch_id', 0)
+        const currentBatchId = await meta.storage.get(BATCH_ID_CURSOR_KEY, 0)
         if (currentBatchId !== payload.batchId) {
             return
         }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -85,6 +85,7 @@ export function addHistoricalEventsExportCapability(
             // thus, kick off a new export chain with a new batchId
             if (exportShouldBeRunning && oldTimestampCursor === currentTimestampCursor) {
                 const batchId = await meta.utils.cursor.increment(BATCH_ID_CURSOR_KEY)
+                createLog(`Restarting export after noticing inactivity. Batch ID: ${batchId}`)
                 await meta.jobs
                     .exportHistoricalEvents({ retriesPerformedSoFar: 0, incrementTimestampCursor: true, batchId })
                     .runNow()

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -237,7 +237,7 @@ describe('e2e', () => {
                 .filter((log) => log[0] === 'exported historical event').length
             expect(exportedEventsCountBeforeJob).toEqual(0)
 
-            const ts = new Date(0).toISOString()
+            const ts = new Date(100).toISOString()
 
             const kwargs = {
                 pluginConfigTeam: 2,

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -237,44 +237,30 @@ describe('e2e', () => {
                 .filter((log) => log[0] === 'exported historical event').length
             expect(exportedEventsCountBeforeJob).toEqual(0)
 
-            const ts = new Date(100).toISOString()
-
             const kwargs = {
                 pluginConfigTeam: 2,
                 pluginConfigId: 39,
                 type: 'Export historical events',
                 jobOp: 'start',
                 payload: {
-                    dateFrom: ts,
-                    dateTo: ts,
+                    dateFrom: new Date(Date.now() - ONE_HOUR).toISOString(),
+                    dateTo: new Date().toISOString(),
                 },
             }
             let args = Object.values(kwargs)
 
             const client = new Client(hub.db, hub.PLUGINS_CELERY_QUEUE)
 
-            // pass in an incorrect date range first
-            client.sendTask('posthog.tasks.plugins.plugin_job', args, {})
-
-            await delay(10000)
-
-            const exportedEventsCountAfterFirstJob = testConsole
-                .read()
-                .filter((log) => log[0] === 'exported historical event').length
-            expect(exportedEventsCountAfterFirstJob).toEqual(0)
-
-            // pass in the correct date range
-            kwargs.payload.dateFrom = new Date(Date.now() - ONE_HOUR).toISOString()
             args = Object.values(kwargs)
             client.sendTask('posthog.tasks.plugins.plugin_job', args, {})
 
             await delayUntilEventIngested(awaitHistoricalEventLogs, 4, 1000)
 
             const exportLogs = testConsole.read().filter((log) => log[0] === 'exported historical event')
-            const exportedEventsCountAfterSecondJob = exportLogs.length
+            const exportedEventsCountAfterJob = exportLogs.length
             const exportedEvents = exportLogs.map((log) => log[1])
 
-            expect(exportedEventsCountAfterSecondJob).toEqual(4)
+            expect(exportedEventsCountAfterJob).toEqual(4)
             expect(exportedEvents.map((e) => e.event)).toEqual(
                 expect.arrayContaining(['historicalEvent1', 'historicalEvent2', 'historicalEvent3', 'historicalEvent4'])
             )

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -237,14 +237,16 @@ describe('e2e', () => {
                 .filter((log) => log[0] === 'exported historical event').length
             expect(exportedEventsCountBeforeJob).toEqual(0)
 
+            const ts = new Date(0).toISOString()
+
             const kwargs = {
                 pluginConfigTeam: 2,
                 pluginConfigId: 39,
                 type: 'Export historical events',
                 jobOp: 'start',
                 payload: {
-                    dateFrom: new Date().toISOString(),
-                    dateTo: new Date().toISOString(),
+                    dateFrom: ts,
+                    dateTo: ts,
                 },
             }
             let args = Object.values(kwargs)

--- a/plugin-server/tests/postgres/e2e.test.ts
+++ b/plugin-server/tests/postgres/e2e.test.ts
@@ -248,14 +248,16 @@ describe('e2e', () => {
                 .filter((log) => log[0] === 'exported historical event').length
             expect(exportedEventsCountBeforeJob).toEqual(0)
 
+            const ts = new Date(0).toISOString()
+
             const kwargs = {
                 pluginConfigTeam: 2,
                 pluginConfigId: 39,
                 type: 'Export historical events',
                 jobOp: 'start',
                 payload: {
-                    dateFrom: new Date().toISOString(),
-                    dateTo: new Date().toISOString(),
+                    dateFrom: ts,
+                    dateTo: ts,
                 },
             }
             let args = Object.values(kwargs)

--- a/plugin-server/tests/postgres/e2e.test.ts
+++ b/plugin-server/tests/postgres/e2e.test.ts
@@ -248,7 +248,7 @@ describe('e2e', () => {
                 .filter((log) => log[0] === 'exported historical event').length
             expect(exportedEventsCountBeforeJob).toEqual(0)
 
-            const ts = new Date(0).toISOString()
+            const ts = new Date(100).toISOString()
 
             const kwargs = {
                 pluginConfigTeam: 2,

--- a/plugin-server/tests/postgres/e2e.test.ts
+++ b/plugin-server/tests/postgres/e2e.test.ts
@@ -248,44 +248,30 @@ describe('e2e', () => {
                 .filter((log) => log[0] === 'exported historical event').length
             expect(exportedEventsCountBeforeJob).toEqual(0)
 
-            const ts = new Date(100).toISOString()
-
             const kwargs = {
                 pluginConfigTeam: 2,
                 pluginConfigId: 39,
                 type: 'Export historical events',
                 jobOp: 'start',
                 payload: {
-                    dateFrom: ts,
-                    dateTo: ts,
+                    dateFrom: new Date(Date.now() - ONE_HOUR).toISOString(),
+                    dateTo: new Date().toISOString(),
                 },
             }
             let args = Object.values(kwargs)
 
             const client = new Client(hub.db, hub.PLUGINS_CELERY_QUEUE)
 
-            // pass in an incorrect date range first
-            client.sendTask('posthog.tasks.plugins.plugin_job', args, {})
-
-            await delay(10000)
-
-            const exportedEventsCountAfterFirstJob = testConsole
-                .read()
-                .filter((log) => log[0] === 'exported historical event').length
-            expect(exportedEventsCountAfterFirstJob).toEqual(0)
-
-            // pass in the correct date range
-            kwargs.payload.dateFrom = new Date(Date.now() - ONE_HOUR).toISOString()
             args = Object.values(kwargs)
             client.sendTask('posthog.tasks.plugins.plugin_job', args, {})
 
             await delayUntilEventIngested(awaitHistoricalEventLogs, 4, 1000)
 
             const exportLogs = testConsole.read().filter((log) => log[0] === 'exported historical event')
-            const exportedEventsCountAfterSecondJob = exportLogs.length
+            const exportedEventsCountAfterJob = exportLogs.length
             const exportedEvents = exportLogs.map((log) => log[1])
 
-            expect(exportedEventsCountAfterSecondJob).toEqual(4)
+            expect(exportedEventsCountAfterJob).toEqual(4)
             expect(exportedEvents.map((e) => e.event)).toEqual(
                 expect.arrayContaining(['historicalEvent1', 'historicalEvent2', 'historicalEvent3', 'historicalEvent4'])
             )

--- a/plugin-server/tests/postgres/vm.test.ts
+++ b/plugin-server/tests/postgres/vm.test.ts
@@ -1091,7 +1091,7 @@ describe('exportEvents', () => {
         expect(Object.keys(vm.tasks.job)).toEqual(
             expect.arrayContaining(['exportEventsWithRetry', 'exportHistoricalEvents', 'Export historical events'])
         )
-        expect(Object.keys(vm.tasks.schedule)).toEqual([])
+        expect(Object.keys(vm.tasks.schedule)).toEqual(['runEveryMinute'])
         expect(
             Object.keys(vm.methods)
                 .filter((m) => !!vm.methods[m as keyof typeof vm.methods])


### PR DESCRIPTION
## Changes

I'm extremely grateful that #7141 went into 1.30.0 because it just made my life much easier when working on exporting a customer's events.

**However**, I realized it could be better. What happened was that something went wrong on the customer's instance, so the export stopped at 1am and didn't pick back up by itself. Had the plugin server crashed, we would have come back up. It also wasn't a plugin error either.

So I decided to add a periodic check on the export. Every 10 minutes, check if we're moving forward. If we're not, "cancel" any previous exports (via a batch ID) and kick things off again. 

This is being done using `runEveryMinute` instead of jobs because scheduled tasks are guaranteed to be debounced, which is what we want here.

## How did you test this code?

Manually. Instructions:

1. Setup a plugin that uses `exportEvents`. Anything will do: `export function exportEvents() {}`
2. Trigger the `Export historical events` job in the interface
3. Disable the plugin and get rid of any jobs in the queue in Postgres `TRUNCATE graphile_worker.jobs`
4. Turn the plugin back on and watch it recover (you might want to change the interval from 10 minutes to something else)
