### PR TITLE
Fix sentry errors from recording logics

### DIFF
--- a/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
@@ -210,12 +210,15 @@ export const seekbarLogic = kea<seekbarLogicType>({
             }
         },
     }),
-    events: ({ actions, values }) => ({
+    events: ({ actions, values, cache }) => ({
         afterMount: () => {
-            window.addEventListener('resize', () => actions.setCurrentPlayerPosition(values.currentPlayerPosition))
+            cache.setCurrentPlayerPosition = () => {
+                actions.setCurrentPlayerPosition(values.currentPlayerPosition)
+            }
+            window.addEventListener('resize', cache.setCurrentPlayerPosition)
         },
         beforeUnmount: () => {
-            window.removeEventListener('resize', () => actions.setCurrentPlayerPosition(values.currentPlayerPosition))
+            window.removeEventListener('resize', cache.setCurrentPlayerPosition)
         },
     }),
 })

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -392,7 +392,7 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
             if (source && (Object.values(RecordingWatchedSource) as string[]).includes(source)) {
                 actions.setSource(source as RecordingWatchedSource)
             }
-            if (values && sessionRecordingId !== values.sessionRecordingId && sessionRecordingId) {
+            if (values && sessionRecordingId && sessionRecordingId !== values.sessionRecordingId) {
                 // Load meta first. Snapshots are loaded once Replayer ref is mounted in sessionRecordingPlayerLogic
                 cache.startTime = performance.now()
                 actions.loadRecordingMeta(sessionRecordingId)
@@ -401,7 +401,6 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
         }
 
         return {
-            '/sessions': urlToAction,
             '/recordings': urlToAction,
             '/person/*': urlToAction,
         }


### PR DESCRIPTION
## Changes

2 small fixes that should resolve [this error](https://sentry.io/organizations/posthog2/issues/2778971871/?project=1899813&query=is%3Aunresolved) and [this one](https://sentry.io/organizations/posthog2/issues/2770942308/?project=1899813)

## How did you test this code?

For the first error, it would happen if the user 
1. opens a recording
2. closes the recording
3. resizes the window

For the first error, it would happen if the user 
1. opens a recording from the persons page
2. closes the recording using the back button


I manually verified both don't happen anymore