### PR TITLE
Upload app from container to s3

### DIFF
--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -47,6 +47,26 @@ jobs:
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
                   echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
+            - name: Extract and push the static asssets to AWS S3
+              run: |
+                  TMP_FOLDER="$(mktemp -d)"
+                  trap 'rm -rf -- "$TMP_FOLDER"' EXIT
+
+                  CONTAINER_NAME="posthog"
+                  IMAGE_NAME="${{ steps.build-image.outputs.image }}"
+                  S3_BUCKET="posthog-app-static"
+
+                  echo "## Extracting static assets from the container..."
+                  docker rm -f $CONTAINER_NAME
+                  docker create --name $CONTAINER_NAME $IMAGE_NAME
+                  docker cp "${CONTAINER_NAME}:/home/posthog/code/frontend/dist/" "${TMP_FOLDER}"
+                  docker rm -f $CONTAINER_NAME
+                  echo "Done!"
+
+                  echo "## Uploading the extracted static assets to the AWS S3 bucket..."
+                  aws s3 cp "${TMP_FOLDER}" "s3://${S3_BUCKET}/" --recursive
+                  echo "Done!"
+
             - name: Fill in the new image ID in the Amazon ECS task definition
               id: task-def-web
               uses: aws-actions/amazon-ecs-render-task-definition@v1

--- a/.github/workflows/prod-container.yml
+++ b/.github/workflows/prod-container.yml
@@ -64,7 +64,7 @@ jobs:
                   echo "Done!"
 
                   echo "## Uploading the extracted static assets to the AWS S3 bucket..."
-                  aws s3 cp "${TMP_FOLDER}" "s3://${S3_BUCKET}/" --recursive
+                  aws s3 cp "${TMP_FOLDER}/dist/" "s3://${S3_BUCKET}/static" --recursive
                   echo "Done!"
 
             - name: Fill in the new image ID in the Amazon ECS task definition


### PR DESCRIPTION
Problem:
We have an issue where during deploys we are simultaneously serving an old and new revision's frontend and backend which can lead to issues where an old backend requests the old revision's frontend and that hits an instance serving only the new revision (thus returning a 404).

Solution:
Serve the frontend from an S3 bucket which has both revision versions available.

https://posthog.slack.com/archives/C01MM7VT7MG/p1638367653333200?thread_ts=1638358466.318100&cid=C01MM7VT7MG