### PR TITLE
Groups: Make test_account_filters work with groups (sessions, lifecycle support)

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -24,6 +24,7 @@ from ee.clickhouse.models.cohort import (
 )
 from ee.clickhouse.models.util import PersonPropertiesMode, is_json
 from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
+from ee.clickhouse.sql.groups import GET_GROUP_IDS_BY_PROPERTY_SQL
 from ee.clickhouse.sql.person import GET_DISTINCT_IDS_BY_PERSON_ID_FILTER, GET_DISTINCT_IDS_BY_PROPERTY_SQL
 from posthog.models.cohort import Cohort
 from posthog.models.event import Selector
@@ -41,6 +42,7 @@ def parse_prop_clauses(
     has_person_id_joined: bool = True,
     person_properties_mode: PersonPropertiesMode = PersonPropertiesMode.USING_SUBQUERY,
     person_id_joined_alias: str = "person_id",
+    group_properties_joined: bool = True,
 ) -> Tuple[str, Dict]:
     final = []
     params: Dict[str, Any] = {}
@@ -103,13 +105,28 @@ def parse_prop_clauses(
             final.append(f"{filter_query} AND {table_name}team_id = %(team_id)s" if team_id else filter_query)
             params.update(filter_params)
         elif prop.type == "group":
-            # :TRICKY: This assumes group properties have already been joined, as in trends query
-            filter_query, filter_params = prop_filter_json_extract(
-                prop, idx, prepend, prop_var=f"group_properties_{prop.group_type_index}", allow_denormalized_props=False
-            )
-
-            final.append(filter_query)
-            params.update(filter_params)
+            if group_properties_joined:
+                filter_query, filter_params = prop_filter_json_extract(
+                    prop,
+                    idx,
+                    prepend,
+                    prop_var=f"group_properties_{prop.group_type_index}",
+                    allow_denormalized_props=False,
+                )
+                final.append(filter_query)
+                params.update(filter_params)
+            else:
+                # :TRICKY: offer groups support for queries which don't support it yet (e.g. lifecycle)
+                filter_query, filter_params = prop_filter_json_extract(
+                    prop, idx, prepend, prop_var=f"group_properties", allow_denormalized_props=False
+                )
+                group_type_index_var = f"{prepend}_group_type_index_{idx}"
+                groups_subquery = GET_GROUP_IDS_BY_PROPERTY_SQL.format(
+                    filters=filter_query, group_type_index_var=group_type_index_var
+                )
+                final.append(f"AND {table_name}$group_{prop.group_type_index} IN ({groups_subquery})")
+                params.update(filter_params)
+                params[group_type_index_var] = prop.group_type_index
         elif prop.type in ("static-cohort", "precalculated-cohort"):
             cohort_id = cast(int, prop.value)
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -116,7 +116,7 @@ def parse_prop_clauses(
                 final.append(filter_query)
                 params.update(filter_params)
             else:
-                # :TRICKY: offer groups support for queries which don't support it yet (e.g. lifecycle)
+                # :TRICKY: offer groups support for queries which don't support automatically joining with groups table yet (e.g. lifecycle)
                 filter_query, filter_params = prop_filter_json_extract(
                     prop, idx, prepend, prop_var=f"group_properties", allow_denormalized_props=False
                 )

--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -26,7 +26,9 @@ class ClickhouseSessionsAvg:
 
         parsed_date_from, parsed_date_to, date_params = parse_timestamps(filter, team.pk)
 
-        filters, params = parse_prop_clauses(filter.properties, team.pk, has_person_id_joined=False)
+        filters, params = parse_prop_clauses(
+            filter.properties, team.pk, has_person_id_joined=False, group_properties_joined=False
+        )
 
         trunc_func = get_trunc_func_ch(filter.interval)
         interval_func = get_interval_func_ch(filter.interval)

--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -12,7 +12,9 @@ class ClickhouseSessionsDist:
 
         parsed_date_from, parsed_date_to, date_params = parse_timestamps(filter, team.pk)
 
-        filters, params = parse_prop_clauses(filter.properties, team.pk, has_person_id_joined=False)
+        filters, params = parse_prop_clauses(
+            filter.properties, team.pk, has_person_id_joined=False, group_properties_joined=False
+        )
 
         entity_conditions, entity_params = entity_query_conditions(filter, team)
         if not entity_conditions:

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -1,0 +1,226 @@
+# name: TestClickhouseLifecycle.test_test_account_filters_with_groups
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(counts) as data,
+         status
+  FROM
+    (SELECT if(status = 'dormant', toInt64(SUM(counts)) * toInt16(-1), toInt64(SUM(counts))) as counts,
+            day_start,
+            status
+     FROM
+       (SELECT ticks.day_start as day_start,
+               toUInt16(0) AS counts,
+               status
+        FROM
+          (SELECT toStartOfDay(toDateTime('2020-01-19 23:59:59') - number * 86400) as day_start
+           FROM numbers(8)
+           UNION ALL SELECT toStartOfDay(toDateTime('2020-01-12 00:00:00')) as day_start) as ticks
+        CROSS JOIN
+          (SELECT status
+           FROM
+             (SELECT ['new', 'returning', 'resurrecting', 'dormant'] as status) ARRAY
+           JOIN status) as sec
+        ORDER BY status,
+                 day_start
+        UNION ALL SELECT subsequent_day,
+                         count(DISTINCT person_id) counts,
+                         status
+        FROM
+          (SELECT *,
+                  if(base_day = toDateTime('0000-00-00 00:00:00'), 'dormant', if(subsequent_day = base_day + INTERVAL 1 DAY, 'returning', if(subsequent_day > earliest + INTERVAL 1 DAY, 'resurrecting', 'new'))) as status
+           FROM
+             (SELECT person_id,
+                     base_day,
+                     min(subsequent_day) as subsequent_day
+              FROM
+                (SELECT person_id,
+                        day as base_day,
+                               events.subsequent_day as subsequent_day
+                 FROM
+                   (SELECT DISTINCT person_id,
+                                    toStartOfDay(events.timestamp) day
+                    FROM events
+                    JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, _timestamp) as person_id
+                       FROM
+                         (SELECT distinct_id,
+                                 person_id,
+                                 max(_timestamp) as _timestamp
+                          FROM person_distinct_id
+                          WHERE team_id = 2
+                          GROUP BY person_id,
+                                   distinct_id,
+                                   team_id
+                          HAVING max(is_deleted) = 0)
+                       GROUP BY distinct_id) pdi on events.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event = '$pageview'
+                      AND $group_0 IN
+                        (SELECT DISTINCT group_key
+                         FROM groups
+                         WHERE team_id = 2
+                           AND group_type_index = 0
+                           AND has(['value'], trim(BOTH '"'
+                                                   FROM JSONExtractRaw(group_properties, 'key'))) )
+                    GROUP BY person_id,
+                             day
+                    HAVING day <= toDateTime('2020-01-19 23:59:59')
+                    AND day >= toDateTime('2020-01-11 00:00:00')) base
+                 JOIN
+                   (SELECT DISTINCT person_id,
+                                    toStartOfDay(events.timestamp) subsequent_day
+                    FROM events
+                    JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, _timestamp) as person_id
+                       FROM
+                         (SELECT distinct_id,
+                                 person_id,
+                                 max(_timestamp) as _timestamp
+                          FROM person_distinct_id
+                          WHERE team_id = 2
+                          GROUP BY person_id,
+                                   distinct_id,
+                                   team_id
+                          HAVING max(is_deleted) = 0)
+                       GROUP BY distinct_id) pdi on events.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event = '$pageview'
+                      AND $group_0 IN
+                        (SELECT DISTINCT group_key
+                         FROM groups
+                         WHERE team_id = 2
+                           AND group_type_index = 0
+                           AND has(['value'], trim(BOTH '"'
+                                                   FROM JSONExtractRaw(group_properties, 'key'))) )
+                    GROUP BY person_id,
+                             subsequent_day
+                    HAVING subsequent_day <= toDateTime('2020-01-19 23:59:59')
+                    AND subsequent_day >= toDateTime('2020-01-11 00:00:00')) events ON base.person_id = events.person_id
+                 WHERE subsequent_day > base_day )
+              GROUP BY person_id,
+                       base_day
+              UNION ALL SELECT person_id,
+                               min(day) as base_day,
+                               min(day) as subsequent_day
+              FROM
+                (SELECT DISTINCT person_id,
+                                 toStartOfDay(events.timestamp) day
+                 FROM events
+                 JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, _timestamp) as person_id
+                    FROM
+                      (SELECT distinct_id,
+                              person_id,
+                              max(_timestamp) as _timestamp
+                       FROM person_distinct_id
+                       WHERE team_id = 2
+                       GROUP BY person_id,
+                                distinct_id,
+                                team_id
+                       HAVING max(is_deleted) = 0)
+                    GROUP BY distinct_id) pdi on events.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND event = '$pageview'
+                   AND $group_0 IN
+                     (SELECT DISTINCT group_key
+                      FROM groups
+                      WHERE team_id = 2
+                        AND group_type_index = 0
+                        AND has(['value'], trim(BOTH '"'
+                                                FROM JSONExtractRaw(group_properties, 'key'))) )
+                 GROUP BY person_id,
+                          day
+                 HAVING day <= toDateTime('2020-01-19 23:59:59')
+                 AND day >= toDateTime('2020-01-11 00:00:00')) base
+              GROUP BY person_id
+              UNION ALL SELECT person_id,
+                               base_day,
+                               subsequent_day
+              FROM
+                (SELECT person_id,
+                        total as base_day,
+                        day_start as subsequent_day
+                 FROM
+                   (SELECT DISTINCT person_id,
+                                    groupArray(toStartOfDay(events.timestamp)) day
+                    FROM events
+                    JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, _timestamp) as person_id
+                       FROM
+                         (SELECT distinct_id,
+                                 person_id,
+                                 max(_timestamp) as _timestamp
+                          FROM person_distinct_id
+                          WHERE team_id = 2
+                          GROUP BY person_id,
+                                   distinct_id,
+                                   team_id
+                          HAVING max(is_deleted) = 0)
+                       GROUP BY distinct_id) pdi on events.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event = '$pageview'
+                      AND $group_0 IN
+                        (SELECT DISTINCT group_key
+                         FROM groups
+                         WHERE team_id = 2
+                           AND group_type_index = 0
+                           AND has(['value'], trim(BOTH '"'
+                                                   FROM JSONExtractRaw(group_properties, 'key'))) )
+                      AND toDateTime(events.timestamp) <= toDateTime('2020-01-19 23:59:59')
+                      AND toStartOfDay(events.timestamp) >= toDateTime('2020-01-12 00:00:00')
+                    GROUP BY person_id) as e
+                 CROSS JOIN
+                   (SELECT toDateTime('0000-00-00 00:00:00') AS total,
+                           toStartOfDay(toDateTime('2020-01-19 23:59:59') - number * 86400) as day_start
+                    from numbers(8)) as b
+                 WHERE has(day, subsequent_day) = 0
+                 ORDER BY person_id,
+                          subsequent_day ASC)
+              WHERE ((empty(toString(neighbor(person_id, -1)))
+                      OR neighbor(person_id, -1) != person_id)
+                     AND subsequent_day != toStartOfDay(toDateTime('2020-01-12 00:00:00') + INTERVAL 1 DAY - INTERVAL 1 HOUR))
+                OR ((neighbor(person_id, -1) = person_id)
+                    AND neighbor(subsequent_day, -1) < subsequent_day - INTERVAL 1 DAY) ) e
+           JOIN
+             (SELECT DISTINCT person_id,
+                              toStartOfDay(min(events.timestamp)) earliest
+              FROM events
+              JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, _timestamp) as person_id
+                 FROM
+                   (SELECT distinct_id,
+                           person_id,
+                           max(_timestamp) as _timestamp
+                    FROM person_distinct_id
+                    WHERE team_id = 2
+                    GROUP BY person_id,
+                             distinct_id,
+                             team_id
+                    HAVING max(is_deleted) = 0)
+                 GROUP BY distinct_id) pdi on events.distinct_id = pdi.distinct_id
+              WHERE team_id = 2
+                AND event = '$pageview'
+                AND $group_0 IN
+                  (SELECT DISTINCT group_key
+                   FROM groups
+                   WHERE team_id = 2
+                     AND group_type_index = 0
+                     AND has(['value'], trim(BOTH '"'
+                                             FROM JSONExtractRaw(group_properties, 'key'))) )
+              GROUP BY person_id) earliest ON e.person_id = earliest.person_id)
+        WHERE subsequent_day <= toDateTime('2020-01-19 23:59:59')
+          AND subsequent_day >= toDateTime('2020-01-12 00:00:00')
+        GROUP BY subsequent_day,
+                 status)
+     GROUP BY day_start,
+              status
+     ORDER BY day_start ASC)
+  GROUP BY status
+  '
+---

--- a/ee/clickhouse/queries/test/__snapshots__/test_sessions.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_sessions.ambr
@@ -5,10 +5,10 @@
          day_start
   FROM
     (SELECT toUInt16(0) AS total,
-            toStartOfDay(toDateTime('2021-11-26 00:00:00') - toIntervalDay(number)) AS day_start
-     FROM numbers(dateDiff('day', toDateTime('2021-11-19 00:00:00'), toDateTime('2021-11-26 00:00:00')))
+            toStartOfDay(toDateTime('2021-08-25 00:00:00') - toIntervalDay(number)) AS day_start
+     FROM numbers(dateDiff('day', toDateTime('2021-08-18 00:00:00'), toDateTime('2021-08-25 00:00:00')))
      UNION ALL SELECT toUInt16(0) AS total,
-                      toStartOfDay(toDateTime('2021-11-19 00:00:00'))
+                      toStartOfDay(toDateTime('2021-08-18 00:00:00'))
      UNION ALL SELECT AVG(session_duration_seconds) as total,
                       toStartOfDay(timestamp) as day_start
      FROM
@@ -37,8 +37,8 @@
                  FROM events
                  WHERE team_id = 2
                    AND ((event = '1st action'))
-                   AND timestamp >= '2021-11-19 00:00:00'
-                   AND timestamp <= '2021-11-26 00:00:00'
+                   AND timestamp >= '2021-08-18 00:00:00'
+                   AND timestamp <= '2021-08-25 00:00:00'
                    AND $group_0 IN
                      (SELECT DISTINCT group_key
                       FROM groups

--- a/ee/clickhouse/queries/test/__snapshots__/test_sessions.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_sessions.ambr
@@ -1,0 +1,63 @@
+# name: TestClickhouseSessions.test_group_filter
+  '
+  
+  SELECT SUM(total),
+         day_start
+  FROM
+    (SELECT toUInt16(0) AS total,
+            toStartOfDay(toDateTime('2021-11-26 00:00:00') - toIntervalDay(number)) AS day_start
+     FROM numbers(dateDiff('day', toDateTime('2021-11-19 00:00:00'), toDateTime('2021-11-26 00:00:00')))
+     UNION ALL SELECT toUInt16(0) AS total,
+                      toStartOfDay(toDateTime('2021-11-19 00:00:00'))
+     UNION ALL SELECT AVG(session_duration_seconds) as total,
+                      toStartOfDay(timestamp) as day_start
+     FROM
+       (SELECT session_duration_seconds,
+               timestamp
+        FROM
+          (SELECT is_new_session,
+                  is_end_session,
+                  if(is_end_session
+                     AND is_new_session, 0, if(is_new_session
+                                               AND (NOT is_end_session), dateDiff('second', toDateTime(timestamp), toDateTime(neighbor(timestamp, 1))), NULL)) AS session_duration_seconds,
+                  timestamp
+           FROM
+             (SELECT timestamp,
+                     neighbor(distinct_id, -1) AS start_possible_neighbor,
+                     neighbor(timestamp, -1) AS start_possible_prev_ts,
+                     if((start_possible_neighbor != distinct_id)
+                        OR (dateDiff('minute', toDateTime(start_possible_prev_ts), toDateTime(timestamp)) > 30), 1, 0) AS is_new_session,
+                     neighbor(distinct_id, 1) AS end_possible_neighbor,
+                     neighbor(timestamp, 1) AS end_possible_prev_ts,
+                     if((end_possible_neighbor != distinct_id)
+                        OR (dateDiff('minute', toDateTime(timestamp), toDateTime(end_possible_prev_ts)) > 30), 1, 0) AS is_end_session
+              FROM
+                (SELECT timestamp,
+                        distinct_id
+                 FROM events
+                 WHERE team_id = 2
+                   AND ((event = '1st action'))
+                   AND timestamp >= '2021-11-19 00:00:00'
+                   AND timestamp <= '2021-11-26 00:00:00'
+                   AND $group_0 IN
+                     (SELECT DISTINCT group_key
+                      FROM groups
+                      WHERE team_id = 2
+                        AND group_type_index = 0
+                        AND has(['5'], trim(BOTH '"'
+                                            FROM JSONExtractRaw(group_properties, 'property'))) )
+                 GROUP BY timestamp,
+                          distinct_id
+                 ORDER BY distinct_id ASC, timestamp ASC))
+           WHERE (is_new_session
+                  AND (NOT is_end_session))
+             OR (is_end_session
+                 AND (NOT is_new_session))
+             OR (is_end_session
+                 AND is_new_session) )
+        WHERE is_new_session )
+     GROUP BY toStartOfDay(timestamp))
+  GROUP BY day_start
+  ORDER BY day_start
+  '
+---

--- a/ee/clickhouse/queries/test/test_lifecycle.py
+++ b/ee/clickhouse/queries/test/test_lifecycle.py
@@ -1,10 +1,16 @@
+from datetime import datetime
 from uuid import uuid4
 
 from ee.clickhouse.models.event import create_event
+from ee.clickhouse.models.group import create_group
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
-from ee.clickhouse.util import ClickhouseTestMixin
+from ee.clickhouse.test.test_journeys import journeys_for
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
+from posthog.constants import FILTER_TEST_ACCOUNTS, TRENDS_LIFECYCLE
 from posthog.models.action import Action
 from posthog.models.action_step import ActionStep
+from posthog.models.filters.filter import Filter
+from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.person import Person
 from posthog.queries.test.test_lifecycle import lifecycle_test_factory
 
@@ -23,4 +29,54 @@ def _create_event(**kwargs):
 
 
 class TestClickhouseLifecycle(ClickhouseTestMixin, lifecycle_test_factory(ClickhouseTrends, _create_event, Person.objects.create, _create_action)):  # type: ignore
-    pass
+    @snapshot_clickhouse_queries
+    def test_test_account_filters_with_groups(self):
+        self.team.test_account_filters = [
+            {"key": "key", "type": "group", "value": "value", "group_type_index": 0},
+        ]
+        self.team.save()
+
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        create_group(self.team.pk, group_type_index=0, group_key="in", properties={"key": "value"})
+        create_group(self.team.pk, group_type_index=0, group_key="out", properties={"key": "othervalue"})
+
+        Person.objects.create(distinct_ids=["person1"], team_id=self.team.pk)
+        Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk)
+        journeys_for(
+            {
+                "person1": [
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 11, 12), "properties": {"$group_0": "out"},},
+                ],
+                "person2": [
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 9, 12), "properties": {"$group_0": "in"},},
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 12, 12), "properties": {"$group_0": "in"},},
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 15, 12), "properties": {"$group_0": "in"},},
+                ],
+            },
+            self.team,
+        )
+
+        result = ClickhouseTrends().run(
+            Filter(
+                data={
+                    "date_from": "2020-01-12T00:00:00Z",
+                    "date_to": "2020-01-19T00:00:00Z",
+                    "events": [{"id": "$pageview", "type": "events", "order": 0}],
+                    "shown_as": TRENDS_LIFECYCLE,
+                    FILTER_TEST_ACCOUNTS: True,
+                },
+                team=self.team,
+            ),
+            self.team,
+        )
+
+        self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
+        for res in result:
+            if res["status"] == "dormant":
+                self.assertEqual(res["data"], [0, -1, 0, 0, -1, 0, 0, 0])
+            elif res["status"] == "returning":
+                self.assertEqual(res["data"], [0, 0, 0, 0, 0, 0, 0, 0])
+            elif res["status"] == "resurrecting":
+                self.assertEqual(res["data"], [1, 0, 0, 1, 0, 0, 0, 0])
+            elif res["status"] == "new":
+                self.assertEqual(res["data"], [0, 0, 0, 0, 0, 0, 0, 0])

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+from freezegun.api import freeze_time
+
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.session_recording_event import create_session_recording_event
 from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
@@ -23,6 +25,7 @@ def _create_session_recording_event(**kwargs):
 
 class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(ClickhouseSessions, _create_event, Person.objects.create)):  # type: ignore
     @snapshot_clickhouse_queries
+    @freeze_time("2021-08-25T22:09:14.252Z")
     def test_group_filter(self):
         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
         # Only checks whether the query crashes or not

--- a/ee/clickhouse/queries/test/test_sessions.py
+++ b/ee/clickhouse/queries/test/test_sessions.py
@@ -4,8 +4,9 @@ from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.session_recording_event import create_session_recording_event
 from ee.clickhouse.queries.sessions.clickhouse_sessions import ClickhouseSessions
 from ee.clickhouse.queries.sessions.list import ClickhouseSessionsList
-from ee.clickhouse.util import ClickhouseTestMixin
-from posthog.models.person import Person
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
+from posthog.models import GroupTypeMapping, Person
+from posthog.models.filters.sessions_filter import SessionsFilter
 from posthog.queries.sessions.test.test_sessions import sessions_test_factory
 from posthog.queries.sessions.test.test_sessions_list import sessions_list_test_factory
 
@@ -21,7 +22,22 @@ def _create_session_recording_event(**kwargs):
 
 
 class TestClickhouseSessions(ClickhouseTestMixin, sessions_test_factory(ClickhouseSessions, _create_event, Person.objects.create)):  # type: ignore
-    pass
+    @snapshot_clickhouse_queries
+    def test_group_filter(self):
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        # Only checks whether the query crashes or not
+        ClickhouseSessions().run(
+            SessionsFilter(
+                data={
+                    "interval": "day",
+                    "session": "avg",
+                    "events": [{"id": "1st action"},],
+                    "properties": [{"key": "property", "value": 5, "type": "group", "group_type_index": 0}],
+                },
+                team=self.team,
+            ),
+            self.team,
+        )
 
 
 class TestClickhouseSessionsList(ClickhouseTestMixin, sessions_list_test_factory(ClickhouseSessionsList, _create_event, _create_session_recording_event)):  # type: ignore

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -49,7 +49,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         event_params: Dict[str, Any] = {}
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, group_properties_joined=False)
 
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
@@ -138,7 +138,7 @@ class ClickhouseLifecycle(LifecycleTrend):
             event_params = {"event": entity.id}
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id)
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, group_properties_joined=False)
 
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(

--- a/ee/clickhouse/sql/groups.py
+++ b/ee/clickhouse/sql/groups.py
@@ -60,3 +60,9 @@ TRUNCATE_GROUPS_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS {GROUPS_TABLE} ON CLUSTER
 INSERT_GROUP_SQL = """
 INSERT INTO groups (group_type_index, group_key, team_id, group_properties, created_at, _timestamp, _offset) SELECT %(group_type_index)s, %(group_key)s, %(team_id)s, %(group_properties)s, %(created_at)s, %(_timestamp)s, 0
 """
+
+GET_GROUP_IDS_BY_PROPERTY_SQL = """
+SELECT DISTINCT group_key
+FROM groups
+WHERE team_id = %(team_id)s AND group_type_index = %({group_type_index_var})s {filters}
+"""

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -1,4 +1,62 @@
-LIFECYCLE_SQL = """
+_LIFECYCLE_EVENTS_QUERY = """
+SELECT *, if(base_day = toDateTime('0000-00-00 00:00:00'), 'dormant', if(subsequent_day = base_day + INTERVAL {interval}, 'returning', if(subsequent_day > earliest + INTERVAL {interval}, 'resurrecting', 'new'))) as status
+FROM (
+    SELECT person_id, base_day, min(subsequent_day) as subsequent_day FROM (
+        SELECT person_id, day as base_day, events.subsequent_day as subsequent_day  FROM (
+            SELECT DISTINCT person_id, {trunc_func}(events.timestamp) day FROM events
+            JOIN
+            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
+            WHERE team_id = %(team_id)s AND {event_query} {filters}
+            GROUP BY person_id, day HAVING day <= toDateTime(%(date_to)s) AND day >= toDateTime(%(prev_date_from)s)
+        ) base
+        JOIN (
+            SELECT DISTINCT person_id, {trunc_func}(events.timestamp) subsequent_day FROM events
+            JOIN
+            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
+            WHERE team_id = %(team_id)s AND {event_query} {filters}
+            GROUP BY person_id, subsequent_day HAVING subsequent_day <= toDateTime(%(date_to)s) AND subsequent_day >= toDateTime(%(prev_date_from)s)
+        ) events ON base.person_id = events.person_id
+        WHERE subsequent_day > base_day
+    )
+    GROUP BY person_id, base_day
+    UNION ALL
+    SELECT person_id, min(day) as base_day, min(day) as subsequent_day  FROM (
+        SELECT DISTINCT person_id, {trunc_func}(events.timestamp) day FROM events
+        JOIN
+        ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
+        WHERE team_id = %(team_id)s AND {event_query} {filters}
+        GROUP BY person_id, day HAVING day <= toDateTime(%(date_to)s) AND day >= toDateTime(%(prev_date_from)s)
+    ) base
+    GROUP BY person_id
+    UNION ALL
+    SELECT person_id, base_day, subsequent_day FROM (
+        SELECT person_id, total as base_day, day_start as subsequent_day FROM (
+            SELECT DISTINCT person_id, groupArray({trunc_func}(events.timestamp)) day FROM events
+            JOIN
+            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
+            WHERE team_id = %(team_id)s AND {event_query} {filters}
+            AND toDateTime(events.timestamp) <= toDateTime(%(date_to)s) AND {trunc_func}(events.timestamp) >= toDateTime(%(date_from)s)
+            GROUP BY person_id
+        ) as e
+        CROSS JOIN (
+            SELECT toDateTime('0000-00-00 00:00:00') AS total, {trunc_func}(toDateTime(%(date_to)s) - number * %(seconds_in_interval)s) as day_start from numbers(%(num_intervals)s)
+        ) as b WHERE has(day, subsequent_day) = 0
+        ORDER BY person_id, subsequent_day ASC
+        ) WHERE
+        ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != {trunc_func}(toDateTime(%(date_from)s) + INTERVAL {interval} - INTERVAL {sub_interval}))
+        OR
+        ( (neighbor(person_id, -1) = person_id) AND neighbor(subsequent_day, -1) < subsequent_day - INTERVAL {interval})
+) e
+JOIN (
+    SELECT DISTINCT person_id, {trunc_func}(min(events.timestamp)) earliest FROM events
+    JOIN
+    ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
+    WHERE team_id = %(team_id)s AND {event_query} {filters}
+    GROUP BY person_id
+) earliest ON e.person_id = earliest.person_id
+"""
+
+LIFECYCLE_SQL = f"""
 SELECT groupArray(day_start) as date, groupArray(counts) as data, status FROM (
     SELECT if(status = 'dormant', toInt64(SUM(counts)) * toInt16(-1), toInt64(SUM(counts))) as counts, day_start, status
     FROM (
@@ -6,16 +64,16 @@ SELECT groupArray(day_start) as date, groupArray(counts) as data, status FROM (
 
         FROM (
             -- Generates all the intervals/ticks in the date range
-            -- NOTE: we build this range by including successive intervals back from the 
+            -- NOTE: we build this range by including successive intervals back from the
             --       upper bound, then including the lower bound in the query also.
 
-            SELECT 
-                {trunc_func}(
+            SELECT
+                {{trunc_func}}(
                     toDateTime(%(date_to)s) - number * %(seconds_in_interval)s
                 ) as day_start
             FROM numbers(%(num_intervals)s)
             UNION ALL
-            SELECT {trunc_func}(toDateTime(%(date_from)s)) as day_start
+            SELECT {{trunc_func}}(toDateTime(%(date_from)s)) as day_start
         ) as ticks
 
         CROSS JOIN (
@@ -28,62 +86,8 @@ SELECT groupArray(day_start) as date, groupArray(counts) as data, status FROM (
 
         UNION ALL
 
-        SELECT subsequent_day, count(DISTINCT person_id) counts, status FROM (
-                SELECT *, if(base_day = toDateTime('0000-00-00 00:00:00'), 'dormant', if(subsequent_day = base_day + INTERVAL {interval}, 'returning', if(subsequent_day > earliest + INTERVAL {interval}, 'resurrecting', 'new'))) as status FROM (
-                    SELECT person_id, base_day, min(subsequent_day) as subsequent_day FROM (
-                        SELECT person_id, day as base_day, events.subsequent_day as subsequent_day  FROM (
-                            SELECT DISTINCT person_id, {trunc_func}(events.timestamp) day FROM events
-                            JOIN
-                            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                            WHERE team_id = %(team_id)s AND {event_query} {filters}
-                            GROUP BY person_id, day HAVING day <= toDateTime(%(date_to)s) AND day >= toDateTime(%(prev_date_from)s)
-                        ) base
-                        JOIN (
-                            SELECT DISTINCT person_id, {trunc_func}(events.timestamp) subsequent_day FROM events
-                            JOIN
-                            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                            WHERE team_id = %(team_id)s AND {event_query} {filters}
-                            GROUP BY person_id, subsequent_day HAVING subsequent_day <= toDateTime(%(date_to)s) AND subsequent_day >= toDateTime(%(prev_date_from)s)
-                        ) events ON base.person_id = events.person_id
-                        WHERE subsequent_day > base_day
-                    )
-                    GROUP BY person_id, base_day
-                    UNION ALL
-                    SELECT person_id, min(day) as base_day, min(day) as subsequent_day  FROM (
-                        SELECT DISTINCT person_id, {trunc_func}(events.timestamp) day FROM events
-                        JOIN
-                        ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                        WHERE team_id = %(team_id)s AND {event_query} {filters}
-                        GROUP BY person_id, day HAVING day <= toDateTime(%(date_to)s) AND day >= toDateTime(%(prev_date_from)s)
-                    ) base
-                    GROUP BY person_id
-                    UNION ALL
-                    SELECT person_id, base_day, subsequent_day FROM (
-                        SELECT person_id, total as base_day, day_start as subsequent_day FROM (
-                            SELECT DISTINCT person_id, groupArray({trunc_func}(events.timestamp)) day FROM events
-                            JOIN
-                            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                            WHERE team_id = %(team_id)s AND {event_query} {filters}
-                            AND toDateTime(events.timestamp) <= toDateTime(%(date_to)s) AND {trunc_func}(events.timestamp) >= toDateTime(%(date_from)s)
-                            GROUP BY person_id
-                        ) as e
-                        CROSS JOIN (
-                            SELECT toDateTime('0000-00-00 00:00:00') AS total, {trunc_func}(toDateTime(%(date_to)s) - number * %(seconds_in_interval)s) as day_start from numbers(%(num_intervals)s)
-                        ) as b WHERE has(day, subsequent_day) = 0
-                        ORDER BY person_id, subsequent_day ASC
-                        ) WHERE
-                        ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != {trunc_func}(toDateTime(%(date_from)s) + INTERVAL {interval} - INTERVAL {sub_interval}))
-                        OR
-                        ( (neighbor(person_id, -1) = person_id) AND neighbor(subsequent_day, -1) < subsequent_day - INTERVAL {interval})
-                    ) e
-                JOIN (
-                    SELECT DISTINCT person_id, {trunc_func}(min(events.timestamp)) earliest FROM events
-                    JOIN
-                    ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                  WHERE team_id = %(team_id)s AND {event_query} {filters}
-                    GROUP BY person_id
-                ) earliest ON e.person_id = earliest.person_id
-        )
+        SELECT subsequent_day, count(DISTINCT person_id) counts, status
+        FROM ({_LIFECYCLE_EVENTS_QUERY})
         WHERE subsequent_day <= toDateTime(%(date_to)s) AND subsequent_day >= toDateTime(%(date_from)s)
         GROUP BY subsequent_day, status
     )
@@ -93,64 +97,10 @@ SELECT groupArray(day_start) as date, groupArray(counts) as data, status FROM (
 GROUP BY status
 """
 
-LIFECYCLE_PEOPLE_SQL = """
-SELECT person_id FROM (
-    SELECT *, if(base_day = toDateTime('0000-00-00 00:00:00'), 'dormant', if(subsequent_day = base_day + INTERVAL {interval}, 'returning', if(subsequent_day > earliest + INTERVAL {interval}, 'resurrecting', 'new'))) as status FROM (
-        SELECT person_id, base_day, min(subsequent_day) as subsequent_day FROM (
-            SELECT person_id, day as base_day, events.subsequent_day as subsequent_day  FROM (
-                SELECT DISTINCT person_id, {trunc_func}(events.timestamp) day FROM events
-                JOIN
-                ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                WHERE team_id = %(team_id)s AND {event_query} {filters}
-                GROUP BY person_id, day HAVING day <= toDateTime(%(date_to)s) AND day >= toDateTime(%(prev_date_from)s)
-            ) base
-            JOIN (
-                SELECT DISTINCT person_id, {trunc_func}(events.timestamp) subsequent_day FROM events
-                JOIN
-                ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                WHERE team_id = %(team_id)s AND {event_query} {filters}
-                GROUP BY person_id, subsequent_day HAVING subsequent_day <= toDateTime(%(date_to)s) AND subsequent_day >= toDateTime(%(prev_date_from)s)
-            ) events ON base.person_id = events.person_id
-            WHERE subsequent_day > base_day
-        )
-        GROUP BY person_id, base_day
-        UNION ALL
-        SELECT person_id, min(day) as base_day, min(day) as subsequent_day  FROM (
-            SELECT DISTINCT person_id, {trunc_func}(events.timestamp) day FROM events
-            JOIN
-            ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-            WHERE team_id = %(team_id)s AND {event_query} {filters}
-            GROUP BY person_id, day HAVING day <= toDateTime(%(date_to)s) AND day >= toDateTime(%(prev_date_from)s)
-        ) base
-        GROUP BY person_id
-        UNION ALL
-        SELECT person_id, base_day, subsequent_day FROM (
-            SELECT person_id, dummy as base_day, day_start as subsequent_day FROM (
-                SELECT DISTINCT person_id, groupArray({trunc_func}(events.timestamp)) day FROM events
-                JOIN
-                ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-                WHERE team_id = %(team_id)s AND {event_query} {filters}
-                AND toDateTime(events.timestamp) <= toDateTime(%(date_to)s) AND {trunc_func}(events.timestamp) >= toDateTime(%(date_from)s)
-                GROUP BY person_id
-            ) as e
-            CROSS JOIN (
-                SELECT toDateTime('0000-00-00 00:00:00') AS dummy, {trunc_func}(toDateTime(%(date_to)s) - number * %(seconds_in_interval)s) as day_start from numbers(%(num_intervals)s)
-            ) as b WHERE has(day, subsequent_day) = 0
-            ORDER BY person_id, subsequent_day ASC
-            ) WHERE
-            ((empty(toString(neighbor(person_id, -1))) OR neighbor(person_id, -1) != person_id) AND subsequent_day != {trunc_func}(toDateTime(%(date_from)s) + INTERVAL {interval} - INTERVAL {sub_interval}))
-            OR
-            ( (neighbor(person_id, -1) = person_id) AND neighbor(subsequent_day, -1) < subsequent_day - INTERVAL {interval})
-        ) e
-    JOIN (
-        SELECT DISTINCT person_id, {trunc_func}(min(events.timestamp)) earliest FROM events
-        JOIN
-        ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on events.distinct_id = pdi.distinct_id
-        WHERE team_id = %(team_id)s AND {event_query} {filters}
-        GROUP BY person_id
-    ) earliest ON e.person_id = earliest.person_id
-) e
+LIFECYCLE_PEOPLE_SQL = f"""
+SELECT person_id
+FROM ({_LIFECYCLE_EVENTS_QUERY}) e
 WHERE status = %(status)s
-AND {trunc_func}(toDateTime(%(target_date)s)) = subsequent_day
+AND {{trunc_func}}(toDateTime(%(target_date)s)) = subsequent_day
 LIMIT %(limit)s OFFSET %(offset)s
 """

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -42,17 +42,6 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
     const formulaAvailable = isTrends && preflight?.is_clickhouse_enabled
     const formulaEnabled = (filters.events?.length || 0) + (filters.actions?.length || 0) > 0
 
-    const taxonomicTypes =
-        isTrends || filters.insight === InsightType.STICKINESS
-            ? [
-                  TaxonomicFilterGroupType.EventProperties,
-                  TaxonomicFilterGroupType.PersonProperties,
-                  ...groupsTaxonomicTypes,
-                  TaxonomicFilterGroupType.Cohorts,
-                  TaxonomicFilterGroupType.Elements,
-              ]
-            : undefined
-
     return (
         <>
             <Row gutter={16}>
@@ -66,7 +55,13 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         showSeriesIndicator
                         singleFilter={filters.insight === InsightType.LIFECYCLE}
                         hideMathSelector={filters.insight === InsightType.LIFECYCLE}
-                        propertiesTaxonomicGroupTypes={taxonomicTypes}
+                        propertiesTaxonomicGroupTypes={[
+                            TaxonomicFilterGroupType.EventProperties,
+                            TaxonomicFilterGroupType.PersonProperties,
+                            ...groupsTaxonomicTypes,
+                            TaxonomicFilterGroupType.Cohorts,
+                            TaxonomicFilterGroupType.Elements,
+                        ]}
                         customRowPrefix={
                             filters.insight === InsightType.LIFECYCLE ? (
                                 <>
@@ -105,7 +100,16 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                     {filters.insight !== InsightType.LIFECYCLE && (
                         <>
                             <GlobalFiltersTitle />
-                            <PropertyFilters taxonomicGroupTypes={taxonomicTypes} pageKey="trends-filters" />
+                            <PropertyFilters
+                                taxonomicGroupTypes={[
+                                    TaxonomicFilterGroupType.EventProperties,
+                                    TaxonomicFilterGroupType.PersonProperties,
+                                    ...groupsTaxonomicTypes,
+                                    TaxonomicFilterGroupType.Cohorts,
+                                    TaxonomicFilterGroupType.Elements,
+                                ]}
+                                pageKey="trends-filters"
+                            />
                             <TestAccountFilter filters={filters} onChange={setFilters} />
                             {formulaAvailable && (
                                 <>

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -4,11 +4,14 @@ import { PropertyFilters } from 'lib/components/PropertyFilters'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { AnyPropertyFilter } from '~/types'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { groupsModel } from '~/models/groupsModel'
 
 export function TestAccountFiltersConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
     const { currentTeam } = useValues(teamLogic)
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const handleChange = (filters: AnyPropertyFilter[]): void => {
         updateCurrentTeam({ test_account_filters: filters })
@@ -23,6 +26,13 @@ export function TestAccountFiltersConfig(): JSX.Element {
                         pageKey="testaccountfilters"
                         propertyFilters={currentTeam?.test_account_filters}
                         onChange={handleChange}
+                        taxonomicGroupTypes={[
+                            TaxonomicFilterGroupType.EventProperties,
+                            TaxonomicFilterGroupType.PersonProperties,
+                            ...groupsTaxonomicTypes,
+                            TaxonomicFilterGroupType.Cohorts,
+                            TaxonomicFilterGroupType.Elements,
+                        ]}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Changes

This PR adds support for groups in test_account_filters. This required allowing group filters in lifecycle (kind of needs a rebuild) and sessions (deprecated), which was added in an inefficient way.

## How did you test this code?

See tests

Also added group properties to test account filter, clicked through sessions and lifecycle.
