### PR TITLE
Add shared dashboard tab

### DIFF
--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -177,3 +177,29 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         events = query_action(action1)
         self.assertEqual(len(events), 1)  # type: ignore
+
+    def test_properties_one(self):
+        # Tests a regression where the second step properties would override those of the first step, causing issues
+        _create_event(
+            event="insight viewed", team=self.team, distinct_id="whatever", properties={"filters_count": 2},
+        )
+
+        action1 = Action.objects.create(team=self.team, name="action1")
+        step1 = ActionStep.objects.create(
+            event="insight viewed",
+            action=action1,
+            properties=[
+                {"key": "insight", "type": "event", "value": ["RETENTION"], "operator": "exact"},
+                {"key": "insight", "type": "event", "value": ["RETENTION2"], "operator": "not_icontains"},
+                {"key": "insight", "type": "event", "value": ["RETENTION3"], "operator": "not_icontains"},
+                {"key": "insight", "type": "event", "value": ["RETENTION4"], "operator": "not_icontains"},
+                {"key": "insight", "type": "event", "value": ["RETENTION5"], "operator": "not_icontains"},
+            ],
+        )
+
+        formatted_query, params = format_action_filter(action1, "")
+        import ipdb
+
+        ipdb.set_trace()
+        events = query_action(action1)
+        self.assertEqual(len(events), 1)  # type: ignore

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -177,29 +177,3 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         events = query_action(action1)
         self.assertEqual(len(events), 1)  # type: ignore
-
-    def test_properties_one(self):
-        # Tests a regression where the second step properties would override those of the first step, causing issues
-        _create_event(
-            event="insight viewed", team=self.team, distinct_id="whatever", properties={"filters_count": 2},
-        )
-
-        action1 = Action.objects.create(team=self.team, name="action1")
-        step1 = ActionStep.objects.create(
-            event="insight viewed",
-            action=action1,
-            properties=[
-                {"key": "insight", "type": "event", "value": ["RETENTION"], "operator": "exact"},
-                {"key": "insight", "type": "event", "value": ["RETENTION2"], "operator": "not_icontains"},
-                {"key": "insight", "type": "event", "value": ["RETENTION3"], "operator": "not_icontains"},
-                {"key": "insight", "type": "event", "value": ["RETENTION4"], "operator": "not_icontains"},
-                {"key": "insight", "type": "event", "value": ["RETENTION5"], "operator": "not_icontains"},
-            ],
-        )
-
-        formatted_query, params = format_action_filter(action1, "")
-        import ipdb
-
-        ipdb.set_trace()
-        events = query_action(action1)
-        self.assertEqual(len(events), 1)  # type: ignore

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -143,7 +143,6 @@
 
                     .anticon-share-alt {
                         font-size: 16px;
-                        color: $success;
                         margin-left: 6px !important;
                         margin-right: 4px;
                     }

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -4,7 +4,7 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { Button, Card, Col, Drawer, Input, Row, Tabs } from 'antd'
 import { dashboardsLogic, DashboardsTab } from 'scenes/dashboard/dashboardsLogic'
 import { Link } from 'lib/components/Link'
-import { AppstoreAddOutlined, PlusOutlined, PushpinFilled, PushpinOutlined } from '@ant-design/icons'
+import { AppstoreAddOutlined, PlusOutlined, PushpinFilled, PushpinOutlined, ShareAltOutlined } from '@ant-design/icons'
 import { NewDashboard } from 'scenes/dashboard/NewDashboard'
 import { PageHeader } from 'lib/components/PageHeader'
 import { AvailableFeature, DashboardMode, DashboardType } from '~/types'
@@ -20,6 +20,7 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { dashboardLogic } from './dashboardLogic'
 import { LemonSpacer } from 'lib/components/LemonRow'
+import { Tooltip } from 'lib/components/Tooltip'
 
 export const scene: SceneExport = {
     component: Dashboards,
@@ -56,12 +57,19 @@ export function Dashboards(): JSX.Element {
             title: 'Name',
             dataIndex: 'name',
             width: '40%',
-            render: function Render(name, { id, description, _highlight }) {
+            render: function Render(name, { id, description, _highlight, is_shared }) {
                 return (
                     <div className={_highlight ? 'highlighted' : undefined} style={{ display: 'inline-block' }}>
                         <Link data-attr="dashboard-name" to={urls.dashboard(id)}>
-                            <h4 className="row-name">{name || 'Untitled'}</h4>
+                            <h4 className="row-name" style={{ display: 'inline' }}>
+                                {name || 'Untitled'}
+                            </h4>
                         </Link>
+                        {is_shared && (
+                            <Tooltip title="This dashboard is shared publicly.">
+                                <ShareAltOutlined style={{ marginLeft: 6 }} />
+                            </Tooltip>
+                        )}
                         {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && description && (
                             <span className="row-description">{description}</span>
                         )}
@@ -160,6 +168,7 @@ export function Dashboards(): JSX.Element {
             >
                 <Tabs.TabPane tab="All Dashboards" key={DashboardsTab.All} />
                 <Tabs.TabPane tab="Pinned" key={DashboardsTab.Pinned} />
+                <Tabs.TabPane tab="Shared" key={DashboardsTab.Shared} />
             </Tabs>
             <div>
                 <Input.Search
@@ -200,13 +209,24 @@ export function Dashboards(): JSX.Element {
                     emptyState={
                         searchTerm ? (
                             `No ${
-                                currentTab === DashboardsTab.Pinned ? 'pinned ' : ''
+                                currentTab === DashboardsTab.Pinned
+                                    ? 'pinned '
+                                    : currentTab === DashboardsTab.Shared
+                                    ? 'shared '
+                                    : ''
                             }dashboards matching "${searchTerm}"!`
                         ) : currentTab === DashboardsTab.Pinned ? (
                             <>
                                 No dashboards have been pinned for quick access yet.{' '}
                                 <Link onClick={() => setCurrentTab(DashboardsTab.All)}>
-                                    Go to All Dashboards to pin one now.
+                                    Go to All Dashboards to pin one.
+                                </Link>
+                            </>
+                        ) : currentTab === DashboardsTab.Shared ? (
+                            <>
+                                No dashboards have been shared yet.{' '}
+                                <Link onClick={() => setCurrentTab(DashboardsTab.All)}>
+                                    Go to All Dashboards to share one.
                                 </Link>
                             </>
                         ) : undefined

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -60,16 +60,18 @@ export function Dashboards(): JSX.Element {
             render: function Render(name, { id, description, _highlight, is_shared }) {
                 return (
                     <div className={_highlight ? 'highlighted' : undefined} style={{ display: 'inline-block' }}>
-                        <Link data-attr="dashboard-name" to={urls.dashboard(id)}>
-                            <h4 className="row-name" style={{ display: 'inline' }}>
-                                {name || 'Untitled'}
-                            </h4>
-                        </Link>
-                        {is_shared && (
-                            <Tooltip title="This dashboard is shared publicly.">
-                                <ShareAltOutlined style={{ marginLeft: 6 }} />
-                            </Tooltip>
-                        )}
+                        <div>
+                            <Link data-attr="dashboard-name" to={urls.dashboard(id)}>
+                                <h4 className="row-name" style={{ display: 'inline' }}>
+                                    {name || 'Untitled'}
+                                </h4>
+                            </Link>
+                            {is_shared && (
+                                <Tooltip title="This dashboard is shared publicly.">
+                                    <ShareAltOutlined style={{ marginLeft: 6 }} />
+                                </Tooltip>
+                            )}
+                        </div>
                         {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && description && (
                             <span className="row-description">{description}</span>
                         )}

--- a/frontend/src/scenes/dashboard/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardsLogic.ts
@@ -47,8 +47,7 @@ export const dashboardsLogic = kea<dashboardsLogicType<DashboardsTab>>({
                     .sort((a, b) => (a.name ?? 'Untitled').localeCompare(b.name ?? 'Untitled'))
                 if (currentTab === DashboardsTab.Pinned) {
                     dashboards = dashboards.filter((d) => d.pinned)
-                }
-                if (currentTab === DashboardsTab.Shared) {
+                } else if (currentTab === DashboardsTab.Shared) {
                     dashboards = dashboards.filter((d) => d.is_shared)
                 }
                 if (!searchTerm) {

--- a/frontend/src/scenes/dashboard/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardsLogic.ts
@@ -10,6 +10,7 @@ import { urls } from 'scenes/urls'
 export enum DashboardsTab {
     All = 'all',
     Pinned = 'pinned',
+    Shared = 'shared',
 }
 
 export const dashboardsLogic = kea<dashboardsLogicType<DashboardsTab>>({
@@ -46,6 +47,9 @@ export const dashboardsLogic = kea<dashboardsLogicType<DashboardsTab>>({
                     .sort((a, b) => (a.name ?? 'Untitled').localeCompare(b.name ?? 'Untitled'))
                 if (currentTab === DashboardsTab.Pinned) {
                     dashboards = dashboards.filter((d) => d.pinned)
+                }
+                if (currentTab === DashboardsTab.Shared) {
+                    dashboards = dashboards.filter((d) => d.is_shared)
                 }
                 if (!searchTerm) {
                     return dashboards


### PR DESCRIPTION
## Changes

Add a tab to filters the dashboards to only show shared dashboards. Also show a little icon to indicate it's shared.

![image](https://user-images.githubusercontent.com/1727427/144238262-5d5bd2cc-1d31-44b7-b296-cacd6236c0b7.png)

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. Share a dashboard.
2. see that that dashboard is listed when you click 'shared'

