### PR TITLE
Person URLs in Funnels

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -107,8 +107,7 @@ class ClickhouseInsightsViewSet(InsightViewSet):
                 ).run()
             }
         else:
-            base_uri = request.build_absolute_uri("/")
-            return {"result": funnel_order_class(team=team, filter=filter, base_uri=base_uri).run()}
+            return {"result": funnel_order_class(team=team, filter=filter).run()}
 
     # ******************************************
     # /projects/:id/insights/funnel/correlation

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -9,24 +9,42 @@ describe('API helper', () => {
             window.fetch = fakeFetch
         })
 
-        it('adds a leading slash to relative URLs', () => {
-            api.get('relative/url')
-            expect(fakeFetch.mock.calls[0][0]).toEqual('/relative/url/')
-        })
+        const testCases = [
+            {
+                url: 'relative/url',
+                expected: '/relative/url/',
+            },
+            {
+                url: '/absolute/url',
+                expected: '/absolute/url/',
+            },
+            {
+                url: 'relative/url?with=parameters',
+                expected: '/relative/url?with=parameters',
+            },
+            {
+                url: '/absolute/url?with=parameters',
+                expected: '/absolute/url?with=parameters',
+            },
+            {
+                url: 'http://some/url',
+                expected: 'http://some/url',
+            },
+            {
+                url: 'https://some/url',
+                expected: 'https://some/url',
+            },
+        ]
 
-        it('does not add leading slash when absolute url with no http', () => {
-            api.get('/absolute/url')
-            expect(fakeFetch.mock.calls[0][0]).toEqual('/absolute/url/')
-        })
+        const verbs = ['get', 'update', 'create', 'delete']
 
-        it('does not add leading slash to http urls', () => {
-            api.get('http://some/url')
-            expect(fakeFetch.mock.calls[0][0]).toEqual('http://some/url')
-        })
-
-        it('does not add leading slash to https urls', () => {
-            api.get('https://some/url')
-            expect(fakeFetch.mock.calls[0][0]).toEqual('https://some/url')
+        verbs.forEach((verb) => {
+            testCases.forEach((testCase) => {
+                it(`when API is using verb ${verb} it normalises ${testCase.url} to ${testCase.expected}`, () => {
+                    api[verb](testCase.url)
+                    expect(fakeFetch.mock.calls[0][0]).toEqual(testCase.expected)
+                })
+            })
         })
     })
 })

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,32 @@
+import api from 'lib/api'
+
+describe('API helper', () => {
+    describe('getting URLs', () => {
+        let fakeFetch: jest.Mock<any, any>
+
+        beforeEach(() => {
+            fakeFetch = jest.fn()
+            window.fetch = fakeFetch
+        })
+
+        it('adds a leading slash to relative URLs', () => {
+            api.get('relative/url')
+            expect(fakeFetch.mock.calls[0][0]).toEqual('/relative/url/')
+        })
+
+        it('does not add leading slash when absolute url with no http', () => {
+            api.get('/absolute/url')
+            expect(fakeFetch.mock.calls[0][0]).toEqual('/absolute/url/')
+        })
+
+        it('does not add leading slash to http urls', () => {
+            api.get('http://some/url')
+            expect(fakeFetch.mock.calls[0][0]).toEqual('http://some/url')
+        })
+
+        it('does not add leading slash to https urls', () => {
+            api.get('https://some/url')
+            expect(fakeFetch.mock.calls[0][0]).toEqual('https://some/url')
+        })
+    })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -236,7 +236,6 @@ const api = {
     },
 
     async get(url: string, signal?: AbortSignal): Promise<any> {
-        console.log(url, 'starting')
         if (url.indexOf('http') !== 0) {
             if (!url.startsWith('/')) {
                 url = '/' + url
@@ -244,7 +243,6 @@ const api = {
 
             url = url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
         }
-        console.log(url, 'transformed')
         let response
         const startTime = new Date().getTime()
         try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -236,10 +236,15 @@ const api = {
     },
 
     async get(url: string, signal?: AbortSignal): Promise<any> {
+        console.log(url, 'starting')
         if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
-        }
+            if (!url.startsWith('/')) {
+                url = '/' + url
+            }
 
+            url = url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
+        }
+        console.log(url, 'transformed')
         let response
         const startTime = new Date().getTime()
         try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -127,6 +127,17 @@ class ApiRequest {
     }
 }
 
+const normalise_url = (url: string): string => {
+    if (url.indexOf('http') !== 0) {
+        if (!url.startsWith('/')) {
+            url = '/' + url
+        }
+
+        url = url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
+    }
+    return url
+}
+
 const api = {
     actions: {
         async get(actionId: ActionType['id']): Promise<ActionType> {
@@ -236,13 +247,7 @@ const api = {
     },
 
     async get(url: string, signal?: AbortSignal): Promise<any> {
-        if (url.indexOf('http') !== 0) {
-            if (!url.startsWith('/')) {
-                url = '/' + url
-            }
-
-            url = url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
-        }
+        url = normalise_url(url)
         let response
         const startTime = new Date().getTime()
         try {
@@ -260,9 +265,7 @@ const api = {
     },
 
     async update(url: string, data: any): Promise<any> {
-        if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
-        }
+        url = normalise_url(url)
         const isFormData = data instanceof FormData
         const startTime = new Date().getTime()
         const response = await fetch(url, {
@@ -285,9 +288,7 @@ const api = {
     },
 
     async create(url: string, data?: any): Promise<any> {
-        if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
-        }
+        url = normalise_url(url)
         const isFormData = data instanceof FormData
         const startTime = new Date().getTime()
         const response = await fetch(url, {
@@ -310,9 +311,7 @@ const api = {
     },
 
     async delete(url: string): Promise<any> {
-        if (url.indexOf('http') !== 0) {
-            url = '/' + url + (url.indexOf('?') === -1 && url[url.length - 1] !== '/' ? '/' : '')
-        }
+        url = normalise_url(url)
         const startTime = new Date().getTime()
         const response = await fetch(url, {
             method: 'DELETE',


### PR DESCRIPTION
## Changes

There were two things combining so that Funnel person URLs could sometimes end up starting `https://api/etc` instead of `https://api.posthog.com`

Most paths through creating a funnel don't add a base_uri. Which means the funnel defaults to an absolute url with no protocol e.g. `/api/etc`

One path through added the current base_uri from the request. For cloud `https://api.posthog.com`

That same path through for cached insights has no request and so added no base uri

-----

The front end had code in `api.get` which ensured a leading and trailing slash for URLs with no protocol.

It didn't check of the URL already had a leading slash and so `/api/etc` was converted to `//api/etc` which the browser renders as `https://api/etc`

-----

This change does two things

1) makes sure the front end only adds a leading slash when it isn't already present.
2) doesn't ever add a base_uri in the backend since everything works fine without it

## How did you test this code?

running locally and adding unit tests
