### PR TITLE
Groups/Feature flags: Allow choosing to aggregate by groups in UI

### DIFF
--- a/cypress/integration/featureFlags.js
+++ b/cypress/integration/featureFlags.js
@@ -14,7 +14,7 @@ describe('Feature Flags', () => {
             .should('have.value', 'This is a new feature.')
 
         // select "add filter" and "property"
-        cy.get('[data-attr=new-prop-filter-feature-flag-null-0-1').click()
+        cy.get('[data-attr=new-prop-filter-feature-flag-null-0-1-').click()
 
         // select the first property
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()

--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -182,7 +182,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType<Breadcrumb>>({
                         })
                         // Current place
                         breadcrumbs.push({
-                            name: featureFlag ? featureFlag.key || 'Unnamed flag' : null,
+                            name: featureFlag ? featureFlag.key || 'New feature flag' : null,
                             here: true,
                         })
                         break

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -23,6 +23,7 @@ interface PropertyFiltersProps {
     taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     showNestedArrow?: boolean
     addButtonType?: ButtonType
+    greyBadges?: boolean
 }
 
 export function PropertyFilters({
@@ -37,6 +38,7 @@ export function PropertyFilters({
     style = {},
     showNestedArrow = false,
     addButtonType = 'link',
+    greyBadges = false,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey }
     const { filters } = useValues(propertyFilterLogic(logicProps))
@@ -63,6 +65,7 @@ export function PropertyFilters({
                                 label={'Add filter'}
                                 addButtonType={addButtonType}
                                 onRemove={remove}
+                                greyBadges={greyBadges}
                                 filterComponent={(onComplete) => {
                                     const propertyFilterCommonProps = {
                                         key: index,

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .property-filter-row {
     .property-filter-button-spacing {
         color: #c4c4c4;
@@ -10,5 +12,14 @@
         position: relative;
         top: -4px;
         user-select: none;
+    }
+
+    .property-filter-grey {
+        color: #2d2d2d;
+        border-color: $grey;
+        background: $grey;
+
+        text-shadow: none;
+        box-shadow: none;
     }
 }

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -28,6 +28,7 @@ interface FilterRowProps {
     label: string
     onRemove: (index: number) => void
     addButtonType?: ButtonType
+    greyBadges?: boolean
 }
 
 export const FilterRow = React.memo(function FilterRow({
@@ -43,6 +44,7 @@ export const FilterRow = React.memo(function FilterRow({
     filterComponent,
     label,
     onRemove,
+    greyBadges,
     addButtonType = 'link',
 }: FilterRowProps) {
     const [open, setOpen] = useState(false)
@@ -106,6 +108,7 @@ export const FilterRow = React.memo(function FilterRow({
                                             onClick={() => setOpen(!open)}
                                             item={item}
                                             setRef={setRef}
+                                            greyBadges={greyBadges}
                                         />
                                     ) : isValidPathCleanFilter(item) ? (
                                         <FilterButton onClick={() => setOpen(!open)} setRef={setRef}>

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -8,29 +8,34 @@ import { keyMapping } from 'lib/components/PropertyKeyInfo'
 
 export interface Props {
     item: AnyPropertyFilter
+    greyBadges?: boolean
     onClick?: () => void
     setRef?: (ref: HTMLElement) => void
 }
 
-export function PropertyFilterButton({ item, onClick, setRef }: Props): JSX.Element {
+export function PropertyFilterButton({ item, ...props }: Props): JSX.Element {
     const { cohorts } = useValues(cohortsModel)
 
-    return (
-        <FilterButton onClick={onClick} setRef={setRef}>
-            {formatPropertyLabel(item, cohorts, keyMapping)}
-        </FilterButton>
-    )
+    return <FilterButton {...props}>{formatPropertyLabel(item, cohorts, keyMapping)}</FilterButton>
 }
 
 interface FilterRowProps {
+    greyBadges?: boolean
     onClick?: () => void
     setRef?: (ref: HTMLElement) => void
     children: string | JSX.Element
 }
 
-export function FilterButton({ onClick, setRef, children }: FilterRowProps): JSX.Element {
+export function FilterButton({ greyBadges, onClick, setRef, children }: FilterRowProps): JSX.Element {
     return (
-        <Button type="primary" shape="round" style={{ maxWidth: '75%' }} onClick={onClick} ref={setRef}>
+        <Button
+            type="primary"
+            shape="round"
+            style={{ maxWidth: '75%' }}
+            onClick={onClick}
+            ref={setRef}
+            className={greyBadges ? 'property-filter-grey' : undefined}
+        >
             <span
                 className="ph-no-capture property-filter-button-label"
                 style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
@@ -5,14 +5,15 @@ import PropertyFilterButton from './PropertyFilterButton'
 type Props = {
     filters: AnyPropertyFilter[]
     style?: CSSProperties
+    greyBadges?: boolean
 }
 
-const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style }: Props) => {
+const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style, greyBadges }: Props) => {
     return (
         <div className="mb" style={style}>
             {filters &&
                 filters.map((item) => {
-                    return <PropertyFilterButton key={item.key} item={item} />
+                    return <PropertyFilterButton key={item.key} item={item} greyBadges={greyBadges} />
                 })}
         </div>
     )

--- a/frontend/src/scenes/feature-flags/FeatureFlag.scss
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.scss
@@ -34,8 +34,15 @@
     }
 }
 
-.flag-form-row {
+.feature-flag-form-row {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     width: 100%;
+
+    .centered {
+        display: flex;
+        align-items: center;
+        white-space: pre-wrap;
+    }
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlag.scss
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.scss
@@ -33,3 +33,9 @@
         }
     }
 }
+
+.flag-form-row {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -560,6 +560,7 @@ export function FeatureFlag(): JSX.Element {
                                             TaxonomicFilterGroupType.Cohorts,
                                         ]}
                                         showConditionBadge
+                                        greyBadges
                                     />
                                     <LemonSpacer large />
 

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -516,8 +516,9 @@ export function FeatureFlag(): JSX.Element {
                                         <div>Duplicate delete</div>
                                     </div>
 
-                                    <LemonSpacer />
+                                    <LemonSpacer large />
                                     <PropertyFilters
+                                        style={{ marginLeft: 15 }}
                                         pageKey={`feature-flag-${featureFlag.id}-${index}-${featureFlag.filters.groups.length}`}
                                         propertyFilters={group?.properties}
                                         onChange={(properties) => updateMatchGroup(index, undefined, properties)}
@@ -528,13 +529,23 @@ export function FeatureFlag(): JSX.Element {
                                         ]}
                                         showConditionBadge
                                     />
-                                    <LemonSpacer />
+                                    <LemonSpacer large />
 
                                     <div className="flag-form-row">
                                         <div>
                                             Roll out to{' '}
-                                            {group.rollout_percentage != null ? group.rollout_percentage : 100}% of{' '}
-                                            <b>{aggregationTargetName}</b> in this set
+                                            <InputNumber
+                                                style={{ width: 70 }}
+                                                onChange={(value): void => {
+                                                    updateMatchGroup(index, value as number)
+                                                }}
+                                                value={
+                                                    group.rollout_percentage != null ? group.rollout_percentage : 100
+                                                }
+                                                min={0}
+                                                max={100}
+                                            />{' '}
+                                            of <b>{aggregationTargetName}</b> in this set
                                         </div>
 
                                         <Slider

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -27,7 +27,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { APISnippet, JSSnippet, PythonSnippet } from 'scenes/feature-flags/FeatureFlagSnippets'
+import { APISnippet, JSSnippet, PythonSnippet, UTM_TAGS } from 'scenes/feature-flags/FeatureFlagSnippets'
 import { LemonSpacer } from 'lib/components/LemonRow'
 
 export const scene: SceneExport = {

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -464,22 +464,7 @@ export function FeatureFlag(): JSX.Element {
                         {featureFlag.filters.groups.map((group, index) => (
                             <Col span={24} md={24} key={`${index}-${featureFlag.filters.groups.length}`}>
                                 <Card style={{ marginBottom: 16 }}>
-                                    {featureFlag.filters.groups.length > 1 && (
-                                        <>
-                                            <span style={{ position: 'absolute', top: 0, right: 0, margin: 4 }}>
-                                                <Tooltip title="Delete this match group" placement="bottomLeft">
-                                                    <Button
-                                                        type="link"
-                                                        icon={<DeleteOutlined />}
-                                                        onClick={() => removeMatchGroup(index)}
-                                                        style={{ color: 'var(--danger)' }}
-                                                    />
-                                                </Tooltip>
-                                            </span>
-                                        </>
-                                    )}
-
-                                    <div className="flag-form-row">
+                                    <div className="flag-form-row" style={{ height: 24 }}>
                                         <div>
                                             <span className="simple-tag tag-light-blue" style={{ marginRight: 8 }}>
                                                 Set {index + 1}
@@ -494,7 +479,18 @@ export function FeatureFlag(): JSX.Element {
                                                 </>
                                             )}
                                         </div>
-                                        <div>Duplicate delete</div>
+                                        <div>
+                                            {featureFlag.filters.groups.length > 1 && (
+                                                <Tooltip title="Delete this condition set" placement="bottomLeft">
+                                                    <Button
+                                                        type="link"
+                                                        icon={<DeleteOutlined />}
+                                                        style={{ width: 24, height: 24 }}
+                                                        onClick={() => removeMatchGroup(index)}
+                                                    />
+                                                </Tooltip>
+                                            )}
+                                        </div>
                                     </div>
 
                                     <LemonSpacer large />
@@ -544,7 +540,7 @@ export function FeatureFlag(): JSX.Element {
                             </Col>
                         ))}
                     </Row>
-                    <Card size="small">
+                    <Card size="small" style={{ marginBottom: 16 }}>
                         <Button type="link" onClick={addMatchGroup} style={{ marginLeft: 5 }}>
                             <PlusOutlined style={{ marginRight: 15 }} /> Add condition set
                         </Button>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -63,6 +63,7 @@ export function FeatureFlag(): JSX.Element {
         variantRolloutSum,
         groupTypes,
         aggregationTargetName,
+        taxonomicGroupTypes,
     } = useValues(featureFlagLogic)
     const {
         addConditionSet,
@@ -554,11 +555,7 @@ export function FeatureFlag(): JSX.Element {
                                         pageKey={`feature-flag-${featureFlag.id}-${index}-${featureFlag.filters.groups.length}`}
                                         propertyFilters={group?.properties}
                                         onChange={(properties) => updateConditionSet(index, undefined, properties)}
-                                        endpoint="person"
-                                        taxonomicGroupTypes={[
-                                            TaxonomicFilterGroupType.PersonProperties,
-                                            TaxonomicFilterGroupType.Cohorts,
-                                        ]}
+                                        taxonomicGroupTypes={taxonomicGroupTypes}
                                         showConditionBadge
                                         greyBadges
                                     />

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -460,19 +460,10 @@ export function FeatureFlag(): JSX.Element {
                         Specify the {aggregationTargetName} to which you want to release this flag. Note that condition
                         sets are rolled out independently of each other.
                     </div>
-                    <Button
-                        type="dashed"
-                        block
-                        icon={<PlusOutlined />}
-                        onClick={addMatchGroup}
-                        style={{ marginBottom: 16 }}
-                    >
-                        Add Group
-                    </Button>
                     <Row gutter={16}>
                         {featureFlag.filters.groups.map((group, index) => (
                             <Col span={24} md={24} key={`${index}-${featureFlag.filters.groups.length}`}>
-                                <Card style={{ position: 'relative', marginBottom: 32, paddingBottom: 16 }}>
+                                <Card style={{ marginBottom: 16 }}>
                                     {featureFlag.filters.groups.length > 1 && (
                                         <>
                                             <span style={{ position: 'absolute', top: 0, right: 0, margin: 4 }}>
@@ -485,24 +476,14 @@ export function FeatureFlag(): JSX.Element {
                                                     />
                                                 </Tooltip>
                                             </span>
-
-                                            <div className="mb">
-                                                <b>
-                                                    Group
-                                                    <span
-                                                        className="simple-tag tag-light-lilac"
-                                                        style={{ marginLeft: 8 }}
-                                                    >
-                                                        {index + 1}
-                                                    </span>
-                                                </b>
-                                            </div>
                                         </>
                                     )}
 
                                     <div className="flag-form-row">
                                         <div>
-                                            <Tag color="blue">Set 1</Tag>
+                                            <span className="simple-tag tag-light-blue" style={{ marginRight: 8 }}>
+                                                Set {index + 1}
+                                            </span>
                                             {group.properties?.length ? (
                                                 <>
                                                     Matching <b>{aggregationTargetName}</b> with filters
@@ -563,6 +544,11 @@ export function FeatureFlag(): JSX.Element {
                             </Col>
                         ))}
                     </Row>
+                    <Card size="small">
+                        <Button type="link" onClick={addMatchGroup} style={{ marginLeft: 5 }}>
+                            <PlusOutlined style={{ marginRight: 15 }} /> Add condition set
+                        </Button>
+                    </Card>
                     <Form.Item className="text-right">
                         <Button
                             icon={<SaveOutlined />}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -325,7 +325,7 @@ export function FeatureFlag(): JSX.Element {
                                 </Popconfirm>
                             </div>
                             <div className="text-muted mb">
-                                Users will be served{' '}
+                                {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
                                 {multivariateEnabled ? (
                                     <>
                                         <strong>a variant key</strong> according to the below distribution
@@ -477,7 +477,7 @@ export function FeatureFlag(): JSX.Element {
                         </div>
                         {showGroupsOptions && (
                             <div className="centered">
-                                Entity
+                                Match by
                                 <Select
                                     value={
                                         featureFlag.filters.aggregation_group_type_index != null

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -61,8 +61,8 @@ export function FeatureFlag(): JSX.Element {
         variantRolloutSum,
     } = useValues(featureFlagLogic)
     const {
-        addMatchGroup,
-        updateMatchGroup,
+        addConditionSet,
+        updateConditionSet,
         removeConditionSet,
         duplicateConditionSet,
         saveFeatureFlag,
@@ -514,7 +514,7 @@ export function FeatureFlag(): JSX.Element {
                                         style={{ marginLeft: 15 }}
                                         pageKey={`feature-flag-${featureFlag.id}-${index}-${featureFlag.filters.groups.length}`}
                                         propertyFilters={group?.properties}
-                                        onChange={(properties) => updateMatchGroup(index, undefined, properties)}
+                                        onChange={(properties) => updateConditionSet(index, undefined, properties)}
                                         endpoint="person"
                                         taxonomicGroupTypes={[
                                             TaxonomicFilterGroupType.PersonProperties,
@@ -530,7 +530,7 @@ export function FeatureFlag(): JSX.Element {
                                             <InputNumber
                                                 style={{ width: 100, marginLeft: 8, marginRight: 8 }}
                                                 onChange={(value): void => {
-                                                    updateMatchGroup(index, value as number)
+                                                    updateConditionSet(index, value as number)
                                                 }}
                                                 value={
                                                     group.rollout_percentage != null ? group.rollout_percentage : 100
@@ -549,7 +549,7 @@ export function FeatureFlag(): JSX.Element {
                                             tipFormatter={(value) => value + '%'}
                                             value={group.rollout_percentage != null ? group.rollout_percentage : 100}
                                             onChange={(value: number) => {
-                                                updateMatchGroup(index, value)
+                                                updateConditionSet(index, value)
                                             }}
                                         />
                                     </div>
@@ -558,7 +558,7 @@ export function FeatureFlag(): JSX.Element {
                         ))}
                     </Row>
                     <Card size="small" style={{ marginBottom: 16 }}>
-                        <Button type="link" onClick={addMatchGroup} style={{ marginLeft: 5 }}>
+                        <Button type="link" onClick={addConditionSet} style={{ marginLeft: 5 }}>
                             <PlusOutlined style={{ marginRight: 15 }} /> Add condition set
                         </Button>
                     </Card>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -18,91 +18,21 @@ import { useActions, useValues } from 'kea'
 import { SceneLoading } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { DeleteOutlined, SaveOutlined, PlusOutlined, ApiFilled, MergeCellsOutlined } from '@ant-design/icons'
-import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { featureFlagLogic } from './featureFlagLogic'
 import { featureFlagLogic as featureFlagClientLogic } from 'lib/logic/featureFlagLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import './FeatureFlag.scss'
 import Checkbox from 'antd/lib/checkbox/Checkbox'
 import { IconExternalLink, IconJavascript, IconPython } from 'lib/components/icons'
-import { teamLogic } from 'scenes/teamLogic'
 import { Tooltip } from 'lib/components/Tooltip'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { APISnippet, JSSnippet, PythonSnippet } from 'scenes/feature-flags/FeatureFlagSnippets'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
     logic: featureFlagLogic,
-}
-
-const UTM_TAGS = '?utm_medium=in-product&utm_campaign=feature-flag'
-
-function JSSnippet({ flagKey }: { flagKey: string }): JSX.Element {
-    return (
-        <>
-            <CodeSnippet language={Language.JavaScript} wrap>
-                {`if (posthog.isFeatureEnabled('${flagKey ?? ''}')) {
-    // run your activation code here
-}`}
-            </CodeSnippet>
-            <div className="mt">
-                Need more information?{' '}
-                <a
-                    target="_blank"
-                    rel="noopener"
-                    href={`https://posthog.com/docs/integrations/js-integration${UTM_TAGS}#feature-flags`}
-                >
-                    Check the docs <IconExternalLink />
-                </a>
-            </div>
-        </>
-    )
-}
-
-function PythonSnippet({ flagKey }: { flagKey: string }): JSX.Element {
-    return (
-        <>
-            <CodeSnippet language={Language.Python} wrap>
-                {`if posthog.feature_enabled("${flagKey}", "user_distinct_id"):
-    runAwesomeFeature()
-`}
-            </CodeSnippet>
-            <div className="mt">
-                Need more information?{' '}
-                <a
-                    target="_blank"
-                    rel="noopener"
-                    href={`https://posthog.com/docs/integrations/python-integration${UTM_TAGS}#feature-flags`}
-                >
-                    Check the docs <IconExternalLink />
-                </a>
-            </div>
-        </>
-    )
-}
-
-function APISnippet(): JSX.Element {
-    const { currentTeam } = useValues(teamLogic)
-    return (
-        <>
-            <CodeSnippet language={Language.Bash} wrap>
-                {`curl ${window.location.origin}/decide/ \\
--X POST -H 'Content-Type: application/json' \\
--d '{
-    "api_key": "${currentTeam ? currentTeam.api_token : '[project_api_key]'}",
-    "distinct_id": "[user distinct id]"
-}'
-                `}
-            </CodeSnippet>
-            <div className="mt">
-                Need more information?{' '}
-                <a target="_blank" rel="noopener" href={`https://posthog.com/docs/api/feature-flags${UTM_TAGS}`}>
-                    Check the docs <IconExternalLink />
-                </a>
-            </div>
-        </>
-    )
 }
 
 function focusVariantKeyField(index: number): void {

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -17,7 +17,14 @@ import {
 import { useActions, useValues } from 'kea'
 import { SceneLoading } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { DeleteOutlined, SaveOutlined, PlusOutlined, ApiFilled, MergeCellsOutlined } from '@ant-design/icons'
+import {
+    DeleteOutlined,
+    CopyOutlined,
+    SaveOutlined,
+    PlusOutlined,
+    ApiFilled,
+    MergeCellsOutlined,
+} from '@ant-design/icons'
 import { featureFlagLogic } from './featureFlagLogic'
 import { featureFlagLogic as featureFlagClientLogic } from 'lib/logic/featureFlagLogic'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -56,7 +63,8 @@ export function FeatureFlag(): JSX.Element {
     const {
         addMatchGroup,
         updateMatchGroup,
-        removeMatchGroup,
+        removeConditionSet,
+        duplicateConditionSet,
         saveFeatureFlag,
         deleteFeatureFlag,
         setMultivariateEnabled,
@@ -480,13 +488,21 @@ export function FeatureFlag(): JSX.Element {
                                             )}
                                         </div>
                                         <div>
+                                            <Tooltip title="Duplicate this condition set" placement="bottomLeft">
+                                                <Button
+                                                    type="link"
+                                                    icon={<CopyOutlined />}
+                                                    style={{ width: 24, height: 24 }}
+                                                    onClick={() => duplicateConditionSet(index)}
+                                                />
+                                            </Tooltip>
                                             {featureFlag.filters.groups.length > 1 && (
                                                 <Tooltip title="Delete this condition set" placement="bottomLeft">
                                                     <Button
                                                         type="link"
                                                         icon={<DeleteOutlined />}
                                                         style={{ width: 24, height: 24 }}
-                                                        onClick={() => removeMatchGroup(index)}
+                                                        onClick={() => removeConditionSet(index)}
                                                     />
                                                 </Tooltip>
                                             )}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -551,7 +551,9 @@ export function FeatureFlag(): JSX.Element {
                                     <LemonSpacer large />
                                     <PropertyFilters
                                         style={{ marginLeft: 15 }}
-                                        pageKey={`feature-flag-${featureFlag.id}-${index}-${featureFlag.filters.groups.length}-${featureFlag.filters.aggregation_group_type_index}`}
+                                        pageKey={`feature-flag-${featureFlag.id}-${index}-${
+                                            featureFlag.filters.groups.length
+                                        }-${featureFlag.filters.aggregation_group_type_index ?? ''}`}
                                         propertyFilters={group?.properties}
                                         onChange={(properties) => updateConditionSet(index, undefined, properties)}
                                         taxonomicGroupTypes={taxonomicGroupTypes}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -580,17 +580,6 @@ export function FeatureFlag(): JSX.Element {
                                             />{' '}
                                             of <b>{aggregationTargetName}</b> in this set
                                         </div>
-
-                                        <Slider
-                                            data-attr="feature-flag-rollout-slider"
-                                            style={{ width: '50%' }}
-                                            tooltipPlacement="top"
-                                            tipFormatter={(value) => value + '%'}
-                                            value={group.rollout_percentage != null ? group.rollout_percentage : 100}
-                                            onChange={(value: number) => {
-                                                updateConditionSet(index, value)
-                                            }}
-                                        />
                                     </div>
                                 </Card>
                             </Col>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -472,7 +472,7 @@ export function FeatureFlag(): JSX.Element {
                         {featureFlag.filters.groups.map((group, index) => (
                             <Col span={24} md={24} key={`${index}-${featureFlag.filters.groups.length}`}>
                                 <Card style={{ marginBottom: 16 }}>
-                                    <div className="flag-form-row" style={{ height: 24 }}>
+                                    <div className="feature-flag-form-row" style={{ height: 24 }}>
                                         <div>
                                             <span className="simple-tag tag-light-blue" style={{ marginRight: 8 }}>
                                                 Set {index + 1}
@@ -524,11 +524,11 @@ export function FeatureFlag(): JSX.Element {
                                     />
                                     <LemonSpacer large />
 
-                                    <div className="flag-form-row">
-                                        <div>
+                                    <div className="feature-flag-form-row">
+                                        <div className="centered">
                                             Roll out to{' '}
                                             <InputNumber
-                                                style={{ width: 70 }}
+                                                style={{ width: 100, marginLeft: 8, marginRight: 8 }}
                                                 onChange={(value): void => {
                                                     updateMatchGroup(index, value as number)
                                                 }}
@@ -537,6 +537,7 @@ export function FeatureFlag(): JSX.Element {
                                                 }
                                                 min={0}
                                                 max={100}
+                                                addonAfter="%"
                                             />{' '}
                                             of <b>{aggregationTargetName}</b> in this set
                                         </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -34,7 +34,6 @@ import { IconExternalLink, IconJavascript, IconPython } from 'lib/components/ico
 import { Tooltip } from 'lib/components/Tooltip'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { APISnippet, JSSnippet, PythonSnippet, UTM_TAGS } from 'scenes/feature-flags/FeatureFlagSnippets'
 import { LemonSpacer } from 'lib/components/LemonRow'
 import { groupsModel } from '~/models/groupsModel'
@@ -552,7 +551,7 @@ export function FeatureFlag(): JSX.Element {
                                     <LemonSpacer large />
                                     <PropertyFilters
                                         style={{ marginLeft: 15 }}
-                                        pageKey={`feature-flag-${featureFlag.id}-${index}-${featureFlag.filters.groups.length}`}
+                                        pageKey={`feature-flag-${featureFlag.id}-${index}-${featureFlag.filters.groups.length}-${featureFlag.filters.aggregation_group_type_index}`}
                                         propertyFilters={group?.properties}
                                         onChange={(properties) => updateConditionSet(index, undefined, properties)}
                                         taxonomicGroupTypes={taxonomicGroupTypes}

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -4,7 +4,7 @@ import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { IconExternalLink } from 'lib/components/icons'
 import { teamLogic } from 'scenes/teamLogic'
 
-const UTM_TAGS = '?utm_medium=in-product&utm_campaign=feature-flag'
+export const UTM_TAGS = '?utm_medium=in-product&utm_campaign=feature-flag'
 
 export function JSSnippet({ flagKey }: { flagKey: string }): JSX.Element {
     return (

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { useValues } from 'kea'
+import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
+import { IconExternalLink } from 'lib/components/icons'
+import { teamLogic } from 'scenes/teamLogic'
+
+const UTM_TAGS = '?utm_medium=in-product&utm_campaign=feature-flag'
+
+export function JSSnippet({ flagKey }: { flagKey: string }): JSX.Element {
+    return (
+        <>
+            <CodeSnippet language={Language.JavaScript} wrap>
+                {`if (posthog.isFeatureEnabled('${flagKey ?? ''}')) {
+    // run your activation code here
+}`}
+            </CodeSnippet>
+            <div className="mt">
+                Need more information?{' '}
+                <a
+                    target="_blank"
+                    rel="noopener"
+                    href={`https://posthog.com/docs/integrations/js-integration${UTM_TAGS}#feature-flags`}
+                >
+                    Check the docs <IconExternalLink />
+                </a>
+            </div>
+        </>
+    )
+}
+
+export function PythonSnippet({ flagKey }: { flagKey: string }): JSX.Element {
+    return (
+        <>
+            <CodeSnippet language={Language.Python} wrap>
+                {`if posthog.feature_enabled("${flagKey}", "user_distinct_id"):
+    runAwesomeFeature()
+`}
+            </CodeSnippet>
+            <div className="mt">
+                Need more information?{' '}
+                <a
+                    target="_blank"
+                    rel="noopener"
+                    href={`https://posthog.com/docs/integrations/python-integration${UTM_TAGS}#feature-flags`}
+                >
+                    Check the docs <IconExternalLink />
+                </a>
+            </div>
+        </>
+    )
+}
+
+export function APISnippet(): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+    return (
+        <>
+            <CodeSnippet language={Language.Bash} wrap>
+                {`curl ${window.location.origin}/decide/ \\
+-X POST -H 'Content-Type: application/json' \\
+-d '{
+    "api_key": "${currentTeam ? currentTeam.api_token : '[project_api_key]'}",
+    "distinct_id": "[user distinct id]"
+}'
+                `}
+            </CodeSnippet>
+            <div className="mt">
+                Need more information?{' '}
+                <a target="_blank" rel="noopener" href={`https://posthog.com/docs/api/feature-flags${UTM_TAGS}`}>
+                    Check the docs <IconExternalLink />
+                </a>
+            </div>
+        </>
+    )
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -182,11 +182,11 @@ function GroupFilters({ group }: { group: FeatureFlagGroupType }): JSX.Element |
         return (
             <div style={{ display: 'flex', alignItems: 'center' }}>
                 <span style={{ flexShrink: 0, marginRight: 5 }}>{group.rollout_percentage}% of</span>
-                <PropertyFiltersDisplay filters={group.properties} style={{ margin: 0, width: '100%' }} />
+                <PropertyFiltersDisplay filters={group.properties} style={{ margin: 0, width: '100%' }} greyBadges />
             </div>
         )
     } else if (group.properties && group.properties.length > 0) {
-        return <PropertyFiltersDisplay filters={group.properties} style={{ margin: 0 }} />
+        return <PropertyFiltersDisplay filters={group.properties} style={{ margin: 0 }} greyBadges />
     } else if (group.rollout_percentage !== null && group.rollout_percentage !== undefined) {
         return `${group.rollout_percentage}% of all users`
     } else {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
@@ -10,6 +10,7 @@ import { urls } from 'scenes/urls'
 import { teamLogic } from '../teamLogic'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 import { groupsModel } from '~/models/groupsModel'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 const NEW_FLAG: FeatureFlagType = {
     id: null,
@@ -41,7 +42,7 @@ const EMPTY_MULTIVARIATE_OPTIONS: MultivariateFlagOptions = {
 export const featureFlagLogic = kea<featureFlagLogicType>({
     path: ['scenes', 'feature-flags', 'featureFlagLogic'],
     connect: {
-        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes']],
+        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes', 'groupsTaxonomicTypes']],
     },
     actions: {
         setFeatureFlagId: (id: number | 'new') => ({ id }),
@@ -299,15 +300,25 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
         aggregationTargetName: [
             (s) => [s.featureFlag, s.groupTypes],
             (featureFlag, groupTypes): string => {
-                if (
-                    featureFlag &&
-                    featureFlag.filters.aggregation_group_type_index != undefined &&
-                    groupTypes.length > 0
-                ) {
+                if (featureFlag && featureFlag.filters.aggregation_group_type_index != null && groupTypes.length > 0) {
                     const groupType = groupTypes[featureFlag.filters.aggregation_group_type_index]
                     return `${groupType.group_type}(s)`
                 }
                 return 'users'
+            },
+        ],
+        taxonomicGroupTypes: [
+            (s) => [s.featureFlag, s.groupsTaxonomicTypes],
+            (featureFlag, groupsTaxonomicTypes): TaxonomicFilterGroupType[] => {
+                if (
+                    featureFlag &&
+                    featureFlag.filters.aggregation_group_type_index != null &&
+                    groupsTaxonomicTypes.length > 0
+                ) {
+                    return [groupsTaxonomicTypes[featureFlag.filters.aggregation_group_type_index]]
+                }
+
+                return [TaxonomicFilterGroupType.PersonProperties, TaxonomicFilterGroupType.Cohorts]
             },
         ],
     },

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
@@ -45,10 +45,10 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
     actions: {
         setFeatureFlagId: (id: number | 'new') => ({ id }),
         setFeatureFlag: (featureFlag: FeatureFlagType) => ({ featureFlag }),
-        addMatchGroup: true,
+        addConditionSet: true,
         removeConditionSet: (index: number) => ({ index }),
         duplicateConditionSet: (index: number) => ({ index }),
-        updateMatchGroup: (
+        updateConditionSet: (
             index: number,
             newRolloutPercentage?: number | null,
             newProperties?: AnyPropertyFilter[]
@@ -76,14 +76,14 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
             null as FeatureFlagType | null,
             {
                 setFeatureFlag: (_, { featureFlag }) => featureFlag,
-                addMatchGroup: (state) => {
+                addConditionSet: (state) => {
                     if (!state) {
                         return state
                     }
                     const groups = [...state?.filters.groups, { properties: [], rollout_percentage: null }]
                     return { ...state, filters: { ...state.filters, groups } }
                 },
-                updateMatchGroup: (state, { index, newRolloutPercentage, newProperties }) => {
+                updateConditionSet: (state, { index, newRolloutPercentage, newProperties }) => {
                     if (!state) {
                         return state
                     }

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
@@ -46,7 +46,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
         setFeatureFlagId: (id: number | 'new') => ({ id }),
         setFeatureFlag: (featureFlag: FeatureFlagType) => ({ featureFlag }),
         addMatchGroup: true,
-        removeMatchGroup: (index: number) => ({ index }),
+        removeConditionSet: (index: number) => ({ index }),
+        duplicateConditionSet: (index: number) => ({ index }),
         updateMatchGroup: (
             index: number,
             newRolloutPercentage?: number | null,
@@ -98,12 +99,19 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
 
                     return { ...state, filters: { ...state.filters, groups } }
                 },
-                removeMatchGroup: (state, { index }) => {
+                removeConditionSet: (state, { index }) => {
                     if (!state) {
                         return state
                     }
                     const groups = [...state.filters.groups]
                     groups.splice(index, 1)
+                    return { ...state, filters: { ...state.filters, groups } }
+                },
+                duplicateConditionSet: (state, { index }) => {
+                    if (!state) {
+                        return state
+                    }
+                    const groups = state.filters.groups.concat([state.filters.groups[index]])
                     return { ...state, filters: { ...state.filters, groups } }
                 },
                 setMultivariateOptions: (state, { multivariateOptions }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
@@ -222,7 +222,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
                             ...state.filters,
                             aggregation_group_type_index: value,
                             // :TRICKY: We reset property filters after changing what you're aggregating by.
-                            groups: state.filters.groups.map((group) => ({ ...group, properties: [] })),
+                            groups: [{ properties: [], rollout_percentage: null }],
                         },
                     }
                 },

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
@@ -212,7 +212,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
                     }
                 },
                 setAggregationGroupTypeIndex: (state, { value }) => {
-                    if (!state) {
+                    if (!state || state.filters.aggregation_group_type_index == value) {
                         return state
                     }
 
@@ -221,6 +221,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
                         filters: {
                             ...state.filters,
                             aggregation_group_type_index: value,
+                            // :TRICKY: We reset property filters after changing what you're aggregating by.
+                            groups: state.filters.groups.map((group) => ({ ...group, properties: [] })),
                         },
                     }
                 },

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.scss
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/index.scss
@@ -5,7 +5,7 @@
     width: 150px;
     margin-top: 6px;
     .ant-select-selector {
-        border-color: #d9d9d9 !important;
+        border-color: $grey !important;
         cursor: pointer !important;
     }
     .ant-select-arrow {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -704,12 +704,10 @@ code.code {
 
 .simple-tag {
     border-radius: $radius;
-    font-weight: bold;
     padding: 2px 6px;
 
-    &.tag-light-lilac {
-        background-color: $hc_light_lilac;
-        color: $hc_navy;
+    &.tag-light-blue {
+        background-color: $blue_100;
     }
 }
 

--- a/frontend/src/toolbar/button/ToolbarButton.scss
+++ b/frontend/src/toolbar/button/ToolbarButton.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 #button-toolbar {
     position: fixed;
     left: 0;

--- a/frontend/src/toolbar/button/ToolbarButton.scss
+++ b/frontend/src/toolbar/button/ToolbarButton.scss
@@ -38,7 +38,7 @@
     transition: opacity ease 0.5s;
     background-color: rgba(255, 255, 255);
     border-radius: 4px;
-    border: 1px solid #d9d9d9;
+    border: 1px solid $grey;
 
     .toolbar-block {
         max-height: 80vh;
@@ -50,7 +50,7 @@
         display: flex;
         align-items: center;
         margin: 0 8px 0 8px;
-        border-bottom: 1px solid #d9d9d9;
+        border-bottom: 1px solid $grey;
 
         .toolbar-info-window-draggable {
             cursor: move;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1134,6 +1134,7 @@ export interface MultivariateFlagOptions {
 interface FeatureFlagFilters {
     groups: FeatureFlagGroupType[]
     multivariate: MultivariateFlagOptions | null
+    aggregation_group_type_index?: number | null
 }
 
 export interface FeatureFlagType {

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -102,6 +102,9 @@ $space: linear-gradient(180deg, #0a092a 0%, #271955 100%);
 // Fonts
 $medium: 500;
 
+// From chris' figma designs
+$grey: #d9d9d9;
+
 // Additional style configurations
 %mixin-base-bordered-card {
     border-radius: var(--radius);


### PR DESCRIPTION
## Changes

Part of https://github.com/PostHog/posthog/issues/7010, depends on https://github.com/PostHog/posthog/pull/7319

This follows the design from https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App. I refreshed the parts of the page that interact directly with condition matching.

![image](https://user-images.githubusercontent.com/148820/143242493-df145d73-a3e4-462e-ac1d-f97bac51ef9d.png)
![image](https://user-images.githubusercontent.com/148820/143242539-1ac248c9-48a1-412d-abae-86749428b565.png)

## How did you test this code?

Manually. Go and create a new feature flag :)
