### PR TITLE
Fix breadcrumbs and add some Cypress tests

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -6,6 +6,10 @@ describe('Dashboard', () => {
 
     it('Dashboards loaded', () => {
         cy.get('h1').should('contain', 'Dashboards')
+        // Breadcrumbs work
+        cy.get('[data-attr=breadcrumb-0]').should('contain', 'HogFlix')
+        cy.get('[data-attr=breadcrumb-1]').should('contain', 'HogFlix Demo App')
+        cy.get('[data-attr=breadcrumb-2]').should('have.text', 'Dashboards')
     })
 
     it('Cannot see tags or description (non-FOSS feature)', () => {
@@ -55,15 +59,22 @@ describe('Dashboard', () => {
     })
 
     it('Create dashboard from a template', () => {
+        const TEST_DASHBOARD_NAME = 'XDefault'
+
         cy.get('[data-attr="new-dashboard"]').click()
-        cy.get('[data-attr=dashboard-name-input]').clear().type('XDefault')
+        cy.get('[data-attr=dashboard-name-input]').clear().type(TEST_DASHBOARD_NAME)
         cy.get('[data-attr=copy-from-template]').click()
         cy.get('[data-attr=dashboard-select-default-app]').click()
 
         cy.get('button').contains('Create').click()
 
-        cy.contains('XDefault').should('exist')
+        cy.contains(TEST_DASHBOARD_NAME).should('exist')
         cy.get('.dashboard-item').its('length').should('be.gte', 2)
+        // Breadcrumbs work
+        cy.get('[data-attr=breadcrumb-0]').should('contain', 'HogFlix')
+        cy.get('[data-attr=breadcrumb-1]').should('contain', 'HogFlix Demo App')
+        cy.get('[data-attr=breadcrumb-2]').should('have.text', 'Dashboards')
+        cy.get('[data-attr=breadcrumb-3]').should('have.text', TEST_DASHBOARD_NAME)
     })
 
     it('Click on a dashboard item dropdown and view graph', () => {

--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -32,6 +32,12 @@ describe('Insights', () => {
         cy.get('[data-attr="insight-save-button"]').click()
         cy.get('[data-attr="insight-edit-button"]').click()
 
+        // Breadcrumbs work
+        cy.get('[data-attr=breadcrumb-0]').should('contain', 'HogFlix')
+        cy.get('[data-attr=breadcrumb-1]').should('contain', 'HogFlix Demo App')
+        cy.get('[data-attr=breadcrumb-2]').should('have.text', 'Insights')
+        cy.get('[data-attr=breadcrumb-3]').should('have.text', 'Unnamed')
+
         // Save and continue editing
         cy.get('[data-attr="insight-save-dropdown"]').click()
         cy.get('[data-attr="insight-save-and-continue"]').click()

--- a/cypress/integration/licenses.js
+++ b/cypress/integration/licenses.js
@@ -2,6 +2,7 @@ describe('Licenses', () => {
     it('Licenses loaded', () => {
         cy.get('[data-attr=top-menu-toggle]').click()
         cy.get('[data-attr=top-menu-item-licenses]').click()
+        cy.get('[data-attr=breadcrumb-0]').should('contain', 'test.posthog.net') // Breadcrumbs work
         cy.get('[data-attr=breadcrumb-1]').should('have.text', 'Licenses') // Breadcrumbs work
         cy.get('h1').should('contain', 'Licenses')
         cy.title().should('equal', 'Licenses • PostHog') // Page title works

--- a/cypress/integration/licenses.js
+++ b/cypress/integration/licenses.js
@@ -2,7 +2,8 @@ describe('Licenses', () => {
     it('Licenses loaded', () => {
         cy.get('[data-attr=top-menu-toggle]').click()
         cy.get('[data-attr=top-menu-item-licenses]').click()
+        cy.get('[data-attr=breadcrumb-1]').should('have.text', 'Licenses') // Breadcrumbs work
         cy.get('h1').should('contain', 'Licenses')
-        cy.title().should('equal', 'Licenses • PostHog')
+        cy.title().should('equal', 'Licenses • PostHog') // Page title works
     })
 })

--- a/frontend/src/layout/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -8,7 +8,7 @@ import { Breadcrumb as IBreadcrumb } from '~/types'
 import clsx from 'clsx'
 import { Popup } from 'lib/components/Popup/Popup'
 
-function Breadcrumb({ breadcrumb }: { breadcrumb: IBreadcrumb }): JSX.Element {
+function Breadcrumb({ breadcrumb, index }: { breadcrumb: IBreadcrumb; index: number }): JSX.Element {
     const [popoverShown, setPopoverShown] = useState(false)
 
     let breadcrumbContent = (
@@ -18,6 +18,7 @@ function Breadcrumb({ breadcrumb }: { breadcrumb: IBreadcrumb }): JSX.Element {
                 (breadcrumb.path || breadcrumb.popup) && 'Breadcrumbs__breadcrumb--actionable'
             )}
             onClick={() => breadcrumb.popup && setPopoverShown(!popoverShown)}
+            data-attr={`breadcrumb-${index}`}
         >
             {breadcrumb.symbol}
             {breadcrumb.name}
@@ -49,11 +50,11 @@ export function Breadcrumbs(): JSX.Element | null {
 
     return firstBreadcrumb ? (
         <div className="Breadcrumbs">
-            <Breadcrumb breadcrumb={firstBreadcrumb} />
-            {tailBreadcrumbs.map((breadcrumb) => (
+            <Breadcrumb breadcrumb={firstBreadcrumb} index={0} />
+            {tailBreadcrumbs.map((breadcrumb, index) => (
                 <React.Fragment key={breadcrumb.name || '…'}>
                     <IconChevronRight className="Breadcrumbs__separator" />
-                    <Breadcrumb breadcrumb={breadcrumb} />
+                    <Breadcrumb breadcrumb={breadcrumb} index={index + 1} />
                 </React.Fragment>
             ))}
         </div>

--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -127,7 +127,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>({
             (activeScene, sceneConfig, appBreadcrumbs, sceneBreadcrumbs) => {
                 if (sceneBreadcrumbs && sceneBreadcrumbs.length > 0) {
                     return [...appBreadcrumbs, ...sceneBreadcrumbs]
-                } else if (sceneConfig) {
+                } else if (sceneConfig?.name) {
                     return [...appBreadcrumbs, { name: sceneConfig.name }]
                 } else if (activeScene) {
                     return [...appBreadcrumbs, { name: identifierToHuman(activeScene) }]


### PR DESCRIPTION
## Changes

Fixes this type of bug that I noticed with Marius:

<img width="376" alt="Screen Shot 2021-12-06 at 20 08 42" src="https://user-images.githubusercontent.com/4550621/144908463-75559ab1-d44a-43a9-89d7-45e713c27363.png">
 
## How did you test this code?

Added E2E tests for breadcrumbs in a few places that cover a few breadcrumb determination mechanisms (entity name, current org/project, scene name).
