### PR TITLE
Groups: Refactor endpoints, single group page

### DIFF
--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from ee.clickhouse.sql.groups import INSERT_GROUP_SQL
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_GROUPS
+from posthog.models import Group
 
 
 def create_group(
@@ -29,6 +30,10 @@ def create_group(
     }
     p = ClickhouseProducer()
     p.produce(topic=KAFKA_GROUPS, sql=INSERT_GROUP_SQL, data=data)
+
+    Group.objects.create(
+        team_id=team_id, group_type_index=group_type_index, group_key=group_key, group_properties=properties, version=0,
+    )
 
 
 def get_aggregation_target_field(

--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -3,7 +3,6 @@ import json
 from typing import Dict, Optional
 
 from django.utils.timezone import now
-from rest_framework import serializers
 
 from ee.clickhouse.sql.groups import INSERT_GROUP_SQL
 from ee.kafka_client.client import ClickhouseProducer
@@ -39,22 +38,3 @@ def get_aggregation_target_field(
         return f"{event_table_alias}.$group_{aggregation_group_type_index}"
     else:
         return f"{distinct_id_table_alias}.person_id"
-
-
-class ClickhouseGroupSerializer(serializers.Serializer):
-    group_type_index = serializers.SerializerMethodField()
-    group_key = serializers.SerializerMethodField()
-    created_at = serializers.SerializerMethodField()
-    group_properties = serializers.SerializerMethodField()
-
-    def get_group_type_index(self, group):
-        return int(group[0])
-
-    def get_group_key(self, group):
-        return group[1]
-
-    def get_created_at(self, group):
-        return group[2]
-
-    def get_group_properties(self, group):
-        return json.loads(group[3])

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 
-from rest_framework import request, response, serializers, viewsets
+from rest_framework import mixins, request, response, serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
 
@@ -19,7 +18,7 @@ class GroupTypeSerializer(serializers.ModelSerializer):
         fields = ["group_type", "group_type_index"]
 
 
-class ClickhouseGroupsTypesView(StructuredViewSetMixin, ListModelMixin, viewsets.GenericViewSet):
+class ClickhouseGroupsTypesView(StructuredViewSetMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = GroupTypeSerializer
     queryset = GroupTypeMapping.objects.all()
     pagination_class = None
@@ -41,12 +40,13 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
 
-class ClickhouseGroupsView(StructuredViewSetMixin, ListModelMixin, RetrieveModelMixin, viewsets.GenericViewSet):
+class ClickhouseGroupsView(StructuredViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = GroupSerializer
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
     pagination_class = GroupCursorPagination
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
+    lookup_field = "group_key"
 
     def get_queryset(self):
         return super().get_queryset().filter(group_type_index=self.request.GET["group_type_index"])

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -3,12 +3,16 @@ from collections import defaultdict
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
+from rest_framework.pagination import CursorPagination
+from rest_framework.permissions import IsAuthenticated
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.group import ClickhouseGroupSerializer
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.utils import PaginationMode, format_paginated_url
+from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 
 
 class GroupTypeSerializer(serializers.ModelSerializer):
@@ -23,45 +27,31 @@ class ClickhouseGroupsTypesView(StructuredViewSetMixin, ListModelMixin, viewsets
     pagination_class = None
 
 
+class GroupCursorPagination(CursorPagination):
+    ordering = "group_key"
+    page_size = 100
+
+
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Group
+        fields = [
+            "group_type_index",
+            "group_key",
+            "group_properties",
+            "created_at",
+        ]
+
+
 class ClickhouseGroupsView(StructuredViewSetMixin, ListModelMixin, viewsets.GenericViewSet):
-    serializer_class = ClickhouseGroupSerializer
-    queryset = None
-    pagination_class = None
+    serializer_class = GroupSerializer
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+    pagination_class = GroupCursorPagination
+    permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
 
-    def list(self, request, *args, **kwargs):
-        limit = int(request.GET.get("limit", 100))
-        offset = int(request.GET.get("offset", 0))
-
-        query_result = sync_execute(
-            """
-                SELECT
-                    %(group_type_index)s,
-                    group_key,
-                    argMax(created_at, _timestamp),
-                    argMax(group_properties, _timestamp)
-                FROM groups
-                WHERE team_id = %(team_id)s
-                  AND group_type_index = %(group_type_index)s
-                GROUP BY group_key
-                ORDER BY group_key
-                LIMIT %(limit)s
-                OFFSET %(offset)s
-            """,
-            {
-                "team_id": self.team_id,
-                "group_type_index": request.GET["group_type_index"],
-                "offset": offset,
-                "limit": limit + 1,
-            },
-        )
-
-        return response.Response(
-            {
-                "next_url": format_paginated_url(request, offset, limit) if len(query_result) > limit else None,
-                "previous_url": format_paginated_url(request, offset, limit, mode=PaginationMode.previous),
-                "results": ClickhouseGroupSerializer(query_result[:limit], many=True).data,
-            }
-        )
+    def get_queryset(self):
+        return super().get_queryset().filter(group_type_index=self.request.GET["group_type_index"])
 
     @action(methods=["GET"], detail=False)
     def property_definitions(self, request: request.Request, **kw):

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -43,7 +43,6 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
 class ClickhouseGroupsView(StructuredViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = GroupSerializer
     queryset = Group.objects.all()
-    serializer_class = GroupSerializer
     pagination_class = GroupCursorPagination
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     lookup_field = "group_key"

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -2,14 +2,12 @@ from collections import defaultdict
 
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework.mixins import ListModelMixin
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.models.group import ClickhouseGroupSerializer
 from posthog.api.routing import StructuredViewSetMixin
-from posthog.api.utils import PaginationMode, format_paginated_url
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
@@ -43,7 +41,7 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
 
-class ClickhouseGroupsView(StructuredViewSetMixin, ListModelMixin, viewsets.GenericViewSet):
+class ClickhouseGroupsView(StructuredViewSetMixin, ListModelMixin, RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = GroupSerializer
     queryset = Group.objects.all()
     serializer_class = GroupSerializer

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel.py
@@ -1,29 +1,14 @@
 import json
 from datetime import datetime
-from typing import List, cast
 
 from ee.api.test.base import LicensedTestMixin
 from ee.clickhouse.models.group import create_group
-from ee.clickhouse.queries.actor_base_query import SerializedGroup, SerializedPerson
-from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
 from ee.clickhouse.test.test_journeys import journeys_for
 from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 from ee.clickhouse.views.test.funnel.util import EventPattern, FunnelRequest, get_funnel_actors_ok, get_funnel_ok
 from posthog.constants import INSIGHT_FUNNELS
-from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.test.base import APIBaseTest
-
-
-def _create_group(**kwargs) -> Group:
-    group = Group.objects.create(**kwargs, version=0)
-    create_group(
-        team_id=group.team.pk,
-        group_type_index=group.group_type_index,
-        group_key=group.group_key,
-        properties=group.group_properties,
-    )
-    return group
 
 
 class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
@@ -34,15 +19,15 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
         GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
 
-        g1 = _create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:5", group_properties={"industry": "finance"}
+        g1 = create_group(
+            team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"}
         )
-        g2 = _create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:6", group_properties={"industry": "technology"}
+        g2 = create_group(
+            team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"}
         )
 
-        g3 = _create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", group_properties={})
-        g4 = _create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", group_properties={})
+        g3 = create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
+        g4 = create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", properties={})
 
         return g1, g2, g3, g4
 

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel.py
@@ -19,21 +19,15 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
         GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
 
-        g1 = create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"}
-        )
-        g2 = create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"}
-        )
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
 
-        g3 = create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
-        g4 = create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", properties={})
-
-        return g1, g2, g3, g4
+        create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
+        create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", properties={})
 
     @snapshot_clickhouse_queries
     def test_funnel_aggregation_with_groups(self):
-        g1, g2, g3, g4 = self._create_groups()
+        self._create_groups()
 
         events_by_person = {
             "user_1": [
@@ -75,11 +69,11 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
 
         actors = get_funnel_actors_ok(self.client, result["user signed up"]["converted_people_url"])
         actor_ids = [str(val["id"]) for val in actors]
-        assert actor_ids == sorted([g1.group_key, g2.group_key])
+        assert actor_ids == ["org:5", "org:6"]
 
     @snapshot_clickhouse_queries
     def test_funnel_group_aggregation_with_groups_entity_filtering(self):
-        g1, g2, g3, g4 = self._create_groups()
+        self._create_groups()
 
         events_by_person = {
             "user_1": [
@@ -123,11 +117,11 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
 
         actors = get_funnel_actors_ok(self.client, result["user signed up"]["converted_people_url"])
         actor_ids = [str(val["id"]) for val in actors]
-        assert actor_ids == sorted([g1.group_key])
+        assert actor_ids == ["org:5"]
 
     @snapshot_clickhouse_queries
     def test_funnel_with_groups_entity_filtering(self):
-        g1, g2, g3, g4 = self._create_groups()
+        self._create_groups()
 
         events_by_person = {
             "user_1": [
@@ -178,7 +172,7 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
 
     @snapshot_clickhouse_queries
     def test_funnel_with_groups_global_filtering(self):
-        g1, g2, g3, g4 = self._create_groups()
+        self._create_groups()
 
         events_by_person = {
             "user_1": [

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_unordered.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_unordered.py
@@ -7,20 +7,8 @@ from ee.clickhouse.test.test_journeys import journeys_for
 from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 from ee.clickhouse.views.test.funnel.util import EventPattern, FunnelRequest, get_funnel_actors_ok, get_funnel_ok
 from posthog.constants import INSIGHT_FUNNELS
-from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.test.base import APIBaseTest
-
-
-def _create_group(**kwargs) -> Group:
-    group = Group.objects.create(**kwargs, version=0)
-    create_group(
-        team_id=group.team.pk,
-        group_type_index=group.group_type_index,
-        group_key=group.group_key,
-        properties=group.group_properties,
-    )
-    return group
 
 
 class ClickhouseTestUnorderedFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
@@ -32,15 +20,11 @@ class ClickhouseTestUnorderedFunnelGroups(ClickhouseTestMixin, LicensedTestMixin
         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
         GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
 
-        _create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:5", group_properties={"industry": "finance"}
-        )
-        _create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:6", group_properties={"industry": "technology"}
-        )
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
 
-        _create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", group_properties={})
-        _create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", group_properties={})
+        create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
+        create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", properties={})
 
         filters = {
             "events": [

--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import uuid4
 
 from freezegun.api import freeze_time
 
@@ -14,7 +13,6 @@ from posthog.api.test.test_trends import (
     get_trends_people_ok,
     get_trends_time_series_ok,
 )
-from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.test.base import APIBaseTest, test_with_materialized_columns
 
@@ -323,17 +321,6 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
         )
 
 
-def _create_group(**kwargs) -> Group:
-    group = Group.objects.create(**kwargs, version=0)
-    create_group(
-        team_id=group.team.pk,
-        group_type_index=group.group_type_index,
-        group_key=group.group_key,
-        properties=group.group_properties,
-    )
-    return group
-
-
 class ClickhouseTestTrendsGroups(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
     maxDiff = None
     CLASS_DATA_LEVEL_SETUP = False
@@ -342,13 +329,11 @@ class ClickhouseTestTrendsGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
         GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
 
-        _create_group(team=self.team, group_type_index=0, group_key="org:5", group_properties={"industry": "finance"})
-        _create_group(
-            team=self.team, group_type_index=0, group_key="org:6", group_properties={"industry": "technology"}
-        )
-        _create_group(team=self.team, group_type_index=0, group_key="org:7", group_properties={"industry": "finance"})
-        _create_group(
-            team=self.team, group_type_index=1, group_key="company:10", group_properties={"industry": "finance"}
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:7", properties={"industry": "finance"})
+        create_group(
+            team_id=self.team.pk, group_type_index=1, group_key="company:10", properties={"industry": "finance"}
         )
 
     @snapshot_clickhouse_queries

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -19,6 +19,7 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.Person]: () => import('./persons/Person'),
     [Scene.Persons]: () => import('./persons/Persons'),
     [Scene.Groups]: () => import('./groups/Groups'),
+    [Scene.Group]: () => import('./groups/Group'),
     [Scene.Action]: () => import('./actions/Action'), // TODO
     [Scene.FeatureFlags]: () => import('./feature-flags/FeatureFlags'),
     [Scene.FeatureFlag]: () => import('./feature-flags/FeatureFlag'),

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -13,7 +13,15 @@ import { PersonHeader } from 'scenes/persons/PersonHeader'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { ResizableColumnType, ResizableTable, TableConfig } from 'lib/components/ResizableTable'
-import { ActionType, ChartDisplayType, EventsTableRowItem, EventType, FilterType, InsightType } from '~/types'
+import {
+    ActionType,
+    AnyPropertyFilter,
+    ChartDisplayType,
+    EventsTableRowItem,
+    EventType,
+    FilterType,
+    InsightType,
+} from '~/types'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { EventName } from 'scenes/actions/EventName'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
@@ -30,6 +38,7 @@ export interface FixedFilters {
     action_id?: ActionType['id']
     person_id?: string | number
     distinct_ids?: string[]
+    properties?: AnyPropertyFilter[]
 }
 
 interface EventsTable {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -198,8 +198,8 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             () => [selectors.currentTeamId, selectors.eventFilter, selectors.orderBy, selectors.properties],
             (teamId, eventFilter, orderBy, properties) =>
                 `/api/projects/${teamId}/events.csv?${toParams({
-                    properties,
                     ...(props.fixedFilters || {}),
+                    properties: [...properties, ...(props.fixedFilters?.properties || [])],
                     ...(eventFilter ? { event: eventFilter } : {}),
                     orderBy: [orderBy],
                 })}`,
@@ -292,8 +292,8 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 clearTimeout(values.pollTimeout)
 
                 const urlParams = toParams({
-                    properties: values.properties,
                     ...(props.fixedFilters || {}),
+                    properties: [...values.properties, ...(props.fixedFilters?.properties || [])],
                     ...(nextParams || {}),
                     ...(values.eventFilter ? { event: values.eventFilter } : {}),
                     orderBy: [values.orderBy],
@@ -330,8 +330,8 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             }
 
             const params: Record<string, unknown> = {
-                properties: values.properties,
                 ...(props.fixedFilters || {}),
+                properties: [...values.properties, ...(props.fixedFilters?.properties || [])],
                 ...(values.eventFilter ? { event: values.eventFilter } : {}),
                 orderBy: [values.orderBy],
             }

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -1,12 +1,86 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Row, Tabs, Col, Card, Skeleton } from 'antd'
 import { useValues } from 'kea'
+import { PropertiesTable } from 'lib/components/PropertiesTable'
+import { TZLabel } from 'lib/components/TimezoneAware'
 import { groupLogic } from 'scenes/groups/groupLogic'
+import { EventsTable } from 'scenes/events/EventsTable'
+import { urls } from 'scenes/urls'
+
+const { TabPane } = Tabs
 
 export function Group(): JSX.Element {
-    const { groupData, groupDataLoading } = useValues(groupLogic)
+    const { groupData, groupDataLoading, groupTypeName, groupKey, groupTypeIndex } = useValues(groupLogic)
+
+    const [activeCardTab, setActiveCardTab] = useState('properties')
+
     return (
         <>
-            Hello there<pre>{JSON.stringify({ groupData, groupDataLoading })}</pre>
+            <div style={{ paddingTop: 32 }}>
+                <Row gutter={16}>
+                    <Col span={16}>
+                        {groupData && (
+                            <EventsTable
+                                pageKey={`${groupTypeIndex}::${groupKey}`}
+                                fixedFilters={{
+                                    properties: [{ key: `$group_${groupTypeIndex}`, value: groupKey }],
+                                }}
+                                sceneUrl={urls.group(groupTypeIndex.toString(), groupKey)}
+                            />
+                        )}
+                    </Col>
+                    <Col span={8}>
+                        <Card className="card-elevated person-detail">
+                            {groupData && (
+                                <>
+                                    <div className="person-header">
+                                        <span className="ph-no-capture text-ellipsis">{groupData.group_key}</span>
+                                    </div>
+                                    <div className="item-group">
+                                        <label>Group type</label>
+                                        <div>{groupTypeName}</div>
+                                    </div>
+                                    <div className="item-group">
+                                        <label>First seen</label>
+                                        <div>{<TZLabel time={groupData.created_at} />}</div>
+                                    </div>
+                                </>
+                            )}
+                            {groupDataLoading && <Skeleton paragraph={{ rows: 4 }} active />}
+                        </Card>
+                        <Card className="card-elevated person-properties" style={{ marginTop: 16 }}>
+                            <Tabs
+                                defaultActiveKey={activeCardTab}
+                                onChange={(tab) => {
+                                    setActiveCardTab(tab)
+                                }}
+                            >
+                                <TabPane
+                                    tab={<span data-attr="group-properties-tab">Properties</span>}
+                                    key="properties"
+                                    disabled={groupDataLoading}
+                                />
+                                <TabPane
+                                    tab={<span data-attr="group-related-tab">Related groups</span>}
+                                    key="related"
+                                    disabled={groupDataLoading}
+                                />
+                            </Tabs>
+                            {groupData &&
+                                (activeCardTab == 'properties' ? (
+                                    <div style={{ maxWidth: '100%', overflow: 'hidden' }}>
+                                        <h3 className="l3">Properties list</h3>
+                                        <PropertiesTable
+                                            properties={groupData.group_properties}
+                                            className="persons-page-props-table"
+                                        />
+                                    </div>
+                                ) : null)}
+                            {groupDataLoading && <Skeleton paragraph={{ rows: 6 }} active />}
+                        </Card>
+                    </Col>
+                </Row>
+            </div>
         </>
     )
 }

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { useValues } from 'kea'
+import { groupLogic } from 'scenes/groups/groupLogic'
+
+export function Group(): JSX.Element {
+    const { groupData, groupDataLoading } = useValues(groupLogic)
+    return (
+        <>
+            Hello there<pre>{JSON.stringify({ groupData, groupDataLoading })}</pre>
+        </>
+    )
+}

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -7,6 +7,8 @@ import { PersonPageHeader } from 'scenes/persons/PersonPageHeader'
 import { LemonTableColumns } from 'lib/components/LemonTable/types'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { LemonTable } from 'lib/components/LemonTable/LemonTable'
+import { Link } from 'lib/components/Link'
+import { urls } from 'scenes/urls'
 
 export function Groups(): JSX.Element {
     const { groups, groupsLoading } = useValues(groupsListLogic)
@@ -17,7 +19,9 @@ export function Groups(): JSX.Element {
             title: 'Key',
             key: 'group_key',
             render: function Render(_, group: Group) {
-                return <>{group.group_key}</>
+                return (
+                    <Link to={urls.group(group.group_type_index.toString(), group.group_key)}>{group.group_key}</Link>
+                )
             },
         },
         {

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -21,7 +21,7 @@ export function Groups(): JSX.Element {
             },
         },
         {
-            title: 'Last updated',
+            title: 'First seen',
             key: 'created_at',
             render: function Render(_, group: Group) {
                 return <TZLabel time={group.created_at} />

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -50,15 +50,15 @@ export function Groups(): JSX.Element {
                 }}
                 pagination={{
                     controlled: true,
-                    onBackward: groups.previous_url
+                    onBackward: groups.previous
                         ? () => {
-                              loadGroups(groups.previous_url)
+                              loadGroups(groups.previous)
                               window.scrollTo(0, 0)
                           }
                         : undefined,
-                    onForward: groups.next_url
+                    onForward: groups.next
                         ? () => {
-                              loadGroups(groups.next_url)
+                              loadGroups(groups.next)
                               window.scrollTo(0, 0)
                           }
                         : undefined,

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -36,6 +36,12 @@ export const groupLogic = kea<groupLogicType>({
             },
         ],
     },
+    selectors: {
+        groupTypeName: [
+            (s) => [s.groupTypes, s.groupTypeIndex],
+            (groupTypes, index): string => groupTypes[index]?.group_type || '',
+        ],
+    },
     urlToAction: ({ actions }) => ({
         '/groups/:groupTypeIndex/:groupKey': ({ groupTypeIndex, groupKey }) => {
             if (groupTypeIndex && groupKey) {

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -1,0 +1,47 @@
+import { kea } from 'kea'
+import api from 'lib/api'
+import { teamLogic } from 'scenes/teamLogic'
+import { groupsModel } from '~/models/groupsModel'
+import { Group } from '~/types'
+import { groupLogicType } from './groupLogicType'
+
+export const groupLogic = kea<groupLogicType>({
+    path: ['groups', 'groupLogic'],
+    connect: { values: [teamLogic, ['currentTeamId'], groupsModel, ['groupsEnabled', 'groupTypes']] },
+    actions: () => ({
+        setGroup: (groupTypeIndex: number, groupKey: string) => ({ groupTypeIndex, groupKey }),
+    }),
+    loaders: ({ values }) => ({
+        groupData: [
+            null as Group | null,
+            {
+                loadGroup: async () => {
+                    const url = `api/projects/${values.currentTeamId}/groups/${values.groupKey}?group_type_index=${values.groupTypeIndex}`
+                    return await api.get(url)
+                },
+            },
+        ],
+    }),
+    reducers: {
+        groupTypeIndex: [
+            0,
+            {
+                setGroup: (_, { groupTypeIndex }) => groupTypeIndex,
+            },
+        ],
+        groupKey: [
+            '',
+            {
+                setGroup: (_, { groupKey }) => groupKey,
+            },
+        ],
+    },
+    urlToAction: ({ actions }) => ({
+        '/groups/:groupTypeIndex/:groupKey': ({ groupTypeIndex, groupKey }) => {
+            if (groupTypeIndex && groupKey) {
+                actions.setGroup(+groupTypeIndex, groupKey)
+                actions.loadGroup()
+            }
+        },
+    }),
+})

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -8,8 +8,8 @@ import { Group } from '~/types'
 import { groupsListLogicType } from './groupsListLogicType'
 
 interface GroupsPaginatedResponse {
-    next_url: string | null
-    previous_url: string | null
+    next: string | null
+    previous: string | null
     results: Group[]
 }
 
@@ -22,7 +22,7 @@ export const groupsListLogic = kea<groupsListLogicType<GroupsPaginatedResponse>>
     }),
     loaders: ({ values }) => ({
         groups: [
-            { next_url: null, previous_url: null, results: [] } as GroupsPaginatedResponse,
+            { next: null, previous: null, results: [] } as GroupsPaginatedResponse,
             {
                 loadGroups: async ({ url }) => {
                     if (values.groupsEnabled) {

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -5,8 +5,8 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { groupsModel } from '~/models/groupsModel'
 import { Group } from '~/types'
-
 import { groupsListLogicType } from './groupsListLogicType'
+
 interface GroupsPaginatedResponse {
     next_url: string | null
     previous_url: string | null

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -23,6 +23,7 @@ const sceneNavAlias: Partial<Record<Scene, Scene>> = {
     [Scene.EventPropertyStats]: Scene.Events,
     [Scene.Person]: Scene.Persons,
     [Scene.Groups]: Scene.Persons,
+    [Scene.Group]: Scene.Persons,
     [Scene.Dashboard]: Scene.Dashboards,
     [Scene.FeatureFlag]: Scene.FeatureFlags,
 }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -19,6 +19,7 @@ export enum Scene {
     Person = 'Person',
     Persons = 'Persons',
     Groups = 'Groups',
+    Group = 'Group',
     Action = 'Action',
     Actions = 'ActionsTable',
     FeatureFlags = 'FeatureFlags',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -85,6 +85,10 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
         projectBased: true,
         name: 'Persons & groups',
     },
+    [Scene.Group]: {
+        projectBased: true,
+        name: 'Persons & groups',
+    },
     [Scene.FeatureFlags]: {
         projectBased: true,
         name: 'Feature flags',
@@ -202,6 +206,7 @@ export const routes: Record<string, Scene> = {
     [urls.person('*', false)]: Scene.Person,
     [urls.persons()]: Scene.Persons,
     [urls.groups(':groupTypeIndex')]: Scene.Groups,
+    [urls.group(':groupTypeIndex', ':groupKey', false)]: Scene.Group,
     [urls.cohort(':id')]: Scene.Cohorts,
     [urls.cohorts()]: Scene.Cohorts,
     [urls.featureFlags()]: Scene.FeatureFlags,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -25,6 +25,8 @@ export const urls = {
     person: (id: string, encode: boolean = true) => (encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`),
     persons: () => '/persons',
     groups: (groupTypeIndex: string) => `/groups/${groupTypeIndex}`,
+    group: (groupTypeIndex: string, groupKey: string, encode: boolean = true) =>
+        `/groups/${groupTypeIndex}/${encode ? encodeURIComponent(groupKey) : groupKey}`,
     cohort: (id: string | number) => `/cohorts/${id}`,
     cohorts: () => '/cohorts',
     featureFlags: () => '/feature_flags',


### PR DESCRIPTION
## Changes

This PR:
- Links to group pages from groups list
- Shows properties, events on a single group page
- Updates some endpoint & pagination logic now that groups exist in both clickhouse and postgres
- Updates some testing-related utils to standardize


In subsequent PRs:
- Related groups
- Recordings support
- Proper breadcrumbs

List view has now links:
![image](https://user-images.githubusercontent.com/148820/143867518-f12c33cc-d20e-43fc-a61d-2f81bb87e160.png)

Single group page now exists:
![image](https://user-images.githubusercontent.com/148820/143867478-81a0b2f3-a777-40bf-9cb4-3e23b2d99371.png)

Pagination:
![image](https://user-images.githubusercontent.com/148820/143868613-c950bf45-09ac-4bfd-91f5-45190d4672c0.png)


## How did you test this code?

See screenshots

