### PR TITLE
perf(retention): add benchmark cases for retention

### DIFF
--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -10,7 +10,9 @@ from ee.clickhouse.queries.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.funnels.funnel_correlation import FunnelCorrelation
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
 from ee.clickhouse.queries.session_recordings.clickhouse_session_recording_list import ClickhouseSessionRecordingList
+from ee.clickhouse.queries.clickhouse_retention import ClickhouseRetention
 from posthog.models import Action, ActionStep, Cohort, Team, Organization
+from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.filter import Filter
@@ -212,7 +214,8 @@ class QuerySuite:
     @benchmark_clickhouse
     def track_correlations_by_events(self):
         filter = Filter(
-            data={"events": [{"id": "user signed up"}, {"id": "insight analyzed"}], **SHORT_DATE_RANGE,}, team=self.team
+            data={"events": [{"id": "user signed up"}, {"id": "insight analyzed"}], **SHORT_DATE_RANGE,},
+            team=self.team,
         )
 
         FunnelCorrelation(filter, self.team).run()
@@ -347,6 +350,60 @@ class QuerySuite:
         )
 
         ClickhouseSessionRecordingList(filter, self.team.pk).run()
+
+    @benchmark_clickhouse
+    def track_retention(self):
+        filter = RetentionFilter(
+            data={
+                "insight": "RETENTION",
+                "target_event": {"id": "$pageview"},
+                "returning_event": {"id": "$pageview"},
+                "total_intervals": 14,
+                "retention_type": "retention_first_time",
+                "period": "Week",
+                **DATE_RANGE,
+            },
+            team=self.team,
+        )
+
+        ClickhouseRetention().run(filter, self.team)
+
+    @benchmark_clickhouse
+    def track_retention_filter_by_person_property(self):
+        filter = RetentionFilter(
+            data={
+                "insight": "RETENTION",
+                "target_event": {"id": "$pageview"},
+                "returning_event": {"id": "$pageview"},
+                "total_intervals": 14,
+                "retention_type": "retention_first_time",
+                "period": "Week",
+                "properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}],
+                **DATE_RANGE,
+            },
+            team=self.team,
+        )
+
+        with no_materialized_columns():
+            ClickhouseRetention().run(filter, self.team)
+
+    @benchmark_clickhouse
+    def track_retention_filter_by_person_property_materialized(self):
+        filter = RetentionFilter(
+            data={
+                "insight": "RETENTION",
+                "target_event": {"id": "$pageview"},
+                "returning_event": {"id": "$pageview"},
+                "total_intervals": 14,
+                "retention_type": "retention_first_time",
+                "period": "Week",
+                "properties": [{"key": "email", "operator": "icontains", "value": ".com", "type": "person"}],
+                **DATE_RANGE,
+            },
+            team=self.team,
+        )
+
+        ClickhouseRetention().run(filter, self.team)
 
     def setup(self):
         for table, property in MATERIALIZED_PROPERTIES:


### PR DESCRIPTION
## Changes

This was pretty much as copy paste job from the stickiness cases. I'm
going to be merging in some changes to retention so I want to get this
in first such that we can see if it affects the perf of these queries at
all. I don't think it touches them, as seen by the snapshot queries
generated by the retention tests not changing in
https://github.com/PostHog/posthog/pull/7431 but better safe than sorry.

Addresses [this comment](https://github.com/PostHog/posthog/pull/7431#pullrequestreview-820773405)

## How did you test this code?

Didn't run locally, but just adding the `performance` label to see if it runs