### PR TITLE
Recordings UX improvements

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -49,6 +49,8 @@ export interface LemonTableProps<T extends Record<string, any>> {
     /** What to show when there's no data. By default it's generic "No data" */
     emptyState?: React.ReactNode
     'data-attr'?: string
+    /** Class name to append to each row */
+    rowClassName?: string
 }
 
 export function LemonTable<T extends Record<string, any>>({
@@ -61,6 +63,7 @@ export function LemonTable<T extends Record<string, any>>({
     pagination,
     defaultSorting,
     emptyState = 'No data',
+    rowClassName,
     ...divProps
 }: LemonTableProps<T>): JSX.Element {
     /** Search param that will be used for storing and syncing the current page */
@@ -198,6 +201,7 @@ export function LemonTable<T extends Record<string, any>>({
                                         key={`LemonTable-row-${rowKey ? data[rowKey] : currentStartIndex + rowIndex}`}
                                         data-row-key={rowKey ? data[rowKey] : rowIndex}
                                         {...onRow?.(data)}
+                                        className={rowClassName}
                                     >
                                         {columns.map((column, columnIndex) => {
                                             const value = column.dataIndex ? data[column.dataIndex] : undefined

--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -4,7 +4,7 @@ import { Col, Popover, Row } from 'antd'
 import { useActions, useValues } from 'kea'
 import { ProjectOutlined, LaptopOutlined, GlobalOutlined, SettingOutlined } from '@ant-design/icons'
 import { Link } from '../Link'
-import { humanTzOffset, shortTimeZone } from 'lib/utils'
+import { humanFriendlyDetailedTime, humanTzOffset, shortTimeZone } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { TooltipPlacement } from 'antd/lib/tooltip'
 import { teamLogic } from '../../../scenes/teamLogic'
@@ -26,7 +26,15 @@ function TZConversionHeader(): JSX.Element {
 }
 
 /** Return a simple label component with timezone conversion UI. */
-export function TZLabel({ time, showSeconds }: { time: string | dayjs.Dayjs; showSeconds?: boolean }): JSX.Element {
+export function TZLabel({
+    time,
+    showSeconds,
+    formatString,
+}: {
+    time: string | dayjs.Dayjs
+    showSeconds?: boolean
+    formatString?: string
+}): JSX.Element {
     const parsedTime = dayjs.isDayjs(time) ? time : dayjs(time)
     const { currentTeam } = useValues(teamLogic)
 
@@ -83,7 +91,9 @@ export function TZLabel({ time, showSeconds }: { time: string | dayjs.Dayjs; sho
 
     return (
         <Popover content={PopoverContent} onVisibleChange={handleVisibleChange}>
-            <span className="tz-label">{parsedTime.fromNow()}</span>
+            <span className="tz-label">
+                {formatString ? humanFriendlyDetailedTime(parsedTime, undefined, formatString) : parsedTime.fromNow()}
+            </span>
         </Popover>
     )
 }

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -235,30 +235,30 @@ describe('median()', () => {
 
 describe('humanFriendlyDuration()', () => {
     it('returns correct value for <= 60', () => {
-        expect(humanFriendlyDuration(60)).toEqual('1min')
+        expect(humanFriendlyDuration(60)).toEqual('1m')
         expect(humanFriendlyDuration(45)).toEqual('45s')
         expect(humanFriendlyDuration(44.8)).toEqual('45s')
         expect(humanFriendlyDuration(45.2)).toEqual('45s')
     })
     it('returns correct value for 60 < t < 120', () => {
-        expect(humanFriendlyDuration(90)).toEqual('1min 30s')
+        expect(humanFriendlyDuration(90)).toEqual('1m 30s')
     })
     it('returns correct value for t > 120', () => {
-        expect(humanFriendlyDuration(360)).toEqual('6min')
+        expect(humanFriendlyDuration(360)).toEqual('6m')
     })
     it('returns correct value for t >= 3600', () => {
         expect(humanFriendlyDuration(3600)).toEqual('1h')
         expect(humanFriendlyDuration(3601)).toEqual('1h 1s')
-        expect(humanFriendlyDuration(3961)).toEqual('1h 6min 1s')
-        expect(humanFriendlyDuration(3961.333)).toEqual('1h 6min 1s')
-        expect(humanFriendlyDuration(3961.666)).toEqual('1h 6min 2s')
+        expect(humanFriendlyDuration(3961)).toEqual('1h 6m 1s')
+        expect(humanFriendlyDuration(3961.333)).toEqual('1h 6m 1s')
+        expect(humanFriendlyDuration(3961.666)).toEqual('1h 6m 2s')
     })
     it('returns correct value for t >= 86400', () => {
         expect(humanFriendlyDuration(86400)).toEqual('1d')
         expect(humanFriendlyDuration(86400.12)).toEqual('1d')
     })
     it('truncates to specified # of units', () => {
-        expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6min')
+        expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6m')
         expect(humanFriendlyDuration(30, 2)).toEqual('30s') // no change
         expect(humanFriendlyDuration(30, 0)).toEqual('') // returns no units (useless)
     })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -507,7 +507,7 @@ export function humanFriendlyDuration(d: string | number | null | undefined, max
 
     const dayDisplay = days > 0 ? days + 'd' : ''
     const hDisplay = h > 0 ? h + 'h' : ''
-    const mDisplay = m > 0 ? m + 'min' : ''
+    const mDisplay = m > 0 ? m + 'm' : ''
     const sDisplay = s > 0 ? s + 's' : hDisplay || mDisplay ? '' : '0s'
 
     let units: string[] = []
@@ -529,7 +529,7 @@ export function humanFriendlyDetailedTime(date: dayjs.Dayjs | string | null, wit
         return 'Never'
     }
     const parsedDate = dayjs(date)
-    let formatString = 'MMMM Do YYYY h:mm'
+    let formatString = 'MMMM DD YYYY h:mm'
     const today = dayjs().startOf('day')
     const yesterday = today.clone().subtract(1, 'days').startOf('day')
     if (parsedDate.isSame(dayjs(), 'm')) {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -524,12 +524,15 @@ export function humanFriendlyDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | 
     return humanFriendlyDuration(diff)
 }
 
-export function humanFriendlyDetailedTime(date: dayjs.Dayjs | string | null, withSeconds: boolean = false): string {
+export function humanFriendlyDetailedTime(
+    date: dayjs.Dayjs | string | null,
+    withSeconds: boolean = false,
+    formatString: string = 'MMMM DD, YYYY h:mm'
+): string {
     if (!date) {
         return 'Never'
     }
     const parsedDate = dayjs(date)
-    let formatString = 'MMMM DD YYYY h:mm'
     const today = dayjs().startOf('day')
     const yesterday = today.clone().subtract(1, 'days').startOf('day')
     if (parsedDate.isSame(dayjs(), 'm')) {

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -190,7 +190,7 @@ export const sceneLogic = kea<sceneLogicType>({
         },
         setScene: ({ scene, scrollToTop }, _, __, previousState) => {
             posthog.capture('$pageview')
-            setPageTitle(identifierToHuman(scene || ''))
+            setPageTitle(sceneConfigurations[scene]?.name || identifierToHuman(scene || ''))
 
             // if we clicked on a link, scroll to top
             const previousScene = selectors.scene(previousState)

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -1,10 +1,6 @@
 import React from 'react'
-
 import { Drawer } from 'lib/components/Drawer'
 import { SessionRecordingPlayerV2 } from 'scenes/session-recordings/player/SessionRecordingPlayerV2'
-import { useValues } from 'kea'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { Button, Col, Row } from 'antd'
 import { ArrowLeftOutlined } from '@ant-design/icons'
 
@@ -14,23 +10,16 @@ interface SessionPlayerDrawerProps {
 }
 
 export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPlayerDrawerProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-
     return (
         <Drawer destroyOnClose visible width="100%" onClose={onClose} className="session-player-drawer-v2">
             <Col style={{ height: '100vh' }}>
                 <Row
-                    style={{ height: 40, borderBottom: '1px solid var(--border)' }}
+                    style={{ height: 48, borderBottom: '1px solid var(--border)' }}
                     align="middle"
                     justify="space-between"
                 >
                     <Button type="link" onClick={onClose}>
-                        <ArrowLeftOutlined /> Back to{' '}
-                        {isPersonPage
-                            ? 'persons'
-                            : featureFlags[FEATURE_FLAGS.REMOVE_SESSIONS]
-                            ? 'recordings'
-                            : 'sessions'}
+                        <ArrowLeftOutlined /> Back to {isPersonPage ? 'persons' : 'recordings'}
                     </Button>
                 </Row>
                 <Row className="session-drawer-body">

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 import { humanFriendlyDuration, humanFriendlyDetailedTime } from '~/lib/utils'
 import { SessionRecordingType } from '~/types'
-import { Button, Card, Col, Row, Table, Typography } from 'antd'
+import { Button, Col, Row, Typography } from 'antd'
 import { sessionRecordingsTableLogic } from './sessionRecordingsTableLogic'
 import { PlayCircleOutlined, CalendarOutlined, InfoCircleOutlined, FilterOutlined } from '@ant-design/icons'
-import { useIsTableScrolling } from 'lib/components/Table/utils'
 import { SessionPlayerDrawer } from './SessionPlayerDrawer'
 import { ActionFilter } from 'scenes/insights/ActionFilter/ActionFilter'
 import { LeftOutlined, RightOutlined } from '@ant-design/icons'
@@ -17,8 +16,9 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
-
 import './SessionRecordingTable.scss'
+import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
+
 interface SessionRecordingsTableProps {
     personUUID?: string
     isPersonPage?: boolean
@@ -75,36 +75,29 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
     } = useActions(sessionRecordingsTableLogicInstance)
     const { preflight } = useValues(preflightLogic)
 
-    const { tableScrollX } = useIsTableScrolling('lg')
-
-    const columns = [
+    const columns: LemonTableColumns<SessionRecordingType> = [
         {
             title: 'Start time',
-            render: function RenderStartTime(sessionRecording: SessionRecordingType) {
+            render: function RenderStartTime(_: any, sessionRecording: SessionRecordingType) {
                 return humanFriendlyDetailedTime(sessionRecording.start_time)
             },
-            span: 1,
         },
         {
             title: 'Duration',
-            render: function RenderDuration(sessionRecording: SessionRecordingType) {
+            render: function RenderDuration(_: any, sessionRecording: SessionRecordingType) {
                 return <span>{humanFriendlyDuration(sessionRecording.recording_duration)}</span>
             },
-            span: 1,
         },
         {
             title: 'Person',
             key: 'person',
-            render: function RenderPersonLink(sessionRecording: SessionRecordingType) {
+            render: function RenderPersonLink(_: any, sessionRecording: SessionRecordingType) {
                 return <PersonHeader withIcon person={sessionRecording.person} />
             },
-            ellipsis: true,
-            span: 3,
         },
 
         {
-            key: 'play',
-            render: function RenderPlayButton(sessionRecording: SessionRecordingType) {
+            render: function RenderPlayButton(_: any, sessionRecording: SessionRecordingType) {
                 return (
                     <div className="play-button-container">
                         <Button
@@ -112,7 +105,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                             data-attr="session-recordings-button"
                             icon={<PlayCircleOutlined />}
                         >
-                            Watch session
+                            Watch recording
                         </Button>
                     </div>
                 )
@@ -231,53 +224,47 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                     </Row>
                 </Row>
             </Row>
-            <Card>
-                <Table
-                    rowKey={(row) => {
-                        return `${row.id}-${row.distinct_id}`
-                    }}
-                    dataSource={sessionRecordings}
-                    columns={columns}
-                    loading={sessionRecordingsResponseLoading}
-                    pagination={false}
-                    onRow={(sessionRecording) => ({
-                        onClick: (e) => {
-                            // Lets the link to the person open the person's page and not the session recording
-                            if (!(e.target as HTMLElement).closest('a')) {
-                                openSessionPlayer(sessionRecording.id, RecordingWatchedSource.RecordingsList)
-                            }
-                        },
-                    })}
-                    size="small"
-                    rowClassName="cursor-pointer"
-                    data-attr="session-recording-table"
-                    scroll={{ x: tableScrollX }}
-                />
-                {(hasPrev || hasNext) && (
-                    <Row className="pagination-control">
-                        <Button
-                            type="link"
-                            disabled={!hasPrev}
-                            onClick={() => {
-                                loadPrev()
-                                window.scrollTo(0, 0)
-                            }}
-                        >
-                            <LeftOutlined /> Previous
-                        </Button>
-                        <Button
-                            type="link"
-                            disabled={!hasNext}
-                            onClick={() => {
-                                loadNext()
-                                window.scrollTo(0, 0)
-                            }}
-                        >
-                            Next <RightOutlined />
-                        </Button>
-                    </Row>
-                )}
-            </Card>
+
+            <LemonTable
+                dataSource={sessionRecordings}
+                columns={columns}
+                loading={sessionRecordingsResponseLoading}
+                onRow={(sessionRecording) => ({
+                    onClick: (e) => {
+                        // Lets the link to the person open the person's page and not the session recording
+                        if (!(e.target as HTMLElement).closest('a')) {
+                            openSessionPlayer(sessionRecording.id, RecordingWatchedSource.RecordingsList)
+                        }
+                    },
+                })}
+                rowClassName="cursor-pointer"
+                data-attr="session-recording-table"
+            />
+            {(hasPrev || hasNext) && (
+                <Row className="pagination-control">
+                    <Button
+                        type="link"
+                        disabled={!hasPrev}
+                        onClick={() => {
+                            loadPrev()
+                            window.scrollTo(0, 0)
+                        }}
+                    >
+                        <LeftOutlined /> Previous
+                    </Button>
+                    <Button
+                        type="link"
+                        disabled={!hasNext}
+                        onClick={() => {
+                            loadNext()
+                            window.scrollTo(0, 0)
+                        }}
+                    >
+                        Next <RightOutlined />
+                    </Button>
+                </Row>
+            )}
+            <div style={{ marginBottom: 64 }} />
             {!!sessionRecordingId && <SessionPlayerDrawer isPersonPage={isPersonPage} onClose={closeSessionPlayer} />}
         </div>
     )

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
-import { humanFriendlyDuration, humanFriendlyDetailedTime } from '~/lib/utils'
+import { humanFriendlyDuration } from '~/lib/utils'
 import { SessionRecordingType } from '~/types'
 import { Button, Col, Row, Typography } from 'antd'
 import { sessionRecordingsTableLogic } from './sessionRecordingsTableLogic'
@@ -18,6 +18,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './SessionRecordingTable.scss'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
+import { TZLabel } from 'lib/components/TimezoneAware'
 
 interface SessionRecordingsTableProps {
     personUUID?: string
@@ -79,7 +80,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
         {
             title: 'Start time',
             render: function RenderStartTime(_: any, sessionRecording: SessionRecordingType) {
-                return humanFriendlyDetailedTime(sessionRecording.start_time)
+                return <TZLabel time={sessionRecording.start_time} formatString="MMMM DD, YYYY h:mm" />
             },
         },
         {

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -47,17 +47,13 @@ export function PlayerMeta(): JSX.Element {
             </Row>
             <Row className="player-meta-other" align="middle" justify="start">
                 <Row className="player-meta-other-description">
-                    {loading ? (
-                        <Skeleton title={false} active paragraph={{ rows: 1 }} />
-                    ) : (
-                        <span className="">{description}</span>
-                    )}
+                    {loading ? <Skeleton title={false} active paragraph={{ rows: 1 }} /> : <span>{description}</span>}
                 </Row>
                 <Row className="player-meta-other-resolution mt-05">
                     {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1, width: '100%' }} />
                     ) : (
-                        <span className="">
+                        <span>
                             {resolution ? (
                                 <>
                                     Resolution: {resolution.width} x {resolution.height} (

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -7,6 +7,7 @@ import { useValues } from 'kea'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
 import { metaLogic } from 'scenes/session-recordings/player/metaLogic'
 import { formatDisplayPercentage } from 'scenes/funnels/funnelUtils'
+import { TZLabel } from 'lib/components/TimezoneAware'
 
 export function PlayerMeta(): JSX.Element {
     const { sessionPerson, description, resolution, scale, meta, loading } = useValues(metaLogic)
@@ -38,7 +39,9 @@ export function PlayerMeta(): JSX.Element {
                     {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1, width: 80 }} />
                     ) : (
-                        <span className="time text-small">{meta.startTime && dayjs(meta.startTime).fromNow()}</span>
+                        <span className="time text-muted">
+                            {meta.startTime && <TZLabel time={dayjs(meta.startTime)} />}
+                        </span>
                     )}
                 </Col>
             </Row>
@@ -47,14 +50,14 @@ export function PlayerMeta(): JSX.Element {
                     {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1 }} />
                     ) : (
-                        <span className="text-small">{description}</span>
+                        <span className="">{description}</span>
                     )}
                 </Row>
-                <Row className="player-meta-other-resolution">
+                <Row className="player-meta-other-resolution mt-05">
                     {loading ? (
                         <Skeleton title={false} active paragraph={{ rows: 1, width: '100%' }} />
                     ) : (
-                        <span className="text-small">
+                        <span className="">
                             {resolution ? (
                                 <>
                                     Resolution: {resolution.width} x {resolution.height} (

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -216,6 +216,6 @@
     }
 
     .ant-drawer-close {
-        padding: 12px 0px;
+        padding: $default_spacing;
     }
 }

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -16,6 +16,7 @@ import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
 import { teamLogic } from '../teamLogic'
 import { dayjs } from 'lib/dayjs'
+import { SessionRecordingType } from '~/types'
 
 export type SessionRecordingId = string
 export type PersonUUID = string
@@ -114,7 +115,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
             },
         ],
         sessionRecordings: [
-            [],
+            [] as SessionRecordingType[],
             {
                 getSessionRecordingsSuccess: (_, { sessionRecordingsResponse }) => {
                     return [...sessionRecordingsResponse.results]


### PR DESCRIPTION
## Changes

From my own dogfooding yesterday, I discovered some UI/UX stuff on the recordings experience worth improving.
* Moves recordings table to `LemonTable`
* Top bar was too tight
* Padding on close button was off
* Recording time ago should show the timezone conversion
* Adjust copy on "sessions" (including page title)

<img width="1394" alt="" src="https://user-images.githubusercontent.com/5864173/143143201-18f5edb4-190d-4620-94aa-0dea969bc86a.png">

## How did you test this code?
- Tested UI with `new-sessions-player-events-list` on & off
