### PR TITLE
Add script tag before </body> instead of </head> 

### DIFF
--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -96,15 +96,15 @@ export function copyIndexHtml(
 
     fse.writeFileSync(
         path.resolve(__dirname, to),
-        fse.readFileSync(path.resolve(__dirname, from), { encoding: 'utf-8' }).replace(
-            '</head>',
-            `   <script type="application/javascript">
-                    ${scriptCode}
-                    ${Object.keys(chunks).length > 0 ? chunkCode : ''}
-                </script>
-                ${cssLinkTag}
-            </head>`
-        )
+        fse
+            .readFileSync(path.resolve(__dirname, from), { encoding: 'utf-8' })
+            .replace('</head>', `${cssLinkTag}</head>`)
+            .replace(
+                '</body>',
+                `<script type="application/javascript">${scriptCode}${
+                    Object.keys(chunks).length > 0 ? chunkCode : ''
+                }</script></body>`
+            )
     )
 }
 


### PR DESCRIPTION
## Changes

- This should fix problems we're having with esbuild.

## How did you test this code?

- Made the change, verified that the HTML was different, reloaded locally, everything kept working. The `<script>` tag was inserted after the `<div>` tag in the DOM.

![image](https://user-images.githubusercontent.com/53387/144929800-4f1e3355-d037-4633-b938-a7d48a72040c.png)
