### PR TITLE
Hobby deploy 1.31.0 migrate script

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -56,8 +56,7 @@ rm -rf compose
 mkdir -p compose
 cat > compose/start <<EOF
 #!/bin/bash
-python manage.py migrate
-python manage.py migrate_clickhouse
+./bin/migrate
 ./bin/docker-server
 ./bin/docker-frontend
 EOF


### PR DESCRIPTION
Use the new migrate script in 1.31.0. This doesn't need to go in the release but must be merged after the release tag is deployed.

Reverts PostHog/posthog#7701