### PR TITLE
Reads display into ChartFilter with new short urls

### DIFF
--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.test.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.test.ts
@@ -1,0 +1,29 @@
+import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
+import { initKeaTestLogic } from '~/test/init'
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+const insightsURL = (additionalPathPart: string = ''): string =>
+    `/insights/smosHASp${additionalPathPart}?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&display=ActionsPie`
+
+describe('the chart filter', () => {
+    let logic: ReturnType<typeof chartFilterLogic.build>
+
+    initKeaTestLogic({
+        logic: chartFilterLogic,
+        props: {},
+        onLogic: (l) => (logic = l),
+    })
+
+    it('reads display type from URL when editing', () => {
+        expectLogic(logic, () => {
+            router.actions.push(insightsURL())
+        }).toMatchValues({ chartFilter: 'ActionsPie' })
+    })
+
+    it('reads display type from URL when viewing', () => {
+        expectLogic(logic, () => {
+            router.actions.push(insightsURL('/edit'))
+        }).toMatchValues({ chartFilter: 'ActionsPie' })
+    })
+})

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.test.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.test.ts
@@ -15,6 +15,10 @@ describe('the chart filter', () => {
         onLogic: (l) => (logic = l),
     })
 
+    it('defaults to null', () => {
+        expectLogic(logic).toMatchValues({ chartFilter: null })
+    })
+
     it('reads display type from URL when editing', () => {
         expectLogic(logic, () => {
             router.actions.push(insightsURL())

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -40,7 +40,7 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights': (_, { display, insight, funnel_viz_type }) => {
+        '/insights/:shortid(/edit)': (_, { display, insight, funnel_viz_type }) => {
             if (display === ChartDisplayType.FunnelViz && !funnel_viz_type) {
                 actions.setChartFilter(FunnelVizType.Steps)
             } else if (display && !funnel_viz_type) {


### PR DESCRIPTION
## Changes

The ChartFilter component needed updating to respond to insights with short URLs

![2021-11-30 13 55 18](https://user-images.githubusercontent.com/984817/144066315-1ce2b3d8-061a-4d3c-9061-60679f77edb9.gif)

## How did you test this code?

with unit tests and manually

1) load an insight in view or edit mode
2) change the type away from linear (which is the default type)
3) refresh the page
4) observe that the chart displayed is the chosen type but the chart filter displays "linear"
