### PR TITLE
Better event position

### DIFF
--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
@@ -213,9 +213,9 @@ describe('sessionRecordingLogic', () => {
 
         expected_events.push({
             ...events[2],
-            playerTime: 39998,
+            playerTime: 38998,
             playerPosition: {
-                time: 40000,
+                time: 39000,
                 windowId: events[2].properties.$window_id as string,
             },
             percentageOfRecordingDuration: 1.46755585429964,

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
@@ -218,7 +218,7 @@ describe('sessionRecordingLogic', () => {
                 time: 39000,
                 windowId: events[2].properties.$window_id as string,
             },
-            percentageOfRecordingDuration: 1.46755585429964,
+            percentageOfRecordingDuration: 1.4308651234056042,
         })
 
         it('load events after metadata with 1min buffer', async () => {

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -307,11 +307,20 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
                 const eventsWithPlayerData: RecordingEventType[] = []
                 const events = response.results ?? []
                 events.forEach((event: EventType) => {
-                    const eventPlayerPosition = getPlayerPositionFromEpochTime(
-                        +dayjs(event.timestamp),
+                    // Try to place the event 1 second before it happens, so the user actually sees it happen after clicking on it
+                    let eventPlayerPosition = getPlayerPositionFromEpochTime(
+                        +dayjs(event.timestamp) - 1000,
                         event.properties?.$window_id ?? '', // If there is no window_id on the event to match the recording metadata
                         values.sessionPlayerData?.metadata?.startAndEndTimesByWindowId
                     )
+                    // If 1 seconds before the event is before the start of the recording, then use the actual timestamp
+                    if (eventPlayerPosition === null) {
+                        eventPlayerPosition = getPlayerPositionFromEpochTime(
+                            +dayjs(event.timestamp),
+                            event.properties?.$window_id ?? '', // If there is no window_id on the event to match the recording metadata
+                            values.sessionPlayerData?.metadata?.startAndEndTimesByWindowId
+                        )
+                    }
                     if (eventPlayerPosition !== null) {
                         const eventPlayerTime = getPlayerTimeFromPlayerPosition(
                             eventPlayerPosition,


### PR DESCRIPTION
## Changes

When you clicked an event in the recordings player, it was weird because you didn't actually see the thing you clicked on. Instead you saw the seconds right after the event. This PR moves events back 1 second, so you see the thing you're expecting.

## How did you test this code?

Adjusted test to reflect the new behavior. Manually tried it out by clicking events + seeing that they now move to right before the actual event.
