### PR TITLE
Update BE tracking to use groups

### DIFF
--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -53,6 +53,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
     @patch("posthoganalytics.capture")
     def test_delete_second_managed_organization(self, mock_capture):
         organization, _, team = Organization.objects.bootstrap(self.user, name="X")
+        organization_props = self.organization.get_analytics_metadata()
         self.assertTrue(Organization.objects.filter(id=organization.id).exists())
         self.assertTrue(Team.objects.filter(id=team.id).exists())
         response = self.client.delete(f"/api/organizations/{organization.id}")
@@ -63,13 +64,14 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "organization deleted",
-            ANY,
+            organization_props,
             groups={"instance": ANY, "organization": str(organization.id)},
         )
 
     @patch("posthoganalytics.capture")
     def test_delete_last_organization(self, mock_capture):
         org_id = self.organization.id
+        organization_props = self.organization.get_analytics_metadata()
         self.assertTrue(Organization.objects.filter(id=org_id).exists())
 
         self.organization_membership.level = OrganizationMembership.Level.OWNER
@@ -86,7 +88,10 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
         self.assertEqual(response_bis.status_code, 404, "Did not return a 404 on trying to delete a nonexistent org")
 
         mock_capture.assert_called_once_with(
-            self.user.distinct_id, "organization deleted", ANY, groups={"instance": ANY, "organization": str(org_id)}
+            self.user.distinct_id,
+            "organization deleted",
+            organization_props,
+            groups={"instance": ANY, "organization": str(org_id)},
         )
 
     def test_no_delete_organization_not_owning(self):

--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -53,7 +53,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
     @patch("posthoganalytics.capture")
     def test_delete_second_managed_organization(self, mock_capture):
         organization, _, team = Organization.objects.bootstrap(self.user, name="X")
-        organization_props = self.organization.get_analytics_metadata()
+        organization_props = organization.get_analytics_metadata()
         self.assertTrue(Organization.objects.filter(id=organization.id).exists())
         self.assertTrue(Team.objects.filter(id=team.id).exists())
         response = self.client.delete(f"/api/organizations/{organization.id}")

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -39,7 +39,7 @@ def send_license_usage():
                     "events_count": events_count,
                     "organization_name": user.current_organization.name,  # type: ignore
                 },
-                groups={"organization": user.current_organization.pk, "instance": SITE_URL,},
+                groups={"organization": user.current_organization.pk, "instance": SITE_URL,},  # type: ignore
             )
             return
 
@@ -52,7 +52,7 @@ def send_license_usage():
                 "license_keys": get_instance_licenses(),
                 "organization_name": user.current_organization.name,  # type: ignore
             },
-            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},
+            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},  # type: ignore
         )
     except Exception as err:
         posthoganalytics.capture(
@@ -63,5 +63,5 @@ def send_license_usage():
                 "date": date_from.strftime("%Y-%m-%d"),
                 "organization_name": user.current_organization.name,  # type: ignore
             },
-            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},
+            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},  # type: ignore
         )

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from ee.clickhouse.client import sync_execute
 from ee.models.license import License
 from posthog.models import User
+from posthog.settings import SITE_URL
 from posthog.tasks.status_report import get_instance_licenses
 
 
@@ -38,6 +39,7 @@ def send_license_usage():
                     "events_count": events_count,
                     "organization_name": user.current_organization.name,  # type: ignore
                 },
+                groups={"organization": user.current_organization.pk, "instance": SITE_URL,},
             )
             return
 
@@ -50,6 +52,7 @@ def send_license_usage():
                 "license_keys": get_instance_licenses(),
                 "organization_name": user.current_organization.name,  # type: ignore
             },
+            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},
         )
     except Exception as err:
         posthoganalytics.capture(
@@ -60,4 +63,5 @@ def send_license_usage():
                 "date": date_from.strftime("%Y-%m-%d"),
                 "organization_name": user.current_organization.name,  # type: ignore
             },
+            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},
         )

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -39,7 +39,7 @@ def send_license_usage():
                     "events_count": events_count,
                     "organization_name": user.current_organization.name,  # type: ignore
                 },
-                groups={"organization": user.current_organization.pk, "instance": SITE_URL,},  # type: ignore
+                groups={"organization": str(user.current_organization.id), "instance": SITE_URL,},  # type: ignore
             )
             return
 
@@ -52,7 +52,7 @@ def send_license_usage():
                 "license_keys": get_instance_licenses(),
                 "organization_name": user.current_organization.name,  # type: ignore
             },
-            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},  # type: ignore
+            groups={"organization": str(user.current_organization.id), "instance": SITE_URL,},  # type: ignore
         )
     except Exception as err:
         posthoganalytics.capture(
@@ -63,5 +63,5 @@ def send_license_usage():
                 "date": date_from.strftime("%Y-%m-%d"),
                 "organization_name": user.current_organization.name,  # type: ignore
             },
-            groups={"organization": user.current_organization.pk, "instance": SITE_URL,},  # type: ignore
+            groups={"organization": str(user.current_organization.id), "instance": SITE_URL,},  # type: ignore
         )

--- a/ee/tasks/test/test_send_license_usage.py
+++ b/ee/tasks/test/test_send_license_usage.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 from uuid import uuid4
 
 from freezegun import freeze_time
@@ -45,6 +45,7 @@ class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIB
             self.user.distinct_id,
             "send license usage data",
             {"date": "2021-10-09", "events_count": 3, "license_keys": ["enterprise"], "organization_name": "Test"},
+            groups={"instance": ANY, "organization": str(self.organization.id)},
         )
 
     @freeze_time("2021-10-10T23:01:00Z")
@@ -69,6 +70,7 @@ class SendLicenseUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIB
             self.user.distinct_id,
             "send license usage data error",
             {"error": "", "date": "2021-10-09", "organization_name": "Test"},
+            groups={"instance": ANY, "organization": str(self.organization.id)},
         )
 
 

--- a/ee/tasks/test/test_send_license_usage.py
+++ b/ee/tasks/test/test_send_license_usage.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from uuid import uuid4
 
-import posthoganalytics
 from freezegun import freeze_time
 
 from ee.api.test.base import LicensedTestMixin

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -23,6 +23,7 @@ from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthenticat
 from posthog.celery import update_cache_item_task
 from posthog.constants import INSIGHT_STICKINESS, TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, TRENDS_STICKINESS
 from posthog.decorators import CacheType, cached_function
+from posthog.event_usage import report_user_action
 from posthog.models import (
     Action,
     ActionStep,
@@ -126,9 +127,7 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
             )
 
         calculate_action.delay(action_id=instance.pk)
-        posthoganalytics.capture(
-            validated_data["created_by"].distinct_id, "action created", instance.get_analytics_metadata()
-        )
+        report_user_action(validated_data["created_by"], "action created", instance.get_analytics_metadata())
 
         return instance
 
@@ -156,8 +155,8 @@ class ActionSerializer(serializers.HyperlinkedModelSerializer):
         instance = super().update(instance, validated_data)
         calculate_action.delay(action_id=instance.pk)
         instance.refresh_from_db()
-        posthoganalytics.capture(
-            self.context["request"].user.distinct_id,
+        report_user_action(
+            self.context["request"].user,
             "action updated",
             {
                 **instance.get_analytics_metadata(),

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List, Union, cast
 
-import posthoganalytics
 from django.core.cache import cache
 from django.db.models import Count, Exists, OuterRef, Prefetch, QuerySet
 from django.db.models.signals import post_save

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -10,6 +10,7 @@ from rest_hooks.signals import raw_hook_event
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.event_usage import report_user_action
 from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import Annotation, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
@@ -101,9 +102,7 @@ def annotation_created(sender, instance, created, raw, using, **kwargs):
 
     if instance.created_by:
         event_name: str = "annotation created" if created else "annotation updated"
-        posthoganalytics.capture(
-            instance.created_by.distinct_id, event_name, instance.get_analytics_metadata(),
-        )
+        report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())
 
 
 class LegacyAnnotationsViewSet(AnnotationsViewSet):

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -69,14 +69,14 @@ class LoginSerializer(serializers.Serializer):
             raise serializers.ValidationError("Invalid email or password.", code="invalid_credentials")
 
         login(request, user, backend="django.contrib.auth.backends.ModelBackend")
-        report_user_logged_in(user.distinct_id, social_provider="")
+        report_user_logged_in(user, social_provider="")
         return user
 
 
 class NonCreatingViewSetMixin(mixins.CreateModelMixin):
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
-            Method `create()` is overridden to send a more appropriate HTTP 
+            Method `create()` is overridden to send a more appropriate HTTP
             status code (as no object is actually created).
             """
         response = super().create(request, *args, **kwargs)

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1,7 +1,6 @@
 import csv
 from typing import Any, Dict, List, Optional, cast
 
-import posthoganalytics
 from django.db.models import Count, QuerySet
 from rest_framework import serializers, viewsets
 from rest_framework.permissions import IsAuthenticated

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -13,6 +13,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import get_target_entity
 from posthog.constants import TRENDS_STICKINESS
+from posthog.event_usage import report_user_action
 from posthog.models import Cohort, Entity
 from posthog.models.event import Event
 from posthog.models.filters.filter import Filter
@@ -80,7 +81,7 @@ class CohortSerializer(serializers.ModelSerializer):
             else:
                 calculate_cohort.delay(cohort.id)
 
-        posthoganalytics.capture(request.user.distinct_id, "cohort created", cohort.get_analytics_metadata())
+        report_user_action(request.user, "cohort created", cohort.get_analytics_metadata())
         return cohort
 
     def _handle_static(self, cohort: Cohort, request: Request):
@@ -151,8 +152,8 @@ class CohortSerializer(serializers.ModelSerializer):
                 else:
                     calculate_cohort.delay(cohort.id)
 
-        posthoganalytics.capture(
-            request.user.distinct_id,
+        report_user_action(
+            request.user,
             "cohort updated",
             {**cohort.get_analytics_metadata(), "updated_by_creator": request.user == cohort.created_by},
         )

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -20,6 +20,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.constants import INSIGHT_TRENDS
+from posthog.event_usage import report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, Insight, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
@@ -102,8 +103,8 @@ class DashboardSerializer(serializers.ModelSerializer):
                     team=team,
                 )
 
-        posthoganalytics.capture(
-            request.user.distinct_id,
+        report_user_action(
+            request.user,
             "dashboard created",
             {
                 **dashboard.get_analytics_metadata(),
@@ -124,9 +125,7 @@ class DashboardSerializer(serializers.ModelSerializer):
         instance = super().update(instance, validated_data)
 
         if "request" in self.context:
-            posthoganalytics.capture(
-                self.context["request"].user.distinct_id, "dashboard updated", instance.get_analytics_metadata()
-            )
+            report_user_action(self.context["request"].user, "dashboard updated", instance.get_analytics_metadata())
 
         return instance
 

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -1,19 +1,15 @@
 import secrets
-from typing import Any, Dict, Optional, Sequence, Type, Union
+from typing import Any, Dict, Sequence, Type, Union
 
-import posthoganalytics
-from django.db.models import Model, Prefetch, QuerySet
-from django.db.models.query_utils import Q
+from django.db.models import Prefetch, QuerySet
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework import mixins, response, serializers, viewsets
 from rest_framework.authentication import BaseAuthentication, BasicAuthentication, SessionAuthentication
-from rest_framework.decorators import action
 from rest_framework.permissions import BasePermission, IsAuthenticated, OperandHolder, SingleOperandHolder
 from rest_framework.request import Request
-from sentry_sdk.api import capture_exception
 
 from posthog.api.insight import InsightSerializer, InsightViewSet
 from posthog.api.routing import StructuredViewSetMixin
@@ -24,8 +20,8 @@ from posthog.event_usage import report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, Insight, Team
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.tasks.update_cache import update_dashboard_item_cache, update_dashboard_items_cache
-from posthog.utils import get_safe_cache, render_template, str_to_bool
+from posthog.tasks.update_cache import update_dashboard_items_cache
+from posthog.utils import render_template
 
 
 class DashboardSerializer(serializers.ModelSerializer):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, Optional, cast
 
-import posthoganalytics
 from django.db.models import Prefetch, QuerySet
 from rest_framework import authentication, exceptions, request, serializers, status, viewsets
 from rest_framework.decorators import action

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthentication
+from posthog.event_usage import report_user_action
 from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import FeatureFlag
 from posthog.models.feature_flag import FeatureFlagOverride
@@ -112,8 +113,8 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         FeatureFlag.objects.filter(key=validated_data["key"], team=self.context["team_id"], deleted=True).delete()
         instance = super().create(validated_data)
 
-        posthoganalytics.capture(
-            request.user.distinct_id, "feature flag created", instance.get_analytics_metadata(),
+        report_user_action(
+            request.user, "feature flag created", instance.get_analytics_metadata(),
         )
 
         return instance
@@ -126,8 +127,8 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         self._update_filters(validated_data)
         instance = super().update(instance, validated_data)
 
-        posthoganalytics.capture(
-            request.user.distinct_id, "feature flag updated", instance.get_analytics_metadata(),
+        report_user_action(
+            request.user, "feature flag updated", instance.get_analytics_metadata(),
         )
         return instance
 
@@ -220,16 +221,12 @@ class FeatureFlagOverrideSerializer(serializers.ModelSerializer):
         )
         request = self.context["request"]
         if created:
-            posthoganalytics.capture(
-                request.user.distinct_id,
-                self._analytics_created_event_name,
-                feature_flag_override.get_analytics_metadata(),
+            report_user_action(
+                request.user, self._analytics_created_event_name, feature_flag_override.get_analytics_metadata(),
             )
         else:
-            posthoganalytics.capture(
-                request.user.distinct_id,
-                self._analytics_updated_event_name,
-                feature_flag_override.get_analytics_metadata(),
+            report_user_action(
+                request.user, self._analytics_updated_event_name, feature_flag_override.get_analytics_metadata(),
             )
         return feature_flag_override
 
@@ -237,9 +234,7 @@ class FeatureFlagOverrideSerializer(serializers.ModelSerializer):
         self._ensure_team_and_feature_flag_match(validated_data)
         request = self.context["request"]
         instance = super().update(instance, validated_data)
-        posthoganalytics.capture(
-            request.user.distinct_id, self._analytics_updated_event_name, instance.get_analytics_metadata()
-        )
+        report_user_action(request.user, self._analytics_updated_event_name, instance.get_analytics_metadata())
         return instance
 
     def _ensure_team_and_feature_flag_match(self, validated_data: Dict):

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -54,7 +54,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
 
         if not self.context.get("bulk_create"):
             report_team_member_invited(
-                self.context["request"].user.distinct_id,
+                self.context["request"].user,
                 name_provided=bool(validated_data.get("first_name")),
                 current_invite_count=invite.organization.active_invites.count(),
                 current_member_count=OrganizationMembership.objects.filter(

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -104,7 +104,7 @@ class OrganizationInviteViewSet(
 
         organization = Organization.objects.get(id=self.organization_id)
         report_bulk_invited(
-            cast(User, self.request.user).distinct_id,
+            cast(User, self.request.user),
             invitee_count=len(serializer.validated_data),
             name_count=sum(1 for invite in serializer.validated_data if invite.get("first_name")),
             current_invite_count=organization.active_invites.count(),

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -63,7 +63,7 @@ class SignupSerializer(serializers.Serializer):
         )
 
         report_user_signed_up(
-            user.distinct_id,
+            user,
             is_instance_first_user=is_instance_first_user,
             is_organization_first_user=True,
             new_onboarding_enabled=(not self._organization.setup_section_2_completed),
@@ -164,7 +164,7 @@ class InviteSignupSerializer(serializers.Serializer):
             )
 
             report_user_signed_up(
-                user.distinct_id,
+                user,
                 is_instance_first_user=False,
                 is_organization_first_user=False,
                 new_onboarding_enabled=(not invite.organization.setup_section_2_completed),
@@ -414,7 +414,7 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
             user = serializer.save()
 
     report_user_signed_up(
-        distinct_id=user.distinct_id,
+        user,
         is_instance_first_user=User.objects.count() == 1,
         is_organization_first_user=not from_invite,
         new_onboarding_enabled=False,

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -9,7 +9,7 @@ from posthog.test.base import APIBaseTest
 def factory_test_action_api(event_factory):
     @patch("posthog.tasks.calculate_action.calculate_action.delay")
     class TestActionApi(APIBaseTest):
-        @patch("posthoganalytics.capture")
+        @patch("posthog.api.action.report_user_action")
         def test_create_action(self, patch_capture, *args):
             Event.objects.create(
                 team=self.team,
@@ -37,7 +37,7 @@ def factory_test_action_api(event_factory):
 
             # Assert analytics are sent
             patch_capture.assert_called_once_with(
-                self.user.distinct_id,
+                self.user,
                 "action created",
                 {
                     "post_to_slack": False,
@@ -78,7 +78,7 @@ def factory_test_action_api(event_factory):
             self.assertEqual(Action.objects.count(), count)
             self.assertEqual(ActionStep.objects.count(), steps_count)
 
-        @patch("posthoganalytics.capture")
+        @patch("posthog.api.action.report_user_action")
         def test_update_action(self, patch_capture, *args):
 
             user = self._create_user("test_user_update")
@@ -134,7 +134,7 @@ def factory_test_action_api(event_factory):
 
             # Assert analytics are sent
             patch_capture.assert_called_with(
-                user.distinct_id,
+                user,
                 "action updated",
                 {
                     "post_to_slack": False,

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -12,7 +12,7 @@ from posthog.test.base import APIBaseTest
 
 
 class TestCohort(APIBaseTest):
-    @patch("posthoganalytics.capture")
+    @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort.delay")
     def test_creating_update_and_calculating(self, patch_calculate_cohort, patch_capture):
         self.team.app_urls = ["http://somewebsite.com"]
@@ -31,7 +31,7 @@ class TestCohort(APIBaseTest):
 
         # Assert analytics are sent
         patch_capture.assert_called_with(
-            self.user.distinct_id,
+            self.user,
             "cohort created",
             {
                 "name_length": 8,
@@ -61,7 +61,7 @@ class TestCohort(APIBaseTest):
 
         # Assert analytics are sent
         patch_capture.assert_called_with(
-            self.user.distinct_id,
+            self.user,
             "cohort updated",
             {
                 "name_length": 9,

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from rest_framework import status
 
@@ -159,7 +159,14 @@ class TestOrganizationAPI(APIBaseTest):
 
             # Assert the event was reported
             mock_capture.assert_called_with(
-                user.distinct_id, "onboarding completed", properties={"team_members_count": 2},
+                user.distinct_id,
+                "onboarding completed",
+                properties={"team_members_count": 2},
+                groups={
+                    "instance": ANY,
+                    "organization": str(self.team.organization_id),
+                    "project": str(self.team.uuid),
+                },
             )
 
     def test_cannot_complete_onboarding_for_another_org(self):

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -1,5 +1,5 @@
 import random
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.core import mail
 from rest_framework import status
@@ -99,6 +99,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
                 "current_member_count": 1,
                 "email_available": True,
             },
+            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
         )
 
         # Assert invite email is sent
@@ -168,6 +169,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
                 "current_member_count": 1,
                 "email_available": True,
             },
+            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
         )
 
     def test_maximum_20_invites_per_request(self):

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 from typing import cast
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 import pytz
@@ -727,6 +727,7 @@ class TestInviteSignup(APIBaseTest):
                 "org_current_project_count": 1,
                 "org_current_members_count": 1,
             },
+            groups={"instance": ANY, "organization": str(new_org.id)},
         )
         mock_identify.assert_called_once()
 
@@ -784,6 +785,7 @@ class TestInviteSignup(APIBaseTest):
                 "org_current_project_count": 1,
                 "org_current_members_count": 2,
             },
+            groups={"instance": ANY, "organization": str(new_org.id)},
         )
 
     def test_cant_claim_sign_up_invite_without_required_attributes(self):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.utils.text import slugify
 from rest_framework import status
@@ -173,6 +173,7 @@ class TestUserAPI(APIBaseTest):
             properties={
                 "updated_attrs": ["anonymize_data", "email", "email_opt_in", "events_column_config", "first_name"],
             },
+            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
         )
 
     @patch("posthoganalytics.capture")
@@ -195,6 +196,7 @@ class TestUserAPI(APIBaseTest):
             self.user.distinct_id,
             "user updated",
             properties={"updated_attrs": ["current_organization", "current_team"]},
+            groups={"instance": ANY, "organization": str(self.new_org.id), "project": str(self.new_project.uuid),},
         )
 
     @patch("posthoganalytics.capture")
@@ -217,6 +219,7 @@ class TestUserAPI(APIBaseTest):
             self.user.distinct_id,
             "user updated",
             properties={"updated_attrs": ["current_organization", "current_team"]},
+            groups={"instance": ANY, "organization": str(self.new_org.id), "project": str(team.uuid),},
         )
 
     def test_cannot_set_mismatching_org_and_team(self):
@@ -328,7 +331,10 @@ class TestUserAPI(APIBaseTest):
         self.assertTrue(user.check_password("a_new_password"))
 
         mock_capture.assert_called_once_with(
-            user.distinct_id, "user updated", properties={"updated_attrs": ["password"]},
+            user.distinct_id,
+            "user updated",
+            properties={"updated_attrs": ["password"]},
+            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
         )
 
         # User can log in with new password
@@ -358,7 +364,10 @@ class TestUserAPI(APIBaseTest):
         self.assertTrue(user.check_password("a_new_password"))
 
         mock_capture.assert_called_once_with(
-            user.distinct_id, "user updated", properties={"updated_attrs": ["password"]},
+            user.distinct_id,
+            "user updated",
+            properties={"updated_attrs": ["password"]},
+            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
         )
 
         # User can log in with new password

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -121,16 +121,15 @@ def report_user_password_reset(user: User) -> None:
     )
 
 
-# :TODO:
 def report_team_member_invited(
-    distinct_id: str, name_provided: bool, current_invite_count: int, current_member_count: int, email_available: bool,
+    user: User, name_provided: bool, current_invite_count: int, current_member_count: int, email_available: bool,
 ) -> None:
     """
     Triggered after a user creates an **individual** invite for a new team member. See `report_bulk_invited`
     for bulk invite creation.
     """
     posthoganalytics.capture(
-        distinct_id,
+        user.distinct_id,
         "team invite executed",
         properties={
             "name_provided": name_provided,
@@ -138,6 +137,7 @@ def report_team_member_invited(
             "current_member_count": current_member_count,
             "email_available": email_available,
         },
+        groups=groups(user.current_organization, user.current_team),
     )
 
 

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -67,15 +67,18 @@ def report_user_joined_organization(organization: Organization, current_user: Us
     )
 
 
-# :TODO:
 def report_user_logged_in(
-    distinct_id: str,
-    social_provider: str = "",  # which third-party provider processed the login (empty = no third-party)
+    user: User, social_provider: str = "",  # which third-party provider processed the login (empty = no third-party)
 ) -> None:
     """
     Reports that a user has logged in to PostHog.
     """
-    posthoganalytics.capture(distinct_id, "user logged in", properties={"social_provider": social_provider})
+    posthoganalytics.capture(
+        user.distinct_id,
+        "user logged in",
+        properties={"social_provider": social_provider},
+        groups=groups(user.current_organization, user.current_team),
+    )
 
 
 def report_onboarding_completed(organization: Organization, current_user: User) -> None:

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -176,6 +176,7 @@ def report_org_usage(organization_id: str, distinct_id: str, properties: Dict[st
         properties,
         groups={"organization": organization_id, "instance": SITE_URL},
     )
+    posthoganalytics.group_identify("organization", organization_id, properties)
 
 
 def report_org_usage_failure(organization_id: str, distinct_id: str, err: str) -> None:

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -166,19 +166,25 @@ def report_bulk_invited(
     )
 
 
-# :TODO:
-def report_org_usage(distinct_id: str, properties: Dict[str, Any]) -> None:
+def report_org_usage(organization_id: str, distinct_id: str, properties: Dict[str, Any]) -> None:
     """
     Triggered daily by Celery scheduler.
     """
     posthoganalytics.capture(
-        distinct_id, "organization usage report", properties,
+        distinct_id,
+        "organization usage report",
+        properties,
+        groups={"organization": organization_id, "instance": SITE_URL},
     )
 
 
-# :TODO:
-def report_org_usage_failure(distinct_id: str, err: str) -> None:
-    posthoganalytics.capture(distinct_id, "organization usage report failure", properties={"error": err,})
+def report_org_usage_failure(organization_id: str, distinct_id: str, err: str) -> None:
+    posthoganalytics.capture(
+        distinct_id,
+        "organization usage report failure",
+        properties={"error": err,},
+        groups={"organization": organization_id, "instance": SITE_URL},
+    )
 
 
 def groups(organization: Optional[Organization] = None, team: Optional[Team] = None):

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -193,6 +193,12 @@ def report_user_action(user: User, event: str, properties: Dict = {}):
     )
 
 
+def report_organization_deleted(user: User, organization: Organization):
+    posthoganalytics.capture(
+        user.distinct_id, "organization deleted", organization.get_analytics_metadata(), groups=groups(organization)
+    )
+
+
 def groups(organization: Optional[Organization] = None, team: Optional[Team] = None):
     result = {"instance": SITE_URL}
     if organization is not None:

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -141,9 +141,8 @@ def report_team_member_invited(
     )
 
 
-# :TODO:
 def report_bulk_invited(
-    distinct_id: str,
+    user: User,
     invitee_count: int,
     name_count: int,
     current_invite_count: int,
@@ -154,7 +153,7 @@ def report_bulk_invited(
     Triggered after a user bulk creates invites for another user.
     """
     posthoganalytics.capture(
-        distinct_id,
+        user.distinct_id,
         "bulk invite executed",
         properties={
             "invitee_count": invitee_count,
@@ -163,6 +162,7 @@ def report_bulk_invited(
             "current_member_count": current_member_count,
             "email_available": email_available,
         },
+        groups=groups(user.current_organization, user.current_team),
     )
 
 

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -187,6 +187,12 @@ def report_org_usage_failure(organization_id: str, distinct_id: str, err: str) -
     )
 
 
+def report_user_action(user: User, event: str, properties: Dict):
+    posthoganalytics.capture(
+        user.distinct_id, event, properties=properties, groups=groups(user.current_organization, user.current_team),
+    )
+
+
 def groups(organization: Optional[Organization] = None, team: Optional[Team] = None):
     result = {"instance": SITE_URL}
     if organization is not None:

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -187,7 +187,7 @@ def report_org_usage_failure(organization_id: str, distinct_id: str, err: str) -
     )
 
 
-def report_user_action(user: User, event: str, properties: Dict):
+def report_user_action(user: User, event: str, properties: Dict = {}):
     posthoganalytics.capture(
         user.distinct_id, event, properties=properties, groups=groups(user.current_organization, user.current_team),
     )

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -196,7 +196,7 @@ def report_user_action(user: User, event: str, properties: Dict = {}):
 def groups(organization: Optional[Organization] = None, team: Optional[Team] = None):
     result = {"instance": SITE_URL}
     if organization is not None:
-        result["organization"] = organization.pk
+        result["organization"] = str(organization.pk)
     if team is not None:
-        result["project"] = team.uuid
+        result["project"] = str(team.uuid)
     return result

--- a/posthog/mixins.py
+++ b/posthog/mixins.py
@@ -1,7 +1,8 @@
 from typing import Dict, Optional
 
-import posthoganalytics
 from rest_framework import response, status
+
+from posthog.event_usage import report_user_action
 
 
 class AnalyticsDestroyModelMixin:
@@ -25,8 +26,5 @@ class AnalyticsDestroyModelMixin:
 
         self.perform_destroy(instance)
 
-        posthoganalytics.capture(
-            request.user.distinct_id, f"{instance._meta.verbose_name} deleted", metadata,
-        )
-
+        report_user_action(request.user, f"{instance._meta.verbose_name} deleted", metadata)
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/posthog/mixins.py
+++ b/posthog/mixins.py
@@ -20,9 +20,7 @@ class AnalyticsDestroyModelMixin:
 
         instance = self.get_object()  # type: ignore
 
-        metadata: Optional[Dict] = instance.get_analytics_metadata() if hasattr(
-            instance, "get_analytics_metadata",
-        ) else None
+        metadata = instance.get_analytics_metadata() if hasattr(instance, "get_analytics_metadata",) else {}
 
         self.perform_destroy(instance)
 

--- a/posthog/mixins.py
+++ b/posthog/mixins.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional
-
 from rest_framework import response, status
 
 from posthog.event_usage import report_user_action

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -99,7 +99,7 @@ def send_all_reports(
 
     for team in Team.objects.exclude(organization__for_internal_metrics=True):
         org = team.organization
-        organization_id = str(org.organization_id)
+        organization_id = str(org.id)
         if organization_id in org_data:
             org_data[organization_id]["teams"].append(team.id)
         else:

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -99,19 +99,19 @@ def send_all_reports(
 
     for team in Team.objects.exclude(organization__for_internal_metrics=True):
         org = team.organization
-        id = str(org.id)
-        if id in org_data:
-            org_data[id]["teams"].append(team.id)
+        organization_id = str(org.organization_id)
+        if organization_id in org_data:
+            org_data[organization_id]["teams"].append(team.id)
         else:
-            org_data[id] = {
+            org_data[organization_id] = {
                 "teams": [team.id],
-                "user_count": get_org_user_count(id),
+                "user_count": get_org_user_count(organization_id),
                 "name": org.name,
                 "created_at": str(org.created_at),
             }
 
-    for id, org in org_data.items():
-        org_owner = get_org_owner_or_first_user(id)
+    for organization_id, org in org_data.items():
+        org_owner = get_org_owner_or_first_user(organization_id)
         if not org_owner:
             continue
         distinct_id = org_owner.distinct_id
@@ -135,9 +135,9 @@ def send_all_reports(
             }
             org_reports.append(report)  # type: ignore
         except Exception as err:
-            report_org_usage_failure(distinct_id, str(err))
+            report_org_usage_failure(organization_id, distinct_id, str(err))
         if not (dry_run or settings.TEST or settings.DEBUG):
-            report_org_usage(distinct_id, report)
+            report_org_usage(organization_id, distinct_id, report)
             time.sleep(0.25)
 
     return org_reports

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -127,7 +127,7 @@ def send_all_reports(
             report: dict = {
                 **metadata,
                 **usage,
-                "organization_id": id,
+                "organization_id": organization_id,
                 "organization_name": org["name"],
                 "organization_created_at": org["created_at"],
                 "organization_user_count": org["user_count"],

--- a/posthog/tasks/org_usage_report.py
+++ b/posthog/tasks/org_usage_report.py
@@ -135,8 +135,10 @@ def send_all_reports(
             }
             org_reports.append(report)  # type: ignore
         except Exception as err:
-            report_org_usage_failure(organization_id, distinct_id, str(err))
-        if not (dry_run or settings.TEST or settings.DEBUG):
+            logger.warning("Organization usage report calculation failed", err)
+            if not dry_run:
+                report_org_usage_failure(organization_id, distinct_id, str(err))
+        if not dry_run:
             report_org_usage(organization_id, distinct_id, report)
             time.sleep(0.25)
 

--- a/posthog/templatetags/posthog_assets.py
+++ b/posthog/templatetags/posthog_assets.py
@@ -65,6 +65,4 @@ def strip_protocol(path: str) -> str:
       {% strip_protocol 'https://app.posthog.com' %}
       =>  "app.posthog.com"
     """
-    print("I'm here!")
-    print(path)
     return re.sub(r"https?:\/\/", "", path)


### PR DESCRIPTION
## Changes

This updates all remaining backend tracking to leverage groups.

Also tracks more organization properties - ones sent from organization usage report. :)

## How did you test this code?

Typechecking + testing a few callsites.
