### PR TITLE
Kill N+1 query in insight list view

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -154,7 +154,7 @@ class InsightSerializer(InsightBasicSerializer):
 
 
 class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    queryset = Insight.objects.all()
+    queryset = Insight.objects.all().select_related("dashboard")
     serializer_class = InsightSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     filter_backends = [DjangoFilterBackend]


### PR DESCRIPTION
This was added in
https://github.com/PostHog/posthog/commit/1b0240d7fa0bad792d182916624f49f540a8ab1e
when we started always including all filters expanded in list view. It's a bad
idea in general, but this fix at least removes the N+1.

This caused insight list to fail to load if you had a lot of insights.

cc @paolodamico 