### PR TITLE
Track groups usage on org usage reports

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -219,6 +219,22 @@ def get_agg_event_count_for_teams_and_period(
     return result
 
 
+def get_agg_events_with_groups_count_for_teams_and_period(
+    team_ids: List[Union[str, int]], begin: timezone.datetime, end: timezone.datetime
+) -> int:
+    result = sync_execute(
+        """
+        SELECT count(1) as count
+        FROM events
+        WHERE team_id IN (%(team_id_clause)s)
+        AND timestamp between %(begin)s AND %(end)s
+        AND ($group_0 != '' OR $group_1 != '' OR $group_2 != '' OR $group_3 != '' OR $group_4 != '')
+    """,
+        {"team_id_clause": team_ids, "begin": begin, "end": end},
+    )[0][0]
+    return result
+
+
 def get_event_count_for_team(team_id: Union[str, int]) -> int:
     result = sync_execute(
         """

--- a/ee/tasks/test/test_org_usage_report.py
+++ b/ee/tasks/test/test_org_usage_report.py
@@ -1,11 +1,15 @@
+from typing import Union
 from uuid import uuid4
 
 from django.utils.timezone import datetime
+from freezegun.api import freeze_time
 
 from ee.clickhouse.models.event import create_event
+from ee.clickhouse.models.group import create_group
+from ee.clickhouse.util import ClickhouseTestMixin
 from ee.tasks.org_usage_report import send_all_org_usage_reports
 from posthog.constants import AnalyticsDBMS
-from posthog.models import Person, Team
+from posthog.models import GroupTypeMapping, Person, Team
 from posthog.tasks.test.test_org_usage_report import factory_org_usage_report
 
 
@@ -13,16 +17,51 @@ def create_person(distinct_id: str, team: Team) -> Person:
     return Person.objects.create(team=team, distinct_ids=[distinct_id])
 
 
-def create_event_clickhouse(distinct_id: str, event: str, lib: str, created_at: datetime, team: Team) -> None:
+def create_event_clickhouse(
+    distinct_id: str, event: str, lib: str, timestamp: Union[datetime, str], team: Team, properties={}
+) -> None:
     create_event(
         event_uuid=uuid4(),
         team=team,
         distinct_id=distinct_id,
         event=event,
-        timestamp=created_at,
-        properties={"$lib": lib},
+        timestamp=timestamp,
+        properties={"$lib": lib, **properties},
     )
 
 
-class TestOrganizationUsageReport(factory_org_usage_report(create_person, create_event_clickhouse, send_all_org_usage_reports, {"EE_AVAILABLE": True, "USE_TZ": False, "PRIMARY_DB": AnalyticsDBMS.CLICKHOUSE})):  # type: ignore
-    pass
+class TestOrganizationUsageReport(ClickhouseTestMixin, factory_org_usage_report(create_person, create_event_clickhouse, send_all_org_usage_reports, {"EE_AVAILABLE": True, "USE_TZ": False, "PRIMARY_DB": AnalyticsDBMS.CLICKHOUSE})):  # type: ignore
+    def test_groups_usage(self):
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
+
+        with freeze_time("2021-11-11 00:30:00"):
+            create_event_clickhouse(
+                event="event",
+                lib="web",
+                distinct_id="user_1",
+                team=self.team,
+                timestamp="2021-11-10 02:00:00",
+                properties={"$group_0": "org:5"},
+            )
+            create_event_clickhouse(
+                event="event",
+                lib="web",
+                distinct_id="user_1",
+                team=self.team,
+                timestamp="2021-11-10 05:00:00",
+                properties={"$group_0": "org:6"},
+            )
+
+            create_event_clickhouse(
+                event="event", lib="web", distinct_id="user_7", team=self.team, timestamp="2021-11-10 10:00:00",
+            )
+
+            all_reports = send_all_org_usage_reports(dry_run=True)
+            org_report = self.select_report_by_org_id(str(self.organization.id), all_reports)
+
+            self.assertEqual(org_report["group_types_total"], 2)
+            self.assertEqual(org_report["event_count_in_month"], 3)
+            self.assertEqual(org_report["event_count_with_groups_month"], 2)

--- a/posthog/tasks/test/test_org_usage_report.py
+++ b/posthog/tasks/test/test_org_usage_report.py
@@ -55,6 +55,8 @@ def factory_org_usage_report(
                 self.assertIsNotNone(org_report["organization_created_at"])
                 self.assertGreaterEqual(org_report["organization_user_count"], 1)
                 self.assertEqual(org_report["team_count"], 1)
+                self.assertEqual(org_report["group_types_total"], 0)
+                self.assertEqual(org_report["event_count_with_groups_month"], 0)
 
             with self.settings(**_instance_settings):
                 with freeze_time("2020-11-02"):


### PR DESCRIPTION
## Changes

This adds tracking on whether groups are used on an organization basis. Will be used to determine the success of the project.

## How did you test this code?

See tests.
