### PR TITLE
Fix cypress trends, paths and retention tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,8 +15,8 @@ jobs:
             - id: set-matrix
               run: |
                   if ${{github.event.pull_request.head.repo.full_name == github.repository}}; then
-                  matrix=$(jq 'map(.)' .github/workflows/e2e_matrix.json)  
-                  else              
+                  matrix=$(jq 'map(.)' .github/workflows/e2e_matrix.json)
+                  else
                   matrix='[{"containers": [1]}]'
                   fi
                   echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
@@ -100,6 +100,8 @@ jobs:
               env:
                   GENERATE_SOURCEMAP: 'false'
               run: |
+                  yarn build
+                  cd plugin-server
                   yarn build
             - name: Boot PostHog
               env:

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -37,11 +37,6 @@ if [[ -n $DYNO_RAM ]]; then
   export WORKER_CONCURRENCY=$(( ($DYNO_RAM - 1) / 512 + 1 ))
 fi
 
-# don't do a full build on e2e tests
-if [[ -n $E2E_TESTING ]]; then
-  export DEBUG=1
-fi
-
 cd plugin-server
 
 if [[ -n $DEBUG ]]; then
@@ -56,7 +51,7 @@ fi
 
 if [[ -n $NO_RESTART_LOOP ]]; then
   echo "▶️ Starting plugin server..."
-  [[ -n $DEBUG ]] && yarn start:dev || yarn start:dist 
+  [[ -n $DEBUG ]] && yarn start:dev || yarn start:dist
 else
   echo "🔁 Starting plugin server in a resiliency loop..."
   while true; do

--- a/frontend/src/scenes/insights/InsightsNav.tsx
+++ b/frontend/src/scenes/insights/InsightsNav.tsx
@@ -101,23 +101,21 @@ export function InsightsNav(): JSX.Element {
                 {tabs.map(({ label, type, dataAttr, hotkey, ref, className }) => {
                     const Outer = ({ children }: { children: ReactNode }): JSX.Element =>
                         INSIGHT_TYPES_METADATA[type]?.description ? (
-                            <Tooltip
-                                placement="top"
-                                title={INSIGHT_TYPES_METADATA[type].description}
-                                data-attr={dataAttr}
-                            >
+                            <Tooltip placement="top" title={INSIGHT_TYPES_METADATA[type].description}>
                                 {children}
                             </Tooltip>
                         ) : (
-                            <span data-attr={dataAttr} ref={ref}>
-                                {children}
-                            </span>
+                            <span ref={ref}>{children}</span>
                         )
                     return (
                         <TabPane
                             key={type}
                             tab={
-                                <Link className={clsx('tab-text', className)} to={createInsightUrl(type)}>
+                                <Link
+                                    className={clsx('tab-text', className)}
+                                    to={createInsightUrl(type)}
+                                    data-attr={dataAttr}
+                                >
                                     <Outer>
                                         {label}
                                         <InsightHotkey hotkey={hotkey} />


### PR DESCRIPTION
Retention and paths were broken in https://github.com/PostHog/posthog/pull/7473

While at it I also took a look at the trends issue. I believe it's a timing issue caused by plugin-server being compiled in the background and not having ingested test data by the time test runs.