### PR TITLE
Groups: Remove group analytics feature flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -80,8 +80,6 @@ export const FEATURE_FLAGS = {
     NEW_SESSIONS_PLAYER: 'new-sessions-player', // owner: @rcmarron
     NEW_SESSIONS_PLAYER_EVENTS_LIST: 'new-sessions-player-events-list', // owner: @rcmarron / @alexkim205
     BREAKDOWN_BY_MULTIPLE_PROPERTIES: '938-breakdown-by-multiple-properties', // owner: @pauldambra
-    GROUP_ANALYTICS: 'group-analytics', // owner: @macobo
-    GROUP_ANALYTICS_INTRODUCTION: 'group-analytics-introduction', // owner: @macobo
     SESSION_INSIGHT_REMOVAL: 'session-insight-removal', // owner: @paolodamico
     FUNNELS_CUE_OPT_OUT: 'funnels-cue-opt-out-7301', // owner: @paolodamico
     FUNNELS_CUE_ENABLED: 'funnels-cue-enabled', // owner: @paolodamico


### PR DESCRIPTION
## Changes

To be merged just before the release.

Decided on this instead of PERSISTENT_FEATURE_FLAGS because we're releasing the feature to all.

Will be merged once we're ready for release, this includes:
- [ ] Blog post
- [ ] Docs
- [ ] Upsell support finish
- [ ] Last touches / fixes

See https://github.com/orgs/PostHog/projects/19/views/1 for more details