### PR TITLE
No longer support postgres from 1.31.0 onwards

### DIFF
--- a/posthog/version.py
+++ b/posthog/version.py
@@ -1,1 +1,13 @@
-VERSION = "1.30.0"
+from posthog.constants import AnalyticsDBMS
+from posthog.settings import PRIMARY_DB
+from posthog.utils import print_warning
+
+VERSION = "1.31.0"
+
+if PRIMARY_DB == AnalyticsDBMS.POSTGRES:
+    print_warning(
+        [
+            "Postgres as the primary database is no longer supported from PostHog 1.31.0 onwwards. Learn how to migrate here: https://posthog.com/docs/self-host/migrate-from-postgres-to-clickhouse"
+        ]
+    )
+    exit(1)


### PR DESCRIPTION
## Changes

Hard stop on Postgres deployments after 1.31.0. Not to be merged yet!

This will allow us to develop without `is_clickhouse_enabled` 