### PR TITLE
Adds user and pass needed for connecting to Docker hosted PSQL

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -23,5 +23,5 @@ if [ $# -eq 0 ]; then
 fi
 
 export REDIS_URL='redis:///'
-psql posthog -c "drop database if exists test_posthog"
+psql posthog -d postgres://posthog:posthog@localhost:5432 -c "drop database if exists test_posthog"
 nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db -s $* --snapshot-update; mypy posthog ee"

--- a/posthog/settings.py
+++ b/posthog/settings.py
@@ -446,7 +446,7 @@ DISABLE_SERVER_SIDE_CURSORS = get_from_env("USING_PGBOUNCER", False, type_cast=s
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 if TEST or DEBUG:
-    DATABASE_URL = os.getenv("DATABASE_URL", "postgres://localhost:5432/posthog")
+    DATABASE_URL = os.getenv("DATABASE_URL", "postgres://posthog:posthog@localhost:5432/posthog")
 else:
     DATABASE_URL = os.getenv("DATABASE_URL", "")
 


### PR DESCRIPTION
Add DB user and pass to DB URL for DEBUG mode and to bin tests for dropping test database

Following the new dev setup creates a postgres DB in Docker with username and password set. 

Our default DB URL in settings.py for debug mode, and our bin/tests scrips both assume passwordless auth is available.

This adds the user and pass

## How did you test this code?

By running a DB migrate and bin/tests before and after and seeing that it didn't work without

Before this change `DEBUG=1 python manage.py migrate` returns `django.db.utils.OperationalError: connection to server at "localhost" (::1), port 5432 failed: fe_sendauth: no password supplied` 

and running `./bin/tests` returns 

```
psql: error: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such file or directory
        Is the server running locally and accepting connections on that socket?
```

