### PR TITLE
Groups upsell UI

### DIFF
--- a/frontend/src/layout/navigation/OrganizationSwitcher.tsx
+++ b/frontend/src/layout/navigation/OrganizationSwitcher.tsx
@@ -2,6 +2,7 @@ import { useActions, useValues } from 'kea'
 import { IconPlus } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonRow, LemonSpacer } from 'lib/components/LemonRow'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Lettermark } from 'lib/components/Lettermark/Lettermark'
 import { membershipLevelToName } from 'lib/utils/permissioning'
 import React from 'react'
@@ -14,9 +15,9 @@ import { navigationLogic } from './navigationLogic'
 
 export function AccessLevelIndicator({ organization }: { organization: OrganizationBasicType }): JSX.Element {
     return (
-        <div className="AccessLevelIndicator" title={`Your ${organization.name} organization access level`}>
+        <LemonTag className="AccessLevelIndicator" title={`Your ${organization.name} organization access level`}>
             {organization.membership_level ? membershipLevelToName.get(organization.membership_level) : '?'}
-        </div>
+        </LemonTag>
     )
 }
 

--- a/frontend/src/layout/navigation/OrganizationSwitcher.tsx
+++ b/frontend/src/layout/navigation/OrganizationSwitcher.tsx
@@ -16,7 +16,7 @@ import { navigationLogic } from './navigationLogic'
 export function AccessLevelIndicator({ organization }: { organization: OrganizationBasicType }): JSX.Element {
     return (
         <LemonTag className="AccessLevelIndicator" title={`Your ${organization.name} organization access level`}>
-            {organization.membership_level ? membershipLevelToName.get(organization.membership_level) : '?'}
+            {(organization.membership_level ? membershipLevelToName.get(organization.membership_level) : null) || '?'}
         </LemonTag>
     )
 }

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -37,6 +37,7 @@ import { ToolbarModal } from '~/layout/ToolbarModal/ToolbarModal'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { groupsModel } from '~/models/groupsModel'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 
 function ProjectSwitcherInternal(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
@@ -70,9 +71,10 @@ interface PageButtonProps extends Pick<LemonButtonProps, 'icon' | 'onClick' | 'p
     identifier: string | number
     sideAction?: Omit<SideAction, 'type'> & { identifier?: string }
     title?: string
+    highlight?: 'beta' | 'new'
 }
 
-function PageButton({ title, sideAction, identifier, ...buttonProps }: PageButtonProps): JSX.Element {
+function PageButton({ title, sideAction, identifier, highlight, ...buttonProps }: PageButtonProps): JSX.Element {
     const { aliasedActiveScene, activeScene } = useValues(sceneLogic)
     const { lastDashboardId } = useValues(dashboardsModel)
 
@@ -104,7 +106,16 @@ function PageButton({ title, sideAction, identifier, ...buttonProps }: PageButto
             data-attr={`menu-item-${identifier.toString().toLowerCase()}`}
             {...buttonProps}
         >
-            {title || sceneConfigurations[identifier].name}
+            <span style={{ flexGrow: 1 }}>{title || sceneConfigurations[identifier].name}</span>
+            {highlight === 'beta' ? (
+                <LemonTag type="warning" style={{ marginLeft: 4, float: 'right' }}>
+                    Beta
+                </LemonTag>
+            ) : highlight === 'new' ? (
+                <LemonTag type="success" style={{ marginLeft: 4, float: 'right' }}>
+                    New
+                </LemonTag>
+            ) : null}
         </LemonButton>
     )
 }
@@ -182,7 +193,12 @@ function Pages(): JSX.Element {
                     identifier: Scene.Insight,
                 }}
             />
-            <PageButton icon={<IconRecording />} identifier={Scene.SessionRecordings} to={urls.sessionRecordings()} />
+            <PageButton
+                icon={<IconRecording />}
+                identifier={Scene.SessionRecordings}
+                to={urls.sessionRecordings()}
+                highlight="beta"
+            />
             <PageButton icon={<IconFlag />} identifier={Scene.FeatureFlags} to={urls.featureFlags()} />
             {featureFlags[FEATURE_FLAGS.EXPERIMENTATION] && (
                 <PageButton icon={<IconFlag />} identifier={Scene.Experiments} to={urls.experiments()} />
@@ -194,6 +210,7 @@ function Pages(): JSX.Element {
                 identifier={Scene.Persons}
                 to={urls.persons()}
                 title={`Persons${showGroupsOptions ? ' & groups' : ''}`}
+                highlight={showGroupsOptions ? 'new' : undefined}
             />
             <PageButton icon={<IconCohort />} identifier={Scene.Cohorts} to={urls.cohorts()} />
             <PageButton icon={<IconComment />} identifier={Scene.Annotations} to={urls.annotations()} />

--- a/frontend/src/layout/navigation/TopBar/TopBar.scss
+++ b/frontend/src/layout/navigation/TopBar/TopBar.scss
@@ -203,10 +203,5 @@
 
 .AccessLevelIndicator {
     font-size: 0.625rem;
-    font-weight: 600;
-    background: var(--border);
-    padding: 0.125rem 0.25rem;
-    border-radius: var(--radius);
     margin-left: 0.5rem;
-    text-transform: uppercase;
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -20,10 +20,10 @@
 }
 
 .LemonButton--primary {
-    background: var(--primary);
+    background: $primary;
     color: #fff;
     &:not(:disabled):hover {
-        background: var(--primary-hover);
+        background: $primary_hover;
     }
     &:not(:disabled):active {
         background: var(--primary-active);

--- a/frontend/src/lib/components/LemonTag/LemonTag.scss
+++ b/frontend/src/lib/components/LemonTag/LemonTag.scss
@@ -1,0 +1,27 @@
+@import '~/vars';
+
+.lemon-tag {
+    font-size: 0.75rem;
+    font-weight: $medium;
+    background: $border;
+    padding: 0.125rem 0.25rem;
+    border-radius: $radius;
+    text-transform: uppercase;
+    display: inline;
+    color: $text_default;
+    line-height: 1rem;
+
+    &.warning {
+        background-color: $warning;
+    }
+
+    &.danger {
+        background-color: $danger;
+        color: $text_light;
+    }
+
+    &.success {
+        background-color: $success;
+        color: $text_light;
+    }
+}

--- a/frontend/src/lib/components/LemonTag/LemonTag.tsx
+++ b/frontend/src/lib/components/LemonTag/LemonTag.tsx
@@ -1,0 +1,16 @@
+import clsx from 'clsx'
+import React from 'react'
+import './LemonTag.scss'
+
+interface LemonTagProps extends React.HTMLAttributes<HTMLDivElement> {
+    type?: 'warning' | 'danger' | 'success' | 'default'
+    children: JSX.Element | string
+}
+
+export function LemonTag({ type = 'default', children, className, ...props }: LemonTagProps): JSX.Element {
+    return (
+        <div className={clsx('lemon-tag', type, className)} {...props}>
+            {children}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -944,3 +944,15 @@ export function IconLegend({ style }: { style?: CSSProperties }): JSX.Element {
         </svg>
     )
 }
+
+export function IconGroups({ style }: { style?: CSSProperties }): JSX.Element {
+    return (
+        <svg width="1em" height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={style}>
+            <path
+                d="M12 6C13.1 6 14 6.9 14 8C14 9.1 13.1 10 12 10C10.9 10 10 9.1 10 8C10 6.9 10.9 6 12 6ZM12 16C14.7 16 17.8 17.29 18 18H6C6.23 17.28 9.31 16 12 16ZM12 4C9.79 4 8 5.79 8 8C8 10.21 9.79 12 12 12C14.21 12 16 10.21 16 8C16 5.79 14.21 4 12 4ZM12 14C9.33 14 4 15.34 4 18V20H20V18C20 15.34 14.67 14 12 14Z"
+                fill="currentColor"
+            />
+            <rect x="0.75" y="0.75" width="22.5" height="22.5" rx="5.25" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+    )
+}

--- a/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
@@ -33,7 +33,7 @@ export function GroupsIntroductionBanner(): JSX.Element | null {
                 </LinkButton>
             )}
             <Link
-                to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
+                to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-site-banner"
                 target="_blank"
                 data-attr="group-analytics-learn-more"
                 style={{ marginLeft: 8 }}

--- a/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionBanner.tsx
@@ -35,6 +35,7 @@ export function GroupsIntroductionBanner(): JSX.Element | null {
             <Link
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-site-banner"
                 target="_blank"
+                rel="noopener"
                 data-attr="group-analytics-learn-more"
                 style={{ marginLeft: 8 }}
             >

--- a/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
@@ -33,7 +33,7 @@ export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element
             <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />
             Unique groups
             <Link
-                to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
+                to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-math-selector"
                 target="_blank"
                 data-attr="group-analytics-learn-more"
                 style={{ marginLeft: 8, fontWeight: 'bold' }}

--- a/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { useValues } from 'kea'
-import { LockOutlined } from '@ant-design/icons'
+import { LockOutlined, QuestionCircleOutlined } from '@ant-design/icons'
 import Select from 'rc-select'
 import { Link } from 'lib/components/Link'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
+import { Tooltip } from 'lib/components/Tooltip'
 
 export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element | null {
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
@@ -30,15 +31,26 @@ export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element
                 color: 'var(--text-muted)',
             }}
         >
-            <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />
+            <Tooltip title="This is a premium feature. Click to learn more.">
+                <Link
+                    to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-math-selector-lock"
+                    target="_blank"
+                    rel="noopener"
+                    data-attr="group-analytics-learn-more"
+                    style={{ marginRight: 4 }}
+                >
+                    <LockOutlined style={{ color: 'var(--warning)' }} />
+                </Link>
+            </Tooltip>
             Unique groups
             <Link
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-math-selector"
                 target="_blank"
+                rel="noopener"
                 data-attr="group-analytics-learn-more"
                 style={{ marginLeft: 8, fontWeight: 'bold' }}
             >
-                Learn more
+                <QuestionCircleOutlined />
             </Link>
         </Select.Option>
     )

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -30,6 +30,7 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
             type={access === GroupsAccessStatus.HasAccess ? 'primary' : undefined}
             to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-page"
             target="_blank"
+            rel="noopener"
             data-attr="group-analytics-learn-more"
             className="groups-introduction__action-button"
         >

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -28,7 +28,7 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
     const learnMoreButton = (
         <LemonButton
             type={access === GroupsAccessStatus.HasAccess ? 'primary' : undefined}
-            to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
+            to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-page"
             target="_blank"
             data-attr="group-analytics-learn-more"
             className="groups-introduction__action-button"

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useValues } from 'kea'
-import { IconExternalLink } from 'lib/components/icons'
+import { IconExternalLink, IconGroups } from 'lib/components/icons'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import './GroupsIntroduction.scss'
 import { LemonButton } from 'lib/components/LemonButton'
@@ -21,13 +21,13 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
             data-attr="group-analytics-upgrade"
             className="groups-introduction__action-button"
         >
-            Upgrade to get Group Analytics
+            Upgrade to get Group analytics
         </LemonButton>
     )
 
     const learnMoreButton = (
         <LemonButton
-            type={access === GroupsAccessStatus.HasAccess ? 'primary' : undefined}
+            type={access === GroupsAccessStatus.HasAccess ? 'primary' : 'highlighted'}
             to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-page"
             target="_blank"
             rel="noopener"
@@ -65,6 +65,7 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
 
     return (
         <div className="groups-introduction">
+            <IconGroups style={{ fontSize: 52, color: 'var(--muted-alt)' }} />
             <h2>{title}</h2>
             <div className="groups-introduction__subtext">{subtext}</div>
             {primaryButton}

--- a/frontend/src/scenes/groups/GroupsTabs.tsx
+++ b/frontend/src/scenes/groups/GroupsTabs.tsx
@@ -5,6 +5,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import React from 'react'
 import { groupsModel } from '~/models/groupsModel'
 import { groupsListLogic } from './groupsListLogic'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 
 export function GroupsTabs(): JSX.Element {
     const { setTab } = useActions(groupsListLogic)
@@ -23,7 +24,17 @@ export function GroupsTabs(): JSX.Element {
             <Tabs.TabPane tab="Persons" key="-1" />
 
             {showGroupsIntroductionPage ? (
-                <Tabs.TabPane tab="Introducing group analytics" key="0" />
+                <Tabs.TabPane
+                    tab={
+                        <>
+                            Introducing Group analytics
+                            <LemonTag type="success" style={{ marginLeft: 4 }}>
+                                New
+                            </LemonTag>
+                        </>
+                    }
+                    key="0"
+                />
             ) : (
                 groupTypes.map((groupType) => (
                     <Tabs.TabPane tab={capitalizeFirstLetter(groupType.group_type)} key={groupType.group_type_index} />

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -8,6 +8,7 @@ import PlusCircleOutlined from '@ant-design/icons/lib/icons/PlusCircleOutlined'
 import { Button } from 'antd'
 import { InfoMessage } from 'lib/components/InfoMessage/InfoMessage'
 import { IconSelectEvents, IconSelectProperties } from 'lib/components/icons'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 
 export function CorrelationConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
@@ -57,7 +58,10 @@ export function CorrelationConfig(): JSX.Element {
     return (
         <>
             <h2 className="subtitle" id="internal-users-filtering">
-                Correlation analysis exclusions
+                Correlation analysis exclusions{' '}
+                <LemonTag type="warning" style={{ marginLeft: 8 }}>
+                    Beta
+                </LemonTag>
             </h2>
             <p>Globally exclude events or properties that do not provide relevant signals for your conversions.</p>
 

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { BindLogic, useActions, useValues } from 'kea'
-import { Button, Card, Divider, Input, Skeleton, Tag } from 'antd'
+import { Button, Card, Divider, Input, Skeleton } from 'antd'
 import { IPCapture } from './IPCapture'
 import { JSSnippet } from 'lib/components/JSSnippet'
 import { SessionRecording } from './SessionRecording'
@@ -31,6 +31,7 @@ import { userLogic } from 'scenes/userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { CorrelationConfig } from './CorrelationConfig'
 import { urls } from 'scenes/urls'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 
 export const scene: SceneExport = {
     component: ProjectSettings,
@@ -197,6 +198,9 @@ export function ProjectSettings(): JSX.Element {
                 <Divider />
                 <h2 className="subtitle" id="path_cleaning_filtering">
                     Path cleaning rules
+                    <LemonTag type="warning" style={{ marginLeft: 8 }}>
+                        Beta
+                    </LemonTag>
                 </h2>
                 <p>
                     Make your <Link to={urls.insightNew({ insight: InsightType.PATHS })}>Paths</Link> clearer by
@@ -255,9 +259,9 @@ export function ProjectSettings(): JSX.Element {
                 <div id="session-recording" />
                 <h2 id="recordings" className="subtitle" style={{ display: 'flex', alignItems: 'center' }}>
                     Recordings
-                    <Tag color="orange" style={{ marginLeft: 8 }}>
-                        BETA
-                    </Tag>
+                    <LemonTag type="warning" style={{ marginLeft: 8 }}>
+                        Beta
+                    </LemonTag>
                 </h2>
                 <p>
                     Watch recordings of how users interact with your web app to see what can be improved. Recordings are

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -15,7 +15,6 @@ NOTE: $medium is a SCSS var; not a keyword
 :root {
     --primary: #{$primary};
     --primary-alt: #{$primary_alt};
-    --primary-hover: #{$primary_hover};
     --primary-active: #{$primary_active};
     --primary-bg-hover: #{$primary_bg_hover};
     --primary-bg-active: #{$primary_bg_active};

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -6,7 +6,7 @@ when changing any base config here, please remember to update antd.less too
 // Main colors
 $primary: #5375ff;
 $primary_alt: #35416b;
-$primary_hover: #eef2ff;
+$primary_hover: #8fa5ff;
 $primary_active: #3d57d9;
 $primary_bg_hover: rgba($primary, 0.1);
 $primary_bg_active: rgba($primary, 0.2);


### PR DESCRIPTION
## Changes

As promised here #7521, improves the UI of group upsells a bit. In addition:
- We now set a hover state for primary lemon button that maintains a decent contrast ratio (still readable).
- We create the reusable lemon tag component.
- We use the cool new lemon tag component (based off of @clarkus's designs) for the beta tags on project settings.

**Main page**
<img width="1212" alt="" src="https://user-images.githubusercontent.com/5864173/145492055-4b21e494-6dbb-49dd-a191-f40dee64528b.png">

**Persistent upsell**
<img width="403" alt="" src="https://user-images.githubusercontent.com/5864173/145492079-3c431ee6-a0fa-43de-8629-5941b1567b79.png">

**Sidebar**
<img width="219" alt="" src="https://user-images.githubusercontent.com/5864173/145492512-a72bc8f1-e434-42bc-9b01-a0aee9724622.png">


## How did you test this code?
See screenshots.