### PR TITLE
Groups: Include site_url in instance(s)

### DIFF
--- a/frontend/src/scenes/PreflightCheck/logic.ts
+++ b/frontend/src/scenes/PreflightCheck/logic.ts
@@ -88,7 +88,9 @@ export const preflightLogic = kea<preflightLogicType<PreflightMode>>({
                 })
 
                 if (values.preflight.site_url) {
-                    posthog.group('instance', values.preflight.site_url)
+                    posthog.group('instance', values.preflight.site_url, {
+                        site_url: values.preflight.site_url,
+                    })
                 }
             }
         },


### PR DESCRIPTION
This makes sure we show all instances in group pages immediately

## How it's tested

Opened Instance tab under Persons & Groups, seeing an entry there