### PR TITLE
silence plugin server sentry logspam

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -108,7 +108,13 @@ export class KafkaQueue implements Queue {
                                 "Probably the batch took longer than the session and we couldn't commit the offset"
                             )
                         }
-                        Sentry.captureException(error)
+                        if (
+                            error.message &&
+                            !error.message.includes('The group is rebalancing, so a rejoin is needed') &&
+                            !error.message.includes('Specified group generation id is not valid')
+                        ) {
+                            Sentry.captureException(error)
+                        }
                         throw error
                     }
                 },

--- a/plugin-server/src/utils/metrics.ts
+++ b/plugin-server/src/utils/metrics.ts
@@ -14,7 +14,6 @@ export async function instrumentQuery<T>(
     try {
         return await runQuery()
     } catch (error) {
-        Sentry.captureException(error, { extra: { query_tag: tag } })
         throw error
     } finally {
         statsd?.timing(metricName, timer, tags)

--- a/plugin-server/src/utils/metrics.ts
+++ b/plugin-server/src/utils/metrics.ts
@@ -13,8 +13,6 @@ export async function instrumentQuery<T>(
     statsd?.increment(`${metricName}.total`, tags)
     try {
         return await runQuery()
-    } catch (error) {
-        throw error
     } finally {
         statsd?.timing(metricName, timer, tags)
     }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -128,7 +128,6 @@ export class EventsProcessor {
                 await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
             } catch (e) {
                 console.error('handleIdentifyOrAlias failed', e, data)
-                Sentry.captureException(e, { extra: { event: data } })
             } finally {
                 clearTimeout(timeout1)
             }
@@ -446,10 +445,6 @@ export class EventsProcessor {
 
                 kafkaMessages = [...updatePersonMessages, ...distinctIdMessages, ...deletePersonMessages]
             } catch (error) {
-                Sentry.captureException(error, {
-                    extra: { mergeInto, mergeIntoDistinctId, otherPerson, otherPersonDistinctId },
-                })
-
                 if (!(error instanceof DatabaseError)) {
                     throw error // Very much not OK, this is some completely unexpected error
                 }


### PR DESCRIPTION
## Changes

The plugin server is spamming Sentry a lot with race condition stuff that's expected. This PR removes a bit more than I'd like but we need a more elegant solution in the future to filter what we send to Sentry or not.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
