### PR TITLE
Change timeout to check execution time to 60 seconds

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -391,6 +391,6 @@
                                        FROM JSONExtractRaw(group_properties_0, 'industry'))) )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
-     order by day_start)
+     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -38,6 +38,7 @@ AGGREGATE_SQL = """
 SELECT groupArray(day_start) as date, groupArray(count) as data FROM (
     SELECT SUM(total) AS count, day_start from ({null_sql} UNION ALL {content_sql}) group by day_start order by day_start
 )
+SETTINGS timeout_before_checking_execution_speed = 60
 """
 
 CUMULATIVE_SQL = """

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -90,7 +90,7 @@
              AND timestamp <= '2012-01-15 23:59:59' )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
-     order by day_start)
+     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_basic.1
@@ -157,7 +157,7 @@
              AND timestamp <= '2012-01-15 23:59:59' )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
-     order by day_start)
+     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.1
@@ -243,7 +243,7 @@
            GROUP BY person_id)
         GROUP BY toStartOfDay(timestamp))
      group by day_start
-     order by day_start)
+     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.3
@@ -552,7 +552,7 @@
              AND NOT has([''], $group_0) )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
-     order by day_start)
+     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsGroups.test_aggregating_by_group.1


### PR DESCRIPTION
## Changes

*Please describe.*  
- adds a custom setting for trend volume queries 
- currently by default it's [set to 10 seconds](https://metabase.posthog.net/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgKlxuRlJPTSBzeXN0ZW0uc2V0dGluZ3NcbldIRVJFIG5hbWUgTElLRSAndGltZW91dF9iZWZvcmVfY2hlY2tpbmdfZXhlY3V0aW9uX3NwZWVkJyIsInRlbXBsYXRlLXRhZ3MiOnt9fSwidHlwZSI6Im5hdGl2ZSJ9LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) 
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
manually test queries