### PR TITLE
Remove dashboard errors with share_token

### DIFF
--- a/posthog/internal_metrics/team.py
+++ b/posthog/internal_metrics/team.py
@@ -385,6 +385,7 @@ def get_internal_metrics_dashboards() -> Dict:
         return {}
 
     clickhouse_dashboard = get_or_create_dashboard(team_id, CLICKHOUSE_DASHBOARD)
+    print("dashboard: ", clickhouse_dashboard)
 
     return {"clickhouse": {"id": clickhouse_dashboard.id, "share_token": clickhouse_dashboard.share_token}}
 
@@ -401,6 +402,7 @@ def get_or_create_dashboard(team_id: int, definition: Dict) -> Dashboard:
             filters=definition["filters"],
             description=description,
             team_id=team_id,
+            is_shared=True,
             share_token=secrets.token_urlsafe(22),
         )
 

--- a/posthog/internal_metrics/team.py
+++ b/posthog/internal_metrics/team.py
@@ -385,7 +385,6 @@ def get_internal_metrics_dashboards() -> Dict:
         return {}
 
     clickhouse_dashboard = get_or_create_dashboard(team_id, CLICKHOUSE_DASHBOARD)
-    print("dashboard: ", clickhouse_dashboard)
 
     return {"clickhouse": {"id": clickhouse_dashboard.id, "share_token": clickhouse_dashboard.share_token}}
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog/issues/7256

Dashboards accessed via share_token need to have set `is_shared` to true.

## How did you test this code?

Run locally, ensure the API request returns the dashboard