### PR TITLE
refactor(deploy): remove `JS_URL` from AWS ECS task definition

### DIFF
--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -23,10 +23,6 @@
             "essential": true,
             "environment": [
                 {
-                    "name": "JS_URL",
-                    "value": "https://app-static.posthog.com"
-                },
-                {
                     "name": "USING_PGBOUNCER",
                     "value": "True"
                 },


### PR DESCRIPTION
It was added in the hope that it would enable controlling where the JS
bundles were loaded, but [here](https://github.com/PostHog/posthog/blob/d58b141c5807fd8e0e90c5e82e40c11ffa78b4c0/frontend/utils.mjs#L72)
we can see that it is in fact a build time substitution and thus has no
use as it is.

For posthog cloud docker image this var is set [here](https://github.com/PostHog/posthog-cloud/blob/3e592205eb75bbbb07a05d359d449080eb8a354c/prod.web.Dockerfile#L3)
within the posthog cloud repo docker image.

We could make this a runtime substitution but for the time being I'll
simply update the hardcoded url to be https://app-static.posthog.com/
rather than the default cloudflare one.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
