### PR TITLE
Fix issue blocking clickhouse migrations on new installs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -155,7 +155,9 @@ jobs:
                   fetch-depth: 1
 
             - name: Start stack with Docker Compose
-              run: docker-compose -f ee/docker-compose.ch.yml up -d ${{ matrix.foss && 'db' || 'db clickhouse zookeeper kafka' }}
+              run: |
+                  docker-compose -f ee/docker-compose.ch.yml down
+                  docker-compose -f ee/docker-compose.ch.yml up -d ${{ matrix.foss && 'db' || 'db clickhouse zookeeper kafka' }}
 
             - name: Set up Python
               uses: actions/setup-python@v2
@@ -275,7 +277,9 @@ jobs:
                   cat multi_tenancy_settings.py >> deploy/posthog/settings.py
                   cat requirements.txt >> deploy/requirements.txt
             - name: Start stack with Docker Compose
-              run: docker-compose -f deploy/ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
+              run: |
+                  docker-compose -f deploy/ee/docker-compose.ch.yml down
+                  docker-compose -f deploy/ee/docker-compose.ch.yml up -d db clickhouse zookeeper kafka
             - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:

--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -47,6 +47,21 @@ QUERY_TIMEOUT_THREAD = get_timer_thread("ee.clickhouse.client", SLOW_QUERY_THRES
 _request_information: Optional[Dict] = None
 
 
+def default_client():
+    """
+    Return a bare bones client for use in places where we are only interested in general ClickHouse state
+    DO NOT USE THIS FOR QUERYING DATA
+    """
+    return SyncClient(
+        host=CLICKHOUSE_HOST,
+        secure=CLICKHOUSE_SECURE,
+        user=CLICKHOUSE_USER,
+        password=CLICKHOUSE_PASSWORD,
+        ca_certs=CLICKHOUSE_CA,
+        verify=CLICKHOUSE_VERIFY,
+    )
+
+
 def make_ch_pool(**overrides) -> ChPool:
     kwargs = {
         "host": CLICKHOUSE_HOST,

--- a/posthog/version_requirement.py
+++ b/posthog/version_requirement.py
@@ -48,9 +48,10 @@ class ServiceVersionRequirement:
         return self.version_string_to_semver(version)
 
     def get_clickhouse_version(self):
-        from ee.clickhouse.client import sync_execute
+        from ee.clickhouse.client import default_client
 
-        rows = sync_execute("SELECT version()")
+        client = default_client()
+        rows = client.execute("SELECT version()")
         version = rows[0][0]
 
         return self.version_string_to_semver(version)


### PR DESCRIPTION
## Changes
![image](https://user-images.githubusercontent.com/391319/144685011-2fb6a683-441b-4b69-92c8-255f640e4a67.png)

This PR breaks migrations on fresh installs of clickhouse:
https://github.com/PostHog/posthog/pull/7283/files#diff-85c6b5fd0ef4eaec4514ac5f364d1a992bc8dcd7870835f6456191e9df42290eR38
why?
- on boot of the django app it starts collecting version numbers for dependent services 
- it then runs select version() even though database doesn't matter there https://github.com/PostHog/posthog/pull/7283/files#diff-0ef67eb217948982da9cce187581f4865d7de896c644379f66d09c2e1254d92fR53
- CLICKHOUSE_DATABASE is used on all connections to clickhouse so if you try to connect to clickhouse and the DB isn't there you are kind of screwed https://github.com/PostHog/posthog/blob/95746b9bce42d04604703edbe5033f5b0d47ba72/ee/clickhouse/client.py#L54

## How did you test this code?

docker-compose -f ee/docker-compose.ch.yml down
docker-compose -f ee/docker-compose.ch.yml up 
