### PR TITLE
Resolve another insights N+1 issue

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_insights.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_insights.ambr
@@ -126,3 +126,42 @@
   LIMIT 100
   '
 ---
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1.5
+  '
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."tags"
+  FROM "posthog_dashboard"
+  WHERE "posthog_dashboard"."id" IN (41,
+                                     42,
+                                     43,
+                                     44,
+                                     45,
+                                     46,
+                                     47,
+                                     48,
+                                     49,
+                                     50,
+                                     51,
+                                     52,
+                                     53,
+                                     54,
+                                     55,
+                                     56,
+                                     57,
+                                     58,
+                                     59,
+                                     60)
+  '
+---

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_insights.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_insights.ambr
@@ -1,0 +1,128 @@
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '
+---
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1.1
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."correlation_config",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1.2
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 21
+  '
+---
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1.3
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  WHERE ("posthog_dashboarditem"."team_id" = 2
+         AND NOT "posthog_dashboarditem"."deleted")
+  '
+---
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1.4
+  '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."tags",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt"
+  FROM "posthog_dashboarditem"
+  WHERE ("posthog_dashboarditem"."team_id" = 2
+         AND NOT "posthog_dashboarditem"."deleted")
+  ORDER BY "posthog_dashboarditem"."order" ASC
+  LIMIT 100
+  '
+---

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_insights.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_insights.ambr
@@ -143,25 +143,38 @@
          "posthog_dashboard"."creation_mode",
          "posthog_dashboard"."tags"
   FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" IN (41,
-                                     42,
-                                     43,
-                                     44,
-                                     45,
-                                     46,
-                                     47,
-                                     48,
-                                     49,
-                                     50,
-                                     51,
-                                     52,
-                                     53,
-                                     54,
-                                     55,
-                                     56,
-                                     57,
-                                     58,
-                                     59,
-                                     60)
+  WHERE "posthog_dashboard"."id" IN (1,
+                                     2,
+                                     3,
+                                     4,
+                                     5 /* ... */)
+  '
+---
+# name: ClickhouseTestInsights.test_insights_does_not_nplus1.6
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" IN (1,
+                                2,
+                                3,
+                                4,
+                                5 /* ... */)
   '
 ---

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -154,7 +154,7 @@ class InsightSerializer(InsightBasicSerializer):
 
 
 class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    queryset = Insight.objects.all().select_related("dashboard")
+    queryset = Insight.objects.all().prefetch_related("dashboard", "created_by")
     serializer_class = InsightSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     filter_backends = [DjangoFilterBackend]

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -143,25 +143,38 @@
          "posthog_dashboard"."creation_mode",
          "posthog_dashboard"."tags"
   FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" IN (61,
-                                     62,
-                                     63,
-                                     64,
-                                     65,
-                                     66,
-                                     67,
-                                     68,
-                                     69,
-                                     70,
-                                     71,
-                                     72,
-                                     73,
-                                     74,
-                                     75,
-                                     76,
-                                     77,
-                                     78,
-                                     79,
-                                     80)
+  WHERE "posthog_dashboard"."id" IN (1,
+                                     2,
+                                     3,
+                                     4,
+                                     5 /* ... */)
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.6
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" IN (1,
+                                2,
+                                3,
+                                4,
+                                5 /* ... */)
   '
 ---

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -1,0 +1,160 @@
+# name: TestInsight.test_insights_does_not_nplus1
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.1
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."correlation_config",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.2
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 21
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.3
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  WHERE ("posthog_dashboarditem"."team_id" = 2
+         AND NOT "posthog_dashboarditem"."deleted")
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.4
+  '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."tags",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt"
+  FROM "posthog_dashboarditem"
+  WHERE ("posthog_dashboarditem"."team_id" = 2
+         AND NOT "posthog_dashboarditem"."deleted")
+  ORDER BY "posthog_dashboarditem"."order" ASC
+  LIMIT 100
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.5
+  '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."tags",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt"
+  FROM "posthog_dashboarditem"
+  WHERE ("posthog_dashboarditem"."team_id" = 2
+         AND NOT "posthog_dashboarditem"."deleted")
+  ORDER BY "posthog_dashboarditem"."order" ASC
+  LIMIT 100
+  '
+---

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -128,33 +128,40 @@
 ---
 # name: TestInsight.test_insights_does_not_nplus1.5
   '
-  SELECT "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."tags",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt"
-  FROM "posthog_dashboarditem"
-  WHERE ("posthog_dashboarditem"."team_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
-  ORDER BY "posthog_dashboarditem"."order" ASC
-  LIMIT 100
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."tags"
+  FROM "posthog_dashboard"
+  WHERE "posthog_dashboard"."id" IN (61,
+                                     62,
+                                     63,
+                                     64,
+                                     65,
+                                     66,
+                                     67,
+                                     68,
+                                     69,
+                                     70,
+                                     71,
+                                     72,
+                                     73,
+                                     74,
+                                     75,
+                                     76,
+                                     77,
+                                     78,
+                                     79,
+                                     80)
   '
 ---

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -164,10 +164,11 @@ def insight_test_factory(event_factory, person_factory):
                     team=self.team,
                     short_id=f"insight{i}",
                     dashboard=dashboard,
+                    created_by=user,
                 )
 
-            # 3 for request overhead (django sessions/auth), then item count + items + dashboards + users
-            with self.assertNumQueries(7):
+            # 4 for request overhead (django sessions/auth), then item count + items + dashboards + users
+            with self.assertNumQueries(8):
                 response = self.client.get(f"/api/projects/{self.team.id}/insights")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(len(response.json()["results"]), 20)

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -8,7 +8,7 @@
   FROM "posthog_featureflag"
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id = 2)
+         AND "posthog_featureflag"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_group_flags_with_overrides.1
@@ -17,7 +17,8 @@
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'distinct_id'
-         AND "posthog_persondistinctid"."team_id = 2 AND "posthog_person"."team_id = 2)
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_group_flags_with_overrides.2
@@ -26,7 +27,8 @@
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'distinct_id'
-         AND "posthog_persondistinctid"."team_id = 2 AND "posthog_person"."team_id = 2)
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_group_flags_with_overrides.3
@@ -36,7 +38,7 @@
          "posthog_grouptypemapping"."group_type",
          "posthog_grouptypemapping"."group_type_index"
   FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."team_id = 2
+  WHERE "posthog_grouptypemapping"."team_id" = 2
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_group_flags_with_overrides.4
@@ -44,8 +46,8 @@
   SELECT ("posthog_group"."group_properties" -> 'name') = '"foo.inc"' AS "condition_0"
   FROM "posthog_group"
   WHERE ("posthog_group"."group_key" = 'PostHog'
-         AND "posthog_group"."group_type_index" = 0
-         AND "posthog_group"."team_id = 2)
+         AND "posthog_group"."group_type_index" = 2
+         AND "posthog_group"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_group_flags_with_overrides.5
@@ -57,9 +59,20 @@
          "posthog_featureflag"."key"
   FROM "posthog_featureflagoverride"
   INNER JOIN "posthog_featureflag" ON ("posthog_featureflagoverride"."feature_flag_id" = "posthog_featureflag"."id")
-  WHERE ("posthog_featureflagoverride"."team_id = 2 AND "posthog_featureflagoverride"."user_id" IN (SELECT W0."id" FROM "posthog_user" W0 WHERE W0."distinct_id" IN (SELECT V0."distinct_id" FROM "posthog_persondistinctid" V0 WHERE V0."person_id" IN (SELECT U0."person_id" FROM "posthog_persondistinctid" U0 WHERE (U0."distinct_id" = 'distinct_id' AND U0."team_id = 2)
-  LIMIT 1))
-  LIMIT 1))
+  WHERE ("posthog_featureflagoverride"."team_id" = 2
+         AND "posthog_featureflagoverride"."user_id" IN
+           (SELECT W0."id"
+            FROM "posthog_user" W0
+            WHERE W0."distinct_id" IN
+                (SELECT V0."distinct_id"
+                 FROM "posthog_persondistinctid" V0
+                 WHERE V0."person_id" IN
+                     (SELECT U0."person_id"
+                      FROM "posthog_persondistinctid" U0
+                      WHERE (U0."distinct_id" = 'distinct_id'
+                             AND U0."team_id" = 2)
+                      LIMIT 1))
+            LIMIT 1))
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_person_flags_with_overrides
@@ -72,7 +85,7 @@
   FROM "posthog_featureflag"
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id = 2)
+         AND "posthog_featureflag"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_person_flags_with_overrides.1
@@ -81,7 +94,8 @@
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'distinct_id'
-         AND "posthog_persondistinctid"."team_id = 2 AND "posthog_person"."team_id = 2)
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_person_flags_with_overrides.2
@@ -90,7 +104,8 @@
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'distinct_id'
-         AND "posthog_persondistinctid"."team_id = 2 AND "posthog_person"."team_id = 2)
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_person_flags_with_overrides.3
@@ -100,7 +115,7 @@
          "posthog_grouptypemapping"."group_type",
          "posthog_grouptypemapping"."group_type_index"
   FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."team_id = 2
+  WHERE "posthog_grouptypemapping"."team_id" = 2
   '
 ---
 # name: TestFeatureFlagsWithOverrides.test_person_flags_with_overrides.4
@@ -112,8 +127,19 @@
          "posthog_featureflag"."key"
   FROM "posthog_featureflagoverride"
   INNER JOIN "posthog_featureflag" ON ("posthog_featureflagoverride"."feature_flag_id" = "posthog_featureflag"."id")
-  WHERE ("posthog_featureflagoverride"."team_id = 2 AND "posthog_featureflagoverride"."user_id" IN (SELECT W0."id" FROM "posthog_user" W0 WHERE W0."distinct_id" IN (SELECT V0."distinct_id" FROM "posthog_persondistinctid" V0 WHERE V0."person_id" IN (SELECT U0."person_id" FROM "posthog_persondistinctid" U0 WHERE (U0."distinct_id" = 'distinct_id' AND U0."team_id = 2)
-  LIMIT 1))
-  LIMIT 1))
+  WHERE ("posthog_featureflagoverride"."team_id" = 2
+         AND "posthog_featureflagoverride"."user_id" IN
+           (SELECT W0."id"
+            FROM "posthog_user" W0
+            WHERE W0."distinct_id" IN
+                (SELECT V0."distinct_id"
+                 FROM "posthog_persondistinctid" V0
+                 WHERE V0."person_id" IN
+                     (SELECT U0."person_id"
+                      FROM "posthog_persondistinctid" U0
+                      WHERE (U0."distinct_id" = 'distinct_id'
+                             AND U0."team_id" = 2)
+                      LIMIT 1))
+            LIMIT 1))
   '
 ---

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -215,6 +215,7 @@ class QueryMatchingTest:
         # :TRICKY: team_id changes every test, avoid it messing with snapshots.
         if replace_all_numbers:
             query = re.sub(r"(\"?) = \d+", r"\1 = 2", query)
+            query = re.sub(r"(\"?) IN \(\d+(, \d+)*\)", r"\1 IN (1, 2, 3, 4, 5 /* ... */)", query)
         else:
             query = re.sub(r"(team|cohort)_id(\"?) = \d+", r"\1_id\2 = 2", query)
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -211,9 +211,19 @@ class QueryMatchingTest:
     snapshot: Any
 
     # :NOTE: Update snapshots by passing --snapshot-update to bin/tests
-    def assertQueryMatchesSnapshot(self, query, params=None):
+    def assertQueryMatchesSnapshot(self, query, params=None, replace_all_numbers=False):
         # :TRICKY: team_id changes every test, avoid it messing with snapshots.
-        query = re.sub(r"(team|cohort)_id\"? = \d+", r"\1_id = 2", query)
+        if replace_all_numbers:
+            query = re.sub(r"(\"?) = \d+", r"\1 = 2", query)
+        else:
+            query = re.sub(r"(team|cohort)_id(\"?) = \d+", r"\1_id\2 = 2", query)
+
+        # Replace organization_id lookups, for postgres
+        query = re.sub(
+            f"organization_id\" = '[^']+'::uuid",
+            "organization_id\" = '00000000-0000-0000-0000-000000000000'::uuid",
+            query,
+        )
 
         assert sqlparse.format(query, reindent=True) == self.snapshot, "\n".join(self.snapshot.get_assert_diff())
         if params is not None:
@@ -239,6 +249,7 @@ def snapshot_postgres_queries(fn):
 
         for query_with_time in context.captured_queries:
             query = query_with_time["sql"]
-            self.assertQueryMatchesSnapshot(query)
+            if "SELECT" in query and "django_session" not in query:
+                self.assertQueryMatchesSnapshot(query, replace_all_numbers=True)
 
     return wrapped


### PR DESCRIPTION
This PR resolves another insights N+1 issue.

I'm using `prefetch_related` to avoid loading the same dashboard/user multiple times if referred to by different insights. 

More queries _can_ be better than a join sometimes! :)

## How did you test this code?

Unit tests, ran development server with --print-sql as well.