### PR TITLE
perf(lifecycle): add benchmark for lifecycle

### DIFF
--- a/ee/benchmarks/README.md
+++ b/ee/benchmarks/README.md
@@ -21,10 +21,10 @@ An action will then run and comment on the benchmarks on your PR.
 ## Installation (local)
 
 These benchmarks are run using *airspeed velocity* so, you need to have
-``asv`` installed,
+``asv`` installed which in turn needs virtualenv (or an anaconda dist),
 
 ```bash
-pip install asv
+pip install asv virtualenv
 ```
 
 ## Running the benchmarks locally
@@ -41,6 +41,14 @@ asv machine --machine ci-benchmarks --config ee/benchmarks/asv.conf.json
 # Replace X with appropriate credentials
 CLICKHOUSE_HOST=X CLICKHOUSE_USER=X CLICKHOUSE_PASSWORD=X CLICKHOUSE_DATABASE=posthog asv run --config ee/benchmarks/asv.conf.json
 ```
+
+You'll probably want to be running one test, with quick iteration. Running e.g.:
+
+```
+asv run --config ee/benchmarks/asv.conf.json --bench track_lifecycle --quick
+```
+
+will run any benchmark regex-matching `track_lifecycle` only once.
 
 See [asv documentation](https://asv.readthedocs.io/en/stable/commands.html#asv-run) for additional information.
 

--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -5,6 +5,7 @@ from .helpers import *
 from datetime import timedelta
 from typing import List, Tuple
 
+from ee.clickhouse.queries.trends.lifecycle import ClickhouseLifecycle
 from ee.clickhouse.materialized_columns import backfill_materialized_columns, get_materialized_columns, materialize
 from ee.clickhouse.queries.stickiness.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.funnels.funnel_correlation import FunnelCorrelation
@@ -457,6 +458,26 @@ class QuerySuite:
         )
 
         ClickhouseRetention().run(filter, self.team)
+
+    @benchmark_clickhouse
+    def track_lifecycle(self):
+        filter = Filter(
+            data={
+                "insight": "LIFECYCLE",
+                "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0, "math": "total"}],
+                "display": "ActionsLineGraph",
+                "interval": "week",
+                "shown_as": "Lifecycle",
+                "date_from": "-14d",
+                "properties": [],
+                "compare": False,
+                "filter_test_accounts": True,
+                **DATE_RANGE,
+            },
+            team=self.team,
+        )
+
+        ClickhouseTrends().run(filter, self.team)
 
     def setup(self):
         for table, property in MATERIALIZED_PROPERTIES:


### PR DESCRIPTION
## Changes

Adds a basic lifecycle query. Also some notes on running benchmarks.

## How did you test this code?

added performance label to PR

Refers to https://github.com/PostHog/posthog/issues/7382