### PR TITLE
Move annotations to new table style

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -198,7 +198,7 @@ export function LemonTable<T extends Record<string, any>>({
                             {dataSource.length ? (
                                 currentFrame.map((data, rowIndex) => (
                                     <tr
-                                        key={`LemonTable-row-${rowKey ? data[rowKey] : currentStartIndex + rowIndex}`}
+                                        key={`LemonTable-td-${rowKey ? data[rowKey] : currentStartIndex + rowIndex}`}
                                         data-row-key={rowKey ? data[rowKey] : rowIndex}
                                         {...onRow?.(data)}
                                         className={rowClassName}
@@ -208,13 +208,9 @@ export function LemonTable<T extends Record<string, any>>({
                                             const contents = column.render ? column.render(value, data) : value
                                             return (
                                                 <td
-                                                    key={
-                                                        column.key
-                                                            ? data[column.key]
-                                                            : column.dataIndex
-                                                            ? data[column.dataIndex]
-                                                            : columnIndex
-                                                    }
+                                                    key={`LemonTable-td-${
+                                                        column.key || column.dataIndex?.toString() || columnIndex
+                                                    }`}
                                                     className={column.className}
                                                     style={{ textAlign: column.align }}
                                                 >

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -18,7 +18,7 @@ export interface Sorting {
 
 export interface LemonTableColumn<T extends Record<string, any>, D extends keyof T> {
     title?: string | React.ReactNode
-    key?: keyof T
+    key?: string
     dataIndex?: D
     render?: (dataValue: T[D] | undefined, record: T) => React.ReactNode | string | boolean | null | undefined
     sorter?: (a: T, b: T) => number

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -31,7 +31,7 @@ export enum PluginsAccessLevel {
 }
 
 export const annotationScopeToName = new Map<string, string>([
-    [AnnotationScope.DashboardItem, 'dashboard item'],
+    [AnnotationScope.DashboardItem, 'insight'],
     [AnnotationScope.Project, 'project'],
     [AnnotationScope.Organization, 'organization'],
 ])

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -16,6 +16,7 @@ import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 import { LemonTable, LemonTableColumns, LemonTableColumn } from 'lib/components/LemonTable/LemonTable'
 import { createdByColumn } from 'lib/components/LemonTable/columnUtils'
+import { TZLabel } from 'lib/components/TimezoneAware'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -53,18 +54,20 @@ export function Annotations(): JSX.Element {
                 )
             },
         },
-        createdByColumn() as LemonTableColumn<AnnotationType, keyof AnnotationType>,
         {
-            title: 'Date marker',
+            title: 'For date',
             render: function RenderDateMarker(_, annotation: AnnotationType): JSX.Element {
-                return <span>{dayjs(annotation.date_marker).format('YYYY-MM-DD')}</span>
+                return <span>{dayjs(annotation.date_marker).format('MMMM DD, YYYY')}</span>
             },
+            sorter: (a, b) => dayjs(a.date_marker).diff(b.date_marker),
         },
+        createdByColumn() as LemonTableColumn<AnnotationType, keyof AnnotationType>,
         {
             title: 'Last updated',
             render: function RenderLastUpdated(_, annotation: AnnotationType): JSX.Element {
-                return <span>{humanFriendlyDetailedTime(annotation.updated_at)}</span>
+                return <TZLabel time={annotation.updated_at} />
             },
+            sorter: (a, b) => dayjs(a.date_marker).diff(b.date_marker),
         },
         {
             title: 'Status',

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -1,23 +1,21 @@
 import React, { useState, useEffect, HTMLAttributes } from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Tag, Button, Modal, Input, Row, Menu, Dropdown } from 'antd'
+import { Tag, Button, Modal, Input, Row, Menu, Dropdown } from 'antd'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { annotationsModel } from '~/models/annotationsModel'
 import { annotationsTableLogic } from './logic'
 import { DeleteOutlined, RedoOutlined, ProjectOutlined, DeploymentUnitOutlined, DownOutlined } from '@ant-design/icons'
 import { annotationScopeToName } from 'lib/constants'
-import { userLogic } from 'scenes/userLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PlusOutlined } from '@ant-design/icons'
-import { createdByColumn } from 'lib/components/Table/Table'
 import { AnnotationType, AnnotationScope } from '~/types'
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs'
 import generatePicker from 'antd/lib/date-picker/generatePicker'
-import { normalizeColumnTitle, useIsTableScrolling } from 'lib/components/Table/utils'
-import { teamLogic } from '../teamLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import { LemonTable, LemonTableColumns, LemonTableColumn } from 'lib/components/LemonTable/LemonTable'
+import { createdByColumn } from 'lib/components/LemonTable/columnUtils'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
@@ -35,14 +33,13 @@ export function Annotations(): JSX.Element {
     const { createGlobalAnnotation } = useActions(annotationsModel)
     const [open, setOpen] = useState(false)
     const [selectedAnnotation, setSelected] = useState(null as AnnotationType | null)
-    const { tableScrollX } = useIsTableScrolling('lg')
 
-    const columns = [
+    const columns: LemonTableColumns<AnnotationType> = [
         {
-            title: normalizeColumnTitle('Annotation'),
+            title: 'Annotation',
             key: 'annotation',
-            fixed: true,
-            render: function RenderAnnotation(annotation: AnnotationType): JSX.Element {
+            width: '30%',
+            render: function RenderAnnotation(_, annotation: AnnotationType): JSX.Element {
                 return (
                     <div
                         className="ph-no-capture"
@@ -56,32 +53,36 @@ export function Annotations(): JSX.Element {
                 )
             },
         },
-        createdByColumn(annotations),
+        createdByColumn() as LemonTableColumn<AnnotationType, keyof AnnotationType>,
         {
-            title: normalizeColumnTitle('Date Marker'),
-            render: function RenderDateMarker(annotation: AnnotationType): JSX.Element {
+            title: 'Date marker',
+            render: function RenderDateMarker(_, annotation: AnnotationType): JSX.Element {
                 return <span>{dayjs(annotation.date_marker).format('YYYY-MM-DD')}</span>
             },
         },
         {
-            title: normalizeColumnTitle('Last Updated'),
-            render: function RenderLastUpdated(annotation: AnnotationType): JSX.Element {
+            title: 'Last updated',
+            render: function RenderLastUpdated(_, annotation: AnnotationType): JSX.Element {
                 return <span>{humanFriendlyDetailedTime(annotation.updated_at)}</span>
             },
         },
         {
-            title: normalizeColumnTitle('Status'),
-            render: function RenderStatus(annotation: AnnotationType): JSX.Element {
+            title: 'Status',
+            render: function RenderStatus(_, annotation: AnnotationType): JSX.Element {
                 return annotation.deleted ? <Tag color="red">Deleted</Tag> : <Tag color="green">Active</Tag>
             },
         },
         {
-            title: normalizeColumnTitle('Type'),
-            render: function RenderType(annotation: AnnotationType): JSX.Element {
-                return annotation.scope !== 'dashboard_item' ? (
-                    <Tag color="blue">Global</Tag>
+            title: 'Scope',
+            render: function RenderType(_, annotation: AnnotationType): JSX.Element {
+                return annotation.scope === AnnotationScope.DashboardItem ? (
+                    <Tag color="blue">Insight</Tag>
+                ) : annotation.scope === AnnotationScope.Project ? (
+                    <Tag color="purple">Project</Tag>
+                ) : annotation.scope === AnnotationScope.Organization ? (
+                    <Tag color="pink">Organization</Tag>
                 ) : (
-                    <Tag color="purple">Dashboard Item</Tag>
+                    <Tag>Unknown ({annotation.scope})</Tag>
                 )
             },
         },
@@ -97,24 +98,22 @@ export function Annotations(): JSX.Element {
             <PageHeader
                 title="Annotations"
                 caption="Here you can add organization- and project-wide annotations. Dashboard-specific ones can be added directly in the dashboard."
-            />
-
-            <div>
-                <div className="mb text-right">
+                buttons={
                     <Button
                         type="primary"
                         data-attr="create-annotation"
                         onClick={(): void => setOpen(true)}
                         icon={<PlusOutlined />}
                     >
-                        Create Annotation
+                        New Annotation
                     </Button>
-                </div>
-                <Table
+                }
+            />
+            <div>
+                <LemonTable
                     data-attr="annotations-table"
-                    size="small"
                     rowKey="id"
-                    pagination={{ pageSize: 99999, hideOnSinglePage: true }}
+                    pagination={{ pageSize: 100 }}
                     rowClassName="cursor-pointer"
                     dataSource={annotations}
                     columns={columns}
@@ -125,7 +124,6 @@ export function Annotations(): JSX.Element {
                             setOpen(true)
                         },
                     })}
-                    scroll={{ x: tableScrollX }}
                 />
                 <div
                     style={{
@@ -143,7 +141,7 @@ export function Annotations(): JSX.Element {
                                 loadAnnotationsNext()
                             }}
                         >
-                            {'Load more annotations'}
+                            Load more annotations
                         </Button>
                     )}
                 </div>
@@ -198,8 +196,6 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
     const [textInput, setTextInput] = useState('')
     const [modalMode, setModalMode] = useState<ModalMode>(ModalMode.CREATE)
     const [selectedDate, setDate] = useState<dayjs.Dayjs>(dayjs())
-    const { currentTeam } = useValues(teamLogic)
-    const { user } = useValues(userLogic)
 
     useEffect(() => {
         if (props.annotation) {
@@ -238,35 +234,32 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
             closable={false}
             visible={props.visible}
             onCancel={props.onCancel}
-            title={modalMode === ModalMode.CREATE ? 'Create Global Annotation' : 'Edit Annotation'}
+            title={modalMode === ModalMode.CREATE ? 'Create annotation' : 'Edit ennotation'}
         >
             {modalMode === ModalMode.CREATE ? (
                 <span>
                     This annotation will appear on all
                     <Dropdown
                         overlay={
-                            <Menu>
-                                {scope === AnnotationScope.Project ? (
-                                    <Menu.Item
-                                        onClick={() => {
-                                            setScope(AnnotationScope.Project)
-                                        }}
-                                        key={AnnotationScope.Project}
-                                        icon={<ProjectOutlined />}
-                                    >
-                                        Project {currentTeam?.name}
-                                    </Menu.Item>
-                                ) : (
-                                    <Menu.Item
-                                        onClick={() => {
-                                            setScope(AnnotationScope.Organization)
-                                        }}
-                                        key={AnnotationScope.Organization}
-                                        icon={<DeploymentUnitOutlined />}
-                                    >
-                                        Organization {user?.organization?.name}
-                                    </Menu.Item>
-                                )}
+                            <Menu activeKey={scope}>
+                                <Menu.Item
+                                    onClick={() => {
+                                        setScope(AnnotationScope.Project)
+                                    }}
+                                    key={AnnotationScope.Project}
+                                    icon={<ProjectOutlined />}
+                                >
+                                    Project
+                                </Menu.Item>
+                                <Menu.Item
+                                    onClick={() => {
+                                        setScope(AnnotationScope.Organization)
+                                    }}
+                                    key={AnnotationScope.Organization}
+                                    icon={<DeploymentUnitOutlined />}
+                                >
+                                    Organization
+                                </Menu.Item>
                             </Menu>
                         }
                     >

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -126,6 +126,7 @@ export function Annotations(): JSX.Element {
                             setOpen(true)
                         },
                     })}
+                    emptyState="No annotations yet"
                 />
                 <div
                     style={{

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -212,6 +212,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
 
     const _onSubmit = (input: string, date: dayjs.Dayjs): void => {
         props.onSubmit(input, date)
+        // Reset input
         setTextInput('')
         setDate(dayjs())
         setScope(AnnotationScope.Project)
@@ -244,23 +245,11 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
                     This annotation will appear on all
                     <Dropdown
                         overlay={
-                            <Menu activeKey={scope}>
-                                <Menu.Item
-                                    onClick={() => {
-                                        setScope(AnnotationScope.Project)
-                                    }}
-                                    key={AnnotationScope.Project}
-                                    icon={<ProjectOutlined />}
-                                >
+                            <Menu activeKey={scope} onSelect={(e) => setScope(e.key as AnnotationScope)}>
+                                <Menu.Item key={AnnotationScope.Project} icon={<ProjectOutlined />}>
                                     Project
                                 </Menu.Item>
-                                <Menu.Item
-                                    onClick={() => {
-                                        setScope(AnnotationScope.Organization)
-                                    }}
-                                    key={AnnotationScope.Organization}
-                                    icon={<DeploymentUnitOutlined />}
-                                >
+                                <Menu.Item key={AnnotationScope.Organization} icon={<DeploymentUnitOutlined />}>
                                     Organization
                                 </Menu.Item>
                             </Menu>

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, HTMLAttributes } from 'react'
 import { useValues, useActions } from 'kea'
 import { Tag, Button, Modal, Input, Row, Menu, Dropdown } from 'antd'
-import { humanFriendlyDetailedTime } from 'lib/utils'
 import { annotationsModel } from '~/models/annotationsModel'
 import { annotationsTableLogic } from './logic'
 import { DeleteOutlined, RedoOutlined, ProjectOutlined, DeploymentUnitOutlined, DownOutlined } from '@ant-design/icons'

--- a/posthog/models/annotation.py
+++ b/posthog/models/annotation.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 
 class Annotation(models.Model):
     class Scope(models.TextChoices):
-        DASHBOARD_ITEM = "dashboard_item", "insight"
+        DASHBOARD_ITEM = "dashboard_item", "dashboard item"
         PROJECT = "project", "project"
         ORGANIZATION = "organization", "organization"
 

--- a/posthog/models/annotation.py
+++ b/posthog/models/annotation.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 
 class Annotation(models.Model):
     class Scope(models.TextChoices):
-        DASHBOARD_ITEM = "dashboard_item", "dashboard item"
+        DASHBOARD_ITEM = "dashboard_item", "insight"
         PROJECT = "project", "project"
         ORGANIZATION = "organization", "organization"
 


### PR DESCRIPTION
## Changes

The Annotations page. Now nicer to nice. Also I fixed some bugginess around scope, though overall annotations are quite rough and it may be worth to spend some time ""nailing"" this feature… when someone complains – for now that's out of scope.

### Before
![Zrzut ekranu 2021-11-24 o 19 26 20](https://user-images.githubusercontent.com/4550621/143294440-fa5debc9-1aa7-48a1-86a1-0008a50a8266.png)

### After
![Zrzut ekranu 2021-11-24 o 19 25 49](https://user-images.githubusercontent.com/4550621/143298003-ed68da41-2776-42c6-bfb7-44afe3984ff3.png)

