### PR TITLE
await addPublicJobIfNotExists

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -31,15 +31,15 @@ const OLD_TIMESTAMP_CURSOR_KEY = 'old_timestamp_cursor'
 
 const INTERFACE_JOB_NAME = 'Export historical events'
 
-export function addHistoricalEventsExportCapability(
+export async function addHistoricalEventsExportCapability(
     hub: Hub,
     pluginConfig: PluginConfig,
     response: PluginConfigVMInternalResponse<PluginMeta<ExportHistoricalEventsUpgrade>>
-): void {
+): Promise<void> {
     const { methods, tasks, meta } = response
 
     // we can void this as the job appearing on the interface is not time-sensitive
-    void addPublicJobIfNotExists(hub.db, pluginConfig.plugin_id, INTERFACE_JOB_NAME, {})
+    await addPublicJobIfNotExists(hub.db, pluginConfig.plugin_id, INTERFACE_JOB_NAME, {})
 
     const oldSetupPlugin = methods.setupPlugin
 

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -225,7 +225,7 @@ export async function createPluginConfigVM(
 
     if (exportEventsExists) {
         upgradeExportEvents(hub, pluginConfig, vmResponse)
-        addHistoricalEventsExportCapability(hub, pluginConfig, vmResponse)
+        await addHistoricalEventsExportCapability(hub, pluginConfig, vmResponse)
     }
 
     setupMetrics(hub, pluginConfig, metrics, exportEventsExists)


### PR DESCRIPTION
## Changes

It's bothering me that `addPublicJobIfNotExists` is our slowest postgres query according to Grafana:

<img width="675" alt="Screenshot 2021-11-29 at 12 47 50" src="https://user-images.githubusercontent.com/38760734/143899050-1c5c6330-f1a2-4a59-b86e-467dae60ec06.png">

I'm reasonably sure this is because it's voided, which is likely to affect the metrics. Would like to test this out though, and if things don't improve, it's something to dig into.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
