### PR TITLE
Experiment create cleanup 2

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -3,9 +3,8 @@ from datetime import datetime
 from typing import List, Optional, Tuple, Type
 
 from numpy.random import default_rng
-from rest_framework.exceptions import ValidationError
 
-from ee.clickhouse.queries.funnels import ClickhouseFunnel, funnel
+from ee.clickhouse.queries.funnels import ClickhouseFunnel
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 
@@ -103,11 +102,6 @@ class ClickhouseFunnelExperimentResult:
         By default, we choose a non-informative prior. That is, both success & failure are equally likely.
         
         """
-        if len(variants) > 2:
-            raise ValidationError("Can't calculate A/B test results for more than 2 variants")
-
-        if len(variants) < 2:
-            raise ValidationError("Can't calculate A/B test results for less than 2 variants")
 
         prior_success, prior_failure = priors
 

--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple, Type
 
 from numpy.random import default_rng
+from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.queries.funnels import ClickhouseFunnel
 from posthog.models.filters.filter import Filter
@@ -102,6 +103,11 @@ class ClickhouseFunnelExperimentResult:
         By default, we choose a non-informative prior. That is, both success & failure are equally likely.
         
         """
+        if len(variants) > 2:
+            raise ValidationError("Can't calculate A/B test results for more than 2 variants", code="too_much_data")
+
+        if len(variants) < 2:
+            raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")
 
         prior_success, prior_failure = priors
 

--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -2,6 +2,10 @@
 
 .experiment-result,
 .experiment-form {
+    .person-selection {
+        padding-top: $default_spacing;
+        border-top: 1px solid $border;
+    }
     .metrics-selection {
         border-top: 1px solid $border;
         padding-top: $default_spacing;
@@ -15,13 +19,6 @@
             }
             .row-action-btn {
                 color: $primary_alt;
-            }
-        }
-
-        &.person-selection {
-            label {
-                font-size: 16px;
-                font-weight: 600;
             }
         }
     }

--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -95,30 +95,13 @@
         min-height: 48px;
     }
 
-    .mde-selection {
-        border-top: 1px solid $border;
-        background-color: $bg_mid;
-        padding: 12px 16px;
-        margin-bottom: 1rem;
-
-        .ant-slider-handle {
-            z-index: 3;
-        }
-
-        .ant-slider-track {
-            z-index: 2;
-        }
-
-        .ant-slider-step {
-            background: darkgray;
-        }
-
-        .estimates {
-            .estimate {
-                font-weight: 500;
-                color: $text-muted;
-                font-size: 12px;
-            }
+    .experiment-preview {
+        margin-bottom: $default_spacing;
+        border-bottom: 1px solid $border;
+        .preview-row {
+            border-bottom: 1px solid $border;
+            padding-bottom: $default_spacing;
+            margin-bottom: $default_spacing;
         }
     }
 }

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1,5 +1,5 @@
 import SaveOutlined from '@ant-design/icons/lib/icons/SaveOutlined'
-import { Alert, Button, Card, Col, Collapse, Form, Input, InputNumber, Row, Tooltip } from 'antd'
+import { Alert, Button, Card, Col, Collapse, Form, Input, Row, Slider, Tooltip } from 'antd'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
@@ -19,6 +19,8 @@ import { IconJavascript } from 'lib/components/icons'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
+import { dayjs } from 'lib/dayjs'
 
 export const scene: SceneExport = {
     component: Experiment,
@@ -34,10 +36,11 @@ export function Experiment(): JSX.Element {
         minimumDetectableChange,
         recommendedSampleSize,
         expectedRunningTime,
-        newExperimentCurrentPage,
         experimentResults,
+        conversionRateForVariant,
     } = useValues(experimentLogic)
-    const { setNewExperimentData, createExperiment, setFilters, endExperiment } = useActions(experimentLogic)
+    const { setNewExperimentData, createExperiment, launchExperiment, setFilters, endExperiment } =
+        useActions(experimentLogic)
 
     const [form] = Form.useForm()
 
@@ -51,10 +54,12 @@ export function Experiment(): JSX.Element {
 
     const conversionRate = conversionMetrics.totalRate * 100
     const entrants = results?.[0]?.count
+    const sampleSize = recommendedSampleSize(conversionRate)
+    const runningTime = expectedRunningTime(entrants, sampleSize)
 
     return (
         <>
-            {experimentId === 'new' || (experimentData && !experimentData.start_date) ? (
+            {experimentId === 'new' ? (
                 <>
                     <Row
                         align="middle"
@@ -62,12 +67,6 @@ export function Experiment(): JSX.Element {
                         style={{ borderBottom: '1px solid var(--border)', marginBottom: '1rem', paddingBottom: 8 }}
                     >
                         <PageHeader title={'New Experiment'} />
-                        <Button
-                            style={{ color: 'var(--primary)', borderColor: 'var(--primary)' }}
-                            onClick={() => createExperiment(true)}
-                        >
-                            Save as draft
-                        </Button>
                     </Row>
                     <Form
                         name="new-experiment"
@@ -80,271 +79,330 @@ export function Experiment(): JSX.Element {
                             feature_flag_key: newExperimentData?.feature_flag_key,
                             description: newExperimentData?.description,
                         }}
-                        onFinish={() => createExperiment()}
+                        onFinish={() => createExperiment(true, runningTime, sampleSize)}
                         scrollToFirstError
                     >
-                        {newExperimentCurrentPage === 0 && (
-                            <div>
-                                <Row>
-                                    <Col span={12} style={{ paddingRight: 24 }}>
-                                        <Form.Item
-                                            label="Name"
-                                            name="name"
-                                            rules={[{ required: true, message: 'You have to enter a name.' }]}
-                                        >
-                                            <Input data-attr="experiment-name" className="ph-ignore-input" />
-                                        </Form.Item>
-                                        <span className="text-small text-muted">
-                                            We are creating a new feature flag here that is unique to the experiment
-                                        </span>
-                                        <Form.Item
-                                            label="Feature flag key"
-                                            name="feature_flag_key"
-                                            rules={[
-                                                {
-                                                    required: true,
-                                                    message: 'You have to create a new feature flag key.',
-                                                },
-                                            ]}
-                                        >
-                                            <Input
-                                                data-attr="experiment-feature-flag-key"
-                                                placeholder="examples: new-landing-page-experiment, betaFeatureExperiment, ab_test_1_experiment"
-                                            />
-                                        </Form.Item>
-                                        <Form.Item label="Description" name="description">
-                                            <Input.TextArea
-                                                data-attr="experiment-description"
-                                                className="ph-ignore-input"
-                                                placeholder="Adding a helpful description can ensure others know what this experiment is about."
-                                            />
-                                        </Form.Item>
-                                        <Form.Item
-                                            label="Select participants"
-                                            name="person-selection"
-                                            className="person-selection"
-                                        >
+                        <div>
+                            <Row>
+                                <Col span={12} style={{ paddingRight: 24 }}>
+                                    <Form.Item
+                                        label="Name"
+                                        name="name"
+                                        rules={[{ required: true, message: 'You have to enter a name.' }]}
+                                    >
+                                        <Input data-attr="experiment-name" className="ph-ignore-input" />
+                                    </Form.Item>
+                                    <Form.Item
+                                        label="Feature flag key"
+                                        name="feature_flag_key"
+                                        rules={[
+                                            {
+                                                required: true,
+                                                message: 'You have to choose a new feature flag key.',
+                                            },
+                                        ]}
+                                        help={
+                                            <span className="text-small text-muted">
+                                                Create a new feature flag that is unique to the experiment
+                                            </span>
+                                        }
+                                    >
+                                        <Input
+                                            data-attr="experiment-feature-flag-key"
+                                            placeholder="examples: new-landing-page-experiment, betaFeatureExperiment, ab_test_1_experiment"
+                                        />
+                                    </Form.Item>
+                                    <Form.Item label="Description" name="description">
+                                        <Input.TextArea
+                                            data-attr="experiment-description"
+                                            className="ph-ignore-input"
+                                            placeholder="Adding a helpful description can ensure others know what this experiment is about."
+                                        />
+                                    </Form.Item>
+                                    <Form.Item
+                                        label="Select participants"
+                                        name="person-selection"
+                                        className="person-selection"
+                                    >
+                                        <Col>
+                                            <div className="text-muted">
+                                                Select the entities who will participate in this experiment. We'll split
+                                                all participants evenly into a <b>control</b> and <b>test</b> group.{' '}
+                                            </div>
+                                            <div style={{ flex: 3, marginRight: 5 }}>
+                                                <PropertyFilters
+                                                    endpoint="person"
+                                                    pageKey={'EditFunnel-property'}
+                                                    propertyFilters={filters.properties || []}
+                                                    onChange={(anyProperties) => {
+                                                        setNewExperimentData({
+                                                            filters: {
+                                                                properties: anyProperties as PropertyFilter[],
+                                                            },
+                                                        })
+                                                        setFilters({
+                                                            properties: anyProperties.filter(isValidPropertyFilter),
+                                                        })
+                                                    }}
+                                                    style={{ margin: '1rem 0 0' }}
+                                                    taxonomicGroupTypes={[
+                                                        TaxonomicFilterGroupType.PersonProperties,
+                                                        TaxonomicFilterGroupType.CohortsWithAllUsers,
+                                                    ]}
+                                                    popoverPlacement="top"
+                                                    taxonomicPopoverPlacement="auto"
+                                                />
+                                            </div>
+                                        </Col>
+                                    </Form.Item>
+                                </Col>
+                                <Col span={12}>
+                                    <Card className="experiment-preview">
+                                        <Row className="preview-row">
                                             <Col>
-                                                <div className="text-muted">
-                                                    Select the entities who will participate in this experiment. We'll
-                                                    split all participants evenly into a <b>control</b> and{' '}
-                                                    <b>experiment</b> group.{' '}
+                                                <div className="card-secondary">Preview</div>
+                                                <div>
+                                                    <span className="mr-05">
+                                                        <b>{newExperimentData?.name}</b>
+                                                    </span>
+                                                    {newExperimentData?.feature_flag_key && (
+                                                        <CopyToClipboardInline
+                                                            explicitValue={newExperimentData.feature_flag_key}
+                                                            iconStyle={{ color: 'var(--text-muted-alt)' }}
+                                                            description="feature flag key"
+                                                        >
+                                                            <span className="text-muted">
+                                                                {newExperimentData.feature_flag_key}
+                                                            </span>
+                                                        </CopyToClipboardInline>
+                                                    )}
                                                 </div>
-                                                <div style={{ flex: 3, marginRight: 5 }}>
-                                                    <PropertyFilters
-                                                        endpoint="person"
-                                                        pageKey={'EditFunnel-property'}
-                                                        propertyFilters={filters.properties || []}
-                                                        onChange={(anyProperties) => {
+                                            </Col>
+                                        </Row>
+                                        <Row className="preview-row">
+                                            <Col span={12}>
+                                                <div className="card-secondary">Target Participant Count</div>
+                                                <div className="pb">
+                                                    <span className="l4">~{sampleSize}</span> persons
+                                                </div>
+                                                <div className="card-secondary">Baseline Conversion Rate</div>
+                                                <div className="l4">{conversionRate.toFixed(1)}%</div>
+                                            </Col>
+                                            <Col span={12}>
+                                                <div className="card-secondary">Target duration</div>
+                                                <div>
+                                                    <span className="l4">~{runningTime}</span> days
+                                                </div>
+                                            </Col>
+                                        </Row>
+                                        <Row className="preview-row">
+                                            <Col>
+                                                <div className="l4">
+                                                    Conversion goal threshold
+                                                    <Tooltip
+                                                        title={`The minimum % change in conversion rate you care about. 
+                                                This means you don't care about variants whose
+                                                conversion rate is between these two percentages.`}
+                                                    >
+                                                        <InfoCircleOutlined style={{ marginLeft: 4 }} />
+                                                    </Tooltip>
+                                                </div>
+                                                <div className="pb text-small text-muted">
+                                                    Apply a threshold to broaden the acceptable range of conversion
+                                                    rates for this experiment. The acceptable range will be the baseline
+                                                    conversion goal +/- the goal threshold.
+                                                </div>
+                                                <div>
+                                                    <span className="l4 pr">Threshold value</span>
+                                                    <Slider
+                                                        min={1}
+                                                        max={20}
+                                                        defaultValue={5}
+                                                        tipFormatter={(value) => `${value}%`}
+                                                        onChange={(value) =>
                                                             setNewExperimentData({
-                                                                filters: {
-                                                                    properties: anyProperties as PropertyFilter[],
-                                                                },
+                                                                parameters: { minimum_detectable_effect: value },
                                                             })
-                                                            setFilters({
-                                                                properties: anyProperties.filter(isValidPropertyFilter),
-                                                            })
-                                                        }}
-                                                        style={{ margin: '1rem 0 0' }}
-                                                        taxonomicGroupTypes={[
-                                                            TaxonomicFilterGroupType.PersonProperties,
-                                                            TaxonomicFilterGroupType.CohortsWithAllUsers,
-                                                        ]}
-                                                        popoverPlacement="top"
-                                                        taxonomicPopoverPlacement="auto"
+                                                        }
+                                                        marks={{ 5: `5%`, 10: `10%` }}
                                                     />
                                                 </div>
                                             </Col>
-                                        </Form.Item>
-                                    </Col>
-                                    <Col span={12}>
-                                        <Card className="experiment-preview">
-                                            <Row className="preview-row">
-                                                <Col>
-                                                    <div className="card-secondary">Preview</div>
-                                                    <div>
-                                                        <span className="mr-05">
-                                                            <b>{newExperimentData?.name}</b>
-                                                        </span>
-                                                        {newExperimentData?.feature_flag_key && (
-                                                            <CopyToClipboardInline
-                                                                explicitValue={newExperimentData.feature_flag_key}
-                                                                iconStyle={{ color: 'var(--text-muted-alt)' }}
-                                                                description="feature flag key"
-                                                            >
-                                                                <span className="text-muted">
-                                                                    {newExperimentData?.feature_flag_key}
-                                                                </span>
-                                                            </CopyToClipboardInline>
-                                                        )}
-                                                    </div>
-                                                </Col>
-                                            </Row>
-                                            <Row className="preview-row">
-                                                <Col span={12}>
-                                                    <div className="card-secondary">Target Participant Count</div>
-                                                    <div className="pb">
-                                                        <span className="l4">
-                                                            ~{recommendedSampleSize(conversionRate)}
-                                                        </span>{' '}
-                                                        persons
-                                                    </div>
-                                                    <div className="card-secondary">Baseline Conversion Rate</div>
-                                                    <div className="l4">{conversionRate.toFixed(1)}%</div>
-                                                </Col>
-                                                <Col span={12}>
-                                                    <div className="card-secondary">Target duration</div>
-                                                    <div>
-                                                        <span className="l4">
-                                                            ~
-                                                            {expectedRunningTime(
-                                                                entrants,
-                                                                recommendedSampleSize(conversionRate)
-                                                            )}
-                                                        </span>{' '}
-                                                        days
-                                                    </div>
-                                                </Col>
-                                            </Row>
-                                            <Row className="preview-row">
-                                                <Col>
-                                                    <div className="l4">
-                                                        Conversion goal threshold
-                                                        <Tooltip
-                                                            title={`The minimum % change in conversion rate you care about. 
-                                                    This means you don't care about variants whose
-                                                    conversion rate is between these two percentages.`}
-                                                        >
-                                                            <InfoCircleOutlined style={{ marginLeft: 4 }} />
-                                                        </Tooltip>
-                                                    </div>
-                                                    <div className="pb text-small text-muted">
-                                                        Apply a threshold to broaden the acceptable range of conversion
-                                                        rates for this experiment. The acceptable range will be the
-                                                        baseline conversion goal +/- the goal threshold.
-                                                    </div>
-                                                    <div>
-                                                        <span className="l4 pr">Threshold value</span>
-                                                        <InputNumber
-                                                            min={1}
-                                                            max={50}
-                                                            defaultValue={5}
-                                                            formatter={(value) => `${value}%`}
-                                                            onChange={(value) =>
-                                                                setNewExperimentData({
-                                                                    parameters: { minimum_detectable_effect: value },
-                                                                })
-                                                            }
-                                                        />
-                                                    </div>
-                                                </Col>
-                                            </Row>
-                                            <Row className="preview-row">
-                                                <Col>
-                                                    <div className="card-secondary mb-05">Conversion goal range</div>
-                                                    <div>
-                                                        <b>
-                                                            {Math.max(
-                                                                0,
-                                                                conversionRate - minimumDetectableChange
-                                                            ).toFixed()}
-                                                            % -{' '}
-                                                            {Math.min(
-                                                                100,
-                                                                conversionRate + minimumDetectableChange
-                                                            ).toFixed()}
-                                                            %
-                                                        </b>
-                                                    </div>
-                                                </Col>
-                                            </Row>
-                                        </Card>
-                                        <Collapse>
-                                            <Collapse.Panel
-                                                header={
-                                                    <div
-                                                        style={{
-                                                            display: 'flex',
-                                                            fontWeight: 'bold',
-                                                            alignItems: 'center',
-                                                        }}
-                                                    >
-                                                        <IconJavascript style={{ marginRight: 6 }} /> Javascript
-                                                        integration instructions
-                                                    </div>
-                                                }
-                                                key="js"
-                                            >
-                                                <JSSnippet
-                                                    variants={['control', 'test']}
-                                                    flagKey={newExperimentData?.feature_flag_key || ''}
-                                                />
-                                            </Collapse.Panel>
-                                        </Collapse>
-                                    </Col>
-                                </Row>
+                                        </Row>
+                                        <Row className="preview-row">
+                                            <Col>
+                                                <div className="card-secondary mb-05">Conversion goal range</div>
+                                                <div>
+                                                    <b>
+                                                        {Math.max(
+                                                            0,
+                                                            conversionRate - minimumDetectableChange
+                                                        ).toFixed()}
+                                                        % -{' '}
+                                                        {Math.min(
+                                                            100,
+                                                            conversionRate + minimumDetectableChange
+                                                        ).toFixed()}
+                                                        %
+                                                    </b>
+                                                </div>
+                                            </Col>
+                                        </Row>
+                                    </Card>
+                                    <Collapse>
+                                        <Collapse.Panel
+                                            header={
+                                                <div
+                                                    style={{
+                                                        display: 'flex',
+                                                        fontWeight: 'bold',
+                                                        alignItems: 'center',
+                                                    }}
+                                                >
+                                                    <IconJavascript style={{ marginRight: 6 }} /> Javascript integration
+                                                    instructions
+                                                </div>
+                                            }
+                                            key="js"
+                                        >
+                                            <JSSnippet
+                                                variants={['control', 'test']}
+                                                flagKey={newExperimentData?.feature_flag_key || ''}
+                                            />
+                                        </Collapse.Panel>
+                                    </Collapse>
+                                </Col>
+                            </Row>
 
-                                <div>
-                                    <Row className="metrics-selection">
-                                        <BindLogic logic={insightLogic} props={insightProps}>
-                                            <Row style={{ width: '100%' }}>
-                                                <Col span={8} style={{ paddingRight: 8 }}>
-                                                    <div className="l3 mb">Goal metric</div>
-                                                    <Row className="text-muted" style={{ marginBottom: '1rem' }}>
-                                                        Define the metric which you are trying to optimize. This is the
-                                                        most important part of your experiment.
-                                                    </Row>
-                                                    <Row>
-                                                        <Card
-                                                            className="action-filters-bordered"
-                                                            style={{ width: '100%', marginRight: 8 }}
-                                                            bodyStyle={{ padding: 0 }}
-                                                        >
-                                                            <ActionFilter
-                                                                filters={filters}
-                                                                setFilters={(actionFilters) => {
-                                                                    setNewExperimentData({ filters: actionFilters })
-                                                                    setFilters(actionFilters)
-                                                                }}
-                                                                typeKey={`EditFunnel-action`}
-                                                                hideMathSelector={true}
-                                                                hideDeleteBtn={filterSteps.length === 1}
-                                                                buttonCopy="Add funnel step"
-                                                                showSeriesIndicator={!isStepsEmpty}
-                                                                seriesIndicatorType="numeric"
-                                                                fullWidth
-                                                                sortable
-                                                                showNestedArrow={true}
-                                                                propertiesTaxonomicGroupTypes={[
-                                                                    TaxonomicFilterGroupType.EventProperties,
-                                                                    TaxonomicFilterGroupType.PersonProperties,
-                                                                    TaxonomicFilterGroupType.Cohorts,
-                                                                    TaxonomicFilterGroupType.Elements,
-                                                                ]}
-                                                                rowClassName="action-filters-bordered"
-                                                            />
-                                                        </Card>
-                                                    </Row>
-                                                </Col>
-                                                <Col span={16}>
-                                                    <InsightContainer disableTable={true} />
-                                                </Col>
-                                            </Row>
-                                        </BindLogic>
-                                    </Row>
-                                    <Button
-                                        icon={<SaveOutlined />}
-                                        className="float-right"
-                                        type="primary"
-                                        htmlType="submit"
-                                    >
-                                        Save
-                                    </Button>
-                                </div>
+                            <div>
+                                <Row className="metrics-selection">
+                                    <BindLogic logic={insightLogic} props={insightProps}>
+                                        <Row style={{ width: '100%' }}>
+                                            <Col span={8} style={{ paddingRight: 8 }}>
+                                                <div className="l3 mb">Goal metric</div>
+                                                <Row className="text-muted" style={{ marginBottom: '1rem' }}>
+                                                    Define the metric which you are trying to optimize. This is the most
+                                                    important part of your experiment.
+                                                </Row>
+                                                <Row>
+                                                    <Card
+                                                        className="action-filters-bordered"
+                                                        style={{ width: '100%', marginRight: 8 }}
+                                                        bodyStyle={{ padding: 0 }}
+                                                    >
+                                                        <ActionFilter
+                                                            filters={filters}
+                                                            setFilters={(actionFilters) => {
+                                                                setNewExperimentData({ filters: actionFilters })
+                                                                setFilters(actionFilters)
+                                                            }}
+                                                            typeKey={`EditFunnel-action`}
+                                                            hideMathSelector={true}
+                                                            hideDeleteBtn={filterSteps.length === 1}
+                                                            buttonCopy="Add funnel step"
+                                                            showSeriesIndicator={!isStepsEmpty}
+                                                            seriesIndicatorType="numeric"
+                                                            fullWidth
+                                                            sortable
+                                                            showNestedArrow={true}
+                                                            propertiesTaxonomicGroupTypes={[
+                                                                TaxonomicFilterGroupType.EventProperties,
+                                                                TaxonomicFilterGroupType.PersonProperties,
+                                                                TaxonomicFilterGroupType.Cohorts,
+                                                                TaxonomicFilterGroupType.Elements,
+                                                            ]}
+                                                            rowClassName="action-filters-bordered"
+                                                        />
+                                                    </Card>
+                                                </Row>
+                                            </Col>
+                                            <Col span={16}>
+                                                <InsightContainer disableTable={true} />
+                                            </Col>
+                                        </Row>
+                                    </BindLogic>
+                                </Row>
+                                <Button
+                                    icon={<SaveOutlined />}
+                                    className="float-right"
+                                    type="primary"
+                                    htmlType="submit"
+                                >
+                                    Save
+                                </Button>
                             </div>
-                        )}
+                        </div>
                     </Form>
                 </>
+            ) : !experimentData?.start_date ? (
+                <div className="confirmation">
+                    {newExperimentData?.description && <Row>Description: {newExperimentData?.description}</Row>}
+                    <Row className="mt">
+                        <Col span={10}>
+                            <Row>
+                                Feature flag key: <b>{newExperimentData?.feature_flag_key}</b>
+                            </Row>
+                            <Row>Variants: 'control' and 'test'</Row>
+                            <Row>The following users will participate in the experiment</Row>
+                            <ul>
+                                {newExperimentData?.filters?.properties?.length ? (
+                                    newExperimentData.filters.properties.map(
+                                        (property: PropertyFilter, idx: number) => (
+                                            <li key={idx}>
+                                                Users with {property.key} {property.operator}{' '}
+                                                {Array.isArray(property.value)
+                                                    ? property.value.map((val) => `${val}, `)
+                                                    : property.value}
+                                            </li>
+                                        )
+                                    )
+                                ) : (
+                                    <li key={'all users'}>All users</li>
+                                )}
+                            </ul>
+                            <Row>Experiment parameters:</Row>
+                            <Row>
+                                <ul>
+                                    <li>
+                                        Recommended running time: ~
+                                        {newExperimentData?.parameters?.recommended_running_time} days
+                                    </li>
+                                    <li>
+                                        Recommended sample size: ~
+                                        {newExperimentData?.parameters?.recommended_sample_size} people
+                                    </li>
+                                </ul>
+                            </Row>
+                        </Col>
+                        <Col span={14}>
+                            <div>
+                                Test that your code works properly for each variant:{' '}
+                                <a href="https://posthog.com/docs/user-guides/feature-flags#develop-locally">
+                                    {' '}
+                                    Follow this guide.{' '}
+                                </a>
+                                <div>
+                                    For your Feature Flag, the override code looks like:
+                                    {['control', 'test'].map((variant) => (
+                                        <div key={variant}>
+                                            {' '}
+                                            {variant}:
+                                            <CodeSnippet language={Language.JavaScript}>
+                                                {`posthog.feature_flags.override({'${newExperimentData?.feature_flag_key}': '${variant}'})`}
+                                            </CodeSnippet>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                            <div>Warning: Remember to not change this code until the experiment ends</div>
+                        </Col>
+                    </Row>
+                    <Row justify="space-between">
+                        <Button type="primary" onClick={() => launchExperiment()}>
+                            Launch
+                        </Button>
+                    </Row>
+                </div>
             ) : experimentData ? (
                 <div className="experiment-result">
                     {experimentData.end_date && <Alert type="info" message="This experiment has ended" />}
@@ -353,6 +411,7 @@ export function Experiment(): JSX.Element {
                         <div>{experimentData?.description}</div>
                         <div>Owner: {experimentData.created_by?.first_name}</div>
                         <div>Feature flag key: {experimentData?.feature_flag_key}</div>
+                        <div>Experiment start date: {dayjs(experimentData.start_date).format('D MMM YYYY')}</div>
                     </div>
 
                     {experimentResults && (
@@ -373,10 +432,20 @@ export function Experiment(): JSX.Element {
                         >
                             <div>
                                 <PageHeader title="Results" />
-                                <div>Probability: {experimentResults?.probability}</div>
+                                <div>
+                                    Probability that test has higher conversion than control:{' '}
+                                    <b>{(experimentResults?.probability * 100).toFixed(1)}%</b>
+                                </div>
                                 {experimentResults.funnel.length === 0 && (
                                     <div className="l4">There were no events related to this experiment.</div>
                                 )}
+
+                                <div>
+                                    Test variant conversion rate: <b>{conversionRateForVariant('test')}</b>
+                                </div>
+                                <div>
+                                    Control variant conversion rate: <b>{conversionRateForVariant('control')}</b>
+                                </div>
                                 <InsightContainer disableTable={true} />
                             </div>
                         </BindLogic>

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1,5 +1,5 @@
 import SaveOutlined from '@ant-design/icons/lib/icons/SaveOutlined'
-import { Alert, Button, Card, Col, Collapse, Form, Input, Row, Slider, Tooltip } from 'antd'
+import { Alert, Button, Card, Col, Collapse, Form, Input, InputNumber, Row, Tooltip } from 'antd'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PropertyFilters } from 'lib/components/PropertyFilters'
@@ -19,6 +19,7 @@ import { IconJavascript } from 'lib/components/icons'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import dayjs from 'dayjs'
 import { LemonButton } from 'lib/components/LemonButton'
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 
 export const scene: SceneExport = {
     component: Experiment,
@@ -31,7 +32,7 @@ export function Experiment(): JSX.Element {
         experimentId,
         experimentData,
         experimentFunnelId,
-        minimimumDetectableChange,
+        minimumDetectableChange,
         recommendedSampleSize,
         expectedRunningTime,
         newExperimentCurrentPage,
@@ -62,7 +63,7 @@ export function Experiment(): JSX.Element {
                         justify="space-between"
                         style={{ borderBottom: '1px solid var(--border)', marginBottom: '1rem', paddingBottom: 8 }}
                     >
-                        <PageHeader title={newExperimentData?.name || 'New Experiment'} />
+                        <PageHeader title={'New Experiment'} />
                         <Button
                             style={{ color: 'var(--primary)', borderColor: 'var(--primary)' }}
                             onClick={() => createExperiment(true)}
@@ -85,212 +86,262 @@ export function Experiment(): JSX.Element {
                             setNewExperimentData(values)
                             nextPage()
                         }}
+                        scrollToFirstError
                     >
                         {newExperimentCurrentPage === 0 && (
                             <div>
-                                <Form.Item
-                                    label="Name"
-                                    name="name"
-                                    rules={[{ required: true, message: 'You have to enter a name.' }]}
-                                >
-                                    <Input data-attr="experiment-name" className="ph-ignore-input" />
-                                </Form.Item>
-                                <Form.Item
-                                    label="Feature flag key"
-                                    name="feature_flag_key"
-                                    rules={[{ required: true, message: 'You have to enter a feature flag key.' }]}
-                                >
-                                    <Input data-attr="experiment-feature-flag-key" />
-                                </Form.Item>
-                                <Form.Item label="Description" name="description">
-                                    <Input.TextArea
-                                        data-attr="experiment-description"
-                                        className="ph-ignore-input"
-                                        placeholder="Adding a helpful description can ensure others know what this experiment is about."
-                                    />
-                                </Form.Item>
-                                <Button icon={<SaveOutlined />} type="primary" htmlType="submit">
-                                    Save and continue
-                                </Button>
+                                <Row>
+                                    <Col span={12} style={{ paddingRight: 24 }}>
+                                        <Form.Item
+                                            label="Name"
+                                            name="name"
+                                            rules={[{ required: true, message: 'You have to enter a name.' }]}
+                                        >
+                                            <Input data-attr="experiment-name" className="ph-ignore-input" />
+                                        </Form.Item>
+                                        <span className="text-small text-muted">
+                                            We are creating a new feature flag here that is unique to the experiment
+                                        </span>
+                                        <Form.Item
+                                            label="Feature flag key"
+                                            name="feature_flag_key"
+                                            rules={[
+                                                {
+                                                    required: true,
+                                                    message: 'You have to create a new feature flag key.',
+                                                },
+                                            ]}
+                                        >
+                                            <Input
+                                                data-attr="experiment-feature-flag-key"
+                                                placeholder="examples: new-landing-page-experiment, betaFeatureExperiment, ab_test_1_experiment"
+                                            />
+                                        </Form.Item>
+                                        <Form.Item label="Description" name="description">
+                                            <Input.TextArea
+                                                data-attr="experiment-description"
+                                                className="ph-ignore-input"
+                                                placeholder="Adding a helpful description can ensure others know what this experiment is about."
+                                            />
+                                        </Form.Item>
+                                    </Col>
+                                    <Col span={12}>
+                                        <Card className="experiment-preview">
+                                            <Row className="preview-row">
+                                                <Col>
+                                                    <div className="card-secondary">Preview</div>
+                                                    <div>
+                                                        <span className="mr-05">
+                                                            <b>{newExperimentData?.name}</b>
+                                                        </span>
+                                                        {newExperimentData?.feature_flag_key && (
+                                                            <CopyToClipboardInline
+                                                                explicitValue={newExperimentData.feature_flag_key}
+                                                                iconStyle={{ color: 'var(--text-muted-alt)' }}
+                                                                description="feature flag key"
+                                                            >
+                                                                <span className="text-muted">
+                                                                    {newExperimentData?.feature_flag_key}
+                                                                </span>
+                                                            </CopyToClipboardInline>
+                                                        )}
+                                                    </div>
+                                                </Col>
+                                            </Row>
+                                            <Row className="preview-row">
+                                                <Col span={12}>
+                                                    <div className="card-secondary">Target Participant Count</div>
+                                                    <div className="pb">
+                                                        <span className="l4">
+                                                            ~{recommendedSampleSize(conversionRate)}
+                                                        </span>{' '}
+                                                        persons
+                                                    </div>
+                                                    <div className="card-secondary">Baseline Conversion Rate</div>
+                                                    <div className="l4">{conversionRate.toFixed(1)}%</div>
+                                                </Col>
+                                                <Col span={12}>
+                                                    <div className="card-secondary">Target duration</div>
+                                                    <div>
+                                                        <span className="l4">
+                                                            ~
+                                                            {expectedRunningTime(
+                                                                entrants,
+                                                                recommendedSampleSize(conversionRate)
+                                                            )}
+                                                        </span>{' '}
+                                                        days
+                                                    </div>
+                                                </Col>
+                                            </Row>
+                                            <Row className="preview-row">
+                                                <Col>
+                                                    <div className="l4">
+                                                        Conversion goal threshold
+                                                        <Tooltip
+                                                            title={`The minimum % change in conversion rate you care about. 
+                                                    This means you don't care about variants whose
+                                                    conversion rate is between these two percentages.`}
+                                                        >
+                                                            <InfoCircleOutlined style={{ marginLeft: 4 }} />
+                                                        </Tooltip>
+                                                    </div>
+                                                    <div className="pb text-small text-muted">
+                                                        Apply a threshold to broaden the acceptable range of conversion
+                                                        rates for this experiment. The acceptable range will be the
+                                                        baseline conversion goal +/- the goal threshold.
+                                                    </div>
+                                                    <div>
+                                                        <span className="l4 pr">Threshold value</span>
+                                                        <InputNumber
+                                                            min={1}
+                                                            max={50}
+                                                            defaultValue={5}
+                                                            formatter={(value) => `${value}%`}
+                                                            onChange={(value) =>
+                                                                setNewExperimentData({
+                                                                    parameters: { minimum_detectable_effect: value },
+                                                                })
+                                                            }
+                                                        />
+                                                    </div>
+                                                </Col>
+                                            </Row>
+                                            <Row className="preview-row">
+                                                <Col>
+                                                    <div className="card-secondary mb-05">Conversion goal range</div>
+                                                    <div>
+                                                        <b>
+                                                            {Math.max(
+                                                                0,
+                                                                conversionRate - minimumDetectableChange
+                                                            ).toFixed()}
+                                                            % -{' '}
+                                                            {Math.min(
+                                                                100,
+                                                                conversionRate + minimumDetectableChange
+                                                            ).toFixed()}
+                                                            %
+                                                        </b>
+                                                    </div>
+                                                </Col>
+                                            </Row>
+                                        </Card>
+                                        <Collapse>
+                                            <Collapse.Panel
+                                                header={
+                                                    <div
+                                                        style={{
+                                                            display: 'flex',
+                                                            fontWeight: 'bold',
+                                                            alignItems: 'center',
+                                                        }}
+                                                    >
+                                                        <IconJavascript style={{ marginRight: 6 }} /> Javascript
+                                                        integration instructions
+                                                    </div>
+                                                }
+                                                key="js"
+                                            >
+                                                <JSSnippet
+                                                    variants={['control', 'test']}
+                                                    flagKey={newExperimentData?.feature_flag_key || ''}
+                                                />
+                                            </Collapse.Panel>
+                                        </Collapse>
+                                    </Col>
+                                </Row>
+
+                                <div>
+                                    <Row className="person-selection">
+                                        <Col>
+                                            <div className="l3 mb">Person selection</div>
+                                            <div className="text-muted">
+                                                Select the persons who will participate in this experiment. We'll split
+                                                all persons evenly in a control and experiment group.
+                                            </div>
+                                            <div style={{ flex: 3, marginRight: 5 }}>
+                                                <PropertyFilters
+                                                    endpoint="person"
+                                                    pageKey={'EditFunnel-property'}
+                                                    propertyFilters={filters.properties || []}
+                                                    onChange={(anyProperties) => {
+                                                        setNewExperimentData({
+                                                            filters: { properties: anyProperties as PropertyFilter[] },
+                                                        })
+                                                        setFilters({
+                                                            properties: anyProperties.filter(isValidPropertyFilter),
+                                                        })
+                                                    }}
+                                                    style={{ margin: '1rem 0 0' }}
+                                                    taxonomicGroupTypes={[
+                                                        TaxonomicFilterGroupType.PersonProperties,
+                                                        TaxonomicFilterGroupType.CohortsWithAllUsers,
+                                                    ]}
+                                                    popoverPlacement="top"
+                                                    taxonomicPopoverPlacement="auto"
+                                                />
+                                            </div>
+                                        </Col>
+                                    </Row>
+                                    <Row className="metrics-selection">
+                                        <BindLogic logic={insightLogic} props={insightProps}>
+                                            <Row style={{ width: '100%' }}>
+                                                <Col span={8} style={{ paddingRight: 8 }}>
+                                                    <div className="l3 mb">Goal metric</div>
+                                                    <Row className="text-muted" style={{ marginBottom: '1rem' }}>
+                                                        Define the metric which you are trying to optimize. This is the
+                                                        most important part of your experiment.
+                                                    </Row>
+                                                    <Row>
+                                                        <Card
+                                                            className="action-filters-bordered"
+                                                            style={{ width: '100%', marginRight: 8 }}
+                                                            bodyStyle={{ padding: 0 }}
+                                                        >
+                                                            <ActionFilter
+                                                                filters={filters}
+                                                                setFilters={(actionFilters) => {
+                                                                    setNewExperimentData({ filters: actionFilters })
+                                                                    setFilters(actionFilters)
+                                                                }}
+                                                                typeKey={`EditFunnel-action`}
+                                                                hideMathSelector={true}
+                                                                hideDeleteBtn={filterSteps.length === 1}
+                                                                buttonCopy="Add funnel step"
+                                                                showSeriesIndicator={!isStepsEmpty}
+                                                                seriesIndicatorType="numeric"
+                                                                fullWidth
+                                                                sortable
+                                                                showNestedArrow={true}
+                                                                propertiesTaxonomicGroupTypes={[
+                                                                    TaxonomicFilterGroupType.EventProperties,
+                                                                    TaxonomicFilterGroupType.PersonProperties,
+                                                                    TaxonomicFilterGroupType.Cohorts,
+                                                                    TaxonomicFilterGroupType.Elements,
+                                                                ]}
+                                                                rowClassName="action-filters-bordered"
+                                                            />
+                                                        </Card>
+                                                    </Row>
+                                                </Col>
+                                                <Col span={16}>
+                                                    <InsightContainer disableTable={true} />
+                                                </Col>
+                                            </Row>
+                                        </BindLogic>
+                                    </Row>
+                                    <Row justify="space-between">
+                                        <Button onClick={prevPage}>Go back</Button>
+                                        <Button icon={<SaveOutlined />} type="primary" htmlType="submit">
+                                            Save and preview
+                                        </Button>
+                                    </Row>
+                                </div>
                             </div>
                         )}
 
                         {newExperimentCurrentPage === 1 && (
-                            <div>
-                                <Row className="person-selection">
-                                    <Col>
-                                        <div className="l3 mb">Person selection</div>
-                                        <div className="text-muted">
-                                            Select the persons who will participate in this experiment. We'll split all
-                                            persons evenly in a control and experiment group.
-                                        </div>
-                                        <div style={{ flex: 3, marginRight: 5 }}>
-                                            <PropertyFilters
-                                                endpoint="person"
-                                                pageKey={'EditFunnel-property'}
-                                                propertyFilters={filters.properties || []}
-                                                onChange={(anyProperties) => {
-                                                    setNewExperimentData({
-                                                        filters: { properties: anyProperties as PropertyFilter[] },
-                                                    })
-                                                    setFilters({
-                                                        properties: anyProperties.filter(isValidPropertyFilter),
-                                                    })
-                                                }}
-                                                style={{ margin: '1rem 0 0' }}
-                                                taxonomicGroupTypes={[
-                                                    TaxonomicFilterGroupType.PersonProperties,
-                                                    TaxonomicFilterGroupType.CohortsWithAllUsers,
-                                                ]}
-                                                popoverPlacement="top"
-                                                taxonomicPopoverPlacement="auto"
-                                            />
-                                        </div>
-                                    </Col>
-                                </Row>
-                                <Row className="metrics-selection">
-                                    <BindLogic logic={insightLogic} props={insightProps}>
-                                        <Row style={{ width: '100%' }}>
-                                            <Col span={8} style={{ paddingRight: 8 }}>
-                                                <div className="l3 mb">Goal metric</div>
-                                                <Row className="text-muted" style={{ marginBottom: '1rem' }}>
-                                                    Define the metric which you are trying to optimize. This is the most
-                                                    important part of your experiment.
-                                                </Row>
-                                                <Row>
-                                                    <Card
-                                                        className="action-filters-bordered"
-                                                        style={{ width: '100%', marginRight: 8 }}
-                                                        bodyStyle={{ padding: 0 }}
-                                                    >
-                                                        <ActionFilter
-                                                            filters={filters}
-                                                            setFilters={(actionFilters) => {
-                                                                setNewExperimentData({ filters: actionFilters })
-                                                                setFilters(actionFilters)
-                                                            }}
-                                                            typeKey={`EditFunnel-action`}
-                                                            hideMathSelector={true}
-                                                            hideDeleteBtn={filterSteps.length === 1}
-                                                            buttonCopy="Add funnel step"
-                                                            showSeriesIndicator={!isStepsEmpty}
-                                                            seriesIndicatorType="numeric"
-                                                            fullWidth
-                                                            sortable
-                                                            showNestedArrow={true}
-                                                            propertiesTaxonomicGroupTypes={[
-                                                                TaxonomicFilterGroupType.EventProperties,
-                                                                TaxonomicFilterGroupType.PersonProperties,
-                                                                TaxonomicFilterGroupType.Cohorts,
-                                                                TaxonomicFilterGroupType.Elements,
-                                                            ]}
-                                                            rowClassName="action-filters-bordered"
-                                                        />
-                                                    </Card>
-                                                </Row>
-                                            </Col>
-                                            <Col span={16}>
-                                                <InsightContainer disableTable={true} />
-                                            </Col>
-                                        </Row>
-                                    </BindLogic>
-                                </Row>
-                                <Row className="mde-selection">
-                                    <Row style={{ width: '100%', marginBottom: 8 }} align="middle" justify="center">
-                                        <Row
-                                            style={{ width: '100%', fontWeight: 500, fontSize: 16 }}
-                                            className="text-muted"
-                                            justify="center"
-                                        >
-                                            Estimates for how long your experiment should run.
-                                        </Row>
-                                        <Col span={8}>
-                                            <Slider
-                                                defaultValue={5}
-                                                min={1}
-                                                max={50}
-                                                trackStyle={{ background: 'black' }}
-                                                onChange={(value) => {
-                                                    setNewExperimentData({
-                                                        parameters: { minimum_detectable_effect: value },
-                                                    })
-                                                }}
-                                                tipFormatter={(value) => `${value}%`}
-                                                marks={
-                                                    Math.floor(conversionRate) > 0
-                                                        ? {
-                                                              [Math.floor(conversionRate)]: `${Math.floor(
-                                                                  conversionRate
-                                                              )}%`,
-                                                              5: `5%`,
-                                                              10: `10%`,
-                                                          }
-                                                        : { 5: `5%`, 10: `10%` }
-                                                }
-                                            />
-                                        </Col>
-                                    </Row>
-                                    <Row style={{ width: '100%' }} justify="center" className="estimates">
-                                        <div style={{ paddingRight: 16, fontWeight: 600, fontSize: 18 }}>
-                                            <div className="text-center">{conversionRate.toFixed(1)}%</div>
-                                            <div className="estimate">Baseline conversion rate</div>
-                                        </div>
-                                        <div
-                                            style={{
-                                                paddingLeft: 16,
-                                                paddingRight: 16,
-                                                borderLeft: '1px solid var(--border)',
-                                                borderRight: '1px solid var(--border)',
-                                                fontWeight: 600,
-                                                fontSize: 18,
-                                            }}
-                                        >
-                                            <div className="text-center">
-                                                {Math.max(0, conversionRate - minimimumDetectableChange).toFixed()}% -{' '}
-                                                {Math.min(100, conversionRate + minimimumDetectableChange).toFixed()}%
-                                            </div>
-                                            <div className="estimate text-center">
-                                                Threshold of caring
-                                                <Tooltip
-                                                    title={`The minimum % change in conversion rate you care about. 
-                                                    This means you don't care about variants whose
-                                                    conversion rate is between these two percentages.`}
-                                                >
-                                                    <InfoCircleOutlined style={{ marginLeft: 4 }} />
-                                                </Tooltip>
-                                            </div>
-                                        </div>
-                                        <div
-                                            style={{
-                                                paddingLeft: 16,
-                                                paddingRight: 16,
-                                                borderLeft: '1px solid var(--border)',
-                                                borderRight: '1px solid var(--border)',
-                                                fontWeight: 600,
-                                                fontSize: 18,
-                                            }}
-                                        >
-                                            <div className="text-center">~{recommendedSampleSize(conversionRate)}</div>
-                                            <div className="estimate">Recommended # of people</div>
-                                        </div>
-                                        <div style={{ paddingLeft: 16, fontWeight: 600, fontSize: 18 }}>
-                                            <div className="text-center">
-                                                ~{expectedRunningTime(entrants, recommendedSampleSize(conversionRate))}
-                                            </div>
-                                            <div className="estimate">Recommended days</div>
-                                        </div>
-                                    </Row>
-                                </Row>
-                                <Row justify="space-between">
-                                    <Button onClick={prevPage}>Go back</Button>
-                                    <Button icon={<SaveOutlined />} type="primary" onClick={nextPage}>
-                                        Save and preview
-                                    </Button>
-                                </Row>
-                            </div>
-                        )}
-
-                        {newExperimentCurrentPage === 2 && (
                             <div className="confirmation">
                                 {newExperimentData?.description && (
                                     <Row>Description: {newExperimentData?.description}</Row>
@@ -317,16 +368,10 @@ export function Experiment(): JSX.Element {
                                                 }
                                                 key="js"
                                             >
-                                                <Form.Item
-                                                    shouldUpdate={(prevValues, currentValues) =>
-                                                        prevValues.key !== currentValues.key
-                                                    }
-                                                >
-                                                    <JSSnippet
-                                                        variants={['control', 'test']}
-                                                        flagKey={newExperimentData?.feature_flag_key || ''}
-                                                    />
-                                                </Form.Item>
+                                                <JSSnippet
+                                                    variants={['control', 'test']}
+                                                    flagKey={newExperimentData?.feature_flag_key || ''}
+                                                />
                                             </Collapse.Panel>
                                         </Collapse>
                                     </Col>

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -17,7 +17,6 @@ import { InsightContainer } from 'scenes/insights/InsightContainer'
 import { JSSnippet } from 'scenes/feature-flags/FeatureFlagSnippets'
 import { IconJavascript } from 'lib/components/icons'
 import { InfoCircleOutlined } from '@ant-design/icons'
-import dayjs from 'dayjs'
 import { LemonButton } from 'lib/components/LemonButton'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 
@@ -55,7 +54,7 @@ export function Experiment(): JSX.Element {
 
     return (
         <>
-            {experimentId === 'new' || !experimentData?.start_date ? (
+            {experimentId === 'new' || (experimentData && !experimentData.start_date) ? (
                 <>
                     <Row
                         align="middle"
@@ -374,15 +373,16 @@ export function Experiment(): JSX.Element {
                         >
                             <div>
                                 <PageHeader title="Results" />
-                                <div>Probability: {experimentResults.probability}</div>
+                                <div>Probability: {experimentResults?.probability}</div>
+                                {experimentResults.funnel.length === 0 && (
+                                    <div className="l4">There were no events related to this experiment.</div>
+                                )}
                                 <InsightContainer disableTable={true} />
                             </div>
                         </BindLogic>
                     )}
-                    {!experimentData.end_date ? (
+                    {!experimentData.end_date && (
                         <LemonButton onClick={() => endExperiment()}>End experiment</LemonButton>
-                    ) : (
-                        <div>Experiment ended {dayjs(experimentData.end_date)}</div>
                     )}
                 </div>
             ) : (

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -46,7 +46,7 @@ describe('experimentLogic', () => {
             logic.actions.setNewExperimentData({ parameters: { minimum_detectable_effect: 10 } })
 
             await expectLogic(logic).toMatchValues({
-                minimimumDetectableChange: 10,
+                minimumDetectableChange: 10,
             })
 
             expect(logic.values.recommendedSampleSize(20)).toEqual(512)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -132,7 +132,8 @@ export const experimentLogic = kea<experimentLogicType>({
                 return
             }
 
-            if (response && response.id) {
+            if (response?.id) {
+                const experimentId = response.id
                 toast.success(
                     <div data-attr="success-toast">
                         <h1>Experiment {isUpdate ? 'updated' : 'created'} successfully!</h1>
@@ -140,11 +141,11 @@ export const experimentLogic = kea<experimentLogicType>({
                     </div>,
                     {
                         onClick: () => {
-                            router.actions.push(urls.experiment(response.id))
+                            router.actions.push(urls.experiment(experimentId))
                         },
                         closeOnClick: true,
                         onClose: () => {
-                            router.actions.push(urls.experiment(response.id))
+                            router.actions.push(urls.experiment(experimentId))
                         },
                     }
                 )
@@ -209,13 +210,14 @@ export const experimentLogic = kea<experimentLogicType>({
             }
         },
         launchExperiment: async () => {
-            const response: Experiment = api.update(
+            const response: Experiment = await api.update(
                 `api/projects/${values.currentTeamId}/experiments/${values.experimentId}`,
                 {
                     start_date: dayjs(),
                 }
             )
-            actions.loadExperimentSuccess(response)
+            actions.setExperimentId(response.id || 'new')
+            actions.loadExperiment()
         },
         endExperiment: async () => {
             await api.update(`api/projects/${values.currentTeamId}/experiments/${values.experimentId}`, {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -22,6 +22,7 @@ import {
 import { experimentLogicType } from './experimentLogicType'
 import { router } from 'kea-router'
 import { experimentsLogic } from './experimentsLogic'
+import { FunnelLayout } from 'lib/constants'
 
 const DEFAULT_DURATION = 14 // days
 
@@ -132,6 +133,7 @@ export const experimentLogic = kea<experimentLogicType>({
                     funnel_viz_type: FunnelVizType.Steps,
                     date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
                     date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                    layout: FunnelLayout.horizontal,
                     ...filters,
                 }),
                 result: null,
@@ -167,7 +169,6 @@ export const experimentLogic = kea<experimentLogicType>({
             if (!experimentData?.start_date) {
                 // loading a draft mode experiment
                 actions.createNewExperimentFunnel(experimentData?.filters)
-                actions.setPage(2)
                 actions.setNewExperimentData({ ...experimentData })
             }
         },
@@ -207,14 +208,14 @@ export const experimentLogic = kea<experimentLogicType>({
                 },
             ],
         ],
-        minimimumDetectableChange: [
+        minimumDetectableChange: [
             (s) => [s.newExperimentData],
             (newExperimentData): number => {
                 return newExperimentData?.parameters?.minimum_detectable_effect || 5
             },
         ],
         recommendedSampleSize: [
-            (s) => [s.minimimumDetectableChange],
+            (s) => [s.minimumDetectableChange],
             (mde) => (conversionRate: number) => {
                 // Using the rule of thumb: 16 * sigma^2 / (mde^2)
                 // refer https://en.wikipedia.org/wiki/Sample_size_determination with default beta and alpha

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -10,11 +10,13 @@ export function JSSnippet({ flagKey, variants }: { flagKey: string; variants?: s
     return (
         <>
             {!!variants?.length ? (
-                <CodeSnippet language={Language.JavaScript} wrap>
-                    {`if (posthog.getFeatureFlag('${flagKey ?? ''}') === '${variants[0]}') {
-    // where '${variants[0]}' is the variant, run your code here
+                variants.map((variant, index) => (
+                    <CodeSnippet key={index} language={Language.JavaScript} wrap>
+                        {`if (posthog.getFeatureFlag('${flagKey ?? ''}') === '${variant}') {
+    // where '${variant}' is the variant, run your code here
 }`}
-                </CodeSnippet>
+                    </CodeSnippet>
+                ))
             ) : (
                 <CodeSnippet language={Language.JavaScript} wrap>
                     {`if (posthog.isFeatureEnabled('${flagKey ?? ''}')) {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -185,6 +185,14 @@ body strong {
     background: none;
 }
 
+.card-secondary {
+    font-size: 11px;
+    color: $text_muted;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
 mark {
     background-color: $mark_color !important;
     border-radius: $radius;


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

- clean up creation page so it's single form
- add preview box
- default funnel insight to vertical view 
- previously, the result page was blanking out on results that had empty data/events. Now we are making the error more explicit on the frontend so the user can see what's happening 

<img width="988" alt="Screen Shot 2021-12-15 at 7 12 20 PM" src="https://user-images.githubusercontent.com/25164963/146284588-bce1891b-2998-43b0-8730-c55ccc6d8d39.png">
<img width="995" alt="Screen Shot 2021-12-15 at 7 12 35 PM" src="https://user-images.githubusercontent.com/25164963/146284608-1f164a64-bcbc-4090-a6b5-523a4b886cc3.png">
<img width="961" alt="Screen Shot 2021-12-15 at 11 41 43 PM" src="https://user-images.githubusercontent.com/25164963/146309707-63a38174-6bba-4511-b96f-323e8b76d9c9.png">


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
