### PR TITLE
ci(e2e): improve debug logging for github action workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,7 +122,8 @@ jobs:
                   wait
                   python manage.py setup_dev
                   mkdir -p /tmp/logs
-                  ./bin/start &> /tmp/logs/start.txt &
+                  ./bin/docker-worker &> /tmp/logs/worker.txt &
+                  ./bin/docker-server &> /tmp/logs/server.txt &
             - name: Cypress run
               uses: cypress-io/github-action@v2
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,15 +118,16 @@ jobs:
                   NO_RESTART_LOOP: 1
               run: |
                   python manage.py collectstatic --noinput &
-                  ./bin/docker-migrate & wait
+                  ./bin/docker-migrate &
+                  wait
                   python manage.py setup_dev
-                  mkdir -p cypress/screenshots
                   ./bin/docker-worker &
                   ./bin/docker-server &
             - name: Cypress run
               uses: cypress-io/github-action@v2
               with:
                   config-file: cypress.e2e.json
+                  video: true
                   record: true
                   parallel: ${{github.event.pull_request.head.repo.full_name == github.repository}}
                   group: 'PostHog Frontend'
@@ -146,4 +147,10 @@ jobs:
               with:
                   name: screenshots
                   path: cypress/screenshots
+              if: ${{ failure() }}
+            - name: Archive test videos
+              uses: actions/upload-artifact@v1
+              with:
+                  name: videos
+                  path: cypress/videos
               if: ${{ failure() }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,8 +121,9 @@ jobs:
                   ./bin/docker-migrate &
                   wait
                   python manage.py setup_dev
-                  ./bin/docker-worker &
-                  ./bin/docker-server &
+                  mkdir -p /tmp/logs
+                  ./bin/docker-worker > /tmp/logs/worker.txt 2>&1 &
+                  ./bin/docker-server > /tmp/logs/server.txt 2>&1 &
             - name: Cypress run
               uses: cypress-io/github-action@v2
               with:
@@ -153,4 +154,11 @@ jobs:
               with:
                   name: videos
                   path: cypress/videos
+              if: ${{ failure() }}
+            - name: Show logs on failure
+              # use artefact here, as I think the output will be too large for display in an action
+              uses: actions/upload-artifact@v1
+              with:
+                  name: logs
+                  path: /tmp/logs
               if: ${{ failure() }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,8 +122,8 @@ jobs:
                   wait
                   python manage.py setup_dev
                   mkdir -p /tmp/logs
-                  ./bin/docker-worker > /tmp/logs/worker.txt 2>&1 &
-                  ./bin/docker-server > /tmp/logs/server.txt 2>&1 &
+                  ./bin/docker-worker &> /tmp/logs/worker.txt &
+                  ./bin/docker-server &> /tmp/logs/server.txt &
             - name: Cypress run
               uses: cypress-io/github-action@v2
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,7 +128,6 @@ jobs:
               uses: cypress-io/github-action@v2
               with:
                   config-file: cypress.e2e.json
-                  video: true
                   record: true
                   parallel: ${{github.event.pull_request.head.repo.full_name == github.repository}}
                   group: 'PostHog Frontend'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,8 +122,7 @@ jobs:
                   wait
                   python manage.py setup_dev
                   mkdir -p /tmp/logs
-                  ./bin/docker-worker &> /tmp/logs/worker.txt &
-                  ./bin/docker-server &> /tmp/logs/server.txt &
+                  ./bin/start &> /tmp/logs/start.txt &
             - name: Cypress run
               uses: cypress-io/github-action@v2
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,6 +128,7 @@ jobs:
               uses: cypress-io/github-action@v2
               with:
                   config-file: cypress.e2e.json
+                  config: retries=2
                   record: true
                   parallel: ${{github.event.pull_request.head.repo.full_name == github.repository}}
                   group: 'PostHog Frontend'

--- a/bin/docker-server
+++ b/bin/docker-server
@@ -6,6 +6,8 @@ gunicorn posthog.wsgi \
     --bind 0.0.0.0:8000 \
     --log-file - \
     --log-level info \
+    --capture-output \
+    --enable-stdio-inheritance \
     --access-logfile - \
     --worker-tmp-dir /dev/shm \
     --workers=2 \

--- a/bin/docker-server
+++ b/bin/docker-server
@@ -6,8 +6,6 @@ gunicorn posthog.wsgi \
     --bind 0.0.0.0:8000 \
     --log-file - \
     --log-level info \
-    --capture-output \
-    --enable-stdio-inheritance \
     --access-logfile - \
     --worker-tmp-dir /dev/shm \
     --workers=2 \

--- a/cypress.e2e.json
+++ b/cypress.e2e.json
@@ -1,10 +1,9 @@
 {
-    "video": false,
+    "video": true,
     "baseUrl": "http://localhost:8000",
     "defaultCommandTimeout": 20000,
     "requestTimeout": 8000,
     "pageLoadTimeout": 80000,
     "projectId": "twojfp",
-    "retries": 2,
     "viewportWidth": 1200
 }

--- a/cypress/integration/retention.js
+++ b/cypress/integration/retention.js
@@ -7,13 +7,17 @@ describe('Retention', () => {
     })
 
     it('should apply filter and navigate to persons', () => {
+        // NOTE: First wait for results to load, try and make the test more
+        // stable. This is to try and avoid an issue where after selecting a
+        // filter property, the results section would be blank
+        cy.get('[data-attr=retention-table').should('exist')
         cy.get('[data-attr=new-prop-filter-insight-retention]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').type('is_demo')
         cy.get('[data-attr=taxonomic-tab-person_properties]').click()
-        cy.get('[data-attr=prop-filter-person_properties-0]').click({ force: true })
+        cy.get('[data-attr=prop-filter-person_properties-0]').click()
         cy.get('[data-attr=prop-val]').click()
-        cy.get('[data-attr=prop-val-0]').click({ force: true })
+        cy.get('[data-attr=prop-val-0]').click()
         cy.get('[data-attr=retention-table').should('exist')
 
         cy.get('.percentage-cell').last().click()


### PR DESCRIPTION
## Changes

Adds artifacts for videos and `bin/docker-*` commands run in the e2e workflow.

I was having some issues debugging some e2e test failures on another branch so played around with getting some more out of the CI run.

Changes of note include:

  1. enabling video output to local disk. I've also kept the record: true setting which will push to cypress.io as I didn't want to make changes that might affect others workflow
  2. redirecing and artifacting backgrounded process output so you can view the logs if there are failures. Here we also update gunicorn settings such that we capture the django app output (I'm not sure where these are going at the moment. Happy to remove this change as I'm not sure the ramifications)
  3. removing retries from the cypress config json, and adding this specifically to the ci github action. i.e. I am trying to optimize for local development as the default setting, and I suggest that when you're running locally you just want to run once then debug so the feedback loop is tight, but in ci we want some resilience.
  4. waiting for the initial retention table to load before doing any filtering. I just want to avoid rerenderings mostly, and remove the force: true settings.  I can remove this change, it was just what happened to be in these commits I cherry-picked but I don't think (famous last words) it should have any detrimental effects)

## How did you test this code?

checked that e2e github workflow runs successfully.
