### PR TITLE
Updates to last seen at cache

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -77,7 +77,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PISCINA_ATOMICS_TIMEOUT: 5000,
         SITE_URL: null,
         NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS: '',
-        EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED_TEAMS: '', // e.g. 2,3
+        EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: false,
     }
 }
 
@@ -135,6 +135,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
             '(advanced) corresponds to the length of time a piscina worker should block for when looking for tasks',
         NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS:
             '(advanced) teams for which to run the new person properties update flow on',
+        EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: 'enable experimental feature to track lastSeenAt',
     }
 }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -46,6 +46,7 @@ export async function startPluginsServer(
     let pingJob: schedule.Job | undefined
     let piscinaStatsJob: schedule.Job | undefined
     let internalMetricsStatsJob: schedule.Job | undefined
+    let flushLastSeenAtCacheJob: schedule.Job | undefined
     let pluginMetricsJob: schedule.Job | undefined
     let piscina: Piscina | undefined
     let queue: Queue | undefined // ingestion queue
@@ -194,6 +195,13 @@ export async function startPluginsServer(
         if (hub.internalMetrics) {
             internalMetricsStatsJob = schedule.scheduleJob('0 * * * * *', async () => {
                 await hub!.internalMetrics?.flush(piscina!)
+            })
+        }
+
+        // every minute flush lastSeenAt cache
+        if (serverConfig.EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED) {
+            flushLastSeenAtCacheJob = schedule.scheduleJob('0 * * * * *', async () => {
+                await hub!.teamManager.flushLastSeenAtCache()
             })
         }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -103,7 +103,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     PISCINA_ATOMICS_TIMEOUT: number
     SITE_URL: string | null
     NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS: string
-    EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED_TEAMS: string
+    EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: boolean
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -163,7 +163,7 @@ export async function createHub(
         db,
         statsd,
         serverConfig.SITE_URL,
-        serverConfig.EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED_TEAMS
+        serverConfig.EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED
     )
     const organizationManager = new OrganizationManager(db)
     const pluginsApiKeyManager = new PluginsApiKeyManager(db)

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -143,6 +143,7 @@ export class TeamManager {
                     this.eventLastSeenCache.set(eventCacheKey, eventTimestamp.valueOf())
                 }
                 // TODO: Allow configuring this via env vars
+                // We flush here every 2 mins (as a failsafe) because the main thread flushes every minute
                 if (this.eventLastSeenCache.size > 1000 || DateTime.now().diff(this.lastFlushAt).as('seconds') > 120) {
                     // to not run out of memory
                     await this.flushLastSeenAtCache()

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -143,7 +143,7 @@ export class TeamManager {
                     this.eventLastSeenCache.set(eventCacheKey, eventTimestamp.valueOf())
                 }
                 // TODO: Allow configuring this via env vars
-                if (this.eventLastSeenCache.size > 1000 || DateTime.now().diff(this.lastFlushAt).as('seconds') > 60) {
+                if (this.eventLastSeenCache.size > 1000 || DateTime.now().diff(this.lastFlushAt).as('seconds') > 120) {
                     // to not run out of memory
                     await this.flushLastSeenAtCache()
                 }

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -159,7 +159,7 @@ export const createProcessEventTests = (
         `
         await resetTestDatabase(testCode, extraServerConfig)
         // TODO: #7422 remove experimental config
-        ;[hub, closeHub] = await createTestHub({ EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED_TEAMS: '2,3' })
+        ;[hub, closeHub] = await createTestHub({ EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: true })
         returned.hub = hub
         returned.closeHub = closeHub
         eventsProcessor = new EventsProcessor(hub)

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -85,8 +85,8 @@
                     "value": "2"
                 },
                 {
-                    "name": "EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED_TEAMS",
-                    "value": "2,2635,572,3777,700"
+                    "name": "EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED",
+                    "value": "True"
                 },
                 {
                     "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",


### PR DESCRIPTION
## Changes
- Based on conversation with @fuziontech, releasing this to everyone on Cloud so we can make sure everything is okay before including it in the self-hosted release (performance looking good).
- Change the way we enable/disable the feature to be instance-based instead of team-based (off by default still).
- Flush the `lastSeenAtCache` from the main thread instead of the event ingestion hot path (@mariusandra's suggestion).

## How did you test this code?
- All these methods include tests (updated too).
- The biggest test is performance which will happen after merge.