### PR TITLE
Adds password reveal functionality to password inputs

### DIFF
--- a/frontend/src/scenes/authentication/PasswordInput.tsx
+++ b/frontend/src/scenes/authentication/PasswordInput.tsx
@@ -87,7 +87,6 @@ export const PasswordInput = React.forwardRef(function PasswordInputInternal(
                 <Input.Password
                     ref={ref}
                     className="ph-ignore-input"
-                    type="password"
                     data-attr="password"
                     placeholder="••••••••••"
                     disabled={disabled}

--- a/frontend/src/scenes/authentication/PasswordInput.tsx
+++ b/frontend/src/scenes/authentication/PasswordInput.tsx
@@ -27,7 +27,7 @@ export const PasswordInput = React.forwardRef(function PasswordInputInternal(
         inputName = 'password',
         ...props
     }: PasswordInputProps,
-    ref: React.LegacyRef<Input>
+    ref: React.Ref<Input>
 ): JSX.Element {
     return (
         <div style={{ marginBottom: 24, ...style }} className="password-input">
@@ -84,7 +84,7 @@ export const PasswordInput = React.forwardRef(function PasswordInputInternal(
                 style={showStrengthIndicator ? { marginBottom: 0 } : undefined}
                 {...props}
             >
-                <Input
+                <Input.Password
                     ref={ref}
                     className="ph-ignore-input"
                     type="password"


### PR DESCRIPTION
## Changes

Closes #6721. 

Adds a password reveal button in the password input component. Turned out to be a very small change than I initially anticipated (thanks to [Ant Design](https://github.com/ant-design/ant-design/pull/13342)!)

### Login page
![Login Page](https://user-images.githubusercontent.com/29891001/143051530-61220cbd-93c1-4685-85a2-02e20e3eb7e3.gif)

### Signup page
![Signup page](https://user-images.githubusercontent.com/29891001/143051666-db915628-c2d0-4e0f-bc08-d8d11324858d.png)

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
Visually

----

(I picked the issue even though it was assigned to someone else because it's been too long since there was any activity there :sweat_smile:)