### PR TITLE
[temp] Reorder cohorts

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -209,7 +209,8 @@ const api = {
                 .update({ data: cohortData })
         },
         async list(): Promise<PaginatedResponse<CohortType>> {
-            return await new ApiRequest().cohorts().get()
+            // TODO: Remove hard limit and paginate cohorts
+            return await new ApiRequest().cohorts().withQueryString('limit=600').get()
         },
         determineDeleteEndpoint(): string {
             return new ApiRequest().cohorts().assembleEndpointUrl()

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -176,7 +176,7 @@ class CohortViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             queryset = queryset.filter(deleted=False)
 
         queryset = queryset.annotate(count=Count("people"))
-        return queryset.select_related("created_by").order_by("id")
+        return queryset.select_related("created_by").order_by("-created_at")
 
 
 class LegacyCohortViewSet(CohortViewSet):


### PR DESCRIPTION
## Changes

*Please describe.*  
- due to bug noted https://github.com/PostHog/posthog/issues/7390 we're only displaying the earliest 100 cohorts created.
- this isn't a solution but a bandaid to atleast see newer cohorts being created
- Possible extra bandaid is just increasing limit to something outrageous for now
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- QA just check that last created cohort is showing up on top
