### PR TITLE
[suggestion] Remove null values in group properties

### DIFF
--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -192,6 +192,10 @@ export function calculateUpdate(
             result.properties_last_updated_at[key] = timestamp.toISO()
         }
     })
+
+    // purge null values
+    result.properties = Object.fromEntries(Object.entries(result.properties).filter(([_, val]) => val != null))
+
     return result
 }
 

--- a/plugin-server/tests/worker/ingestion/properties-updater.test.ts
+++ b/plugin-server/tests/worker/ingestion/properties-updater.test.ts
@@ -181,6 +181,18 @@ describe('upsertGroup()', () => {
         expect(group.properties_last_updated_at).toEqual({ foo: PAST_TIMESTAMP.toISO() })
     })
 
+    it('clears null values', async () => {
+        await upsert({ foo: 'bar' }, PAST_TIMESTAMP)
+        await upsert({ foo: null }, FUTURE_TIMESTAMP)
+
+        const group = await fetchGroup()
+
+        expect(group.version).toEqual(2)
+        expect(group.group_properties).toEqual({})
+        expect(group.properties_last_operation).toEqual({ foo: 'set' })
+        expect(group.properties_last_updated_at).toEqual({ foo: FUTURE_TIMESTAMP.toISO() })
+    })
+
     it('handles updating properties as new ones come in', async () => {
         await upsert({ foo: 'bar', a: 1 }, PAST_TIMESTAMP)
         await upsert({ foo: 'zeta', b: 2 }, FUTURE_TIMESTAMP)


### PR DESCRIPTION
## Changes

*Please describe.*  
- suggestion for a way to allow group property deletes
- This means that when a user passes a key with a null value it will delete the key. Allows the deletion of old unwanted keys
- TODO: add docs if accepted
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- added plugin server test