### PR TITLE
Remove collapse insight

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -260,7 +260,6 @@ export const eventUsageLogic = kea<
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
         reportInsightsTabReset: true,
-        reportInsightsControlsCollapseToggle: (collapsed: boolean) => ({ collapsed }),
         reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
         reportInsightShortUrlVisited: (valid: boolean, insight: InsightType | null) => ({ valid, insight }),
         reportSavedInsightTabChanged: (tab: string) => ({ tab }),
@@ -624,9 +623,6 @@ export const eventUsageLogic = kea<
         },
         reportInsightsTabReset: async () => {
             posthog.capture('insights tab reset')
-        },
-        reportInsightsControlsCollapseToggle: async (payload) => {
-            posthog.capture('insight controls collapse toggled', payload)
         },
         reportInsightsTableCalcToggled: async (payload) => {
             posthog.capture('insights table calc toggled', payload)

--- a/frontend/src/scenes/insights/Insights.scss
+++ b/frontend/src/scenes/insights/Insights.scss
@@ -81,22 +81,6 @@ $funnel_canvas_background: #fafafa;
         .ant-card-body {
             padding: $default_spacing * 0.8 $default_spacing;
         }
-
-        .collapse-control {
-            position: absolute;
-            right: $default_spacing / 2;
-            top: $default_spacing / 2;
-            cursor: pointer;
-            z-index: $z_raised;
-        }
-
-        &.collapsed {
-            cursor: pointer;
-            border-color: $primary !important;
-            .tabs-inner {
-                display: none;
-            }
-        }
     }
 
     .insights-graph-container {

--- a/frontend/src/scenes/insights/Insights.tsx
+++ b/frontend/src/scenes/insights/Insights.tsx
@@ -6,7 +6,6 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { router } from 'kea-router'
 import { FunnelTab, PathTab, RetentionTab, SessionTab, TrendTab } from './InsightTabs'
 import { insightLogic } from './insightLogic'
-import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { insightCommandLogic } from './insightCommandLogic'
 import { HotKeys, ItemMode, InsightType } from '~/types'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
@@ -43,7 +42,6 @@ export function Insights(): JSX.Element {
         insightProps,
         activeView,
         filters,
-        controlsCollapsed,
         insight,
         insightMode,
         filtersChanged,
@@ -51,16 +49,8 @@ export function Insights(): JSX.Element {
         tagLoading,
         metadataEditable,
     } = useValues(logic)
-    const {
-        setActiveView,
-        toggleControlsCollapsed,
-        setInsightMode,
-        saveInsight,
-        setFilters,
-        setInsightMetadata,
-        saveNewTag,
-        deleteTag,
-    } = useActions(logic)
+    const { setActiveView, setInsightMode, saveInsight, setFilters, setInsightMetadata, saveNewTag, deleteTag } =
+        useActions(logic)
 
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
@@ -238,26 +228,7 @@ export function Insights(): JSX.Element {
 
                     <Row gutter={16}>
                         <Col span={24} xl={verticalLayout ? 8 : undefined}>
-                            <Card
-                                className={`insight-controls${controlsCollapsed ? ' collapsed' : ''}`}
-                                onClick={() => controlsCollapsed && toggleControlsCollapsed()}
-                            >
-                                <div
-                                    role="button"
-                                    title={controlsCollapsed ? 'Expand panel' : 'Collapse panel'}
-                                    className="collapse-control"
-                                    onClick={() => !controlsCollapsed && toggleControlsCollapsed()}
-                                >
-                                    {controlsCollapsed ? <DownOutlined /> : <UpOutlined />}
-                                </div>
-                                {controlsCollapsed && (
-                                    <div>
-                                        <h3 className="l3">Query definition</h3>
-                                        <span className="text-small text-muted">
-                                            Click here to view and change the query events, filters and other settings.
-                                        </span>
-                                    </div>
-                                )}
+                            <Card className="insight-controls">
                                 <div className="tabs-inner">
                                     {/* These are insight specific filters. They each have insight specific logics */}
                                     {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -83,7 +83,6 @@ export const insightLogic = kea<insightLogicType>({
         setTimeout: (timeout: number | null) => ({ timeout }),
         setLastRefresh: (lastRefresh: string | null) => ({ lastRefresh }),
         setNotFirstLoad: () => {},
-        toggleControlsCollapsed: true,
         saveNewTag: (tag: string) => ({ tag }),
         deleteTag: (tag: string) => ({ tag }),
         setInsight: (insight: Partial<DashboardItemType>, options: SetInsightOptions) => ({
@@ -354,12 +353,6 @@ export const insightLogic = kea<insightLogicType>({
                 setNotFirstLoad: () => false,
             },
         ],
-        controlsCollapsed: [
-            false,
-            {
-                toggleControlsCollapsed: (state) => !state,
-            },
-        ],
         queryStartTimes: [
             {} as Record<string, number>,
             {
@@ -530,9 +523,6 @@ export const insightLogic = kea<insightLogicType>({
             if (values.timeout) {
                 clearTimeout(values.timeout)
             }
-        },
-        toggleControlsCollapsed: async () => {
-            eventUsageLogic.actions.reportInsightsControlsCollapseToggle(values.controlsCollapsed)
         },
         saveNewTag: async ({ tag }) => {
             if (values.insight.tags?.includes(tag)) {


### PR DESCRIPTION
## Changes

Removes the option to collapse insight definition as it's almost never used ([source](https://app.posthog.com/insights?insight=TRENDS&display=ActionsLineGraph&actions=%5B%5D&events=%5B%7B%22id%22%3A%22%24autocapture%22%2C%22name%22%3A%22%24autocapture%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math%22%3A%22total%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22selector%22%2C%22value%22%3A%5B%22.collapse-control%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22element%22%7D%5D%7D%2C%7B%22id%22%3A%22insight%20analyzed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A1%2C%22name%22%3A%22insight%20analyzed%22%7D%2C%7B%22id%22%3A%22insight%20controls%20collapse%20toggled%22%2C%22type%22%3A%22events%22%2C%22order%22%3A2%2C%22name%22%3A%22insight%20controls%20collapse%20toggled%22%7D%5D&properties=%5B%5D&filter_test_accounts=true&compare=false&new_entity=%5B%5D&date_from=-30d&interval=week#fromItem=519802&edit=true)) and no longer makes sense with the new insight view-only mode.

## How did you test this code?
- Tested with trends, funnels, paths & lifecycle.
