### PR TITLE
Groups: Show "related groups" under group and person pages.

### DIFF
--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -8,11 +8,12 @@ from ee.clickhouse.sql.groups import INSERT_GROUP_SQL
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_GROUPS
 from posthog.models import Group
+from posthog.models.property import GroupTypeIndex
 
 
 def create_group(
     team_id: int,
-    group_type_index: int,
+    group_type_index: GroupTypeIndex,
     group_key: str,
     properties: Optional[Dict] = {},
     timestamp: Optional[datetime.datetime] = None,
@@ -37,7 +38,7 @@ def create_group(
 
 
 def get_aggregation_target_field(
-    aggregation_group_type_index: Optional[int], event_table_alias: str, distinct_id_table_alias: str
+    aggregation_group_type_index: Optional[GroupTypeIndex], event_table_alias: str, distinct_id_table_alias: str
 ) -> str:
     if aggregation_group_type_index is not None:
         return f"{event_table_alias}.$group_{aggregation_group_type_index}"

--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -8,7 +8,7 @@ from ee.clickhouse.sql.groups import INSERT_GROUP_SQL
 from ee.kafka_client.client import ClickhouseProducer
 from ee.kafka_client.topics import KAFKA_GROUPS
 from posthog.models import Group
-from posthog.models.property import GroupTypeIndex
+from posthog.models.filters.utils import GroupTypeIndex
 
 
 def create_group(

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -27,7 +27,7 @@ from ee.clickhouse.sql.trends.top_elements import TOP_ELEMENTS_ARRAY_OF_KEY_SQL
 from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filters.filter import Filter
-from posthog.models.property import GroupTypeIndex, TableWithProperties
+from posthog.models.filters.utils import GroupTypeIndex
 
 ALL_USERS_COHORT_ID = 0
 

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -27,7 +27,7 @@ from ee.clickhouse.sql.trends.top_elements import TOP_ELEMENTS_ARRAY_OF_KEY_SQL
 from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filters.filter import Filter
-from posthog.models.property import TableWithProperties
+from posthog.models.property import GroupTypeIndex, TableWithProperties
 
 ALL_USERS_COHORT_ID = 0
 
@@ -104,7 +104,7 @@ def get_breakdown_prop_values(
 def _to_value_expression(
     breakdown_type: Union[Literal["event", "person", "cohort", "group"], None],
     breakdown: Union[str, List[Union[str, int]], None],
-    breakdown_group_type_index: Optional[int],
+    breakdown_group_type_index: Optional[GroupTypeIndex],
 ) -> str:
     if breakdown_type == "person":
         return get_single_or_multi_property_string_expr(breakdown, table="person", query_alias="value")

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -10,7 +10,8 @@ from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
-from posthog.models.property import GroupTypeIndex, PropertyIdentifier, PropertyType, TableWithProperties
+from posthog.models.filters.utils import GroupTypeIndex
+from posthog.models.property import PropertyIdentifier, PropertyType, TableWithProperties
 
 
 class ColumnOptimizer:

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -50,7 +50,7 @@ class ColumnOptimizer:
     @cached_property
     def group_types_to_query(self) -> Set[GroupTypeIndex]:
         used_properties = self._used_properties_with_type("group")
-        return set(cast(int, group_type_index) for _, _, group_type_index in used_properties)
+        return set(cast(GroupTypeIndex, group_type_index) for _, _, group_type_index in used_properties)
 
     @cached_property
     def should_query_elements_chain_column(self) -> bool:

--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -1,0 +1,125 @@
+import json
+from datetime import timedelta
+from functools import cached_property
+from typing import Dict, List, Literal, Optional, TypedDict, Union
+
+from django.utils.timezone import now
+
+from ee.clickhouse.client import sync_execute
+from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS
+from posthog.models.filters.utils import validate_group_type_index
+from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models.property import GroupTypeIndex
+
+DISTINCT_IDS_JOIN = f"JOIN ({GET_TEAM_PERSON_DISTINCT_IDS}) pdi on e.distinct_id = pdi.distinct_id"
+
+
+class RelatedActorsResponse(TypedDict):
+    type: Literal["person", "group"]
+    group_type_index: Optional[GroupTypeIndex]
+    id: str
+    person: Optional[Dict]
+
+
+class RelatedActorsQuery:
+    """
+    This query calculates other groups and persons that are related to a person or a group.
+
+    Two actors are considered related if they have had shared events in the past 90 days.
+    """
+
+    def __init__(self, team_id: int, group_type_index: Optional[Union[GroupTypeIndex, str]], id: str):
+        self.team_id = team_id
+        self.group_type_index = validate_group_type_index("group_type_index", group_type_index)
+        self.id = id
+
+    def run(self) -> List[RelatedActorsResponse]:
+        results = self._query_related_people()
+        for group_type_mapping in GroupTypeMapping.objects.filter(team_id=self.team_id):
+            results.extend(self._query_related_groups(group_type_mapping.group_type_index))
+        return results
+
+    @property
+    def is_aggregating_by_groups(self) -> bool:
+        return self.group_type_index is not None
+
+    def _query_related_people(self) -> List[RelatedActorsResponse]:
+        if not self.is_aggregating_by_groups:
+            return []
+
+        # :KLUDGE: We need to fetch distinct_id + person properties to be able to link to user properly.
+        rows = sync_execute(
+            f"""
+            SELECT person_id, any(e.distinct_id), any(person_props)
+            FROM events e
+            {DISTINCT_IDS_JOIN}
+            JOIN (
+                SELECT id, any(properties) as person_props
+                FROM person
+                WHERE team_id = %(team_id)s
+                GROUP BY id
+                HAVING max(is_deleted) = 0
+            ) person ON pdi.person_id = person.id
+            WHERE team_id = %(team_id)s
+              AND timestamp > %(after)s
+              AND timestamp < %(before)s
+              AND {self._filter_clause}
+            GROUP BY person_id
+            """,
+            self._params,
+        )
+
+        return [
+            RelatedActorsResponse(
+                type="person",
+                group_type_index=None,
+                id=person_id,
+                person={"distinct_ids": [distinct_id], "properties": json.loads(person_props)},
+            )
+            for (person_id, distinct_id, person_props) in rows
+        ]
+
+    def _query_related_groups(self, group_type_index: GroupTypeIndex) -> List[RelatedActorsResponse]:
+        if group_type_index == self.group_type_index:
+            return []
+
+        rows = sync_execute(
+            f"""
+            SELECT DISTINCT $group_{group_type_index} AS group_key
+            FROM events e
+            {'' if self.is_aggregating_by_groups else DISTINCT_IDS_JOIN}
+            JOIN (
+                SELECT group_key
+                FROM groups
+                WHERE team_id = %(team_id)s AND group_type_index = %(group_type_index)s
+                GROUP BY group_key
+            ) groups ON $group_{group_type_index} = groups.group_key
+            WHERE team_id = %(team_id)s
+              AND timestamp > %(after)s
+              AND timestamp < %(before)s
+              AND group_key != ''
+              AND {self._filter_clause}
+            ORDER BY group_key
+            """,
+            {**self._params, "group_type_index": group_type_index},
+        )
+        return [
+            RelatedActorsResponse(type="group", group_type_index=group_type_index, id=group_key, person=None)
+            for (group_key,) in rows
+        ]
+
+    @property
+    def _filter_clause(self):
+        if self.is_aggregating_by_groups:
+            return f"$group_{self.group_type_index} = %(id)s"
+        else:
+            return "person_id = %(id)s"
+
+    @cached_property
+    def _params(self):
+        return {
+            "team_id": self.team_id,
+            "id": self.id,
+            "after": (now() - timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%S.%f"),
+            "before": now().strftime("%Y-%m-%dT%H:%M:%S.%f"),
+        }

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -7,6 +7,7 @@ from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -58,6 +59,14 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
             return response.Response(data)
         except Group.DoesNotExist:
             raise NotFound()
+
+    @action(methods=["GET"], detail=False)
+    def related(self, request: request.Request, pk=None, **kw) -> response.Response:
+        group_type_index = request.GET.get("group_type_index")
+        id = request.GET["id"]
+
+        results = RelatedActorsQuery(self.team.pk, group_type_index, id).run()
+        return response.Response(results)
 
     @action(methods=["GET"], detail=False)
     def property_definitions(self, request: request.Request, **kw):

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -20,7 +20,7 @@ class GroupTypeSerializer(serializers.ModelSerializer):
 
 class ClickhouseGroupsTypesView(StructuredViewSetMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = GroupTypeSerializer
-    queryset = GroupTypeMapping.objects.all()
+    queryset = GroupTypeMapping.objects.all().order_by("group_type_index")
     pagination_class = None
 
 

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
@@ -1,0 +1,120 @@
+# name: ClickhouseTestGroupsApi.test_related_groups
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_groups_related_?$ (ClickhouseGroupsView) */
+  SELECT person_id,
+         any(e.distinct_id),
+         any(person_props)
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, _timestamp) as person_id
+     FROM
+       (SELECT distinct_id,
+               person_id,
+               max(_timestamp) as _timestamp
+        FROM person_distinct_id
+        WHERE team_id = 2
+        GROUP BY person_id,
+                 distinct_id,
+                 team_id
+        HAVING max(is_deleted) = 0)
+     GROUP BY distinct_id) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT id,
+            any(properties) as person_props
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id
+     HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+  WHERE team_id = 2
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND $group_0 = '0::0'
+  GROUP BY person_id
+  '
+---
+# name: ClickhouseTestGroupsApi.test_related_groups.1
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_groups_related_?$ (ClickhouseGroupsView) */
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 2
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 2
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND $group_0 = '0::0'
+  ORDER BY group_key
+  '
+---
+# name: ClickhouseTestGroupsApi.test_related_groups_person
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_groups_related_?$ (ClickhouseGroupsView) */
+  SELECT DISTINCT $group_0 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, _timestamp) as person_id
+     FROM
+       (SELECT distinct_id,
+               person_id,
+               max(_timestamp) as _timestamp
+        FROM person_distinct_id
+        WHERE team_id = 2
+        GROUP BY person_id,
+                 distinct_id,
+                 team_id
+        HAVING max(is_deleted) = 0)
+     GROUP BY distinct_id) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 2
+       AND group_type_index = 0
+     GROUP BY group_key) groups ON $group_0 = groups.group_key
+  WHERE team_id = 2
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND person_id = '01795392-cc00-0003-7dc7-67a694604d72'
+  ORDER BY group_key
+  '
+---
+# name: ClickhouseTestGroupsApi.test_related_groups_person.1
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_groups_related_?$ (ClickhouseGroupsView) */
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, _timestamp) as person_id
+     FROM
+       (SELECT distinct_id,
+               person_id,
+               max(_timestamp) as _timestamp
+        FROM person_distinct_id
+        WHERE team_id = 2
+        GROUP BY person_id,
+                 distinct_id,
+                 team_id
+        HAVING max(is_deleted) = 0)
+     GROUP BY distinct_id) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 2
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 2
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND person_id = '01795392-cc00-0003-7dc7-67a694604d72'
+  ORDER BY group_key
+  '
+---

--- a/ee/clickhouse/views/test/funnel/util.py
+++ b/ee/clickhouse/views/test/funnel/util.py
@@ -1,20 +1,11 @@
 import dataclasses
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Literal, Optional, TypedDict, Union
 
 from django.test.client import Client
 
-from ee.clickhouse.queries.actor_base_query import SerializedGroup, SerializedPerson
 from ee.clickhouse.queries.funnels.funnel_correlation import EventOddsRatioSerialized
 from posthog.constants import FunnelCorrelationType
+from posthog.models.property import GroupTypeIndex
 
 
 class EventPattern(TypedDict, total=False):
@@ -42,7 +33,7 @@ class FunnelRequest:
     events: str
     date_from: str
     insight: str
-    aggregation_group_type_index: Optional[int] = None
+    aggregation_group_type_index: Optional[GroupTypeIndex] = None
     date_to: Optional[str] = None
     properties: Optional[str] = None
     funnel_order_type: Optional[str] = None

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -1,10 +1,17 @@
-from datetime import datetime
+from uuid import UUID, uuid4
 
 from freezegun.api import freeze_time
 
+from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.group import create_group
-from ee.clickhouse.util import ClickhouseTestMixin
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
+from posthog.models import Event, GroupTypeMapping, Person
 from posthog.test.base import APIBaseTest
+
+
+def _create_event(**kwargs):
+    kwargs["event_uuid"] = uuid4()
+    create_event(**kwargs)
 
 
 class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
@@ -56,11 +63,14 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             group_key="key",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
+        create_group(
+            team_id=self.team.pk, group_type_index=1, group_key="foo//bar", properties={},
+        )
 
-        fail_response = self.client.get(f"/api/projects/{self.team.id}/groups/key?group_type_index=1")
+        fail_response = self.client.get(f"/api/projects/{self.team.id}/groups/find?group_type_index=1&group_key=key")
         self.assertEqual(fail_response.status_code, 404)
 
-        ok_response = self.client.get(f"/api/projects/{self.team.id}/groups/key?group_type_index=0")
+        ok_response = self.client.get(f"/api/projects/{self.team.id}/groups/find?group_type_index=0&group_key=key")
         self.assertEqual(ok_response.status_code, 200)
         self.assertEqual(
             ok_response.json(),
@@ -70,6 +80,53 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                 "group_properties": {"industry": "finance", "name": "Mr. Krabs"},
                 "group_type_index": 0,
             },
+        )
+        ok_response = self.client.get(f"/api/projects/{self.team.id}/groups/find?group_type_index=1&group_key=foo//bar")
+        self.assertEqual(ok_response.status_code, 200)
+        self.assertEqual(
+            ok_response.json(),
+            {
+                "created_at": "2021-05-02T00:00:00Z",
+                "group_key": "foo//bar",
+                "group_properties": {},
+                "group_type_index": 1,
+            },
+        )
+
+    @freeze_time("2021-05-10")
+    @snapshot_clickhouse_queries
+    def test_related_groups(self):
+        uuid = self._create_related_groups_data()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/groups/related?id=0::0&group_type_index=0").json()
+        self.assertEqual(
+            response,
+            [
+                {
+                    "type": "person",
+                    "id": str(uuid),
+                    "group_type_index": None,
+                    "person": {"distinct_ids": ["1"], "properties": {}},
+                },
+                {"type": "group", "id": "1::2", "group_type_index": 1, "person": None},
+                {"type": "group", "id": "1::3", "group_type_index": 1, "person": None},
+            ],
+        )
+
+    @freeze_time("2021-05-10")
+    @snapshot_clickhouse_queries
+    def test_related_groups_person(self):
+        uuid = self._create_related_groups_data()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/groups/related?id={uuid}").json()
+        self.assertEqual(
+            response,
+            [
+                {"type": "group", "id": "0::0", "group_type_index": 0, "person": None},
+                {"type": "group", "id": "0::1", "group_type_index": 0, "person": None},
+                {"type": "group", "id": "1::2", "group_type_index": 1, "person": None},
+                {"type": "group", "id": "1::3", "group_type_index": 1, "person": None},
+            ],
         )
 
     def test_property_definitions(self):
@@ -111,3 +168,64 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         ).json()
         self.assertEqual(len(response), 0)
         self.assertEqual(response, [])
+
+    def _create_related_groups_data(self):
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="playlist", group_type_index=1)
+
+        uuid = UUID("01795392-cc00-0003-7dc7-67a694604d72")
+
+        p1 = Person.objects.create(uuid=uuid, team_id=self.team.pk, distinct_ids=["1", "2"])
+        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["3"])
+        p3 = Person.objects.create(team_id=self.team.pk, distinct_ids=["4"])
+
+        create_group(self.team.pk, 0, "0::0")
+        create_group(self.team.pk, 0, "0::1")
+        create_group(self.team.pk, 1, "1::2")
+        create_group(self.team.pk, 1, "1::3")
+        create_group(self.team.pk, 1, "1::4")
+        create_group(self.team.pk, 1, "1::5")
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            timestamp="2021-05-05 00:00:00",
+            properties={"$group_0": "0::0", "$group_1": "1::2"},
+        )
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            timestamp="2021-05-05 00:00:00",
+            properties={"$group_0": "0::0", "$group_1": "1::3"},
+        )
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            timestamp="2021-05-05 00:00:00",
+            properties={"$group_0": "0::1", "$group_1": "1::3"},
+        )
+
+        # Event too old, not counted
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            timestamp="2000-05-05 00:00:00",
+            properties={"$group_0": "0::0", "$group_1": "1::4"},
+        )
+
+        # No such group exists in groups table
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            timestamp="2000-05-05 00:00:00",
+            properties={"$group_0": "0::0", "$group_1": "no such group"},
+        )
+
+        return uuid

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Row, Tabs, Col, Card, Skeleton } from 'antd'
+import { InfoCircleOutlined } from '@ant-design/icons'
 import { useValues } from 'kea'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
@@ -7,6 +8,7 @@ import { groupLogic } from 'scenes/groups/groupLogic'
 import { EventsTable } from 'scenes/events/EventsTable'
 import { urls } from 'scenes/urls'
 import { RelatedGroups } from 'scenes/groups/RelatedGroups'
+import { Tooltip } from 'lib/components/Tooltip'
 
 const { TabPane } = Tabs
 
@@ -62,7 +64,16 @@ export function Group(): JSX.Element {
                                     disabled={groupDataLoading}
                                 />
                                 <TabPane
-                                    tab={<span data-attr="group-related-tab">Related groups</span>}
+                                    tab={
+                                        <span data-attr="group-related-tab">
+                                            Related people & groups
+                                            <Tooltip
+                                                title={`Shows people and groups which have shared events with this ${groupTypeName} in the last 90 days.`}
+                                            >
+                                                <InfoCircleOutlined style={{ marginLeft: 4 }} />
+                                            </Tooltip>
+                                        </span>
+                                    }
                                     key="related"
                                     disabled={groupDataLoading}
                                 />

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -6,6 +6,7 @@ import { TZLabel } from 'lib/components/TimezoneAware'
 import { groupLogic } from 'scenes/groups/groupLogic'
 import { EventsTable } from 'scenes/events/EventsTable'
 import { urls } from 'scenes/urls'
+import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 
 const { TabPane } = Tabs
 
@@ -75,7 +76,9 @@ export function Group(): JSX.Element {
                                             className="persons-page-props-table"
                                         />
                                     </div>
-                                ) : null)}
+                                ) : (
+                                    <RelatedGroups id={groupKey} groupTypeIndex={groupTypeIndex} />
+                                ))}
                             {groupDataLoading && <Skeleton paragraph={{ rows: 6 }} active />}
                         </Card>
                     </Col>

--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react'
-import { useActions, useValues } from 'kea'
+import React from 'react'
+import { useValues } from 'kea'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
 import { RelatedActor } from '~/types'
 import { Skeleton } from 'antd'
@@ -17,13 +17,8 @@ interface Props {
 }
 
 export function RelatedGroups({ groupTypeIndex, id }: Props): JSX.Element {
-    const { relatedActors, relatedActorsLoading } = useValues(relatedGroupsLogic)
-    const { loadRelatedActors } = useActions(relatedGroupsLogic)
+    const { relatedActors, relatedActorsLoading } = useValues(relatedGroupsLogic({ groupTypeIndex, id }))
     const { groupTypes } = useValues(groupsModel)
-
-    useEffect(() => {
-        loadRelatedActors(groupTypeIndex, id)
-    }, [groupTypeIndex, id])
 
     if (relatedActorsLoading) {
         return <Skeleton paragraph={{ rows: 2 }} active />

--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -52,10 +52,18 @@ export function RelatedGroups({ groupTypeIndex, id }: Props): JSX.Element {
                 let url: string
                 if (actor.type == 'group') {
                     url = urls.group(actor.group_type_index, actor.id)
-                    return <Link to={url}>{actor.id}</Link>
+                    return (
+                        <Link to={url} data-attr="related-group-link">
+                            {actor.id}
+                        </Link>
+                    )
                 } else {
                     url = urls.person(actor.person.distinct_ids[0])
-                    return <Link to={url}>{asDisplay(actor.person)}</Link>
+                    return (
+                        <Link to={url} data-attr="related-person-link">
+                            {asDisplay(actor.person)}
+                        </Link>
+                    )
                 }
             },
         },

--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import { useActions, useValues } from 'kea'
-import { groupLogic } from 'scenes/groups/groupLogic'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
 import { RelatedActor } from '~/types'
 import { Skeleton } from 'antd'
@@ -10,19 +9,20 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { urls } from 'scenes/urls'
 import { Link } from 'lib/components/Link'
 import { asDisplay } from 'scenes/persons/PersonHeader'
+import { relatedGroupsLogic } from 'scenes/groups/relatedGroupsLogic'
 
 interface Props {
-    groupTypeIndex: number
+    groupTypeIndex: number | null
     id: string
 }
 
 export function RelatedGroups({ groupTypeIndex, id }: Props): JSX.Element {
-    const { relatedActors, relatedActorsLoading } = useValues(groupLogic)
-    const { loadRelatedActors } = useActions(groupLogic)
+    const { relatedActors, relatedActorsLoading } = useValues(relatedGroupsLogic)
+    const { loadRelatedActors } = useActions(relatedGroupsLogic)
     const { groupTypes } = useValues(groupsModel)
 
     useEffect(() => {
-        loadRelatedActors()
+        loadRelatedActors(groupTypeIndex, id)
     }, [groupTypeIndex, id])
 
     if (relatedActorsLoading) {

--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect } from 'react'
+import { useActions, useValues } from 'kea'
+import { groupLogic } from 'scenes/groups/groupLogic'
+import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable/LemonTable'
+import { RelatedActor } from '~/types'
+import { Skeleton } from 'antd'
+import { groupsModel } from '~/models/groupsModel'
+import UserOutlined from '@ant-design/icons/lib/icons/UserOutlined'
+import { capitalizeFirstLetter } from 'lib/utils'
+import { urls } from 'scenes/urls'
+import { Link } from 'lib/components/Link'
+import { asDisplay } from 'scenes/persons/PersonHeader'
+
+interface Props {
+    groupTypeIndex: number
+    id: string
+}
+
+export function RelatedGroups({ groupTypeIndex, id }: Props): JSX.Element {
+    const { relatedActors, relatedActorsLoading } = useValues(groupLogic)
+    const { loadRelatedActors } = useActions(groupLogic)
+    const { groupTypes } = useValues(groupsModel)
+
+    useEffect(() => {
+        loadRelatedActors()
+    }, [groupTypeIndex, id])
+
+    if (relatedActorsLoading) {
+        return <Skeleton paragraph={{ rows: 2 }} active />
+    }
+
+    const columns: LemonTableColumns<RelatedActor> = [
+        {
+            title: 'Type',
+            key: 'type',
+            render: function RenderCount(_, actor: RelatedActor) {
+                if (actor.type === 'group') {
+                    return <>{capitalizeFirstLetter(groupTypes[actor.group_type_index]?.group_type ?? '')}</>
+                } else {
+                    return (
+                        <>
+                            <UserOutlined /> Person
+                        </>
+                    )
+                }
+            },
+        },
+        {
+            title: 'id',
+            key: 'id',
+            render: function RenderCount(_, actor: RelatedActor) {
+                let url: string
+                if (actor.type == 'group') {
+                    url = urls.group(actor.group_type_index, actor.id)
+                    return <Link to={url}>{actor.id}</Link>
+                } else {
+                    url = urls.person(actor.person.distinct_ids[0])
+                    return <Link to={url}>{asDisplay(actor.person)}</Link>
+                }
+            },
+        },
+    ]
+
+    return relatedActors.length ? (
+        <LemonTable
+            dataSource={relatedActors}
+            columns={columns}
+            rowKey="id"
+            pagination={{ pageSize: 30, hideOnSinglePage: true }}
+            embedded
+        />
+    ) : (
+        <i>No related groups found</i>
+    )
+}

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -1,5 +1,6 @@
 import { kea } from 'kea'
 import api from 'lib/api'
+import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { Group } from '~/types'
@@ -16,7 +17,8 @@ export const groupLogic = kea<groupLogicType>({
             null as Group | null,
             {
                 loadGroup: async () => {
-                    const url = `api/projects/${values.currentTeamId}/groups/${values.groupKey}?group_type_index=${values.groupTypeIndex}`
+                    const params = { group_type_index: values.groupTypeIndex, group_key: values.groupKey }
+                    const url = `api/projects/${values.currentTeamId}/groups/find?${toParams(params)}`
                     return await api.get(url)
                 },
             },
@@ -45,7 +47,7 @@ export const groupLogic = kea<groupLogicType>({
     urlToAction: ({ actions }) => ({
         '/groups/:groupTypeIndex/:groupKey': ({ groupTypeIndex, groupKey }) => {
             if (groupTypeIndex && groupKey) {
-                actions.setGroup(+groupTypeIndex, groupKey)
+                actions.setGroup(+groupTypeIndex, decodeURIComponent(groupKey))
                 actions.loadGroup()
             }
         },

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -3,7 +3,7 @@ import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { Group, RelatedActor } from '~/types'
+import { Group } from '~/types'
 import { groupLogicType } from './groupLogicType'
 
 export const groupLogic = kea<groupLogicType>({
@@ -21,18 +21,6 @@ export const groupLogic = kea<groupLogicType>({
                     const url = `api/projects/${values.currentTeamId}/groups/find?${toParams(params)}`
                     return await api.get(url)
                 },
-            },
-        ],
-        relatedActors: [
-            [] as RelatedActor[],
-            {
-                loadRelatedActors: async () => {
-                    const params = { group_type_index: values.groupTypeIndex, id: values.groupKey }
-                    const url = `api/projects/${values.currentTeamId}/groups/related?${toParams(params)}`
-
-                    return await api.get(url)
-                },
-                setGroup: () => [],
             },
         ],
     }),

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -3,7 +3,7 @@ import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { Group } from '~/types'
+import { Group, RelatedActor } from '~/types'
 import { groupLogicType } from './groupLogicType'
 
 export const groupLogic = kea<groupLogicType>({
@@ -21,6 +21,18 @@ export const groupLogic = kea<groupLogicType>({
                     const url = `api/projects/${values.currentTeamId}/groups/find?${toParams(params)}`
                     return await api.get(url)
                 },
+            },
+        ],
+        relatedActors: [
+            [] as RelatedActor[],
+            {
+                loadRelatedActors: async () => {
+                    const params = { group_type_index: values.groupTypeIndex, id: values.groupKey }
+                    const url = `api/projects/${values.currentTeamId}/groups/related?${toParams(params)}`
+
+                    return await api.get(url)
+                },
+                setGroup: () => [],
             },
         ],
     }),

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -8,22 +8,32 @@ import { relatedGroupsLogicType } from './relatedGroupsLogicType'
 export const relatedGroupsLogic = kea<relatedGroupsLogicType>({
     path: ['scenes', 'groups', 'relatedGroupsLogic'],
     connect: { values: [teamLogic, ['currentTeamId']] },
+
+    props: {} as {
+        groupTypeIndex: number | null
+        id: string
+    },
+    key: (props) => `${props.groupTypeIndex}-${props.id}`,
+
     actions: () => ({
-        loadRelatedActors: (groupTypeIndex: number | null, id: string) => ({ groupTypeIndex, id }),
+        loadRelatedActors: true,
     }),
-    loaders: ({ values }) => ({
+    loaders: ({ values, props }) => ({
         relatedActors: [
             [] as RelatedActor[],
             {
-                loadRelatedActors: async ({ groupTypeIndex, id }) => {
+                loadRelatedActors: async () => {
                     const url = `api/projects/${values.currentTeamId}/groups/related?${toParams({
-                        group_type_index: groupTypeIndex,
-                        id,
+                        group_type_index: props.groupTypeIndex,
+                        id: props.id,
                     })}`
                     return await api.get(url)
                 },
                 setGroup: () => [],
             },
         ],
+    }),
+    events: ({ actions }) => ({
+        afterMount: actions.loadRelatedActors,
     }),
 })

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -1,0 +1,29 @@
+import { kea } from 'kea'
+import api from 'lib/api'
+import { toParams } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
+import { RelatedActor } from '~/types'
+
+import { relatedGroupsLogicType } from './relatedGroupsLogicType'
+export const relatedGroupsLogic = kea<relatedGroupsLogicType>({
+    path: ['scenes', 'groups', 'relatedGroupsLogic'],
+    connect: { values: [teamLogic, ['currentTeamId']] },
+    actions: () => ({
+        loadRelatedActors: (groupTypeIndex: number | null, id: string) => ({ groupTypeIndex, id }),
+    }),
+    loaders: ({ values }) => ({
+        relatedActors: [
+            [] as RelatedActor[],
+            {
+                loadRelatedActors: async ({ groupTypeIndex, id }) => {
+                    const url = `api/projects/${values.currentTeamId}/groups/related?${toParams({
+                        group_type_index: groupTypeIndex,
+                        id,
+                    })}`
+                    return await api.get(url)
+                },
+                setGroup: () => [],
+            },
+        ],
+    }),
+})

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Row, Tabs, Col, Card, Skeleton, Tag, Dropdown, Menu, Button, Popconfirm } from 'antd'
+import { InfoCircleOutlined } from '@ant-design/icons'
 import { EventsTable } from 'scenes/events'
 import { SessionRecordingsTable } from 'scenes/session-recordings/SessionRecordingsTable'
 import { useActions, useValues, BindLogic } from 'kea'
@@ -14,10 +15,13 @@ import { PersonCohorts } from './PersonCohorts'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { NewPropertyComponent } from './NewPropertyComponent'
 import { TZLabel } from 'lib/components/TimezoneAware'
+import { Tooltip } from 'lib/components/Tooltip'
 import { PersonsTabType } from '~/types'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
+import { groupsModel } from '~/models/groupsModel'
+import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 
 const { TabPane } = Tabs
 
@@ -42,6 +46,7 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element {
     const { deletePerson, editProperty, navigateToTab, setSplitMergeModalShown } = useActions(
         personsLogic(personsLogicProps)
     )
+    const { showGroupsOptions } = useValues(groupsModel)
 
     const ids = (
         <Menu>
@@ -181,8 +186,25 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element {
                                     key="cohorts"
                                     disabled={personLoading}
                                 />
+                                {showGroupsOptions && (
+                                    <TabPane
+                                        tab={
+                                            <span data-attr="persons-related-tab">
+                                                Related groups
+                                                <Tooltip
+                                                    title={`Shows people and groups which have shared events with this person in the last 90 days.`}
+                                                >
+                                                    <InfoCircleOutlined style={{ marginLeft: 4 }} />
+                                                </Tooltip>
+                                            </span>
+                                        }
+                                        key="related"
+                                        disabled={personLoading}
+                                    />
+                                )}
                             </Tabs>
                             {person &&
+                                person.uuid &&
                                 (activeCardTab == 'properties' ? (
                                     <div style={{ maxWidth: '100%', overflow: 'hidden' }}>
                                         <NewPropertyComponent />
@@ -195,8 +217,10 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element {
                                             className="persons-page-props-table"
                                         />
                                     </div>
-                                ) : (
+                                ) : activeCardTab == 'cohorts' ? (
                                     <PersonCohorts />
+                                ) : (
+                                    <RelatedGroups id={person.uuid} groupTypeIndex={null} />
                                 ))}
                             {!person && personLoading && <Skeleton paragraph={{ rows: 6 }} active />}
                         </Card>

--- a/frontend/src/scenes/persons/PersonPageHeader.tsx
+++ b/frontend/src/scenes/persons/PersonPageHeader.tsx
@@ -5,15 +5,15 @@ import { GroupsTabs } from 'scenes/groups/GroupsTabs'
 import { groupsModel } from '~/models/groupsModel'
 
 export function PersonPageHeader({ hideGroupTabs }: { hideGroupTabs?: boolean }): JSX.Element {
-    const { groupsEnabled } = useValues(groupsModel)
+    const { showGroupsOptions } = useValues(groupsModel)
 
     return (
         <>
             <PageHeader
-                title={`Persons${groupsEnabled ? ' & groups' : ''}`}
-                caption={`A catalog of your product's end users${groupsEnabled ? ' and groups' : ''}.`}
+                title={`Persons${showGroupsOptions ? ' & groups' : ''}`}
+                caption={`A catalog of your product's end users${showGroupsOptions ? ' and groups' : ''}.`}
             />
-            {!hideGroupTabs && groupsEnabled && <GroupsTabs />}
+            {!hideGroupTabs && showGroupsOptions && <GroupsTabs />}
         </>
     )
 }

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -24,7 +24,7 @@ export const urls = {
     person: (id: string, encode: boolean = true) => (encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`),
     persons: () => '/persons',
     groups: (groupTypeIndex: string) => `/groups/${groupTypeIndex}`,
-    group: (groupTypeIndex: string, groupKey: string, encode: boolean = true) =>
+    group: (groupTypeIndex: string | number, groupKey: string, encode: boolean = true) =>
         `/groups/${groupTypeIndex}/${encode ? encodeURIComponent(groupKey) : groupKey}`,
     cohort: (id: string | number) => `/cohorts/${id}`,
     cohorts: () => '/cohorts',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1325,6 +1325,20 @@ export interface Experiment {
     filters: Partial<FilterType>
 }
 
+interface RelatedPerson {
+    type: 'person'
+    id: string
+    person: Pick<PersonType, 'distinct_ids' | 'properties'>
+}
+
+interface RelatedGroup {
+    type: 'group'
+    group_type_index: number
+    id: string
+}
+
+export type RelatedActor = RelatedPerson | RelatedGroup
+
 export interface SelectOption {
     value: string
     label?: string

--- a/posthog/models/entity.py
+++ b/posthog/models/entity.py
@@ -9,6 +9,7 @@ from posthog.models.action import Action
 from posthog.models.filters.mixins.funnel import FunnelFromToStepsMixin
 from posthog.models.filters.mixins.property import PropertyMixin
 from posthog.models.filters.utils import validate_group_type_index
+from posthog.models.property import GroupTypeIndex
 from posthog.models.utils import sane_repr
 
 MATH_TYPE = Literal[
@@ -41,7 +42,7 @@ class Entity(PropertyMixin):
     custom_name: Optional[str]
     math: Optional[MATH_TYPE]
     math_property: Optional[str]
-    math_group_type_index: Optional[int]
+    math_group_type_index: Optional[GroupTypeIndex]
     # Index is not set at all by default (meaning: access = AttributeError) - it's populated in EntitiesMixin.entities
     # Used for identifying entities within a single query during query building,
     # which generally uses Entity objects processed by EntitiesMixin

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -41,7 +41,7 @@ from posthog.constants import (
 from posthog.models.entity import Entity, ExclusionEntity
 from posthog.models.filters.mixins.base import BaseParamMixin, BreakdownType, IntervalType
 from posthog.models.filters.mixins.utils import cached_property, include_dict, process_bool
-from posthog.models.filters.utils import validate_group_type_index
+from posthog.models.filters.utils import GroupTypeIndex, validate_group_type_index
 from posthog.utils import relative_date_parse
 
 ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
@@ -168,7 +168,7 @@ class BreakdownMixin(BaseParamMixin):
         return self._data.get(BREAKDOWN_TYPE, None)
 
     @cached_property
-    def breakdown_group_type_index(self) -> Optional[int]:
+    def breakdown_group_type_index(self) -> Optional[GroupTypeIndex]:
         value = self._data.get(BREAKDOWN_GROUP_TYPE_INDEX, None)
         return validate_group_type_index(BREAKDOWN_GROUP_TYPE_INDEX, value)
 

--- a/posthog/models/filters/mixins/groups.py
+++ b/posthog/models/filters/mixins/groups.py
@@ -3,12 +3,12 @@ from typing import Optional
 from posthog.constants import AGGREGATION_GROUP_TYPE_INDEX
 from posthog.models.filters.mixins.common import BaseParamMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
-from posthog.models.filters.utils import validate_group_type_index
+from posthog.models.filters.utils import GroupTypeIndex, validate_group_type_index
 
 
 class GroupsAggregationMixin(BaseParamMixin):
     @cached_property
-    def aggregation_group_type_index(self) -> Optional[int]:
+    def aggregation_group_type_index(self) -> Optional[GroupTypeIndex]:
         value = self._data.get(AGGREGATION_GROUP_TYPE_INDEX)
         return validate_group_type_index(AGGREGATION_GROUP_TYPE_INDEX, value)
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -52,7 +52,7 @@ class SimplifyFilterMixin:
         entity = EntityClass(entity_params)
         properties = self._simplify_properties(team, entity.properties, **kwargs)
         if entity.math == "unique_group":
-            properties.append(self._group_set_property(cast(int, entity.math_group_type_index)))
+            properties.append(self._group_set_property(cast(GroupTypeIndex, entity.math_group_type_index)))
 
         return EntityClass({**entity_params, "properties": properties}).to_dict()
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, TypeVar, cast
 
+from posthog.models.property import GroupTypeIndex
 from posthog.utils import is_clickhouse_enabled
 
 if TYPE_CHECKING:  # Avoid circular import
@@ -78,7 +79,7 @@ class SimplifyFilterMixin:
 
         return [property]
 
-    def _group_set_property(self, group_type_index: int) -> "Property":
+    def _group_set_property(self, group_type_index: GroupTypeIndex) -> "Property":
         from posthog.models.property import Property
 
         return Property(key=f"$group_{group_type_index}", value="", operator="is_not",)

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -12,6 +12,7 @@ from posthog.constants import (
     INSIGHT_STICKINESS,
     INSIGHT_TRENDS,
 )
+from posthog.models.property import GroupTypeIndex
 from posthog.utils import is_clickhouse_enabled
 
 
@@ -50,7 +51,7 @@ def get_filter(team, data: dict = {}, request: Optional[Request] = None):
     return Filter(data=data, request=request, team=team)
 
 
-def validate_group_type_index(param_name: str, value: Any, required=False) -> Optional[int]:
+def validate_group_type_index(param_name: str, value: Any, required=False) -> Optional[GroupTypeIndex]:
     error = ValidationError(
         f"{param_name} is required to be greater than 0 and less than {GROUP_TYPES_LIMIT}", code="invalid"
     )

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
+from typing_extensions import Literal
 
 from posthog.constants import (
     GROUP_TYPES_LIMIT,
@@ -12,8 +13,9 @@ from posthog.constants import (
     INSIGHT_STICKINESS,
     INSIGHT_TRENDS,
 )
-from posthog.models.property import GroupTypeIndex
 from posthog.utils import is_clickhouse_enabled
+
+GroupTypeIndex = Literal[0, 1, 2, 3, 4]
 
 
 def earliest_timestamp_func(team_id: int):

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -1,8 +1,7 @@
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
-from typing_extensions import Literal
 
 from posthog.constants import (
     GROUP_TYPES_LIMIT,

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -24,7 +24,7 @@ OperatorType = Literal[
 ]
 
 GroupTypeName = str
-GroupTypeIndex = int
+GroupTypeIndex = Literal[0, 1, 2, 3, 4]
 PropertyIdentifier = Tuple[PropertyName, PropertyType, Optional[GroupTypeIndex]]
 
 NEGATED_OPERATORS = ["is_not", "not_icontains", "not_regex", "is_not_set"]
@@ -36,7 +36,7 @@ class Property:
     operator: Optional[OperatorType]
     value: ValueT
     type: PropertyType
-    group_type_index: Optional[int]
+    group_type_index: Optional[GroupTypeIndex]
 
     def __init__(
         self,

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -12,7 +12,7 @@ from typing import (
 
 from django.db.models import Exists, OuterRef, Q
 
-from posthog.models.filters.utils import validate_group_type_index
+from posthog.models.filters.utils import GroupTypeIndex, validate_group_type_index
 from posthog.utils import is_valid_regex
 
 ValueT = Union[str, int, List[str]]
@@ -24,7 +24,6 @@ OperatorType = Literal[
 ]
 
 GroupTypeName = str
-GroupTypeIndex = Literal[0, 1, 2, 3, 4]
 PropertyIdentifier = Tuple[PropertyName, PropertyType, Optional[GroupTypeIndex]]
 
 NEGATED_OPERATORS = ["is_not", "not_icontains", "not_regex", "is_not_set"]


### PR DESCRIPTION
## Changes

This PR:
- Adds "related groups" tab to person and groups pages, linking to groups & persons that have shared events with the active person/group
- Fixes linking to groups with names that contain special characters
- Refactors backend types a bit

![image](https://user-images.githubusercontent.com/148820/144224030-2b92d3e5-6156-4e73-8305-6adca2e35be2.png)

![image](https://user-images.githubusercontent.com/148820/144223993-3123eaff-3b14-4c5c-bba6-a2d617183640.png)


## How did you test this code?

See screenshots + tests.
