### PR TITLE
Make sure private projects stay secret for those without access

### DIFF
--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -8,7 +8,6 @@ from rest_framework.status import (
 
 from ee.api.test.base import APILicensedTest
 from ee.models.explicit_team_membership import ExplicitTeamMembership
-from posthog.models import organization
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -385,12 +384,35 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
         other_team = Team.objects.create(organization=self.organization, name="Other", access_control=True)
-        # Other team should not be returned as it's restricted for the logged-in user
+
+        # The other team should not be returned as it's restricted for the logged-in user
         with self.assertNumQueries(9):
-            response = self.client.get(f"/api/projects/")
-        self.assertEqual(response.status_code, HTTP_200_OK)
+            projects_response = self.client.get(f"/api/projects/")
+        with self.assertNumQueries(10):
+            current_org_response = self.client.get(f"/api/organizations/{self.organization.id}/")
+
+        self.assertEqual(projects_response.status_code, HTTP_200_OK)
         self.assertEqual(
-            response.json().get("results"),
+            projects_response.json().get("results"),
+            [
+                {
+                    "id": self.team.id,
+                    "uuid": str(self.team.uuid),
+                    "organization": str(self.organization.id),
+                    "api_token": self.team.api_token,
+                    "name": self.team.name,
+                    "completed_snippet_onboarding": False,
+                    "ingested_event": False,
+                    "is_demo": False,
+                    "timezone": "UTC",
+                    "access_control": False,
+                    "effective_membership_level": int(OrganizationMembership.Level.MEMBER),
+                }
+            ],
+        )
+        self.assertEqual(current_org_response.status_code, HTTP_200_OK)
+        self.assertEqual(
+            current_org_response.json().get("teams"),
             [
                 {
                     "id": self.team.id,

--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -388,7 +388,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         # The other team should not be returned as it's restricted for the logged-in user
         with self.assertNumQueries(9):
             projects_response = self.client.get(f"/api/projects/")
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             current_org_response = self.client.get(f"/api/organizations/{self.organization.id}/")
 
         self.assertEqual(projects_response.status_code, HTTP_200_OK)

--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -36,7 +36,7 @@ export function ProjectSwitcherOverlay(): JSX.Element {
                 title={
                     isProjectCreationForbidden
                         ? "You aren't allowed to create a project. Your organization access level is probably insufficient."
-                        : null
+                        : undefined
                 }
                 onClick={() => {
                     hideProjectSwitcher()

--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -33,6 +33,11 @@ export function ProjectSwitcherOverlay(): JSX.Element {
                 icon={<IconPlus />}
                 fullWidth
                 disabled={isProjectCreationForbidden}
+                title={
+                    isProjectCreationForbidden
+                        ? "You aren't allowed to create a project. Your organization access level is probably insufficient."
+                        : null
+                }
                 onClick={() => {
                     hideProjectSwitcher()
                     guardAvailableFeature(
@@ -95,6 +100,7 @@ function OtherProjectButton({ team }: { team: TeamBasicType }): JSX.Element {
             title={`Switch to project ${team.name}`}
             type="stealth"
             fullWidth
+            disabled={!team.effective_membership_level}
         >
             <span style={{ paddingRight: 8 }}>{team.name}</span>
         </LemonButtonWithSideAction>

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -119,7 +119,7 @@ function License(): JSX.Element {
                     <div>{relevantLicense ? `${identifierToHuman(relevantLicense.plan)} plan` : 'Free plan'}</div>
                     {relevantLicense && (
                         <div className="supplement">
-                            Valid till {dayjs(relevantLicense.valid_until).format('D MMM YYYY')}
+                            Valid until {dayjs(relevantLicense.valid_until).format('D MMM YYYY')}
                         </div>
                     )}
                 </div>

--- a/frontend/src/lib/components/LemonButton/index.tsx
+++ b/frontend/src/lib/components/LemonButton/index.tsx
@@ -53,7 +53,7 @@ function LemonButtonInternal(
     }
     return workingButton
 }
-export const LemonButton = React.forwardRef(LemonButtonInternal)
+export const LemonButton = React.forwardRef(LemonButtonInternal) as typeof LemonButtonInternal
 
 export type SideAction = Pick<LemonButtonProps, 'onClick' | 'popup' | 'to' | 'icon' | 'type' | 'tooltip' | 'data-attr'>
 

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -137,7 +137,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
             for team in instance.teams.all()
             if team.get_effective_membership_level(self.context["request"].user) is not None
         )
-        return TeamBasicSerializer(visible_teams, context=self.context, many=True).data
+        return cast(List[Dict[str, Any]], TeamBasicSerializer(visible_teams, context=self.context, many=True).data)
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -132,12 +132,11 @@ class OrganizationSerializer(serializers.ModelSerializer):
         }
 
     def get_teams(self, instance: Organization) -> List[Dict[str, Any]]:
-        visible_teams = (
-            team
-            for team in instance.teams.all()
-            if team.get_effective_membership_level(self.context["request"].user) is not None
+        teams = cast(
+            List[Dict[str, Any]], TeamBasicSerializer(instance.teams.all(), context=self.context, many=True).data
         )
-        return cast(List[Dict[str, Any]], TeamBasicSerializer(visible_teams, context=self.context, many=True).data)
+        visible_teams = [team for team in teams if team["effective_membership_level"] is not None]
+        return visible_teams
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from django.conf import settings
 from django.db.models import Model, QuerySet
@@ -10,7 +10,6 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import TeamBasicSerializer
 from posthog.constants import AvailableFeature
 from posthog.event_usage import report_onboarding_completed, report_organization_deleted
-from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
 from posthog.permissions import (
@@ -62,7 +61,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
     setup = (
         serializers.SerializerMethodField()
     )  # Information related to the current state of the onboarding/setup process
-    teams = TeamBasicSerializer(many=True, read_only=True)
+    teams = serializers.SerializerMethodField()
 
     class Meta:
         model = Organization
@@ -131,6 +130,14 @@ class OrganizationSerializer(serializers.ModelSerializer):
             "non_demo_team_id": non_demo_team_id,
             "has_invited_team_members": instance.invites.exists() or instance.members.count() > 1,
         }
+
+    def get_teams(self, instance: Organization) -> List[Dict[str, Any]]:
+        visible_teams = (
+            team
+            for team in instance.teams.all()
+            if team.get_effective_membership_level(self.context["request"].user) is not None
+        )
+        return TeamBasicSerializer(visible_teams, context=self.context, many=True).data
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Changes

Fixes [an issue found in release testing](https://docs.google.com/document/d/1tyTChgLM8ZKCIyP05yDeyzS7y-s2ii5lm5WltREO3so/edit?disco=AAAATE15Opk).

## How did you test this code?

Extended an existing test case. It previously checked only the `projects` endpoint, but we need to have analogous logic in the `Organization` serializer too.
