### PR TITLE
Show 'match by' for projects with single group type

### DIFF
--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -40,7 +40,7 @@ export const groupsModel = kea<groupsModelType>({
         ],
         showGroupsOptions: [
             (s) => [s.groupsEnabled, s.groupTypes],
-            (enabled, groupTypes) => enabled && groupTypes.length > 1,
+            (enabled, groupTypes) => enabled && groupTypes.length > 0,
         ],
         groupsTaxonomicTypes: [
             (s) => [s.groupTypes],


### PR DESCRIPTION
## Changes

Lowered the number of group types needed to show the match by dropdown.

## How did you test this code?

@weyert partially tested the affect of this change by having a single group type on a test project and then adding a second one - after adding the second one it showed up
