### PR TITLE
Fix handling of insight results for load more breakdown values

### DIFF
--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -85,7 +85,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                             </div>
                             <div>
                                 <Button
-                                    style={{ textAlign: 'center' }}
+                                    style={{ textAlign: 'center', marginBottom: 16 }}
                                     onClick={loadMoreBreakdownValues}
                                     loading={breakdownValuesLoading}
                                 >

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -141,6 +141,7 @@ export const trendsLogic = kea<trendsLogicType>({
             const { filters } = values
             const response = await api.get(values.loadMoreBreakdownUrl)
             insightLogic(props).actions.loadResultsSuccess({
+                ...values.insight,
                 result: [...values.results, ...(response.result ? response.result : [])],
                 filters: filters,
                 next: response.next,


### PR DESCRIPTION
## Changes

"Load More Breakdown Values" on trends broke a while ago ( most probably because of this: https://github.com/PostHog/posthog/pull/6368 ) - since load more breakdown values was basically adding to the result set of the insight, while discarding the id.

This caused the insight to be re-fetched, which removed the extra values coming from "Load more".

## How did you test this code?

Manually, see video:

![2021-11-23 14 28 57](https://user-images.githubusercontent.com/7115141/143043385-b50451ef-d1a0-4e2a-aa50-caef765715fe.gif)



