### PR TITLE
`task-definition.web.json` - update domain record for static assets

### DIFF
--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -24,7 +24,7 @@
             "environment": [
                 {
                     "name": "JS_URL",
-                    "value": "https://d1l1qibt80hm9p.cloudfront.net"
+                    "value": "https://app-static.posthog.com"
                 },
                 {
                     "name": "USING_PGBOUNCER",


### PR DESCRIPTION
## Changes
I've paired with @hazzadous in order to improve our initial CDN setup we deployed yesterday. This PR switches the domain record we use to serve static assets.

Note: both `https://d1l1qibt80hm9p.cloudfront.net` and `https://app-static.posthog.com` are currently using as origin the same S3 bucket.

Additionally, `https://app-static.posthog.com` uses a default TTL of 1 hour. We can invalidate cached assets in CF (if necessary) by following [this doc](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html). 

## How did you test this code?

```
➜  ~ curl -I https://d1l1qibt80hm9p.cloudfront.net/static/index-WJJHIWV6.css
HTTP/2 200
content-type: text/css
content-length: 725172
vary: Accept-Encoding
date: Fri, 03 Dec 2021 09:32:24 GMT
last-modified: Fri, 03 Dec 2021 08:53:18 GMT
etag: "dbafe3f9748f150ecb56f2fdda112b25"
accept-ranges: bytes
server: AmazonS3
vary: Origin
x-cache: Miss from cloudfront
via: 1.1 ddf1a4286ca5a84e441f34f1b121a3ca.cloudfront.net (CloudFront)
x-amz-cf-pop: HAM50-C1
x-amz-cf-id: DlWPVUqJ9MnXkILvVmmKM4pzwhUjoM2fMH56FRGGBzNJac2NjQQh8Q==
```

VS

```
➜  ~ curl -I https://app-static.posthog.com/static/index-WJJHIWV6.css
HTTP/2 200
content-type: text/css
content-length: 725172
date: Fri, 03 Dec 2021 09:27:37 GMT
last-modified: Fri, 03 Dec 2021 08:53:18 GMT
etag: "dbafe3f9748f150ecb56f2fdda112b25"
accept-ranges: bytes
server: AmazonS3
vary: Accept-Encoding
x-cache: Hit from cloudfront
via: 1.1 be43ad4ac2015a11cc932d5a96f3e717.cloudfront.net (CloudFront)
x-amz-cf-pop: HAM50-C2
x-amz-cf-id: 0-9P0dRV4q3sI8aOA_OP-_-1gO55Q7Ot84sIMWEKB4-QmZ87zwKx9g==
age: 309
```
