### PR TITLE
feat(retention): add support for multiple breakdown props

### DIFF
--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -369,6 +369,28 @@ class QuerySuite:
         ClickhouseRetention().run(filter, self.team)
 
     @benchmark_clickhouse
+    def track_retention_with_person_breakdown(self):
+        filter = RetentionFilter(
+            data={
+                "insight": "RETENTION",
+                "target_event": {"id": "$pageview"},
+                "returning_event": {"id": "$pageview"},
+                "total_intervals": 14,
+                "retention_type": "retention_first_time",
+                "breakdown_type": "person",
+                "breakdowns": [
+                    {"type": "person", "property": "$browser"},
+                    {"type": "person", "property": "$browser_version"},
+                ],
+                "period": "Week",
+                **DATE_RANGE,
+            },
+            team=self.team,
+        )
+
+        ClickhouseRetention().run(filter, self.team)
+
+    @benchmark_clickhouse
     def track_retention_filter_by_person_property(self):
         filter = RetentionFilter(
             data={

--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -388,7 +388,8 @@ class QuerySuite:
             team=self.team,
         )
 
-        ClickhouseRetention().run(filter, self.team)
+        with no_materialized_columns():
+            ClickhouseRetention().run(filter, self.team)
 
     @benchmark_clickhouse
     def track_retention_filter_by_person_property(self):

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -66,7 +66,7 @@ def make_ch_pool(**overrides) -> ChPool:
 
 
 if PRIMARY_DB != AnalyticsDBMS.CLICKHOUSE:
-    ch_client: Optional[Client] = None
+    ch_client = None  # type: Client
 
     class ClickHouseNotConfigured(NotImplementedError):
         def __init__(self, msg='This function only works if PRIMARY_DB is set to indicate ClickHouse!"', *args):

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -3,13 +3,12 @@ import hashlib
 import json
 import types
 from time import perf_counter
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import sqlparse
 from aioch import Client
 from asgiref.sync import async_to_sync
 from clickhouse_driver import Client as SyncClient
-from clickhouse_driver.util.escape import escape_params
 from clickhouse_pool import ChPool
 from django.conf import settings as app_settings
 from django.core.cache import cache
@@ -67,7 +66,7 @@ def make_ch_pool(**overrides) -> ChPool:
 
 
 if PRIMARY_DB != AnalyticsDBMS.CLICKHOUSE:
-    ch_client = None  # type: Client
+    ch_client: Optional[Client] = None
 
     class ClickHouseNotConfigured(NotImplementedError):
         def __init__(self, msg='This function only works if PRIMARY_DB is set to indicate ClickHouse!"', *args):
@@ -166,6 +165,23 @@ else:
                     save_query(prepared_sql, execution_time)
         return result
 
+    def substitute_params(query, params):
+        """
+        Helper method to ease rendering of sql clickhouse queries progressively.
+        For example, there are many places where we construct queries to be used
+        as subqueries of others. Each time we generate a subquery we also pass
+        up the "bound" parameters to be used to render the query, which
+        otherwise only happens at the point of calling clickhouse via the
+        clickhouse_driver `Client`.
+
+        This results in sometimes large lists of parameters with no relevance to
+        the containing query being passed up. Rather than do this, we can
+        instead "render" the subqueries prior to using as a subquery, so our
+        containing code is only responsible for it's parameters, and we can
+        avoid any potential param collisions.
+        """
+        return cast(SyncClient, ch_client).substitute_params(query, params)
+
 
 def _prepare_query(client: SyncClient, query: str, args: QueryArgs):
     """
@@ -189,10 +205,10 @@ def _prepare_query(client: SyncClient, query: str, args: QueryArgs):
     clickhouse_driver at this moment in time decides based on the
     below predicate.
     """
-    if isinstance(args, (list, tuple, types.GeneratorType)):
+    if args is None or isinstance(args, (list, tuple, types.GeneratorType)):
         rendered_sql = query
     else:
-        rendered_sql = client.substitute_params(query, args or {})
+        rendered_sql = client.substitute_params(query, args)
         args = None
 
     formatted_sql = sqlparse.format(rendered_sql, strip_comments=True)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -268,7 +268,7 @@ def property_table(property: Property) -> TableWithProperties:
 
 
 def get_single_or_multi_property_string_expr(
-    breakdown, table: TableWithProperties, query_alias: Literal["prop", "value", "breakdown_values"]
+    breakdown, table: TableWithProperties, query_alias: Literal["prop", "value", None]
 ):
     """
     When querying for breakdown properties:
@@ -276,6 +276,12 @@ def get_single_or_multi_property_string_expr(
      * If it is an array of strings, we extract each of those properties and concatenate them into a single value
     clickhouse parameterizes into a query template from a flat list using % string formatting
     values are escaped and inserted in the query here instead of adding new items to the flat list of values
+
+    :param query_alias:
+
+        Specifies the SQL query alias to add to the expression e.g. `AS prop`. If this is specified as None, then
+        no alias will be appended.
+
     """
 
     column = "properties" if table == "events" else "person_props"
@@ -289,6 +295,9 @@ def get_single_or_multi_property_string_expr(
             expressions.append(expr)
 
         expression = f"array({','.join(expressions)})"
+
+    if query_alias is None:
+        return expression
 
     return f"{expression} AS {query_alias}"
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -268,7 +268,7 @@ def property_table(property: Property) -> TableWithProperties:
 
 
 def get_single_or_multi_property_string_expr(
-    breakdown, table: TableWithProperties, query_alias: Literal["prop", "value"]
+    breakdown, table: TableWithProperties, query_alias: Literal["prop", "value", "breakdown_values"]
 ):
     """
     When querying for breakdown properties:

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict, Iterable, List, Tuple, cast
+from typing import Any, Dict, List, NamedTuple, Tuple, Union, cast
 
 from django.db.models.query import Prefetch
 
-from ee.clickhouse.client import sync_execute
+from ee.clickhouse.client import substitute_params, sync_execute
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.person import get_persons_by_uuids
 from ee.clickhouse.models.property import parse_prop_clauses
@@ -17,9 +17,11 @@ from ee.clickhouse.sql.retention.people_in_period import (
     RETENTION_PEOPLE_PER_PERIOD_SQL,
 )
 from ee.clickhouse.sql.retention.retention import (
+    INITIAL_BREAKDOWN_INTERVAL_SQL,
     INITIAL_INTERVAL_SQL,
     REFERENCE_EVENT_SQL,
     REFERENCE_EVENT_UNIQUE_SQL,
+    RETENTION_BREAKDOWN_SQL,
     RETENTION_PEOPLE_SQL,
     RETENTION_SQL,
 )
@@ -37,9 +39,11 @@ from posthog.models.person import Person
 from posthog.models.team import Team
 from posthog.queries.retention import AppearanceRow, Retention
 
+CohortKey = NamedTuple("CohortKey", (("breakdown_values", Tuple[str]), ("period", int)))
+
 
 class ClickhouseRetention(Retention):
-    def _execute_sql(self, filter: RetentionFilter, team: Team,) -> Dict[Tuple[int, int], Dict[str, Any]]:
+    def _get_retention_by_cohort(self, filter: RetentionFilter, team: Team,) -> Dict[Tuple[int, int], Dict[str, Any]]:
         period = filter.period
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         date_from = filter.date_from
@@ -76,7 +80,7 @@ class ClickhouseRetention(Retention):
         )
 
         initial_interval_result = sync_execute(
-            INITIAL_INTERVAL_SQL.format(reference_event_sql=target_event_query, trunc_func=trunc_func,), all_params
+            INITIAL_INTERVAL_SQL.format(reference_event_sql=target_event_query, trunc_func=trunc_func,), all_params,
         )
 
         result_dict = {}
@@ -87,6 +91,105 @@ class ClickhouseRetention(Retention):
             result_dict.update({(res[0], res[1]): {"count": res[2], "people": []}})
 
         return result_dict
+
+    def _get_retention_by_breakdown_values(
+        self, filter: RetentionFilter, team: Team,
+    ) -> Dict[CohortKey, Dict[str, Any]]:
+        period = filter.period
+        is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
+        date_from = filter.date_from
+        trunc_func = get_trunc_func_ch(period)
+
+        returning_event_query_templated, returning_event_params = RetentionEventsQuery(
+            filter=filter, team_id=team.pk, event_query_type=RetentionQueryType.RETURNING,
+        ).get_query()
+
+        returning_event_query = substitute_params(returning_event_query_templated, returning_event_params)
+
+        target_event_query_templated, target_event_params = RetentionEventsQuery(
+            filter=filter,
+            team_id=team.pk,
+            event_query_type=(
+                RetentionQueryType.TARGET_FIRST_TIME if is_first_time_retention else RetentionQueryType.TARGET
+            ),
+        ).get_query()
+
+        target_event_query = substitute_params(target_event_query_templated, target_event_params)
+
+        all_params = {
+            "team_id": team.pk,
+            "start_date": date_from.strftime(
+                "%Y-%m-%d{}".format(" %H:%M:%S" if filter.period == "Hour" else " 00:00:00")
+            ),
+            "total_intervals": filter.total_intervals,
+            "period": period.lower(),
+            "breakdown_by": filter.breakdown,
+        }
+
+        result = sync_execute(
+            substitute_params(RETENTION_BREAKDOWN_SQL, all_params).format(
+                returning_event_query=returning_event_query,
+                trunc_func=trunc_func,
+                target_event_query=target_event_query,
+                GET_TEAM_PERSON_DISTINCT_IDS=substitute_params(GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team.pk}),
+            )
+        )
+
+        result = [(tuple(res[0]), *res[1:]) for res in result]  # make breakdown hashable, required later
+
+        initial_interval_result = sync_execute(
+            substitute_params(INITIAL_BREAKDOWN_INTERVAL_SQL, all_params).format(
+                reference_event_sql=target_event_query, trunc_func=trunc_func,
+            ),
+        )
+
+        initial_interval_result = [
+            (tuple(res[0]), *res[1:]) for res in initial_interval_result
+        ]  # make breakdown hashable, required later
+
+        result_dict = {}
+        for initial_res in initial_interval_result:
+            result_dict.update({CohortKey(initial_res[0], 0): {"count": initial_res[1], "people": []}})
+
+        for res in result:
+            result_dict.update({CohortKey(res[0], res[1]): {"count": res[2], "people": []}})
+
+        return result_dict
+
+    def run(self, filter: RetentionFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        if filter.display == TRENDS_LINEAR:
+            # If we get a display=TRENDS_LINEAR then don't do anything special
+            # with breakdowns. This code path will be removed anyway in a future
+            # change.
+            retention_by_cohort = self._get_retention_by_cohort(filter, team)
+            return self.process_graph_result(retention_by_cohort, filter)
+        if filter.breakdowns:
+            retention_by_breakdown = self._get_retention_by_breakdown_values(filter, team)
+            return self.process_breakdown_table_result(retention_by_breakdown, filter)
+        else:
+            # If we're not using breakdowns, just use the non-clickhouse
+            # `process_table_result`
+            retention_by_cohort = self._get_retention_by_cohort(filter, team)
+            return self.process_table_result(retention_by_cohort, filter)
+
+    def process_breakdown_table_result(
+        self, resultset: Dict[CohortKey, Dict[str, Any]], filter: RetentionFilter,
+    ):
+        result = [
+            {
+                "values": [
+                    resultset.get(CohortKey(breakdown_values, interval), {"count": 0, "people": []})
+                    for interval in range(filter.total_intervals)
+                ],
+                "label": "::".join(breakdown_values),
+                "breakdown_values": breakdown_values,
+            }
+            for breakdown_values in set(
+                cohort_key.breakdown_values for cohort_key in cast(Dict[CohortKey, Dict[str, Any]], resultset).keys()
+            )
+        ]
+
+        return result
 
     def _get_condition(self, target_entity: Entity, table: str, prepend: str = "") -> Tuple[str, Dict]:
         if target_entity.type == TREND_FILTER_TYPE_ACTIONS:

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NamedTuple, Tuple, Union, cast
+from typing import Any, Dict, List, NamedTuple, Tuple, cast
 
 from django.db.models.query import Prefetch
 

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -163,7 +163,7 @@ class ClickhouseRetention(Retention):
             # change.
             retention_by_cohort = self._get_retention_by_cohort(filter, team)
             return self.process_graph_result(retention_by_cohort, filter)
-        if filter.breakdowns:
+        if filter.breakdowns and filter.breakdown_type:
             retention_by_breakdown = self._get_retention_by_breakdown_values(filter, team)
             return self.process_breakdown_table_result(retention_by_breakdown, filter)
         else:

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Tuple
 
-from ee.clickhouse.client import substitute_params
 from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.group import get_aggregation_target_field
 from ee.clickhouse.models.property import get_single_or_multi_property_string_expr

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -24,12 +24,20 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_0)
-       AND team_id = 2 ) event
+       AND team_id = 2
+     ORDER BY event_date,
+              target) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      e.$group_0 as target,
@@ -50,12 +58,21 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_0)
-       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
+       AND team_id = 2
+     ORDER BY event_date,
+              target) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -88,12 +105,21 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_0)
-       AND team_id = 2 )
+       AND team_id = 2
+     ORDER BY event_date,
+              target)
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -124,12 +150,20 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_1)
-       AND team_id = 2 ) event
+       AND team_id = 2
+     ORDER BY event_date,
+              target) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      e.$group_1 as target,
@@ -150,12 +184,21 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_1)
-       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
+       AND team_id = 2
+     ORDER BY event_date,
+              target) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -188,12 +231,21 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_1)
-       AND team_id = 2 )
+       AND team_id = 2
+     ORDER BY event_date,
+              target)
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -225,6 +277,12 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -236,7 +294,9 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) event
+                                    FROM JSONExtractRaw(group_properties_0, 'industry')))
+     ORDER BY event_date,
+              target) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      pdi.person_id as target,
@@ -258,6 +318,13 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -269,7 +336,9 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) reference_event ON (event.target = reference_event.target)
+                                    FROM JSONExtractRaw(group_properties_0, 'industry')))
+     ORDER BY event_date,
+              target) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -303,6 +372,13 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -314,7 +390,9 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) )
+                                    FROM JSONExtractRaw(group_properties_0, 'industry')))
+     ORDER BY event_date,
+              target)
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -346,6 +424,12 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -356,7 +440,9 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry') ) event
+       AND JSONHas(group_properties_0, 'industry')
+     ORDER BY event_date,
+              target) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      pdi.person_id as target,
@@ -378,6 +464,13 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -388,7 +481,9 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry') ) reference_event ON (event.target = reference_event.target)
+       AND JSONHas(group_properties_0, 'industry')
+     ORDER BY event_date,
+              target) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -422,6 +517,13 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -432,7 +534,9 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry') )
+       AND JSONHas(group_properties_0, 'industry')
+     ORDER BY event_date,
+              target)
   GROUP BY event_date
   ORDER BY event_date
   '

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -24,20 +24,12 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_0)
-       AND team_id = 2
-     ORDER BY event_date,
-              target) event
+       AND team_id = 2 ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      e.$group_0 as target,
@@ -58,21 +50,12 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
-     INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_0)
-       AND team_id = 2
-     ORDER BY event_date,
-              target) reference_event ON (event.target = reference_event.target)
+       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -105,21 +88,12 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
-     INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_0)
-       AND team_id = 2
-     ORDER BY event_date,
-              target)
+       AND team_id = 2 )
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -150,20 +124,12 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_1)
-       AND team_id = 2
-     ORDER BY event_date,
-              target) event
+       AND team_id = 2 ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      e.$group_1 as target,
@@ -184,21 +150,12 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
-     INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_1)
-       AND team_id = 2
-     ORDER BY event_date,
-              target) reference_event ON (event.target = reference_event.target)
+       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -231,21 +188,12 @@
                     team_id
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
-     INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND NOT has([''], $group_1)
-       AND team_id = 2
-     ORDER BY event_date,
-              target)
+       AND team_id = 2 )
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -277,12 +225,6 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -294,9 +236,7 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry')))
-     ORDER BY event_date,
-              target) event
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      pdi.person_id as target,
@@ -318,13 +258,6 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -336,9 +269,7 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry')))
-     ORDER BY event_date,
-              target) reference_event ON (event.target = reference_event.target)
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -372,13 +303,6 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -390,9 +314,7 @@
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
        AND has(['technology'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(group_properties_0, 'industry')))
-     ORDER BY event_date,
-              target)
+                                    FROM JSONExtractRaw(group_properties_0, 'industry'))) )
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -424,12 +346,6 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -440,9 +356,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry')
-     ORDER BY event_date,
-              target) event
+       AND JSONHas(group_properties_0, 'industry') ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      pdi.person_id as target,
@@ -464,13 +378,6 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -481,9 +388,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry')
-     ORDER BY event_date,
-              target) reference_event ON (event.target = reference_event.target)
+       AND JSONHas(group_properties_0, 'industry') ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -517,13 +422,6 @@
            HAVING max(is_deleted) = 0)
         GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
      INNER JOIN
-       (SELECT id,
-               argMax(properties, _timestamp) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
         FROM groups
@@ -534,9 +432,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND JSONHas(group_properties_0, 'industry')
-     ORDER BY event_date,
-              target)
+       AND JSONHas(group_properties_0, 'industry') )
   GROUP BY event_date
   ORDER BY event_date
   '

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -50,10 +50,13 @@ class RetentionTests(TestCase):
 
         retention_by_cohort_by_period = get_by_cohort_by_period_from_response(response=retention)
 
-        assert retention_by_cohort_by_period == {
-            "Day 0": {"1": 2, "2": 1,},  # ["person 1", "person 2"]  # ["person 1"]
-            "Day 1": {"1": 1},  # ["person 3"]
-        }
+        self.assertEqual(
+            retention_by_cohort_by_period,
+            {
+                "Day 0": {"1": 2, "2": 1,},  # ["person 1", "person 2"]  # ["person 1"]
+                "Day 1": {"1": 1},  # ["person 3"]
+            },
+        )
 
     def test_can_specify_breakdown_person_property(self):
         """
@@ -102,10 +105,13 @@ class RetentionTests(TestCase):
 
         retention_by_cohort_by_period = get_by_cohort_by_period_from_response(response=retention)
 
-        assert retention_by_cohort_by_period == {
-            "Chrome": {"1": 1, "2": 1},
-            "Safari": {"1": 1, "2": 1},  # IMPORTANT: the "2" value is from past the requested `date_to`
-        }
+        self.assertEqual(
+            retention_by_cohort_by_period,
+            {
+                "Chrome": {"1": 1, "2": 1},
+                "Safari": {"1": 1, "2": 1},  # IMPORTANT: the "2" value is from past the requested `date_to`
+            },
+        )
 
     def test_can_specify_breakdown_event_property(self):
         """
@@ -157,10 +163,13 @@ class RetentionTests(TestCase):
 
         retention_by_cohort_by_period = get_by_cohort_by_period_from_response(response=retention)
 
-        assert retention_by_cohort_by_period == {
-            "Chrome": {"1": 1, "2": 1},
-            "Safari": {"1": 1, "2": 1},  # IMPORTANT: the "2" value is from past the requested `date_to`
-        }
+        self.assertEqual(
+            retention_by_cohort_by_period,
+            {
+                "Chrome": {"1": 1, "2": 1},
+                "Safari": {"1": 1, "2": 1},  # IMPORTANT: the "2" value is from past the requested `date_to`
+            },
+        )
 
 
 def setup_user_activity_by_day(daily_activity, team):

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -208,7 +208,7 @@ class RetentionRequest:
     retention_type: Literal["retention_first_time"]  # probably not an exhaustive list
 
     breakdowns: Optional[List[Breakdown]] = None
-    breakdown_type: Optional[Literal["person", "events"]] = None
+    breakdown_type: Optional[Literal["person", "event"]] = None
 
 
 class Value(TypedDict):

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -11,6 +11,7 @@ from ee.clickhouse.views.test.funnel.util import EventPattern
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.utils import json_encode_request_params
 
 
 class RetentionTests(TestCase):
@@ -235,11 +236,7 @@ def get_retention(client: Client, team_id: int, request: RetentionRequest):
     return client.get(
         f"/api/projects/{team_id}/insights/retention/",
         # NOTE: for get requests we need to JSON encode non-scalars
-        data={
-            k: (v if isinstance(v, (str, numbers.Number)) else json.dumps(v))
-            for k, v in asdict(request).items()
-            if v is not None
-        },
+        data=json_encode_request_params(asdict(request)),
     )
 
 

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -8,8 +8,6 @@ from django.test.client import Client
 
 from ee.clickhouse.test.test_journeys import _create_all_events, update_or_create_person
 from ee.clickhouse.views.test.funnel.util import EventPattern
-
-# from posthog.api.test.test_event import get_events_ok
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -1,32 +1,37 @@
 import json
 import numbers
-from typing import List, Literal, TypedDict, Union
+from dataclasses import asdict, dataclass
+from typing import List, Literal, Optional, TypedDict, Union
 
 from django.test import TestCase
 from django.test.client import Client
 
-from ee.clickhouse.test.test_journeys import journeys_for
+from ee.clickhouse.test.test_journeys import _create_all_events, update_or_create_person
 from ee.clickhouse.views.test.funnel.util import EventPattern
+
+# from posthog.api.test.test_event import get_events_ok
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 
 
 class RetentionTests(TestCase):
-    def test_can_get_line_chart_and_fetch_people(self):
+    def test_can_get_retention_cohort_breakdown(self):
         organization = create_organization(name="test")
         team = create_team(organization=organization)
         user = create_user(email="test@posthog.com", password="1234", organization=organization)
 
         self.client.force_login(user)
 
-        journeys_for(
-            events_by_person={
-                "person that stays forever": [
-                    {"event": "target event", "timestamp": "2020-01-01"},
-                    {"event": "target event", "timestamp": "2020-01-02"},
-                ],
-                "person that leaves on 2020-01-02": [{"event": "target event", "timestamp": "2020-01-01"}],
+        update_or_create_person(distinct_ids=["person 1"], team_id=team.pk)
+        update_or_create_person(distinct_ids=["person 2"], team_id=team.pk)
+        update_or_create_person(distinct_ids=["person 3"], team_id=team.pk)
+
+        setup_user_activity_by_day(
+            daily_activity={
+                "2020-01-01": {"person 1": [{"event": "target event"}], "person 2": [{"event": "target event"}]},
+                "2020-01-02": {"person 1": [{"event": "target event"}], "person 3": [{"event": "target event"}]},
+                "2020-01-03": {"person 1": [{"event": "target event"}], "person 3": [{"event": "target event"}]},
             },
             team=team,
         )
@@ -40,22 +45,145 @@ class RetentionTests(TestCase):
                 date_from="2020-01-01",
                 total_intervals=2,
                 date_to="2020-01-02",
-                display="ActionsLineGraph",
                 period="Day",
                 retention_type="retention_first_time",
             ),
         )
 
-        trend_series = retention["result"][0]
-        retention_by_day = get_people_for_retention_trend_series(client=self.client, trend_series=trend_series)
+        retention_by_cohort_by_period = get_by_cohort_by_period_from_response(response=retention)
 
-        assert retention_by_day == {
-            "2020-01-01": ["person that leaves on 2020-01-02", "person that stays forever"],
-            "2020-01-02": ["person that stays forever"],
+        assert retention_by_cohort_by_period == {
+            "Day 0": {"1": 2, "2": 1,},  # ["person 1", "person 2"]  # ["person 1"]
+            "Day 1": {"1": 1},  # ["person 3"]
+        }
+
+    def test_can_specify_breakdown_person_property(self):
+        """
+        By default, we group users together by the first time they perform the
+        `target_event`. However, we should also be able to specify, e.g. the
+        users OS to be able to compare retention between the OSs.
+        """
+        organization = create_organization(name="test")
+        team = create_team(organization=organization)
+        user = create_user(email="test@posthog.com", password="1234", organization=organization)
+
+        self.client.force_login(user)
+
+        update_or_create_person(distinct_ids=["person 1"], team_id=team.pk, properties={"os": "Chrome"})
+        update_or_create_person(distinct_ids=["person 2"], team_id=team.pk, properties={"os": "Safari"})
+
+        setup_user_activity_by_day(
+            daily_activity={
+                "2020-01-01": {"person 1": [{"event": "target event"}]},
+                "2020-01-02": {"person 1": [{"event": "target event"}], "person 2": [{"event": "target event"}]},
+                # IMPORTANT: we include data past the end of the requested
+                # window, as we want to ensure that we pick up all retention
+                # periods for a user. e.g. for "person 2" we do not want to miss
+                # the count from 2020-01-03 e.g. the second period, otherwise we
+                # will skew results for users that didn't perform their target
+                # event right at the beginning of the requested range.
+                "2020-01-03": {"person 1": [{"event": "target event"}], "person 2": [{"event": "target event"}]},
+            },
+            team=team,
+        )
+
+        retention = get_retention_ok(
+            client=self.client,
+            team_id=team.pk,
+            request=RetentionRequest(
+                target_entity={"id": "target event", "type": "events"},
+                returning_entity={"id": "target event", "type": "events"},
+                date_from="2020-01-01",
+                total_intervals=2,
+                date_to="2020-01-02",
+                period="Day",
+                retention_type="retention_first_time",
+                breakdowns=[Breakdown(type="person", property="os")],
+            ),
+        )
+
+        retention_by_cohort_by_period = get_by_cohort_by_period_from_response(response=retention)
+
+        assert retention_by_cohort_by_period == {
+            "Chrome": {"1": 1, "2": 1},
+            "Safari": {"1": 1, "2": 1},  # IMPORTANT: the "2" value is from past the requested `date_to`
+        }
+
+    def test_can_specify_breakdown_event_property(self):
+        """
+        By default, we group users together by the first time they perform the
+        `target_event`. However, we should also be able to specify, e.g. the
+        users OS to be able to compare retention between the OSs.
+        """
+        organization = create_organization(name="test")
+        team = create_team(organization=organization)
+        user = create_user(email="test@posthog.com", password="1234", organization=organization)
+
+        self.client.force_login(user)
+
+        update_or_create_person(distinct_ids=["person 1"], team_id=team.pk)
+        update_or_create_person(distinct_ids=["person 2"], team_id=team.pk)
+
+        setup_user_activity_by_day(
+            daily_activity={
+                "2020-01-01": {"person 1": [{"event": "target event", "properties": {"os": "Chrome"}}]},
+                "2020-01-02": {
+                    "person 1": [{"event": "target event"}],
+                    "person 2": [{"event": "target event", "properties": {"os": "Safari"}}],
+                },
+                # IMPORTANT: we include data past the end of the requested
+                # window, as we want to ensure that we pick up all retention
+                # periods for a user. e.g. for "person 2" we do not want to miss
+                # the count from 2020-01-03 e.g. the second period, otherwise we
+                # will skew results for users that didn't perform their target
+                # event right at the beginning of the requested range.
+                "2020-01-03": {"person 1": [{"event": "target event"}], "person 2": [{"event": "target event"}]},
+            },
+            team=team,
+        )
+
+        retention = get_retention_ok(
+            client=self.client,
+            team_id=team.pk,
+            request=RetentionRequest(
+                target_entity={"id": "target event", "type": "events"},
+                returning_entity={"id": "target event", "type": "events"},
+                date_from="2020-01-01",
+                total_intervals=2,
+                date_to="2020-01-02",
+                period="Day",
+                retention_type="retention_first_time",
+                breakdowns=[Breakdown(type="event", property="os")],
+            ),
+        )
+
+        retention_by_cohort_by_period = get_by_cohort_by_period_from_response(response=retention)
+
+        assert retention_by_cohort_by_period == {
+            "Chrome": {"1": 1, "2": 1},
+            "Safari": {"1": 1, "2": 1},  # IMPORTANT: the "2" value is from past the requested `date_to`
         }
 
 
-class RetentionRequest(TypedDict):
+def setup_user_activity_by_day(daily_activity, team):
+    _create_all_events(
+        [
+            {"distinct_id": person_id, "team": team, "timestamp": timestamp, **event}
+            for timestamp, people in daily_activity.items()
+            for person_id, events in people.items()
+            for event in events
+        ]
+    )
+
+
+@dataclass
+class Breakdown:
+    type: str
+    property: str
+
+
+@dataclass
+class RetentionRequest:
     date_from: str  # From what I can tell, this doesn't do anything, rather `total_intervals` is used
     total_intervals: int
     date_to: str
@@ -63,22 +191,25 @@ class RetentionRequest(TypedDict):
     returning_entity: EventPattern
     period: Union[Literal["Hour"], Literal["Day"], Literal["Week"], Literal["Month"]]
     retention_type: Literal["retention_first_time"]  # probably not an exhaustive list
-    display: Literal["ActionsLineGraph"]  # probably not an exhaustive list
+
+    breakdowns: Optional[List[Breakdown]] = None
 
 
-class Series(TypedDict):
-    days: List[str]
-    data: List[int]
-
-    # List of people urls corresponding to `data`
-    people_urls: List[str]
+class Value(TypedDict):
+    count: int
 
 
-class RetentionTrendResponse(TypedDict):
-    result: List[Series]
+class Cohort(TypedDict):
+    values: List[Value]
+    date: str
+    label: str
 
 
-def get_retention_ok(client: Client, team_id: int, request: RetentionRequest):
+class RetentionResponse(TypedDict):
+    result: List[Cohort]
+
+
+def get_retention_ok(client: Client, team_id: int, request: RetentionRequest) -> RetentionResponse:
     response = get_retention(client=client, team_id=team_id, request=request)
     assert response.status_code == 200, response.content
     return response.json()
@@ -88,17 +219,16 @@ def get_retention(client: Client, team_id: int, request: RetentionRequest):
     return client.get(
         f"/api/projects/{team_id}/insights/retention/",
         # NOTE: for get requests we need to JSON encode non-scalars
-        data={k: (v if isinstance(v, (str, numbers.Number)) else json.dumps(v)) for k, v in request.items()},
+        data={
+            k: (v if isinstance(v, (str, numbers.Number)) else json.dumps(v))
+            for k, v in asdict(request).items()
+            if v is not None
+        },
     )
 
 
-def get_people_for_retention_trend_series(client: Client, trend_series: Series):
-    def get_people_ids_via_url(people_url):
-        response = client.get(people_url)
-        assert response.status_code == 200, response.content
-        return sorted([distinct_id for person in response.json()["result"] for distinct_id in person["distinct_ids"]])
-
+def get_by_cohort_by_period_from_response(response: RetentionResponse):
     return {
-        day: get_people_ids_via_url(people_url) if count else []
-        for day, count, people_url in zip(trend_series["days"], trend_series["data"], trend_series["people_urls"])
+        cohort["label"]: {f"{period + 1}": value["count"] for period, value in enumerate(cohort["values"])}
+        for cohort in response["result"]
     }

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -100,6 +100,10 @@ class RetentionTests(TestCase):
                 period="Day",
                 retention_type="retention_first_time",
                 breakdowns=[Breakdown(type="person", property="os")],
+                # NOTE: we need to specify breakdown_type as well, as the
+                # breakdown logic currently does not support multiple differing
+                # types
+                breakdown_type="person",
             ),
         )
 
@@ -158,6 +162,10 @@ class RetentionTests(TestCase):
                 period="Day",
                 retention_type="retention_first_time",
                 breakdowns=[Breakdown(type="event", property="os")],
+                # NOTE: we need to specify breakdown_type as well, as the
+                # breakdown logic currently does not support multiple differing
+                # types
+                breakdown_type="event",
             ),
         )
 
@@ -200,6 +208,7 @@ class RetentionRequest:
     retention_type: Literal["retention_first_time"]  # probably not an exhaustive list
 
     breakdowns: Optional[List[Breakdown]] = None
+    breakdown_type: Optional[Literal["person", "events"]] = None
 
 
 class Value(TypedDict):

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -11,7 +11,7 @@ from ee.clickhouse.views.test.funnel.util import EventPattern
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
-from posthog.utils import json_encode_request_params
+from posthog.utils import encode_get_request_params
 
 
 class RetentionTests(TestCase):
@@ -236,7 +236,7 @@ def get_retention(client: Client, team_id: int, request: RetentionRequest):
     return client.get(
         f"/api/projects/{team_id}/insights/retention/",
         # NOTE: for get requests we need to JSON encode non-scalars
-        data=json_encode_request_params(asdict(request)),
+        data=encode_get_request_params(asdict(request)),
     )
 
 

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -15,7 +15,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.queries.abstract_test.test_compare import AbstractCompareTest
 from posthog.queries.stickiness import Stickiness
 from posthog.test.base import APIBaseTest
-from posthog.utils import json_encode_request_params
+from posthog.utils import encode_get_request_params
 
 
 def get_stickiness(client: Client, team_id: int, request: Dict[str, Any]):
@@ -23,7 +23,7 @@ def get_stickiness(client: Client, team_id: int, request: Dict[str, Any]):
 
 
 def get_stickiness_ok(client: Client, team_id: int, request: Dict[str, Any]):
-    response = get_stickiness(client=client, team_id=team_id, request=json_encode_request_params(data=request))
+    response = get_stickiness(client=client, team_id=team_id, request=encode_get_request_params(data=request))
     assert response.status_code == 200
     return response.json()
 
@@ -33,7 +33,7 @@ def get_stickiness_people(client: Client, team_id: int, request: Dict[str, Any])
 
 
 def get_stickiness_people_ok(client: Client, team_id: int, request: Dict[str, Any]):
-    response = get_stickiness_people(client=client, team_id=team_id, request=json_encode_request_params(data=request))
+    response = get_stickiness_people(client=client, team_id=team_id, request=encode_get_request_params(data=request))
     assert response.status_code == 200
     return response.json()
 

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -8,7 +8,7 @@ from rest_framework import request
 
 from posthog.models.filters.mixins.common import BaseParamMixin
 from posthog.models.utils import sane_repr
-from posthog.utils import json_encode_request_params
+from posthog.utils import encode_get_request_params
 
 
 class BaseFilter(BaseParamMixin):
@@ -40,7 +40,7 @@ class BaseFilter(BaseParamMixin):
         return ret
 
     def to_params(self) -> Dict[str, str]:
-        return json_encode_request_params(data=self.to_dict())
+        return encode_get_request_params(data=self.to_dict())
 
     def toJSON(self):
         return json.dumps(self.to_dict(), default=lambda o: o.__dict__, sort_keys=True, indent=4)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -867,8 +867,13 @@ def get_milliseconds_between_dates(d1: dt.datetime, d2: dt.datetime) -> int:
     return abs(int((d1 - d2).total_seconds() * 1000))
 
 
-def json_encode_request_params(data: Dict[str, Any]) -> Dict[str, str]:
-    return {key: encode_value_as_param(value=value) for key, value in data.items() if value is not None}
+def encode_get_request_params(data: Dict[str, Any]) -> Dict[str, str]:
+    return {
+        key: encode_value_as_param(value=value)
+        for key, value in data.items()
+        # NOTE: we cannot encode `None` as a GET parameter, so we simply omit it
+        if value is not None
+    }
 
 
 class DataclassJSONEncoder(json.JSONEncoder):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -868,7 +868,7 @@ def get_milliseconds_between_dates(d1: dt.datetime, d2: dt.datetime) -> int:
 
 
 def json_encode_request_params(data: Dict[str, Any]) -> Dict[str, str]:
-    return {key: encode_value_as_param(value=value) for key, value in data.items()}
+    return {key: encode_value_as_param(value=value) for key, value in data.items() if value is not None}
 
 
 class DataclassJSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
## Changes

This just reuses the work done for funnel multiple breakdown values. I
haven't tested this with anything other than person or event properties.
Rather than try to get it working for all the other property types.
    
The change adds a new `breakdowns` parameter to the retention endpoint,
that is the same as for funnels, e.g. it looks like:
    
    ```
    {
        ...
        "breakdowns": [{"type": "person", "property": "os"}, ...],
        "breakdown_type": "person",
        ...
    }
    ```
    
The return structure is the same as the non-breakdown version, except we
also include a `breakdown_values` property that is e.g. `["Chrome",
"95"]`, and the `label` attribute for this case would be "Chrome::95".

Breakdowns do not include the cohorts breakdown, although this could be a further feature, although without this I think we still get some useful insights.

I'll put the frontend related code in a separate PR.

## Context

Aside from achieving parity with solutions such as [Mixpanel retention breakdown](https://help.mixpanel.com/hc/en-us/articles/360001370146-Build-a-Retention-Report-#breakdown) and [Amplitude's retention "grouped by" functionality](https://help.amplitude.com/hc/en-us/articles/360050153151-Build-a-retention-analysis), we want to enabled our users to validate hypotheses about how user characteristics affect retention.

Example use cases being:

 1. does the experience in different browsers affect retention
 2. does the version of the software a user is using affect the retention
 3. does the location of a user affect the retention
 4. does the marketing campaign a user was acquired by affect a users retention

The action on validation being, for example, investigating the performance of the app on different browsers/versions, or looking at the translation of the website to clarify that alternative internationalisation are up to scratch.

As it is, we show a breakdown by first "target event" occurrence, which allows us to see how the timing of a user onboarding affects the retention of users in cohorts. Typically users of similar types come in at the same time, e.g. through advertising with specific messaging.

## Followups

 1. display trend graph on same page as table
 2. get other prs

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
