### PR TITLE
Fix urlToAction on /persons page

### DIFF
--- a/frontend/src/scenes/groups/groupsList.test.ts
+++ b/frontend/src/scenes/groups/groupsList.test.ts
@@ -35,4 +35,18 @@ describe('groupsListLogic', () => {
             .toMatchValues({ currentTab: '0' })
             .toDispatchActions(['loadGroups'])
     })
+
+    it('when moving from groups to persons, the tab sets as expected, but only once', async () => {
+        router.actions.push(urls.groups('0'))
+        await expectLogic(logic)
+            .toDispatchActions(['setTab'])
+            .toMatchValues({ currentTab: '0' })
+            .toDispatchActions(['loadGroups'])
+
+        router.actions.push(urls.persons())
+        await expectLogic(logic).toDispatchActions(['setTab']).toMatchValues({ currentTab: '-1' })
+
+        router.actions.push(urls.persons() + '?q=test')
+        await expectLogic(logic).toNotHaveDispatchedActions(['setTab'])
+    })
 })

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -73,7 +73,7 @@ export const groupsListLogic = kea<groupsListLogicType<GroupsPaginatedResponse>>
             return urls.persons()
         },
     }),
-    urlToAction: ({ actions }) => ({
+    urlToAction: ({ actions, values }) => ({
         '/groups/:id': ({ id }) => {
             if (id) {
                 actions.setTab(id)
@@ -81,7 +81,9 @@ export const groupsListLogic = kea<groupsListLogicType<GroupsPaginatedResponse>>
             }
         },
         '/persons': () => {
-            actions.setTab('-1')
+            if (values.currentTab !== '-1') {
+                actions.setTab('-1')
+            }
         },
     }),
 })


### PR DESCRIPTION
## Changes

Fixing: https://posthog.slack.com/archives/C0113360FFV/p1639596647231400

If the URL changed when we were already on the persons tab, we would still set the tab. This would cause a loop between `urlToAction` and `actionToUrl`.

## How did you test this code?

Added a test + tried searching when already on the persons tab and verified no `Pageview` events were fired.
