### PR TITLE
Don't capture error messages for trends

### DIFF
--- a/ee/clickhouse/queries/trends/clickhouse_trends.py
+++ b/ee/clickhouse/queries/trends/clickhouse_trends.py
@@ -44,13 +44,7 @@ class ClickhouseTrends(ClickhouseTrendsTotalVolume, ClickhouseLifecycle, Clickho
 
     def _run_query(self, filter: Filter, entity: Entity, team_id: int) -> List[Dict[str, Any]]:
         sql, params, parse_function = self._get_sql_for_entity(filter, entity, team_id)
-        try:
-            result = sync_execute(sql, params)
-        except Exception as e:
-            capture_exception(e)
-            if settings.TEST or settings.DEBUG:
-                raise e
-            result = []
+        result = sync_execute(sql, params)
 
         result = parse_function(result)
         serialized_data = self._format_serialized(entity, result)


### PR DESCRIPTION
## Changes

Don't capture error messages for trends.
- Closes #7530 by showing an error message when the query errors
- Should actually fix #7435, as we weren't setting refresh_attempt as we were swallowing the error.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Unit tests
- I haven't been able to get my local dev env up and running yet...
