### PR TITLE
Fix breaking down by group properties

### DIFF
--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -1,4 +1,8 @@
-import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
 import React, { useState } from 'react'
 import { Popup } from 'lib/components/Popup/Popup'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
@@ -11,7 +15,7 @@ import { ButtonType } from 'antd/lib/button'
 
 export interface TaxonomicBreakdownButtonProps {
     breakdownType?: TaxonomicFilterGroupType
-    onChange: (breakdown: TaxonomicFilterValue, groupType: TaxonomicFilterGroupType) => void
+    onChange: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => void
     onlyCohorts?: boolean
     buttonType?: ButtonType
 }
@@ -32,7 +36,7 @@ export function TaxonomicBreakdownButton({
                     groupType={breakdownType}
                     onChange={(taxonomicGroup, value) => {
                         if (value) {
-                            onChange(value, taxonomicGroup.type)
+                            onChange(value, taxonomicGroup)
                             setOpen(false)
                         }
                     }}

--- a/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -5,7 +5,11 @@ import {
     propertyFilterTypeToTaxonomicFilterType,
     taxonomicFilterTypeToPropertyFilterType,
 } from 'lib/components/PropertyFilters/utils'
-import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicBreakdownButton } from 'scenes/insights/BreakdownFilter/TaxonomicBreakdownButton'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { useValues } from 'kea'
@@ -98,8 +102,8 @@ export function BreakdownFilter({ filters, setFilters, buttonType }: TaxonomicBr
               </Tag>
           ))
 
-    const onChange = (changedBreakdown: TaxonomicFilterValue, groupType: TaxonomicFilterGroupType): void => {
-        const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(groupType) as BreakdownType
+    const onChange = (changedBreakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup): void => {
+        const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type) as BreakdownType
 
         if (changedBreakdownType) {
             let newFilters: Partial<FilterType>
@@ -109,14 +113,16 @@ export function BreakdownFilter({ filters, setFilters, buttonType }: TaxonomicBr
                         .filter((b): b is string | number => !!b)
                         .map((b) => ({ property: b, type: changedBreakdownType })),
                     breakdown_type: changedBreakdownType,
+                    breakdown_group_type_index: taxonomicGroup.groupTypeIndex,
                 }
             } else {
                 newFilters = {
                     breakdown:
-                        groupType === TaxonomicFilterGroupType.CohortsWithAllUsers
+                        taxonomicGroup.type === TaxonomicFilterGroupType.CohortsWithAllUsers
                             ? [...breakdownParts, changedBreakdown].filter((b): b is string | number => !!b)
                             : changedBreakdown,
                     breakdown_type: changedBreakdownType,
+                    breakdown_group_type_index: taxonomicGroup.groupTypeIndex,
                 }
             }
             setFilters(newFilters)

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -1,7 +1,6 @@
 import { cleanFilters } from './cleanFilters'
-import { ChartDisplayType, InsightType } from '~/types'
+import { ChartDisplayType, FilterType, InsightType } from '~/types'
 import { FEATURE_FLAGS, ShownAsValue } from 'lib/constants'
-import { cleanFilters } from './cleanFilters'
 
 describe('cleanFilters', () => {
     it('switches display to table if moving from TRENDS to RETENTION', () => {
@@ -70,20 +69,30 @@ describe('cleanFilters', () => {
     })
 
     const breakdownIndexTestCases = [
-        { provided: 0, expected: 0 },
-        { provided: 27, expected: 27 },
-        { provided: null, expected: undefined },
-        { provided: undefined, expected: undefined },
-        { provided: 0, breakdown_type: 'event', expected: undefined },
+        {
+            filters: { breakdown_type: 'group', breakdown_group_type_index: 0, insight: InsightType.TRENDS },
+            expected: 0,
+        },
+        {
+            filters: { breakdown_type: 'group', breakdown_group_type_index: 3, insight: InsightType.TRENDS },
+            expected: 3,
+        },
+        {
+            filters: { breakdown_type: 'group', breakdown_group_type_index: null, insight: InsightType.TRENDS },
+            expected: undefined,
+        },
+        {
+            filters: { breakdown_type: 'group', breakdown_group_type_index: undefined, insight: InsightType.TRENDS },
+            expected: undefined,
+        },
+        {
+            filters: { breakdown_type: 'event', breakdown_group_type_index: 0, insight: InsightType.TRENDS },
+            expected: undefined,
+        },
     ]
     breakdownIndexTestCases.forEach((testCase) => {
-        testCase.breakdown_type = testCase.breakdown_type || 'group'
-        it(`can add a breakdown_group_type_index of ${testCase.provided} when breakdown type is ${testCase.breakdown_type}`, () => {
-            const cleanedFilters = cleanFilters({
-                breakdown_type: testCase.breakdown_type as BreakdownType,
-                breakdown_group_type_index: testCase.provided,
-                insight: InsightType.TRENDS,
-            })
+        it(`can add a breakdown_group_type_index of ${testCase.filters.breakdown_group_type_index} when breakdown type is ${testCase.filters.breakdown_type}`, () => {
+            const cleanedFilters = cleanFilters(testCase.filters as Partial<FilterType>)
             expect(cleanedFilters.breakdown_group_type_index).toEqual(testCase.expected)
         })
     })

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -1,6 +1,7 @@
 import { cleanFilters } from './cleanFilters'
 import { ChartDisplayType, InsightType } from '~/types'
 import { FEATURE_FLAGS, ShownAsValue } from 'lib/constants'
+import { cleanFilters } from './cleanFilters'
 
 describe('cleanFilters', () => {
     it('switches display to table if moving from TRENDS to RETENTION', () => {
@@ -66,6 +67,25 @@ describe('cleanFilters', () => {
 
         expect(cleanedFilters).toHaveProperty('breakdowns', [{ property: '$browser', type: 'event' }])
         expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
+    })
+
+    const breakdownIndexTestCases = [
+        { provided: 0, expected: 0 },
+        { provided: 27, expected: 27 },
+        { provided: null, expected: undefined },
+        { provided: undefined, expected: undefined },
+        { provided: 0, breakdown_type: 'event', expected: undefined },
+    ]
+    breakdownIndexTestCases.forEach((testCase) => {
+        testCase.breakdown_type = testCase.breakdown_type || 'group'
+        it(`can add a breakdown_group_type_index of ${testCase.provided} when breakdown type is ${testCase.breakdown_type}`, () => {
+            const cleanedFilters = cleanFilters({
+                breakdown_type: testCase.breakdown_type as BreakdownType,
+                breakdown_group_type_index: testCase.provided,
+                insight: InsightType.TRENDS,
+            })
+            expect(cleanedFilters.breakdown_group_type_index).toEqual(testCase.expected)
+        })
     })
 
     it('removes empty breakdowns array', () => {

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -58,7 +58,7 @@ const cleanBreakdownParams = (
             cleanedParams['breakdown'] = filters.breakdown
         }
 
-        if (filters.breakdown_group_type_index != undefined) {
+        if (filters.breakdown_type === 'group' && typeof filters.breakdown_group_type_index === 'number') {
             cleanedParams['breakdown_group_type_index'] = filters.breakdown_group_type_index
         }
     }

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -58,7 +58,7 @@ const cleanBreakdownParams = (
             cleanedParams['breakdown'] = filters.breakdown
         }
 
-        if (filters.breakdown_type === 'group' && typeof filters.breakdown_group_type_index != undefined) {
+        if (filters.breakdown_type === 'group' && filters.breakdown_group_type_index != undefined) {
             cleanedParams['breakdown_group_type_index'] = filters.breakdown_group_type_index
         }
     }

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -58,7 +58,7 @@ const cleanBreakdownParams = (
             cleanedParams['breakdown'] = filters.breakdown
         }
 
-        if (filters.breakdown_group_type_index) {
+        if (filters.breakdown_group_type_index != undefined) {
             cleanedParams['breakdown_group_type_index'] = filters.breakdown_group_type_index
         }
     }

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -58,7 +58,7 @@ const cleanBreakdownParams = (
             cleanedParams['breakdown'] = filters.breakdown
         }
 
-        if (filters.breakdown_type === 'group' && typeof filters.breakdown_group_type_index === 'number') {
+        if (filters.breakdown_type === 'group' && typeof filters.breakdown_group_type_index != undefined) {
             cleanedParams['breakdown_group_type_index'] = filters.breakdown_group_type_index
         }
     }


### PR DESCRIPTION
This broke due to a refactor in https://github.com/PostHog/posthog/pull/7353
which undid the change of https://github.com/PostHog/posthog/pull/7013

I assume the issue was logistical - the branch was in progress for so
long it failed to merge/rebase properly and changes got ignored.

The biggest change was _removing_ the data transformation at various
callbacks in the call chain, which this re-adds.