### PR TITLE
Insight analytics fixes

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -147,6 +147,7 @@ export const eventUsageLogic = kea<
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
+        reportInsightCreated: (insight: InsightType) => ({ insight }),
         reportInsightViewed: (
             filters: Partial<FilterType>,
             isFirstLoad: boolean,
@@ -343,6 +344,10 @@ export const eventUsageLogic = kea<
                 posthog_properties_count,
             }
             posthog.capture('person viewed', properties)
+        },
+        reportInsightCreated: async ({ insight }, breakpoint) => {
+            await breakpoint(500) // Debounce to avoid multiple quick "New insight" clicks being reported
+            posthog.capture('insight created', { insight })
         },
         reportInsightViewed: async ({ filters, isFirstLoad, fromDashboard, delay, changedFilters }, breakpoint) => {
             if (!delay) {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -402,6 +402,7 @@ export const eventUsageLogic = kea<
             } else if (insight === 'STICKINESS') {
                 properties.stickiness_days = filters.stickiness_days
             }
+            properties.compare = filters.compare // "Compare previous" option
 
             const eventName = delay ? 'insight analyzed' : 'insight viewed'
             posthog.capture(eventName, { ...properties, ...(changedFilters ? changedFilters : {}) })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -147,7 +147,7 @@ export const eventUsageLogic = kea<
     actions: {
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
-        reportInsightCreated: (insight: InsightType) => ({ insight }),
+        reportInsightCreated: (insight: InsightType | null) => ({ insight }),
         reportInsightViewed: (
             filters: Partial<FilterType>,
             isFirstLoad: boolean,

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1376,7 +1376,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
             },
             breakpoint: BreakPointFunction
         ) => {
-            if (visible && values.shouldReportCorrelationViewed) {
+            if (visible && values.correlationAnalysisAvailable && values.shouldReportCorrelationViewed) {
                 eventUsageLogic.actions.reportCorrelationViewed(values.filters, 0)
                 await breakpoint(10000)
                 eventUsageLogic.actions.reportCorrelationViewed(values.filters, 10)
@@ -1391,7 +1391,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
             },
             breakpoint: BreakPointFunction
         ) => {
-            if (visible && values.shouldReportPropertyCorrelationViewed) {
+            if (visible && values.correlationAnalysisAvailable && values.shouldReportPropertyCorrelationViewed) {
                 eventUsageLogic.actions.reportCorrelationViewed(values.filters, 0, true)
                 await breakpoint(10000)
                 eventUsageLogic.actions.reportCorrelationViewed(values.filters, 10, true)

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -132,9 +132,16 @@ describe('insightLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.setFilters({ insight: InsightType.FUNNELS })
             }).toDispatchActions([
-                eventUsageLogic.actionCreators.reportInsightViewed({ insight: InsightType.FUNNELS }, true, false, 0, {
-                    changed_insight: InsightType.TRENDS,
-                }),
+                eventUsageLogic.actionCreators.reportInsightViewed(
+                    { insight: InsightType.FUNNELS },
+                    ItemMode.View,
+                    true,
+                    false,
+                    0,
+                    {
+                        changed_insight: InsightType.TRENDS,
+                    }
+                ),
             ])
         })
     })

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -306,6 +306,8 @@ export const insightLogic = kea<insightLogicType>({
                 setFilters: (state, { filters }) => cleanFilters(filters, state),
                 setInsight: (state, { insight: { filters }, options: { overrideFilter } }) =>
                     overrideFilter ? cleanFilters(filters || {}) : state,
+                loadInsightSuccess: (state, { insight }) =>
+                    Object.keys(state).length === 0 && insight.filters ? insight.filters : state,
                 loadResultsSuccess: (state, { insight }) =>
                     Object.keys(state).length === 0 && insight.filters ? insight.filters : state,
             },
@@ -607,7 +609,6 @@ export const insightLogic = kea<insightLogicType>({
             }
         },
         loadInsightSuccess: async ({ payload, insight }) => {
-            actions.setFilters(insight.filters)
             // loaded `/api/projects/:id/insights`, but it didn't have `results`, so make another query
             if (!insight.result && values.filters && !payload?.doNotLoadResults) {
                 actions.loadResults()
@@ -652,7 +653,7 @@ export const insightLogic = kea<insightLogicType>({
                 newInsight
             )
             breakpoint()
-            eventUsageLogic.actions.reportInsightCreated(filters.insight || null)
+            eventUsageLogic.actions.reportInsightCreated(filters?.insight || null)
             router.actions.replace(
                 urls.insightEdit(createdInsight.short_id, cleanFilters(createdInsight.filters || filters || {}))
             )

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -62,6 +62,10 @@ export const insightLogic = kea<insightLogicType>({
         setActiveView: (type: InsightType) => ({ type }),
         updateActiveView: (type: InsightType) => ({ type }),
         setFilters: (filters: Partial<FilterType>, insightMode?: ItemMode) => ({ filters, insightMode }),
+        reportInsightViewed: (filters: Partial<FilterType>, previousFilters?: Partial<FilterType>) => ({
+            filters,
+            previousFilters,
+        }),
         startQuery: (queryId: string) => ({ queryId }),
         endQuery: (
             queryId: string,
@@ -420,23 +424,13 @@ export const insightLogic = kea<insightLogicType>({
         ],
     },
     listeners: ({ actions, selectors, values, props }) => ({
-        setFilters: async ({ filters }, breakpoint, _, previousState) => {
-            const { fromDashboard } = router.values.hashParams
+        setFilters: async ({ filters }, _, __, previousState) => {
             const previousFilters = selectors.filters(previousState)
             if (objectsEqual(previousFilters, filters)) {
                 return
             }
 
-            const changedKeysObj: Record<string, any> = extractObjectDiffKeys(previousFilters, filters)
-
-            eventUsageLogic.actions.reportInsightViewed(
-                filters,
-                values.insightMode,
-                values.isFirstLoad,
-                Boolean(fromDashboard),
-                0,
-                changedKeysObj
-            )
+            actions.reportInsightViewed(filters, previousFilters)
             actions.setNotFirstLoad()
 
             const filterLength = (filter?: Partial<FilterType>): number =>
@@ -470,11 +464,24 @@ export const insightLogic = kea<insightLogicType>({
             ) {
                 actions.loadResults()
             }
+        },
+        reportInsightViewed: async ({ filters, previousFilters }, breakpoint) => {
+            const { fromDashboard } = router.values.hashParams
+            const changedKeysObj: Record<string, any> | undefined =
+                previousFilters && extractObjectDiffKeys(previousFilters, filters)
 
-            // tests will wait for all breakpoints to finish
-            await breakpoint(IS_TEST_MODE ? 1 : 10000)
             eventUsageLogic.actions.reportInsightViewed(
-                filters,
+                filters || {},
+                values.insightMode,
+                values.isFirstLoad,
+                Boolean(fromDashboard),
+                0,
+                changedKeysObj
+            )
+            await breakpoint(IS_TEST_MODE ? 1 : 10000) // Tests will wait for all breakpoints to finish
+
+            eventUsageLogic.actions.reportInsightViewed(
+                filters || {},
                 values.insightMode,
                 values.isFirstLoad,
                 Boolean(fromDashboard),
@@ -609,6 +616,7 @@ export const insightLogic = kea<insightLogicType>({
             }
         },
         loadInsightSuccess: async ({ payload, insight }) => {
+            actions.reportInsightViewed(insight?.filters || {})
             // loaded `/api/projects/:id/insights`, but it didn't have `results`, so make another query
             if (!insight.result && values.filters && !payload?.doNotLoadResults) {
                 actions.loadResults()

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -306,8 +306,6 @@ export const insightLogic = kea<insightLogicType>({
                 setFilters: (state, { filters }) => cleanFilters(filters, state),
                 setInsight: (state, { insight: { filters }, options: { overrideFilter } }) =>
                     overrideFilter ? cleanFilters(filters || {}) : state,
-                loadInsightSuccess: (state, { insight }) =>
-                    Object.keys(state).length === 0 && insight.filters ? insight.filters : state,
                 loadResultsSuccess: (state, { insight }) =>
                     Object.keys(state).length === 0 && insight.filters ? insight.filters : state,
             },
@@ -609,6 +607,7 @@ export const insightLogic = kea<insightLogicType>({
             }
         },
         loadInsightSuccess: async ({ payload, insight }) => {
+            actions.setFilters(insight.filters)
             // loaded `/api/projects/:id/insights`, but it didn't have `results`, so make another query
             if (!insight.result && values.filters && !payload?.doNotLoadResults) {
                 actions.loadResults()

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -651,6 +651,7 @@ export const insightLogic = kea<insightLogicType>({
                 newInsight
             )
             breakpoint()
+            eventUsageLogic.actions.reportInsightCreated(filters.insight || null)
             router.actions.replace(
                 urls.insightEdit(createdInsight.short_id, cleanFilters(createdInsight.filters || filters || {}))
             )

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -431,6 +431,7 @@ export const insightLogic = kea<insightLogicType>({
 
             eventUsageLogic.actions.reportInsightViewed(
                 filters,
+                values.insightMode,
                 values.isFirstLoad,
                 Boolean(fromDashboard),
                 0,
@@ -474,6 +475,7 @@ export const insightLogic = kea<insightLogicType>({
             await breakpoint(IS_TEST_MODE ? 1 : 10000)
             eventUsageLogic.actions.reportInsightViewed(
                 filters,
+                values.insightMode,
                 values.isFirstLoad,
                 Boolean(fromDashboard),
                 10,


### PR DESCRIPTION
## Changes

Resolves #7347. All three points should be fixed. I also instrumented a new event: "insight created".

## How did you test this code?

Reproduced cases mentioned in the issue manually. Unfortunately this isn't really testable with Jest, as the instrumentations relies heavily on how `insightLogic` is used, meaning any refactor of insight components and other logics could easily make tests test the wrong thing. Some E2E testing of instrumentation would be ideal, but I don't know if there's a way to do that already and didn't want to get into it currently.