### PR TITLE
Fix Correlation Properties Dropdown

### DIFF
--- a/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
+++ b/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
@@ -94,11 +94,10 @@
             overflow-y: auto;
 
             .checkbox {
-                display: block;
                 padding: 8px;
 
                 height: 40px;
-                margin: 4px 0px;
+                margin: 2px 0px;
                 width: 100%;
 
                 background: #ffffff;

--- a/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
+++ b/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
@@ -56,7 +56,7 @@
         left: 0;
         right: 0;
 
-        min-width: 350px;
+        min-width: 320px;
 
         // Make sure we don't get covered up
         z-index: 100; // number is abritrary

--- a/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
+++ b/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.scss
@@ -56,7 +56,7 @@
         left: 0;
         right: 0;
 
-        min-width: 300px;
+        min-width: 350px;
 
         // Make sure we don't get covered up
         z-index: 100; // number is abritrary


### PR DESCRIPTION
## Changes

A recent change seems to have borked the Properties Correlation dropdown.

Also fixes https://github.com/PostHog/posthog/issues/7086 (until we get even bigger property names :$ )

Before:

![image](https://user-images.githubusercontent.com/7115141/143898306-3013c2af-1bfb-47b4-8a89-a5a66b5cb774.png)


After:
![image](https://user-images.githubusercontent.com/7115141/143894224-32d0f53f-5ae0-47c5-9ff3-974e46805230.png)


## How did you test this code?

Run locally, see the box.
