### PR TITLE
perf(retention): limit the number of breakdowns we return

### DIFF
--- a/ee/clickhouse/queries/clickhouse_retention.py
+++ b/ee/clickhouse/queries/clickhouse_retention.py
@@ -126,6 +126,7 @@ class ClickhouseRetention(Retention):
             "total_intervals": filter.total_intervals,
             "period": period.lower(),
             "breakdown_by": filter.breakdown,
+            "limit": filter.breakdown_limit_or_default,
         }
 
         result = sync_execute(

--- a/ee/clickhouse/sql/retention/retention.py
+++ b/ee/clickhouse/sql/retention/retention.py
@@ -88,7 +88,11 @@ SELECT datediff(%(period)s, {trunc_func}(toDateTime(%(start_date)s)), event_date
 INITIAL_BREAKDOWN_INTERVAL_SQL = """
     SELECT 
         target_event.breakdown_values AS breakdown_values,
-        count(DISTINCT target_event.target)
+        count(DISTINCT target_event.target) as count
     FROM ({reference_event_sql}) AS target_event
-    GROUP BY breakdown_values ORDER BY breakdown_values
+
+    GROUP BY breakdown_values
+    ORDER BY count DESC
+
+    LIMIT %(limit)s
 """

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -201,6 +201,15 @@ class RetentionTests(TestCase, ClickhouseTestMixin):
                     "person 2": [{"event": "target event", "properties": {"os": "Chrome"}},],
                     "person 3": [{"event": "target event", "properties": {"os": "Safari"}}],
                 },
+                #  Include the next day also, to ensure it's not just the initial
+                #  interval that is getting handled. (NOTE: adding this as as of
+                #  the time of writing we do two separate queries one for initial
+                #  event and another for the rest)
+                "2020-01-02": {
+                    "person 1": [{"event": "target event", "properties": {"os": "Chrome"}},],
+                    "person 2": [{"event": "target event", "properties": {"os": "Chrome"}},],
+                    "person 3": [{"event": "target event", "properties": {"os": "Safari"}}],
+                },
             },
             team=team,
         )

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -149,7 +149,7 @@ class BreakdownMixin(BaseParamMixin):
 
     @property
     def breakdown_limit_or_default(self) -> int:
-        return self._breakdown_limit or 10
+        return int(self._breakdown_limit or 10)
 
     @include_dict
     def breakdown_to_dict(self):


### PR DESCRIPTION
## Changes

This is to guard against us returning a potentially huge response when
breakdown is specified. There are some very high cardinality fields,
e.g. distinct ids which could result in large data transfer and slow
render times.

As far as I can tell there isn't a way to specify the limit, but we
could add such an frontend option to load more breakdown values.

Note that I also needed to cast `Filter.breakdown_limit_or_default` to
an int instead of the string that is recieved from, e.g. form encoded
requests. :fingerscrossed: the tests pick up if this breaks anything.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
