### PR TITLE
Clarify placeholder for EventNames selection box

### DIFF
--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -23,7 +23,7 @@ export function EventName({ value, onChange, isActionStep = false }: EventNameIn
                 filterOption={(input, option) => option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0}
                 disabled={isActionStep && eventNamesGrouped[0].options.length === 0}
                 value={value || undefined}
-                placeholder="All events"
+                placeholder="Choose an event"
                 data-attr="event-name-box"
             >
                 {eventNamesGrouped.map((typeGroup) => {


### PR DESCRIPTION
Users were confused about leaving this empty leading to selecting all events, which isn't the case.

Used in two places:

![image](https://user-images.githubusercontent.com/7115141/143018423-50fe05e1-a816-49f7-a06e-cebbc27ae534.png)

and when creating new action:

![image](https://user-images.githubusercontent.com/7115141/143018491-6348c7a8-caab-48bd-931e-f01192710823.png)


## How did you test this code?

YOLO
