### PR TITLE
Automatically switch to Value chart type on breakdown

### DIFF
--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -105,7 +105,7 @@ describe('Trends', () => {
 
     it('Apply property breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
-        cy.get('[data-attr=prop-filter-event_properties-2]').click()
+        cy.get('[data-attr=prop-filter-event_properties-1]').click()
         cy.get('[data-attr=trend-bar-value-graph]').should('exist')
     })
 

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -106,14 +106,14 @@ describe('Trends', () => {
     it('Apply property breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=prop-filter-event_properties-2]').click()
-        cy.get('[data-attr=trend-line-graph]').should('exist')
+        cy.get('[data-attr=trend-bar-value-graph]').should('exist')
     })
 
     it('Apply all users cohort breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=taxonomic-tab-cohorts_with_all]').click()
         cy.contains('All Users*').click()
-        cy.get('[data-attr=trend-line-graph]').should('exist')
+        cy.get('[data-attr=trend-bar-value-graph]').should('exist')
     })
 
     it('Save to dashboard', () => {

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -20,7 +20,7 @@ interface ChartFilterProps {
 }
 
 export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): JSX.Element {
-    const { chartFilter } = useValues(chartFilterLogic)
+    const { chartFilter, highlightChartChange } = useValues(chartFilterLogic)
     const { setChartFilter } = useActions(chartFilterLogic)
     const { preflight } = useValues(preflightLogic)
 
@@ -123,19 +123,21 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
                   },
               ]
     return (
-        <Select
-            key="2"
-            defaultValue={filters.display || defaultDisplay}
-            value={chartFilter || defaultDisplay}
-            onChange={(value: ChartDisplayType | FunnelVizType) => {
-                setChartFilter(value)
-                onChange(value)
-            }}
-            bordered={false}
-            dropdownMatchSelectWidth={false}
-            data-attr="chart-filter"
-            disabled={disabled}
-            options={options}
-        />
+        <span style={{ padding: '6px 0 ' }} className={highlightChartChange ? 'highlighted' : ''}>
+            <Select
+                key="2"
+                defaultValue={filters.display || defaultDisplay}
+                value={chartFilter || defaultDisplay}
+                onChange={(value: ChartDisplayType | FunnelVizType) => {
+                    setChartFilter(value)
+                    onChange(value)
+                }}
+                bordered={false}
+                dropdownMatchSelectWidth={false}
+                data-attr="chart-filter"
+                disabled={disabled}
+                options={options}
+            />
+        </span>
     )
 }

--- a/frontend/src/scenes/insights/Trends.cy-spec.js
+++ b/frontend/src/scenes/insights/Trends.cy-spec.js
@@ -84,10 +84,6 @@ xdescribe('<Insights /> trends', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=prop-breakdown-select]').click().type('Browser').type('{enter}')
 
-        cy.get('[data-attr=chart-filter]').click()
-        cy.contains('Value').click()
-        cy.get('body').click()
-
         cy.wait(1000)
         cy.get('.graph-container').should('be.visible')
 
@@ -266,7 +262,7 @@ xdescribe('<Insights /> trends', () => {
                 breakdown: '$browser',
                 breakdown_type: 'event',
             })
-            cy.get('[data-attr="trend-line-graph"]').should('be.visible')
+            cy.get('.graph-container').should('be.visible')
             cy.get('[data-attr="add-breakdown-button"]').should('contain', 'Browser')
         })
     })

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -12,6 +12,21 @@ describe('cleanFilters', () => {
         ).toEqual(expect.objectContaining({ insight: InsightType.RETENTION, display: ChartDisplayType.ActionsTable }))
     })
 
+    it('switches display to value if adding a breakdown', () => {
+        expect(
+            cleanFilters(
+                { insight: InsightType.TRENDS, display: ChartDisplayType.ActionsLineGraphLinear },
+                { insight: InsightType.TRENDS, display: ChartDisplayType.ActionsLineGraphLinear, breakdown: 'email' }
+            )
+        ).toEqual(
+            expect.objectContaining({
+                insight: InsightType.RETENTION,
+                display: ChartDisplayType.ActionsBarChartValue,
+                breakdown: 'email',
+            })
+        )
+    })
+
     it('removes shownas if moving from stickiness to trends', () => {
         expect(
             cleanFilters(

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -15,8 +15,8 @@ describe('cleanFilters', () => {
     it('switches display to value if adding a breakdown', () => {
         expect(
             cleanFilters(
-                { insight: InsightType.TRENDS, display: ChartDisplayType.ActionsLineGraphLinear },
-                { insight: InsightType.TRENDS, display: ChartDisplayType.ActionsLineGraphLinear, breakdown: 'email' }
+                { insight: InsightType.TRENDS, display: ChartDisplayType.ActionsLineGraphLinear, breakdown: 'email' },
+                { insight: InsightType.TRENDS, display: ChartDisplayType.ActionsLineGraphLinear }
             )
         ).toEqual(
             expect.objectContaining({

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -20,7 +20,7 @@ describe('cleanFilters', () => {
             )
         ).toEqual(
             expect.objectContaining({
-                insight: InsightType.RETENTION,
+                insight: InsightType.TRENDS,
                 display: ChartDisplayType.ActionsBarChartValue,
                 breakdown: 'email',
             })

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -136,7 +136,9 @@ export function cleanFilters(filters: Partial<FilterType>, oldFilters?: Partial<
             ...filters,
             interval: autocorrectInterval(filters),
             display:
-                filters.session && filters.session === 'dist'
+                filters.breakdown && !oldFilters?.breakdown
+                    ? ChartDisplayType.ActionsBarChartValue // automatically select value if breakdown
+                    : filters.session && filters.session === 'dist'
                     ? ChartDisplayType.ActionsTable
                     : insightChanged
                     ? ChartDisplayType.ActionsLineGraphLinear


### PR DESCRIPTION
## Changes

Value is a much more logical type for visualising breakdowns (as normally you want to know 'the most used browser over the entire period', not per day), and basically 100% of the time I find myself clicking breakdown, waiting 5 seconds, then selecting the value.

[The data says about 20% of people do the same thing as me](https://app.posthog.com/insights?insight=FUNNELS&date_from=-90d&actions=%5B%5D&events=%5B%7B%22id%22%3A%22insight%20viewed%22%2C%22name%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22properties%22%3A%5B%7B%22key%22%3A%22display%22%2C%22value%22%3A%5B%22ActionsLineGraph%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%7B%22id%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A1%2C%22name%22%3A%22insight%20viewed%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22display%22%2C%22value%22%3A%5B%22ActionsBarValue%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%5D&display=FunnelViz&interval=day&properties=%5B%7B%22key%22%3A%22breakdown%22%2C%22value%22%3A%22is_set%22%2C%22operator%22%3A%22is_set%22%2C%22type%22%3A%22event%22%7D%5D&filter_test_accounts=true&funnel_to_step=1&funnel_viz_type=steps&funnel_window_interval_unit=minute&funnel_window_interval=5&exclusions=%5B%5D&funnel_from_step=0#edit=true) but my gut feel is they don't know about this feature and they'd be better served if we implemented this.

I have not implemented automatically going back to line chart if you remove the dropdown as I think this might lead to too much confusion.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- some unit tests
- Manual testing:
  - Go to insights, select a dropdown value
  - see that the chart type has changed (including a little highlight on the select!)
