### PR TITLE
Add JSON field to plugin config

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -49,6 +49,18 @@ const SecretFieldIcon = (): JSX.Element => (
     </>
 )
 
+const FieldLabel = ({ fieldConfig }: { fieldConfig: PluginConfigSchema }): JSX.Element => (
+    <>
+        {fieldConfig.secret && <SecretFieldIcon />}
+        {fieldConfig.name || fieldConfig.key}
+        {fieldConfig.type === 'json' && (
+            <>
+                &nbsp;<Tag>JSON</Tag>
+            </>
+        )}
+    </>
+)
+
 export function PluginDrawer(): JSX.Element {
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
@@ -317,12 +329,7 @@ export function PluginDrawer(): JSX.Element {
                                     {fieldConfig.type && isValidField(fieldConfig) ? (
                                         <Form.Item
                                             hidden={!!fieldConfig.key && invisibleFields.includes(fieldConfig.key)}
-                                            label={
-                                                <>
-                                                    {fieldConfig.secret && <SecretFieldIcon />}
-                                                    {fieldConfig.name || fieldConfig.key}
-                                                </>
-                                            }
+                                            label={<FieldLabel fieldConfig={fieldConfig} />}
                                             extra={
                                                 fieldConfig.hint && (
                                                     <small>

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -13,7 +13,7 @@ import { SourcePluginTag } from 'scenes/plugins/plugin/SourcePluginTag'
 import { PluginSource } from './PluginSource'
 import { PluginConfigChoice, PluginConfigSchema } from '@posthog/plugin-scaffold'
 import { PluginField } from 'scenes/plugins/edit/PluginField'
-import { endWithPunctation } from 'lib/utils'
+import { endWithPunctation, validateJsonFormItem } from 'lib/utils'
 import { canGloballyManagePlugins, canInstallPlugins } from '../access'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { capabilitiesInfo } from './CapabilitiesInfo'
@@ -350,6 +350,11 @@ export function PluginDrawer(): JSX.Element {
                                                         (!!fieldConfig.key && requiredFields.includes(fieldConfig.key)),
                                                     message: 'Please enter a value!',
                                                 },
+                                                fieldConfig.type === 'json'
+                                                    ? {
+                                                          validator: validateJsonFormItem,
+                                                      }
+                                                    : {},
                                             ]}
                                         >
                                             <PluginField

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold/src/types'
 import { EditOutlined } from '@ant-design/icons'
 import { SECRET_FIELD_VALUE } from 'scenes/plugins/utils'
+import MonacoEditor from '@monaco-editor/react'
 
 export function PluginField({
     value,
@@ -46,6 +47,8 @@ export function PluginField({
                 </Select.Option>
             ))}
         </Select>
+    ) : fieldConfig.type === 'json' ? (
+        <MonacoEditor value={value} onChange={onChange} language="json" theme="vs-dark" height={200} />
     ) : (
         <strong style={{ color: 'var(--danger)' }}>
             Unknown field type "<code>{fieldConfig.type}</code>".


### PR DESCRIPTION
## Changes

Adds the ability to pass JSON in a plugin config field. This primarily an improvement to the frontend/text editing experience.

Currently out of scope: actually parsing the JSON to an object.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
