### PR TITLE
Update sentry org to posthog2 in GH action

### DIFF
--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -132,7 +132,7 @@ jobs:
               uses: getsentry/action-release@v1
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_ORG: posthog
+                  SENTRY_ORG: posthog2
                   SENTRY_PROJECT: posthog
               with:
                   environment: production


### PR DESCRIPTION
## Changes

Updating the name of our sentry org to allow the GH action to notify sentry on prod deployments. Should resolve this: https://github.com/PostHog/posthog/runs/4371139362?check_suite_focus=true

## How did you test this code?

...
