### PR TITLE
Fix Sigma box styling

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.scss
@@ -123,7 +123,6 @@
     line-height: 16px;
     text-align: right;
 
-    display: flex;
     letter-spacing: 0.02em;
     text-transform: uppercase;
 


### PR DESCRIPTION
## Changes

On large screens, the box takes up too much space.

Before:

![image](https://user-images.githubusercontent.com/7115141/145844963-9bd4a4ba-b786-47f3-8513-42b9fd4d3944.png)



After:

![image](https://user-images.githubusercontent.com/7115141/145844887-f4eefca0-acca-40c4-963d-3fbf9a2d6576.png)


## How did you test this code?

Chrome dev tools - toggle on and off
