### PR TITLE
Fix meta information stuck in loading state

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -61,7 +61,7 @@ export function PlayerMeta(): JSX.Element {
                                     {formatDisplayPercentage(scale)}%)
                                 </>
                             ) : (
-                                <>Resolution not found</>
+                                <>Resolution: ...</>
                             )}
                         </span>
                     )}

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -9,13 +9,13 @@ import { metaLogic } from 'scenes/session-recordings/player/metaLogic'
 import { formatDisplayPercentage } from 'scenes/funnels/funnelUtils'
 
 export function PlayerMeta(): JSX.Element {
-    const { sessionPerson, description, resolution, scale, meta, isMetaLoading } = useValues(metaLogic)
+    const { sessionPerson, description, resolution, scale, meta, loading } = useValues(metaLogic)
 
     return (
         <Col className="player-meta-container">
             <Row className="player-meta-person" align="middle" justify="space-between" wrap={false}>
                 <Row className="player-meta-person-title" align="middle" wrap={false}>
-                    {isMetaLoading ? (
+                    {loading ? (
                         <Space>
                             <Skeleton.Avatar active size="small" shape="circle" />
                             <Skeleton title={false} active paragraph={{ rows: 1, width: 160 }} />
@@ -35,7 +35,7 @@ export function PlayerMeta(): JSX.Element {
                     )}
                 </Row>
                 <Col>
-                    {isMetaLoading ? (
+                    {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1, width: 80 }} />
                     ) : (
                         <span className="time text-small">{meta.startTime && dayjs(meta.startTime).fromNow()}</span>
@@ -44,14 +44,14 @@ export function PlayerMeta(): JSX.Element {
             </Row>
             <Row className="player-meta-other" align="middle" justify="start">
                 <Row className="player-meta-other-description">
-                    {isMetaLoading ? (
+                    {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1 }} />
                     ) : (
                         <span className="text-small">{description}</span>
                     )}
                 </Row>
                 <Row className="player-meta-other-resolution">
-                    {isMetaLoading ? (
+                    {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1, width: '100%' }} />
                     ) : (
                         <span className="text-small">

--- a/frontend/src/scenes/session-recordings/player/metaLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/metaLogic.test.ts
@@ -4,6 +4,7 @@ import { initKeaTestLogic } from '~/test/init'
 import { sessionRecordingLogic } from 'scenes/session-recordings/sessionRecordingLogic'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { metaLogic } from 'scenes/session-recordings/player/metaLogic'
+import { SessionPlayerData } from '~/types'
 
 jest.mock('lib/api')
 
@@ -20,8 +21,24 @@ describe('metaLogic', () => {
     })
 
     describe('core assumptions', () => {
-        it('mounts other logics', async () => {
-            await expectLogic(logic).toMount([sessionRecordingLogic, sessionRecordingPlayerLogic])
+        it('mounts other logics', () => {
+            expectLogic(logic).toMount([sessionRecordingLogic, sessionRecordingPlayerLogic])
+        })
+        it('starts with loading state', () => {
+            expectLogic(logic).toMatchValues({
+                loading: true,
+            })
+        })
+    })
+
+    describe('loading state', () => {
+        it('stops loading after meta load is successful', async () => {
+            await expectLogic(logic).toMatchValues({ loading: true })
+            await expectLogic(logic, () => {
+                logic.actions.loadRecordingMetaSuccess({} as SessionPlayerData)
+            })
+                .toDispatchActions(['loadRecordingMetaSuccess'])
+                .toMatchValues({ loading: false })
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/player/metaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/metaLogic.ts
@@ -53,10 +53,7 @@ export const metaLogic = kea<metaLogicType>({
                 // Find snapshot to pull resolution from
                 const lastIndex = findLastIndex(snapshots, (s: eventWithTime) => 'width' in s.data)
                 if (lastIndex === -1) {
-                    return {
-                        width: 0,
-                        height: 0,
-                    }
+                    return null
                 }
                 const currIndex = snapshots.findIndex(
                     (s: eventWithTime) => s.timestamp > time.current && 'width' in s.data


### PR DESCRIPTION
## Changes

Fixes a bug here https://github.com/PostHog/posthog/issues/6483

There was a bug where at some moments of the recording, the player meta card would return into a loading state. This happened because we were retrieving the current snapshots incorrectly which returned null resolutions. Decoupling the loading state from this selector fixed the issue.

## How did you test this code?

Add logic test