### PR TITLE
Tooltip shows on entire axis intersect

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -227,7 +227,7 @@ export function LineGraph({
             // If bar, we want to only show the tooltip for what we're hovering over
             // to avoid confusion
             axis: type === 'horizontalBar' ? 'xy' : 'x',
-            intersect: type === 'horizontalBar',
+            intersect: false,
             itemSort: (a, b) => b.yLabel - a.yLabel,
             callbacks: {
                 label: function labelElement(tooltipItem, data) {


### PR DESCRIPTION
## Changes

Super simple fix for #5698. Instead of assigning a minimum width to the tooltip hover area, let's simply show the tooltip whenever the mouse intersects the corresponding x-axis.

**Before**

https://user-images.githubusercontent.com/13460330/144551477-7b4ca948-e3e0-4e8f-a506-56da6b3a8364.mov

**After**

https://user-images.githubusercontent.com/13460330/144551488-e496b91b-ca7c-4018-bf1d-098ef9a68299.mov


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
