### PR TITLE
Revert "Add script tag before </body> instead of </head> "

### DIFF
--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -96,15 +96,15 @@ export function copyIndexHtml(
 
     fse.writeFileSync(
         path.resolve(__dirname, to),
-        fse
-            .readFileSync(path.resolve(__dirname, from), { encoding: 'utf-8' })
-            .replace('</head>', `${cssLinkTag}</head>`)
-            .replace(
-                '</body>',
-                `<script type="application/javascript">${scriptCode}${
-                    Object.keys(chunks).length > 0 ? chunkCode : ''
-                }</script></body>`
-            )
+        fse.readFileSync(path.resolve(__dirname, from), { encoding: 'utf-8' }).replace(
+            '</head>',
+            `   <script type="application/javascript">
+                    ${scriptCode}
+                    ${Object.keys(chunks).length > 0 ? chunkCode : ''}
+                </script>
+                ${cssLinkTag}
+            </head>`
+        )
     )
 }
 


### PR DESCRIPTION
Reverts PostHog/posthog#7545

Going to revert it, because now we won't load any JS before the full CSS file loads.

![image](https://user-images.githubusercontent.com/53387/145008084-110f5b3e-ac83-4192-b8a1-a8906c197511.png)

I was afraid of that, but I assumed the browser would already fetch the JS chunks, but I was wrong.