### PR TITLE
Use the primary blue in the posthog checkbox

### DIFF
--- a/frontend/src/lib/components/PHCheckbox.tsx
+++ b/frontend/src/lib/components/PHCheckbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { colors } from '~/vars'
 
 interface Props {
     checked: boolean
@@ -11,7 +12,7 @@ interface Props {
 export const PHCheckbox = ({
     checked,
     indeterminate,
-    color = 'blue',
+    color = colors.$primary,
     disabled = false,
     ...props
 }: Props): JSX.Element => (

--- a/frontend/src/lib/components/PHCheckbox.tsx
+++ b/frontend/src/lib/components/PHCheckbox.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { colors } from '~/vars'
 
 interface Props {
     checked: boolean
@@ -12,7 +11,7 @@ interface Props {
 export const PHCheckbox = ({
     checked,
     indeterminate,
-    color = colors.$primary,
+    color = 'var(--primary)',
     disabled = false,
     ...props
 }: Props): JSX.Element => (

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -1,5 +1,9 @@
-/* This file contains the main styling configuration for PostHog. We also use AntD which uses LESS,
-when changing any base config here, please remember to update antd.less too  */
+/*
+This file contains the main styling configuration for PostHog. We also use AntD which uses LESS,
+when changing any base config here, please remember to update antd.less too
+
+Some values from this file are duplicated in ./vars.ts. If you edit this file, check there too
+*/
 
 // Main colors
 $primary: #5375ff;

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -1,8 +1,6 @@
 /*
 This file contains the main styling configuration for PostHog. We also use AntD which uses LESS,
 when changing any base config here, please remember to update antd.less too
-
-Some values from this file are duplicated in ./vars.ts. If you edit this file, check there too
 */
 
 // Main colors

--- a/frontend/src/vars.ts
+++ b/frontend/src/vars.ts
@@ -1,2 +1,3 @@
 // z-indexes from vars.scss
 export const styles = { zDrawer: 950, zGraphAnnotationPrompt: 99 }
+export const colors = { $primary: '#5375ff' }

--- a/frontend/src/vars.ts
+++ b/frontend/src/vars.ts
@@ -1,3 +1,7 @@
-// z-indexes from vars.scss
+/*
+values duplicated from ./vars.scss
+
+if change values here, check there too
+*/
 export const styles = { zDrawer: 950, zGraphAnnotationPrompt: 99 }
 export const colors = { $primary: '#5375ff' }

--- a/frontend/src/vars.ts
+++ b/frontend/src/vars.ts
@@ -4,4 +4,3 @@ Values duplicated from ./vars.scss
 If you edit this file, check there too
 */
 export const styles = { zDrawer: 950, zGraphAnnotationPrompt: 99 }
-export const colors = { $primary: '#5375ff' }

--- a/frontend/src/vars.ts
+++ b/frontend/src/vars.ts
@@ -1,7 +1,7 @@
 /*
-values duplicated from ./vars.scss
+Values duplicated from ./vars.scss
 
-if change values here, check there too
+If you edit this file, check there too
 */
 export const styles = { zDrawer: 950, zGraphAnnotationPrompt: 99 }
 export const colors = { $primary: '#5375ff' }


### PR DESCRIPTION
## Changes

See #6560 

Uses the primary blue in the posthog checkbox

### Before

![Screenshot 2021-11-29 at 15 19 36](https://user-images.githubusercontent.com/984817/143894880-6a3add7a-a052-4589-9aea-165f86553089.png)

### After

![Screenshot 2021-11-29 at 15 19 00](https://user-images.githubusercontent.com/984817/143894894-efa03d83-5e0f-4fe5-add6-6adcf7d68ee0.png)

## How did you test this code?

creating a funnel with a breakdown and checking the colour
