### PR TITLE
refactor(clickhouse): add and use helper render_query not sub_params

### DIFF
--- a/ee/clickhouse/client.py
+++ b/ee/clickhouse/client.py
@@ -180,7 +180,7 @@ else:
                     save_query(prepared_sql, execution_time)
         return result
 
-    def _substitute_params(query, params):
+    def _substitute_params(query: str, params: QueryArgs):
         """
         Helper method to ease rendering of sql clickhouse queries progressively.
         For example, there are many places where we construct queries to be used
@@ -197,11 +197,7 @@ else:
         """
         return cast(SyncClient, ch_client).substitute_params(query, params)
 
-    def render_query(
-        query_template: str,
-        params: Optional[Dict[str, Union[int, float, str, List, Tuple]]] = None,
-        fragments: Optional[Dict[str, str]] = None,
-    ) -> str:
+    def render_query(query_template: str, params: QueryArgs = None, fragments: Optional[Dict[str, str]] = None,) -> str:
         """
         Given a SQL template that can use both printf style interpolation
         (%-formatting) and format string syntax. These serve separate purposes:

--- a/ee/clickhouse/queries/person_distinct_id_query.py
+++ b/ee/clickhouse/queries/person_distinct_id_query.py
@@ -4,9 +4,9 @@ from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS, GET_TEAM_PERS
 
 
 def get_team_distinct_ids_query(team_id: int) -> str:
-    from ee.clickhouse.client import substitute_params
+    from ee.clickhouse.client import render_query
 
     if str(team_id) in settings.PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS:
-        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE, {"team_id": team_id})
+        return render_query(GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE, params={"team_id": team_id})
     else:
-        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id})
+        return render_query(GET_TEAM_PERSON_DISTINCT_IDS, params={"team_id": team_id})

--- a/ee/clickhouse/queries/retention/clickhouse_retention.py
+++ b/ee/clickhouse/queries/retention/clickhouse_retention.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, NamedTuple, Tuple, Union
 from urllib.parse import urlencode
 
-from ee.clickhouse.client import substitute_params, sync_execute
+from ee.clickhouse.client import render_query, sync_execute
 from ee.clickhouse.queries.retention.retention_event_query import RetentionEventsQuery
 from ee.clickhouse.sql.retention.retention import RETENTION_BREAKDOWN_SQL
 from posthog.constants import RETENTION_FIRST_TIME, RetentionQueryType
@@ -146,7 +146,7 @@ def build_returning_event_query(filter: RetentionFilter, team: Team):
         event_query_type=RetentionQueryType.RETURNING,
     ).get_query()
 
-    query = substitute_params(returning_event_query_templated, returning_event_params)
+    query = render_query(returning_event_query_templated, params=returning_event_params)
 
     return query
 
@@ -162,6 +162,6 @@ def build_target_event_query(filter: RetentionFilter, team: Team):
         ),
     ).get_query()
 
-    query = substitute_params(target_event_query_templated, target_event_params)
+    query = render_query(target_event_query_templated, params=target_event_params)
 
     return query


### PR DESCRIPTION
Adding this helped to highlight the order in which queries should be
rendered i.e. we need to sub params before we sub SQL fragments, to
ensure we do not double substitute fragment SQL.

This is just to highlight a potential solution, but perhaps not blocking the 
[other branch](https://github.com/PostHog/posthog/pull/7748) that resolves an issue with double sub in a less invasive way

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
