### PR TITLE
Always allow editing insight name

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -12,6 +12,18 @@ describe('Dashboard', () => {
         cy.get('[data-attr=breadcrumb-2]').should('have.text', 'Dashboards')
     })
 
+    it('Adding new insight to dashboard works', () => {
+        cy.get('[data-attr=menu-item-insight]').click() // Create a new insight
+        cy.get('[data-attr="insight-save-button"]').click() // Save the insight
+        cy.get('[data-attr="edit-prop-name"]').click() // Rename insight
+        cy.focused().clear().type('Test Insight Zeus')
+        cy.get('button').contains('Done').click() // Save the new name
+        cy.get('[data-attr="save-to-dashboard-button"]').click() // Open the Save to dashboard modal
+        cy.get('button').contains('Add insight to dashboard').click() // Add the insight to a dashboard
+        cy.get('[data-attr="save-to-dashboard-button"]').click() // Go to the dashboard
+        cy.get('[data-attr="insight-name"]').should('contain', 'Test Insight Zeus') // Check if the insight is there
+    })
+
     it('Cannot see tags or description (non-FOSS feature)', () => {
         cy.get('h1').should('contain', 'Dashboards')
         cy.get('th').contains('Description').should('not.exist')

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -1,9 +1,7 @@
 import { Button, Input } from 'antd'
 import { EditOutlined, LockOutlined } from '@ant-design/icons'
 import React, { useEffect, useState } from 'react'
-import { useValues } from 'kea'
 import './EditableField.scss'
-import { insightLogic } from 'scenes/insights/insightLogic'
 import { Tooltip } from '../Tooltip'
 
 interface EditableFieldProps {

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -87,8 +87,14 @@ export function EditableField({
                         >
                             <EditOutlined />
                         </Button>
-                    ) : <Tooltip title="This field is part of PostHog's team-oriented feature set and requires a premium plan. Check PostHog pricing." isDefaultTooltip><LockOutlined 
-                    style={{marginLeft: 6, color: 'var(--text-muted)'}}/></Tooltip>}
+                    ) : (
+                        <Tooltip
+                            title="This field is part of PostHog's team-oriented feature set and requires a premium plan. Check PostHog pricing."
+                            isDefaultTooltip
+                        >
+                            <LockOutlined style={{ marginLeft: 6, color: 'var(--text-muted)' }} />
+                        </Tooltip>
+                    )}
                 </div>
             )}
         </div>

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -1,14 +1,17 @@
 import { Button, Input } from 'antd'
-import { EditOutlined } from '@ant-design/icons'
+import { EditOutlined, LockOutlined } from '@ant-design/icons'
 import React, { useEffect, useState } from 'react'
 import { useValues } from 'kea'
 import './EditableField.scss'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { Tooltip } from '../Tooltip'
 
 interface EditableFieldProps {
     name: string
     value: string
     placeholder?: string
+    /** Whether editing is locked due to this being a premium feature. */
+    locked?: boolean
     className: string
     dataAttr: string
     onChange: (value: string) => void
@@ -22,20 +25,22 @@ export function EditableField({
     className,
     dataAttr,
     placeholder,
+    locked,
     multiline,
 }: EditableFieldProps): JSX.Element {
-    const { metadataEditable } = useValues(insightLogic)
     const [isEditing, setIsEditing] = useState(false)
     const [editedValue, setEditedValue] = useState(value)
+
     useEffect(() => {
         setEditedValue(value)
     }, [value])
+
     return (
         <div
             className={`editable-field${className ? ` ${className}` : ''} ${isEditing ? 'edit-mode' : 'view-mode'}`}
             data-attr={dataAttr}
         >
-            {metadataEditable && isEditing ? (
+            {isEditing ? (
                 <div className="edit-container ant-input-affix-wrapper ant-input-affix-wrapper-lg editable-textarea-wrapper">
                     <Input.TextArea
                         autoFocus
@@ -69,7 +74,7 @@ export function EditableField({
             ) : (
                 <div className="view-container">
                     <span className="field">{value || <i>{placeholder}</i>}</span>
-                    {metadataEditable && (
+                    {!locked ? (
                         <Button
                             type="link"
                             onClick={() => {
@@ -82,7 +87,8 @@ export function EditableField({
                         >
                             <EditOutlined />
                         </Button>
-                    )}
+                    ) : <Tooltip title="This field is part of PostHog's team-oriented feature set and requires a premium plan. Check PostHog pricing." isDefaultTooltip><LockOutlined 
+                    style={{marginLeft: 6, color: 'var(--text-muted)'}}/></Tooltip>}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -129,7 +129,7 @@ export function DashboardHeader(): JSX.Element {
                 hotkey="n"
                 className="hide-lte-md"
             >
-                Add graph
+                New insight
             </HotkeyButton>
             <HotkeyButton
                 type="primary"

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -82,7 +82,7 @@ export function EmptyDashboardComponent(): JSX.Element {
                             icon={<PlusOutlined />}
                             hotkey="n"
                         >
-                            Add graph
+                            New insight
                         </HotkeyButton>
                     </div>
                 </Card>

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -171,14 +171,6 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                         items: state?.items.map((item) => ({ ...item, layouts: itemLayouts[item.short_id] })),
                     } as DashboardType
                 },
-                [dashboardsModel.actionTypes.updateDashboardItem]: (state, { item }) => {
-                    return state
-                        ? ({
-                              ...state,
-                              items: state?.items.map((i) => (i.short_id === item.short_id ? item : i)) || [],
-                          } as DashboardType)
-                        : null
-                },
                 [dashboardsModel.actionTypes.updateDashboardRefreshStatus]: (
                     state,
                     { shortId, refreshing, last_refresh }
@@ -498,6 +490,9 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         },
         [dashboardsModel.actionTypes.addDashboardSuccess]: ({ dashboard }) => {
             router.actions.push(`/dashboard/${dashboard.id}`)
+        },
+        [dashboardsModel.actionTypes.updateDashboardItem]: () => {
+            actions.loadDashboardItems()
         },
         setIsSharedDashboard: ({ id, isShared }) => {
             dashboardsModel.actions.setIsSharedDashboard({ id, isShared })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -171,6 +171,14 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                         items: state?.items.map((item) => ({ ...item, layouts: itemLayouts[item.short_id] })),
                     } as DashboardType
                 },
+                [dashboardsModel.actionTypes.updateDashboardItem]: (state, { item }) => {
+                    return state
+                        ? ({
+                              ...state,
+                              items: state?.items.map((i) => (i.short_id === item.short_id ? item : i)) || [],
+                          } as DashboardType)
+                        : null
+                },
                 [dashboardsModel.actionTypes.updateDashboardRefreshStatus]: (
                     state,
                     { shortId, refreshing, last_refresh }
@@ -490,9 +498,6 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         },
         [dashboardsModel.actionTypes.addDashboardSuccess]: ({ dashboard }) => {
             router.actions.push(`/dashboard/${dashboard.id}`)
-        },
-        [dashboardsModel.actionTypes.updateDashboardItem]: () => {
-            actions.loadDashboardItems()
         },
         setIsSharedDashboard: ({ id, isShared }) => {
             dashboardsModel.actions.setIsSharedDashboard({ id, isShared })

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -36,16 +36,8 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
     useMountedLogic(insightCommandLogic)
 
     const logic = insightLogic({ dashboardItemId: shortId, syncWithUrl: true })
-    const {
-        insightProps,
-        activeView,
-        filters,
-        insight,
-        insightMode,
-        filtersChanged,
-        savedFilters,
-        tagLoading,
-    } = useValues(logic)
+    const { insightProps, activeView, filters, insight, insightMode, filtersChanged, savedFilters, tagLoading } =
+        useValues(logic)
     const {
         setActiveView,
         setInsightMode,
@@ -56,7 +48,7 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
         deleteTag,
         saveAs,
     } = useActions(logic)
-    const { hasAvailableFeature} = useValues(userLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { saveCohortWithFilters, setCohortModalVisible } = useActions(personsModalLogic)

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -6,7 +6,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { FunnelTab, PathTab, RetentionTab, SessionTab, TrendTab } from './InsightTabs'
 import { insightLogic } from './insightLogic'
 import { insightCommandLogic } from './insightCommandLogic'
-import { HotKeys, ItemMode, InsightType, InsightShortId } from '~/types'
+import { HotKeys, ItemMode, InsightType, InsightShortId, AvailableFeature } from '~/types'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
 import { NPSPrompt } from 'lib/experimental/NPSPrompt'
@@ -24,6 +24,7 @@ import { UNNAMED_INSIGHT_NAME } from './EmptyStates'
 import { InsightSaveButton } from './InsightSaveButton'
 import posthog from 'posthog-js'
 import { helpButtonLogic } from 'lib/components/HelpButton/HelpButton'
+import { userLogic } from 'scenes/userLogic'
 
 export const scene: SceneExport = {
     component: Insight,
@@ -44,7 +45,6 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
         filtersChanged,
         savedFilters,
         tagLoading,
-        metadataEditable,
     } = useValues(logic)
     const {
         setActiveView,
@@ -56,7 +56,7 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
         deleteTag,
         saveAs,
     } = useActions(logic)
-
+    const { hasAvailableFeature} = useValues(userLogic)
     const { reportHotkeyNavigation } = useActions(eventUsageLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { saveCohortWithFilters, setCohortModalVisible } = useActions(personsModalLogic)
@@ -173,8 +173,9 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                     onChange={(value) => setInsightMetadata({ description: value })}
                     className={'insight-metadata-description'}
                     dataAttr={'insight-description'}
+                    locked={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
                 />
-                {metadataEditable ? (
+                {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) ? (
                     <div className={'insight-metadata-tags'} data-attr="insight-tags">
                         <ObjectTags
                             tags={insight.tags ?? []}

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -5,7 +5,6 @@ import posthog from 'posthog-js'
 import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
 import { insightLogicType } from './insightLogicType'
 import {
-    AvailableFeature,
     Breadcrumb,
     InsightModel,
     FilterType,
@@ -29,7 +28,6 @@ import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { extractObjectDiffKeys, findInsightFromMountedLogic, getInsightId } from './utils'
 import { teamLogic } from '../teamLogic'
 import { Scene } from 'scenes/sceneTypes'
-import { userLogic } from 'scenes/userLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { urls } from 'scenes/urls'

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -33,6 +33,7 @@ import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { urls } from 'scenes/urls'
 import { generateRandomAnimal } from 'lib/utils/randomAnimal'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -147,6 +148,7 @@ export const insightLogic = kea<insightLogicType>({
                     }
                     callback?.(updatedInsight)
                     savedInsightsLogic.findMounted()?.actions.loadInsights()
+                    dashboardLogic.findMounted()?.actions.loadDashboardItems()
                     dashboardsModel.actions.updateDashboardItem(updatedInsight)
                     return updatedInsight
                 },

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -418,10 +418,6 @@ export const insightLogic = kea<insightLogicType>({
             (savedFilters, filters) =>
                 filters && savedFilters && !objectsEqual(cleanFilters(savedFilters), cleanFilters(filters)),
         ],
-        metadataEditable: [
-            () => [userLogic.selectors.user],
-            (user) => user?.organization?.available_features?.includes(AvailableFeature.DASHBOARD_COLLABORATION),
-        ],
         syncWithUrl: [
             () => [(_, props: InsightLogicProps) => props.syncWithUrl, router.selectors.location],
             (syncWithUrl, { pathname }) => syncWithUrl && pathname.startsWith('/insights/'),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -752,7 +752,7 @@ export interface PluginLogEntry {
 }
 
 export enum AnnotationScope {
-    Insight = 'insight',
+    Insight = 'dashboard_item',
     Project = 'project',
     Organization = 'organization',
 }


### PR DESCRIPTION
## Changes

Oddly on free PostHog an insight's name could only be edited from a dashboard and not on the insight's page. Also, it was completely unclear why the description field wasn't editable. These problems should be fixed by this.
There is no change for premium PostHog.

| Before | After |
| --- | --- |
| <img width="169" alt="Screenshot 2021-12-10 at 12 49 09" src="https://user-images.githubusercontent.com/4550621/145570075-26a3db20-fbe6-4ca8-8138-24d6e4273818.png"> | <img width="197" alt="Screenshot 2021-12-10 at 12 48 30" src="https://user-images.githubusercontent.com/4550621/145570073-f276393e-b326-49b6-bf0b-d5cbcf241600.png"> |