### PR TITLE
Groups: Introduction banner and empty state in persons page

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -61,6 +61,7 @@ class License(models.Model):
         AvailableFeature.INGESTION_TAXONOMY,
         AvailableFeature.PATHS_ADVANCED,
         AvailableFeature.CORRELATION_ANALYSIS,
+        AvailableFeature.GROUP_ANALYTICS,
     ]
 
     ENTERPRISE_PLAN = "enterprise"

--- a/frontend/src/layout/navigation/TopBar/Announcement.tsx
+++ b/frontend/src/layout/navigation/TopBar/Announcement.tsx
@@ -10,21 +10,21 @@ import { GroupsIntroductionBanner } from 'lib/introductions/GroupsIntroductionBa
 window.process = MOCK_NODE_PROCESS
 
 export function Announcement(): JSX.Element | null {
-    const { relevantAnnouncementType, cloudAnnouncement } = useValues(announcementLogic)
+    const { shownAnnouncementType, cloudAnnouncement } = useValues(announcementLogic)
     const { hideAnnouncement } = useActions(announcementLogic)
 
     let message = <Fragment />
-    if (relevantAnnouncementType === AnnouncementType.CloudFlag && cloudAnnouncement) {
+    if (shownAnnouncementType === AnnouncementType.CloudFlag && cloudAnnouncement) {
         message = <ReactMarkdown className="strong">{cloudAnnouncement}</ReactMarkdown>
-    } else if (relevantAnnouncementType === AnnouncementType.GroupAnalytics) {
+    } else if (shownAnnouncementType === AnnouncementType.GroupAnalytics) {
         message = <GroupsIntroductionBanner />
     }
 
     return (
-        <div className={clsx('Announcement', !relevantAnnouncementType && 'Announcement--hidden')}>
+        <div className={clsx('Announcement', !shownAnnouncementType && 'Announcement--hidden')}>
             {message}
 
-            <CloseOutlined className="Announcement__close" onClick={() => hideAnnouncement(relevantAnnouncementType)} />
+            <CloseOutlined className="Announcement__close" onClick={() => hideAnnouncement(shownAnnouncementType)} />
         </div>
     )
 }

--- a/frontend/src/layout/navigation/TopBar/Announcement.tsx
+++ b/frontend/src/layout/navigation/TopBar/Announcement.tsx
@@ -5,6 +5,7 @@ import { CloseOutlined } from '@ant-design/icons'
 import { MOCK_NODE_PROCESS } from 'lib/constants'
 import { announcementLogic, AnnouncementType } from '~/layout/navigation/TopBar/announcementLogic'
 import { useActions, useValues } from 'kea'
+import { GroupsIntroductionBanner } from 'lib/introductions/GroupsIntroductionBanner'
 
 window.process = MOCK_NODE_PROCESS
 
@@ -14,7 +15,9 @@ export function Announcement(): JSX.Element | null {
 
     let message = <Fragment />
     if (relevantAnnouncementType === AnnouncementType.CloudFlag && cloudAnnouncement) {
-        message = <ReactMarkdown>{cloudAnnouncement}</ReactMarkdown>
+        message = <ReactMarkdown className="strong">{cloudAnnouncement}</ReactMarkdown>
+    } else if (relevantAnnouncementType === AnnouncementType.GroupAnalytics) {
+        message = <GroupsIntroductionBanner />
     }
 
     return (

--- a/frontend/src/layout/navigation/TopBar/Announcement.tsx
+++ b/frontend/src/layout/navigation/TopBar/Announcement.tsx
@@ -1,22 +1,27 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import ReactMarkdown from 'react-markdown'
 import clsx from 'clsx'
 import { CloseOutlined } from '@ant-design/icons'
 import { MOCK_NODE_PROCESS } from 'lib/constants'
+import { announcementLogic, AnnouncementType } from '~/layout/navigation/TopBar/announcementLogic'
+import { useActions, useValues } from 'kea'
 
 window.process = MOCK_NODE_PROCESS
 
-export interface AnnouncementProps {
-    message: string
-    visible: boolean
-    onClose: () => void
-}
+export function Announcement(): JSX.Element | null {
+    const { relevantAnnouncementType, cloudAnnouncement } = useValues(announcementLogic)
+    const { hideAnnouncement } = useActions(announcementLogic)
 
-export function Announcement({ message, visible, onClose }: AnnouncementProps): JSX.Element {
+    let message = <Fragment />
+    if (relevantAnnouncementType === AnnouncementType.CloudFlag && cloudAnnouncement) {
+        message = <ReactMarkdown>{cloudAnnouncement}</ReactMarkdown>
+    }
+
     return (
-        <div className={clsx('Announcement', !visible && 'Announcement--hidden')}>
-            <ReactMarkdown>{message}</ReactMarkdown>
-            <CloseOutlined className="Announcement__close" onClick={onClose} />
+        <div className={clsx('Announcement', !relevantAnnouncementType && 'Announcement--hidden')}>
+            {message}
+
+            <CloseOutlined className="Announcement__close" onClick={() => hideAnnouncement(relevantAnnouncementType)} />
         </div>
     )
 }

--- a/frontend/src/layout/navigation/TopBar/TopBar.scss
+++ b/frontend/src/layout/navigation/TopBar/TopBar.scss
@@ -78,7 +78,8 @@
         font-weight: 600;
     }
 
-    .GroupsAnnouncement__button:link {
+    .GroupsAnnouncement__button:link,
+    .GroupsAnnouncement__button:visited {
         color: #2d2d2d;
         background-color: #dcb1e3;
         margin-left: 8px;

--- a/frontend/src/layout/navigation/TopBar/TopBar.scss
+++ b/frontend/src/layout/navigation/TopBar/TopBar.scss
@@ -55,7 +55,6 @@
     background: #000;
     font-size: 1rem;
     color: white;
-    font-weight: 600;
     height: 3rem;
     padding: 0 1rem 0 0.5rem; // padding is larger on the right to accommodate the close button
     text-align: center;
@@ -74,6 +73,16 @@
     }
     a:visited {
         color: var(--purple-light);
+    }
+    .bold {
+        font-weight: 600;
+    }
+
+    .GroupsAnnouncement__button:link {
+        color: #2d2d2d;
+        background-color: #dcb1e3;
+        margin-left: 8px;
+        margin-right: 8px;
     }
 }
 

--- a/frontend/src/layout/navigation/TopBar/TopBar.tsx
+++ b/frontend/src/layout/navigation/TopBar/TopBar.tsx
@@ -12,7 +12,6 @@ import { BulkInviteModal } from '../../../scenes/organization/Settings/BulkInvit
 import { Link } from '../../../lib/components/Link'
 import { IconMenu, IconMenuOpen } from '../../../lib/components/icons'
 import { CreateProjectModal } from '../../../scenes/project/CreateProjectModal'
-import { announcementLogic } from '~/layout/navigation/TopBar/announcementLogic'
 import './TopBar.scss'
 
 export function TopBar(): JSX.Element {
@@ -21,14 +20,9 @@ export function TopBar(): JSX.Element {
     const { toggleSideBar, hideInviteModal, hideCreateOrganizationModal, hideCreateProjectModal } =
         useActions(navigationLogic)
 
-    const { announcementMessage, isAnnouncementShown } = useValues(announcementLogic)
-    const { hideAnnouncement } = useActions(announcementLogic)
-
     return (
         <>
-            {announcementMessage && (
-                <Announcement message={announcementMessage} visible={isAnnouncementShown} onClose={hideAnnouncement} />
-            )}
+            <Announcement />
             <header className="TopBar">
                 <div className="TopBar__segment TopBar__segment--left">
                     {!bareNav && (

--- a/frontend/src/layout/navigation/TopBar/TopBar.tsx
+++ b/frontend/src/layout/navigation/TopBar/TopBar.tsx
@@ -12,20 +12,17 @@ import { BulkInviteModal } from '../../../scenes/organization/Settings/BulkInvit
 import { Link } from '../../../lib/components/Link'
 import { IconMenu, IconMenuOpen } from '../../../lib/components/icons'
 import { CreateProjectModal } from '../../../scenes/project/CreateProjectModal'
+import { announcementLogic } from '~/layout/navigation/TopBar/announcementLogic'
 import './TopBar.scss'
 
 export function TopBar(): JSX.Element {
-    const {
-        isSideBarShown,
-        bareNav,
-        announcementMessage,
-        isAnnouncementShown,
-        isInviteModalShown,
-        isCreateOrganizationModalShown,
-        isCreateProjectModalShown,
-    } = useValues(navigationLogic)
-    const { toggleSideBar, hideAnnouncement, hideInviteModal, hideCreateOrganizationModal, hideCreateProjectModal } =
+    const { isSideBarShown, bareNav, isInviteModalShown, isCreateOrganizationModalShown, isCreateProjectModalShown } =
+        useValues(navigationLogic)
+    const { toggleSideBar, hideInviteModal, hideCreateOrganizationModal, hideCreateProjectModal } =
         useActions(navigationLogic)
+
+    const { announcementMessage, isAnnouncementShown } = useValues(announcementLogic)
+    const { hideAnnouncement } = useActions(announcementLogic)
 
     return (
         <>

--- a/frontend/src/layout/navigation/TopBar/announcementLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.ts
@@ -4,29 +4,60 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { announcementLogicType } from './announcementLogicType'
 
-export const announcementLogic = kea<announcementLogicType>({
+export enum AnnouncementType {
+    CloudFlag = 'CloudFlag',
+    GroupAnalytics = 'GroupAnalytics',
+}
+
+export const announcementLogic = kea<announcementLogicType<AnnouncementType>>({
+    path: ['layout', 'navigation', 'TopBar', 'announcementLogic'],
     connect: {
         values: [featureFlagLogic, ['featureFlags']],
     },
     actions: {
-        hideAnnouncement: true,
+        hideAnnouncement: (type: AnnouncementType | null) => ({ type }),
     },
     reducers: {
-        isAnnouncementShown: [
-            true,
+        persistedClosedAnnouncements: [
+            {} as Record<AnnouncementType, boolean>,
+            { persist: true },
             {
-                hideAnnouncement: () => false,
+                hideAnnouncement: (state, { type }) => {
+                    // :TRICKY: We don't close cloud announcements forever, just until reload
+                    if (!type || type === AnnouncementType.CloudFlag) {
+                        return state
+                    }
+                    return { ...state, [type]: true }
+                }
+            },
+        ],
+        closed: [
+            false,
+            {
+                hideAnnouncement: () => true,
             },
         ],
     },
     selectors: {
-        announcementMessage: [
+        shownAnnouncementType: [
+            (s) => [s.relevantAnnouncementType, s.closed, s.persistedClosedAnnouncements],
+            (relevantAnnouncementType, closed, persistedClosedAnnouncements): AnnouncementType | null => {
+                if (closed || (relevantAnnouncementType && persistedClosedAnnouncements[relevantAnnouncementType])) {
+                    return null
+                }
+                return relevantAnnouncementType
+            }
+        ],
+        relevantAnnouncementType: [
+            (s) => [s.cloudAnnouncement],
+            (cloudAnnouncement): AnnouncementType | null =>
+                cloudAnnouncement ? AnnouncementType.CloudFlag : null,
+        ],
+        cloudAnnouncement: [
             (s) => [s.featureFlags],
             (featureFlags): string | null => {
                 const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
-                return flagValue && typeof flagValue === 'string'
-                    ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
-                    : null
+                return !!flagValue && typeof flagValue === 'string' ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT] : null
             },
         ],
     },

--- a/frontend/src/layout/navigation/TopBar/announcementLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.ts
@@ -1,0 +1,33 @@
+import { kea } from 'kea'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { announcementLogicType } from './announcementLogicType'
+
+export const announcementLogic = kea<announcementLogicType>({
+    connect: {
+        values: [featureFlagLogic, ['featureFlags']],
+    },
+    actions: {
+        hideAnnouncement: true,
+    },
+    reducers: {
+        isAnnouncementShown: [
+            true,
+            {
+                hideAnnouncement: () => false,
+            },
+        ],
+    },
+    selectors: {
+        announcementMessage: [
+            (s) => [s.featureFlags],
+            (featureFlags): string | null => {
+                const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
+                return flagValue && typeof flagValue === 'string'
+                    ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
+                    : null
+            },
+        ],
+    },
+})

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -1,8 +1,6 @@
 import dayjs from 'dayjs'
 import { kea } from 'kea'
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -24,12 +22,11 @@ type WarningType =
 export const navigationLogic = kea<navigationLogicType<WarningType>>({
     path: ['layout', 'navigation', 'navigationLogic'],
     connect: {
-        values: [featureFlagLogic, ['featureFlags'], sceneLogic, ['sceneConfig']],
+        values: [sceneLogic, ['sceneConfig']],
     },
     actions: {
         toggleSideBar: true,
         hideSideBar: true,
-        hideAnnouncement: true,
         openSitePopover: true,
         closeSitePopover: true,
         toggleSitePopover: true,
@@ -51,12 +48,6 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             {
                 toggleSideBar: (state) => !state,
                 hideSideBar: () => false,
-            },
-        ],
-        isAnnouncementShown: [
-            true,
-            {
-                hideAnnouncement: () => false,
             },
         ],
         isSitePopoverOpen: [
@@ -118,15 +109,6 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
         isSideBarShown: [
             (s) => [s.isSideBarShownRaw, s.bareNav],
             (isSideBarShownRaw, bareNav) => isSideBarShownRaw && !bareNav,
-        ],
-        announcementMessage: [
-            (s) => [s.featureFlags],
-            (featureFlags): string | null => {
-                const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
-                return flagValue && typeof flagValue === 'string'
-                    ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
-                    : null
-            },
         ],
         systemStatus: [
             () => [

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -80,6 +80,7 @@ export const FEATURE_FLAGS = {
     NEW_SESSIONS_PLAYER_EVENTS_LIST: 'new-sessions-player-events-list', // owner: @rcmarron / @alexkim205
     BREAKDOWN_BY_MULTIPLE_PROPERTIES: '938-breakdown-by-multiple-properties', // owner: @pauldambra
     GROUP_ANALYTICS: 'group-analytics', // owner: @macobo
+    GROUP_ANALYTICS_INTRODUCTION: 'group-analytics-introduction', // owner: @macobo
     SESSION_INSIGHT_REMOVAL: 'session-insight-removal', // owner: @paolodamico
     FUNNELS_CUE_OPT_OUT: 'funnels-cue-opt-out-7301', // owner: @paolodamico
     FUNNELS_CUE_ENABLED: 'funnels-cue-enabled', // owner: @paolodamico

--- a/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
@@ -36,6 +36,7 @@ export function GroupsIntroductionBanner(): JSX.Element | null {
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
                 target="_blank"
                 data-attr="group-analytics-learn-more"
+                style={{ marginLeft: 8 }}
             >
                 Learn more
             </Link>

--- a/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
@@ -2,17 +2,36 @@ import React from 'react'
 import { useValues } from 'kea'
 import { LinkButton } from 'lib/components/LinkButton'
 import { Link } from 'lib/components/Link'
-import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 
 export function GroupsIntroductionBanner(): JSX.Element | null {
-    const { upgradeLink } = useValues(groupsAccessLogic)
+    const { groupsAccessStatus, upgradeLink } = useValues(groupsAccessLogic)
+
+    const showUpgradeButton = [GroupsAccessStatus.NoAccess, GroupsAccessStatus.HasGroupTypes].includes(
+        groupsAccessStatus
+    )
+
+    let introductionSegment = (
+        <>
+            <strong>🎉 Introducing group analytics!</strong> Analyze how groups interact with your product as a whole.
+        </>
+    )
+    if (groupsAccessStatus === GroupsAccessStatus.HasGroupTypes) {
+        introductionSegment = (
+            <>
+                <strong>🎉 Looks like you're tracking groups!</strong> Upgrade today to use groups in Insights.
+            </>
+        )
+    }
 
     return (
         <div>
-            <strong>🎉 Introducing group analytics!</strong> Analyze how groups interact with your product as a whole.
-            <LinkButton to={upgradeLink} className="GroupsAnnouncement__button" data-attr="group-analytics-upgrade">
-                Upgrade
-            </LinkButton>
+            {introductionSegment}
+            {showUpgradeButton && (
+                <LinkButton to={upgradeLink} className="GroupsAnnouncement__button" data-attr="group-analytics-upgrade">
+                    Upgrade
+                </LinkButton>
+            )}
             <Link
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
                 target="_blank"

--- a/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useValues } from 'kea'
+import { LinkButton } from 'lib/components/LinkButton'
+import { Link } from 'lib/components/Link'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+
+export function GroupsIntroductionBanner(): JSX.Element | null {
+    const { upgradeLink } = useValues(groupsAccessLogic)
+
+    return (
+        <div>
+            <strong>🎉 Introducing group analytics!</strong> Analyze how groups interact with your product as a whole.
+            <LinkButton to={upgradeLink} className="GroupsAnnouncement__button" data-attr="group-analytics-upgrade">
+                Upgrade
+            </LinkButton>
+            <Link
+                to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
+                target="_blank"
+                data-attr="group-analytics-learn-more"
+            >
+                Learn more
+            </Link>
+        </div>
+    )
+}

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -60,5 +60,9 @@ export const groupsAccessLogic = kea<groupsAccessLogicType<GroupsAccessStatus>>(
                 }
             },
         ],
+        upgradeLink: [
+            (s) => [s.preflight],
+            (preflight) => (preflight?.cloud ? '/organization/billing' : '/instance/licenses'),
+        ],
     },
 })

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -60,6 +60,7 @@ export const groupsAccessLogic = kea<groupsAccessLogicType<GroupsAccessStatus>>(
                 }
             },
         ],
+        showGroupsAnnouncementBanner: [(s) => [s.groupsAccessStatus], (status) => status !== GroupsAccessStatus.Hidden],
         upgradeLink: [
             (s) => [s.preflight],
             (preflight) => (preflight?.cloud ? '/organization/billing' : '/instance/licenses'),

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -1,0 +1,64 @@
+import { kea } from 'kea'
+import { AvailableFeature } from '~/types'
+import { teamLogic } from 'scenes/teamLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { userLogic } from 'scenes/userLogic'
+
+import { groupsAccessLogicType } from './groupsAccessLogicType'
+export enum GroupsAccessStatus {
+    AlreadyUsing,
+    HasAccess,
+    HasGroupTypes,
+    NoAccess,
+    Hidden,
+}
+
+export const groupsAccessLogic = kea<groupsAccessLogicType<GroupsAccessStatus>>({
+    path: ['lib', 'introductions', 'groupsAccessLogic'],
+    connect: {
+        values: [
+            teamLogic,
+            ['currentTeam'],
+            featureFlagLogic,
+            ['featureFlags'],
+            preflightLogic,
+            ['clickhouseEnabled', 'preflight'],
+            userLogic,
+            ['hasAvailableFeature'],
+        ],
+    },
+    selectors: {
+        groupsCanBeEnabled: [
+            (s) => [s.featureFlags, s.clickhouseEnabled],
+            (featureFlags, clickhouseEnabled) => featureFlags[FEATURE_FLAGS.GROUP_ANALYTICS] && clickhouseEnabled,
+        ],
+        groupsEnabled: [
+            (s) => [s.groupsCanBeEnabled, s.hasAvailableFeature],
+            (groupsCanBeEnabled, hasAvailableFeature) =>
+                groupsCanBeEnabled && hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
+        ],
+        // Used to toggle various upsell mechanisms for groups
+        groupsAccessStatus: [
+            (s) => [s.groupsCanBeEnabled, s.groupsEnabled, s.currentTeam, s.preflight],
+            (canBeEnabled, isEnabled, currentTeam, preflight): GroupsAccessStatus => {
+                const hasGroups = currentTeam?.has_group_types
+                const hideUpsell = preflight?.instance_preferences?.disable_paid_fs
+                if (!canBeEnabled) {
+                    return GroupsAccessStatus.Hidden
+                } else if (isEnabled && hasGroups) {
+                    return GroupsAccessStatus.AlreadyUsing
+                } else if (hideUpsell) {
+                    return GroupsAccessStatus.Hidden
+                } else if (isEnabled) {
+                    return GroupsAccessStatus.HasAccess
+                } else if (hasGroups) {
+                    return GroupsAccessStatus.HasGroupTypes
+                } else {
+                    return GroupsAccessStatus.NoAccess
+                }
+            },
+        ],
+    },
+})

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -39,18 +39,15 @@ export const groupsAccessLogic = kea<groupsAccessLogicType<GroupsAccessStatus>>(
             (groupsCanBeEnabled, hasAvailableFeature) =>
                 groupsCanBeEnabled && hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
         ],
-        // Used to toggle various upsell mechanisms for groups
+        // Used to toggle various introduction views related to groups
         groupsAccessStatus: [
             (s) => [s.groupsCanBeEnabled, s.groupsEnabled, s.currentTeam, s.preflight],
             (canBeEnabled, isEnabled, currentTeam, preflight): GroupsAccessStatus => {
                 const hasGroups = currentTeam?.has_group_types
-                const hideUpsell = preflight?.instance_preferences?.disable_paid_fs
-                if (!canBeEnabled) {
+                if (!canBeEnabled || preflight?.instance_preferences?.disable_paid_fs) {
                     return GroupsAccessStatus.Hidden
                 } else if (isEnabled && hasGroups) {
                     return GroupsAccessStatus.AlreadyUsing
-                } else if (hideUpsell) {
-                    return GroupsAccessStatus.Hidden
                 } else if (isEnabled) {
                     return GroupsAccessStatus.HasAccess
                 } else if (hasGroups) {

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -41,10 +41,14 @@ export const groupsAccessLogic = kea<groupsAccessLogicType<GroupsAccessStatus>>(
         ],
         // Used to toggle various introduction views related to groups
         groupsAccessStatus: [
-            (s) => [s.groupsCanBeEnabled, s.groupsEnabled, s.currentTeam, s.preflight],
-            (canBeEnabled, isEnabled, currentTeam, preflight): GroupsAccessStatus => {
+            (s) => [s.featureFlags, s.groupsCanBeEnabled, s.groupsEnabled, s.currentTeam, s.preflight],
+            (featureFlags, canBeEnabled, isEnabled, currentTeam, preflight): GroupsAccessStatus => {
                 const hasGroups = currentTeam?.has_group_types
-                if (!canBeEnabled || preflight?.instance_preferences?.disable_paid_fs) {
+                if (
+                    !canBeEnabled ||
+                    preflight?.instance_preferences?.disable_paid_fs ||
+                    !featureFlags[FEATURE_FLAGS.GROUP_ANALYTICS_INTRODUCTION]
+                ) {
                     return GroupsAccessStatus.Hidden
                 } else if (isEnabled && hasGroups) {
                     return GroupsAccessStatus.AlreadyUsing

--- a/frontend/src/models/groupPropertiesModel.ts
+++ b/frontend/src/models/groupPropertiesModel.ts
@@ -3,12 +3,12 @@ import { groupPropertiesModelType } from './groupPropertiesModelType'
 import api from 'lib/api'
 import { GroupTypeProperties, PersonProperty } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
-import { groupsModel } from './groupsModel'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 
 export const groupPropertiesModel = kea<groupPropertiesModelType>({
     path: ['models', 'groupPropertiesModel'],
     connect: {
-        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupsEnabled']],
+        values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled']],
     },
     loaders: ({ values }) => ({
         allGroupProperties: [

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -1,12 +1,13 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { GroupType } from '~/types'
+import { AvailableFeature, GroupType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { groupsModelType } from './groupsModelType'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { userLogic } from 'scenes/userLogic'
 
 export const groupsModel = kea<groupsModelType>({
     path: ['models', 'groupsModel'],
@@ -18,6 +19,8 @@ export const groupsModel = kea<groupsModelType>({
             ['featureFlags'],
             preflightLogic,
             ['clickhouseEnabled'],
+            userLogic,
+            ['hasAvailableFeature'],
         ],
     },
     loaders: ({ values }) => ({
@@ -35,8 +38,11 @@ export const groupsModel = kea<groupsModelType>({
     }),
     selectors: {
         groupsEnabled: [
-            (s) => [s.featureFlags, s.clickhouseEnabled],
-            (featureFlags, clickhouseEnabled) => featureFlags[FEATURE_FLAGS.GROUP_ANALYTICS] && clickhouseEnabled,
+            (s) => [s.featureFlags, s.clickhouseEnabled, s.hasAvailableFeature],
+            (featureFlags, clickhouseEnabled, hasAvailableFeature) =>
+                featureFlags[FEATURE_FLAGS.GROUP_ANALYTICS] &&
+                clickhouseEnabled &&
+                hasAvailableFeature(AvailableFeature.CORRELATION_ANALYSIS),
         ],
         showGroupsOptions: [
             (s) => [s.groupsEnabled, s.groupTypes],

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -10,6 +10,8 @@ import { LemonTable } from 'lib/components/LemonTable'
 import { Link } from 'lib/components/Link'
 import { urls } from 'scenes/urls'
 import { SceneExport } from 'scenes/sceneTypes'
+import { GroupsAccessStatus, groupsModel } from '~/models/groupsModel'
+import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 
 export const scene: SceneExport = {
     component: Groups,
@@ -19,6 +21,20 @@ export const scene: SceneExport = {
 export function Groups(): JSX.Element {
     const { groups, groupsLoading } = useValues(groupsListLogic)
     const { loadGroups } = useActions(groupsListLogic)
+    const { groupsAccessStatus } = useValues(groupsModel)
+
+    if (
+        groupsAccessStatus == GroupsAccessStatus.HasAccess ||
+        groupsAccessStatus == GroupsAccessStatus.HasGroupTypes ||
+        groupsAccessStatus == GroupsAccessStatus.NoAccess
+    ) {
+        return (
+            <>
+                <PersonPageHeader />
+                <GroupsIntroduction access={groupsAccessStatus} />
+            </>
+        )
+    }
 
     const columns: LemonTableColumns<Group> = [
         {

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -10,8 +10,8 @@ import { LemonTable } from 'lib/components/LemonTable'
 import { Link } from 'lib/components/Link'
 import { urls } from 'scenes/urls'
 import { SceneExport } from 'scenes/sceneTypes'
-import { GroupsAccessStatus, groupsModel } from '~/models/groupsModel'
 import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 
 export const scene: SceneExport = {
     component: Groups,
@@ -21,7 +21,7 @@ export const scene: SceneExport = {
 export function Groups(): JSX.Element {
     const { groups, groupsLoading } = useValues(groupsListLogic)
     const { loadGroups } = useActions(groupsListLogic)
-    const { groupsAccessStatus } = useValues(groupsModel)
+    const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
     if (
         groupsAccessStatus == GroupsAccessStatus.HasAccess ||

--- a/frontend/src/scenes/groups/GroupsIntroduction.scss
+++ b/frontend/src/scenes/groups/GroupsIntroduction.scss
@@ -1,0 +1,30 @@
+@import '~/vars.scss';
+
+.groups-introduction {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+
+    margin-top: 16px;
+
+    h2 {
+        font-size: 32px;
+        font-weight: 600;
+        margin-bottom: 8px;
+
+        .highlight {
+            font-weight: 700;
+        }
+    }
+
+    .groups-introduction__subtext {
+        max-width: 500px;
+        margin-bottom: 16px;
+    }
+
+    .groups-introduction__action-button {
+        min-width: 300px;
+        margin-bottom: 8px;
+    }
+}

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -2,8 +2,7 @@ import { useValues } from 'kea'
 import { IconExternalLink } from 'lib/components/icons'
 import { LinkButton } from 'lib/components/LinkButton'
 import React from 'react'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
-import { GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import './GroupsIntroduction.scss'
 
 interface Props {
@@ -13,12 +12,11 @@ interface Props {
 export function GroupsIntroduction({ access }: Props): JSX.Element {
     let title, subtext, primaryButton, secondaryButton
 
-    const { preflight } = useValues(preflightLogic)
-    const isCloud = !!preflight?.cloud
+    const { upgradeLink } = useValues(groupsAccessLogic)
 
     const upgradeButton = (
         <LinkButton
-            to={isCloud ? '/organization/billing' : '/instance/licenses'}
+            to={upgradeLink}
             type="primary"
             data-attr="group-analytics-upgrade"
             className="groups-introduction__action-button"

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -1,38 +1,75 @@
+import { useValues } from 'kea'
+import { IconExternalLink } from 'lib/components/icons'
+import { LinkButton } from 'lib/components/LinkButton'
 import React from 'react'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { GroupsAccessStatus } from '~/models/groupsModel'
+import './GroupsIntroduction.scss'
 
 interface Props {
     access: GroupsAccessStatus.NoAccess | GroupsAccessStatus.HasAccess | GroupsAccessStatus.HasGroupTypes
 }
 
 export function GroupsIntroduction({ access }: Props): JSX.Element {
-    let title, subtext, actionButton, learnMoreButton
+    let title, subtext, primaryButton, secondaryButton
+
+    const { preflight } = useValues(preflightLogic)
+    const isCloud = !!preflight?.cloud
+
+    const upgradeButton = (
+        <LinkButton
+            to={isCloud ? '/organization/billing' : '/instance/licenses'}
+            type="primary"
+            data-attr="group-analytics-upgrade"
+            className="groups-introduction__action-button"
+        >
+            Upgrade to get Group Analytics
+        </LinkButton>
+    )
+
+    const learnMoreButton = (
+        <LinkButton
+            type={access === GroupsAccessStatus.HasAccess ? 'primary' : undefined}
+            to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-introduction"
+            target="_blank"
+            data-attr="group-analytics-learn-more"
+            className="groups-introduction__action-button"
+        >
+            Learn how to track groups in PostHog <IconExternalLink style={{ marginLeft: 8 }} />
+        </LinkButton>
+    )
 
     if (access === GroupsAccessStatus.NoAccess) {
-        title = <>Introducing Group Analytics</>
+        title = (
+            <>
+                Introducing <span className="highlight">Group Analytics</span>!
+            </>
+        )
         subtext = (
             <>
                 Analyze how groups interact with your product as a whole instead of individual users (e.g. retention by
                 companies instead of by users)
             </>
         )
-        actionButton = <>Upgrade to get Group Analytics</>
-        learnMoreButton = <>Learn how to track groups in PostHog</>
+        primaryButton = upgradeButton
+        secondaryButton = learnMoreButton
     } else if (access === GroupsAccessStatus.HasAccess) {
         title = <>You're almost done!</>
         subtext = <>Learn how to track groups in your code</>
+        primaryButton = learnMoreButton
     } else {
+        // HasGroupTypes
         title = <>Looks like you're tracking groups!</>
-        subtext = <>Upgrade today to use groups in insights.</>
-        actionButton = <>Upgrade to get Group Analytics</>
+        subtext = <>Upgrade today to use groups in Insights.</>
+        primaryButton = upgradeButton
     }
 
     return (
         <div className="groups-introduction">
-            {title}
-            {subtext}
-            {actionButton}
-            {learnMoreButton}
+            <h2>{title}</h2>
+            <div className="groups-introduction__subtext">{subtext}</div>
+            {primaryButton}
+            {secondaryButton}
         </div>
     )
 }

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { GroupsAccessStatus } from '~/models/groupsModel'
+
+interface Props {
+    access: GroupsAccessStatus.NoAccess | GroupsAccessStatus.HasAccess | GroupsAccessStatus.HasGroupTypes
+}
+
+export function GroupsIntroduction({ access }: Props): JSX.Element {
+    let title, subtext, actionButton, learnMoreButton
+
+    if (access === GroupsAccessStatus.NoAccess) {
+        title = <>Introducing Group Analytics</>
+        subtext = (
+            <>
+                Analyze how groups interact with your product as a whole instead of individual users (e.g. retention by
+                companies instead of by users)
+            </>
+        )
+        actionButton = <>Upgrade to get Group Analytics</>
+        learnMoreButton = <>Learn how to track groups in PostHog</>
+    } else if (access === GroupsAccessStatus.HasAccess) {
+        title = <>You're almost done!</>
+        subtext = <>Learn how to track groups in your code</>
+    } else {
+        title = <>Looks like you're tracking groups!</>
+        subtext = <>Upgrade today to use groups in insights.</>
+        actionButton = <>Upgrade to get Group Analytics</>
+    }
+
+    return (
+        <div className="groups-introduction">
+            {title}
+            {subtext}
+            {actionButton}
+            {learnMoreButton}
+        </div>
+    )
+}

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -3,7 +3,7 @@ import { IconExternalLink } from 'lib/components/icons'
 import { LinkButton } from 'lib/components/LinkButton'
 import React from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
-import { GroupsAccessStatus } from '~/models/groupsModel'
+import { GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import './GroupsIntroduction.scss'
 
 interface Props {
@@ -30,7 +30,7 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
     const learnMoreButton = (
         <LinkButton
             type={access === GroupsAccessStatus.HasAccess ? 'primary' : undefined}
-            to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-introduction"
+            to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
             target="_blank"
             data-attr="group-analytics-learn-more"
             className="groups-introduction__action-button"

--- a/frontend/src/scenes/groups/GroupsTabs.tsx
+++ b/frontend/src/scenes/groups/GroupsTabs.tsx
@@ -2,20 +2,31 @@ import { Tabs } from 'antd'
 import { useActions, useValues } from 'kea'
 import { capitalizeFirstLetter } from 'lib/utils'
 import React from 'react'
-import { groupsModel } from '~/models/groupsModel'
+import { GroupsAccessStatus, groupsModel } from '~/models/groupsModel'
 import { groupsListLogic } from './groupsListLogic'
 
 export function GroupsTabs(): JSX.Element {
     const { setTab } = useActions(groupsListLogic)
     const { currentTab } = useValues(groupsListLogic)
-    const { groupTypes } = useValues(groupsModel)
+    const { groupTypes, groupsAccessStatus } = useValues(groupsModel)
+
+    const showGroupsIntroductionPage = [
+        GroupsAccessStatus.HasAccess,
+        GroupsAccessStatus.HasGroupTypes,
+        GroupsAccessStatus.NoAccess,
+    ].includes(groupsAccessStatus)
 
     return (
         <Tabs activeKey={currentTab} onChange={(activeKey) => setTab(activeKey)}>
             <Tabs.TabPane tab="Persons" key="-1" />
-            {groupTypes.map((groupType) => (
-                <Tabs.TabPane tab={capitalizeFirstLetter(groupType.group_type)} key={groupType.group_type_index} />
-            ))}
+
+            {showGroupsIntroductionPage ? (
+                <Tabs.TabPane tab="Introducing group analytics" key="0" />
+            ) : (
+                groupTypes.map((groupType) => (
+                    <Tabs.TabPane tab={capitalizeFirstLetter(groupType.group_type)} key={groupType.group_type_index} />
+                ))
+            )}
         </Tabs>
     )
 }

--- a/frontend/src/scenes/groups/GroupsTabs.tsx
+++ b/frontend/src/scenes/groups/GroupsTabs.tsx
@@ -1,14 +1,16 @@
 import { Tabs } from 'antd'
 import { useActions, useValues } from 'kea'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import React from 'react'
-import { GroupsAccessStatus, groupsModel } from '~/models/groupsModel'
+import { groupsModel } from '~/models/groupsModel'
 import { groupsListLogic } from './groupsListLogic'
 
 export function GroupsTabs(): JSX.Element {
     const { setTab } = useActions(groupsListLogic)
     const { currentTab } = useValues(groupsListLogic)
-    const { groupTypes, groupsAccessStatus } = useValues(groupsModel)
+    const { groupTypes } = useValues(groupsModel)
+    const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
     const showGroupsIntroductionPage = [
         GroupsAccessStatus.HasAccess,

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -10,7 +10,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 
 export const groupLogic = kea<groupLogicType>({
     path: ['groups', 'groupLogic'],
-    connect: { values: [teamLogic, ['currentTeamId'], groupsModel, ['groupsEnabled', 'groupTypes']] },
+    connect: { values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes']] },
     actions: () => ({
         setGroup: (groupTypeIndex: number, groupKey: string) => ({ groupTypeIndex, groupKey }),
     }),

--- a/frontend/src/scenes/groups/groupsList.test.ts
+++ b/frontend/src/scenes/groups/groupsList.test.ts
@@ -1,10 +1,8 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import { defaultAPIMocks, mockAPI, MOCK_TEAM_ID } from 'lib/api.mock'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { groupsModel } from '~/models/groupsModel'
-import { initKeaTests } from '~/test/init'
+import { initKeaTestLogic } from '~/test/init'
 import { groupsListLogic } from './groupsListLogic'
 
 jest.mock('lib/api')
@@ -15,17 +13,19 @@ describe('groupsListLogic', () => {
     mockAPI(async (url) => {
         const { pathname } = url
         if (`api/projects/${MOCK_TEAM_ID}/groups/?group_type_index=0` === pathname) {
-            return { result: ['result from api'], next_url: null, previous_url: null }
+            return { result: ['result from api'], next: null, previous: null }
         }
         return defaultAPIMocks(url)
     })
 
-    beforeEach(async () => {
-        initKeaTests()
-        groupsModel.mount()
-        teamLogic.mount()
-        logic = groupsListLogic()
-        logic.mount()
+    initKeaTestLogic({
+        logic: groupsListLogic,
+        props: {},
+        onLogic: (l) => (logic = l),
+    })
+
+    beforeEach(() => {
+        jest.spyOn(logic.selectors, 'groupsEnabled').mockReturnValue(true)
     })
 
     it('sets the tab and loads groups upon tab change', async () => {

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -1,5 +1,6 @@
 import { kea } from 'kea'
 import api from 'lib/api'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -15,7 +16,9 @@ interface GroupsPaginatedResponse {
 
 export const groupsListLogic = kea<groupsListLogicType<GroupsPaginatedResponse>>({
     path: ['groups', 'groupsListLogic'],
-    connect: { values: [teamLogic, ['currentTeamId'], groupsModel, ['groupsEnabled', 'groupTypes']] },
+    connect: {
+        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes'], groupsAccessLogic, ['groupsEnabled']],
+    },
     actions: () => ({
         loadGroups: (url?: string | null) => ({ url }),
         setTab: (tab: string) => ({ tab }),

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -10,9 +10,6 @@ import { teamLogic } from './teamLogic'
 
 export const userLogic = kea<userLogicType>({
     path: ['scenes', 'userLogic'],
-    connect: {
-        values: [teamLogic, ['currentTeam']],
-    },
     actions: () => ({
         loadUser: (resetOnFailure?: boolean) => ({ resetOnFailure }),
         updateCurrentTeam: (teamId: number, destination?: string) => ({ teamId, destination }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -35,6 +35,7 @@ export enum AvailableFeature {
     INGESTION_TAXONOMY = 'ingestion_taxonomy',
     PATHS_ADVANCED = 'paths_advanced',
     CORRELATION_ANALYSIS = 'correlation_analysis',
+    GROUP_ANALYTICS = 'group_analytics',
 }
 
 export type ColumnChoice = string[] | 'DEFAULT'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -190,6 +190,8 @@ export interface TeamType extends TeamBasicType {
     path_cleaning_filters: Record<string, any>[]
     data_attributes: string[]
 
+    has_group_types: boolean
+
     // Uses to exclude person properties from correlation analysis results, for
     // example can be used to exclude properties that have trivial causation
     correlation_config: {

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -34,6 +34,7 @@ class TestTeamAPI(APIBaseTest):
         self.assertEqual(response_data["timezone"], "UTC")
         self.assertEqual(response_data["is_demo"], False)
         self.assertEqual(response_data["slack_incoming_webhook"], self.team.slack_incoming_webhook)
+        self.assertEqual(response_data["has_group_types"], False)
 
         # TODO: These assertions will no longer make sense when we fully remove these attributes from the model
         self.assertNotIn("event_names", response_data)

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -14,6 +14,7 @@ class AvailableFeature(str, Enum):
     INGESTION_TAXONOMY = "ingestion_taxonomy"
     PATHS_ADVANCED = "paths_advanced"
     CORRELATION_ANALYSIS = "correlation_analysis"
+    GROUP_ANALYTICS = "group_analytics"
 
 
 TREND_FILTER_TYPE_ACTIONS = "actions"


### PR DESCRIPTION
## Changes

This PR adds groups introduction/upsell prompts with accordance of https://github.com/PostHog/posthog/issues/7491

The prompts are behind a separate feature flag given docs are not yet ready and to avoid internal confusion.

Note for reviewer: I'll be building on top of this PR so will resolve comments in a follow-up. :)

## Screenshots

![image](https://user-images.githubusercontent.com/148820/144795686-41b9c0b9-5bb9-43e3-a108-f28aba3a051a.png)
Banner, user has access to group analytics

![image](https://user-images.githubusercontent.com/148820/144795604-29fa82f0-a57e-4f4c-9fd5-dbc9fb4e13e1.png)
Banner, when user has instrumented their code but not upgraded

![image](https://user-images.githubusercontent.com/148820/144795791-377cf4e7-4ac3-48ea-b414-3fd900d180af.png)
Banner, user needs to upgrade + instrument

![image](https://user-images.githubusercontent.com/148820/144795850-6cea090b-f7ba-4812-a020-7baee96330b4.png)
Persons empty state, user needs to upgrade + instrument

![image](https://user-images.githubusercontent.com/148820/144796303-2f68686f-53ec-49d3-8b48-2cb357d2794f.png)
Persons empty state, when user has instrumented their code but not upgraded

Etc..

## How did you test this code?

See various screenshots
