### PR TITLE
Add selectors when creating actions through the events table

### DIFF
--- a/frontend/src/lib/actionUtils.ts
+++ b/frontend/src/lib/actionUtils.ts
@@ -1,0 +1,56 @@
+import { ElementType } from '~/types'
+import { cssEscape } from 'lib/utils/cssEscape'
+
+// these plus any element with cursor:pointer will be click targets
+export const CLICK_TARGETS = ['a', 'button', 'input', 'select', 'textarea', 'label']
+export const CLICK_TARGET_SELECTOR = CLICK_TARGETS.join(', ')
+
+// always ignore the following
+export const TAGS_TO_IGNORE = ['html', 'body', 'meta', 'head', 'script', 'link', 'style']
+
+export const escapeRegex = (str: string): string => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1')
+
+export function matchesDataAttribute(element: ElementType, dataAttributes: string[]): string | void {
+    if (!element.attributes) {
+        return
+    }
+    for (const attribute of dataAttributes) {
+        const regex = new RegExp(`^attr__${attribute.split('*').map(escapeRegex).join('.*')}$`)
+        const match = Object.keys(element.attributes).find((a) => regex.test(a))
+        if (match) {
+            return match.replace(/^attr__/, '')
+        }
+    }
+}
+
+export function elementToSelector(element: ElementType, dataAttributes: string[]): string {
+    let selector = ''
+    const attribute = matchesDataAttribute(element, dataAttributes)
+    if (attribute) {
+        selector += `[${attribute}="${element.attributes[`attr__${attribute}`]}"]`
+        return selector
+    }
+    if (element.attr_id) {
+        selector += `#${cssEscape(element.attr_id)}`
+        return selector
+    }
+    if (element.tag_name) {
+        selector += cssEscape(element.tag_name)
+    }
+    if (element.attr_class) {
+        selector += element.attr_class
+            .filter((a) => a)
+            .map((a) => `.${cssEscape(a)}`)
+            .join('')
+    }
+    if (element.href && element.tag_name === 'a') {
+        selector += `[href="${cssEscape(element.href)}"]`
+    }
+    if (element.nth_child) {
+        selector += `:nth-child(${parseInt(element.nth_child as any)})`
+    }
+    if (element.nth_of_type) {
+        selector += `:nth-of-type(${parseInt(element.nth_of_type as any)})`
+    }
+    return selector
+}

--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -14,7 +14,8 @@ import { dayjs } from 'lib/dayjs'
 const { TabPane } = Tabs
 
 export function EventDetails({ event }: { event: EventType }): JSX.Element {
-    const { currentTeamId } = useValues(teamLogic)
+    const { currentTeamId, currentTeam } = useValues(teamLogic)
+    const dataAttributes = currentTeam?.data_attributes || []
 
     const [showHiddenProps, setShowHiddenProps] = useState(false)
 
@@ -37,7 +38,7 @@ export function EventDetails({ event }: { event: EventType }): JSX.Element {
         <>
             {currentTeamId && (
                 <Button
-                    onClick={() => createActionFromEvent(currentTeamId, event, 0)}
+                    onClick={() => createActionFromEvent(currentTeamId, event, 0, dataAttributes)}
                     style={{ float: 'right', zIndex: 1, marginTop: 8 }}
                     type="primary"
                 >

--- a/frontend/src/scenes/events/createActionFromEvent.test.js
+++ b/frontend/src/scenes/events/createActionFromEvent.test.js
@@ -10,10 +10,15 @@ jest.mock('kea-router', () => ({
 }))
 
 describe('createActionFromEvent()', () => {
-    given('subject', () => () => createActionFromEvent(given.teamId, given.event, given.increment, given.recurse))
+    given(
+        'subject',
+        () => () =>
+            createActionFromEvent(given.teamId, given.event, given.increment, given.dataAttributes, given.recurse)
+    )
 
     given('teamId', () => 44)
     given('increment', () => 0)
+    given('dataAttributes', () => [])
     given('recurse', () => jest.fn())
 
     given('event', () => ({
@@ -67,24 +72,115 @@ describe('createActionFromEvent()', () => {
 
         describe('$autocapture events', () => {
             given('eventName', () => '$autocapture')
-            given('eventType', () => 'submit')
-            given('elements', () => [{ tag_name: 'form', text: 'Submit form!' }, {}])
 
-            it('handles submit $autocapture events with elements', async () => {
-                await given.subject()
+            describe('without data attributes', () => {
+                given('eventType', () => 'submit')
+                given('elements', () => [
+                    { tag_name: 'form', text: 'Submit form!', attributes: { 'attr__data-attr': 'form' } },
+                ])
 
-                expect(api.actions.create).toHaveBeenCalledWith({
-                    name: 'submitted form with text "Submit form!"',
-                    steps: [
-                        {
-                            event: '$autocapture',
-                            url: 'http://foo.bar/some/path',
-                            url_matching: 'exact',
-                            tag_name: 'form',
-                            text: 'Submit form!',
-                            properties: [{ key: '$event_type', value: 'submit' }],
-                        },
-                    ],
+                it('handles submit $autocapture events with elements', async () => {
+                    await given.subject()
+
+                    expect(api.actions.create).toHaveBeenCalledWith({
+                        name: 'submitted form with text "Submit form!"',
+                        steps: [
+                            {
+                                event: '$autocapture',
+                                url: 'http://foo.bar/some/path',
+                                url_matching: 'exact',
+                                tag_name: 'form',
+                                text: 'Submit form!',
+                                properties: [{ key: '$event_type', value: 'submit' }],
+                            },
+                        ],
+                    })
+                })
+            })
+
+            describe('with data attributes', () => {
+                given('eventType', () => 'click')
+                given('elements', () => [
+                    { tag_name: 'input', text: 'Submit form!' },
+                    { tag_name: 'form', text: 'Submit form!', attributes: { 'attr__data-attr': 'form' } },
+                ])
+                given('dataAttributes', () => ['data-attr'])
+
+                it('handles data attributes', async () => {
+                    await given.subject()
+
+                    expect(api.actions.create).toHaveBeenCalledWith({
+                        name: 'clicked input with text "Submit form!"',
+                        steps: [
+                            {
+                                event: '$autocapture',
+                                url: 'http://foo.bar/some/path',
+                                url_matching: 'exact',
+                                tag_name: 'input',
+                                href: undefined,
+                                text: 'Submit form!',
+                                selector: '[data-attr="form"] > input',
+                            },
+                        ],
+                    })
+                })
+            })
+
+            describe('with data attributes on a link', () => {
+                given('eventType', () => 'click')
+                given('elements', () => [
+                    { tag_name: 'svg' },
+                    { tag_name: 'a', text: 'Submit form via link!', attributes: { 'attr__data-attr': 'link' } },
+                    { tag_name: 'form', text: 'Submit form!', attributes: { 'attr__data-attr': 'form' } },
+                ])
+                given('dataAttributes', () => ['data-attr'])
+
+                it('handles data attributes', async () => {
+                    await given.subject()
+
+                    expect(api.actions.create).toHaveBeenCalledWith({
+                        name: 'clicked svg',
+                        steps: [
+                            {
+                                event: '$autocapture',
+                                url: 'http://foo.bar/some/path',
+                                url_matching: 'exact',
+                                href: undefined,
+                                tag_name: 'svg',
+                                text: undefined,
+                                selector: '[data-attr="link"]',
+                            },
+                        ],
+                    })
+                })
+            })
+
+            describe('with wildcard data attributes', () => {
+                given('eventType', () => 'click')
+                given('elements', () => [
+                    { tag_name: 'svg' },
+                    { tag_name: 'a', text: 'Submit form via link!', attributes: { 'attr__data-attr': 'link' } },
+                    { tag_name: 'form', text: 'Submit form!', attributes: { 'attr__data-attr': 'form' } },
+                ])
+                given('dataAttributes', () => ['data-at*'])
+
+                it('handles data attributes', async () => {
+                    await given.subject()
+
+                    expect(api.actions.create).toHaveBeenCalledWith({
+                        name: 'clicked svg',
+                        steps: [
+                            {
+                                event: '$autocapture',
+                                url: 'http://foo.bar/some/path',
+                                url_matching: 'exact',
+                                href: undefined,
+                                tag_name: 'svg',
+                                text: undefined,
+                                selector: '[data-attr="link"]',
+                            },
+                        ],
+                    })
                 })
             })
         })

--- a/frontend/src/scenes/events/createActionFromEvent.test.js
+++ b/frontend/src/scenes/events/createActionFromEvent.test.js
@@ -209,7 +209,13 @@ describe('createActionFromEvent()', () => {
         it('recurses with increment + 1', async () => {
             await given.subject()
 
-            expect(given.recurse).toHaveBeenCalledWith(given.teamId, given.event, 1, given.recurse)
+            expect(given.recurse).toHaveBeenCalledWith(
+                given.teamId,
+                given.event,
+                1,
+                given.dataAttributes,
+                given.recurse
+            )
             expect(toast).not.toHaveBeenCalled()
         })
 

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -2,12 +2,13 @@
 import { kea } from 'kea'
 import { encodeParams } from 'kea-router'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
-import { elementToActionStep, elementToSelector, toolbarFetch, trimElement } from '~/toolbar/utils'
+import { elementToActionStep, toolbarFetch, trimElement } from '~/toolbar/utils'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { heatmapLogicType } from './heatmapLogicType'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
 import { posthog } from '~/toolbar/posthog'
 import { collectAllElementsDeep, querySelectorAllDeep } from 'query-selector-shadow-dom'
+import { elementToSelector } from 'lib/actionUtils'
 
 export const heatmapLogic = kea<heatmapLogicType>({
     path: ['toolbar', 'elements', 'heatmapLogic'],
@@ -89,8 +90,8 @@ export const heatmapLogic = kea<heatmapLogicType>({
 
     selectors: {
         elements: [
-            (selectors) => [selectors.events],
-            (events) => {
+            (selectors) => [selectors.events, toolbarLogic.selectors.dataAttributes],
+            (events, dataAttributes) => {
                 // cache all elements in shadow roots
                 const allElements = collectAllElementsDeep('*', document)
                 const elements: CountedHTMLElement[] = []
@@ -98,7 +99,7 @@ export const heatmapLogic = kea<heatmapLogicType>({
                     let combinedSelector
                     let lastSelector
                     for (let i = 0; i < event.elements.length; i++) {
-                        const selector = elementToSelector(event.elements[i])
+                        const selector = elementToSelector(event.elements[i], dataAttributes)
                         combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
 
                         try {


### PR DESCRIPTION
## Changes

- When clicking this blue button in the events table...
![image](https://user-images.githubusercontent.com/53387/145001117-df0488b7-c70b-4362-b919-1448ddb2c46e.png)
- ... we used to not fill in the "selector" filed. Now we do, if there's a "id" or "data-*" match:
![image](https://user-images.githubusercontent.com/53387/145001188-ef825b86-bb44-459f-9764-075563f4d128.png)
- I also moved some shared components away from `toolbar/utils` into `lib/actionUtils`


## How did you test this code?

Improved the test suite for the affected function to check the new cases.