### PR TITLE
More updates to stale events

### DIFF
--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -57,10 +57,11 @@ export class TeamManager {
         const params: (string | number)[] = []
 
         const startTime = DateTime.now()
+        const cacheSize = this.eventLastSeenCache.size
 
         const lastFlushedSecondsAgo = DateTime.now().diff(this.lastFlushAt).as('seconds')
         status.info(
-            `🚽 Starting flushLastSeenAtCache. Cache size: ${this.eventLastSeenCache.size} items. Last flushed: ${lastFlushedSecondsAgo} seconds ago.`
+            `🚽 Starting flushLastSeenAtCache. Cache size: ${cacheSize} items. Last flushed: ${lastFlushedSecondsAgo} seconds ago.`
         )
 
         const events = this.eventLastSeenCache
@@ -87,6 +88,7 @@ export class TeamManager {
             )
         }
         const elapsedTime = DateTime.now().diff(startTime).as('milliseconds')
+        this.statsd?.set('flushLastSeenAtCache.Size', cacheSize)
         this.statsd?.timing('flushLastSeenAtCache', elapsedTime)
         status.info(`✅ 🚽 flushLastSeenAtCache finished successfully in ${elapsedTime} ms.`)
     }

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -89,6 +89,7 @@ export class TeamManager {
         }
         const elapsedTime = DateTime.now().diff(startTime).as('milliseconds')
         this.statsd?.set('flushLastSeenAtCache.Size', cacheSize)
+        this.statsd?.set('flushLastSeenAtCache.QuerySize', params.length)
         this.statsd?.timing('flushLastSeenAtCache', elapsedTime)
         status.info(`✅ 🚽 flushLastSeenAtCache finished successfully in ${elapsedTime} ms.`)
     }

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -10,6 +10,7 @@ from posthog.models import EventDefinition
 from posthog.permissions import OrganizationMemberPermissions, TeamMemberAccessPermission
 
 
+# If EE is enabled, we use ee.api.ee_event_definition.EnterpriseEventDefinitionSerializer
 class EventDefinitionSerializer(serializers.ModelSerializer):
     class Meta:
         model = EventDefinition
@@ -55,7 +56,7 @@ class EventDefinitionViewSet(
                     FROM ee_enterpriseeventdefinition
                     FULL OUTER JOIN posthog_eventdefinition ON posthog_eventdefinition.id=ee_enterpriseeventdefinition.eventdefinition_ptr_id
                     WHERE team_id = %(team_id)s {search_query}
-                    ORDER BY query_usage_30_day DESC NULLS LAST, name ASC
+                    ORDER BY query_usage_30_day DESC NULLS LAST, last_seen_at DESC NULLS LAST, name ASC
                     """,
                     params={"team_id": self.team_id, **search_kwargs},
                 )

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -86,7 +86,7 @@
                 },
                 {
                     "name": "EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED_TEAMS",
-                    "value": "2"
+                    "value": "2,2635,572,3777,700"
                 },
                 {
                     "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",


### PR DESCRIPTION
## Changes

A few extra improvements following up stale events:
- Now feeling adventurous and releasing this for the top 4 most active teams aside from us. Tracking performance [here](https://metrics.posthog.net/d/FAdzeThnz/plugin-server-event-metadata-enrichment-last-seen-at).
- Added some extra checkpoints to measure performance.
- We now use `last_seen_at` as a secondary sorting in event definitions (as performance with `query_usage_30_day` has been solid)

## How did you test this code?
- Tested the sorting locally.
