### PR TITLE
Switch `.loading-overlay` background from dark gray to white

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -793,7 +793,7 @@ body {
     position: absolute;
     top: 0;
     left: 0;
-    background: transparentize($bg_charcoal, 0.5);
+    background: rgba(255, 255, 255, 0.5);
     text-align: center;
     min-height: 6rem;
     z-index: $z_content_overlay;


### PR DESCRIPTION
## Changes

The loading overlay used to increase brightness, but in #7427 yesterday it was made dark. This is IMO kind of jarring however – every time something loads instead of things just becoming more muted (our UI generally being white), there's now a big flash of gray:
![Zrzut ekranu 2021-12-2 o 20 07 49](https://user-images.githubusercontent.com/4550621/144487070-fe02cb16-5df7-4cad-8715-380299bfdf69.png)
This brings back the previous style (identical as used e.g. in our tables when they are loading):
![Zrzut ekranu 2021-12-2 o 20 13 17](https://user-images.githubusercontent.com/4550621/144487726-2ea03ac7-eb4c-4805-a65f-a6e4351f62af.png)
