### PR TITLE
Use chunked entrypoints

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -6,7 +6,10 @@ import fse from 'fs-extra'
 function writeIndexHtml(chunks = {}, entrypoints = []) {
     copyIndexHtml('src/index.html', 'dist/index.html', 'index', chunks, entrypoints)
     copyIndexHtml('src/layout.html', 'dist/layout.html', 'index', chunks, entrypoints)
-    copyIndexHtml('src/shared_dashboard.html', 'dist/shared_dashboard.html', 'shared_dashboard', chunks, [])
+}
+
+function writeSharedDashboardHtml(chunks = {}, entrypoints = []) {
+    copyIndexHtml('src/shared_dashboard.html', 'dist/shared_dashboard.html', 'shared_dashboard', chunks, entrypoints)
 }
 
 let pauseServer = () => {}
@@ -39,6 +42,10 @@ function onBuildComplete(config, buildResponse) {
         writeIndexHtml(chunks, entrypoints)
     }
 
+    if (config.name === 'Shared Dashboard') {
+        writeSharedDashboardHtml(chunks, entrypoints)
+    }
+
     // copy "index-TMOJQ3VI.js" -> "index.js"
     for (const entrypoint of entrypoints) {
         const withoutHash = entrypoint.replace(/-([A-Z0-9]+).(js|css)$/, '.$2')
@@ -55,7 +62,8 @@ function onBuildComplete(config, buildResponse) {
 }
 
 copyPublicFolder()
-writeIndexHtml({}, [])
+writeIndexHtml()
+writeSharedDashboardHtml()
 
 await Promise.all([
     buildOrWatch({

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -2,96 +2,91 @@
 import * as path from 'path'
 import {
     __dirname,
-    copyIndexHtml,
     copyPublicFolder,
-    buildOrWatch,
     isDev,
     startServer,
     createHashlessEntrypoints,
+    buildInParallel,
+    copyIndexHtml,
 } from './utils.mjs'
 
-function writeIndexHtml(chunks = {}, entrypoints = []) {
+export function writeIndexHtml(chunks = {}, entrypoints = []) {
     copyIndexHtml('src/index.html', 'dist/index.html', 'index', chunks, entrypoints)
     copyIndexHtml('src/layout.html', 'dist/layout.html', 'index', chunks, entrypoints)
 }
 
-function writeSharedDashboardHtml(chunks = {}, entrypoints = []) {
+export function writeSharedDashboardHtml(chunks = {}, entrypoints = []) {
     copyIndexHtml('src/shared_dashboard.html', 'dist/shared_dashboard.html', 'shared_dashboard', chunks, entrypoints)
 }
 
-let pauseServer = () => {}
-let resumeServer = () => {}
+let server
 if (isDev) {
     console.log(`👀 Starting dev server`)
-    const serverResponse = startServer()
-    pauseServer = serverResponse.pauseServer
-    resumeServer = serverResponse.resumeServer
+    server = startServer()
 } else {
     console.log(`🛳 Starting production build`)
 }
 let buildsInProgress = 0
-function onBuildStart() {
-    if (buildsInProgress === 0) {
-        pauseServer()
-    }
-    buildsInProgress++
-}
-function onBuildComplete(config, buildResponse) {
-    const { chunks, entrypoints } = buildResponse
-
-    if (config.name === 'PostHog App') {
-        if (Object.keys(chunks).length === 0) {
-            throw new Error('Could not get chunk metadata for bundle "PostHog App."')
-        }
-        if (Object.keys(entrypoints).length === 0) {
-            throw new Error('Could not get entrypoint for bundle "PostHog App."')
-        }
-        writeIndexHtml(chunks, entrypoints)
-    }
-
-    if (config.name === 'Shared Dashboard') {
-        writeSharedDashboardHtml(chunks, entrypoints)
-    }
-
-    createHashlessEntrypoints(entrypoints)
-
-    buildsInProgress--
-    if (buildsInProgress === 0) {
-        resumeServer()
-    }
-}
 
 copyPublicFolder()
 writeIndexHtml()
 writeSharedDashboardHtml()
 
-await Promise.all([
-    buildOrWatch({
-        name: 'PostHog App',
-        entryPoints: ['src/index.tsx'],
-        bundle: true,
-        splitting: true,
-        format: 'esm',
-        outdir: path.resolve(__dirname, 'dist'),
-        onBuildStart,
-        onBuildComplete,
-    }),
-    buildOrWatch({
-        name: 'Shared Dashboard',
-        entryPoints: ['src/scenes/dashboard/SharedDashboard.tsx'],
-        bundle: true,
-        format: 'iife',
-        outfile: path.resolve(__dirname, 'dist', 'shared_dashboard.js'),
-        onBuildStart,
-        onBuildComplete,
-    }),
-    buildOrWatch({
-        name: 'Toolbar',
-        entryPoints: ['src/toolbar/index.tsx'],
-        bundle: true,
-        format: 'iife',
-        outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),
-        onBuildStart,
-        onBuildComplete,
-    }),
-])
+buildInParallel(
+    [
+        {
+            name: 'PostHog App',
+            entryPoints: ['src/index.tsx'],
+            bundle: true,
+            splitting: true,
+            format: 'esm',
+            outdir: path.resolve(__dirname, 'dist'),
+        },
+        {
+            name: 'Shared Dashboard',
+            entryPoints: ['src/scenes/dashboard/SharedDashboard.tsx'],
+            bundle: true,
+            format: 'iife',
+            outfile: path.resolve(__dirname, 'dist', 'shared_dashboard.js'),
+        },
+        {
+            name: 'Toolbar',
+            entryPoints: ['src/toolbar/index.tsx'],
+            bundle: true,
+            format: 'iife',
+            outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),
+        },
+    ],
+    {
+        onBuildStart: () => {
+            if (buildsInProgress === 0) {
+                server?.pauseServer()
+            }
+            buildsInProgress++
+        },
+        onBuildComplete(config, buildResponse) {
+            const { chunks, entrypoints } = buildResponse
+
+            if (config.name === 'PostHog App') {
+                if (Object.keys(chunks).length === 0) {
+                    throw new Error('Could not get chunk metadata for bundle "PostHog App."')
+                }
+                if (Object.keys(entrypoints).length === 0) {
+                    throw new Error('Could not get entrypoint for bundle "PostHog App."')
+                }
+                writeIndexHtml(chunks, entrypoints)
+            }
+
+            if (config.name === 'Shared Dashboard') {
+                writeSharedDashboardHtml(chunks, entrypoints)
+            }
+
+            createHashlessEntrypoints(entrypoints)
+
+            buildsInProgress--
+            if (buildsInProgress === 0) {
+                server?.resumeServer()
+            }
+        },
+    }
+)

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import * as path from 'path'
-import { __dirname, copyIndexHtml, copyPublicFolder, buildOrWatch, isDev, startServer } from './utils.mjs'
-import fse from 'fs-extra'
+import {
+    __dirname,
+    copyIndexHtml,
+    copyPublicFolder,
+    buildOrWatch,
+    isDev,
+    startServer,
+    createHashlessEntrypoints,
+} from './utils.mjs'
 
 function writeIndexHtml(chunks = {}, entrypoints = []) {
     copyIndexHtml('src/index.html', 'dist/index.html', 'index', chunks, entrypoints)
@@ -46,14 +53,7 @@ function onBuildComplete(config, buildResponse) {
         writeSharedDashboardHtml(chunks, entrypoints)
     }
 
-    // copy "index-TMOJQ3VI.js" -> "index.js"
-    for (const entrypoint of entrypoints) {
-        const withoutHash = entrypoint.replace(/-([A-Z0-9]+).(js|css)$/, '.$2')
-        fse.writeFileSync(
-            path.resolve(__dirname, 'dist', withoutHash),
-            fse.readFileSync(path.resolve(__dirname, 'dist', entrypoint))
-        )
-    }
+    createHashlessEntrypoints(entrypoints)
 
     buildsInProgress--
     if (buildsInProgress === 0) {

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -96,6 +96,17 @@ export function copyIndexHtml(
     )
 }
 
+/** Makes copies: "index-TMOJQ3VI.js" -> "index.js" */
+export function createHashlessEntrypoints(entrypoints) {
+    for (const entrypoint of entrypoints) {
+        const withoutHash = entrypoint.replace(/-([A-Z0-9]+).(js|css)$/, '.$2')
+        fse.writeFileSync(
+            path.resolve(__dirname, 'dist', withoutHash),
+            fse.readFileSync(path.resolve(__dirname, 'dist', entrypoint))
+        )
+    }
+}
+
 export const commonConfig = {
     sourcemap: true,
     incremental: isDev,

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -50,6 +50,7 @@ export function copyPublicFolder() {
         }
     })
 }
+
 export function copyIndexHtml(
     from = 'src/index.html',
     to = 'dist/index.html',
@@ -160,6 +161,18 @@ function getChunks(result) {
     return chunks
 }
 
+export async function buildInParallel(configs, { onBuildStart, onBuildComplete }) {
+    await Promise.all(
+        configs.map((config) =>
+            buildOrWatch({
+                ...config,
+                onBuildStart,
+                onBuildComplete,
+            })
+        )
+    )
+}
+
 export async function buildOrWatch(config) {
     const { name, onBuildStart, onBuildComplete, ..._config } = config
 
@@ -178,7 +191,7 @@ export async function buildOrWatch(config) {
             return
         }
         buildAgain = false
-        onBuildStart?.()
+        onBuildStart?.(config)
         reloadLiveServer()
         buildPromise = runBuild()
         const buildResponse = await buildPromise


### PR DESCRIPTION
## Changes

- Instead of `index.js`, we now have `index.js` AND `index-HASH.js` (same for `.css`)
- The generated `.html` files (to be further consumed by django) will contain the correct HASH inside.
- Code smell: I hardcoded a bunch of paths, but since there are already other hardcoded paths in these scripts, I'm personally fine with this.

## How did you test this code?

- Reloaded the browser locally, before the build had finished (got `index.js?t=` still), and also after (got `index-HASH.js`), and saw that the right files were loading.
![image](https://user-images.githubusercontent.com/53387/144411120-db89045d-6df6-4a62-9caf-484723413b45.png)
- Made sure the toolbar loaded fine
- Also checked saved dashboards
![image](https://user-images.githubusercontent.com/53387/144411767-2e55daf4-8c1c-4f32-8695-042ca9f89d3f.png)
