### PR TITLE
Fix sentry type error in updateperson

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -562,7 +562,9 @@ export class DB {
         RETURNING version`
 
         const updateResult: QueryResult = await this.postgresQuery(queryString, values, 'updatePerson', client)
-
+        if (updateResult.rows.length == 0) {
+            throw new Error(`Person with team_id="${person.team_id}" and uuid="${person.uuid} couldn't be updated`)
+        }
         const updatedPersonVersion: Person['version'] = Number(updateResult.rows[0].version)
         const updatedPerson: Person = { ...person, ...update, version: updatedPersonVersion }
 


### PR DESCRIPTION
## Changes

https://sentry.io/organizations/posthog/issues/2794493692/?project=5592816&query=is%3Aunresolved

This is a problem we've had in the old update path for a long time, since we don't lock the person row the person could have been merged or deleted before we reach the update. 
This is an improvement as we no longer send the outdated person to ClickHouse and this could have created some problems there with duplicate persons in the past.

## How did you test this code?

CI
