### PR TITLE
Groups: Handle groups in /my_flags endpoint and toolbar

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Union, cast
+import json
+from typing import Any, Dict, Optional, cast
 
 import posthoganalytics
 from django.db.models import Prefetch, QuerySet
@@ -128,11 +129,11 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
             queryset = queryset.filter(deleted=False)
         return queryset.order_by("-created_at")
 
-    # :TODO: Add groups support to this endpoint
     @action(methods=["GET"], detail=False)
     def my_flags(self, request: request.Request, **kwargs):
         if not request.user.is_authenticated:  # for mypy
             raise exceptions.NotAuthenticated()
+
         feature_flags = (
             FeatureFlag.objects.filter(team=self.team, active=True, deleted=False)
             .prefetch_related(
@@ -144,6 +145,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
             )
             .order_by("-created_at")
         )
+        groups = json.loads(request.GET.get("groups", "{}"))
         flags = []
         for feature_flag in feature_flags:
             my_overrides = feature_flag.my_overrides  # type: ignore
@@ -151,7 +153,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, AnalyticsDestroyModelMixin, vie
             if len(my_overrides) > 0:
                 override = my_overrides[0]
 
-            match = feature_flag.matches(request.user.distinct_id)
+            match = feature_flag.matches(request.user.distinct_id, groups)
             value_for_user_without_override = (match.variant or True) if match else False
 
             flags.append(

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1,9 +1,9 @@
+import json
 from unittest.mock import patch
 
-from rest_framework import response, status
+from rest_framework import status
 
-from posthog.api import feature_flag
-from posthog.models import FeatureFlag, User
+from posthog.models import FeatureFlag, GroupTypeMapping, User
 from posthog.models.feature_flag import FeatureFlagOverride
 from posthog.test.base import APIBaseTest
 
@@ -434,6 +434,33 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(first_flag["feature_flag"]["key"], "alpha-feature")
         self.assertEqual(first_flag["value_for_user_without_override"], False)
         self.assertEqual(first_flag["override"], None)
+
+    @patch("posthoganalytics.capture")
+    def test_my_flags_groups(self, mock_capture):
+        self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "groups flag",
+                "key": "groups-flag",
+                "filters": {"aggregation_group_type_index": 0, "groups": [{"rollout_percentage": 100,}]},
+            },
+            format="json",
+        )
+
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        groups_flag = response.json()[0]
+        self.assertEqual(groups_flag["feature_flag"]["key"], "groups-flag")
+        self.assertEqual(groups_flag["value_for_user_without_override"], False)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/my_flags", data={"groups": json.dumps({"organization": "7"})}
+        )
+        groups_flag = response.json()[0]
+        self.assertEqual(groups_flag["feature_flag"]["key"], "groups-flag")
+        self.assertEqual(groups_flag["value_for_user_without_override"], True)
 
     def test_create_override(self):
         # Boolean override value


### PR DESCRIPTION
This fixes https://github.com/PostHog/posthog/issues/7360

The two-way data communication here is a bit iffy but /shrug

## How did you test this code?

Unit tests
Also create a feature flag with groups, checked toolbar state.