### PR TITLE
Always run frontend outside docker locally

### DIFF
--- a/ee/bin/docker-ch-dev-web
+++ b/ee/bin/docker-ch-dev-web
@@ -2,4 +2,4 @@
 
 set -e
 
-./ee/bin/docker-ch-dev-backend & ./bin/docker-frontend
+./ee/bin/docker-ch-dev-backend

--- a/ee/docker-compose.ch.arm64.yml
+++ b/ee/docker-compose.ch.arm64.yml
@@ -62,6 +62,7 @@ services:
             PGHOST: db
             PGUSER: posthog
             PGPASSWORD: posthog
+            SKIP_SERVICE_VERSION_REQUIREMENTS: 1
         depends_on:
             - db
             - redis
@@ -77,7 +78,6 @@ services:
         command: '${CH_WEB_SCRIPT:-./ee/bin/docker-ch-dev-web}'
         ports:
             - '8000:8000'
-            - '8234:8234'
     plugins:
         build:
             context: ../

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -38,11 +38,9 @@ class PostHogConfig(AppConfig):
             for service_version_requirement in settings.SERVICE_VERSION_REQUIREMENTS:
                 [in_range, version] = service_version_requirement.is_service_in_accepted_version()
                 if not in_range:
-                    start_anyway = input(
-                        f"Service {service_version_requirement.service} is in version {version}. Expected range: {str(service_version_requirement.supported_version)}. PostHog may not work correctly with the current version. Continue? [y/n]"
+                    print(
+                        f"\033[91mService {service_version_requirement.service} is in version {version}. Expected range: {str(service_version_requirement.supported_version)}. PostHog may not work correctly with the current version. To continue anyway, add SKIP_SERVICE_VERSION_REQUIREMENTS=1 as an environment variable\033[0m",
                     )
-                    if start_anyway.lower() != "y":
-                        print(f"Unsupported version for service {service_version_requirement.service}, exiting...")
-                        exit(1)
+                    exit(1)
 
         init_special_migrations()


### PR DESCRIPTION
## Changes

When running `yarn arm64:ch-dev:start` the web container crashes because we're running the frontend twice and it can't allocate the port.

Also get rid of the y/n question with mis-matched versions in favour of a crash + error message.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
