### PR TITLE
Make the sidebar behave

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -76,6 +76,7 @@ interface PageButtonProps extends Pick<LemonButtonProps, 'icon' | 'onClick' | 'p
 
 function PageButton({ title, sideAction, identifier, highlight, ...buttonProps }: PageButtonProps): JSX.Element {
     const { aliasedActiveScene, activeScene } = useValues(sceneLogic)
+    const { hideSideBarMobile } = useActions(navigationLogic)
     const { lastDashboardId } = useValues(dashboardsModel)
 
     const isActiveSide: boolean = sideAction?.identifier === aliasedActiveScene
@@ -89,6 +90,7 @@ function PageButton({ title, sideAction, identifier, highlight, ...buttonProps }
         <LemonButtonWithSideAction
             fullWidth
             type={isActive ? 'highlighted' : 'stealth'}
+            onClick={hideSideBarMobile}
             sideAction={{
                 ...sideAction,
                 type: isActiveSide ? 'highlighted' : isActive ? undefined : 'stealth',
@@ -104,6 +106,7 @@ function PageButton({ title, sideAction, identifier, highlight, ...buttonProps }
             fullWidth
             type={isActive ? 'highlighted' : 'stealth'}
             data-attr={`menu-item-${identifier.toString().toLowerCase()}`}
+            onClick={hideSideBarMobile}
             {...buttonProps}
         >
             <span style={{ flexGrow: 1 }}>{title || sceneConfigurations[identifier].name}</span>
@@ -122,7 +125,7 @@ function PageButton({ title, sideAction, identifier, highlight, ...buttonProps }
 
 function Pages(): JSX.Element {
     const { currentOrganization } = useValues(organizationLogic)
-    const { showToolbarModal } = useActions(navigationLogic)
+    const { showToolbarModal, hideSideBarMobile } = useActions(navigationLogic)
     const { pinnedDashboards } = useValues(dashboardsModel)
     const { featureFlags } = useValues(featureFlagLogic)
     const { showGroupsOptions } = useValues(groupsModel)
@@ -154,6 +157,7 @@ function Pages(): JSX.Element {
                     popup: {
                         visible: arePinnedDashboardsShown,
                         onClickOutside: () => setArePinnedDashboardsShown(false),
+                        onClickInside: hideSideBarMobile,
                         overlay: (
                             <div className="SideBar__pinned-dashboards">
                                 <h5>Pinned dashboards</h5>
@@ -191,6 +195,7 @@ function Pages(): JSX.Element {
                     to: urls.insightNew({ insight: InsightType.TRENDS }),
                     tooltip: 'New insight',
                     identifier: Scene.Insight,
+                    onClick: hideSideBarMobile,
                 }}
             />
             <PageButton icon={<IconRecording />} identifier={Scene.SessionRecordings} to={urls.sessionRecordings()} />
@@ -221,7 +226,7 @@ function Pages(): JSX.Element {
 export function SideBar({ children }: { children: React.ReactNode }): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { isSideBarShown, isToolbarModalShown } = useValues(navigationLogic)
-    const { hideSideBar, hideToolbarModal } = useActions(navigationLogic)
+    const { hideSideBarMobile, hideToolbarModal } = useActions(navigationLogic)
 
     return (
         <div className={clsx('SideBar', 'SideBar__layout', !isSideBarShown && 'SideBar--hidden')}>
@@ -236,7 +241,7 @@ export function SideBar({ children }: { children: React.ReactNode }): JSX.Elemen
                     )}
                 </div>
             </div>
-            <div className="SideBar__overlay" onClick={hideSideBar} />
+            <div className="SideBar__overlay" onClick={hideSideBarMobile} />
             {children}
             <ToolbarModal visible={isToolbarModalShown} onCancel={hideToolbarModal} />
         </div>

--- a/frontend/src/layout/navigation/TopBar/TopBar.tsx
+++ b/frontend/src/layout/navigation/TopBar/TopBar.tsx
@@ -15,10 +15,21 @@ import { CreateProjectModal } from '../../../scenes/project/CreateProjectModal'
 import './TopBar.scss'
 
 export function TopBar(): JSX.Element {
-    const { isSideBarShown, bareNav, isInviteModalShown, isCreateOrganizationModalShown, isCreateProjectModalShown } =
-        useValues(navigationLogic)
-    const { toggleSideBar, hideInviteModal, hideCreateOrganizationModal, hideCreateProjectModal } =
-        useActions(navigationLogic)
+    const {
+        isSideBarShown,
+        bareNav,
+        mobileLayout,
+        isInviteModalShown,
+        isCreateOrganizationModalShown,
+        isCreateProjectModalShown,
+    } = useValues(navigationLogic)
+    const {
+        toggleSideBarBase,
+        toggleSideBarMobile,
+        hideInviteModal,
+        hideCreateOrganizationModal,
+        hideCreateProjectModal,
+    } = useActions(navigationLogic)
 
     return (
         <>
@@ -26,7 +37,10 @@ export function TopBar(): JSX.Element {
             <header className="TopBar">
                 <div className="TopBar__segment TopBar__segment--left">
                     {!bareNav && (
-                        <div className="TopBar__hamburger" onClick={toggleSideBar}>
+                        <div
+                            className="TopBar__hamburger"
+                            onClick={mobileLayout ? toggleSideBarMobile : toggleSideBarBase}
+                        >
                             {isSideBarShown ? <IconMenuOpen /> : <IconMenu />}
                         </div>
                     )}

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -25,8 +25,9 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
         values: [sceneLogic, ['sceneConfig']],
     },
     actions: {
-        toggleSideBar: true,
-        hideSideBar: true,
+        toggleSideBarBase: true,
+        toggleSideBarMobile: true,
+        hideSideBarMobile: true,
         openSitePopover: true,
         closeSitePopover: true,
         toggleSitePopover: true,
@@ -43,11 +44,20 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
         setHotkeyNavigationEngaged: (hotkeyNavigationEngaged: boolean) => ({ hotkeyNavigationEngaged }),
     },
     reducers: {
-        isSideBarShownRaw: [
-            window.innerWidth >= 992, // Sync width threshold with Sass variable $lg!
+        // Non-mobile base
+        isSideBarShownBase: [
+            true,
+            { persist: true },
             {
-                toggleSideBar: (state) => !state,
-                hideSideBar: () => false,
+                toggleSideBarBase: (state) => !state,
+            },
+        ],
+        // Mobile, applied on top of base, so that the sidebar does not show up annoyingly when shrinking the window
+        isSideBarShownMobile: [
+            false,
+            {
+                toggleSideBarMobile: (state) => !state,
+                hideSideBarMobile: () => false,
             },
         ],
         isSitePopoverOpen: [
@@ -102,13 +112,15 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
     },
     windowValues: () => ({
         fullscreen: (window) => !!window.document.fullscreenElement,
+        mobileLayout: (window) => window.innerWidth < 992, // Sync width threshold with Sass variable $lg!
     }),
     selectors: {
         /** `bareNav` whether the current scene should display a sidebar at all */
         bareNav: [(s) => [s.fullscreen, s.sceneConfig], (fullscreen, sceneConfig) => fullscreen || sceneConfig?.plain],
         isSideBarShown: [
-            (s) => [s.isSideBarShownRaw, s.bareNav],
-            (isSideBarShownRaw, bareNav) => isSideBarShownRaw && !bareNav,
+            (s) => [s.mobileLayout, s.isSideBarShownBase, s.isSideBarShownMobile, s.bareNav],
+            (mobileLayout, isSideBarShownBase, isSideBarShownMobile, bareNav) =>
+                !bareNav && (mobileLayout ? isSideBarShownMobile : isSideBarShownBase),
         ],
         systemStatus: [
             () => [


### PR DESCRIPTION
## Changes

When working on dashboards recently, specifically the responsive grid, I was getting annoyed by the sidebar's behavior.
This fixes a few things:
- closes #7091
- closes #7090
- resolves having to manually hide the sidebar after using it to navigate to a different page

In action:
![2021-12-13 16 12 56](https://user-images.githubusercontent.com/4550621/145838261-00dd9ffe-3531-49f1-b5b5-996e6716c7a2.gif)

## How did you test this code?

Repeated the routine from the gif above.
