### PR TITLE
Shorten "Click to view persons/groups" tooltip to fit

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -52,7 +52,7 @@ export function InsightTooltip({
             {inspectPersonsLabel && (
                 <div className="inspect-persons-label">
                     <IconHandClick />
-                    Click on data point to view persons or groups
+                    Click to view persons/groups
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Changes

Small simplification of the tooltip so that it fits neatly into one line:

| Before | After |
| --- | --- |
| <img width="351" alt="Screenshot 2021-12-13 at 16 48 45" src="https://user-images.githubusercontent.com/4550621/145848853-4c578a7c-cf52-49e0-a8cd-3528cfeafbeb.png"> | <img width="254" alt="Screenshot 2021-12-13 at 16 50 23" src="https://user-images.githubusercontent.com/4550621/145848856-0d4738df-70da-4d32-9cd1-4e4a699afc0d.png"> |
