### PR TITLE
Pagination improvements

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -56,7 +56,7 @@ export interface LemonTableProps<T extends Record<string, any>> {
     sorting?: Sorting | null
     /** Sorting change handler for controlled sort order. */
     onSort?: (newSorting: Sorting | null) => void
-    /** What to show when there's no data. The default value is generic `'No data'`. */
+    /** What to show when there's no data. */
     emptyState?: React.ReactNode
     /** What to describe the entries as, singular and plural. The default value is `['entry', 'entries']`. */
     nouns?: [string, string]
@@ -83,7 +83,7 @@ export function LemonTable<T extends Record<string, any>>({
     defaultSorting = null,
     sorting,
     onSort,
-    emptyState = 'No data',
+    emptyState,
     nouns = ['entry', 'entries'],
     className,
     'data-attr': dataAttr,
@@ -311,7 +311,9 @@ export function LemonTable<T extends Record<string, any>>({
                                 ))
                             ) : (
                                 <tr>
-                                    <td colSpan={columns.length + Number(!!expandable)}>{emptyState}</td>
+                                    <td colSpan={columns.length + Number(!!expandable)}>
+                                        {emptyState || `No ${nouns[1]}`}
+                                    </td>
                                 </tr>
                             )}
                         </tbody>

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -28,8 +28,8 @@ function determineColumnKey(column: LemonTableColumn<any, any>, obligation?: str
 }
 
 export interface LemonTableProps<T extends Record<string, any>> {
-    /** Element key that will also be used in pagination to improve search param uniqueness. */
-    key?: string
+    /** Table ID that will also be used in pagination to add uniqueness to search params (page + order). */
+    id?: string
     columns: LemonTableColumns<T>
     dataSource: T[]
     /** Which column to use for the row key, as an alternative to the default row index mechanism. */
@@ -67,7 +67,7 @@ export interface LemonTableProps<T extends Record<string, any>> {
 }
 
 export function LemonTable<T extends Record<string, any>>({
-    key,
+    id,
     columns,
     dataSource,
     rowKey,
@@ -89,25 +89,53 @@ export function LemonTable<T extends Record<string, any>>({
     'data-attr': dataAttr,
 }: LemonTableProps<T>): JSX.Element {
     /** Search param that will be used for storing and syncing the current page */
-    const currentPageParam = key ? `${key}_page` : 'page'
+    const currentPageParam = id ? `${id}_page` : 'page'
+    /** Search param that will be used for storing and syncing sorting */
+    const currentSortingParam = id ? `${id}_order` : 'order'
 
     const { location, searchParams, hashParams } = useValues(router)
     const { push } = useActions(router)
 
     // A tuple signaling scrollability, on the left and on the right respectively
     const [isScrollable, setIsScrollable] = useState([false, false])
-    // Sorting state machine
-    const [sortingState, setSortingState] = useState<Sorting | null>(defaultSorting)
-    const currentSorting = sorting !== undefined ? sorting : sortingState
 
-    // Push a new browing history item to keep track of the current page
+    /** Push a new browing history item to keep track of the current page */
     const setLocalCurrentPage = useCallback(
         (newPage: number) => push(location.pathname, { ...searchParams, [currentPageParam]: newPage }, hashParams),
+        [location, searchParams, hashParams, push]
+    )
+    /** Replace the current browsing history item to change sorting */
+    const setLocalSorting = useCallback(
+        (newSorting: Sorting | null) =>
+            push(
+                location.pathname,
+                {
+                    ...searchParams,
+                    [currentSortingParam]: newSorting
+                        ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
+                        : undefined,
+                },
+                hashParams
+            ),
         [location, searchParams, hashParams, push]
     )
 
     const scrollRef = useRef<HTMLDivElement>(null)
 
+    /** Sorting. */
+    const currentSorting =
+        sorting ||
+        (searchParams[currentSortingParam]
+            ? searchParams[currentSortingParam].startsWith('-')
+                ? {
+                      columnKey: searchParams[currentSortingParam].substr(1),
+                      order: -1,
+                  }
+                : {
+                      columnKey: searchParams[currentSortingParam],
+                      order: 1,
+                  }
+            : defaultSorting)
     /** Number of entries in total. */
     const entryCount: number | null = pagination?.controlled ? pagination.entryCount || null : dataSource.length
     /** Number of pages. */
@@ -181,6 +209,7 @@ export function LemonTable<T extends Record<string, any>>({
 
     return (
         <div
+            id={id}
             className={clsx(
                 'LemonTable',
                 size && size !== 'middle' && `LemonTable--${size}`,
@@ -222,7 +251,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                               determineColumnKey(column, 'sorting'),
                                                               disableSortingCancellation
                                                           )
-                                                          setSortingState(nextSorting)
+                                                          setLocalSorting(nextSorting)
                                                           onSort?.(nextSorting)
                                                       }
                                                     : undefined

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -117,7 +117,6 @@ export function Annotations(): JSX.Element {
                 <LemonTable
                     data-attr="annotations-table"
                     rowKey="id"
-                    pagination={{ pageSize: 100 }}
                     rowClassName="cursor-pointer"
                     dataSource={annotations}
                     columns={columns}

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -61,7 +61,7 @@ const cohortsUrlLogic = kea<cohortsUrlLogicType>({
     actionToUrl: ({ values }) => ({
         setOpenCohort: () =>
             combineUrl(
-                '/cohorts' + (values.openCohort ? `/${values.openCohort.id || 'new'}` : ''),
+                values.openCohort ? urls.cohort(values.openCohort.id || 'new') : urls.cohorts(),
                 router.values.searchParams
             ).url,
     }),

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -26,7 +26,7 @@ import { userLogic } from 'scenes/userLogic'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonSpacer } from 'lib/components/LemonRow'
-import { combineUrl } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 
 const NEW_COHORT: CohortType = {
     id: 'new',
@@ -59,7 +59,11 @@ const cohortsUrlLogic = kea<cohortsUrlLogicType>({
         },
     },
     actionToUrl: ({ values }) => ({
-        setOpenCohort: () => '/cohorts' + (values.openCohort ? '/' + (values.openCohort.id || 'new') : ''),
+        setOpenCohort: () =>
+            combineUrl(
+                '/cohorts' + (values.openCohort ? `/${values.openCohort.id || 'new'}` : ''),
+                router.values.searchParams
+            ).url,
     }),
     urlToAction: ({ actions, values }) => ({
         '/cohorts(/:cohortId)': async ({ cohortId }) => {
@@ -95,6 +99,7 @@ export function Cohorts(): JSX.Element {
     const { openCohort } = useValues(cohortsUrlLogic)
     const { setOpenCohort, exportCohortPersons } = useActions(cohortsUrlLogic)
     const { hasAvailableFeature } = useValues(userLogic)
+    const { searchParams } = useValues(router)
     const [searchTerm, setSearchTerm] = useState(false as string | false)
 
     const columns: LemonTableColumns<CohortType> = [
@@ -107,7 +112,7 @@ export function Cohorts(): JSX.Element {
             render: function Render(name, { id, description }) {
                 return (
                     <>
-                        <Link data-attr="dashboard-name" to={urls.cohort(id)}>
+                        <Link data-attr="dashboard-name" to={combineUrl(urls.cohort(id), searchParams).url}>
                             <h4 className="row-name">{name || 'Untitled'}</h4>
                         </Link>
                         {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && description && (
@@ -240,7 +245,7 @@ export function Cohorts(): JSX.Element {
                     columns={columns}
                     loading={cohortsLoading}
                     rowKey="id"
-                    pagination={{ pageSize: 20 }}
+                    pagination={{ pageSize: 30 }}
                     dataSource={searchTerm ? searchCohorts(cohorts, searchTerm) : cohorts}
                 />
                 <Drawer

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -247,6 +247,7 @@ export function Cohorts(): JSX.Element {
                     rowKey="id"
                     pagination={{ pageSize: 30 }}
                     dataSource={searchTerm ? searchCohorts(cohorts, searchTerm) : cohorts}
+                    nouns={['cohort', 'cohorts']}
                 />
                 <Drawer
                     title={openCohort?.id === 'new' ? 'New cohort' : openCohort?.name}

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -112,7 +112,7 @@ export function Cohorts(): JSX.Element {
             render: function Render(name, { id, description }) {
                 return (
                     <>
-                        <Link data-attr="dashboard-name" to={combineUrl(urls.cohort(id), searchParams).url}>
+                        <Link to={combineUrl(urls.cohort(id), searchParams).url}>
                             <h4 className="row-name">{name || 'Untitled'}</h4>
                         </Link>
                         {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && description && (

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -5,7 +5,7 @@ import Skeleton from 'antd/lib/skeleton'
 import { CohortType } from '~/types'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
 
-export function PersonCohorts(): JSX.Element {
+export function PersonCohorts(): JSX.Element | string {
     const { cohorts, cohortsLoading } = useValues(personsLogic)
     const { loadCohorts, navigateToCohort } = useActions(personsLogic)
 
@@ -37,9 +37,9 @@ export function PersonCohorts(): JSX.Element {
         },
     ]
 
-    return (
+    return cohorts?.length ? (
         <LemonTable
-            dataSource={cohorts || []}
+            dataSource={cohorts}
             loading={cohortsLoading}
             columns={columns}
             rowClassName="cursor-pointer"
@@ -49,7 +49,8 @@ export function PersonCohorts(): JSX.Element {
             onRow={(cohort) => ({
                 onClick: () => navigateToCohort(cohort),
             })}
-            emptyState="This person doesn't belong to any cohort"
         />
+    ) : (
+        "This person doesn't belong to any cohort"
     )
 }

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -44,7 +44,7 @@ export function PersonCohorts(): JSX.Element {
             columns={columns}
             rowClassName="cursor-pointer"
             rowKey="id"
-            pagination={{ pageSize: 20, hideOnSinglePage: true }}
+            pagination={{ pageSize: 30, hideOnSinglePage: true }}
             embedded
             onRow={(cohort) => ({
                 onClick: () => navigateToCohort(cohort),

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -5,7 +5,7 @@ import Skeleton from 'antd/lib/skeleton'
 import { CohortType } from '~/types'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
 
-export function PersonCohorts(): JSX.Element | string {
+export function PersonCohorts(): JSX.Element {
     const { cohorts, cohortsLoading } = useValues(personsLogic)
     const { loadCohorts, navigateToCohort } = useActions(personsLogic)
 
@@ -51,6 +51,6 @@ export function PersonCohorts(): JSX.Element | string {
             })}
         />
     ) : (
-        "This person doesn't belong to any cohort"
+        <i>This person doesn't belong to any cohort</i>
     )
 }


### PR DESCRIPTION
## Changes

1. Fixes to table pagination in a few places (it was borked in Cohorts due to the atypical drawer URL logic and confusing with Annotations' "Load more").
2. Now automatically paginated tables (i.e. not paginated via the API) are permalinkable – both the order and page are in the URL, so you can always send your friend where you are in PostHog (within the same project ofc…).

![Zrzut ekranu 2021-11-26 o 17 28 30](https://user-images.githubusercontent.com/4550621/143610993-86a0114e-c7b0-488b-b53c-9bbf3f0f01cd.png)
