### PR TITLE
Fix `lint-staged` globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,9 +203,9 @@
         }
     },
     "lint-staged": {
-        "*.{js,ts,mjs,tsx,json,yaml,yml,css,scss}": "prettier --write",
-        "(posthog/**/*)*.{js,ts,mjs,tsx}": "eslint -c .eslintrc.js --fix",
-        "(plugin-server/**/*)*.{js,ts,mjs,tsx}": "eslint -c plugin-server/.eslintrc.js --fix",
+        "*.{js,jsx,mjs,ts,tsx,json,yaml,yml,css,scss}": "prettier --write",
+        "(frontend/**).{js,jsx,mjs,ts,tsx}": "eslint -c .eslintrc.js --fix",
+        "(plugin-server/**).{js,jsx,mjs,ts,tsx}": "eslint -c plugin-server/.eslintrc.js --fix",
         "*.{py,pyi}": [
             "flake8 --select=E9,F63,F7,F82,W605",
             "black",


### PR DESCRIPTION
## Changes

So I was wondering why the pre-commit hook recently hasn't been automatically catching unused variables, wrong types etc. that the PR check then complains about and which I then have to fix manually. Turns out that since the monorepofication the `lint-staged` glob was set up to lint JS/TS files inside `posthog/`… which is the base backend directory. The frontend is in `frontend/`.