### PR TITLE
Update event/property key info with groups and recording IDs

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -224,11 +224,35 @@ export const keyMapping: KeyMappingInterface = {
         },
         $identify: {
             label: 'Identify',
-            description: 'Tie a user to their actions',
+            description: 'A user has been identified with properties',
+        },
+        $groupidentify: {
+            label: 'Group Identify',
+            description: 'A group has been identified with properties',
+        },
+        $groups: {
+            label: 'Groups',
+            description: 'Relevant groups',
+        },
+        $group_key: {
+            label: 'Group Key',
+            description: 'Specified group key',
+        },
+        $group_type: {
+            label: 'Group Type',
+            description: 'Specified group type',
+        },
+        $window_id: {
+            label: 'Window ID',
+            description: 'Unique window ID for session recording disambiguation',
+        },
+        $session_id: {
+            label: 'Session ID',
+            description: 'Unique session ID for session recording disambiguation',
         },
         $rageclick: {
             label: 'Rageclick',
-            description: 'When a user repeatedly clicks a targeted area or element over a short period of time',
+            description: 'A user has rapidly and repeatedly clicked in a single place',
         },
         $set: {
             label: 'Set',

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -234,6 +234,10 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Groups',
             description: 'Relevant groups',
         },
+        $group_set: {
+            label: 'Group Set',
+            description: 'Group properties to be set',
+        },
         $group_key: {
             label: 'Group Key',
             description: 'Specified group key',
@@ -256,11 +260,11 @@ export const keyMapping: KeyMappingInterface = {
         },
         $set: {
             label: 'Set',
-            description: '',
+            description: 'Person properties to be set',
         },
         $set_once: {
             label: 'Set Once',
-            description: '',
+            description: 'Person properties to be set if not set already (i.e. first-touch)',
         },
         $capture_failed_request: {
             label: 'Capture Failed Request',

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -234,6 +234,27 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Groups',
             description: 'Relevant groups',
         },
+        // There are at most 5 group types per project, so indexes 0, 1, 2, 3, and 4
+        $group_0: {
+            label: 'Group 1',
+            hide: true,
+        },
+        $group_1: {
+            label: 'Group 2',
+            hide: true,
+        },
+        $group_2: {
+            label: 'Group 3',
+            hide: true,
+        },
+        $group_3: {
+            label: 'Group 4',
+            hide: true,
+        },
+        $group_4: {
+            label: 'Group 5',
+            hide: true,
+        },
         $group_set: {
             label: 'Group Set',
             description: 'Group properties to be set',
@@ -249,10 +270,12 @@ export const keyMapping: KeyMappingInterface = {
         $window_id: {
             label: 'Window ID',
             description: 'Unique window ID for session recording disambiguation',
+            hide: true,
         },
         $session_id: {
             label: 'Session ID',
             description: 'Unique session ID for session recording disambiguation',
+            hide: true,
         },
         $rageclick: {
             label: 'Rageclick',
@@ -559,20 +582,14 @@ export function PropertyKeyTitle({ data }: { data: KeyMapping }): JSX.Element {
 export function PropertyKeyDescription({ data, value }: { data: KeyMapping; value: string }): JSX.Element {
     return (
         <span>
+            {data.description ? <p>{data.description}</p> : null}
             {data.examples ? (
-                <>
-                    <span>{data.description}</span>
-                    <br />
-                    <br />
-                    <span>
-                        <i>Example: </i>
-                        {data.examples.join(', ')}
-                    </span>
-                </>
-            ) : (
-                data.description
-            )}
-            <hr />
+                <p>
+                    <i>Example: </i>
+                    {data.examples.join(', ')}
+                </p>
+            ) : null}
+            {data.description || data.examples ? <hr /> : null}
             Sent as <code style={{ padding: '2px 3px' }}>{value}</code>
         </span>
     )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1364,7 +1364,7 @@ export interface SelectOptionWithChildren extends SelectOption {
 
 export interface KeyMapping {
     label: string
-    description: string | JSX.Element
+    description?: string | JSX.Element
     examples?: string[]
     hide?: boolean
 }


### PR DESCRIPTION
## Changes

Fixes the `$foo`s:
| Before | After |
| --- | --- |
| ![Zrzut ekranu 2021-12-7 o 12 00 51](https://user-images.githubusercontent.com/4550621/145018458-1a222fbd-0b06-47fb-8a02-9c829f634e3a.png) | ![Zrzut ekranu 2021-12-7 o 12 16 17](https://user-images.githubusercontent.com/4550621/145019681-1934201e-b865-4607-9bc8-25c621e65959.png) |

Not sure what to do about `$group_${i}` though… Ideas?

