### PR TITLE
Fix antd taxonomic filters whitespace regression

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.scss
@@ -5,6 +5,7 @@
     background: white;
 
     .ant-tabs-tab {
+        margin: 0;
         margin-right: 16px;
     }
 


### PR DESCRIPTION
## Changes

Here's how property filtering modals look on master:

![image](https://user-images.githubusercontent.com/148820/143587912-875f3655-4b13-4e80-975a-745132c6bc89.png)

This makes using groups (or other filtering) worse due to the excessive whitespace.

I believe I introduced this in https://github.com/PostHog/posthog/pull/7319 - invisible css changes conflicting with ours. Other pages using <Tabs> looked okay to me.

After:
![image](https://user-images.githubusercontent.com/148820/143588149-82037ea6-e2da-47bc-a44a-0891a7fe456a.png)

(Note this is not ideal either but reverts us back to where we were)

## How did you test this code?

Screenshots
