### PR TITLE
Disable entrypoint hashing for esbuild in dev

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -71,7 +71,7 @@ buildInParallel(
                 if (Object.keys(chunks).length === 0) {
                     throw new Error('Could not get chunk metadata for bundle "PostHog App."')
                 }
-                if (Object.keys(entrypoints).length === 0) {
+                if (!isDev && Object.keys(entrypoints).length === 0) {
                     throw new Error('Could not get entrypoint for bundle "PostHog App."')
                 }
                 writeIndexHtml(chunks, entrypoints)

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -124,7 +124,8 @@ export const commonConfig = {
     publicPath: '/static',
     assetNames: 'assets/[name]-[hash]',
     chunkNames: '[name]-[hash]',
-    entryNames: '[dir]/[name]-[hash]',
+    // no hashes in dev mode for faster reloads --> we save the old hash in index.html otherwise
+    entryNames: isDev ? '[dir]/[name]' : '[dir]/[name]-[hash]',
     plugins: [sassPlugin, lessPlugin],
     define: {
         global: 'globalThis',


### PR DESCRIPTION
## Changes

- This affects reloads in dev mode. Currently with chunks, we write the name of the chunk in `index.html` after the build has completed. Thus when we reload the browser on changes, django still serves the old index.html, and while we block and wait for the build to complete, we will still serve the old index-OLDHASH.js. 
- This fixes that.

## How did you test this code?

- By developing locally.