### PR TITLE
[patch] add longer timeout for scene test

### DIFF
--- a/frontend/src/scenes/sceneLogic.test.ts
+++ b/frontend/src/scenes/sceneLogic.test.ts
@@ -60,7 +60,7 @@ describe('sceneLogic', () => {
         await expectLogic(logic).toDispatchActions(['openScene', 'loadScene', 'setScene']).toMatchValues({
             scene: Scene.SavedInsights,
         })
-    })
+    }, 10000)
 
     it('persists the loaded scenes', async () => {
         await expectLogic(logic)


### PR DESCRIPTION
## Changes

*Please describe.*  
- the`changing URL runs openScene, loadScene and setScene` jest test has been timing out at 5seconds. 
- test whether a longer timeout will have success
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- adjusting a test directly
