### PR TITLE
Groups: Feature flag validation + analytics property

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -83,7 +83,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
             is_valid = properties_all_match(lambda prop: prop.type in ["person", "cohort"])
             if not is_valid:
                 raise serializers.ValidationError("Filters are not valid (can only use person and cohort properties)")
-        elif aggregation_group_type_index is not None:
+        else:
             is_valid = properties_all_match(
                 lambda prop: prop.type == "group" and prop.group_type_index == aggregation_group_type_index
             )

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -13,6 +13,7 @@ from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthenticat
 from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import FeatureFlag
 from posthog.models.feature_flag import FeatureFlagOverride
+from posthog.models.property import Property
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 
 
@@ -67,6 +68,29 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError("There is already a feature flag with this key.", code="unique")
 
         return value
+
+    def validate_filters(self, filters):
+        aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
+
+        def properties_all_match(predicate):
+            return all(
+                predicate(Property(**property))
+                for condition in filters["groups"]
+                for property in condition.get("properties", [])
+            )
+
+        if aggregation_group_type_index is None:
+            is_valid = properties_all_match(lambda prop: prop.type in ["person", "cohort"])
+            if not is_valid:
+                raise serializers.ValidationError("Filters are not valid (can only use person and cohort properties)")
+        elif aggregation_group_type_index is not None:
+            is_valid = properties_all_match(
+                lambda prop: prop.type == "group" and prop.group_type_index == aggregation_group_type_index
+            )
+            if not is_valid:
+                raise serializers.ValidationError("Filters are not valid (can only use group properties)")
+
+        return filters
 
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> FeatureFlag:
         request = self.context["request"]

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -94,7 +94,8 @@ class TestFeatureFlag(APIBaseTest):
         ).json()
         self.assertFalse(feature_flag["is_simple_flag"])
 
-    def test_is_simple_flag_groups(self):
+    @patch("posthoganalytics.capture")
+    def test_is_simple_flag_groups(self, mock_capture):
         feature_flag = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
             data={
@@ -105,6 +106,22 @@ class TestFeatureFlag(APIBaseTest):
             format="json",
         ).json()
         self.assertFalse(feature_flag["is_simple_flag"])
+        # Assert analytics are sent
+        instance = FeatureFlag.objects.get(id=feature_flag["id"])
+        mock_capture.assert_called_once_with(
+            self.user.distinct_id,
+            "feature flag created",
+            {
+                "groups_count": 1,
+                "has_variants": False,
+                "variants_count": 0,
+                "has_rollout_percentage": True,
+                "has_filters": False,
+                "filter_count": 0,
+                "created_at": instance.created_at,
+                "aggregating_by_groups": True,
+            },
+        )
 
     @patch("posthoganalytics.capture")
     def test_create_feature_flag(self, mock_capture):
@@ -130,6 +147,7 @@ class TestFeatureFlag(APIBaseTest):
                 "has_filters": False,
                 "filter_count": 0,
                 "created_at": instance.created_at,
+                "aggregating_by_groups": False,
             },
         )
 
@@ -158,6 +176,7 @@ class TestFeatureFlag(APIBaseTest):
                 "has_filters": False,
                 "filter_count": 0,
                 "created_at": instance.created_at,
+                "aggregating_by_groups": False,
             },
         )
 
@@ -198,6 +217,7 @@ class TestFeatureFlag(APIBaseTest):
                 "has_rollout_percentage": False,
                 "filter_count": 0,
                 "created_at": instance.created_at,
+                "aggregating_by_groups": False,
             },
         )
 
@@ -299,6 +319,7 @@ class TestFeatureFlag(APIBaseTest):
                 "has_filters": True,
                 "filter_count": 1,
                 "created_at": instance.created_at,
+                "aggregating_by_groups": False,
             },
         )
 
@@ -326,6 +347,7 @@ class TestFeatureFlag(APIBaseTest):
                 "has_filters": False,
                 "filter_count": 0,
                 "created_at": instance.created_at,
+                "aggregating_by_groups": False,
             },
         )
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -62,6 +62,7 @@ class FeatureFlag(models.Model):
             "has_rollout_percentage": any(condition.get("rollout_percentage") for condition in self.conditions),
             "filter_count": filter_count,
             "created_at": self.created_at,
+            "aggregating_by_groups": self.aggregation_group_type_index is not None,
         }
 
     @property


### PR DESCRIPTION
## Changes

This PR adds:
- Group analytics-specific metadata for feature flags
- Validations for feature flags editing if someone sneaks by FE validations

## How did you test this code?

See tests. Also clicked through adding a new flag, didn't run into validation errors.
