### PR TITLE
Try to fix flake in `sceneLogic.test.ts`

### DIFF
--- a/frontend/src/lib/api.mock.ts
+++ b/frontend/src/lib/api.mock.ts
@@ -80,7 +80,7 @@ export function defaultAPIMocks(
             'api/projects/@current/event_definitions/',
         ].includes(pathname)
     ) {
-        return { results: [] }
+        return { results: [], next: null }
     }
     throw new Error(`Unmocked fetch to: ${pathname} with params: ${JSON.stringify(searchParams)}`)
 }

--- a/frontend/src/scenes/sceneLogic.test.ts
+++ b/frontend/src/scenes/sceneLogic.test.ts
@@ -11,22 +11,6 @@ import { appScenes } from 'scenes/appScenes'
 
 jest.mock('lib/api')
 
-const expectedAnnotation = partial({
-    name: Scene.Annotations,
-    component: expect.any(Function),
-    logic: expect.any(Function),
-    sceneParams: { hashParams: {}, params: {}, searchParams: {} },
-    lastTouch: expect.any(Number),
-})
-
-const expectedDashboard = partial({
-    name: Scene.Dashboard,
-    component: expect.any(Function),
-    logic: expect.any(Function),
-    sceneParams: { hashParams: {}, params: { id: '123' }, searchParams: {} },
-    lastTouch: expect.any(Number),
-})
-
 describe('sceneLogic', () => {
     let logic: ReturnType<typeof sceneLogic.build>
 
@@ -63,6 +47,21 @@ describe('sceneLogic', () => {
     })
 
     it('persists the loaded scenes', async () => {
+        const expectedAnnotation = partial({
+            name: Scene.Annotations,
+            component: expect.any(Function),
+            logic: expect.any(Function),
+            sceneParams: { hashParams: {}, params: {}, searchParams: {} },
+            lastTouch: expect.any(Number),
+        })
+
+        const expectedMySettings = partial({
+            name: Scene.MySettings,
+            component: expect.any(Function),
+            sceneParams: { hashParams: {}, params: {}, searchParams: {} },
+            lastTouch: expect.any(Number),
+        })
+
         await expectLogic(logic)
             .delay(1)
             .toMatchValues({
@@ -70,13 +69,13 @@ describe('sceneLogic', () => {
                     [Scene.Annotations]: expectedAnnotation,
                 }),
             })
-        router.actions.push(urls.dashboard(123))
+        router.actions.push(urls.mySettings())
         await expectLogic(logic)
             .delay(1)
             .toMatchValues({
                 loadedScenes: partial({
                     [Scene.Annotations]: expectedAnnotation,
-                    [Scene.Dashboard]: expectedDashboard,
+                    [Scene.MySettings]: expectedMySettings,
                 }),
             })
     })

--- a/frontend/src/scenes/sceneLogic.test.ts
+++ b/frontend/src/scenes/sceneLogic.test.ts
@@ -56,9 +56,9 @@ describe('sceneLogic', () => {
         await expectLogic(logic).toDispatchActions(['openScene', 'loadScene', 'setScene']).toMatchValues({
             scene: Scene.Annotations,
         })
-        router.actions.push(urls.savedInsights())
+        router.actions.push(urls.mySettings())
         await expectLogic(logic).toDispatchActions(['openScene', 'loadScene', 'setScene']).toMatchValues({
-            scene: Scene.SavedInsights,
+            scene: Scene.MySettings,
         })
     })
 


### PR DESCRIPTION
## Changes

- Changes a scene in a test to hopefully reduce flakes.
- Adds `next:null` to the mocked API endpoint to reduce some log noise

## How did you test this code?

- Ran tests locally
- Running in CI now