### PR TITLE
Revert "Tooltip shows on entire axis intersect"

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -227,7 +227,7 @@ export function LineGraph({
             // If bar, we want to only show the tooltip for what we're hovering over
             // to avoid confusion
             axis: type === 'horizontalBar' ? 'xy' : 'x',
-            intersect: false,
+            intersect: type === 'horizontalBar',
             itemSort: (a, b) => b.yLabel - a.yLabel,
             callbacks: {
                 label: function labelElement(tooltipItem, data) {


### PR DESCRIPTION
#7499 somewhat improved #5698, but it also broke the tooltip's behavior in a confusing way:
![2021-12-03 14 53 14](https://user-images.githubusercontent.com/4550621/144629639-97abbeb6-8fd9-45f0-a49b-84df9e69f931.gif)
I propose rolling the change back.