### PR TITLE
Fix e2e tests

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -449,9 +449,9 @@ export const insightLogic = kea<insightLogicType>({
             (s) => [s.insight],
             (insight) => {
                 return dateFilterToText(
-                    insight?.result?.[0].filter?.date_from ?? insight?.result?.[0]?.days?.[0],
+                    insight?.result?.[0]?.filter?.date_from ?? insight?.result?.[0]?.days?.[0],
                     insight?.last_refresh ??
-                        insight?.result?.[0].filter?.date_to ??
+                        insight?.result?.[0]?.filter?.date_to ??
                         insight?.result?.[0]?.days?.[insight?.result?.[0]?.days.length - 1],
                     getFormattedLastWeekDate(),
                     undefined,


### PR DESCRIPTION
Example failure: https://github.com/PostHog/posthog/runs/4502331598?check_suite_focus=true

```
      cons:error ✘  TypeError: Cannot read property 'filter' of undefined
                        at dn.selectors.currentFormattedDateRange (http://localhost:8000/static/chunk-RTJPMRIF.js:23:221527)
                        at http://localhost:8000/static/chunk-RTJPMRIF.js:5:2440
                        at http://localhost:8000/static/chunk-RTJPMRIF.js:5:1858
                        at http://localhost:8000/static/chunk-RTJPMRIF.js:5:2570
                        at Object.currentFormattedDateRange (http://localhost:8000/static/chunk-RTJPMRIF.js:5:1858)
                        at e.selectors.<computed> (http://localhost:8000/static/chunk-RTJPMRIF.js:6:10033)
                        at K8 (http://localhost:8000/static/chunk-RTJPMRIF.js:1:23019)
                        at Object.useSelector (http://localhost:8000/static/chunk-RTJPMRIF.js:5:578)
                        at Object.get (http://localhost:8000/static/chunk-RTJPMRIF.js:14:1534)
                        at $n (http://localhost:8000/static/chunk-YJDU6Z ...
```

Cause seems to be this improper null guard.

https://github.com/PostHog/posthog/pull/7647 broke this and was merged
in with broken tests
