### PR TITLE
Table improvements + "Create action from event" moved

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/Breadcrumbs.scss
+++ b/frontend/src/layout/navigation/Breadcrumbs/Breadcrumbs.scss
@@ -10,7 +10,7 @@
     margin-top: 1rem;
     cursor: default;
     overflow-x: auto;
-    @media screen and (min-width: $lg) {
+    @media screen and (min-width: $md) {
         // Disable fullwidth hacks for viewport widths where the sidebar affects layout
         width: auto;
         padding: 0;

--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -36,10 +36,9 @@
     &.LemonTable--scrollable-left::before {
         opacity: 1;
     }
-    h4.row-name {
+    .row-name {
         font-size: 0.875rem;
         font-weight: 600;
-        color: inherit;
         margin-bottom: 0.125rem;
     }
     .row-description {
@@ -60,7 +59,7 @@
         font-weight: 600;
         letter-spacing: 0.03125rem;
         text-transform: uppercase;
-        > th {
+        > tr > th {
             text-align: left;
         }
     }
@@ -72,12 +71,12 @@
             &.LemonTable__expansion {
                 background: var(--bg-side);
                 > td {
-                    padding: 0; // DIsable padding inside the expansion for better tailored placement of contents
+                    padding: 0; // Disable padding inside the expansion for better tailored placement of contents
                 }
             }
             > td {
-                padding-top: 0.25rem;
-                padding-bottom: 0.25rem;
+                padding-top: 0.5rem;
+                padding-bottom: 0.5rem;
             }
         }
     }

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -56,8 +56,8 @@ export function ActionsTable(): JSX.Element {
             sorter: (a: ActionType, b: ActionType) => ('' + a.name).localeCompare(b.name),
             render: function RenderName(name, action: ActionType, index: number): JSX.Element {
                 return (
-                    <Link data-attr={'action-link-' + index} to={urls.action(action.id)}>
-                        <h4 className="row-name">{name || <i>Unnnamed action</i>}</h4>
+                    <Link data-attr={'action-link-' + index} to={urls.action(action.id)} className="row-name">
+                        {name || <i>Unnnamed action</i>}
                     </Link>
                 )
             },

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -112,8 +112,8 @@ export function Cohorts(): JSX.Element {
             render: function Render(name, { id, description }) {
                 return (
                     <>
-                        <Link to={combineUrl(urls.cohort(id), searchParams).url}>
-                            <h4 className="row-name">{name || 'Untitled'}</h4>
+                        <Link to={combineUrl(urls.cohort(id), searchParams).url} className="row-name">
+                            {name || 'Untitled'}
                         </Link>
                         {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && description && (
                             <span className="row-description">{description}</span>

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -61,10 +61,8 @@ export function Dashboards(): JSX.Element {
                 return (
                     <div className={_highlight ? 'highlighted' : undefined} style={{ display: 'inline-block' }}>
                         <div>
-                            <Link data-attr="dashboard-name" to={urls.dashboard(id)}>
-                                <h4 className="row-name" style={{ display: 'inline' }}>
-                                    {name || 'Untitled'}
-                                </h4>
+                            <Link data-attr="dashboard-name" to={urls.dashboard(id)} className="row-name">
+                                {name || 'Untitled'}
                             </Link>
                             {is_shared && (
                                 <Tooltip title="This dashboard is shared publicly.">

--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -3,20 +3,14 @@ import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { EventElements } from 'scenes/events/EventElements'
 import { Tabs, Button } from 'antd'
-import { createActionFromEvent } from './createActionFromEvent'
 import { EventJSON } from 'scenes/events/EventJSON'
 import { EventType } from '../../types'
 import { Properties } from '@posthog/plugin-scaffold'
-import { useValues } from 'kea'
-import { teamLogic } from '../teamLogic'
 import { dayjs } from 'lib/dayjs'
 
 const { TabPane } = Tabs
 
 export function EventDetails({ event }: { event: EventType }): JSX.Element {
-    const { currentTeamId, currentTeam } = useValues(teamLogic)
-    const dataAttributes = currentTeam?.data_attributes || []
-
     const [showHiddenProps, setShowHiddenProps] = useState(false)
 
     const displayedEventProperties: Properties = {}
@@ -35,52 +29,40 @@ export function EventDetails({ event }: { event: EventType }): JSX.Element {
     }
 
     return (
-        <>
-            {currentTeamId && (
-                <Button
-                    onClick={() => createActionFromEvent(currentTeamId, event, 0, dataAttributes)}
-                    style={{ float: 'right', zIndex: 1, marginTop: 8 }}
-                    type="primary"
-                >
-                    Create action from event
-                </Button>
-            )}
-
-            <Tabs
-                data-attr="event-details"
-                defaultActiveKey="properties"
-                style={{ float: 'left', width: '100%', marginTop: -38 }}
-                tabBarStyle={{ margin: 0 }}
-            >
-                <TabPane tab="Properties" key="properties">
-                    <PropertiesTable
-                        properties={{
-                            $timestamp: dayjs(event.timestamp).toISOString(),
-                            ...displayedEventProperties,
-                            ...visibleHiddenProperties,
-                        }}
-                    />
-                    {hiddenPropsCount > 0 && (
-                        <small>
-                            <Button
-                                style={{ margin: '8px 0 0 8px' }}
-                                type="link"
-                                onClick={() => setShowHiddenProps(!showHiddenProps)}
-                            >
-                                {hiddenPropsCount} hidden properties. Click to {showHiddenProps ? 'hide' : 'show'}.
-                            </Button>
-                        </small>
-                    )}
-                </TabPane>
-                <TabPane tab="JSON" key="json">
-                    <EventJSON event={event} />
-                </TabPane>
-                {event.elements && event.elements.length > 0 && (
-                    <TabPane tab="Elements" key="elements">
-                        <EventElements event={event} />
-                    </TabPane>
+        <Tabs
+            data-attr="event-details"
+            defaultActiveKey="properties"
+            style={{ float: 'left', width: '100%' }}
+            tabBarStyle={{ margin: 0 }}
+        >
+            <TabPane tab="Properties" key="properties">
+                <PropertiesTable
+                    properties={{
+                        $timestamp: dayjs(event.timestamp).toISOString(),
+                        ...displayedEventProperties,
+                        ...visibleHiddenProperties,
+                    }}
+                />
+                {hiddenPropsCount > 0 && (
+                    <small>
+                        <Button
+                            style={{ margin: '8px 0 0 8px' }}
+                            type="link"
+                            onClick={() => setShowHiddenProps(!showHiddenProps)}
+                        >
+                            {hiddenPropsCount} hidden properties. Click to {showHiddenProps ? 'hide' : 'show'}.
+                        </Button>
+                    </small>
                 )}
-            </Tabs>
-        </>
+            </TabPane>
+            <TabPane tab="JSON" key="json">
+                <EventJSON event={event} />
+            </TabPane>
+            {event.elements && event.elements.length > 0 && (
+                <TabPane tab="Elements" key="elements">
+                    <EventElements event={event} />
+                </TabPane>
+            )}
+        </Tabs>
     )
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -42,8 +42,8 @@ export function FeatureFlags(): JSX.Element {
             render: function Render(_, featureFlag: FeatureFlagType) {
                 return (
                     <>
-                        <Link to={featureFlag.id ? urls.featureFlag(featureFlag.id) : undefined}>
-                            <h4 className="row-name">{stringWithWBR(featureFlag.key, 17)}</h4>
+                        <Link to={featureFlag.id ? urls.featureFlag(featureFlag.id) : undefined} className="row-name">
+                            {stringWithWBR(featureFlag.key, 17)}
                         </Link>
                         {featureFlag.name && <span className="row-description">{featureFlag.name}</span>}
                     </>

--- a/frontend/src/scenes/saved-insights/SavedInsights.scss
+++ b/frontend/src/scenes/saved-insights/SavedInsights.scss
@@ -5,6 +5,11 @@
     display: flex;
     flex-direction: column;
 
+    td {
+        padding-bottom: 0.75rem !important;
+        padding-top: 0.75rem !important;
+    }
+
     .new-insight-dropdown-btn {
         cursor: pointer;
         height: 40px;
@@ -18,15 +23,6 @@
         font-size: 24px;
         &:hover {
             background: rgba(83, 117, 255, 0.05);
-        }
-    }
-
-    .order-by {
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        &:hover {
-            color: $primary;
         }
     }
 

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -191,10 +191,10 @@ export function SavedInsights(): JSX.Element {
             key: 'name',
             render: function renderName(name: string, insight) {
                 return (
-                    <Col>
-                        <Row wrap={false}>
-                            <Link to={urls.insightView(insight.short_id, insight.filters)}>
-                                <h4 className="row-name">{name || <i>{UNNAMED_INSIGHT_NAME}</i>}</h4>
+                    <>
+                        <div style={{ display: 'flex', alignItems: 'center' }}>
+                            <Link to={urls.insightView(insight.short_id, insight.filters)} className="row-name">
+                                {name || <i>{UNNAMED_INSIGHT_NAME}</i>}
                             </Link>
                             <div
                                 style={{ cursor: 'pointer', width: 'fit-content', marginLeft: 8 }}
@@ -206,11 +206,11 @@ export function SavedInsights(): JSX.Element {
                                     <StarOutlined className="star-outlined" />
                                 )}
                             </div>
-                        </Row>
+                        </div>
                         {hasDashboardCollaboration && insight.description && (
                             <span className="row-description">{insight.description}</span>
                         )}
-                    </Col>
+                    </>
                 )
             },
         },

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -11,7 +11,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Sorting } from 'lib/components/LemonTable'
 import { urls } from 'scenes/urls'
 
-export const INSIGHTS_PER_PAGE = 15
+export const INSIGHTS_PER_PAGE = 20
 
 export interface InsightsResult {
     results: DashboardItemType[]


### PR DESCRIPTION
## Changes

A few improvements pertaining to list views:
- a bit more breathing room for table cells with more than two lines of content
- column header is left-aligned by default to better delineate columns
- saved insight star is always centered (it was weirdly at the very top for multiline titles)
- increased saved insights page size from 15 to 20 for more practical pages
- simplified some code
- moved "Create action from event" to the new ellipsis menu as per https://github.com/PostHog/posthog/pull/7550#issuecomment-987790430

| Before | After |
| :---: | :---: |
| ![Zrzut ekranu 2021-12-7 o 14 44 26](https://user-images.githubusercontent.com/4550621/145043263-a271484e-27b0-4eb0-9ce9-80a6a2073196.png) | ![Zrzut ekranu 2021-12-7 o 14 43 44](https://user-images.githubusercontent.com/4550621/145043259-15542304-77e6-411c-8b76-39510fcd823f.png) |
| ![Zrzut ekranu 2021-12-7 o 14 47 14](https://user-images.githubusercontent.com/4550621/145043271-d76f966a-9153-4856-b61e-90ccfff8cb5a.png) | ![Zrzut ekranu 2021-12-7 o 14 46 58](https://user-images.githubusercontent.com/4550621/145043273-0cea56a5-3309-4c96-a162-5a7958781c7d.png) |
| ![Zrzut ekranu 2021-12-7 o 14 48 05](https://user-images.githubusercontent.com/4550621/145043335-b0ac7d09-9148-4c49-9181-d46d7a48eaa2.png) | ![Zrzut ekranu 2021-12-7 o 14 59 00](https://user-images.githubusercontent.com/4550621/145043625-2b276c39-7394-41f4-a43a-5c6686730a2e.png)  |