### PR TITLE
Removes the customize columns feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -70,7 +70,6 @@ export const FEATURE_FLAGS = {
     // Experiments / beta features
     INGESTION_GRID: 'ingestion-grid-exp-3', // owner: @kpthatsme
     TRAILING_WAU_MAU: '3638-trailing-wau-mau', // owner: @EDsCODE
-    EVENT_COLUMN_CONFIG: '4141-event-columns', // owner: @pauldambra
     MULTIVARIATE_SUPPORT: '5440-multivariate-support', // owner: @mariusandra
     FUNNEL_HORIZONTAL_UI: '5730-funnel-horizontal-ui', // owner: @alexkim205
     DIVE_DASHBOARDS: 'hackathon-dive-dashboards', // owner: @tiina303

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -17,8 +17,6 @@ import { ActionType, EventsTableRowItem, EventType, InsightType } from '~/types'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { EventName } from 'scenes/actions/EventName'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { Tooltip } from 'lib/components/Tooltip'
 import { LabelledSwitch } from 'scenes/events/LabelledSwitch'
 import clsx from 'clsx'
@@ -68,7 +66,6 @@ export function EventsTable({
 
     const { propertyNames } = useValues(propertyDefinitionsModel)
     const { fetchNextEvents, prependNewEvents, setEventFilter, toggleAutomaticLoad } = useActions(logic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const showLinkToPerson = !fixedFilters?.person_id
     const newEventsRender = (item: Record<string, any>, colSpan: number): Record<string, any> => {
@@ -327,15 +324,13 @@ export function EventsTable({
                             </Tooltip>
                         )}
                     </Col>
-                    {featureFlags[FEATURE_FLAGS.EVENT_COLUMN_CONFIG] && (
-                        <Col flex="0">
-                            <TableConfig
-                                availableColumns={propertyNames}
-                                immutableColumns={['event', 'person', 'when']}
-                                defaultColumns={defaultColumns.map((e) => e.key || '')}
-                            />
-                        </Col>
-                    )}
+                    <Col flex="0">
+                        <TableConfig
+                            availableColumns={propertyNames}
+                            immutableColumns={['event', 'person', 'when']}
+                            defaultColumns={defaultColumns.map((e) => e.key || '')}
+                        />
+                    </Col>
                 </Row>
 
                 <div>


### PR DESCRIPTION
## Changes

Customise columns has been receiving over 10 clicks a day on cloud with no user feedback. We should remove the feature flag and roll it out to everyone

## How did you test this code?

* run the site locally
* visit the events & actions page
* see that the customise columns button is present 
* click it and check it works
* assert there are no errors in the console
