### PR TITLE
Move the funnel logic so it's initialised as late as possible

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItem.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItem.tsx
@@ -221,7 +221,7 @@ export function DashboardItem({
     const { loadResults } = useActions(insightLogic(logicProps))
 
     const { reportDashboardItemRefreshed } = useActions(eventUsageLogic)
-    const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
+
     const previousLoading = usePrevious(insightLoading)
     const diveDashboard = item.dive_dashboard ? getDashboard(item.dive_dashboard) : null
 
@@ -236,6 +236,9 @@ export function DashboardItem({
     const BlockingEmptyState = (() => {
         // Insight specific empty states - note order is important here
         if (item.filters.insight === InsightType.FUNNELS) {
+            // only mount the funnel logic if this dashboard item is a funnel
+            const { areFiltersValid, isValidFunnel, areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
+
             if (!areFiltersValid) {
                 return <FunnelSingleStepState />
             }


### PR DESCRIPTION
## Changes

For #7376 we want to only mount funnel logic when necessary, but it is also a low priority piece of work

This change moves the funnel logic initialisation into the only branch in the DashboardItem that cares about the funnel logic values

## How did you test this code?

Creating a dashboard with no funnel and using redux dev tools to see that the funnel logic is not mounted, then adding a funnel to the dashboard and seeing that it is
