### PR TITLE
Groups: Show groups introduction information in dropdowns

### DIFF
--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -343,9 +343,9 @@ export function IconUpdate(): JSX.Element {
 }
 
 /** Material Design Offline Bolt icon. */
-export function IconOffline(): JSX.Element {
+export function IconOffline({ style }: { style?: CSSProperties }): JSX.Element {
     return (
-        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style={style}>
             <path
                 d="m12 2.02c-5.51 0-9.98 4.47-9.98 9.98s4.47 9.98 9.98 9.98 9.98-4.47 9.98-9.98-4.47-9.98-9.98-9.98zm0 17.96c-4.4 0-7.98-3.58-7.98-7.98s3.58-7.98 7.98-7.98 7.98 3.58 7.98 7.98-3.58 7.98-7.98 7.98zm.75-14.98-4.5 8.5h3.14v5.5l4.36-8.5h-3z"
                 fill="currentColor"

--- a/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
@@ -40,7 +40,7 @@ export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element
             >
                 <span>
                     <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />
-                    Unique groups.
+                    Unique groups
                     <Link
                         to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
                         target="_blank"

--- a/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { useValues } from 'kea'
+import { LockOutlined } from '@ant-design/icons'
+import Select from 'rc-select'
+import { Link } from 'lib/components/Link'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
+import { IconOffline } from 'lib/components/icons'
+
+export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element | null {
+    const { groupsAccessStatus, upgradeLink } = useValues(groupsAccessLogic)
+
+    if (
+        ![GroupsAccessStatus.HasAccess, GroupsAccessStatus.HasGroupTypes, GroupsAccessStatus.NoAccess].includes(
+            groupsAccessStatus
+        )
+    ) {
+        return null
+    }
+
+    return (
+        <Select.Option
+            key="groups"
+            value={value}
+            disabled
+            style={{
+                height: '100%',
+                width: '100%',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                backgroundColor: 'var(--bg-side)',
+                color: 'var(--text-muted)',
+            }}
+        >
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <span>
+                    <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />
+                    Unique groups.
+                    <Link
+                        to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
+                        target="_blank"
+                        data-attr="group-analytics-learn-more"
+                        style={{ marginLeft: 8, fontWeight: 'bold' }}
+                    >
+                        Learn more
+                    </Link>
+                </span>
+
+                {groupsAccessStatus !== GroupsAccessStatus.HasAccess && (
+                    <Link to={upgradeLink} target="_blank" style={{ marginLeft: 8 }}>
+                        <IconOffline style={{ height: 20, width: 20 }} />
+                    </Link>
+                )}
+            </div>
+        </Select.Option>
+    )
+}

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -4,12 +4,12 @@ import { GroupType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsModelType } from './groupsModelType'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 
 export const groupsModel = kea<groupsModelType>({
     path: ['models', 'groupsModel'],
     connect: {
-        values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled']],
+        values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled', 'groupsAccessStatus']],
     },
     loaders: ({ values }) => ({
         groupTypes: [
@@ -26,8 +26,8 @@ export const groupsModel = kea<groupsModelType>({
     }),
     selectors: {
         showGroupsOptions: [
-            (s) => [s.groupsEnabled, s.groupTypes],
-            (enabled, groupTypes) => enabled && groupTypes.length > 0,
+            (s) => [s.groupsAccessStatus, s.groupsEnabled, s.groupTypes],
+            (status, enabled, groupTypes) => status !== GroupsAccessStatus.Hidden || (enabled && groupTypes.length > 0),
         ],
         groupsTaxonomicTypes: [
             (s) => [s.groupTypes],

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -37,6 +37,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { APISnippet, JSSnippet, PythonSnippet, UTM_TAGS } from 'scenes/feature-flags/FeatureFlagSnippets'
 import { LemonSpacer } from 'lib/components/LemonRow'
 import { groupsModel } from '~/models/groupsModel'
+import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -90,6 +91,9 @@ export function FeatureFlag(): JSX.Element {
     useEffect(() => {
         form.setFieldsValue({ ...featureFlag })
     }, [featureFlag])
+
+    // :KLUDGE: Match by select only allows Select.Option as children, so render groups option directly rather than as a child
+    const matchByGroupsIntroductionOption = GroupsIntroductionOption({ value: -2 })
 
     return (
         <div className="feature-flag">
@@ -491,6 +495,10 @@ export function FeatureFlag(): JSX.Element {
                                     style={{ marginLeft: 8 }}
                                     data-attr="feature-flag-aggregation-filter"
                                     dropdownMatchSelectWidth={false}
+                                    dropdownAlign={{
+                                        // Align this dropdown by the right-hand-side of button
+                                        points: ['tr', 'br'],
+                                    }}
                                 >
                                     <Select.Option key={-1} value={-1}>
                                         Users
@@ -503,6 +511,7 @@ export function FeatureFlag(): JSX.Element {
                                             {capitalizeFirstLetter(groupType.group_type)}(s)
                                         </Select.Option>
                                     ))}
+                                    {matchByGroupsIntroductionOption}
                                 </Select>
                             </div>
                         )}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -36,6 +36,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import clsx from 'clsx'
 import { apiValueToMathType, mathsLogic, mathTypeToApiValues } from 'scenes/trends/mathsLogic'
+import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 
 const determineFilterLabel = (visible: boolean, filter: Partial<ActionFilter>): string => {
     if (visible) {
@@ -480,6 +481,7 @@ function MathSelector({
             onChange={(value) => onMathSelect(index, value)}
             data-attr={`math-selector-${index}`}
             dropdownMatchSelectWidth={false}
+            dropdownStyle={{ width: 320 }}
         >
             <Select.OptGroup key="event aggregates" label="Event aggregation">
                 {math_entries.map(([key, { name, description, onProperty }]) => {
@@ -515,6 +517,8 @@ function MathSelector({
                         </Select.Option>
                     )
                 })}
+                {/* :KLUDGE: Select only allows Select.Option as children, so render groups option directly rather than as a child */}
+                {GroupsIntroductionOption({ value: '' })}
             </Select.OptGroup>
             <Select.OptGroup key="property aggregates" label="Property aggregation">
                 {propertyMathEntries.map(([key, { name, description, onProperty }]) => {

--- a/frontend/src/scenes/insights/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/AggregationSelect.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useValues } from 'kea'
 import { Select } from 'antd'
 import { groupsModel } from '~/models/groupsModel'
+import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 
 const UNIQUE_USERS = -1
 
@@ -35,6 +36,8 @@ export function AggregationSelect({ aggregationGroupTypeIndex, onChange }: Aggre
                     <div style={{ height: '100%', width: '100%' }}>unique {groupType.group_type}(s)</div>
                 </Select.Option>
             ))}
+            {/* :KLUDGE: Select only allows Select.Option as children, so render groups option directly rather than as a child */}
+            {GroupsIntroductionOption({ value: -2 })}
         </Select>
     )
 }


### PR DESCRIPTION
## Changes

Part of https://github.com/PostHog/posthog/issues/7491, this introduces groups information into all dropdowns where we show groups.

## Screenshots

![image](https://user-images.githubusercontent.com/148820/144815284-71a34fc5-36ca-45d1-91c6-5570e5fc5638.png)
Under trends

![image](https://user-images.githubusercontent.com/148820/144815708-675980ea-2c37-4291-aeca-fa80391bb4f5.png)
Under trends (if user has access but no groups)

![image](https://user-images.githubusercontent.com/148820/144815378-0b2635d0-249e-4414-bfda-7e1569973cd4.png)
Under funnels

![image](https://user-images.githubusercontent.com/148820/144815413-e5b4c550-276e-497b-a049-30b4b3c4fa17.png)
Under retention

![image](https://user-images.githubusercontent.com/148820/144815196-baa8d687-d56c-4b1b-ac9b-37f794ee0932.png)
Under feature flags

## How did you test this code?

Return static values in `hasAvailableFeature:` and `groupsEnabled:`
