### PR TITLE
fix hobby deploy in 1.30.0

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -56,7 +56,8 @@ rm -rf compose
 mkdir -p compose
 cat > compose/start <<EOF
 #!/bin/bash
-./bin/migrate
+python manage.py migrate
+python manage.py migrate_clickhouse
 ./bin/docker-server
 ./bin/docker-frontend
 EOF


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Fixes #7690.

We should revert this when we push out 1.31.0.

The change was valid, but the hobby deploy pulls from the `latest-release` tag, where the ./bin/migrate command doesn't exist.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
