### PR TITLE
feat(retention): add ability to create a static cohort from table

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -31,7 +31,7 @@ export function RetentionTab(): JSX.Element {
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)
 
-    // TODO: Update constant in retentionTableLogic.ts when releasing 4050
+    // TODO: Update constant in retentionTableLogic.tsx when releasing 4050
     const retentionOptions = {
         [`${RETENTION_FIRST_TIME}`]: 'for the first time',
         [`${RETENTION_RECURRING}`]: 'recurringly',

--- a/frontend/src/scenes/insights/__stories__/Retention.stories.tsx
+++ b/frontend/src/scenes/insights/__stories__/Retention.stories.tsx
@@ -14,12 +14,11 @@ export default {
 
 export const TrendsSmoothing = (): JSX.Element => {
     worker.use(
-        rest.get('/api/projects/:projectId/insights/retention/', (_, res, ctx) => {
-            return res(ctx.json(sampleRetentionResponse))
-        }),
-        rest.get('/api/person/retention', (_, res, ctx) => {
-            return res(ctx.json(sampleRetentionPeopleResponse))
-        })
+        rest.get('/api/projects/:projectId/insights/retention/', (_, res, ctx) =>
+            res(ctx.json(sampleRetentionResponse))
+        ),
+        rest.get('/api/person/retention', (_, res, ctx) => res(ctx.json(sampleRetentionPeopleResponse))),
+        rest.post('/api/projects/:projectId/cohorts/', (_, res, ctx) => res(ctx.json({ id: 1 })))
     )
 
     const history = createMemoryHistory({

--- a/frontend/src/scenes/insights/__stories__/Retention.stories.tsx
+++ b/frontend/src/scenes/insights/__stories__/Retention.stories.tsx
@@ -16,6 +16,9 @@ export const TrendsSmoothing = (): JSX.Element => {
     worker.use(
         rest.get('/api/projects/:projectId/insights/retention/', (_, res, ctx) => {
             return res(ctx.json(sampleRetentionResponse))
+        }),
+        rest.get('/api/person/retention', (_, res, ctx) => {
+            return res(ctx.json(sampleRetentionPeopleResponse))
         })
     )
 
@@ -27,7 +30,6 @@ export const TrendsSmoothing = (): JSX.Element => {
                 target_event: JSON.stringify([{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }]),
                 returning_event: JSON.stringify([{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }]),
                 actions: JSON.stringify([]),
-                interval: 'day',
                 new_entity: JSON.stringify([]),
                 date_from: '-14d',
                 exclusions: JSON.stringify([]),
@@ -88,7 +90,7 @@ const sampleRetentionResponse = {
                 { count: 3, people: [] },
                 { count: 6, people: [] },
             ],
-            label: 'Day 0',
+            label: 'Week 0',
             date: '2021-11-13T00:00:00Z',
         },
         {
@@ -104,7 +106,7 @@ const sampleRetentionResponse = {
                 { count: 3, people: [] },
                 { count: 3, people: [] },
             ],
-            label: 'Day 1',
+            label: 'Week 1',
             date: '2021-11-14T00:00:00Z',
         },
         {
@@ -119,7 +121,7 @@ const sampleRetentionResponse = {
                 { count: 13, people: [] },
                 { count: 6, people: [] },
             ],
-            label: 'Day 2',
+            label: 'Week 2',
             date: '2021-11-15T00:00:00Z',
         },
         {
@@ -133,7 +135,7 @@ const sampleRetentionResponse = {
                 { count: 29, people: [] },
                 { count: 10, people: [] },
             ],
-            label: 'Day 3',
+            label: 'Week 3',
             date: '2021-11-16T00:00:00Z',
         },
         {
@@ -146,7 +148,7 @@ const sampleRetentionResponse = {
                 { count: 28, people: [] },
                 { count: 14, people: [] },
             ],
-            label: 'Day 4',
+            label: 'Week 4',
             date: '2021-11-17T00:00:00Z',
         },
         {
@@ -158,7 +160,7 @@ const sampleRetentionResponse = {
                 { count: 34, people: [] },
                 { count: 20, people: [] },
             ],
-            label: 'Day 5',
+            label: 'Week 5',
             date: '2021-11-18T00:00:00Z',
         },
         {
@@ -169,7 +171,7 @@ const sampleRetentionResponse = {
                 { count: 56, people: [] },
                 { count: 24, people: [] },
             ],
-            label: 'Day 6',
+            label: 'Week 6',
             date: '2021-11-19T00:00:00Z',
         },
         {
@@ -179,7 +181,7 @@ const sampleRetentionResponse = {
                 { count: 18, people: [] },
                 { count: 12, people: [] },
             ],
-            label: 'Day 7',
+            label: 'Week 7',
             date: '2021-11-20T00:00:00Z',
         },
         {
@@ -188,7 +190,7 @@ const sampleRetentionResponse = {
                 { count: 33, people: [] },
                 { count: 16, people: [] },
             ],
-            label: 'Day 8',
+            label: 'Week 8',
             date: '2021-11-21T00:00:00Z',
         },
         {
@@ -196,11 +198,47 @@ const sampleRetentionResponse = {
                 { count: 1183, people: [] },
                 { count: 36, people: [] },
             ],
-            label: 'Day 9',
+            label: 'Week 9',
             date: '2021-11-22T00:00:00Z',
         },
         { values: [{ count: 810, people: [] }], label: 'Day 10', date: '2021-11-23T00:00:00Z' },
     ],
     last_refresh: '2021-11-23T13:45:29.314009Z',
     is_cached: true,
+}
+
+const sampleRetentionPeopleResponse = {
+    result: [
+        {
+            person: {
+                id: 195158300,
+                name: 'test_user@posthog.com',
+                distinct_ids: ['1234'],
+                properties: {
+                    $os: 'Mac OS X',
+                    email: 'test_user@posthog.com',
+                },
+                is_identified: true,
+                created_at: '2021-11-15T15:23:54.099000Z',
+                uuid: '017d27d1-173a-2345-9bb1-337a0bb07be3',
+            },
+            appearances: [true, true, true, true, true, true, true, true, true],
+        },
+        {
+            person: {
+                id: 194626019,
+                name: 'test@posthog.com',
+                distinct_ids: ['abc'],
+                properties: {
+                    $os: 'Mac OS X',
+                    email: 'test@posthog.com',
+                },
+                is_identified: false,
+                created_at: '2021-11-15T14:12:41.919000Z',
+                uuid: '017d23f1-6326-3456-0c5c-af00affbd563',
+            },
+            appearances: [true, true, true, true, true, false, true, true, true],
+        },
+    ],
+    next: 'https://app.posthog.com/api/person/retention/?insight=RETENTION&target_entity=%7B%22id%22%3A%22%24pageview%22%2C%22name%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%7D&returning_entity=%7B%22id%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22name%22%3A%22%24pageview%22%7D&period=Day&retention_type=retention_first_time&display=ActionsTable&properties=%5B%5D&selected_interval=2&offset=100',
 }

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -18,6 +18,7 @@ import clsx from 'clsx'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import UsergroupAddOutlined from '@ant-design/icons/lib/icons/UsergroupAddOutlined'
 
 export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: number | null }): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -111,7 +112,12 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
                     visible={modalVisible}
                     closable={true}
                     onCancel={dismissModal}
-                    footer={<Button onClick={dismissModal}>Close</Button>}
+                    footer={
+                        <>
+                            <Button icon={<UsergroupAddOutlined />}>Save as cohort</Button>
+                            <Button onClick={dismissModal}>Close</Button>
+                        </>
+                    }
                     style={{
                         top: 20,
                         minWidth: results[selectedRow]?.values[0]?.count === 0 ? '10%' : '90%',

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -34,7 +34,7 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
     const results = _results as RetentionTablePayload[]
     const people = _people as RetentionTablePeoplePayload
 
-    const { loadPeople, loadMorePeople } = useActions(logic)
+    const { loadPeople, loadMorePeople, handleSaveCohort } = useActions(logic)
     const [modalVisible, setModalVisible] = useState(false)
     const [selectedRow, selectRow] = useState(0)
     const [isLatestPeriod, setIsLatestPeriod] = useState(false)
@@ -114,7 +114,9 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
                     onCancel={dismissModal}
                     footer={
                         <>
-                            <Button icon={<UsergroupAddOutlined />}>Save as cohort</Button>
+                            <Button icon={<UsergroupAddOutlined />} onClick={handleSaveCohort}>
+                                Save as cohort
+                            </Button>
                             <Button onClick={dismissModal}>Close</Button>
                         </>
                     }

--- a/frontend/src/scenes/retention/retentionTableLogic.tsx
+++ b/frontend/src/scenes/retention/retentionTableLogic.tsx
@@ -5,7 +5,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { retentionTableLogicType } from './retentionTableLogicType'
 import { ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_TABLE, RETENTION_FIRST_TIME, RETENTION_RECURRING } from 'lib/constants'
 import { actionsModel } from '~/models/actionsModel'
-import { ActionType, InsightLogicProps, FilterType, InsightType, CohortType, PersonType } from '~/types'
+import { ActionType, InsightLogicProps, FilterType, InsightType, CohortType } from '~/types'
 import {
     RetentionTablePayload,
     RetentionTrendPayload,

--- a/frontend/src/scenes/retention/retentionTableLogic.tsx
+++ b/frontend/src/scenes/retention/retentionTableLogic.tsx
@@ -1,19 +1,24 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { toParams } from 'lib/utils'
+import { errorToast, toParams } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { retentionTableLogicType } from './retentionTableLogicType'
 import { ACTIONS_LINE_GRAPH_LINEAR, ACTIONS_TABLE, RETENTION_FIRST_TIME, RETENTION_RECURRING } from 'lib/constants'
 import { actionsModel } from '~/models/actionsModel'
-import { ActionType, InsightLogicProps, FilterType, InsightType } from '~/types'
+import { ActionType, InsightLogicProps, FilterType, InsightType, CohortType, PersonType } from '~/types'
 import {
     RetentionTablePayload,
     RetentionTrendPayload,
     RetentionTablePeoplePayload,
     RetentionTrendPeoplePayload,
+    RetentionTableAppearanceType,
 } from 'scenes/retention/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
+import { teamLogic } from 'scenes/teamLogic'
+import { toast } from 'react-toastify'
+import React from 'react'
+import { Link } from 'lib/components/Link'
 
 export const dateOptions = ['Hour', 'Day', 'Week', 'Month']
 
@@ -35,7 +40,14 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
     path: (key) => ['scenes', 'retention', 'retentionTableLogic', key],
     connect: (props: InsightLogicProps) => ({
-        values: [insightLogic(props), ['filters', 'insight', 'insightLoading'], actionsModel, ['actions']],
+        values: [
+            insightLogic(props),
+            ['filters', 'insight', 'insightLoading'],
+            actionsModel,
+            ['actions'],
+            teamLogic,
+            ['currentTeamId'],
+        ],
         actions: [insightLogic(props), ['loadResultsSuccess']],
     }),
     actions: () => ({
@@ -43,6 +55,7 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
         loadMorePeople: true,
         updatePeople: (people) => ({ people }),
         clearPeople: true,
+        handleSaveCohort: true,
     }),
     loaders: ({ values }) => ({
         people: {
@@ -110,6 +123,63 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
                     next: peopleResult['next'],
                 }
                 actions.updatePeople(newPeople)
+            }
+        },
+        handleSaveCohort: async () => {
+            // Create a cohort for the people displayed in the table.
+
+            // NOTE: for now we just upload a static cohort using a csv, but
+            // this doesn't scale well if we have lots of people in a cohort. So
+            // we are just sending the people that we happen to have locally.
+            //
+            // For larger cohort sizes we'd need to find a different solution
+            const result = values.people.result
+            if (!result) {
+                return
+            }
+
+            // NOTE: I couldn't figure out how to get narrowing here to remove
+            // the `PersonType[]` union case
+            const peopleAppearences = result as RetentionTableAppearanceType[]
+
+            const formData = new FormData()
+            const peopleCsvData = `
+                user_id,
+                ${peopleAppearences.flatMap(({ person }) => person.distinct_ids).join(',\n')}
+            `
+            const peopleCsvBlob = new Blob([peopleCsvData], { type: 'application/csv' })
+            formData.append('csv', peopleCsvBlob, 'people.csv')
+
+            // NOTE: we are not offering the user the ability to name before
+            // creating the cohort. They can do this action as a cohort edit.
+            formData.append('name', 'New retention cohort')
+            formData.append('is_static', 'true')
+
+            try {
+                const savedCohort = await api.cohorts.create(formData as Partial<CohortType>)
+
+                toast.success(
+                    <div data-attr="success-toast">
+                        <h1>Cohort saved successfully!</h1>
+                        <p>
+                            {/* Make sure we link to the new cohort, so the user can e.g. edit the name easily */}
+                            <Link to={'/cohorts/' + savedCohort.id}>Click here to see the cohort.</Link>
+                        </p>
+                    </div>,
+                    {
+                        toastId: `cohort-saved-${savedCohort.id}`,
+                    }
+                )
+            } catch (error: any) {
+                errorToast(
+                    'Error saving your cohort',
+                    'Attempting to save this cohort returned an error:',
+                    error.status !== 0
+                        ? error.detail
+                        : "Check your internet connection and make sure you don't have an extension blocking our requests.",
+                    error.code
+                )
+                return
             }
         },
     }),


### PR DESCRIPTION
## Changes

This change adds the ability to create a cohort from the cohort table
    view, i.e. the one that you get to be clicking on a cohort row in the
    retention table, bringing up a table of the people in that cohort,
    showing which periods they were active.
    
Note that this is a static cohort we're creating which will only include
    the people currently displayed in the table. This is better than nothing
    although ideally we'd have some method that scales up to larger cohort
    sizes more easily.

<img width="1020" alt="Screenshot 2021-11-24 at 12 55 05" src="https://user-images.githubusercontent.com/128561/143242407-7106764e-1313-4d3b-8a4e-2b1ed6074688.png">

## How did you test this code?

Manually in storybooks and local dev env
