### PR TITLE
Load insights after save as

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -559,6 +559,7 @@ describe('insightLogic', () => {
     test('Save as new insight', async () => {
         const url = combineUrl('/insights', { insight: InsightType.FUNNELS }).url
         router.actions.push(url)
+        savedInsightsLogic.mount()
 
         logic = insightLogic({
             dashboardItemId: 42,
@@ -572,6 +573,7 @@ describe('insightLogic', () => {
             logic.actions.saveAsNamingSuccess('New Insight (copy)')
         })
             .toDispatchActions(['setInsight'])
+            .toDispatchActions(savedInsightsLogic, ['loadInsights'])
             .toMatchValues({
                 filters: partial({ insight: InsightType.FUNNELS }),
                 // savedFilters: partial({ insight: InsightType.FUNNELS }),

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -576,6 +576,7 @@ export const insightLogic = kea<insightLogicType>({
             })
             toast(`You're now working on a copy of ${values.insight.name}`)
             actions.setInsight(insight, { fromPersistentApi: true })
+            savedInsightsLogic.findMounted()?.actions.loadInsights()
             if (values.syncWithUrl) {
                 router.actions.push('/insights', router.values.searchParams, {
                     ...router.values.hashParams,


### PR DESCRIPTION
## Changes

When 'saving as new insight' that new insight wouldn't show up if you looked at the list of insights. Now it will.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manual (create insight, save it, then save as new insight, go to insights, verify the new insight is there)
unit test