### PR TITLE
Make async events migration not required on Cloud

### DIFF
--- a/posthog/async_migrations/migrations/0001_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0001_events_sample_by.py
@@ -1,4 +1,5 @@
 from constance import config
+from django.conf import settings
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.events import EVENTS_TABLE
@@ -114,6 +115,9 @@ class Migration(AsyncMigrationDefinition):
     ]
 
     def is_required(self):
+        if settings.MULTI_TENANCY:
+            return False
+
         res = sync_execute(f"SHOW CREATE TABLE {EVENTS_TABLE_NAME}")
         return "ORDER BY (team_id, toDate(timestamp), cityHash64(distinct_id), cityHash64(uuid))" not in res[0][0]
 


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

We manually ran this migration on Cloud, but also we use a distributed table, so the `is_required` check currently returns true. It shouldn't.

This doesn't need to go on the release btw @paolodamico - tagged you to confirm if this is the right way to check that we're on Cloud.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
