### PR TITLE
Make heatmap error-resilient

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -99,7 +99,7 @@ export const heatmapLogic = kea<heatmapLogicType>({
                     let combinedSelector
                     let lastSelector
                     for (let i = 0; i < event.elements.length; i++) {
-                        const selector = elementToSelector(event.elements[i], dataAttributes)
+                        const selector = elementToSelector(event.elements[i], dataAttributes) || '*'
                         combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
 
                         try {
@@ -149,7 +149,7 @@ export const heatmapLogic = kea<heatmapLogicType>({
                             }
                         } catch (error) {
                             console.error('Invalid selector!', combinedSelector)
-                            throw error
+                            break
                         }
 
                         lastSelector = combinedSelector


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/5993
- Somehow we had some bad selectors, which then caused the entire heatmap to crash, instead of being casually ignored.

## How did you test this code?

- I followed the steps in the issue to reproduce the bug. Then I saved the production API response, and stubbed that in locally to get the same crash. Then I figured out what's wrong, and saw that we sometimes have an empty selector that's causing bugs.
- I also made sure that silently ignoring the error wouldn't cause other issues. 