### PR TITLE
Fix error too deep recursion

### DIFF
--- a/ee/clickhouse/models/action.py
+++ b/ee/clickhouse/models/action.py
@@ -46,7 +46,6 @@ def format_action_filter(
 
             prop_query, prop_params = parse_prop_clauses(
                 Filter(data={"properties": step.properties}).properties,
-                team_id=action.team.pk if filter_by_team else None,
                 prepend=f"action_props_{action.pk}_{step.pk}",
                 table_name=table_name,
                 person_properties_mode=person_properties_mode,

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -242,9 +242,11 @@ def get_person_ids_by_cohort_id(team: Team, cohort_id: int):
     from ee.clickhouse.models.property import parse_prop_clauses
 
     filters = Filter(data={"properties": [{"key": "id", "value": cohort_id, "type": "cohort"}],})
-    filter_query, filter_params = parse_prop_clauses(filters.properties, team.pk, table_name="pdi")
+    filter_query, filter_params = parse_prop_clauses(filters.properties, table_name="pdi")
 
-    results = sync_execute(GET_PERSON_IDS_BY_FILTER.format(distinct_query=filter_query, query=""), filter_params,)
+    results = sync_execute(
+        GET_PERSON_IDS_BY_FILTER.format(distinct_query=filter_query, query=""), {**filter_params, "team_id": team.pk}
+    )
 
     return [str(row[0]) for row in results]
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -102,7 +102,7 @@ def parse_prop_clauses(
                 allow_denormalized_props=allow_denormalized_props,
             )
 
-            final.append(filter_query)
+            final.append(f" AND {filter_query}")
             params.update(filter_params)
         elif prop.type == "group":
             if group_properties_joined:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -35,7 +35,6 @@ from posthog.utils import is_valid_regex, relative_date_parse
 
 def parse_prop_clauses(
     filters: List[Property],
-    team_id: Optional[int],
     prepend: str = "global",
     table_name: str = "",
     allow_denormalized_props: bool = True,
@@ -46,15 +45,13 @@ def parse_prop_clauses(
 ) -> Tuple[str, Dict]:
     final = []
     params: Dict[str, Any] = {}
-    if team_id is not None:
-        params["team_id"] = team_id
     if table_name != "":
         table_name += "."
 
     for idx, prop in enumerate(filters):
         if prop.type == "cohort":
             try:
-                cohort = Cohort.objects.get(pk=prop.value, team_id=team_id)
+                cohort = Cohort.objects.get(pk=prop.value)
             except Cohort.DoesNotExist:
                 final.append("AND 0 = 13")  # If cohort doesn't exist, nothing can match
             else:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -102,7 +102,7 @@ def parse_prop_clauses(
                 allow_denormalized_props=allow_denormalized_props,
             )
 
-            final.append(f" AND {filter_query}")
+            final.append(f" {filter_query}")
             params.update(filter_params)
         elif prop.type == "group":
             if group_properties_joined:

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -102,7 +102,7 @@ def parse_prop_clauses(
                 allow_denormalized_props=allow_denormalized_props,
             )
 
-            final.append(f"{filter_query} AND {table_name}team_id = %(team_id)s" if team_id else filter_query)
+            final.append(filter_query)
             params.update(filter_params)
         elif prop.type == "group":
             if group_properties_joined:

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -42,7 +42,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.1
   <class 'tuple'> (
-    ' AND has(%(vglobal_0)s, mat_event_prop) AND trim(BOTH \'"\' FROM JSONExtractRaw(person_props, %(kglobalperson_1)s)) ILIKE %(vglobalperson_1)s',
+    ' AND has(%(vglobal_0)s, mat_event_prop) AND pmat_email ILIKE %(vglobalperson_1)s',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kglobalperson_1': 'email',

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -1,7 +1,7 @@
 # name: test_parse_prop_clauses_defaults
   <class 'tuple'> (
     '
-       AND has(%(vglobal_0)s, mat_event_prop) AND distinct_id IN (
+       AND has(%(vglobal_0)s, trim(BOTH '"' FROM JSONExtractRaw(properties, %(kglobal_0)s))) AND distinct_id IN (
       SELECT distinct_id
       FROM (
           
@@ -42,7 +42,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.1
   <class 'tuple'> (
-    ' AND has(%(vglobal_0)s, mat_event_prop) AND pmat_email ILIKE %(vglobalperson_1)s',
+    ' AND has(%(vglobal_0)s, trim(BOTH \'"\' FROM JSONExtractRaw(properties, %(kglobal_0)s))) AND trim(BOTH \'"\' FROM JSONExtractRaw(person_props, %(kglobalperson_1)s)) ILIKE %(vglobalperson_1)s',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kglobalperson_1': 'email',
@@ -55,7 +55,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.2
   <class 'tuple'> (
-    ' AND has(%(vglobal_0)s, mat_event_prop)',
+    ' AND has(%(vglobal_0)s, trim(BOTH \'"\' FROM JSONExtractRaw(properties, %(kglobal_0)s)))',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'vglobal_0': <class 'list'> [

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -1,7 +1,7 @@
 # name: test_parse_prop_clauses_defaults
   <class 'tuple'> (
     '
-      AND has(%(vglobal_0)s, trim(BOTH '"' FROM JSONExtractRaw(properties, %(kglobal_0)s))) AND distinct_id IN (
+       AND has(%(vglobal_0)s, mat_event_prop) AND distinct_id IN (
       SELECT distinct_id
       FROM (
           
@@ -42,7 +42,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.1
   <class 'tuple'> (
-    'AND has(%(vglobal_0)s, trim(BOTH \'"\' FROM JSONExtractRaw(properties, %(kglobal_0)s))) AND trim(BOTH \'"\' FROM JSONExtractRaw(person_props, %(kglobalperson_1)s)) ILIKE %(vglobalperson_1)s',
+    ' AND has(%(vglobal_0)s, mat_event_prop) AND trim(BOTH \'"\' FROM JSONExtractRaw(person_props, %(kglobalperson_1)s)) ILIKE %(vglobalperson_1)s',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kglobalperson_1': 'email',
@@ -55,7 +55,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.2
   <class 'tuple'> (
-    'AND has(%(vglobal_0)s, trim(BOTH \'"\' FROM JSONExtractRaw(properties, %(kglobal_0)s)))',
+    ' AND has(%(vglobal_0)s, mat_event_prop)',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'vglobal_0': <class 'list'> [

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -79,7 +79,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],})
-        query, params = parse_prop_clauses(filter.properties, self.team.pk)
+        query, params = parse_prop_clauses(filter.properties)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 1)
@@ -107,7 +107,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort1 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk}], name="cohort1",)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_clauses(filter.properties, self.team.pk)
+        query, params = parse_prop_clauses(filter.properties)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 1)
@@ -146,7 +146,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             filter = Filter(
                 data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team
             )
-            query, params = parse_prop_clauses(filter.properties, self.team.pk)
+            query, params = parse_prop_clauses(filter.properties)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
             self.assertEqual(len(result), 1)
@@ -158,7 +158,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             filter = Filter(
                 data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team
             )
-            query, params = parse_prop_clauses(filter.properties, self.team.pk)
+            query, params = parse_prop_clauses(filter.properties)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
             self.assertEqual(len(result), 2)
@@ -198,7 +198,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             filter = Filter(
                 data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team
             )
-            query, params = parse_prop_clauses(filter.properties, self.team.pk)
+            query, params = parse_prop_clauses(filter.properties)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
             self.assertEqual(len(result), 1)
@@ -210,7 +210,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             filter = Filter(
                 data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team
             )
-            query, params = parse_prop_clauses(filter.properties, self.team.pk)
+            query, params = parse_prop_clauses(filter.properties)
             final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
             result = sync_execute(final_query, {**params, "team_id": self.team.pk})
             self.assertEqual(len(result), 2)
@@ -235,7 +235,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_clauses(filter.properties, self.team.pk)
+        query, params = parse_prop_clauses(filter.properties)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)
@@ -263,7 +263,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_clauses(filter.properties, self.team.pk)
+        query, params = parse_prop_clauses(filter.properties)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 0)

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -19,7 +19,7 @@ from posthog.models.team import Team
 def _filter_events(
     filter: Filter, team: Team, person_query: Optional[bool] = False, order_by: Optional[str] = None,
 ):
-    prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
+    prop_filters, prop_filter_params = parse_prop_clauses(filter.properties)
     params = {"team_id": team.pk, **prop_filter_params}
 
     if order_by == "id":
@@ -230,9 +230,7 @@ class TestFiltering(
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
 
-        prop_clause, prop_clause_params = parse_prop_clauses(
-            filter.properties, self.team.pk, has_person_id_joined=False
-        )
+        prop_clause, prop_clause_params = parse_prop_clauses(filter.properties, has_person_id_joined=False)
         query = """
         SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
         """.format(
@@ -244,9 +242,7 @@ class TestFiltering(
 
         # test cohort2 with negation
         filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team)
-        prop_clause, prop_clause_params = parse_prop_clauses(
-            filter.properties, self.team.pk, has_person_id_joined=False
-        )
+        prop_clause, prop_clause_params = parse_prop_clauses(filter.properties, has_person_id_joined=False)
         query = """
         SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
         """.format(

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -38,7 +38,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
     CLASS_DATA_LEVEL_SETUP = False
 
     def _run_query(self, filter: Filter) -> List:
-        query, params = parse_prop_clauses(filter.properties, self.team.pk, allow_denormalized_props=True)
+        query, params = parse_prop_clauses(filter.properties, allow_denormalized_props=True)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         return sync_execute(final_query, {**params, "team_id": self.team.pk})
 
@@ -338,10 +338,7 @@ class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
 
     def _run_query(self, filter: Filter, join_person_tables=False) -> List:
         query, params = parse_prop_clauses(
-            filter.properties,
-            self.team.pk,
-            allow_denormalized_props=True,
-            person_properties_mode=PersonPropertiesMode.EXCLUDE,
+            filter.properties, allow_denormalized_props=True, person_properties_mode=PersonPropertiesMode.EXCLUDE,
         )
         joins = ""
         if join_person_tables:
@@ -436,14 +433,14 @@ def test_parse_prop_clauses_defaults(snapshot):
         }
     )
 
-    assert parse_prop_clauses(filter.properties, None) == snapshot
+    assert parse_prop_clauses(filter.properties) == snapshot
     assert (
         parse_prop_clauses(
-            filter.properties, None, person_properties_mode=PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN
+            filter.properties, person_properties_mode=PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN
         )
         == snapshot
     )
-    assert parse_prop_clauses(filter.properties, None, person_properties_mode=PersonPropertiesMode.EXCLUDE) == snapshot
+    assert parse_prop_clauses(filter.properties, person_properties_mode=PersonPropertiesMode.EXCLUDE) == snapshot
 
 
 TEST_BREAKDOWN_PROCESSING = [

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -50,7 +50,6 @@ def get_breakdown_prop_values(
     parsed_date_from, parsed_date_to, date_params = parse_timestamps(filter=filter, team_id=team_id)
     prop_filters, prop_filter_params = parse_prop_clauses(
         filter.properties + entity.properties,
-        team_id,
         table_name="e",
         prepend="e_brkdwn",
         person_properties_mode=PersonPropertiesMode.EXCLUDE,
@@ -132,7 +131,7 @@ def _format_all_query(team_id: int, filter: Filter, **kwargs) -> Tuple[str, Dict
         props_to_filter = [*props_to_filter, *entity.properties]
 
     prop_filters, prop_filter_params = parse_prop_clauses(
-        props_to_filter, team_id, prepend="all_cohort_", table_name="all_events"
+        props_to_filter, prepend="all_cohort_", table_name="all_events"
     )
     query = f"""
             SELECT DISTINCT distinct_id, {ALL_USERS_COHORT_ID} as value

--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -105,7 +105,7 @@ class ClickhouseRetention(Retention):
         period = filter.period
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties)
 
         returning_entity = filter.returning_entity if filter.selected_interval > 0 else filter.target_entity
         target_query, target_params = self._get_condition(filter.target_entity, table="e")
@@ -161,7 +161,7 @@ class ClickhouseRetention(Retention):
         period = filter.period
         is_first_time_retention = filter.retention_type == RETENTION_FIRST_TIME
         trunc_func = get_trunc_func_ch(period)
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties)
 
         target_query, target_params = self._get_condition(filter.target_entity, table="e")
         target_query_formatted = "AND {target_query}".format(target_query=target_query)

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -159,7 +159,6 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
             else:
                 filter_query, filter_params = parse_prop_clauses(
                     [prop],
-                    self._team_id,
                     prepend=f"global_{idx}",
                     allow_denormalized_props=True,
                     person_properties_mode=PersonPropertiesMode.EXCLUDE,

--- a/ee/clickhouse/queries/funnels/base.py
+++ b/ee/clickhouse/queries/funnels/base.py
@@ -411,7 +411,6 @@ class ClickhouseFunnelBase(ABC, Funnel):
     def _build_filters(self, entity: Entity, index: int) -> str:
         prop_filters, prop_filter_params = parse_prop_clauses(
             entity.properties,
-            self._team.pk,
             prepend=str(index),
             person_properties_mode=PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
             person_id_joined_alias="aggregation_target",

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -385,7 +385,6 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-08 23:59:59'
        AND NOT has([''], $group_0)
-       AND e.team_id = 2
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -512,8 +511,7 @@
                             AND event IN ['buy', 'play movie', 'sign up']
                             AND timestamp >= '2020-01-01 00:00:00'
                             AND timestamp <= '2020-01-08 23:59:59'
-                            AND NOT has([''], $group_0)
-                            AND team_id = 2 ) events
+                            AND NOT has([''], $group_0) ) events
                        WHERE (step_0 = 1
                               OR step_1 = 1
                               OR step_2 = 1) ))))

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -41,13 +41,11 @@
                            timestamp,
                            if(((event = 'user signed up'
                                 AND has(['val'], trim(BOTH '"'
-                                                      FROM JSONExtractRaw(properties, 'key')))
-                                AND team_id = 2)) , 1, 0) as step_0,
+                                                      FROM JSONExtractRaw(properties, 'key'))))) , 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(((event = 'paid'
                                 AND has(['val'], trim(BOTH '"'
-                                                      FROM JSONExtractRaw(properties, 'key')))
-                                AND team_id = 2)) , 1, 0) as step_1,
+                                                      FROM JSONExtractRaw(properties, 'key'))))) , 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM
                       (SELECT e.event as event,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -19,7 +19,6 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-08 23:59:59'
        AND NOT has([''], $group_0)
-       AND e.team_id = 2
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -122,8 +121,7 @@
                     WHERE team_id = 2
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-08 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (1=1) ))
            WHERE step_0 = 1 ))
      GROUP BY aggregation_target,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -146,7 +146,6 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-08 23:59:59'
        AND NOT has([''], $group_0)
-       AND e.team_id = 2
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -174,7 +173,6 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-08 23:59:59'
        AND NOT has([''], $group_0)
-       AND e.team_id = 2
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -202,7 +200,6 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-08 23:59:59'
        AND NOT has([''], $group_0)
-       AND e.team_id = 2
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -304,8 +301,7 @@
                       AND event IN ['buy', 'play movie', 'sign up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-08 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1
                         OR step_2 = 1) ))
@@ -377,8 +373,7 @@
                       AND event IN ['buy', 'play movie', 'sign up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-08 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1
                         OR step_2 = 1) ))
@@ -450,8 +445,7 @@
                       AND event IN ['buy', 'play movie', 'sign up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-08 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1
                         OR step_2 = 1) ))

--- a/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
+++ b/ee/clickhouse/queries/session_recordings/clickhouse_session_recording_list.py
@@ -216,7 +216,6 @@ class ClickhouseSessionRecordingList(ClickhouseEventQuery):
             filters, filter_params = parse_prop_clauses(
                 entity.properties,
                 prepend=prepend,
-                team_id=self._team_id,
                 allow_denormalized_props=True,
                 has_person_id_joined=True,
                 person_properties_mode=PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,

--- a/ee/clickhouse/queries/sessions/average.py
+++ b/ee/clickhouse/queries/sessions/average.py
@@ -27,7 +27,7 @@ class ClickhouseSessionsAvg:
         parsed_date_from, parsed_date_to, date_params = parse_timestamps(filter, team.pk)
 
         filters, params = parse_prop_clauses(
-            filter.properties, team.pk, has_person_id_joined=False, group_properties_joined=False
+            filter.properties, has_person_id_joined=False, group_properties_joined=False
         )
 
         trunc_func = get_trunc_func_ch(filter.interval)

--- a/ee/clickhouse/queries/sessions/distribution.py
+++ b/ee/clickhouse/queries/sessions/distribution.py
@@ -13,7 +13,7 @@ class ClickhouseSessionsDist:
         parsed_date_from, parsed_date_to, date_params = parse_timestamps(filter, team.pk)
 
         filters, params = parse_prop_clauses(
-            filter.properties, team.pk, has_person_id_joined=False, group_properties_joined=False
+            filter.properties, has_person_id_joined=False, group_properties_joined=False
         )
 
         entity_conditions, entity_params = entity_query_conditions(filter, team)

--- a/ee/clickhouse/queries/sessions/util.py
+++ b/ee/clickhouse/queries/sessions/util.py
@@ -14,7 +14,6 @@ def event_entity_to_query(entity: Entity, team: Team, prepend="event_entity") ->
 
         prop_query, prop_params = parse_prop_clauses(
             entity.properties,
-            team_id=team.pk,
             prepend="{}_props".format(prepend),
             allow_denormalized_props=False,
             has_person_id_joined=False,

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -77,7 +77,6 @@
     AND timestamp <= '2021-01-21 23:59:59'
     AND has(['Jane'], trim(BOTH '"'
                            FROM JSONExtractRaw(properties, 'name')))
-    AND team_id = 2
   '
 ---
 # name: TestEventQuery.test_basic_event_filter
@@ -151,9 +150,7 @@
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
     AND timestamp <= '2020-01-14 23:59:59'
     AND has(['hi'], mat_test_prop)
-    AND team_id = 2
     AND has(['hi'], mat_test_prop)
-    AND team_id = 2
   '
 ---
 # name: TestEventQuery.test_element
@@ -241,7 +238,6 @@
     AND timestamp <= '2021-05-07 23:59:59'
     AND has(['test_val'], trim(BOTH '"'
                                FROM JSONExtractRaw(properties, 'some_key')))
-    AND team_id = 2
   '
 ---
 # name: TestEventQuery.test_event_properties_filter.1
@@ -255,7 +251,6 @@
     AND timestamp <= '2021-05-07 23:59:59'
     AND has(['test_val'], trim(BOTH '"'
                                FROM JSONExtractRaw(properties, 'some_key')))
-    AND team_id = 2
   '
 ---
 # name: TestEventQuery.test_groups_filters

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -28,8 +28,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], $group_0)
-       AND team_id = 2 ) event
+       AND NOT has([''], $group_0) ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      e.$group_0 as target,
@@ -54,8 +53,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], $group_0)
-       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
+       AND NOT has([''], $group_0) ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -92,8 +90,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], $group_0)
-       AND team_id = 2 )
+       AND NOT has([''], $group_0) )
   GROUP BY event_date
   ORDER BY event_date
   '
@@ -128,8 +125,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], $group_1)
-       AND team_id = 2 ) event
+       AND NOT has([''], $group_1) ) event
   JOIN
     (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                      e.$group_1 as target,
@@ -154,8 +150,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], $group_1)
-       AND team_id = 2 ) reference_event ON (event.target = reference_event.target)
+       AND NOT has([''], $group_1) ) reference_event ON (event.target = reference_event.target)
   WHERE toStartOfWeek(event.event_date) > toStartOfWeek(reference_event.event_date)
   GROUP BY base_interval,
            intervals_from_base
@@ -192,8 +187,7 @@
        AND e.event = '$pageview'
        AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
        AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-       AND NOT has([''], $group_1)
-       AND team_id = 2 )
+       AND NOT has([''], $group_1) )
   GROUP BY event_date
   ORDER BY event_date
   '

--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -64,7 +64,7 @@ class ClickhouseTrendsBreakdown:
 
         props_to_filter = [*self.filter.properties, *self.entity.properties]
         prop_filters, prop_filter_params = parse_prop_clauses(
-            props_to_filter, self.team_id, table_name="e", person_properties_mode=PersonPropertiesMode.EXCLUDE,
+            props_to_filter, table_name="e", person_properties_mode=PersonPropertiesMode.EXCLUDE,
         )
         aggregate_operation, _, math_params = process_math(self.entity)
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -49,7 +49,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         event_params: Dict[str, Any] = {}
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, group_properties_joined=False)
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, group_properties_joined=False)
 
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
@@ -138,7 +138,7 @@ class ClickhouseLifecycle(LifecycleTrend):
             event_params = {"event": entity.id}
 
         props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, team_id, group_properties_joined=False)
+        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, group_properties_joined=False)
 
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(

--- a/ee/clickhouse/views/element.py
+++ b/ee/clickhouse/views/element.py
@@ -17,7 +17,7 @@ class ClickhouseElementViewSet(ElementViewSet):
 
         date_from, date_to, date_params = parse_timestamps(filter, team_id=self.team.pk)
 
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, self.team.pk)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties)
         result = sync_execute(
             GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters),
             {"team_id": self.team.pk, **prop_filter_params, **date_params},

--- a/ee/clickhouse/views/events.py
+++ b/ee/clickhouse/views/events.py
@@ -54,7 +54,7 @@ class ClickhouseEventsViewSet(EventViewSet):
             },
             long_date_from,
         )
-        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, team.pk, has_person_id_joined=False)
+        prop_filters, prop_filter_params = parse_prop_clauses(filter.properties, has_person_id_joined=False)
 
         if request.GET.get("action_id"):
             try:

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -387,8 +387,7 @@
        AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
        AND timestamp <= '2012-01-14 23:59:59'
        AND has(['val'], trim(BOTH '"'
-                             FROM JSONExtractRaw(properties, 'key')))
-       AND team_id = 2 )
+                             FROM JSONExtractRaw(properties, 'key'))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0
@@ -520,8 +519,7 @@
        AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
        AND timestamp <= '2012-01-14 23:59:59'
        AND has(['val'], trim(BOTH '"'
-                             FROM JSONExtractRaw(properties, 'key')))
-       AND team_id = 2 )
+                             FROM JSONExtractRaw(properties, 'key'))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0
@@ -551,8 +549,7 @@
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND NOT has([''], $group_0)
-             AND team_id = 2 )
+             AND NOT has([''], $group_0) )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
      order by day_start)
@@ -570,8 +567,7 @@
        AND event = '$pageview'
        AND timestamp >= '2020-01-02 00:00:00'
        AND timestamp <= '2020-01-02 23:59:59'
-       AND NOT has([''], $group_0)
-       AND team_id = 2 )
+       AND NOT has([''], $group_0) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -62,8 +62,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -134,9 +133,7 @@
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
                       AND NOT has([''], $group_0)
-                      AND team_id = 2
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -184,8 +181,7 @@
                 (SELECT aggregation_target,
                         timestamp,
                         if(event = 'user signed up'
-                           AND has(['org:5'], $group_0)
-                           AND team_id = 2, 1, 0) as step_0,
+                           AND has(['org:5'], $group_0), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
@@ -215,8 +211,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -257,8 +252,7 @@
                 (SELECT aggregation_target,
                         timestamp,
                         if(event = 'user signed up'
-                           AND has(['org:5'], $group_0)
-                           AND team_id = 2, 1, 0) as step_0,
+                           AND has(['org:5'], $group_0), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
@@ -289,9 +283,7 @@
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
                       AND NOT has([''], $group_0)
-                      AND team_id = 2
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -339,8 +331,7 @@
                 (SELECT aggregation_target,
                         timestamp,
                         if(event = 'user signed up'
-                           AND has(['org:5'], $group_0)
-                           AND team_id = 2, 1, 0) as step_0,
+                           AND has(['org:5'], $group_0), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
@@ -410,8 +401,7 @@
                 (SELECT aggregation_target,
                         timestamp,
                         if(event = 'user signed up'
-                           AND has(['org:5'], $group_0)
-                           AND team_id = 2, 1, 0) as step_0,
+                           AND has(['org:5'], $group_0), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -63,8 +63,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1
@@ -115,8 +114,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))
@@ -188,9 +186,7 @@
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
                       AND NOT has([''], $group_0)
-                      AND team_id = 2
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1
@@ -242,9 +238,7 @@
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
                       AND NOT has([''], $group_0)
-                      AND team_id = 2
-                      AND NOT has([''], $group_0)
-                      AND team_id = 2 ) events
+                      AND NOT has([''], $group_0) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))


### PR DESCRIPTION
## Changes

Fix [this sentry error](https://sentry.io/organizations/posthog2/issues/2714891907/?project=1899813&query=is%3Aunresolved+toodeeprecursion&statsPeriod=14d) when there's too many repeated team_id clauses (I think a clickhouse issues).

I _think_ it's safe to remove as none of the other filters in `parse_prop_clauses` filter on team either (like person, cohort etc).

Wasn't able to write a unit test where this failed locally.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Existing unit tests should uncover any issues