### PR TITLE
Fix insight icons

### DIFF
--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -700,10 +700,11 @@ interface InsightIconProps {
     background?: string
     noBackground?: boolean
     children?: React.ReactNode
+    style: CSSProperties
 }
-function InsightIcon({ background = '#747EA2', noBackground = false, children }: InsightIconProps): JSX.Element {
+function InsightIcon({ background = '#747EA2', noBackground = false, children, style }: InsightIconProps): JSX.Element {
     return (
-        <svg width="1em" height="1em" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="1em" height="1em" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style={style}>
             {!noBackground ? <rect width="100%" height="100%" rx="4" fill={background} /> : null}
             {children}
         </svg>

--- a/frontend/src/scenes/saved-insights/SavedInsights.scss
+++ b/frontend/src/scenes/saved-insights/SavedInsights.scss
@@ -134,9 +134,8 @@
         margin-right: 8px;
         position: relative;
         .icon-container-inner {
-            position: absolute;
-            top: -6px;
-            left: -5px;
+            font-size: 22px;
+            margin-left: -2px;
         }
     }
 }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -121,9 +121,11 @@ function NewInsightButton(): JSX.Element {
                             <Row wrap={false}>
                                 <Col flex="none">
                                     {listedInsightTypeMetadata.icon && (
-                                        <div style={{ fontSize: '2rem' }}>
-                                            <listedInsightTypeMetadata.icon color="var(--muted-alt)" noBackground />
-                                        </div>
+                                        <listedInsightTypeMetadata.icon
+                                            color="var(--muted-alt)"
+                                            noBackground
+                                            style={{ fontSize: '2rem' }}
+                                        />
                                     )}
                                 </Col>
                                 <Col flex="Auto" style={{ paddingLeft: '1rem' }}>
@@ -179,11 +181,7 @@ export function SavedInsights(): JSX.Element {
             render: function renderType(_, insight) {
                 const typeMetadata = INSIGHT_TYPES_METADATA[insight.filters?.insight || InsightType.TRENDS]
                 if (typeMetadata && typeMetadata.icon) {
-                    return (
-                        <span style={{ fontSize: '2rem' }}>
-                            <typeMetadata.icon />
-                        </span>
-                    )
+                    return <typeMetadata.icon style={{ display: 'block', fontSize: '2rem' }} />
                 }
             },
         },


### PR DESCRIPTION
## Changes

Some styling fixes:

| Before | After |
| --- | --- |
| <img width="69" alt="Screen Shot 2021-12-06 at 16 45 32" src="https://user-images.githubusercontent.com/4550621/144898764-f7d4ca1c-c578-4179-8cff-00185772327d.png"> | <img width="70" alt="Screen Shot 2021-12-06 at 19 06 04" src="https://user-images.githubusercontent.com/4550621/144898772-5074434f-4b0b-49bb-80ac-fa7851e4cdc0.png"> |
| <img width="148" alt="Screen Shot 2021-12-06 at 19 01 26" src="https://user-images.githubusercontent.com/4550621/144898780-be6af648-0592-4784-a78c-d25d6b0f0fac.png"> | <img width="155" alt="Screen Shot 2021-12-06 at 19 04 32" src="https://user-images.githubusercontent.com/4550621/144898774-7866d658-2900-4d89-bddd-eeb0ea64ce77.png"> |

