### PR TITLE
Align "New insight" button size with all other "New x" buttons

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -17,6 +17,7 @@ import {
     RightOutlined,
     StarFilled,
     StarOutlined,
+    PlusOutlined,
     UnorderedListOutlined,
 } from '@ant-design/icons'
 import './SavedInsights.scss'
@@ -176,7 +177,6 @@ function NewInsightButton(): JSX.Element {
         <Dropdown.Button
             overlayStyle={{ borderColor: 'var(--primary)' }}
             style={{ marginLeft: 8 }}
-            size="large"
             type="primary"
             onClick={() => {
                 router.actions.push(urls.newInsight(InsightType.TRENDS))
@@ -184,6 +184,7 @@ function NewInsightButton(): JSX.Element {
             overlay={menu}
             icon={<IconArrowDropDown style={{ fontSize: 25 }} data-attr="saved-insights-new-insight-dropdown" />}
         >
+            <PlusOutlined />
             New Insight
         </Dropdown.Button>
     )


### PR DESCRIPTION
## Changes

"New Insight" seemed a bit oversized. This way it fits in with all other our buttons.

| Before | After | Comparison |
| --- | --- | --- |
| ![Zrzut ekranu 2021-11-24 o 15 23 38](https://user-images.githubusercontent.com/4550621/143256114-3587a193-d3c9-425c-b37a-1efbc97ba193.png) | ![Zrzut ekranu 2021-11-24 o 15 23 42](https://user-images.githubusercontent.com/4550621/143256105-2f6580fe-c357-4e68-8d25-f27782d9e18d.png) | ![Zrzut ekranu 2021-11-24 o 15 23 48](https://user-images.githubusercontent.com/4550621/143256109-7a9d3ec7-9298-4fbf-a824-49600fc4e8d6.png) |

(We can also align them the other way around – literally 2 lines per button – but this one was just standing out like a thumb – size-wise)