### PR TITLE
original behaviour was to set breakdown_values regardless of if it wa…

### DIFF
--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -356,8 +356,7 @@ class ClickhouseFunnelBase(ABC, Funnel):
                 extra_join = self._get_cohort_breakdown_join()
             else:
                 values = self._get_breakdown_conditions()
-                if values:
-                    self.params.update({"breakdown_values": values})
+                self.params.update({"breakdown_values": values})
 
         return FUNNEL_INNER_EVENT_STEPS_QUERY.format(
             steps=steps,

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -1540,17 +1540,15 @@ class TestClickhouseFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFu
         self.assertEqual(result[1]["count"], 0)
 
     def test_breakdown_values_is_set_on_the_query_with_fewer_than_two_entities(self):
+        """
+        failing test for https://sentry.io/organizations/posthog/issues/2807609211/?project=1899813&referrer=slack
+        """
 
         filter_with_breakdown = {
-            "events": [{"id": "user signed up", "type": "events", "order": 0},],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
+            "events": [{"id": "with one entity", "type": "events", "order": 0},],
             "breakdown": "something",
-            "breakdown_type": "event",
         }
-        filter = Filter(data=filter_with_breakdown)
-        funnel = ClickhouseFunnel(filter, self.team)
+        funnel = ClickhouseFunnel(Filter(data=filter_with_breakdown), self.team)
 
         # because this calls get_step_counts_query
         # which calls get_step_counts_without_aggregation_query

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -1538,3 +1538,24 @@ class TestClickhouseFunnel(ClickhouseTestMixin, funnel_test_factory(ClickhouseFu
 
         self.assertEqual(result[1]["name"], "paid")
         self.assertEqual(result[1]["count"], 0)
+
+    def test_breakdown_values_is_set_on_the_query_with_fewer_than_two_entities(self):
+
+        filter_with_breakdown = {
+            "events": [{"id": "user signed up", "type": "events", "order": 0},],
+            "insight": INSIGHT_FUNNELS,
+            "date_from": "2020-01-01",
+            "date_to": "2020-01-14",
+            "breakdown": "something",
+            "breakdown_type": "event",
+        }
+        filter = Filter(data=filter_with_breakdown)
+        funnel = ClickhouseFunnel(filter, self.team)
+
+        # because this calls get_step_counts_query
+        # which calls get_step_counts_without_aggregation_query
+        # which calls _get_inner_event_query
+        # which calls _get_breakdown_conditions
+        funnel.get_query()
+
+        assert "breakdown_values" in funnel.params


### PR DESCRIPTION
…s truthy

## Changes

In #7074 a side effect was moved up a level out of the `_get_breakdown_conditions` method of `ee/clickhouse/queries/funnels/base.py`.

The side effect was to set breakdown_values. 

Since merging we have seen one instance of this bug in Sentry https://sentry.io/organizations/posthog/issues/2807609211/?project=1899813&referrer=slack

`KeyError 'breakdown_values'` when trying to template a clickhouse query.

This change ensures we set breakdown_values in the dcitionary we templates from even if its value is falsy

## How did you test this code?

By letting tests run on this PR
