### PR TITLE
dev(codespaces): make sure REDIS_URL set in codespaces

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -15,6 +15,7 @@ PRIMARY_DB=clickhouse
 DATABASE_URL=postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}
 KAFKA_ENABLED=true
 KAFKA_HOSTS=kafka:9092
+REDIS_URL=redis://redis:6379
 
 # Clickhouse settings
 CLICKHOUSE_HOST=clickhouse


### PR DESCRIPTION
This needs to be set for django to get to the redis celery broker
properly.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
