### PR TITLE
Groups: Show the correct tab as active when navigating between groups/persons

### DIFF
--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -80,5 +80,8 @@ export const groupsListLogic = kea<groupsListLogicType<GroupsPaginatedResponse>>
                 actions.loadGroups()
             }
         },
+        '/persons': () => {
+            actions.setTab('-1')
+        },
     }),
 })


### PR DESCRIPTION
Currently master has this bug:
- Go to a groups list
- Open a group
- Click on Persons & groups

Expected result:
- Person tab active

Actual result:
- Group tab active but you see persons

This is because the tabs logic uses groupsLogic to decide which tab is
active.

## How did you test this code?

Did the repro case, did not occur anymore.