### PR TITLE
Make HTTP tests not log spam

### DIFF
--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -690,6 +690,7 @@ EMAIL_REPORTS_ENABLED: bool = get_from_env("EMAIL_REPORTS_ENABLED", False, type_
 
 # Setup logging
 LOGGING_FORMATTER_NAME = os.getenv("LOGGING_FORMATTER_NAME", "default")
+DEFAULT_LOG_LEVEL = os.getenv("DJANGO_LOG_LEVEL", "ERROR" if TEST else "INFO")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -701,15 +702,15 @@ LOGGING = {
         "console": {"class": "logging.StreamHandler", "formatter": LOGGING_FORMATTER_NAME,},
         "null": {"class": "logging.NullHandler",},
     },
-    "root": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "INFO")},
+    "root": {"handlers": ["console"], "level": DEFAULT_LOG_LEVEL},
     "loggers": {
-        "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "INFO")},
+        "django": {"handlers": ["console"], "level": DEFAULT_LOG_LEVEL},
         "django.server": {"handlers": ["null"]},  # blackhole Django server logs (this is only needed in DEV)
         "django.utils.autoreload": {
             "handlers": ["null"],
         },  # blackhole Django autoreload logs (this is only needed in DEV)
-        "axes": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "INFO")},
-        "statsd": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "INFO")},
+        "axes": {"handlers": ["console"], "level": DEFAULT_LOG_LEVEL},
+        "statsd": {"handlers": ["console"], "level": DEFAULT_LOG_LEVEL},
     },
 }
 


### PR DESCRIPTION
Currently running any tests that hit the API results in logspam which makes the test output unreadable (~6 lines of output per test). This silences that.
