### PR TITLE
Experiment creation cleanup

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -5,7 +5,7 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import React, { useState } from 'react'
+import React from 'react'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { ActionFilter } from 'scenes/insights/ActionFilter/ActionFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -21,12 +21,10 @@ export const scene: SceneExport = {
 }
 
 export function Experiment(): JSX.Element {
-    const { newExperimentData, experimentId, experimentData, experimentFunnel } = useValues(experimentLogic)
-    const { setNewExperimentData, createExperiment, setFilters } = useActions(experimentLogic)
+    const { newExperimentData, experimentId, experimentData, experimentFunnel, newExperimentCurrentPage } =
+        useValues(experimentLogic)
+    const { setNewExperimentData, createExperiment, setFilters, nextPage, prevPage } = useActions(experimentLogic)
     const [form] = Form.useForm()
-    const [page, setPage] = useState(0)
-    const nextPage = (): void => setPage(page + 1)
-    const prevPage = (): void => setPage(page - 1)
 
     const { insightProps } = useValues(
         insightLogic({
@@ -39,7 +37,7 @@ export function Experiment(): JSX.Element {
 
     return (
         <>
-            {experimentId === 'new' ? (
+            {experimentId === 'new' || !experimentData?.start_date ? (
                 <>
                     <Row
                         align="middle"
@@ -60,12 +58,17 @@ export function Experiment(): JSX.Element {
                         className="experiment-form"
                         form={form}
                         onValuesChange={(values) => setNewExperimentData(values)}
+                        initialValues={{
+                            name: newExperimentData?.name,
+                            feature_flag_key: newExperimentData?.feature_flag_key,
+                            description: newExperimentData?.description,
+                        }}
                         onFinish={(values) => {
                             setNewExperimentData(values)
                             nextPage()
                         }}
                     >
-                        {page === 0 && (
+                        {newExperimentCurrentPage === 0 && (
                             <div>
                                 <Form.Item
                                     label="Name"
@@ -94,7 +97,7 @@ export function Experiment(): JSX.Element {
                             </div>
                         )}
 
-                        {page === 1 && (
+                        {newExperimentCurrentPage === 1 && (
                             <div>
                                 <Col className="person-selection">
                                     <div className="l3 mb">Person selection</div>
@@ -126,14 +129,7 @@ export function Experiment(): JSX.Element {
                                     </div>
                                 </Col>
                                 <Row className="metrics-selection">
-                                    <BindLogic
-                                        logic={insightLogic}
-                                        props={{
-                                            dashboardItemId: experimentFunnel?.short_id,
-                                            filters: experimentFunnel?.filters,
-                                            syncWithUrl: false,
-                                        }}
-                                    >
+                                    <BindLogic logic={insightLogic} props={insightProps}>
                                         <Row style={{ width: '100%' }}>
                                             <Col span={8} style={{ paddingRight: 8 }}>
                                                 <div className="l3 mb">Goal metric</div>
@@ -188,7 +184,7 @@ export function Experiment(): JSX.Element {
                             </div>
                         )}
 
-                        {page === 2 && (
+                        {newExperimentCurrentPage === 2 && (
                             <div className="confirmation">
                                 <div>Name: {newExperimentData?.name}</div>
                                 {newExperimentData?.description && (

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -1,0 +1,38 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+import { defaultAPIMocks, mockAPI, MOCK_TEAM_ID } from 'lib/api.mock'
+import { urls } from 'scenes/urls'
+import { initKeaTestLogic } from '~/test/init'
+import { InsightType } from '~/types'
+import { experimentLogic } from './experimentLogic'
+
+jest.mock('lib/api')
+
+describe('experimentLogic', () => {
+    let logic: ReturnType<typeof experimentLogic.build>
+
+    mockAPI(async (url) => {
+        const { pathname } = url
+        if (pathname === `api/projects/${MOCK_TEAM_ID}/insights`) {
+            return { short_id: 'a5qqECqP', filters: { insight: InsightType.FUNNELS } }
+        }
+        return defaultAPIMocks(url)
+    })
+
+    initKeaTestLogic({
+        logic: experimentLogic,
+        props: {},
+        onLogic: (l) => (logic = l),
+    })
+
+    describe('when creating a new experiment', () => {
+        it('creates an insight funnel and clears the new experiment form', async () => {
+            router.actions.push(urls.experiment('new'))
+            await expectLogic(logic)
+                .toDispatchActions(['setExperimentFunnel'])
+                .toMatchValues({
+                    experimentFunnel: { short_id: 'a5qqECqP', filters: { insight: InsightType.FUNNELS } },
+                })
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -8,23 +8,28 @@ import { toast } from 'react-toastify'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { teamLogic } from 'scenes/teamLogic'
-import { Experiment, InsightType, InsightModel, FunnelVizType } from '~/types'
+import { Experiment, InsightType, InsightModel, FunnelVizType, FilterType } from '~/types'
 
 import { experimentLogicType } from './experimentLogicType'
 import { urls } from 'scenes/urls'
 import { router } from 'kea-router'
+import { experimentsLogic } from './experimentsLogic'
 
 export const experimentLogic = kea<experimentLogicType>({
     path: ['scenes', 'experiment', 'experimentLogic'],
     connect: { values: [teamLogic, ['currentTeamId']] },
     actions: {
         setExperiment: (experiment: Experiment) => ({ experiment }),
-        createExperiment: (draft?: boolean) => ({ draft }),
+        createExperiment: (draft: boolean) => ({ draft }),
         setExperimentFunnel: (funnel: InsightModel) => ({ funnel }),
         createNewExperimentFunnel: true,
-        setFilters: (filters) => ({ filters }),
+        setFilters: (filters: Partial<FilterType>) => ({ filters }),
         setExperimentId: (experimentId: number | 'new') => ({ experimentId }),
         setNewExperimentData: (experimentData: Partial<Experiment>) => ({ experimentData }),
+        nextPage: true,
+        prevPage: true,
+        setPage: (page: number) => ({ page }),
+        emptyData: true,
     },
     reducers: {
         experimentId: [
@@ -43,6 +48,7 @@ export const experimentLogic = kea<experimentLogicType>({
                     }
                     return { ...vals, ...experimentData }
                 },
+                emptyData: () => null,
             },
         ],
         experimentFunnel: [
@@ -51,14 +57,28 @@ export const experimentLogic = kea<experimentLogicType>({
                 setExperimentFunnel: (_, { funnel }) => funnel,
             },
         ],
+        newExperimentCurrentPage: [
+            0,
+            {
+                nextPage: (page) => page + 1,
+                prevPage: (page) => page - 1,
+                setPage: (_, { page }) => page,
+            },
+        ],
     },
     listeners: ({ values, actions }) => ({
         createExperiment: async ({ draft }) => {
             try {
-                await api.create(`api/projects/${values.currentTeamId}/experiments`, {
-                    ...values.newExperimentData,
-                    ...(!draft && { start_date: dayjs() }),
-                })
+                if (values.newExperimentData?.id) {
+                    await api.update(`api/projects/${values.currentTeamId}/experiments/${values.experimentId}`, {
+                        start_date: dayjs(),
+                    })
+                } else {
+                    await api.create(`api/projects/${values.currentTeamId}/experiments`, {
+                        ...values.newExperimentData,
+                        ...(!draft && { start_date: dayjs() }),
+                    })
+                }
             } catch (error) {
                 errorToast(
                     'Error creating your experiment',
@@ -73,10 +93,11 @@ export const experimentLogic = kea<experimentLogicType>({
             toast.success(
                 <div data-attr="success-toast">
                     <h1>Experimentation created successfully!</h1>
-                    <p>Click here to go back to the feature flag list.</p>
+                    <p>Click here to go back to the experiments list.</p>
                 </div>,
                 {
                     onClick: () => {
+                        experimentsLogic.actions.loadExperiments()
                         router.actions.push(urls.experiments())
                     },
                     closeOnClick: true,
@@ -99,6 +120,12 @@ export const experimentLogic = kea<experimentLogicType>({
         },
         setFilters: ({ filters }) => {
             funnelLogic.findMounted({ dashboardItemId: values.experimentFunnel?.short_id })?.actions.setFilters(filters)
+        },
+        loadExperimentSuccess: ({ experimentData }) => {
+            if (!experimentData?.start_date) {
+                actions.setPage(2)
+                actions.setNewExperimentData({ ...experimentData })
+            }
         },
     }),
     loaders: ({ values }) => ({
@@ -125,6 +152,8 @@ export const experimentLogic = kea<experimentLogicType>({
                 // like in featureFlagLogic.tsx
                 if (parsedId === 'new') {
                     actions.createNewExperimentFunnel()
+                    actions.emptyData()
+                    actions.setPage(0)
                 }
                 if (parsedId !== values.experimentId) {
                     actions.setExperimentId(parsedId)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -20,7 +20,7 @@ export const experimentLogic = kea<experimentLogicType>({
     connect: { values: [teamLogic, ['currentTeamId']] },
     actions: {
         setExperiment: (experiment: Experiment) => ({ experiment }),
-        createExperiment: (draft: boolean) => ({ draft }),
+        createExperiment: (draft?: boolean) => ({ draft }),
         setExperimentFunnel: (funnel: InsightModel) => ({ funnel }),
         createNewExperimentFunnel: true,
         setFilters: (filters: Partial<FilterType>) => ({ filters }),

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -22,7 +22,7 @@ export const experimentLogic = kea<experimentLogicType>({
         setExperiment: (experiment: Experiment) => ({ experiment }),
         createExperiment: (draft?: boolean) => ({ draft }),
         setExperimentFunnel: (funnel: InsightModel) => ({ funnel }),
-        createNewExperimentFunnel: true,
+        createNewExperimentFunnel: (filters?: Partial<FilterType>) => ({ filters }),
         setFilters: (filters: Partial<FilterType>) => ({ filters }),
         setExperimentId: (experimentId: number | 'new') => ({ experimentId }),
         setNewExperimentData: (experimentData: Partial<Experiment>) => ({ experimentData }),
@@ -104,12 +104,16 @@ export const experimentLogic = kea<experimentLogicType>({
                 }
             )
         },
-        createNewExperimentFunnel: async () => {
+        createNewExperimentFunnel: async ({ filters }) => {
             const newInsight = {
                 name: generateRandomAnimal(),
                 description: '',
                 tags: [],
-                filters: cleanFilters({ insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps }),
+                filters: cleanFilters({
+                    insight: InsightType.FUNNELS,
+                    funnel_viz_type: FunnelVizType.Steps,
+                    ...filters,
+                }),
                 result: null,
             }
             const createdInsight: InsightModel = await api.create(
@@ -123,6 +127,8 @@ export const experimentLogic = kea<experimentLogicType>({
         },
         loadExperimentSuccess: ({ experimentData }) => {
             if (!experimentData?.start_date) {
+                // loading a draft mode experiment
+                actions.createNewExperimentFunnel(experimentData?.filters)
                 actions.setPage(2)
                 actions.setNewExperimentData({ ...experimentData })
             }

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.tsx
@@ -262,7 +262,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
             toast.success(
                 <div>
                     <h1>Your feature flag has been saved!</h1>
-                    <p>Click here to back to the feature flag list.</p>
+                    <p>Click here to go back to the feature flag list.</p>
                 </div>,
                 {
                     onClick: () => {


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Things fixed:

- Opening a draft mode experiment will first lead to the new experiment confirmation page and then you can go back and edit the experiment again 
- Validations and success/error toasts


https://user-images.githubusercontent.com/25164963/145844468-7e2f6841-3751-4761-bf71-28c294160ce7.mov


https://user-images.githubusercontent.com/25164963/145844470-7a72b61b-104a-4f78-b689-25836e1e7573.mov



## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
