### PR TITLE
Groups: Improve list experience

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -27,7 +27,7 @@ class ClickhouseGroupsTypesView(StructuredViewSetMixin, mixins.ListModelMixin, v
 
 
 class GroupCursorPagination(CursorPagination):
-    ordering = "group_key"
+    ordering = "-created_at"
     page_size = 100
 
 

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -19,15 +19,17 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_groups_list(self):
-        create_group(
-            team_id=self.team.pk,
-            group_type_index=0,
-            group_key="org:5",
-            properties={"industry": "finance", "name": "Mr. Krabs"},
-        )
-        create_group(
-            team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"},
-        )
+        with freeze_time("2021-05-01"):
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key="org:5",
+                properties={"industry": "finance", "name": "Mr. Krabs"},
+            )
+        with freeze_time("2021-05-02"):
+            create_group(
+                team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"},
+            )
         create_group(
             team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={"name": "Plankton"},
         )
@@ -41,14 +43,14 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                 "results": [
                     {
                         "created_at": "2021-05-02T00:00:00Z",
-                        "group_key": "org:5",
-                        "group_properties": {"industry": "finance", "name": "Mr. Krabs"},
+                        "group_key": "org:6",
+                        "group_properties": {"industry": "technology"},
                         "group_type_index": 0,
                     },
                     {
-                        "created_at": "2021-05-02T00:00:00Z",
-                        "group_key": "org:6",
-                        "group_properties": {"industry": "technology"},
+                        "created_at": "2021-05-01T00:00:00Z",
+                        "group_key": "org:5",
+                        "group_properties": {"industry": "finance", "name": "Mr. Krabs"},
                         "group_type_index": 0,
                     },
                 ],

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -10,6 +10,7 @@ import { urls } from 'scenes/urls'
 import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
+import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 
 const { TabPane } = Tabs
 
@@ -43,7 +44,9 @@ export function Group(): JSX.Element {
                             {groupData && (
                                 <>
                                     <div className="person-header">
-                                        <span className="ph-no-capture text-ellipsis">{groupData.group_key}</span>
+                                        <span className="ph-no-capture text-ellipsis">
+                                            {groupDisplayId(groupData.group_key, groupData.group_properties)}
+                                        </span>
                                     </div>
                                     <div className="item-group">
                                         <label>Group type</label>

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -12,6 +12,7 @@ import { urls } from 'scenes/urls'
 import { SceneExport } from 'scenes/sceneTypes'
 import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
+import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 
 export const scene: SceneExport = {
     component: Groups,
@@ -42,7 +43,9 @@ export function Groups(): JSX.Element {
             key: 'group_key',
             render: function Render(_, group: Group) {
                 return (
-                    <Link to={urls.group(group.group_type_index.toString(), group.group_key)}>{group.group_key}</Link>
+                    <Link to={urls.group(group.group_type_index.toString(), group.group_key)}>
+                        {groupDisplayId(group.group_key, group.group_properties)}
+                    </Link>
                 )
             },
         },

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -19,7 +19,7 @@ export const scene: SceneExport = {
 }
 
 export function Groups(): JSX.Element {
-    const { groups, groupsLoading } = useValues(groupsListLogic)
+    const { currentTabName, groups, groupsLoading } = useValues(groupsListLogic)
     const { loadGroups } = useActions(groupsListLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
@@ -38,7 +38,7 @@ export function Groups(): JSX.Element {
 
     const columns: LemonTableColumns<Group> = [
         {
-            title: 'Key',
+            title: currentTabName,
             key: 'group_key',
             render: function Render(_, group: Group) {
                 return (

--- a/frontend/src/scenes/persons/GroupActorHeader.tsx
+++ b/frontend/src/scenes/persons/GroupActorHeader.tsx
@@ -12,8 +12,16 @@ export function GroupActorHeader({ actor }: GroupActorHeaderProps): JSX.Element 
     return (
         <Link to={urls.group(actor.group_type_index.toString(), actor.group_key)}>
             <div className="person-header identified">
-                <span className="ph-no-capture">{actor.id}</span>
+                <span className="ph-no-capture">{groupDisplayId(actor.group_key, actor.properties)}</span>
             </div>
         </Link>
     )
+}
+
+// Analogue to frontend/src/scenes/persons/PersonHeader.tsx#asDisplay
+export function groupDisplayId(groupKey: string, properties: Record<string, any>): string {
+    if (properties.name) {
+        return properties.name.toString()
+    }
+    return groupKey
 }


### PR DESCRIPTION
## Changes

In this PR:
1. We start ordering groups list by created_at timestamp (same as persons)
2. We use `name` property as the default value we show for a given group, with group_key being a fallback

Action item from groups testing

## How did you test this code?

This is what it looks like. Before it had a random UUID.

![image](https://user-images.githubusercontent.com/148820/145408463-d6a164d1-ff2a-47e8-8521-c5c1c3196387.png)