### PR TITLE
Alert when license has expired

### DIFF
--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -223,11 +223,9 @@ export function SitePopover(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { isSitePopoverOpen, systemStatus } = useValues(navigationLogic)
     const { toggleSitePopover, closeSitePopover } = useActions(navigationLogic)
-    const { licenses } = useValues(licenseLogic)
+    const { relevantLicense } = useValues(licenseLogic)
     useMountedLogic(licenseLogic)
 
-    /** Most relevant license. */
-    const relevantLicense = licenses[licenses.length - 1] as LicenseType | undefined
     const expired = relevantLicense && isLicenseExpired(relevantLicense)
 
     return (

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -30,6 +30,7 @@ import {
     OtherOrganizationButton,
 } from '~/layout/navigation/OrganizationSwitcher'
 import { dayjs } from 'lib/dayjs'
+import { isLicenseExpired } from 'scenes/instance/Licenses'
 
 function SitePopoverSection({ title, children }: { title?: string; children: any }): JSX.Element {
     return (
@@ -106,22 +107,28 @@ function InviteMembersButton(): JSX.Element {
     )
 }
 
-function License(): JSX.Element {
+function License({
+    license,
+    expired,
+}: {
+    license: LicenseType | undefined
+    expired: boolean | undefined
+}): JSX.Element {
     const { closeSitePopover } = useActions(navigationLogic)
-    const { licenses } = useValues(licenseLogic)
-
-    const relevantLicense = licenses[0] as LicenseType | undefined
 
     return (
-        <LemonRow icon={<Lettermark name={relevantLicense ? relevantLicense.plan : '–'} />} fullWidth>
+        <LemonRow icon={<Lettermark name={license ? license.plan : '–'} />} fullWidth>
             <>
                 <div className="SitePopover__main-info">
-                    <div>{relevantLicense ? `${identifierToHuman(relevantLicense.plan)} plan` : 'Free plan'}</div>
-                    {relevantLicense && (
-                        <div className="supplement">
-                            Valid until {dayjs(relevantLicense.valid_until).format('D MMM YYYY')}
-                        </div>
-                    )}
+                    <div>{license ? `${identifierToHuman(license.plan)} plan` : 'Free plan'}</div>
+                    {license &&
+                        (!expired ? (
+                            <div className="supplement">
+                                Valid until {dayjs(license.valid_until).format('D MMM YYYY')}
+                            </div>
+                        ) : (
+                            <div className="supplement supplement--danger">Expired!</div>
+                        ))}
                 </div>
                 <Link
                     to={urls.instanceLicenses()}
@@ -216,7 +223,12 @@ export function SitePopover(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { isSitePopoverOpen, systemStatus } = useValues(navigationLogic)
     const { toggleSitePopover, closeSitePopover } = useActions(navigationLogic)
+    const { licenses } = useValues(licenseLogic)
     useMountedLogic(licenseLogic)
+
+    /** Most relevant license. */
+    const relevantLicense = licenses[licenses.length - 1] as LicenseType | undefined
+    const expired = relevantLicense && isLicenseExpired(relevantLicense)
 
     return (
         <Popup
@@ -253,7 +265,7 @@ export function SitePopover(): JSX.Element {
                     )}
                     {(!preflight?.cloud || user?.is_staff) && (
                         <SitePopoverSection title="PostHog status">
-                            {!preflight?.cloud && <License />}
+                            {!preflight?.cloud && <License license={relevantLicense} expired={expired} />}
                             <SystemStatus />
                             {!preflight?.cloud && <Version />}
                         </SitePopoverSection>
@@ -267,10 +279,10 @@ export function SitePopover(): JSX.Element {
             <div className="SitePopover__crumb" onClick={toggleSitePopover} data-attr="top-menu-toggle">
                 <div
                     className="SitePopover__profile-picture"
-                    title={systemStatus ? undefined : 'Potential system issue'}
+                    title={!systemStatus ? 'Potential system issue' : expired ? 'License expired' : undefined}
                 >
                     <ProfilePicture name={user?.first_name} email={user?.email} size="md" />
-                    {!systemStatus && <IconExclamation className="SitePopover__danger" />}
+                    {(!systemStatus || expired) && <IconExclamation className="SitePopover__danger" />}
                 </div>
                 <IconArrowDropDown />
             </div>

--- a/frontend/src/scenes/instance/Licenses/index.tsx
+++ b/frontend/src/scenes/instance/Licenses/index.tsx
@@ -8,17 +8,22 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
+import { LicenseType } from '~/types'
 
 export const scene: SceneExport = {
     component: Licenses,
     logic: licenseLogic,
 }
 
+export function isLicenseExpired(license: LicenseType): boolean {
+    return new Date(license.valid_until) < new Date()
+}
+
 const columns = [
     {
         title: 'Active',
         render: function renderActive(license: any) {
-            return new Date(license.valid_until) > new Date() ? 'active' : 'expired'
+            return isLicenseExpired(license) ? 'expired' : 'active'
         },
     },
     {

--- a/frontend/src/scenes/instance/Licenses/logic.ts
+++ b/frontend/src/scenes/instance/Licenses/logic.ts
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify'
 import { licenseLogicType } from './logicType'
 import { APIErrorType, LicenseType } from '~/types'
 import { preflightLogic } from '../../PreflightCheck/logic'
+import { isLicenseExpired } from '.'
 
 export const licenseLogic = kea<licenseLogicType>({
     path: ['scenes', 'instance', 'Licenses', 'licenseLogic'],
@@ -45,6 +46,15 @@ export const licenseLogic = kea<licenseLogicType>({
             null as null | APIErrorType,
             {
                 setError: (_, { error }) => error,
+            },
+        ],
+    },
+    selectors: {
+        relevantLicense: [
+            (s) => [s.licenses],
+            (licenses): LicenseType | undefined => {
+                // We determine the most relevant license to be the one that's still active OR the one addded last
+                return licenses.find((license) => !isLicenseExpired(license)) || licenses[licenses.length - 1]
             },
         ],
     },

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -196,6 +196,10 @@ mark {
     overflow: hidden;
     color: var(--muted-alt);
     font-size: 0.8125rem;
+    &--danger {
+        color: var(--danger);
+        font-weight: 600;
+    }
 }
 
 code.code {


### PR DESCRIPTION
## Changes

I have a license for local testing but premium features weren't enabled for me today. Turns out that the license just expired and I didn't notice because there was no warning. So, to avoid similar pain for customers, this adds a warning.

<img width="333" alt="Screenshot 2021-12-16 at 12 56 03" src="https://user-images.githubusercontent.com/4550621/146381186-f60d7f62-3ab0-41bb-8258-3eb9b7c3bb83.png">

## How did you test this code?

Manually by creating `License`s and playing around with the expiration date.