### PR TITLE
Add names to celery nodes (#7054 pt. 2)

### DIFF
--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-NODE_ID=$(python3 -c "import random; print(random.randint(0, 10000000000))")
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler -n "worker#$NODE_ID"
+celery -A posthog beat -S redbeat.RedBeatScheduler -n node@%%h

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
 
+NODE_ID=$(python3 -c "import random; print(random.randint(0, 10000000000))")
+
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler -n $(openssl rand -hex 10)
+celery -A posthog beat -S redbeat.RedBeatScheduler -n "worker#$NODE_ID"

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -2,4 +2,4 @@
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"
-celery -A posthog beat -S redbeat.RedBeatScheduler
+celery -A posthog beat -S redbeat.RedBeatScheduler -n $(openssl rand -hex 10)

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -63,11 +63,9 @@ if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &
 fi
 
-NODE_ID=$(python3 -c "import random; print(random.randint(0, 10000000000))")
-
 FLAGS=()
 FLAGS+=("-Ofair")
-FLAGS+=("-n worker#$NODE_ID")
+FLAGS+=("-n node@%%h")
 [ "$with_gossip" == "false" ]    && FLAGS+=("--without-gossip")
 [ "$with_mingle" == "false" ]    && FLAGS+=("--without-mingle")
 [ "$with_heartbeat" == "false" ] && FLAGS+=("--without-heartbeat")

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -63,8 +63,11 @@ if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &
 fi
 
+NODE_ID=$(openssl rand -hex 10)
+
 FLAGS=()
 FLAGS+=("-Ofair")
+FLAGS+=("-n $NODE_ID")
 [ "$with_gossip" == "false" ]    && FLAGS+=("--without-gossip")
 [ "$with_mingle" == "false" ]    && FLAGS+=("--without-mingle")
 [ "$with_heartbeat" == "false" ] && FLAGS+=("--without-heartbeat")

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -63,11 +63,11 @@ if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &
 fi
 
-NODE_ID=$(openssl rand -hex 10)
+NODE_ID=$(python3 -c "import random; print(random.randint(0, 10000000000))")
 
 FLAGS=()
 FLAGS+=("-Ofair")
-FLAGS+=("-n $NODE_ID")
+FLAGS+=("-n worker#$NODE_ID")
 [ "$with_gossip" == "false" ]    && FLAGS+=("--without-gossip")
 [ "$with_mingle" == "false" ]    && FLAGS+=("--without-mingle")
 [ "$with_heartbeat" == "false" ] && FLAGS+=("--without-heartbeat")

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -4,10 +4,8 @@ set -e
 # this kills all processes when the last one terminates
 trap 'kill $(jobs -p)' EXIT
 
-NODE_ID=$(python3 -c "import random; print(random.randint(0, 10000000000))")
-
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair -n "worker#$NODE_ID" &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair -n node@%%h &
 
 # start celery plugin worker
 ./bin/plugin-server

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -5,7 +5,7 @@ set -e
 trap 'kill $(jobs -p)' EXIT
 
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair -n $(openssl rand -hex 10) &
 
 # start celery plugin worker
 ./bin/plugin-server

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -4,8 +4,10 @@ set -e
 # this kills all processes when the last one terminates
 trap 'kill $(jobs -p)' EXIT
 
+NODE_ID=$(python3 -c "import random; print(random.randint(0, 10000000000))")
+
 # start celery worker with heartbeat (-B)
-celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair -n $(openssl rand -hex 10) &
+celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle -Ofair -n "worker#$NODE_ID" &
 
 # start celery plugin worker
 ./bin/plugin-server


### PR DESCRIPTION
## Changes

While working on #7054 I stumbled upon the fact that we don't name our celery nodes. We've always shipped with one node, but with the chart people can now scale up to 20 very easily.

Not only is it best practice to name them, I also need this in order to keep track of nodes crashing when running special migrations.

@mariusandra tagged because you worked on these scripts last apparently.

## How did you test this code?

Ran the scripts locally