### PR TITLE
Remove correlation-analysis FF

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -79,7 +79,6 @@ export const FEATURE_FLAGS = {
     REMOVE_SESSIONS: '6050-remove-sessions', // owner: @rcmarron
     FUNNEL_VERTICAL_BREAKDOWN: '5733-funnel-vertical-breakdown', // owner: @alexkim205
     RENAME_FILTERS: '6063-rename-filters', // owner: @alexkim205
-    CORRELATION_ANALYSIS: 'correlation-analysis', // owner: @neilkakkar
     SIGMA_ANALYSIS: 'sigma-analysis', // owner: @neilkakkar
     NEW_SESSIONS_PLAYER: 'new-sessions-player', // owner: @rcmarron
     NEW_SESSIONS_PLAYER_EVENTS_LIST: 'new-sessions-player-events-list', // owner: @rcmarron / @alexkim205

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -508,14 +508,6 @@ describe('funnelLogic', () => {
         // teamLogic to update the currentTeam, and also explicitly mount the
         // userLogic.
 
-        it('initially not loaded', async () => {
-            await expectLogic(logic)
-                .toFinishListeners()
-                .toMatchValues({
-                    propertyCorrelations: { events: [] },
-                })
-        })
-
         it('Selecting all properties returns expected result', async () => {
             featureFlagLogic.actions.setFeatureFlags(['correlation-analysis'], { 'correlation-analysis': true })
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1013,11 +1013,9 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
             },
         ],
         correlationAnalysisAvailable: [
-            (s) => [s.hasAvailableFeature, s.clickhouseFeaturesEnabled, s.featureFlags],
-            (hasAvailableFeature, clickhouseFeaturesEnabled, featureFlags) =>
-                featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] &&
-                clickhouseFeaturesEnabled &&
-                hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
+            (s) => [s.hasAvailableFeature, s.clickhouseFeaturesEnabled],
+            (hasAvailableFeature, clickhouseFeaturesEnabled) =>
+                clickhouseFeaturesEnabled && hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
         ],
         allProperties: [
             (s) => [s.inversePropertyNames, s.excludedPropertyNames],

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1014,7 +1014,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
         ],
         correlationAnalysisAvailable: [
             (s) => [s.hasAvailableFeature, s.clickhouseFeaturesEnabled],
-            (hasAvailableFeature, clickhouseFeaturesEnabled) =>
+            (hasAvailableFeature, clickhouseFeaturesEnabled): boolean =>
                 clickhouseFeaturesEnabled && hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
         ],
         allProperties: [

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -187,11 +187,7 @@ export function InsightContainer(): JSX.Element {
             </Card>
             {renderTable()}
 
-            {preflight?.is_clickhouse_enabled &&
-            activeView === InsightType.FUNNELS &&
-            featureFlags[FEATURE_FLAGS.CORRELATION_ANALYSIS] ? (
-                <FunnelCorrelation />
-            ) : null}
+            {preflight?.is_clickhouse_enabled && activeView === InsightType.FUNNELS && <FunnelCorrelation />}
         </>
     )
 }

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -62,7 +62,9 @@ export function InsightContainer(): JSX.Element {
         showErrorMessage,
         insightLoading,
     } = useValues(insightLogic)
-    const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
+    const { areFiltersValid, isValidFunnel, areExclusionFiltersValid, correlationAnalysisAvailable } = useValues(
+        funnelLogic(insightProps)
+    )
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
@@ -187,7 +189,7 @@ export function InsightContainer(): JSX.Element {
             </Card>
             {renderTable()}
 
-            {preflight?.is_clickhouse_enabled && activeView === InsightType.FUNNELS && <FunnelCorrelation />}
+            {correlationAnalysisAvailable && activeView === InsightType.FUNNELS && <FunnelCorrelation />}
         </>
     )
 }


### PR DESCRIPTION
## Changes

Removes the feature flag: it's shipped to everyone, we've gotten positive feedback, the UI is now ironed out and we're starting to get some usage (if little, 3% of funnel usage), [source](https://app.posthog.com/insights?insight=TRENDS&actions=%5B%5D&events=%5B%7B%22id%22%3A%22correlation%20analyzed%22%2C%22name%22%3A%22correlation%20analyzed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%7D%2C%7B%22id%22%3A%22insight%20analyzed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A1%2C%22name%22%3A%22insight%20analyzed%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22insight%22%2C%22value%22%3A%5B%22FUNNELS%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%5D&display=ActionsLineGraph&properties=%5B%5D&filter_test_accounts=true&funnel_viz_type=steps&exclusions=%5B%5D&funnel_from_step=0&funnel_to_step=1&new_entity=%5B%5D&date_from=-30d&interval=week#fromItem=518551&edit=true).

## How did you test this code?
- Tested that the correlation analysis feature showed up for everyone.
