### PR TITLE
Improved Dashboard Error Feedback

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -44,6 +44,7 @@ function DashboardView(): JSX.Element {
         items,
         filters: dashboardFilters,
         dashboardMode,
+        receivedErrorsFromAPI,
     } = useValues(dashboardLogic)
     const { dashboardsLoading } = useValues(dashboardsModel)
     const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
@@ -136,7 +137,7 @@ function DashboardView(): JSX.Element {
                     <DashboardItems />
                 </div>
             ) : (
-                <EmptyDashboardComponent />
+                <EmptyDashboardComponent emptyWithErrors={receivedErrorsFromAPI} />
             )}
         </div>
     )

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -16,6 +16,7 @@ import { EmptyDashboardComponent } from './EmptyDashboardComponent'
 import { NotFound } from 'lib/components/NotFound'
 import { DashboardReloadAction, LastRefreshText } from 'scenes/dashboard/DashboardReloadAction'
 import { SceneExport } from 'scenes/sceneTypes'
+import { InsightErrorState } from 'scenes/insights/EmptyStates'
 
 interface Props {
     id?: string
@@ -101,7 +102,11 @@ function DashboardView(): JSX.Element {
     return (
         <div className="dashboard">
             {dashboardMode !== DashboardMode.Public && dashboardMode !== DashboardMode.Internal && <DashboardHeader />}
-            {items && items.length ? (
+            {receivedErrorsFromAPI ? (
+                <InsightErrorState title={'There was an error loading this dashboard'} />
+            ) : !items || items.length === 0 ? (
+                <EmptyDashboardComponent />
+            ) : (
                 <div>
                     <div className="dashboard-items-actions">
                         <div className="left-item">
@@ -136,8 +141,6 @@ function DashboardView(): JSX.Element {
                     </div>
                     <DashboardItems />
                 </div>
-            ) : (
-                <EmptyDashboardComponent emptyWithErrors={receivedErrorsFromAPI} />
             )}
         </div>
     )

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -258,7 +258,7 @@ export function DashboardItem({
 
     // Empty states that can coexist with the graph (e.g. Loading)
     const CoexistingEmptyState = (() => {
-        if (isLoading || insightLoading) {
+        if (isLoading || insightLoading || isReloading) {
             return <Loading />
         }
         return null
@@ -272,8 +272,9 @@ export function DashboardItem({
             } ph-no-capture`}
             {...longPressProps}
             data-attr={'dashboard-item-' + index}
-            style={{ border: isHighlighted ? '1px solid var(--primary)' : undefined, opacity: isReloading ? 0.5 : 1 }}
+            style={{ border: isHighlighted ? '1px solid var(--primary)' : undefined }}
         >
+            {!BlockingEmptyState && CoexistingEmptyState}
             <div className={`dashboard-item-container ${className}`}>
                 <div className="dashboard-item-header" style={{ cursor: isOnEditMode ? 'move' : 'inherit' }}>
                     <div className="dashboard-item-title" data-attr="dashboard-item-title">
@@ -570,7 +571,6 @@ export function DashboardItem({
                 )}
 
                 <div className={`dashboard-item-content ${_type}`} onClickCapture={onClick}>
-                    {!BlockingEmptyState && CoexistingEmptyState}
                     {!!BlockingEmptyState ? (
                         BlockingEmptyState
                     ) : (

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -51,7 +51,7 @@ import { urls } from 'scenes/urls'
 interface DashboardItemProps {
     item: DashboardItemType
     dashboardId?: number
-    receivedErrorFromAPI: boolean
+    receivedErrorFromAPI?: boolean
     updateItemColor?: (insightId: number, itemClassName: string) => void
     setDiveDashboard?: (insightId: number, diveDashboard: number | null) => void
     loadDashboardItems?: () => void

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -249,7 +249,7 @@ export function DashboardItem({
 
         // Insight agnostic empty states
         if (showErrorMessage || receivedErrorFromAPI) {
-            return <InsightErrorState smallContainer={true} />
+            return <InsightErrorState excludeDetail={true} />
         }
         if (showTimeoutMessage) {
             return <InsightTimeoutState isLoading={isLoading} />

--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -51,6 +51,7 @@ import { urls } from 'scenes/urls'
 interface DashboardItemProps {
     item: DashboardItemType
     dashboardId?: number
+    receivedErrorFromAPI: boolean
     updateItemColor?: (insightId: number, itemClassName: string) => void
     setDiveDashboard?: (insightId: number, diveDashboard: number | null) => void
     loadDashboardItems?: () => void
@@ -148,6 +149,7 @@ const dashboardDiveLink = (dive_dashboard: number, dive_source_id: InsightShortI
 export function DashboardItem({
     item,
     dashboardId,
+    receivedErrorFromAPI,
     updateItemColor,
     setDiveDashboard,
     loadDashboardItems,
@@ -246,8 +248,8 @@ export function DashboardItem({
         }
 
         // Insight agnostic empty states
-        if (showErrorMessage) {
-            return <InsightErrorState />
+        if (showErrorMessage || receivedErrorFromAPI) {
+            return <InsightErrorState smallContainer={true} />
         }
         if (showTimeoutMessage) {
             return <InsightTimeoutState isLoading={isLoading} />

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -67,10 +67,6 @@
 
     // sync this with lib/colors.js
 
-    .loading-overlay {
-        background: transparent;
-    }
-
     &.blue {
         --item-background: hsl(212, 63%, 40%);
         --item-darker: hsl(212, 63%, 35%);
@@ -107,9 +103,6 @@
     &.purple,
     &.green,
     &.black {
-        .loading-overlay {
-            filter: brightness(300%);
-        }
         color: white;
         background: var(--item-background);
         .dashboard-item-header .dashboard-item-title a {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -25,6 +25,7 @@ export function DashboardItems(): JSX.Element {
         dashboardMode,
         isRefreshing,
         highlightedInsightId,
+        refreshStatus,
     } = useValues(dashboardLogic)
     const {
         loadDashboardItems,
@@ -108,6 +109,7 @@ export function DashboardItems(): JSX.Element {
                     <DashboardItem
                         key={item.short_id}
                         doNotLoad
+                        receivedErrorFromAPI={refreshStatus[item.short_id]?.error || false}
                         dashboardId={dashboard?.id}
                         item={item}
                         layout={resizingItem?.i === item.short_id ? resizingItem : layoutForItem[item.short_id]}

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { PlusOutlined } from '@ant-design/icons'
 import { dashboardLogic } from './dashboardLogic'
 import { useActions } from 'kea'
+import { InsightErrorState } from 'scenes/insights/EmptyStates'
 
 function SkeletonOne(): JSX.Element {
     return (
@@ -73,30 +74,25 @@ export interface EmptyDashboardComponentProps {
 export function EmptyDashboardComponent({ emptyWithErrors }: EmptyDashboardComponentProps): JSX.Element {
     const { addGraph } = useActions(dashboardLogic)
 
-    return (
+    return emptyWithErrors ? (
+        <InsightErrorState title={'There was an error loading this dashboard'} />
+    ) : (
         <div className="empty-state">
             <div className="cta">
-                {emptyWithErrors ? (
-                    <Card className="card-elevated" title={'Could not load this dashboard'} extra={'💣'}>
-                        You can try refreshing the page or{' '}
-                        <a href="https://posthog.com/slack">join our community on Slack</a> and ask for support
-                    </Card>
-                ) : (
-                    <Card className="card-elevated">
-                        <h3 className="l3">Dashboard empty</h3>
-                        <p>This dashboard sure would look better with some graphs!</p>
-                        <div className="mt text-center">
-                            <HotkeyButton
-                                onClick={() => addGraph()}
-                                data-attr="dashboard-add-graph-header"
-                                icon={<PlusOutlined />}
-                                hotkey="n"
-                            >
-                                Add graph
-                            </HotkeyButton>
-                        </div>
-                    </Card>
-                )}
+                <Card className="card-elevated">
+                    <h3 className="l3">Dashboard empty</h3>
+                    <p>This dashboard sure would look better with some graphs!</p>
+                    <div className="mt text-center">
+                        <HotkeyButton
+                            onClick={() => addGraph()}
+                            data-attr="dashboard-add-graph-header"
+                            icon={<PlusOutlined />}
+                            hotkey="n"
+                        >
+                            Add graph
+                        </HotkeyButton>
+                    </div>
+                </Card>
             </div>
             <Row gutter={16}>
                 <Col span={24} lg={12}>

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -66,26 +66,37 @@ function SkeletonTwo(): JSX.Element {
     )
 }
 
-export function EmptyDashboardComponent(): JSX.Element {
+export interface EmptyDashboardComponentProps {
+    emptyWithErrors: boolean
+}
+
+export function EmptyDashboardComponent({ emptyWithErrors }: EmptyDashboardComponentProps): JSX.Element {
     const { addGraph } = useActions(dashboardLogic)
 
     return (
         <div className="empty-state">
             <div className="cta">
-                <Card className="card-elevated">
-                    <h3 className="l3">Dashboard empty</h3>
-                    <p>This dashboard sure would look better with some graphs!</p>
-                    <div className="mt text-center">
-                        <HotkeyButton
-                            onClick={() => addGraph()}
-                            data-attr="dashboard-add-graph-header"
-                            icon={<PlusOutlined />}
-                            hotkey="n"
-                        >
-                            Add graph
-                        </HotkeyButton>
-                    </div>
-                </Card>
+                {emptyWithErrors ? (
+                    <Card className="card-elevated" title={'Could not load this dashboard'} extra={'💣'}>
+                        You can try refreshing the page or{' '}
+                        <a href="https://posthog.com/slack">join our community on Slack</a> and ask for support
+                    </Card>
+                ) : (
+                    <Card className="card-elevated">
+                        <h3 className="l3">Dashboard empty</h3>
+                        <p>This dashboard sure would look better with some graphs!</p>
+                        <div className="mt text-center">
+                            <HotkeyButton
+                                onClick={() => addGraph()}
+                                data-attr="dashboard-add-graph-header"
+                                icon={<PlusOutlined />}
+                                hotkey="n"
+                            >
+                                Add graph
+                            </HotkeyButton>
+                        </div>
+                    </Card>
+                )}
             </div>
             <Row gutter={16}>
                 <Col span={24} lg={12}>

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { PlusOutlined } from '@ant-design/icons'
 import { dashboardLogic } from './dashboardLogic'
 import { useActions } from 'kea'
-import { InsightErrorState } from 'scenes/insights/EmptyStates'
 
 function SkeletonOne(): JSX.Element {
     return (
@@ -67,16 +66,10 @@ function SkeletonTwo(): JSX.Element {
     )
 }
 
-export interface EmptyDashboardComponentProps {
-    emptyWithErrors: boolean
-}
-
-export function EmptyDashboardComponent({ emptyWithErrors }: EmptyDashboardComponentProps): JSX.Element {
+export function EmptyDashboardComponent(): JSX.Element {
     const { addGraph } = useActions(dashboardLogic)
 
-    return emptyWithErrors ? (
-        <InsightErrorState title={'There was an error loading this dashboard'} />
-    ) : (
+    return (
         <div className="empty-state">
             <div className="cta">
                 <Card className="card-elevated">

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -33,6 +33,13 @@ describe('dashboardLogic', () => {
             }
         } else if (pathname === `api/projects/${MOCK_TEAM_ID}/dashboards/7/`) {
             throw new Error('💣')
+        } else if (pathname === `api/projects/${MOCK_TEAM_ID}/dashboards/8/`) {
+            return {
+                ...dashboardJson,
+                items: [{ id: 1001, short_id: '1001' }],
+            }
+        } else if (pathname === `api/projects/${MOCK_TEAM_ID}/insights/1001`) {
+            throw new Error('💣')
         } else if (pathname.startsWith(`api/projects/${MOCK_TEAM_ID}/insights/`)) {
             return dashboardJson.items.find(({ id }: any) => String(id) === pathname.split('/')[4])
         }
@@ -66,6 +73,27 @@ describe('dashboardLogic', () => {
             await expectLogic(logic).toMatchValues({
                 receivedErrorsFromAPI: true,
             })
+        })
+    })
+
+    describe('when a dashboard item API errors', () => {
+        initKeaTestLogic({
+            logic: dashboardLogic,
+            props: {
+                id: 8,
+            },
+            onLogic: (l) => (logic = l),
+        })
+
+        it('allows consumers to respond', async () => {
+            await expectLogic(logic, () => {
+                // try and load dashboard items data once dashboard is loaded
+                logic.actions.refreshAllDashboardItemsManual()
+            })
+                .toFinishAllListeners()
+                .toMatchValues({
+                    refreshStatus: { 1001: { error: true } },
+                })
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -31,6 +31,8 @@ describe('dashboardLogic', () => {
                     { ...dashboardJson.items[1], id: 999, short_id: '999' },
                 ],
             }
+        } else if (pathname === `api/projects/${MOCK_TEAM_ID}/dashboards/7/`) {
+            throw new Error('💣')
         } else if (pathname.startsWith(`api/projects/${MOCK_TEAM_ID}/insights/`)) {
             return dashboardJson.items.find(({ id }: any) => String(id) === pathname.split('/')[4])
         }
@@ -48,6 +50,22 @@ describe('dashboardLogic', () => {
 
         it('does not fetch dashboard items on mount', async () => {
             await expectLogic(logic).toNotHaveDispatchedActions(['loadDashboardItems'])
+        })
+    })
+
+    describe('when the dashboard API errors', () => {
+        initKeaTestLogic({
+            logic: dashboardLogic,
+            props: {
+                id: 7,
+            },
+            onLogic: (l) => (logic = l),
+        })
+
+        it('allows consumers to respond', async () => {
+            await expectLogic(logic).toMatchValues({
+                receivedErrorsFromAPI: true,
+            })
         })
     })
 
@@ -76,6 +94,7 @@ describe('dashboardLogic', () => {
                     .toMatchValues({
                         allItems: dashboardJson,
                         items: truth((items) => items.length === 2),
+                        receivedErrorsFromAPI: false,
                     })
             })
         })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -45,6 +45,9 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
     key: (props) => props.id || 'dashboardLogic',
 
     actions: {
+        setReceivedErrorsFromAPI: (receivedErrors: boolean) => ({
+            receivedErrors,
+        }),
         addNewDashboard: true,
         loadDashboardItems: ({
             refresh,
@@ -90,6 +93,8 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
             null as DashboardType | null,
             {
                 loadDashboardItems: async ({ refresh, dive_source_id }) => {
+                    actions.setReceivedErrorsFromAPI(false)
+
                     if (!props.id) {
                         console.warn('Called `loadDashboardItems` but ID is not set.')
                         return
@@ -111,6 +116,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                         if (error.status === 404) {
                             return []
                         }
+                        actions.setReceivedErrorsFromAPI(true)
                         throw error
                     }
                 },
@@ -123,6 +129,13 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         ],
     }),
     reducers: ({ props }) => ({
+        receivedErrorsFromAPI: [
+            false,
+            {
+                setReceivedErrorsFromAPI: (_: boolean, { receivedErrors }: { receivedErrors: boolean }) =>
+                    receivedErrors,
+            },
+        ],
         filters: [
             { date_from: null, date_to: null } as FilterType,
             {

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -104,7 +104,7 @@ export interface InsightErrorStateProps {
 
 export function InsightErrorState({ excludeDetail, title }: InsightErrorStateProps): JSX.Element {
     return (
-        <div className="insight-empty-state error">
+        <div className={clsx(['insight-empty-state', 'error', { 'match-container': excludeDetail }])}>
             <div className="empty-state-inner">
                 <div className="illustration-main">
                     <IllustrationDanger />

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -98,11 +98,11 @@ export function InsightTimeoutState({ isLoading }: { isLoading: boolean }): JSX.
 }
 
 export interface InsightErrorStateProps {
-    smallContainer?: boolean
+    excludeDetail?: boolean
     title?: string
 }
 
-export function InsightErrorState({ smallContainer, title }: InsightErrorStateProps): JSX.Element {
+export function InsightErrorState({ excludeDetail, title }: InsightErrorStateProps): JSX.Element {
     return (
         <div className="insight-empty-state error">
             <div className="empty-state-inner">
@@ -110,7 +110,7 @@ export function InsightErrorState({ smallContainer, title }: InsightErrorStatePr
                     <IllustrationDanger />
                 </div>
                 <h2>{title || 'There was an error completing this query'}</h2>
-                {!smallContainer && (
+                {!excludeDetail && (
                     <div className="mt">
                         We apologize for this unexpected situation. There are a few things you can do:
                         <ol>

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -97,56 +97,63 @@ export function InsightTimeoutState({ isLoading }: { isLoading: boolean }): JSX.
     )
 }
 
-export function InsightErrorState(): JSX.Element {
+export interface InsightErrorStateProps {
+    smallContainer?: boolean
+    title?: string
+}
+
+export function InsightErrorState({ smallContainer, title }: InsightErrorStateProps): JSX.Element {
     return (
         <div className="insight-empty-state error">
             <div className="empty-state-inner">
                 <div className="illustration-main">
                     <IllustrationDanger />
                 </div>
-                <h2>There was an error completing this query</h2>
-                <div className="mt">
-                    We apologize for this unexpected situation. There are a few things you can do:
-                    <ol>
-                        <li>
-                            First and foremost you can <b>try again</b>. We recommended you wait a few moments before
-                            doing so.
-                        </li>
-                        <li>
-                            <a
-                                data-attr="insight-error-raise-issue"
-                                href="https://github.com/PostHog/posthog/issues/new?labels=bug&template=bug_report.md"
-                                target="_blank"
-                                rel="noreferrer noopener"
-                            >
-                                Raise an issue
-                            </a>{' '}
-                            in our GitHub repository.
-                        </li>
-                        <li>
-                            Get in touch with us{' '}
-                            <a
-                                data-attr="insight-error-slack"
-                                href="https://posthog.com/slack"
-                                rel="noopener noreferrer"
-                                target="_blank"
-                            >
-                                on Slack
-                            </a>
-                            .
-                        </li>
-                        <li>
-                            Email us at{' '}
-                            <a
-                                data-attr="insight-error-email"
-                                href="mailto:hey@posthog.com?subject=Insight%20graph%20error"
-                            >
-                                hey@posthog.com
-                            </a>
-                            .
-                        </li>
-                    </ol>
-                </div>
+                <h2>{title || 'There was an error completing this query'}</h2>
+                {!smallContainer && (
+                    <div className="mt">
+                        We apologize for this unexpected situation. There are a few things you can do:
+                        <ol>
+                            <li>
+                                First and foremost you can <b>try again</b>. We recommended you wait a few moments
+                                before doing so.
+                            </li>
+                            <li>
+                                <a
+                                    data-attr="insight-error-raise-issue"
+                                    href="https://github.com/PostHog/posthog/issues/new?labels=bug&template=bug_report.md"
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                >
+                                    Raise an issue
+                                </a>{' '}
+                                in our GitHub repository.
+                            </li>
+                            <li>
+                                Get in touch with us{' '}
+                                <a
+                                    data-attr="insight-error-slack"
+                                    href="https://posthog.com/slack"
+                                    rel="noopener noreferrer"
+                                    target="_blank"
+                                >
+                                    on Slack
+                                </a>
+                                .
+                            </li>
+                            <li>
+                                Email us at{' '}
+                                <a
+                                    data-attr="insight-error-email"
+                                    href="mailto:hey@posthog.com?subject=Insight%20graph%20error"
+                                >
+                                    hey@posthog.com
+                                </a>
+                                .
+                            </li>
+                        </ol>
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -314,6 +314,46 @@ $funnel_canvas_background: #fafafa;
     }
 }
 
+.dashboard-item {
+    .insight-empty-state {
+        &.match-container {
+            background-color: transparent;
+        }
+    }
+
+    &.purple {
+        .insight-empty-state {
+            &.match-container {
+                &.error {
+                    .illustration-main {
+                        color: $text_light;
+                    }
+
+                    h2 {
+                        color: $text_light;
+                    }
+                }
+            }
+        }
+    }
+
+    &:not(.purple) {
+        .insight-empty-state {
+            &.match-container {
+                &.error {
+                    .illustration-main {
+                        color: $danger;
+                    }
+
+                    h2 {
+                        color: $danger;
+                    }
+                }
+            }
+        }
+    }
+}
+
 .trends-insights-container {
     position: relative;
     min-height: min(calc(90vh - 16rem), 36rem);

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -786,10 +786,9 @@ body {
     position: absolute;
     top: 0;
     left: 0;
-    background: $bg_charcoal;
+    background: transparentize($bg_charcoal, 0.5);
     text-align: center;
     min-height: 6rem;
-    opacity: 0.5;
     z-index: $z_content_overlay;
     display: flex;
     align-items: center;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -789,7 +789,7 @@ body {
     background: $bg_charcoal;
     text-align: center;
     min-height: 6rem;
-    opacity: 0.7;
+    opacity: 0.5;
     z-index: $z_content_overlay;
     display: flex;
     align-items: center;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -779,3 +779,27 @@ body {
         border-radius: var(--radius);
     }
 }
+
+.loading-overlay {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: $bg_charcoal;
+    text-align: center;
+    min-height: 6rem;
+    opacity: 0.7;
+    z-index: $z_content_overlay;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &.over-table {
+        display: block;
+        background: rgba(0, 0, 0, 0.1);
+        td {
+            display: block;
+        }
+    }
+}

--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -14,30 +14,6 @@
     }
 }
 
-.loading-overlay {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    background: #fff;
-    text-align: center;
-    min-height: 6rem;
-    opacity: 0.7;
-    z-index: $z_content_overlay;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    &.over-table {
-        display: block;
-        background: rgba(0, 0, 0, 0.1);
-        td {
-            display: block;
-        }
-    }
-}
-
 .code-container {
     position: relative;
     .action-icon-container {


### PR DESCRIPTION
## Changes

Closes #6285 

This introduces three changes

1) makes the loading overlay for insights less subtle so loading is easier to see on slow connections
2) adds an error state for individual insights on a dashboard to distinguish from their empty state
3) adds an error state for an entire dashboard to distinguish from its empty state

### before loading change

![before](https://user-images.githubusercontent.com/984817/144045307-691622e4-9659-42c7-93fb-e2b290015b82.gif)

### after loading change

![after](https://user-images.githubusercontent.com/984817/144045341-4533960d-d7ae-4431-b512-6982249a32ba.gif)

### whole dashboard error

#### before

<img width="631" alt="Screenshot 2021-11-30 at 12 14 46" src="https://user-images.githubusercontent.com/984817/144045604-b51246f1-0696-49da-839b-324cb94f9518.png">

#### after

<img width="838" alt="Screenshot 2021-11-30 at 12 06 12" src="https://user-images.githubusercontent.com/984817/144045416-2506cd7c-b104-4e2f-8221-69a0a3b870fc.png">

### individual item errors

#### before

<img width="1243" alt="Screenshot 2021-11-30 at 12 16 09" src="https://user-images.githubusercontent.com/984817/144045853-a6742b0a-619c-4204-ac75-0fc76abf4f06.png">

#### after

<img width="1414" alt="Screenshot 2021-11-30 at 11 58 55" src="https://user-images.githubusercontent.com/984817/144045452-e10f5c2f-fde0-42b5-a589-27f35e86ecb3.png">

## How did you test this code?

with some unit tests and manual testing

in order to test manually the easiest route is to load a dashboard then run `redis-cli KEYS "*cache*" | xargs redis-cli DEL` so the cache for the items is removed and then insert a throw in either the `dashboardLogic > loaders > allItems` to `dashboardLogic > refreshAllDashboardItems > fetchItemFunctions` depending on if you want to error on all items or individual items respectively then either refresh the page or click to refresh the dashboard
