### PR TITLE
fixes for new short insight urls

### DIFF
--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -103,7 +103,8 @@ describe('Trends', () => {
         cy.get('[data-attr=date-filter]').click()
         cy.contains('Last 30 days').click()
 
-        cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
+        cy.get('[data-attr="date-filter"] .ant-select-selection-item').contains('Last 30 days')
+        cy.get('[data-attr=trend-line-graph]', { timeout: 10000 }).should('exist')
     })
 
     it('Apply property breakdown', () => {

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.test.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.test.ts
@@ -2,9 +2,8 @@ import { chartFilterLogic } from 'lib/components/ChartFilter/chartFilterLogic'
 import { initKeaTestLogic } from '~/test/init'
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
-
-const insightsURL = (additionalPathPart: string = ''): string =>
-    `/insights/smosHASp${additionalPathPart}?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&display=ActionsPie`
+import { urls } from 'scenes/urls'
+import { ChartDisplayType, InsightShortId } from '~/types'
 
 describe('the chart filter', () => {
     let logic: ReturnType<typeof chartFilterLogic.build>
@@ -20,14 +19,20 @@ describe('the chart filter', () => {
     })
 
     it('reads display type from URL when editing', () => {
+        const url = urls.insightEdit('12345' as InsightShortId, {
+            display: ChartDisplayType.ActionsPieChart,
+        })
         expectLogic(logic, () => {
-            router.actions.push(insightsURL())
+            router.actions.push(url)
         }).toMatchValues({ chartFilter: 'ActionsPie' })
     })
 
     it('reads display type from URL when viewing', () => {
+        const url = urls.insightView('12345' as InsightShortId, {
+            display: ChartDisplayType.ActionsPieChart,
+        })
         expectLogic(logic, () => {
-            router.actions.push(insightsURL('/edit'))
+            router.actions.push(url)
         }).toMatchValues({ chartFilter: 'ActionsPie' })
     })
 })

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.test.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.test.ts
@@ -1,0 +1,46 @@
+import { initKeaTestLogic } from '~/test/init'
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+import { intervalFilterLogic } from 'lib/components/IntervalFilter/intervalFilterLogic'
+import { IntervalKeyType } from 'lib/components/IntervalFilter/intervals'
+
+const insightsURL = (
+    additionalPathPart: string = '',
+    dateFrom?: '-90d' | '-14d' | undefined,
+    interval?: IntervalKeyType | undefined
+): string => {
+    let url = `/insights/smosHASp${additionalPathPart}?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&display=ActionsPie`
+    if (dateFrom) {
+        url = `${url}&date_from=${dateFrom}`
+    }
+    if (interval) {
+        url = `${url}&interval=${interval}`
+    }
+    return url
+}
+
+describe('the intervalFilterLogic', () => {
+    let logic: ReturnType<typeof intervalFilterLogic.build>
+
+    initKeaTestLogic({
+        logic: intervalFilterLogic,
+        props: {},
+        onLogic: (l) => (logic = l),
+    })
+
+    it('defaults to null', () => {
+        expectLogic(logic).toMatchValues({ dateFrom: null, interval: null })
+    })
+
+    it('reads "date from" and "interval" from URL when editing', () => {
+        expectLogic(logic, () => {
+            router.actions.push(insightsURL('', '-90d', 'hour'))
+        }).toMatchValues({ dateFrom: '-90d', interval: 'hour' })
+    })
+
+    it('reads "date from" and "interval" from URL when viewing', () => {
+        expectLogic(logic, () => {
+            router.actions.push(insightsURL('/edit', '-14d', 'week'))
+        }).toMatchValues({ dateFrom: '-14d', interval: 'week' })
+    })
+})

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.test.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.test.ts
@@ -2,22 +2,8 @@ import { initKeaTestLogic } from '~/test/init'
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import { intervalFilterLogic } from 'lib/components/IntervalFilter/intervalFilterLogic'
-import { IntervalKeyType } from 'lib/components/IntervalFilter/intervals'
-
-const insightsURL = (
-    additionalPathPart: string = '',
-    dateFrom?: '-90d' | '-14d' | undefined,
-    interval?: IntervalKeyType | undefined
-): string => {
-    let url = `/insights/smosHASp${additionalPathPart}?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&display=ActionsPie`
-    if (dateFrom) {
-        url = `${url}&date_from=${dateFrom}`
-    }
-    if (interval) {
-        url = `${url}&interval=${interval}`
-    }
-    return url
-}
+import { urls } from 'scenes/urls'
+import { InsightShortId } from '~/types'
 
 describe('the intervalFilterLogic', () => {
     let logic: ReturnType<typeof intervalFilterLogic.build>
@@ -33,14 +19,22 @@ describe('the intervalFilterLogic', () => {
     })
 
     it('reads "date from" and "interval" from URL when editing', () => {
+        const url = urls.insightEdit('12345' as InsightShortId, {
+            date_from: '-90d',
+            interval: 'hour',
+        })
         expectLogic(logic, () => {
-            router.actions.push(insightsURL('', '-90d', 'hour'))
+            router.actions.push(url)
         }).toMatchValues({ dateFrom: '-90d', interval: 'hour' })
     })
 
     it('reads "date from" and "interval" from URL when viewing', () => {
+        const url = urls.insightView('12345' as InsightShortId, {
+            date_from: '-14d',
+            interval: 'week',
+        })
         expectLogic(logic, () => {
-            router.actions.push(insightsURL('/edit', '-14d', 'week'))
+            router.actions.push(url)
         }).toMatchValues({ dateFrom: '-14d', interval: 'week' })
     })
 })

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -47,7 +47,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights/:shortid(/edit)': (_, { interval, date_from }) => {
+        '/insights/:shortId(/edit)': (_, { interval, date_from }) => {
             if (interval) {
                 actions.setIntervalFilter(interval)
             }

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -47,7 +47,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
         },
     }),
     urlToAction: ({ actions }) => ({
-        '/insights': (_, { interval, date_from }) => {
+        '/insights/:shortid(/edit)': (_, { interval, date_from }) => {
             if (interval) {
                 actions.setIntervalFilter(interval)
             }

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.test.ts
@@ -2,21 +2,8 @@ import { initKeaTestLogic } from '~/test/init'
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import { insightDateFilterLogic } from 'scenes/insights/InsightDateFilter/insightDateFilterLogic'
-
-const insightsURL = (
-    additionalPathPart: string = '',
-    dateFrom?: string | undefined,
-    dateTo?: string | undefined
-): string => {
-    let url = `/insights/smosHASp${additionalPathPart}?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&display=ActionsPie`
-    if (dateFrom) {
-        url = `${url}&date_from=${dateFrom}`
-    }
-    if (dateTo) {
-        url = `${url}&date_to=${dateTo}`
-    }
-    return url
-}
+import { urls } from 'scenes/urls'
+import { InsightShortId } from '~/types'
 
 describe('the insightDateFilterLogic', () => {
     let logic: ReturnType<typeof insightDateFilterLogic.build>
@@ -32,14 +19,22 @@ describe('the insightDateFilterLogic', () => {
     })
 
     it('reads "date from" and "date to" from URL when editing', () => {
+        const url = urls.insightEdit('12345' as InsightShortId, {
+            date_from: '2021-12-13',
+            date_to: '2021-12-14',
+        })
         expectLogic(logic, () => {
-            router.actions.push(insightsURL('', '2021-12-13', '2022-01-14'))
-        }).toMatchValues({ dates: { dateFrom: '2021-12-13', dateTo: '2022-01-14' } })
+            router.actions.push(url)
+        }).toMatchValues({ dates: { dateFrom: '2021-12-13', dateTo: '2021-12-14' } })
     })
 
     it('reads "date from" and "date to" from URL when viewing', () => {
+        const url = urls.insightView('12345' as InsightShortId, {
+            date_from: '2021-12-14',
+            date_to: '2021-12-15',
+        })
         expectLogic(logic, () => {
-            router.actions.push(insightsURL('/edit', '2021-12-14', '2022-01-15'))
-        }).toMatchValues({ dates: { dateFrom: '2021-12-14', dateTo: '2022-01-15' } })
+            router.actions.push(url)
+        }).toMatchValues({ dates: { dateFrom: '2021-12-14', dateTo: '2021-12-15' } })
     })
 })

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.test.ts
@@ -1,0 +1,45 @@
+import { initKeaTestLogic } from '~/test/init'
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+import { insightDateFilterLogic } from 'scenes/insights/InsightDateFilter/insightDateFilterLogic'
+
+const insightsURL = (
+    additionalPathPart: string = '',
+    dateFrom?: string | undefined,
+    dateTo?: string | undefined
+): string => {
+    let url = `/insights/smosHASp${additionalPathPart}?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&display=ActionsPie`
+    if (dateFrom) {
+        url = `${url}&date_from=${dateFrom}`
+    }
+    if (dateTo) {
+        url = `${url}&date_to=${dateTo}`
+    }
+    return url
+}
+
+describe('the insightDateFilterLogic', () => {
+    let logic: ReturnType<typeof insightDateFilterLogic.build>
+
+    initKeaTestLogic({
+        logic: insightDateFilterLogic,
+        props: {},
+        onLogic: (l) => (logic = l),
+    })
+
+    it('defaults to no dates', () => {
+        expectLogic(logic).toMatchValues({ dates: { dateFrom: undefined, dateTo: undefined } })
+    })
+
+    it('reads "date from" and "date to" from URL when editing', () => {
+        expectLogic(logic, () => {
+            router.actions.push(insightsURL('', '2021-12-13', '2022-01-14'))
+        }).toMatchValues({ dates: { dateFrom: '2021-12-13', dateTo: '2022-01-14' } })
+    })
+
+    it('reads "date from" and "date to" from URL when viewing', () => {
+        expectLogic(logic, () => {
+            router.actions.push(insightsURL('/edit', '2021-12-14', '2022-01-15'))
+        }).toMatchValues({ dates: { dateFrom: '2021-12-14', dateTo: '2022-01-15' } })
+    })
+})

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -65,7 +65,7 @@ export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
         },
     }),
     urlToAction: ({ actions, values }) => ({
-        '/insights/': (_: any, { date_from, date_to }: UrlParams) => {
+        '/insights/:shortid(/edit)': (_: any, { date_from, date_to }: UrlParams) => {
             if (!values.initialLoad && !objectsEqual(date_from, values.dates.dateFrom)) {
                 actions.dateAutomaticallyChanged()
             }

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -65,7 +65,7 @@ export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
         },
     }),
     urlToAction: ({ actions, values }) => ({
-        '/insights/:shortid(/edit)': (_: any, { date_from, date_to }: UrlParams) => {
+        '/insights/:shortId(/edit)': (_: any, { date_from, date_to }: UrlParams) => {
             if (!values.initialLoad && !objectsEqual(date_from, values.dates.dateFrom)) {
                 actions.dateAutomaticallyChanged()
             }


### PR DESCRIPTION
## Changes

fixes two more insight chart filters that were not picking up properties from insight short urls

see #7434 

![other fitlers](https://user-images.githubusercontent.com/984817/144225785-ad322813-d515-4564-8a80-bf217b65b6fd.gif)

## How did you test this code?

writing tests and running manually to see that filter values were maintained after a page refresh
