### PR TITLE
Groups: Fix individual group page

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -10,12 +10,11 @@ import { urls } from 'scenes/urls'
 import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
-import { Groups } from 'scenes/groups/Groups'
 
 const { TabPane } = Tabs
 
 export const scene: SceneExport = {
-    component: Groups,
+    component: Group,
     logic: groupLogic,
 }
 


### PR DESCRIPTION
:sweat_smile: this was accidentally broken in the breadcrumbs PR https://github.com/PostHog/posthog/pull/7423 by marius' refactor and links led to a broken version of the list page.