### PR TITLE
Add logging to all postgresql queries with query context

### DIFF
--- a/ee/benchmarks/helpers.py
+++ b/ee/benchmarks/helpers.py
@@ -16,6 +16,7 @@ django.setup()
 
 from ee.clickhouse import client
 from ee.clickhouse.materialized_columns.columns import get_materialized_columns
+from posthog.management import query_logging
 from posthog.models.utils import UUIDT
 
 get_column = lambda rows, index: [row[index] for row in rows]
@@ -23,12 +24,12 @@ get_column = lambda rows, index: [row[index] for row in rows]
 
 def run_query(fn, *args):
     uuid = str(UUIDT())
-    client._request_information = {"kind": "benchmark", "id": f"{uuid}::${fn.__name__}"}
+    query_logging.request_information = {"kind": "benchmark", "id": f"{uuid}::${fn.__name__}"}
     try:
         fn(*args)
         return get_clickhouse_query_stats(uuid)
     finally:
-        client._request_information = None
+        query_logging.request_information = None
 
 
 def get_clickhouse_query_stats(uuid):

--- a/ee/clickhouse/middleware.py
+++ b/ee/clickhouse/middleware.py
@@ -4,6 +4,7 @@ from django.urls.base import resolve
 from loginas.utils import is_impersonated_session
 
 from posthog.internal_metrics import incr
+from posthog.management import query_logging
 from posthog.utils import is_clickhouse_enabled
 
 
@@ -18,11 +19,10 @@ class CHQueries(object):
         then do it now.
 
         """
-        from ee.clickhouse import client
 
         route = resolve(request.path)
         route_id = f"{route.route} ({route.func.__name__})"
-        client._request_information = {
+        query_logging.request_information = {
             "save": (
                 is_clickhouse_enabled()
                 and request.user.pk
@@ -38,6 +38,6 @@ class CHQueries(object):
         if "api/" in route_id and "capture" not in route_id:
             incr("http_api_request_response", tags={"id": route_id, "status_code": response.status_code})
 
-        client._request_information = None
+        query_logging.request_information = None
 
         return response

--- a/ee/clickhouse/test/test_client.py
+++ b/ee/clickhouse/test/test_client.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from ee.clickhouse import client
 from ee.clickhouse.client import CACHE_TTL, _deserialize, _key_hash, cache_sync_execute, sync_execute
 from ee.clickhouse.util import ClickhouseTestMixin
+from posthog.management import query_logging
 
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
@@ -60,7 +61,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         # First add in the request information that should be added to the sql.
         # We check this to make sure it is not removed by the comment stripping
         with self.capture_select_queries() as sqls:
-            client._request_information = {"kind": "request", "id": "1"}
+            query_logging.request_information = {"kind": "request", "id": "1"}
             sync_execute(
                 query="""
                     -- this request returns 1

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -3,6 +3,8 @@ import os
 import posthoganalytics
 from django.apps import AppConfig
 from django.conf import settings
+from django.db.backends.signals import connection_created
+from django.dispatch.dispatcher import receiver
 
 from posthog.special_migrations.manager import init_special_migrations
 from posthog.utils import get_git_branch, get_git_commit, get_machine_id
@@ -46,3 +48,10 @@ class PostHogConfig(AppConfig):
                         exit(1)
 
         init_special_migrations()
+
+
+@receiver(connection_created)
+def on_db_connection_ready(sender, connection, **kwargs):
+    from posthog.management.query_logging import execute_pg_query_with_logging
+
+    connection.execute_wrappers.append(execute_pg_query_with_logging)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -140,18 +140,16 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 # Set up clickhouse query instrumentation
 @task_prerun.connect
 def set_up_instrumentation(task_id, task, **kwargs):
-    if is_clickhouse_enabled() and settings.EE_AVAILABLE:
-        from ee.clickhouse import client
+    from posthog.management import query_logging
 
-        client._request_information = {"kind": "celery", "id": task.name}
+    query_logging.request_information = {"kind": "celery", "id": task.name}
 
 
 @task_postrun.connect
 def teardown_instrumentation(task_id, task, **kwargs):
-    if is_clickhouse_enabled() and settings.EE_AVAILABLE:
-        from ee.clickhouse import client
+    from posthog.management import query_logging
 
-        client._request_information = None
+    query_logging.request_information = None
 
 
 @app.task(ignore_result=True)

--- a/posthog/management/query_logging.py
+++ b/posthog/management/query_logging.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, Optional
 
+import psycopg2.sql
+
 request_information: Optional[Dict] = None
 
 
@@ -11,6 +13,9 @@ def execute_pg_query_with_logging(execute, sql, *args, **kwargs):
 
     Install this via connection.execute_wrappers.append
     """
+
+    if isinstance(sql, psycopg2.sql.SQL):
+        sql = sql.string
 
     return execute(f"{sql_comment()}{sql}", *args, **kwargs)
 

--- a/posthog/management/query_logging.py
+++ b/posthog/management/query_logging.py
@@ -1,0 +1,22 @@
+# Wraps the default django.db.backends.postgresql database wrapper, but adds comments to queries being executed
+
+from typing import Dict, Optional
+
+request_information: Optional[Dict] = None
+
+
+def execute_pg_query_with_logging(execute, sql, *args, **kwargs):
+    """
+    Executes the query with a comment with request information prepended.
+
+    Install this via connection.execute_wrappers.append
+    """
+
+    return execute(f"{sql_comment()}{sql}", *args, **kwargs)
+
+
+def sql_comment():
+    if request_information is not None:
+        return f"/* {request_information['kind']}:{request_information['id'].replace('/', '_')} */ "
+    else:
+        return ""


### PR DESCRIPTION
Uses the exact same pattern as we do currently for clickhouse, just
hooking in there differently

## How did you test this code?

Added print statements and inspected my console output
