### PR TITLE
Revert "ci(e2e): manually split cypress tests to improve speed"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,54 +1,38 @@
 name: E2E
 
 on:
-    pull_request:
-    push:
-        branches: [master]
+    - pull_request
 
 jobs:
-    # Job that lists and chunks spec file names and caches node modules
     cypress_prep:
         name: Cypress E2E preparation
         runs-on: ubuntu-latest
         outputs:
-            specs: ${{ steps.set-specs.outputs.specs }}
-
+            matrix: ${{ steps.set-matrix.outputs.matrix }}
         steps:
-            - uses: actions/checkout@v2
-            - id: set-specs
-              # List cypress/integration and produce a JSON array of the files, in chunks
-              run: echo "::set-output name=specs::$(ls cypress/integration/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(3) | join("\n")' | jq --slurp -c .)"
-
-            - uses: actions/cache@v2
-              id: cypress-node-modules-cache-3
-              with:
-                  path: |
-                      **/node_modules
-                      ~/.cache/Cypress
-                  key: ${{ runner.os }}-cypress-node-modules-3-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-cypress-node-modules-3-
-            - name: Yarn install deps
-              if: steps.cypress-node-modules-cache-3.outputs.cache-hit != 'true'
+            - name: Check out
+              uses: actions/checkout@v2
+            - id: set-matrix
               run: |
-                  yarn install --frozen-lockfile
-                  yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
-                  cd plugin-server
-                  yarn install --frozen-lockfile
+                  if ${{github.event.pull_request.head.repo.full_name == github.repository}}; then
+                  matrix=$(jq 'map(.)' .github/workflows/e2e_matrix.json)
+                  else
+                  matrix='[{"containers": [1]}]'
+                  fi
+                  echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
 
     cypress:
-        name: Cypress E2E tests (${{ strategy.job-index }})
-        if: ${{ github.ref != 'refs/heads/master' }} # Don't run on master, we only cace about node_modules cache
+        name: Cypress E2E tests
         runs-on: ubuntu-18.04
-        needs: [cypress_prep]
+        needs: cypress_prep
 
         strategy:
             # when one test fails, DO NOT cancel the other
-            # containers, as there may be other spec failures
-            # we want to know about.
+            # containers, because this will kill Cypress processes
+            # leaving the Dashboard hanging ...
+            # https://github.com/cypress-io/github-action/issues/48
             fail-fast: false
-            matrix:
-                specs: ${{ fromJson(needs.cypress_prep.outputs.specs) }}
+            matrix: ${{fromJson(needs.cypress_prep.outputs.matrix)}}
 
         services:
             postgres:
@@ -76,7 +60,6 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-
             - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:
@@ -105,7 +88,7 @@ jobs:
                       ~/.cache/Cypress
                   key: ${{ runner.os }}-cypress-node-modules-3-${{ hashFiles('**/yarn.lock') }}
                   restore-keys: |
-                      ${{ runner.os }}-cypress-node-modules-3-
+                      ${{ runner.os }}-cypress-node-modules-3
             - name: Yarn install deps
               if: steps.cypress-node-modules-cache-3.outputs.cache-hit != 'true'
               run: |
@@ -146,12 +129,20 @@ jobs:
               with:
                   config-file: cypress.e2e.json
                   config: retries=2
+                  record: true
+                  parallel: ${{github.event.pull_request.head.repo.full_name == github.repository}}
+                  group: 'PostHog Frontend'
                   # We're already installing cypress above
                   # We have to install it separately otherwise the tests fail.
                   install: false
                   # We already install cypress separately, we don't need to install it again here
                   install-command: echo "no"
-                  spec: ${{ matrix.specs }}
+              env:
+                  # pass the Dashboard record key as an environment variable
+                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                  # Recommended: pass the GitHub token lets this action correctly
+                  # determine the unique run id necessary to re-run the checks
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Archive test screenshots
               uses: actions/upload-artifact@v1
               with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,17 +80,7 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 14
-            - uses: actions/cache@v2
-              id: cypress-node-modules-cache-3
-              with:
-                  path: |
-                      **/node_modules
-                      ~/.cache/Cypress
-                  key: ${{ runner.os }}-cypress-node-modules-3-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-cypress-node-modules-3
             - name: Yarn install deps
-              if: steps.cypress-node-modules-cache-3.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
                   yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0


### PR DESCRIPTION
Reverts PostHog/posthog#7558

Looks like on current pull requests the plugin server isn't running properly, reverting to see if it's the issue

e.g. see https://github.com/PostHog/posthog/runs/4491622617?check_suite_focus=true