### PR TITLE
Improve the date filter on recordings list

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -3,6 +3,7 @@ import { Select } from 'antd'
 import { dateMapping, isDate, dateFilterToText } from 'lib/utils'
 import { DateFilterRange } from 'lib/components/DateFilter/DateFilterRange'
 import { dayjs } from 'lib/dayjs'
+import { dateMappingOption } from '~/types'
 
 export interface DateFilterProps {
     defaultValue: string
@@ -13,6 +14,7 @@ export interface DateFilterProps {
     onChange?: (fromDate: string, toDate: string) => void
     disabled?: boolean
     getPopupContainer?: (props: any) => HTMLElement
+    dateOptions?: Record<string, dateMappingOption>
 }
 
 interface RawDateFilterProps extends DateFilterProps {
@@ -31,6 +33,7 @@ export function DateFilter({
     getPopupContainer,
     dateFrom,
     dateTo,
+    dateOptions = dateMapping,
 }: RawDateFilterProps): JSX.Element {
     const [rangeDateFrom, setRangeDateFrom] = useState(
         dateFrom && isDate.test(dateFrom as string) ? dayjs(dateFrom) : undefined
@@ -55,7 +58,7 @@ export function DateFilter({
                 setDateRangeOpen(true)
             }
         } else {
-            setDate(dateMapping[v].values[0], dateMapping[v].values[1])
+            setDate(dateOptions[v].values[0], dateOptions[v].values[1])
         }
     }
 
@@ -86,7 +89,7 @@ export function DateFilter({
     }
 
     const parsedValue = useMemo(
-        () => dateFilterToText(dateFrom, dateTo, defaultValue),
+        () => dateFilterToText(dateFrom, dateTo, defaultValue, dateOptions),
         [dateFrom, dateTo, defaultValue]
     )
 
@@ -126,7 +129,7 @@ export function DateFilter({
             }}
         >
             {[
-                ...Object.entries(dateMapping).map(([key, { inactive }]) => {
+                ...Object.entries(dateOptions).map(([key, { inactive }]) => {
                     if (key === 'Custom' && !showCustom) {
                         return null
                     }

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -198,6 +198,14 @@ describe('dateFilterToText()', () => {
         expect(dateFilterToText('-1d', 'dStart', 'default')).toEqual('Yesterday')
         expect(dateFilterToText('-1mStart', '-1mEnd', 'default')).toEqual('Previous month')
     })
+
+    it('can have overridden date options', () => {
+        expect(
+            dateFilterToText('-21d', null, 'default', {
+                'Last 3 weeks': { values: ['-21d'] },
+            })
+        ).toEqual('Last 3 weeks')
+    })
 })
 
 describe('hexToRGBA()', () => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, PropsWithChildren } from 'react'
 import api from './api'
 import { toast } from 'react-toastify'
 import { Button } from 'antd'
-import { EventType, FilterType, ActionFilter, IntervalType, ItemMode, DashboardMode } from '~/types'
+import { EventType, FilterType, ActionFilter, IntervalType, ItemMode, DashboardMode, dateMappingOption } from '~/types'
 import { tagColors } from 'lib/colors'
 import { CustomerServiceOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 import { WEBHOOK_SERVICES } from 'lib/constants'
@@ -684,11 +684,6 @@ export function determineDifferenceType(
     }
 }
 
-interface dateMappingOption {
-    inactive?: boolean // Options removed due to low usage (see relevant PR); will not show up for new insights but will be kept for existing
-    values: string[]
-}
-
 export const dateMapping: Record<string, dateMappingOption> = {
     Custom: { values: [] },
     Today: { values: ['dStart'] },
@@ -710,7 +705,8 @@ export const isDate = /([0-9]{4}-[0-9]{2}-[0-9]{2})/
 export function dateFilterToText(
     dateFrom: string | dayjs.Dayjs | null | undefined,
     dateTo: string | dayjs.Dayjs | null | undefined,
-    defaultValue: string
+    defaultValue: string,
+    dateOptions: Record<string, dateMappingOption> = dateMapping
 ): string {
     if (dayjs.isDayjs(dateFrom) && dayjs.isDayjs(dateTo)) {
         return `${dateFrom.format('YYYY-MM-DD')} - ${dateTo.format('YYYY-MM-DD')}`
@@ -741,7 +737,7 @@ export function dateFilterToText(
     }
 
     let name = defaultValue
-    Object.entries(dateMapping).map(([key, { values }]) => {
+    Object.entries(dateOptions).map(([key, { values }]) => {
         if (values[0] === dateFrom && values[1] === dateTo && key !== 'Custom') {
             name = key
         }

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -204,12 +204,18 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                                     <span> {key}</span>
                                 </>
                             )}
-                            defaultValue="Last 30 days"
+                            defaultValue="Last 7 days"
                             bordered={true}
                             dateFrom={fromDate ?? undefined}
                             dateTo={toDate ?? undefined}
                             onChange={(changedDateFrom, changedDateTo) => {
                                 setDateRange(changedDateFrom, changedDateTo)
+                            }}
+                            dateOptions={{
+                                Custom: { values: [] },
+                                'Last 24 hours': { values: ['-24h'] },
+                                'Last 7 days': { values: ['-7d'] },
+                                'Last 21 days': { values: ['-21d'] },
                             }}
                         />
                     </Row>

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -172,7 +172,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
             },
         ],
         fromDate: [
-            dayjs().subtract(30, 'days').format('YYYY-MM-DD') as null | string,
+            dayjs().subtract(7, 'days').format('YYYY-MM-DD') as null | string,
             {
                 setDateRange: (_, { incomingFromDate }) => incomingFromDate ?? null,
             },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1399,3 +1399,8 @@ export interface VersionType {
     version: string
     release_date?: string
 }
+
+export interface dateMappingOption {
+    inactive?: boolean // Options removed due to low usage (see relevant PR); will not show up for new insights but will be kept for existing
+    values: string[]
+}


### PR DESCRIPTION
## Changes

This PR has 2 goals:
- Makes it clearer that recordings only go back 21 days by limited the options in the date filter.
- Sets the default date range for the recordings query to 7 days (before it was 30 - which didn't really make sense). This will also speed it up the query. (Helping: https://github.com/PostHog/posthog/issues/7247)

## How did you test this code?

Verified that the new date filter starts as '7 days ago', the filter reflects the expected ranges, and the resulting clickhouse query has the right date range.