### PR TITLE
Alternative side-effects solution for async migrations

### DIFF
--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -42,9 +42,18 @@ class AsyncMigrationOperation:
         self.rollback_fn = rollback_fn
 
     @classmethod
-    def simple_op(cls, sql, rollback, database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE):
+    def simple_op(
+        cls,
+        sql,
+        rollback,
+        database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE,
+        resumable=False,
+        timeout_seconds: int = 60,
+    ):
         return cls(
-            fn=cls.get_db_op(database=database, sql=sql), rollback_fn=cls.get_db_op(database=database, sql=rollback),
+            fn=cls.get_db_op(database=database, sql=sql, timeout_seconds=timeout_seconds),
+            rollback_fn=cls.get_db_op(database=database, sql=rollback, timeout_seconds=timeout_seconds),
+            resumable=resumable,
         )
 
     @classmethod

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -52,7 +52,7 @@ class AsyncMigrationOperation:
     ):
         return cls(
             fn=cls.get_db_op(database=database, sql=sql, timeout_seconds=timeout_seconds),
-            rollback_fn=cls.get_db_op(database=database, sql=rollback, timeout_seconds=timeout_seconds),
+            rollback_fn=cls.get_db_op(database=database, sql=rollback),
             resumable=resumable,
         )
 

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -27,7 +27,7 @@ class AsyncMigrationOperation:
     def __init__(
         self,
         fn=lambda query_id: None,  # potentially we should rename to something other than query_id
-        rollback_fn=lambda query_id: None,  # Raise an exeception here if we don't want it to be possible to roll back
+        rollback_fn=lambda query_id: None,
         resumable=False,
     ):
         fn = fn
@@ -42,7 +42,13 @@ class AsyncMigrationOperation:
         self.rollback_fn = rollback_fn
 
     @classmethod
-    def get_db_op(sql="", database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE, timeout_seconds: int = 60):
+    def simple_op(cls, sql, rollback, database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE):
+        return cls(
+            fn=cls.get_db_op(database=database, sql=sql), rollback_fn=cls.get_db_op(database=database, sql=rollback),
+        )
+
+    @classmethod
+    def get_db_op(cls, sql="", database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE, timeout_seconds: int = 60):
         # timeout is currently CH only
         def run_db_op(query_id):
             if database == AnalyticsDBMS.CLICKHOUSE:

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -25,10 +25,7 @@ class AsyncMigrationType:
 
 class AsyncMigrationOperation:
     def __init__(
-        self,
-        fn=lambda query_id: None,  # potentially we should rename to something other than query_id
-        rollback_fn=lambda query_id: None,
-        resumable=False,
+        self, fn=lambda id_: None, rollback_fn=lambda id_: None, resumable=False,
     ):
         fn = fn
         # if the operation is dynamic and knows how to restart correctly after a crash

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -26,7 +26,7 @@ class AsyncMigrationOperation:
     def __init__(
         self, fn: Callable[[str], None], rollback_fn: Callable[[str], None] = lambda _: None, resumable=False,
     ):
-        fn = fn
+        self.fn = fn
         # if the operation is dynamic and knows how to restart correctly after a crash
         # Example:
         #   - Not resumable: `INSERT INTO table1 (col1) SELECT col1 FROM table2`

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -15,11 +15,11 @@ ONE_DAY = 60 * 60 * 24
 TEMPORARY_TABLE_NAME = "person_distinct_id_async_migration"
 
 
-def example_fn(_):
+def example_fn(uuid: str):
     pass
 
 
-def example_rollback_fn():
+def example_rollback_fn(uuid: str):
     pass
 
 

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -15,6 +15,14 @@ ONE_DAY = 60 * 60 * 24
 TEMPORARY_TABLE_NAME = "person_distinct_id_async_migration"
 
 
+def example_fn(_):
+    pass
+
+
+def example_rollback_fn():
+    pass
+
+
 class Migration(AsyncMigrationDefinition):
 
     description = "An example async migration."
@@ -82,6 +90,7 @@ class Migration(AsyncMigrationDefinition):
             sql=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
             rollback=f"DROP TABLE IF EXISTS person_distinct_id_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
         ),
+        AsyncMigrationOperation(fn=example_fn, rollback_fn=example_rollback_fn),
     ]
 
     def healthcheck(self):

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -27,24 +27,23 @@ class Migration(AsyncMigrationDefinition):
     ]
 
     operations = [
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=PERSONS_DISTINCT_ID_TABLE_SQL().replace(PERSONS_DISTINCT_ID_TABLE, TEMPORARY_TABLE_NAME, 1),
             rollback=f"DROP TABLE IF EXISTS {TEMPORARY_TABLE_NAME} ON CLUSTER {CLICKHOUSE_CLUSTER}",
         ),
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DROP TABLE person_distinct_id_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
             rollback=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
         ),
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DROP TABLE kafka_person_distinct_id ON CLUSTER {CLICKHOUSE_CLUSTER}",
             rollback=KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL,
         ),
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
-            timeout_seconds=ONE_DAY,
             sql=f"""
                 INSERT INTO {TEMPORARY_TABLE_NAME} (distinct_id, person_id, team_id, _sign, _timestamp, _offset)
                 SELECT
@@ -58,7 +57,7 @@ class Migration(AsyncMigrationDefinition):
             """,
             rollback=f"DROP TABLE IF EXISTS {TEMPORARY_TABLE_NAME}",
         ),
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 RENAME TABLE
@@ -73,12 +72,12 @@ class Migration(AsyncMigrationDefinition):
                 ON CLUSTER {CLICKHOUSE_CLUSTER}
             """,
         ),
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL,
             rollback=f"DROP TABLE IF EXISTS kafka_person_distinct_id ON CLUSTER {CLICKHOUSE_CLUSTER}",
         ),
-        AsyncMigrationOperation(
+        AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
             rollback=f"DROP TABLE IF EXISTS person_distinct_id_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",

--- a/posthog/async_migrations/examples/test.py
+++ b/posthog/async_migrations/examples/test.py
@@ -43,7 +43,7 @@ class Migration(AsyncMigrationDefinition):
             rollback="TRUNCATE TABLE test_async_migration",
         ),
         AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
-        AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)"),
+        AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)", resumable=True),
         AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.POSTGRES,
             sql="UPDATE test_async_migration SET value='c' WHERE key='a'",

--- a/posthog/async_migrations/examples/test.py
+++ b/posthog/async_migrations/examples/test.py
@@ -12,11 +12,11 @@ class SideEffects:
         self.side_effect_count = 0
         self.side_effect_rollback_count = 0
 
-    def side_effect(self):
+    def side_effect(self, query_id):
         self.side_effect_count += 1
         return
 
-    def side_effect_rollback(self):
+    def side_effect_rollback(self, query_id):
         self.side_effect_rollback_count += 1
         return
 
@@ -33,27 +33,41 @@ class Migration(AsyncMigrationDefinition):
 
     operations = [
         AsyncMigrationOperation(
-            database=AnalyticsDBMS.POSTGRES,
-            sql="CREATE TABLE test_async_migration ( key VARCHAR, value VARCHAR )",
-            rollback="DROP TABLE test_async_migration",
-            side_effect=sec.side_effect,
-            side_effect_rollback=sec.side_effect_rollback,
+            fn=AsyncMigrationOperation.get_db_op(
+                database=AnalyticsDBMS.POSTGRES, sql="CREATE TABLE test_async_migration ( key VARCHAR, value VARCHAR )"
+            ),
+            rollback_fn=AsyncMigrationOperation.get_db_op(
+                database=AnalyticsDBMS.POSTGRES, sql="DROP TABLE test_async_migration"
+            ),
         ),
         AsyncMigrationOperation(
-            database=AnalyticsDBMS.POSTGRES,
-            sql="INSERT INTO test_async_migration (key, value) VALUES ('a', 'b')",
-            rollback="TRUNCATE TABLE test_async_migration",
-            side_effect=sec.side_effect,
-            side_effect_rollback=sec.side_effect_rollback,
+            fn=AsyncMigrationOperation.get_db_op(
+                database=AnalyticsDBMS.POSTGRES, sql="INSERT INTO test_async_migration (key, value) VALUES ('a', 'b')"
+            ),
+            rollback_fn=AsyncMigrationOperation.get_db_op(
+                database=AnalyticsDBMS.POSTGRES, sql="TRUNCATE TABLE test_async_migration"
+            ),
         ),
-        AsyncMigrationOperation(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)", rollback="", resumable=True),
         AsyncMigrationOperation(
-            database=AnalyticsDBMS.POSTGRES,
-            sql="UPDATE test_async_migration SET value='c' WHERE key='a'",
-            rollback="UPDATE test_async_migration SET value='b' WHERE key='a'",
+            fn=sec.side_effect,
+            rollback_fn=sec.side_effect_rollback,
+        ),
+        AsyncMigrationOperation(
+            fn=AsyncMigrationOperation.get_db_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)"),
+            resumable=True,
+        ),
+        AsyncMigrationOperation(
+            fn=AsyncMigrationOperation.get_db_op(
+                database=AnalyticsDBMS.POSTGRES, sql="UPDATE test_async_migration SET value='c' WHERE key='a'"
+            ),
+            rollback_fn=AsyncMigrationOperation.get_db_op(
+                database=AnalyticsDBMS.POSTGRES, sql="UPDATE test_async_migration SET value='b' WHERE key='a'"
+            ),
             resumable=True,  # why? because 'update where' queries can safely be re-run
-            side_effect=sec.side_effect,
-            side_effect_rollback=sec.side_effect_rollback,
+        ),
+        AsyncMigrationOperation(
+            fn=sec.side_effect,
+            rollback_fn=sec.side_effect_rollback,
         ),
     ]
 

--- a/posthog/async_migrations/examples/test.py
+++ b/posthog/async_migrations/examples/test.py
@@ -12,11 +12,11 @@ class SideEffects:
         self.side_effect_count = 0
         self.side_effect_rollback_count = 0
 
-    def side_effect(self, query_id):
+    def side_effect(self, _):
         self.side_effect_count += 1
         return
 
-    def side_effect_rollback(self, query_id):
+    def side_effect_rollback(self, _):
         self.side_effect_rollback_count += 1
         return
 

--- a/posthog/async_migrations/examples/test.py
+++ b/posthog/async_migrations/examples/test.py
@@ -37,13 +37,14 @@ class Migration(AsyncMigrationDefinition):
             sql="CREATE TABLE test_async_migration ( key VARCHAR, value VARCHAR )",
             rollback="DROP TABLE test_async_migration",
         ),
+        AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
         AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.POSTGRES,
             sql="INSERT INTO test_async_migration (key, value) VALUES ('a', 'b')",
             rollback="TRUNCATE TABLE test_async_migration",
         ),
-        AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
         AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)", resumable=True),
+        AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
         AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.POSTGRES,
             sql="UPDATE test_async_migration SET value='c' WHERE key='a'",

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -76,8 +76,8 @@ class Migration(AsyncMigrationDefinition):
             rollback=f"ATTACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
         ),
         AsyncMigrationOperation(
-            fn=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
-            rollback_fn=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
+            fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
+            rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
         ),
         AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
@@ -117,8 +117,8 @@ class Migration(AsyncMigrationDefinition):
             rollback=f"DETACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
         ),
         AsyncMigrationOperation(
-            fn=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
-            rollback_fn=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
+            fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
+            rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
         ),
     ]
 

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -71,7 +71,7 @@ class Migration(AsyncMigrationDefinition):
             timeout_seconds=7 * 24 * 60 * 60,  # one week
         ),
         AsyncMigrationOperation(
-            fn=lambda _: None,
+            fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
             rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
             resumable=True,
         ),
@@ -79,9 +79,6 @@ class Migration(AsyncMigrationDefinition):
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DETACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
             rollback=f"ATTACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
-        ),
-        AsyncMigrationOperation(
-            fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False), resumable=True,
         ),
         AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -54,7 +54,7 @@ class Migration(AsyncMigrationDefinition):
         return [self.migrate_team_operation(team_id) for team_id in self._team_ids]
 
     def migrate_team_operation(self, team_id: int):
-        return AsyncMigrationOperation(
+        return AsyncMigrationOperation.simple_op(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 INSERT INTO person_distinct_id2(team_id, distinct_id, person_id, is_deleted, version)

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -121,7 +121,6 @@ def run_async_migration_next_op(migration_name: str, migration_instance: Optiona
 
     try:
         execute_op(op, current_query_id)
-        op.side_effect()
         update_async_migration(
             migration_instance=migration_instance,
             current_query_id=current_query_id,
@@ -155,9 +154,7 @@ def update_migration_progress(migration_instance: AsyncMigration):
 
     migration_instance.refresh_from_db()
     try:
-        progress = get_async_migration_definition(migration_instance.name).progress(
-            migration_instance  # type: ignore
-        )
+        progress = get_async_migration_definition(migration_instance.name).progress(migration_instance)  # type: ignore
         update_async_migration(migration_instance=migration_instance, progress=progress)
     except:
         pass
@@ -173,15 +170,9 @@ def attempt_migration_rollback(migration_instance: AsyncMigration, force: bool =
     try:
         ops = get_async_migration_definition(migration_instance.name).operations
 
-        i = len(ops) - 1
-        for op in reversed(ops[: migration_instance.current_operation_index + 1]):
-            if not op.rollback:
-                if op.rollback == "":
-                    continue
-                raise Exception(f"No rollback provided for operation at index {i}: {op.sql}")
+        for op_index in range(migration_instance.current_operation_index, -1, -1):
+            op = ops[op_index]
             execute_op(op, str(UUIDT()), rollback=True)
-            op.side_effect_rollback()
-            i -= 1
     except Exception as e:
         error = str(e)
 

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -169,8 +169,9 @@ def attempt_migration_rollback(migration_instance: AsyncMigration, force: bool =
 
     try:
         ops = get_async_migration_definition(migration_instance.name).operations
-
-        for op_index in range(migration_instance.current_operation_index, -1, -1):
+        # if the migration was completed the index is set 1 after, normally we should try rollback for current op
+        current_index = min(migration_instance.current_operation_index, len(ops) - 1)
+        for op_index in range(current_index, -1, -1):
             op = ops[op_index]
             execute_op(op, str(UUIDT()), rollback=True)
     except Exception as e:

--- a/posthog/async_migrations/test/test_0002_events_sample_by.py
+++ b/posthog/async_migrations/test/test_0002_events_sample_by.py
@@ -18,7 +18,7 @@ def execute_query(query: str) -> Any:
     return sync_execute(query)
 
 
-class Test0001EventsSampleBy(BaseTest):
+class Test0002EventsSampleBy(BaseTest):
 
     # This set up is necessary to mimic the state of the DB before the new default schema came into place
     def setUp(self):
@@ -100,4 +100,4 @@ class Test0001EventsSampleBy(BaseTest):
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
         self.assertEqual(sm.progress, 100)
         self.assertEqual(sm.last_error, "")
-        self.assertEqual(sm.current_operation_index, 7)
+        self.assertEqual(sm.current_operation_index, 10)

--- a/posthog/async_migrations/test/test_0002_events_sample_by.py
+++ b/posthog/async_migrations/test/test_0002_events_sample_by.py
@@ -100,4 +100,4 @@ class Test0002EventsSampleBy(BaseTest):
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
         self.assertEqual(sm.progress, 100)
         self.assertEqual(sm.last_error, "")
-        self.assertEqual(sm.current_operation_index, 10)
+        self.assertEqual(sm.current_operation_index, 9)

--- a/posthog/async_migrations/test/test_definition.py
+++ b/posthog/async_migrations/test/test_definition.py
@@ -2,7 +2,6 @@ import pytest
 from infi.clickhouse_orm.utils import import_submodules
 
 from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
-from posthog.async_migrations.examples.example import example_fn, example_rollback_fn
 from posthog.async_migrations.setup import ASYNC_MIGRATIONS_EXAMPLE_MODULE_PATH
 from posthog.constants import AnalyticsDBMS
 from posthog.test.base import BaseTest
@@ -13,6 +12,7 @@ class TestAsyncMigrationDefinition(BaseTest):
     @pytest.mark.ee
     def test_get_async_migration_definition(self):
         from ee.clickhouse.sql.person import PERSONS_DISTINCT_ID_TABLE_MV_SQL
+        from posthog.async_migrations.examples.example import example_fn, example_rollback_fn
 
         modules = import_submodules(ASYNC_MIGRATIONS_EXAMPLE_MODULE_PATH)
         example_migration = modules["example"].Migration()

--- a/posthog/async_migrations/test/test_definition.py
+++ b/posthog/async_migrations/test/test_definition.py
@@ -2,6 +2,7 @@ import pytest
 from infi.clickhouse_orm.utils import import_submodules
 
 from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.examples.example import example_fn, example_rollback_fn
 from posthog.async_migrations.setup import ASYNC_MIGRATIONS_EXAMPLE_MODULE_PATH
 from posthog.constants import AnalyticsDBMS
 from posthog.test.base import BaseTest
@@ -21,6 +22,6 @@ class TestAsyncMigrationDefinition(BaseTest):
         self.assertEqual(example_migration.description, "An example async migration.")
         self.assertEqual(example_migration.posthog_min_version, "1.29.0")
         self.assertEqual(example_migration.posthog_max_version, "1.30.0")
-        self.assertEqual(example_migration.operations[-1].sql, PERSONS_DISTINCT_ID_TABLE_MV_SQL)
-        self.assertEqual(example_migration.operations[-1].database, AnalyticsDBMS.CLICKHOUSE)
+        self.assertEqual(example_migration.operations[-1].fn, example_fn)
+        self.assertEqual(example_migration.operations[-1].rollback_fn, example_rollback_fn)
         self.assertTrue(isinstance(example_migration.service_version_requirements[0], ServiceVersionRequirement))

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -16,9 +16,12 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import MigrationStatus
 from posthog.test.base import BaseTest
 
-DEFAULT_CH_OP = AsyncMigrationOperation(sql="SELECT 1", timeout_seconds=10)
+DEFAULT_CH_OP = AsyncMigrationOperation.get_db_op(sql="SELECT 1", timeout_seconds=10)
 
-DEFAULT_POSTGRES_OP = AsyncMigrationOperation(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1",)
+DEFAULT_POSTGRES_OP = AsyncMigrationOperation.get_db_op(
+    database=AnalyticsDBMS.POSTGRES,
+    sql="SELECT 1",
+)
 
 
 class TestUtils(BaseTest):

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -16,12 +16,9 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import MigrationStatus
 from posthog.test.base import BaseTest
 
-DEFAULT_CH_OP = AsyncMigrationOperation.get_db_op(sql="SELECT 1", timeout_seconds=10)
+DEFAULT_CH_OP = AsyncMigrationOperation.simple_op(sql="SELECT 1", timeout_seconds=10)
 
-DEFAULT_POSTGRES_OP = AsyncMigrationOperation.get_db_op(
-    database=AnalyticsDBMS.POSTGRES,
-    sql="SELECT 1",
-)
+DEFAULT_POSTGRES_OP = AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1",)
 
 
 class TestUtils(BaseTest):

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -11,11 +11,11 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
 
 
-def execute_op(op: AsyncMigrationOperation, query_id: str, rollback: bool = False):
+def execute_op(op: AsyncMigrationOperation, id_: str, rollback: bool = False):
     """
     Execute the fn or rollback_fn
     """
-    op.rollback_fn(query_id) if rollback else op.fn(query_id)
+    op.rollback_fn(id_) if rollback else op.fn(id_)
 
 
 def execute_op_clickhouse(sql: str, query_id: str, timeout_seconds: int):
@@ -53,8 +53,7 @@ def trigger_migration(migration_instance: AsyncMigration, fresh_start: bool = Tr
     task = run_async_migration.delay(migration_instance.name, fresh_start)
 
     update_async_migration(
-        migration_instance=migration_instance,
-        celery_task_id=str(task.id),
+        migration_instance=migration_instance, celery_task_id=str(task.id),
     )
 
 

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -11,11 +11,11 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
 
 
-def execute_op(op: AsyncMigrationOperation, id_: str, rollback: bool = False):
+def execute_op(op: AsyncMigrationOperation, uuid: str, rollback: bool = False):
     """
     Execute the fn or rollback_fn
     """
-    op.rollback_fn(id_) if rollback else op.fn(id_)
+    op.rollback_fn(uuid) if rollback else op.fn(uuid)
 
 
 def execute_op_clickhouse(sql: str, query_id: str, timeout_seconds: int):

--- a/posthog/tasks/test/test_async_migrations.py
+++ b/posthog/tasks/test/test_async_migrations.py
@@ -70,7 +70,7 @@ class TestAsyncMigrations(BaseTest):
         sm.refresh_from_db()
 
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
-        self.assertEqual(sm.current_operation_index, 4)
+        self.assertEqual(sm.current_operation_index, 7)
         self.assertEqual(sm.progress, 100)
 
     @pytest.mark.ee


### PR DESCRIPTION
## Changes

For better clarity and more flexibility in the future changing the side-effect concept to be AsyncMigrationOperation taking function pointers instead.

## How did you test this code?

CI