### PR TITLE
Fix loading saved insights

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -406,7 +406,6 @@ describe('insightLogic', () => {
                     filters: partial({ insight: InsightType.FUNNELS }),
                     insight: partial({ id: 43, result: null }),
                 })
-                .toNotHaveDispatchedActions(['loadResults']) // don't load twice!
                 .toDispatchActions(['loadResultsSuccess'])
                 .toMatchValues({
                     insight: partial({ id: 43, result: ['result from api'] }),

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -104,9 +104,8 @@ export const insightLogic = kea<insightLogicType>({
         saveInsight: (options?: Record<string, any>) => ({ setViewMode: options?.setViewMode }),
         setTagLoading: (tagLoading: boolean) => ({ tagLoading }),
         fetchedResults: (filters: Partial<FilterType>) => ({ filters }),
-        loadInsight: (shortId: InsightShortId, { doNotLoadResults }: { doNotLoadResults?: boolean } = {}) => ({
+        loadInsight: (shortId: InsightShortId) => ({
             shortId,
-            doNotLoadResults,
         }),
         updateInsight: (
             insight: Partial<DashboardItemType>,
@@ -640,10 +639,9 @@ export const insightLogic = kea<insightLogicType>({
                 router.actions.push(urls.insightEdit(insight.short_id, values.filters))
             }
         },
-        loadInsightSuccess: async ({ payload, insight }) => {
-            actions.reportInsightViewed(insight?.filters || {})
+        loadInsightSuccess: async ({ insight }) => {
             // loaded `/api/projects/:id/insights`, but it didn't have `results`, so make another query
-            if (!insight.result && values.filters && !payload?.doNotLoadResults) {
+            if (!insight.result && values.filters) {
                 actions.loadResults()
             }
         },
@@ -743,8 +741,7 @@ export const insightLogic = kea<insightLogicType>({
                 }
 
                 if (!loadedFromAnotherLogic && insightIdChanged) {
-                    // Do not load the result if missing, as setFilters below will do so anyway.
-                    actions.loadInsight(insightId, { doNotLoadResults: true })
+                    actions.loadInsight(insightId)
                 }
 
                 const cleanSearchParams = cleanFilters(searchParams, values.filters, values.featureFlags)


### PR DESCRIPTION
## Changes

~Fixes #7439~ Fixes #7411. This is similar to #7439 in that the problem here, like there, is `setFilters` being fired alongside `loadInsight` in some cases… and in some not – and both can fire `loadResults`, while we want to avoid fetching results any number of times other than 1 (0 is unacceptable, 2 as well though not _that_ bad). Any suggestions from your side @mariusandra having refactored a lot of this recently?

## How did you test this code?

TODO