### PR TITLE
Enable event property tracker for all teams

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -79,7 +79,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SITE_URL: null,
         NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS: '',
         EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: true,
-        EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED_TEAMS: '',
+        EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: true,
     }
 }
 
@@ -139,8 +139,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS:
             '(advanced) teams for which to run the new person properties update flow on',
         EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: '(advanced) enable experimental feature to track lastSeenAt',
-        EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED_TEAMS:
-            '(advanced) teams for which to enable experimental feature to track event properties',
+        EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: '(advanced) enable experimental feature to track event properties',
     }
 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -105,7 +105,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     SITE_URL: string | null
     NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS: string
     EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: boolean
-    EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED_TEAMS: string
+    EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: boolean
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -121,7 +121,6 @@ export const createProcessEventTests = (
             PLUGINS_CELERY_QUEUE: 'test-plugins-celery-queue',
             CELERY_DEFAULT_QUEUE: 'test-celery-default-queue',
             LOG_LEVEL: LogLevel.Log,
-            EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED_TEAMS: '2',
             ...(extraServerConfig ?? {}),
             ...(additionalProps ?? {}),
         })

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -22,9 +22,7 @@ describe('TeamManager()', () => {
     let teamManager: TeamManager
 
     beforeEach(async () => {
-        ;[hub, closeHub] = await createHub({
-            EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: true,
-        })
+        ;[hub, closeHub] = await createHub()
         await resetTestDatabase()
         teamManager = hub.teamManager
     })

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -23,7 +23,7 @@ describe('TeamManager()', () => {
 
     beforeEach(async () => {
         ;[hub, closeHub] = await createHub({
-            EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED_TEAMS: '2',
+            EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: true,
         })
         await resetTestDatabase()
         teamManager = hub.teamManager

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -85,16 +85,8 @@
                     "value": "2"
                 },
                 {
-                    "name": "EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED",
-                    "value": "True"
-                },
-                {
                     "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",
                     "value": "2,2635"
-                },
-                {
-                    "name": "EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED_TEAMS",
-                    "value": "2"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

- It's been running nicely for our team.
- This PR enables it for all teams, with a flag we can set to disable the feature completely.

## How did you test this code?

- Enabled it locally for all, didn't see anything change --> properties were being tracked.