### PR TITLE
Always open community card

### DIFF
--- a/frontend/src/scenes/plugins/tabs/repository/RepositoryTab.tsx
+++ b/frontend/src/scenes/plugins/tabs/repository/RepositoryTab.tsx
@@ -15,7 +15,10 @@ export enum RepositorySection {
 
 export function RepositoryTab(): JSX.Element {
     const { repositoryLoading, filteredUninstalledPlugins } = useValues(pluginsLogic)
-    const [repositorySectionsOpen, setRepositorySectionsOpen] = useState([RepositorySection.Official])
+    const [repositorySectionsOpen, setRepositorySectionsOpen] = useState([
+        RepositorySection.Official,
+        RepositorySection.Community,
+    ])
 
     const officialPlugins = filteredUninstalledPlugins.filter((plugin) => plugin.maintainer === 'official')
     const communityPlugins = filteredUninstalledPlugins.filter((plugin) => plugin.maintainer === 'community')


### PR DESCRIPTION
## Changes

By default the community tab is closed which is confusing when you're searching for something that is a community plugin.

![image](https://user-images.githubusercontent.com/1727427/145032875-d187269b-85ea-4dc5-8a48-ad9033b8ce16.png)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

I didn't. Should be fine 🤞 
