### PR TITLE
Last seen at enabled for self-hosted

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -77,7 +77,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PISCINA_ATOMICS_TIMEOUT: 5000,
         SITE_URL: null,
         NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS: '',
-        EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: false,
+        EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: true,
     }
 }
 

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -158,8 +158,7 @@ export const createProcessEventTests = (
             }
         `
         await resetTestDatabase(testCode, extraServerConfig)
-        // TODO: #7422 remove experimental config
-        ;[hub, closeHub] = await createTestHub({ EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: true })
+        ;[hub, closeHub] = await createTestHub()
         returned.hub = hub
         returned.closeHub = closeHub
         eventsProcessor = new EventsProcessor(hub)

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -22,8 +22,7 @@ describe('TeamManager()', () => {
     let teamManager: TeamManager
 
     beforeEach(async () => {
-        // TODO: #7422 remove experimental config
-        ;[hub, closeHub] = await createHub({ ...defaultConfig, EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: true })
+        ;[hub, closeHub] = await createHub()
         await resetTestDatabase()
         teamManager = hub.teamManager
     })
@@ -233,7 +232,10 @@ describe('TeamManager()', () => {
 
         // TODO: #7422 temporary test
         it('last_seen_at feature is experimental and completely disabled', async () => {
-            const [newHub, closeNewHub] = await createHub({ ...defaultConfig })
+            const [newHub, closeNewHub] = await createHub({
+                ...defaultConfig,
+                EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: false,
+            })
             const newTeamManager = newHub.teamManager
             newTeamManager.lastFlushAt = DateTime.fromISO('2010-01-01T22:22:22.000Z') // a long time ago
             await newTeamManager.updateEventNamesAndProperties(2, '$pageview', {}, DateTime.now())


### PR DESCRIPTION
## Changes

Looks like performance in Cloud was pretty solid. Will sync up with @fuziontech today to do a final pass. For context, we won't show the "stale" label yet until we've had more time to capture this metadata (i.e. next release).

## How did you test this code?
Functional plugin tests.
