### PR TITLE
Open startup dashboard template

### DIFF
--- a/frontend/src/scenes/dashboard/NewDashboard.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboard.tsx
@@ -38,6 +38,9 @@ export function NewDashboard(): JSX.Element {
                     <Select.Option data-attr="dashboard-select-default-app" value="DEFAULT_APP">
                         Default Dashboard - Web App
                     </Select.Option>
+                    <Select.Option data-attr="dashboard-select-default-app" value="OPEN_STARTUP">
+                        Open Startup
+                    </Select.Option>
                 </Select>
             </Form.Item>
 

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -57,15 +57,18 @@ class DashboardSerializer(serializers.ModelSerializer):
         use_template: str = validated_data.pop("use_template", None)
         use_dashboard: int = validated_data.pop("use_dashboard", None)
         validated_data = self._update_creation_mode(validated_data, use_template, use_dashboard)
-        dashboard = Dashboard.objects.create(team=team, **validated_data)
 
         if use_template:
             try:
-                create_dashboard_from_template(use_template, dashboard)
+                dashboard = create_dashboard_from_template(
+                    use_template, team=team, name=validated_data["name"], created_by=request.user
+                )
             except AttributeError:
                 raise serializers.ValidationError({"use_template": "Invalid value provided."})
+        else:
+            dashboard = Dashboard.objects.create(team=team, **validated_data)
 
-        elif use_dashboard:
+        if use_dashboard:
             try:
                 from posthog.api.insight import InsightSerializer
 

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -1,5 +1,5 @@
 import random
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 from django.utils.timezone import now
 
@@ -24,9 +24,16 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.insight import Insight
 
 DASHBOARD_COLORS: List[str] = ["white", "blue", "green", "purple", "black"]
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from posthog.models import Team, User
 
 
-def _create_default_app_items(dashboard: Dashboard) -> None:
+def _create_default_app_items(
+    team: "Team", created_by: Optional["User"] = None, name: Optional[str] = "My App Dashboard"
+) -> Dashboard:
+    dashboard = Dashboard.objects.create(name=name, pinned=True, team=team, created_by=created_by)
 
     Insight.objects.create(
         team=dashboard.team,
@@ -144,15 +151,177 @@ def _create_default_app_items(dashboard: Dashboard) -> None:
         description="Shows a breakdown of where unique users came from when visiting your app.",
     )
 
+    return dashboard
+
+
+def _create_open_startup(
+    team: "Team", created_by: Optional["User"] = None, name: Optional[str] = "Open Startup"
+) -> None:
+    dashboard = Dashboard.objects.create(
+        name=name,
+        description='Instantly join the ranks of an open startup. Share your metrics, be publicly accountable. Click "send or share" at the top right to get a snippet you can embed in your website.',
+        team=team,
+        created_by=created_by,
+    )
+    items = [
+        {
+            "name": "Weekly pageviews",
+            "filters": {
+                "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                "actions": [],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "week",
+                "date_from": "-90d",
+                "properties": [],
+                "filter_test_accounts": True,
+            },
+            "layouts": {
+                "lg": {"h": 5, "w": 6, "x": 18, "y": 0},
+                "sm": {"h": 5, "w": 4, "x": 4, "y": 0, "moved": False, "static": False},
+                "xs": {"h": 5, "w": 6, "x": 0, "y": 15},
+                "xxs": {"h": 5, "w": 2, "x": 0, "y": 15},
+            },
+            "color": "green",
+            "description": "",
+        },
+        {
+            "name": "Conversion funnel",
+            "filters": {
+                "events": [
+                    {"id": "$pageview", "name": "$pageview", "type": "events", "order": 0},
+                    {
+                        "id": "$pageview",
+                        "name": "$pageview",
+                        "type": "events",
+                        "order": 1,
+                        "custom_name": "Replace me!",
+                    },
+                ],
+                "actions": [],
+                "display": "FunnelViz",
+                "insight": "FUNNELS",
+                "interval": "day",
+                "exclusions": [],
+                "properties": [],
+                "funnel_to_step": 1,
+                "funnel_viz_type": "steps",
+                "funnel_from_step": 0,
+                "filter_test_accounts": True,
+            },
+            "layouts": {
+                "lg": {"h": 5, "w": 6, "x": 6, "y": 5},
+                "sm": {"h": 8, "w": 4, "x": 8, "y": 5, "moved": False, "static": False},
+                "xs": {"h": 5, "w": 6, "x": 0, "y": 25},
+                "xxs": {"h": 5, "w": 2, "x": 0, "y": 25},
+            },
+            "description": "How many users go from visiting your home page to signing up. Replace the second pageview with the correct pageview or a sign up event.",
+        },
+        {
+            "name": "Traffic source",
+            "filters": {
+                "events": [{"id": "$pageview", "math": "dau", "name": "$pageview", "type": "events", "order": 0}],
+                "actions": [],
+                "display": "ActionsBarValue",
+                "insight": "TRENDS",
+                "interval": "day",
+                "breakdown": "$initial_referring_domain",
+                "date_from": "-90d",
+                "new_entity": [],
+                "properties": [],
+                "breakdown_type": "person",
+                "filter_test_accounts": True,
+            },
+            "layouts": {
+                "lg": {"h": 5, "w": 6, "x": 0, "y": 5},
+                "sm": {"h": 8, "w": 4, "x": 0, "y": 5, "moved": False, "static": False},
+                "xs": {"h": 5, "w": 6, "x": 0, "y": 20},
+                "xxs": {"h": 5, "w": 2, "x": 0, "y": 20},
+            },
+            "description": "Where your traffic is coming from",
+        },
+        {
+            "name": "Weekly Active Users",
+            "filters": {
+                "events": [{"id": "$pageview", "math": "dau", "name": "$pageview", "type": "events", "order": 0}],
+                "actions": [],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "week",
+                "date_from": "-90d",
+                "new_entity": [],
+                "properties": [],
+                "filter_test_accounts": True,
+            },
+            "layouts": {
+                "lg": {"h": 5, "w": 6, "x": 6, "y": 0},
+                "sm": {"h": 5, "w": 4, "x": 0, "y": 0, "moved": False, "static": False},
+                "xs": {"h": 5, "w": 6, "x": 0, "y": 5},
+                "xxs": {"h": 5, "w": 2, "x": 0, "y": 5},
+            },
+            "color": "blue",
+        },
+        {
+            "name": "GitHub stars",
+            "filters": {
+                "events": [{"id": "Github Star", "name": "Github Star", "type": "events", "order": 0}],
+                "actions": [],
+                "compare": False,
+                "display": "ActionsLineGraphCumulative",
+                "insight": "TRENDS",
+                "interval": "week",
+                "date_from": "all",
+                "new_entity": [],
+                "properties": [],
+                "filter_test_accounts": False,
+            },
+            "layouts": {
+                "lg": {"h": 5, "w": 6, "x": 0, "y": 0},
+                "sm": {"h": 8, "w": 4, "x": 4, "y": 5, "moved": False, "static": False},
+                "xs": {"h": 5, "w": 6, "x": 0, "y": 0},
+                "xxs": {"h": 5, "w": 2, "x": 0, "y": 0},
+            },
+            "color": "black",
+            "description": "Show the number of stars your project has. To use, enable the GitHub stars plugin.",
+        },
+        {
+            "name": "Your key metric!",
+            "filters": {
+                "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                "actions": [],
+                "display": "ActionsLineGraph",
+                "insight": "TRENDS",
+                "interval": "week",
+                "date_from": "-90d",
+                "properties": [],
+                "filter_test_accounts": True,
+            },
+            "layouts": {
+                "lg": {"h": 5, "w": 6, "x": 12, "y": 0},
+                "sm": {"h": 5, "w": 4, "x": 8, "y": 0, "moved": False, "static": False},
+                "xs": {"h": 5, "w": 6, "x": 0, "y": 10},
+                "xxs": {"h": 5, "w": 2, "x": 0, "y": 10},
+            },
+            "color": "purple",
+            "description": "User sign ups, bookings, checkouts. Change 'Pageview' to the event that's relevant to you.",
+        },
+    ]
+    for item in items:
+        Insight.objects.create(dashboard=dashboard, created_by=created_by, team=team, **item)
+    return dashboard
+
 
 DASHBOARD_TEMPLATES: Dict[str, Callable] = {
     "DEFAULT_APP": _create_default_app_items,
+    "OPEN_STARTUP": _create_open_startup,
 }
 
 
-def create_dashboard_from_template(template_key: str, dashboard: Dashboard) -> None:
+def create_dashboard_from_template(
+    template_key: str, team: "Team", created_by: Optional["User"] = None, name: Optional[str] = None
+) -> Dashboard:
 
     if template_key not in DASHBOARD_TEMPLATES:
         raise AttributeError(f"Invalid template key `{template_key}` provided.")
 
-    DASHBOARD_TEMPLATES[template_key](dashboard)
+    return DASHBOARD_TEMPLATES[template_key](team, created_by, name)

--- a/posthog/models/team.py
+++ b/posthog/models/team.py
@@ -62,8 +62,7 @@ class TeamManager(models.Manager):
         # Create default dashboards (skipped for demo projects)
         # TODO: Support multiple dashboard flavors based on #2822 personalization
         if default_dashboards:
-            dashboard = Dashboard.objects.create(name="My App Dashboard", pinned=True, team=team)
-            create_dashboard_from_template("DEFAULT_APP", dashboard)
+            dashboard = create_dashboard_from_template("DEFAULT_APP", team)
         return team
 
     def create(self, *args, **kwargs) -> "Team":


### PR DESCRIPTION
## Changes

Seeing if we can get some traction by providing the default embeddable open startup dashboard.

![image](https://user-images.githubusercontent.com/1727427/144643851-a97ab4b9-5b1a-490a-a5ec-b5f285f82971.png)

Todo:
- Stripe? I have no idea how our current plugin works and if we can get revenue numbers from there, need to look into this
- Some more metrics?

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Create new dashboard, select 'open startup' template.
