### PR TITLE
Remove Filter Renaming FF

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -33,7 +33,7 @@ interface InsightsLabelProps {
     hasMultipleSeries?: boolean // Whether the graph has multiple discrete series (not breakdown values)
     showCountedByTag?: boolean // Force 'counted by' tag to show (always shown when action.math is set)
     allowWrap?: boolean // Allow wrapping to multiple lines (useful for long values like URLs)
-    useCustomName?: boolean // Whether to show new custom name (FF `6063-rename-filters`). `{custom_name} ({id})`.
+    useCustomName?: boolean // Whether to show new custom name. `{custom_name} ({id})`.
     hideSeriesSubtitle?: boolean // Whether to show the base event/action name (if a custom name is set) in the insight label
     onLabelClick?: () => void // Click handler for inner label
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -77,7 +77,6 @@ export const FEATURE_FLAGS = {
     NEW_PATHS_UI_EDGE_WEIGHTS: 'new-paths-ui-edge-weights', // owner: @neilkakkar
     REMOVE_SESSIONS: '6050-remove-sessions', // owner: @rcmarron
     FUNNEL_VERTICAL_BREAKDOWN: '5733-funnel-vertical-breakdown', // owner: @alexkim205
-    RENAME_FILTERS: '6063-rename-filters', // owner: @alexkim205
     SIGMA_ANALYSIS: 'sigma-analysis', // owner: @neilkakkar
     NEW_SESSIONS_PLAYER: 'new-sessions-player', // owner: @rcmarron
     NEW_SESSIONS_PLAYER_EVENTS_LIST: 'new-sessions-player-events-list', // owner: @rcmarron / @alexkim205

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -519,10 +519,8 @@ export function FunnelBarGraph({ color = 'white' }: { color?: string }): JSX.Ele
                                 <div className="funnel-step-title">
                                     {filters.funnel_order_type === StepOrderValue.UNORDERED ? (
                                         <span>Completed {humanizeOrder(step.order)} steps</span>
-                                    ) : featureFlags[FEATURE_FLAGS.RENAME_FILTERS] ? (
-                                        <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
                                     ) : (
-                                        <PropertyKeyInfo value={step.name} style={{ maxWidth: '100%' }} />
+                                        <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
                                     )}
                                 </div>
                                 {clickhouseFeaturesEnabled &&

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -24,7 +24,6 @@ import {
 } from '@ant-design/icons'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { BareEntity, entityFilterLogic } from '../entityFilterLogic'
-import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -141,7 +140,6 @@ export function ActionFilterRow({
         duplicateFilter,
     } = useActions(logic)
     const { numericalPropertyNames } = useValues(propertyDefinitionsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { mathDefinitions } = useValues(mathsLogic)
 
     const visible = typeof filter.order === 'number' ? entityFilterVisible[filter.order] : false
@@ -238,11 +236,7 @@ export function ActionFilterRow({
                     }}
                 >
                     <span className="text-overflow" style={{ maxWidth: '100%' }}>
-                        {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] ? (
-                            <EntityFilterInfo filter={filter} />
-                        ) : (
-                            <PropertyKeyInfo value={name || 'Select action'} disablePopover />
-                        )}
+                        <EntityFilterInfo filter={filter} />
                     </span>
                     <DownOutlined style={{ fontSize: 10 }} />
                 </Button>
@@ -398,9 +392,7 @@ export function ActionFilterRow({
                             </>
                         )}
                         {(horizontalUI || fullWidth) && !hideFilter && <Col>{propertyFiltersButton}</Col>}
-                        {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && (horizontalUI || fullWidth) && !hideRename && (
-                            <Col>{renameRowButton}</Col>
-                        )}
+                        {(horizontalUI || fullWidth) && !hideRename && <Col>{renameRowButton}</Col>}
                         {(horizontalUI || fullWidth) && !hideFilter && <Col>{duplicateRowButton}</Col>}
                         {!hideDeleteBtn && !horizontalUI && !singleFilter && (
                             <Col className="column-delete-btn">{deleteButton}</Col>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -62,7 +62,6 @@ export function FunnelStepTable(): JSX.Element | null {
     function getColumns(): ColumnsType<FlattenedFunnelStep> | ColumnsType<FlattenedFunnelStepByBreakdown> {
         if (isNewVertical) {
             const _columns: ColumnsType<FlattenedFunnelStepByBreakdown> = []
-            const useCustomName = !!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]
             const isOnlySeries = flattenedBreakdowns.length === 1
 
             _columns.push({
@@ -115,8 +114,7 @@ export function FunnelStepTable(): JSX.Element | null {
                         />,
                         showLabels,
                         undefined,
-                        dashboardItemId,
-                        useCustomName
+                        dashboardItemId
                     )
                 },
                 fixed: 'left',
@@ -147,8 +145,7 @@ export function FunnelStepTable(): JSX.Element | null {
                         renderColumnTitle('Breakdown'),
                         showLabels,
                         undefined,
-                        dashboardItemId,
-                        useCustomName
+                        dashboardItemId
                     )
                 },
                 fixed: 'left',
@@ -165,8 +162,7 @@ export function FunnelStepTable(): JSX.Element | null {
                         renderSubColumnTitle('Rate'),
                         showLabels,
                         undefined,
-                        dashboardItemId,
-                        useCustomName
+                        dashboardItemId
                     )
                 },
                 fixed: 'left',
@@ -204,8 +200,7 @@ export function FunnelStepTable(): JSX.Element | null {
                             ),
                             showLabels,
                             step,
-                            dashboardItemId,
-                            useCustomName
+                            dashboardItemId
                         )
                     },
                     width: 80,
@@ -245,8 +240,7 @@ export function FunnelStepTable(): JSX.Element | null {
                             renderSubColumnTitle('Rate'),
                             showLabels,
                             step,
-                            dashboardItemId,
-                            useCustomName
+                            dashboardItemId
                         )
                     },
                     width: 80,
@@ -286,8 +280,7 @@ export function FunnelStepTable(): JSX.Element | null {
                                 ),
                                 showLabels,
                                 step,
-                                dashboardItemId,
-                                useCustomName
+                                dashboardItemId
                             )
                         },
                         width: 80,
@@ -328,8 +321,7 @@ export function FunnelStepTable(): JSX.Element | null {
                                 renderSubColumnTitle('Rate'),
                                 showLabels,
                                 step,
-                                dashboardItemId,
-                                useCustomName
+                                dashboardItemId
                             )
                         },
                         width: 80,
@@ -354,8 +346,7 @@ export function FunnelStepTable(): JSX.Element | null {
                                 renderSubColumnTitle('Avg. time'),
                                 showLabels,
                                 step,
-                                dashboardItemId,
-                                useCustomName
+                                dashboardItemId
                             )
                         },
                         width: 80,
@@ -457,7 +448,7 @@ export function FunnelStepTable(): JSX.Element | null {
                         iconStyle={{ marginRight: 12 }}
                         hideIcon={!isBreakdownChild}
                         allowWrap
-                        useCustomName={!!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]}
+                        useCustomName
                     />
                 )
             },

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
@@ -99,8 +99,7 @@ export const renderGraphAndHeader = (
     headerElement: JSX.Element,
     showLabels: boolean,
     step?: FunnelStepWithConversionMetrics,
-    dashboardItemId?: number,
-    useCustomName?: boolean
+    dashboardItemId?: number
 ): JSX.Element | RenderedCell<FlattenedFunnelStepByBreakdown> => {
     const stepIndex = step?.order ?? 0
     if (rowIndex === 0 || rowIndex === 1) {
@@ -148,11 +147,7 @@ export const renderGraphAndHeader = (
                     children: (
                         <div className="funnel-step-title">
                             <span className="funnel-step-glyph">{zeroPad(humanizeOrder(stepIndex), 2)}</span>
-                            {useCustomName && step ? (
-                                <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
-                            ) : (
-                                <PropertyKeyInfo value={step?.name ?? ''} disableIcon className="funnel-step-name" />
-                            )}
+                            {step && <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />}
                             <FunnelStepDropdown index={stepIndex} />
                         </div>
                     ),

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -16,9 +16,8 @@ import { DownOutlined, InfoCircleOutlined, EditOutlined } from '@ant-design/icon
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesToggleWrapper } from './components/SeriesToggleWrapper'
-import { ACTIONS_LINE_GRAPH_CUMULATIVE, ACTIONS_PIE_CHART, ACTIONS_TABLE, FEATURE_FLAGS } from 'lib/constants'
+import { ACTIONS_LINE_GRAPH_CUMULATIVE, ACTIONS_PIE_CHART, ACTIONS_TABLE } from 'lib/constants'
 import { IndexedTrendResult } from 'scenes/trends/types'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { entityFilterLogic } from '../ActionFilter/entityFilterLogic'
 import './InsightsTable.scss'
@@ -62,7 +61,6 @@ export function InsightsTable({
     const logic = insightsTableLogic({ hasMathUniqueFilter })
     const { calcColumnState } = useValues(logic)
     const { setCalcColumnState } = useActions(logic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const isSingleEntity = indexedResults.length === 1
     const colorList = getChartColors('white')
@@ -140,7 +138,7 @@ export function InsightsTable({
         render: function RenderLabel({}, item: IndexedTrendResult): JSX.Element {
             return (
                 <div className="series-name-wrapper-col">
-                    {featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && canEditSeriesNameInline && (
+                    {canEditSeriesNameInline && (
                         <div className="edit-icon" onClick={() => handleEditClick(item)}>
                             <EditOutlined />
                         </div>
@@ -154,16 +152,12 @@ export function InsightsTable({
                         breakdownValue={item.breakdown_value === '' ? 'None' : item.breakdown_value?.toString()}
                         hideBreakdown
                         hideIcon
-                        useCustomName={!!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]}
+                        useCustomName
                         className={clsx({
-                            editable: featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && canEditSeriesNameInline,
+                            editable: canEditSeriesNameInline,
                         })}
                         hideSeriesSubtitle
-                        onLabelClick={
-                            featureFlags[FEATURE_FLAGS.RENAME_FILTERS] && canEditSeriesNameInline
-                                ? () => handleEditClick(item)
-                                : undefined
-                        }
+                        onLabelClick={canEditSeriesNameInline ? () => handleEditClick(item) : undefined}
                     />
                 </div>
             )

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -14,8 +14,6 @@ import { useEscapeKey } from 'lib/hooks/useEscapeKey'
 import './LineGraph.scss'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { InsightTooltip } from '../InsightTooltip/InsightTooltip'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 
 //--Chart Style Options--//
@@ -67,7 +65,6 @@ export function LineGraph({
     const [annotationInRange, setInRange] = useState(false)
     const [tooltipVisible, setTooltipVisible] = useState(false)
     const size = useWindowSize()
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const annotationsCondition =
         type === 'line' && datasets?.length > 0 && !inSharedMode && datasets[0].labels?.[0] !== '1 day' // stickiness graphs
@@ -280,7 +277,7 @@ export function LineGraph({
                                     : entityData.breakdown_value
                             }
                             seriesStatus={entityData.status}
-                            useCustomName={!!featureFlags[FEATURE_FLAGS.RENAME_FILTERS]}
+                            useCustomName
                         />
                     )
                 },

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -119,7 +119,6 @@ if env_feature_flags != "0" and env_feature_flags.lower() != "false" and not DEB
         # Add hard-coded feature flags for static releases here
         "3638-trailing-wau-mau",  # pending UI/UX improvements; functionality ready
         "5440-multivariate-support",
-        "6063-rename-filters",
         "4141-event-columns",
         "new-paths-ui",
         "new-paths-ui-edge-weights",


### PR DESCRIPTION
## Changes

Now that the renaming filter feature is out to all cloud users, this PR removes this unused FF. 

## How did you test this code?

Historical tests pass + smoke tests
