### PR TITLE
Fix funnel trends incomplete data points when conversion window overlaps

### DIFF
--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -14,7 +14,7 @@ export function FunnelLineGraph({
 }: Omit<ChartParams, 'filters'>): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const logic = funnelLogic(insightProps)
-    const { steps, filters, aggregationTargetLabel } = useValues(logic)
+    const { steps, filters, aggregationTargetLabel, incompletenessOffsetFromEnd } = useValues(logic)
     const { loadPeople } = useActions(personsModalLogic)
 
     return (
@@ -24,10 +24,11 @@ export function FunnelLineGraph({
             color={color}
             datasets={steps}
             labels={steps?.[0]?.labels ?? ([] as string[])}
-            isInProgress={!filters.date_to}
+            isInProgress={incompletenessOffsetFromEnd < 0}
             dashboardItemId={dashboardItemId}
             inSharedMode={inSharedMode}
             percentage={true}
+            incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
             onClick={
                 dashboardItemId
                     ? null

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -1,4 +1,11 @@
-import { EMPTY_BREAKDOWN_VALUES, getBreakdownStepValues, getMeanAndStandardDeviation } from './funnelUtils'
+import {
+    EMPTY_BREAKDOWN_VALUES,
+    getBreakdownStepValues,
+    getIncompleteConversionWindowStartDate,
+    getMeanAndStandardDeviation,
+} from './funnelUtils'
+import { FunnelConversionWindowTimeUnit } from '~/types'
+import { dayjs } from 'lib/dayjs'
 
 describe('getMeanAndStandardDeviation', () => {
     const arrayToExpectedValues: [number[], number[]][] = [
@@ -97,5 +104,42 @@ describe('getBreakdownStepValues()', () => {
         expect(getBreakdownStepValues({ breakdown: null, breakdown_value: null }, 21)).toStrictEqual(
             EMPTY_BREAKDOWN_VALUES
         )
+    })
+})
+
+describe('getIncompleteConversionWindowStartDate()', () => {
+    const windows = [
+        {
+            funnel_window_interval: 60,
+            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Minute,
+            expected: '2018-04-04T15:00:00.000Z',
+        },
+        {
+            funnel_window_interval: 24,
+            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Hour,
+            expected: '2018-04-03T16:00:00.000Z',
+        },
+        {
+            funnel_window_interval: 7,
+            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Day,
+            expected: '2018-03-28T16:00:00.000Z',
+        },
+        {
+            funnel_window_interval: 53,
+            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Week,
+            expected: '2017-03-29T16:00:00.000Z',
+        },
+        {
+            funnel_window_interval: 12,
+            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Month,
+            expected: '2017-04-04T16:00:00.000Z',
+        },
+    ]
+    const frozenStartDate = dayjs('2018-04-04T16:00:00.000Z')
+
+    windows.forEach(({ expected, ...w }) => {
+        it(`get start date of conversion window ${w.funnel_window_interval} ${w.funnel_window_interval_unit}s`, () => {
+            expect(getIncompleteConversionWindowStartDate(w, frozenStartDate).toISOString()).toEqual(expected)
+        })
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -15,7 +15,9 @@ import {
     FunnelStepReference,
     TeamType,
     FlattenedFunnelStepByBreakdown,
+    FunnelConversionWindow,
 } from '~/types'
+import { dayjs } from 'lib/dayjs'
 
 const PERCENTAGE_DISPLAY_PRECISION = 1 // Number of decimals to show in percentages
 
@@ -371,4 +373,12 @@ export function getMeanAndStandardDeviation(values?: number[]): number[] {
     })
     const avgSquareDiff = squareDiffs.reduce((acc, current) => current + acc, 0) / n
     return [average, Math.sqrt(avgSquareDiff)]
+}
+
+export function getIncompleteConversionWindowStartDate(
+    window: FunnelConversionWindow,
+    startDate: dayjs.Dayjs = dayjs()
+): dayjs.Dayjs {
+    const { funnel_window_interval, funnel_window_interval_unit } = window
+    return startDate.subtract(funnel_window_interval, funnel_window_interval_unit)
 }

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -41,6 +41,7 @@ export function LineGraph({
     showPersonsModal = true,
     tooltipPreferAltTitle = false,
     isCompare = false,
+    incompletenessOffsetFromEnd = -1, // Number of data points at end of dataset to replace with a dotted line. Only used in line graphs.
 }) {
     const chartRef = useRef()
     const myLineChart = useRef()
@@ -177,12 +178,10 @@ export function LineGraph({
             datasets = [
                 ...datasets.map((dataset, index) => {
                     let datasetCopy = Object.assign({}, dataset)
-                    let data = [...(dataset.data || [])]
-                    let _labels = [...(dataset.labels || [])]
-                    let days = [...(dataset.days || [])]
-                    data.pop()
-                    _labels.pop()
-                    days.pop()
+                    const sliceTo = incompletenessOffsetFromEnd || (datasetCopy.data?.length ?? 0)
+                    const data = [...(dataset.data || [])].slice(0, sliceTo)
+                    const _labels = [...(dataset.labels || [])].slice(0, sliceTo)
+                    const days = [...(dataset.days || [])].slice(0, sliceTo)
                     datasetCopy.data = data
                     datasetCopy.labels = _labels
                     datasetCopy.days = days
@@ -190,7 +189,6 @@ export function LineGraph({
                 }),
                 ...datasets.map((dataset, index) => {
                     let datasetCopy = Object.assign({}, dataset)
-                    let datasetLength = datasetCopy.data?.length ?? 0
                     datasetCopy.dotted = true
 
                     // if last date is still active show dotted line
@@ -198,12 +196,12 @@ export function LineGraph({
                         datasetCopy.borderDash = [10, 10]
                     }
 
-                    datasetCopy.data =
-                        datasetCopy.data?.length > 2
-                            ? datasetCopy.data.map((datum, idx) =>
-                                  idx === datasetLength - 1 || idx === datasetLength - 2 ? datum : null
-                              )
-                            : datasetCopy.data
+                    // Nullify dates that don't have dotted line
+                    const sliceFrom = incompletenessOffsetFromEnd - 1 || (datasetCopy.data?.length ?? 0)
+                    datasetCopy.data = (datasetCopy.data?.slice(0, sliceFrom).map(() => null) ?? []).concat(
+                        datasetCopy.data?.slice(sliceFrom) ?? []
+                    )
+
                     return processDataset(datasetCopy, index)
                 }),
             ]
@@ -213,6 +211,7 @@ export function LineGraph({
         } else {
             datasets = datasets.map((dataset, index) => processDataset(dataset, index))
         }
+        console.log('STEPS datasets', datasets)
 
         const tickOptions = {
             autoSkip: true,

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.jsx
@@ -211,7 +211,6 @@ export function LineGraph({
         } else {
             datasets = datasets.map((dataset, index) => processDataset(dataset, index))
         }
-        console.log('STEPS datasets', datasets)
 
         const tickOptions = {
             autoSkip: true,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1005,6 +1005,8 @@ export interface FunnelStep {
     breakdown?: BreakdownKeyType
     breakdowns?: Breakdown[]
     breakdown_value?: BreakdownKeyType
+    data?: number[]
+    days?: string[]
 
     // Url that you can GET to retrieve the people that converted in this step
     converted_people_url: string
@@ -1036,8 +1038,8 @@ export interface FunnelTimeConversionMetrics {
 }
 
 export interface FunnelConversionWindow {
-    funnel_window_interval_unit?: FunnelConversionWindowTimeUnit
-    funnel_window_interval?: number | undefined
+    funnel_window_interval_unit: FunnelConversionWindowTimeUnit
+    funnel_window_interval: number
 }
 
 // https://github.com/PostHog/posthog/blob/master/posthog/models/filters/mixins/funnel.py#L100


### PR DESCRIPTION
## Changes

Closes #7645

Changes: Now we indicate incomplete data in funnel trends whenever there is overlap with conversion window time ranges and the current date. 


https://user-images.githubusercontent.com/13460330/145903587-1d672287-0d9f-486f-850e-b9acbc6d99d4.mov



## How did you test this code?

Util test + manual visual QA + regression tests pass (for other line graphs pass).
