### PR TITLE
Update dashboard before refreshing

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -121,11 +121,6 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                         throw error
                     }
                 },
-                updateDashboard: async (filters: Partial<FilterType>) => {
-                    return await api.update(`api/projects/${teamLogic.values.currentTeamId}/dashboards/${props.id}`, {
-                        filters,
-                    })
-                },
             },
         ],
     }),
@@ -491,7 +486,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
             }
         },
     }),
-    listeners: ({ actions, values, key, cache }) => ({
+    listeners: ({ actions, values, key, cache, props }) => ({
         addNewDashboard: async () => {
             prompt({ key: `new-dashboard-${key}` }).actions.prompt({
                 title: 'New dashboard',
@@ -605,7 +600,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         },
         updateAndRefreshDashboard: async (_, breakpoint) => {
             await breakpoint(200)
-            actions.updateDashboard(values.filters)
+            await api.update(`api/projects/${teamLogic.values.currentTeamId}/dashboards/${props.id}`, values.filters)
             actions.refreshAllDashboardItems()
         },
         setDates: ({ dateFrom, dateTo, reloadDashboard }) => {


### PR DESCRIPTION
## Changes

When updating the date filter on the dashboard, we were patching at the same time as refreshing which would lead to inconsistencies/race conditions.
![image](https://user-images.githubusercontent.com/1727427/145111370-72a65a12-9b48-42a3-8c97-bc1810fa6e11.png)

After:
![image](https://user-images.githubusercontent.com/1727427/145111406-cd932c94-c930-4a11-9e7d-e22e01ef92fc.png)

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Set a custom date for the dashboard. See that the patch happens before the refresh.
