### PR TITLE
Fix shared dashboard icon

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -60,8 +60,8 @@ export function Dashboards(): JSX.Element {
             render: function Render(name, { id, description, _highlight, is_shared }) {
                 return (
                     <div className={_highlight ? 'highlighted' : undefined} style={{ display: 'inline-block' }}>
-                        <div>
-                            <Link data-attr="dashboard-name" to={urls.dashboard(id)} className="row-name">
+                        <div className="row-name">
+                            <Link data-attr="dashboard-name" to={urls.dashboard(id)}>
                                 {name || 'Untitled'}
                             </Link>
                             {is_shared && (


### PR DESCRIPTION
## Changes

Fixes this:
<img width="335" alt="Screenshot 2021-12-10 at 13 59 51" src="https://user-images.githubusercontent.com/4550621/145577947-298097c1-f799-4001-b921-bc3ac0326cda.png">
