### PR TITLE
Hide table config in groups page

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -45,6 +45,7 @@ interface EventsTable {
     filtersEnabled?: boolean
     pageKey?: string
     hidePersonColumn?: boolean
+    hideTableConfig?: boolean
     sceneUrl?: string
 }
 
@@ -53,6 +54,7 @@ export function EventsTable({
     filtersEnabled = true,
     pageKey = 'EventsTable',
     hidePersonColumn,
+    hideTableConfig,
     sceneUrl,
 }: EventsTable = {}): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
@@ -348,11 +350,13 @@ export function EventsTable({
                             checked={automaticLoadEnabled}
                             onChange={toggleAutomaticLoad}
                         />
-                        <TableConfig
-                            availableColumns={propertyNames}
-                            immutableColumns={['event', 'person']}
-                            defaultColumns={defaultColumns.map((e) => e.key || '')}
-                        />
+                        {!hideTableConfig && (
+                            <TableConfig
+                                availableColumns={propertyNames}
+                                immutableColumns={['event', 'person']}
+                                defaultColumns={defaultColumns.map((e) => e.key || '')}
+                            />
+                        )}
                         {exportUrl && (
                             <Tooltip title="Export up to 10,000 latest events." placement="left">
                                 <Button icon={<DownloadOutlined />} onClick={startDownload}>

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -35,6 +35,7 @@ export function Group(): JSX.Element {
                                     properties: [{ key: `$group_${groupTypeIndex}`, value: groupKey }],
                                 }}
                                 sceneUrl={urls.group(groupTypeIndex.toString(), groupKey)}
+                                hideTableConfig
                             />
                         )}
                     </Col>


### PR DESCRIPTION
## Changes

Action item from groups testing session - this is confusing for groups
due to it not being clear what properties this contains

## How did you test this code?

![image](https://user-images.githubusercontent.com/148820/145401751-390127be-9b1e-4a48-b6cf-f849a28703d6.png)
