### PR TITLE
Unify switches

### DIFF
--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -6,9 +6,15 @@
     flex-shrink: 0;
     width: 36px;
     height: 20px;
+    line-height: 20px;
     background: none;
     border: none;
     cursor: pointer;
+    vertical-align: middle;
+    &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
 }
 
 .LemonSwitch__slider {

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
@@ -17,7 +17,6 @@ export default {
 } as ComponentMeta<typeof _LemonSwitch>
 
 export function LemonSwitch({ loading }: { loading: boolean }): JSX.Element {
-    const [isChecked, setIsChecked] = useState(false)
 
-    return <_LemonSwitch loading={loading} checked={isChecked} onChange={setIsChecked} />
+    return <_LemonSwitch loading={loading} />
 }

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
@@ -4,30 +4,43 @@ import './LemonSwitch.scss'
 
 export interface LemonSwitchProps {
     id?: string
-    onChange: (newChecked: boolean) => void
-    checked: boolean
+    onChange?: (newChecked: boolean) => void
+    onClick?: React.MouseEventHandler<HTMLButtonElement>
+    checked?: boolean
+    defaultChecked?: boolean
     loading?: boolean
+    disabled?: boolean
     /** Whether the switch should use the alternative primary color. */
     alt?: boolean
     style?: React.CSSProperties
 }
 
-export function LemonSwitch({ id, onChange, checked, loading, alt, style }: LemonSwitchProps): JSX.Element {
+export function LemonSwitch({ id, onChange, onClick, checked,disabled, defaultChecked = false, loading, alt, style }: LemonSwitchProps): JSX.Element {
+    const [internalChecked, setInternalChecked] = useState(defaultChecked)
     const [isActive, setIsActive] = useState(false)
+
+    const realChecked = checked ?? internalChecked
 
     return (
         <button
             id={id}
             type="button"
             role="switch"
+            disabled={disabled}
             className={clsx(
                 'LemonSwitch',
-                checked && 'LemonSwitch--checked',
+                realChecked && 'LemonSwitch--checked',
                 isActive && 'LemonSwitch--active',
                 loading && 'LemonSwitch--loading',
                 alt && 'LemonSwitch--alt'
             )}
-            onClick={() => onChange(!checked)}
+            onClick={(e) => {
+                if (!loading) {
+                    onClick?.(e)
+                    setInternalChecked(!realChecked)
+                    onChange?.(!realChecked)
+                }
+            }}
             onMouseDown={() => setIsActive(true)}
             onMouseUp={() => setIsActive(false)}
             onMouseOut={() => setIsActive(false)}

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react'
-import { Modal, Switch, Button } from 'antd'
+import { Modal, Button } from 'antd'
 import { useActions, useValues } from 'kea'
 import { CopyToClipboardInput } from 'lib/components/CopyToClipboard'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function ShareModal({ visible, onCancel }: { visible: boolean; onCancel: () => void }): JSX.Element {
     const { dashboard } = useValues(dashboardLogic)
     const { setIsSharedDashboard } = useActions(dashboardLogic)
     const [isShared, setIsShared] = useState(dashboard?.is_shared)
     const url = window.location.origin
+
     return dashboard ? (
         <Modal
             visible={visible}
@@ -17,9 +19,9 @@ export function ShareModal({ visible, onCancel }: { visible: boolean; onCancel: 
             title="Share your dashboard with people outside of PostHog."
             destroyOnClose
         >
-            <Switch
-                onClick={(_, e) => e.stopPropagation()}
-                checked={isShared}
+            <LemonSwitch
+                onClick={(e) => e.stopPropagation()}
+                checked={isShared ?? false}
                 data-attr="share-dashboard-switch"
                 onChange={(active) => {
                     setIsShared(active)

--- a/frontend/src/scenes/events/LabelledSwitch.tsx
+++ b/frontend/src/scenes/events/LabelledSwitch.tsx
@@ -1,4 +1,5 @@
-import { Space, Switch, Typography } from 'antd'
+import { Space, Typography } from 'antd'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 import React from 'react'
 import './LabelledSwitch.scss'
 
@@ -16,7 +17,7 @@ export function LabelledSwitch({ align, enabled, label, onToggle }: LabelledSwit
                 <Typography.Text ellipsis={true} className="labelled-switch-title">
                     {label}
                 </Typography.Text>
-                <Switch checked={enabled} onChange={onToggle} />
+                <LemonSwitch checked={enabled} onChange={onToggle} />
             </div>
         </Space>
     )

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -30,6 +30,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -194,7 +195,7 @@ export function FeatureFlag(): JSX.Element {
                                         }}
                                     </Form.Item>
                                     <Form.Item name="active" noStyle valuePropName="checked">
-                                        <Switch />
+                                        <LemonSwitch disabled />
                                     </Form.Item>
                                 </Form.Item>
                                 {featureFlagId !== 'new' && (

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathCleanFilterToggle.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathCleanFilterToggle.tsx
@@ -1,9 +1,10 @@
-import { Row, Switch } from 'antd'
+import { Row, } from 'antd'
 import { useValues } from 'kea'
 import React from 'react'
 import { FilterType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { Tooltip } from 'lib/components/Tooltip'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function PathCleanFilterToggle({
     filters,
@@ -32,7 +33,7 @@ export function PathCleanFilterToggle({
                 >
                     Apply global path URL cleaning
                 </label>
-                <Switch
+                <LemonSwitch
                     disabled={!hasFilters}
                     checked={hasFilters ? filters.path_replacements : false}
                     onChange={(checked: boolean) => {

--- a/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
@@ -1,4 +1,4 @@
-import { Row, Switch } from 'antd'
+import { Row } from 'antd'
 import { useValues } from 'kea'
 import { Link } from 'lib/components/Link'
 import React from 'react'
@@ -6,6 +6,7 @@ import { FilterType } from '~/types'
 import { SettingOutlined } from '@ant-design/icons'
 import { teamLogic } from 'scenes/teamLogic'
 import { Tooltip } from 'lib/components/Tooltip'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function TestAccountFilter({
     filters,
@@ -26,14 +27,13 @@ export function TestAccountFilter({
             }
         >
             <Row style={{ alignItems: 'center', flexWrap: 'nowrap' }}>
-                <Switch
+                <LemonSwitch
                     disabled={!hasFilters}
                     checked={hasFilters ? filters.filter_test_accounts : false}
                     onChange={(checked: boolean) => {
                         localStorage.setItem('default_filter_test_accounts', checked.toString())
                         onChange({ filter_test_accounts: checked })
                     }}
-                    size="small"
                 />
                 <label
                     style={{

--- a/frontend/src/scenes/me/Settings/OptOutCapture.tsx
+++ b/frontend/src/scenes/me/Settings/OptOutCapture.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
-import { Switch } from 'antd'
 import { userLogic } from 'scenes/userLogic'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function OptOutCapture(): JSX.Element {
     const { user, userLoading } = useValues(userLogic)
@@ -17,7 +17,7 @@ export function OptOutCapture(): JSX.Element {
                 We also understand there are many reasons why people don't want to or aren't allowed to send this usage
                 data. If you would like to anonymize your personal usage data, just tick the box below.
             </p>
-            <Switch
+            <LemonSwitch
                 data-attr="anonymize-data-collection"
                 onChange={(checked) => updateUser({ anonymize_data: checked })}
                 defaultChecked={user?.anonymize_data}

--- a/frontend/src/scenes/me/Settings/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/me/Settings/UpdateEmailPreferences.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Switch } from 'antd'
 import { userLogic } from 'scenes/userLogic'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function UpdateEmailPreferences(): JSX.Element {
     const { user, userLoading } = useValues(userLogic)
@@ -9,8 +9,7 @@ export function UpdateEmailPreferences(): JSX.Element {
 
     return (
         <div>
-            <Switch
-                // @ts-expect-error - id works just fine despite not being in CompoundedComponent
+            <LemonSwitch
                 id="email-preferences"
                 data-attr="email-preferences"
                 onChange={() => {

--- a/frontend/src/scenes/onboarding/OnboardingSetup.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingSetup.tsx
@@ -1,6 +1,6 @@
 import { PageHeader } from 'lib/components/PageHeader'
 import React from 'react'
-import { Button, Col, Collapse, Progress, Row, Switch } from 'antd'
+import { Button, Col, Collapse, Progress, Row } from 'antd'
 import {
     ProjectOutlined,
     CodeOutlined,
@@ -24,6 +24,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 const { Panel } = Collapse
 
@@ -234,7 +235,7 @@ export function OnboardingSetup(): JSX.Element {
                                             ) : (
                                                 <span style={{ color: 'var(--danger)' }}>Disabled</span>
                                             )}
-                                            <Switch
+                                            <LemonSwitch
                                                 checked={currentTeam?.session_recording_opt_in}
                                                 loading={currentTeamLoading}
                                                 style={{ marginLeft: 6 }}

--- a/frontend/src/scenes/organization/Settings/index.tsx
+++ b/frontend/src/scenes/organization/Settings/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Button, Card, Input, Divider, Select, Skeleton, Switch } from 'antd'
+import { Button, Card, Input, Divider, Select, Skeleton } from 'antd'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Invites } from './Invites'
 import { Members } from './Members'
@@ -12,6 +12,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { IconExternalLink } from 'lib/components/icons'
 import { userLogic } from 'scenes/userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export const scene: SceneExport = {
     component: OrganizationSettings,
@@ -119,8 +120,7 @@ function EmailPreferences({ isRestricted }: RestrictedComponentProps): JSX.Eleme
                 Notification Preferences
             </h2>
             <div>
-                <Switch
-                    // @ts-expect-error - id works just fine despite not being in CompoundedComponent
+                <LemonSwitch
                     id="is-member-join-email-enabled-switch"
                     data-attr="is-member-join-email-enabled-switch"
                     onChange={(checked) => {

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
-import { Button, Form, Popconfirm, Space, Switch, Tag } from 'antd'
+import { Button, Form, Popconfirm, Space,  Tag } from 'antd'
 import { DeleteOutlined, CodeOutlined, LockFilled, GlobalOutlined, RollbackOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from 'scenes/plugins/plugin/PluginImage'
@@ -20,6 +20,7 @@ import { capabilitiesInfo } from './CapabilitiesInfo'
 import { Tooltip } from 'lib/components/Tooltip'
 import { PluginJobOptions } from './interface-jobs/PluginJobOptions'
 import { MOCK_NODE_PROCESS } from 'lib/constants'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 window.process = MOCK_NODE_PROCESS
 
@@ -32,7 +33,7 @@ function EnabledDisabledSwitch({
 }): JSX.Element {
     return (
         <>
-            <Switch checked={value} onChange={onChange} />
+            <LemonSwitch checked={value} onChange={onChange} />
             <strong style={{ paddingLeft: 10 }}>{value ? 'Enabled' : 'Disabled'}</strong>
         </>
     )

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Col, Popconfirm, Row, Space, Switch, Tag } from 'antd'
+import { Button, Card, Col, Popconfirm, Row, Space,  Tag } from 'antd'
 import { useActions, useValues } from 'kea'
 import React from 'react'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
@@ -28,6 +28,7 @@ import { canInstallPlugins } from '../access'
 import { LinkButton } from 'lib/components/LinkButton'
 import { PluginUpdateButton } from './PluginUpdateButton'
 import { Tooltip } from 'lib/components/Tooltip'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function PluginAboutButton({ url, disabled = false }: { url: string; disabled?: boolean }): JSX.Element {
     return (
@@ -142,7 +143,7 @@ export function PluginCard({
                                 cancelText="No"
                                 disabled={rearranging}
                             >
-                                <Switch checked={pluginConfig.enabled ?? false} disabled={rearranging} />
+                                <LemonSwitch checked={pluginConfig.enabled ?? false} disabled={rearranging} />
                             </Popconfirm>
                         </Col>
                     )}

--- a/frontend/src/scenes/project/Settings/AccessControl.tsx
+++ b/frontend/src/scenes/project/Settings/AccessControl.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Switch } from 'antd'
 import { AvailableFeature } from '~/types'
 import { organizationLogic } from '../../organizationLogic'
 import { useActions, useValues } from 'kea'
@@ -8,6 +7,7 @@ import { sceneLogic } from '../../sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { LockOutlined, UnlockOutlined } from '@ant-design/icons'
 import { userLogic } from 'scenes/userLogic'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function AccessControl({ isRestricted }: RestrictedComponentProps): JSX.Element {
     const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
@@ -46,8 +46,7 @@ export function AccessControl({ isRestricted }: RestrictedComponentProps): JSX.E
                     </>
                 )}
             </p>
-            <Switch
-                // @ts-expect-error - id works just fine despite not being in CompoundedComponent
+            <LemonSwitch
                 id="access-control-switch"
                 onChange={(checked) => {
                     guardAvailableFeature(

--- a/frontend/src/scenes/project/Settings/IPCapture.tsx
+++ b/frontend/src/scenes/project/Settings/IPCapture.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
-import { Switch } from 'antd'
 import { teamLogic } from 'scenes/teamLogic'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function IPCapture(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
@@ -9,8 +9,7 @@ export function IPCapture(): JSX.Element {
 
     return (
         <div>
-            <Switch
-                // @ts-expect-error - id works just fine despite not being in CompoundedComponent
+            <LemonSwitch
                 id="anonymize-ip"
                 onChange={(checked) => {
                     updateCurrentTeam({ anonymize_ips: checked })

--- a/frontend/src/scenes/project/Settings/SessionRecording.tsx
+++ b/frontend/src/scenes/project/Settings/SessionRecording.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
-import { Input, Switch } from 'antd'
+import { Input } from 'antd'
 import { teamLogic } from 'scenes/teamLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function SessionRecording(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
@@ -16,8 +17,7 @@ export function SessionRecording(): JSX.Element {
     return (
         <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 8 }}>
-                <Switch
-                    // @ts-expect-error - id works just fine despite not being in CompoundedComponent
+                <LemonSwitch
                     id="opt-in-session-recording-switch"
                     data-attr="opt-in-session-recording-switch"
                     onChange={(checked) => {
@@ -38,7 +38,7 @@ export function SessionRecording(): JSX.Element {
             {currentTeam?.session_recording_opt_in && !preflight?.cloud && !preflight?.is_clickhouse_enabled && (
                 <>
                     <div style={{ marginBottom: 8 }}>
-                        <Switch
+                        <LemonSwitch
                             data-attr="session-recording-retention-period-switch"
                             onChange={(checked) => {
                                 const newPeriod = checked ? 7 : null

--- a/frontend/src/scenes/project/Settings/ToolbarSettings.tsx
+++ b/frontend/src/scenes/project/Settings/ToolbarSettings.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
 import { userLogic } from 'scenes/userLogic'
-import { Col, Row, Switch } from 'antd'
+import { Col, Row } from 'antd'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 /* TODO: This should be moved to user's settings (good first issue) */
 export function ToolbarSettings(): JSX.Element {
@@ -12,8 +13,7 @@ export function ToolbarSettings(): JSX.Element {
         <div>
             <Row style={{ flexFlow: 'row' }}>
                 <Col>
-                    <Switch
-                        // @ts-expect-error - id works just fine despite not being in CompoundedComponent
+                    <LemonSwitch
                         id="posthog-toolbar-switch"
                         onChange={() => {
                             updateUser({

--- a/frontend/src/scenes/sessions/SessionsView.tsx
+++ b/frontend/src/scenes/sessions/SessionsView.tsx
@@ -1,7 +1,7 @@
 // DEPRECATED in favor of SessionsRecordings.tsx
 import React, { useRef } from 'react'
 import { useValues, useActions, BindLogic } from 'kea'
-import { Button, Space, Badge, Switch, Row } from 'antd'
+import { Button, Space, Badge, Row } from 'antd'
 import { Link } from 'lib/components/Link'
 import { sessionsTableLogic } from 'scenes/sessions/sessionsTableLogic'
 import { humanFriendlyDetailedTime, stripHTTP, pluralize, humanFriendlyDuration } from '~/lib/utils'
@@ -32,6 +32,7 @@ import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDraw
 import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -187,8 +188,7 @@ export function SessionsView({ personIds, isPersonPage = false }: SessionsTableP
                 <div className="sessions-view-actions-left-items">
                     {filters.length > 0 && (
                         <Row className="action ml-05">
-                            <Switch
-                                // @ts-expect-error `id` prop is valid on switch
+                            <LemonSwitch
                                 id="show-only-matches"
                                 onChange={setShowOnlyMatches}
                                 checked={showOnlyMatches}

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -3,11 +3,12 @@ import './featureFlags.scss'
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
-import { Radio, Switch, Row, Typography, List, Button, Input } from 'antd'
+import { Radio,  Row, Typography, List, Button, Input } from 'antd'
 import { AnimatedCollapsible } from './AnimatedCollapsible'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { urls } from 'scenes/urls'
 import { IconExternalLinkBold } from 'lib/components/icons'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 
 export function FeatureFlags(): JSX.Element {
     const { showLocalFeatureFlagWarning, searchTerm, filteredFlags } = useValues(featureFlagsLogic)
@@ -79,7 +80,7 @@ export function FeatureFlags(): JSX.Element {
                                         >
                                             <IconExternalLinkBold />
                                         </a>
-                                        <Switch
+                                        <LemonSwitch
                                             checked={!!currentValue}
                                             onChange={(checked) => {
                                                 const newValue =


### PR DESCRIPTION
## Changes

Proposal to replace switches for 🍋-style. I don't feel strongly about using either AntD or our design here, but this is a very simple thing to replace and it's not great to have unintended variety like this in the product.

My two design observations are:

- `LemonSwitch` in the default size may be too prominent in the query setting "Filter out itnernal and test users", since there's no `size="small"` variant, but not sure

    | Before | After |
    | --- | --- |
    | ![Zrzut ekranu 2021-11-23 o 18 47 39](https://user-images.githubusercontent.com/4550621/143081575-25518d97-a6dc-45ed-bad1-16b8060a285a.png) | ![Zrzut ekranu 2021-11-23 o 18 46 54](https://user-images.githubusercontent.com/4550621/143082077-0daac186-5987-48bf-8f5b-ae49012b5ce2.png) |

- `LemonSwitch` seems significantly less prominent in project settings

    | Before | After |
	| --- | --- |
	| ![Zrzut ekranu 2021-11-23 o 19 19 17](https://user-images.githubusercontent.com/4550621/143081799-37a5f50c-1302-4dfd-a54e-7466256a2b2d.png) | ![Zrzut ekranu 2021-11-23 o 19 19 11](https://user-images.githubusercontent.com/4550621/143081795-12bdf4b3-6df9-4a2a-8cc4-d1bb551454be.png) |
