### PR TITLE
Fix service version warning message

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -739,7 +739,7 @@ SKIP_SERVICE_VERSION_REQUIREMENTS = get_from_env(
 )
 
 if SKIP_SERVICE_VERSION_REQUIREMENTS:
-    print_warning("Skipping service version requirements. This is dangerous and PostHog might not work as expected!")
+    print_warning(["Skipping service version requirements. This is dangerous and PostHog might not work as expected!"])
 
 SERVICE_VERSION_REQUIREMENTS = [
     ServiceVersionRequirement(service="postgresql", supported_version=">=11.0.0,<=14.1.0",),


### PR DESCRIPTION
## Changes

Service warning message was being split up character-by-character, causing console spam

```
l
i
k
e

t
h
i
s
.
```

This PR fixes that. `print_warning` expects a Sequence, like a list or tuple, but it will split up a single string if given just that.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
