### PR TITLE
Simplify and fix dashboard items grid sizing

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -452,28 +452,6 @@ export function delay(ms: number): Promise<number> {
     return new Promise((resolve) => window.setTimeout(resolve, ms))
 }
 
-/**
- * Trigger a resize event on window.
- */
-export function triggerResize(): void {
-    try {
-        window.dispatchEvent(new Event('resize'))
-    } catch (error) {
-        // will break on IE11
-    }
-}
-
-/**
- * Trigger a resize event on window a few times between 10 to 2000 ms after the menu was collapsed/expanded.
- * We need this so the dashboard resizes itself properly, as the available div width will still
- * change when the sidebar's expansion is animating.
- */
-export function triggerResizeAfterADelay(): void {
-    for (const duration of [10, 100, 500, 750, 1000, 2000]) {
-        window.setTimeout(triggerResize, duration)
-    }
-}
-
 export function clearDOMTextSelection(): void {
     if (window.getSelection) {
         if (window.getSelection()?.empty) {

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -1,5 +1,9 @@
 @import '~/vars';
 
+.dashboard-items-wrapper {
+    width: 100%; // This provides the width for the dashboard items grid
+}
+
 .dashboard-item {
     display: block;
     background: white;

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -1,11 +1,11 @@
 import './DashboardItems.scss'
 
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useActions, useValues } from 'kea'
-import { Responsive, WidthProvider } from 'react-grid-layout'
+import { Responsive as ReactGridLayout } from 'react-grid-layout'
 
 import { DashboardItem } from 'scenes/dashboard/DashboardItem'
-import { isMobile, triggerResize, triggerResizeAfterADelay } from 'lib/utils'
+import { isMobile } from 'lib/utils'
 import { InsightModel, DashboardMode } from '~/types'
 import { insightsModel } from '~/models/insightsModel'
 import { dashboardLogic, BREAKPOINT_COLUMN_COUNTS, BREAKPOINTS } from 'scenes/dashboard/dashboardLogic'
@@ -14,8 +14,7 @@ import clsx from 'clsx'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { InsightCard } from 'lib/components/InsightCard'
-
-const ReactGridLayout = WidthProvider(Responsive)
+import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 
 export function DashboardItems(): JSX.Element {
     const {
@@ -41,8 +40,6 @@ export function DashboardItems(): JSX.Element {
     const { duplicateInsight } = useActions(insightsModel)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    // make sure the dashboard takes up the right size
-    useEffect(() => triggerResizeAfterADelay(), [])
     const [resizingItem, setResizingItem] = useState<any>(null)
 
     // can not click links when dragging and 250ms after
@@ -54,100 +51,94 @@ export function DashboardItems(): JSX.Element {
         wobbly: dashboardMode === DashboardMode.Edit && isMobile(),
     })
 
-    return (
-        <ReactGridLayout
-            className={className}
-            isDraggable={dashboardMode === DashboardMode.Edit}
-            isResizable={dashboardMode === DashboardMode.Edit}
-            layouts={layouts}
-            rowHeight={80}
-            margin={[16, 16]}
-            containerPadding={[0, 0]}
-            onLayoutChange={(_, newLayouts) => {
-                updateLayouts(newLayouts)
-                triggerResize()
-            }}
-            onWidthChange={(containerWidth, _, newCols) => {
-                updateContainerWidth(containerWidth, newCols)
-            }}
-            measureBeforeMount
-            breakpoints={BREAKPOINTS}
-            resizeHandles={['s', 'e', 'se']}
-            cols={BREAKPOINT_COLUMN_COUNTS}
-            onResize={(_layout: any, _oldItem: any, newItem: any) => {
-                if (!resizingItem || resizingItem.w !== newItem.w || resizingItem.h !== newItem.h) {
-                    setResizingItem(newItem)
-                }
+    const { width: gridWrapperWidth, ref: gridWrapperRef } = useResizeObserver()
 
-                // Trigger the resize event for funnels, as they won't update their dimensions
-                // when their container is resized and must be recalculated.
-                // Skip this for other types as it slows down the interactions a bit.
-                const item = items?.find((i: any) => i.id === parseInt(newItem.i))
-                if (item?.filters.display === 'FunnelViz') {
-                    triggerResize()
-                }
-            }}
-            onResizeStop={() => {
-                setResizingItem(null)
-                triggerResizeAfterADelay()
-            }}
-            onDrag={() => {
-                isDragging.current = true
-                if (dragEndTimeout.current) {
-                    window.clearTimeout(dragEndTimeout.current)
-                }
-            }}
-            onDragStop={() => {
-                if (dragEndTimeout.current) {
-                    window.clearTimeout(dragEndTimeout.current)
-                }
-                dragEndTimeout.current = window.setTimeout(() => {
-                    isDragging.current = false
-                }, 250)
-            }}
-            draggableCancel=".anticon,.ant-dropdown,table,.ant-popover-content,button,.Popup"
-        >
-            {items?.map((item: InsightModel, index: number) =>
-                featureFlags[FEATURE_FLAGS.DASHBOARD_REDESIGN] ? (
-                    <InsightCard
-                        key={item.short_id}
-                        insight={item}
-                        index={index}
-                        loading={isRefreshing(item.short_id)}
-                        apiError={refreshStatus[item.short_id]?.error || false}
-                        highlighted={highlightedInsightId && item.short_id === highlightedInsightId}
-                        updateColor={(color) => updateItemColor(item.id, color)}
-                        removeItem={() => removeItem(item.id)}
-                        refresh={() => refreshAllDashboardItems([item])}
-                    />
-                ) : (
-                    <div key={item.short_id} className="dashboard-item-wrapper">
-                        <DashboardItem
+    return (
+        <div className="dashboard-items-wrapper" ref={gridWrapperRef}>
+            <ReactGridLayout
+                width={gridWrapperWidth}
+                className={className}
+                isDraggable={dashboardMode === DashboardMode.Edit}
+                isResizable={dashboardMode === DashboardMode.Edit}
+                layouts={layouts}
+                rowHeight={80}
+                margin={[16, 16]}
+                containerPadding={[0, 0]}
+                onLayoutChange={(_, newLayouts) => {
+                    updateLayouts(newLayouts)
+                }}
+                onWidthChange={(containerWidth, _, newCols) => {
+                    updateContainerWidth(containerWidth, newCols)
+                }}
+                breakpoints={BREAKPOINTS}
+                resizeHandles={['s', 'e', 'se']}
+                cols={BREAKPOINT_COLUMN_COUNTS}
+                onResize={(_layout: any, _oldItem: any, newItem: any) => {
+                    if (!resizingItem || resizingItem.w !== newItem.w || resizingItem.h !== newItem.h) {
+                        setResizingItem(newItem)
+                    }
+                }}
+                onResizeStop={() => {
+                    setResizingItem(null)
+                }}
+                onDrag={() => {
+                    isDragging.current = true
+                    if (dragEndTimeout.current) {
+                        window.clearTimeout(dragEndTimeout.current)
+                    }
+                }}
+                onDragStop={() => {
+                    if (dragEndTimeout.current) {
+                        window.clearTimeout(dragEndTimeout.current)
+                    }
+                    dragEndTimeout.current = window.setTimeout(() => {
+                        isDragging.current = false
+                    }, 250)
+                }}
+                draggableCancel=".anticon,.ant-dropdown,table,.ant-popover-content,button,.Popup"
+            >
+                {items?.map((item: InsightModel, index: number) =>
+                    featureFlags[FEATURE_FLAGS.DASHBOARD_REDESIGN] ? (
+                        <InsightCard
                             key={item.short_id}
-                            doNotLoad
-                            receivedErrorFromAPI={refreshStatus[item.short_id]?.error || false}
-                            dashboardId={dashboard?.id}
-                            item={item}
-                            layout={resizingItem?.i === item.short_id ? resizingItem : layoutForItem[item.short_id]}
-                            isReloading={isRefreshing(item.short_id)}
-                            reload={() => refreshAllDashboardItems([item])}
-                            loadDashboardItems={loadDashboardItems}
-                            setDiveDashboard={setDiveDashboard}
-                            duplicateDashboardItem={duplicateInsight}
-                            moveDashboardItem={(it: InsightModel, dashboardId: number) =>
-                                duplicateInsight(it, dashboardId, true)
-                            }
-                            updateItemColor={updateItemColor}
-                            isDraggingRef={isDragging}
-                            dashboardMode={dashboardMode}
-                            isHighlighted={highlightedInsightId && item.short_id === highlightedInsightId}
-                            isOnEditMode={dashboardMode === DashboardMode.Edit}
-                            setEditMode={() => setDashboardMode(DashboardMode.Edit, DashboardEventSource.LongPress)}
+                            insight={item}
                             index={index}
+                            loading={isRefreshing(item.short_id)}
+                            apiError={refreshStatus[item.short_id]?.error || false}
+                            highlighted={highlightedInsightId && item.short_id === highlightedInsightId}
+                            updateColor={(color) => updateItemColor(item.id, color)}
+                            removeItem={() => removeItem(item.id)}
+                            refresh={() => refreshAllDashboardItems([item])}
                         />
-                    </div>
-                )
-            )}
-        </ReactGridLayout>
+                    ) : (
+                        <div key={item.short_id} className="dashboard-item-wrapper">
+                            <DashboardItem
+                                key={item.short_id}
+                                doNotLoad
+                                receivedErrorFromAPI={refreshStatus[item.short_id]?.error || false}
+                                dashboardId={dashboard?.id}
+                                item={item}
+                                layout={resizingItem?.i === item.short_id ? resizingItem : layoutForItem[item.short_id]}
+                                isReloading={isRefreshing(item.short_id)}
+                                reload={() => refreshAllDashboardItems([item])}
+                                loadDashboardItems={loadDashboardItems}
+                                setDiveDashboard={setDiveDashboard}
+                                duplicateDashboardItem={duplicateInsight}
+                                moveDashboardItem={(it: InsightModel, dashboardId: number) =>
+                                    duplicateInsight(it, dashboardId, true)
+                                }
+                                updateItemColor={updateItemColor}
+                                isDraggingRef={isDragging}
+                                dashboardMode={dashboardMode}
+                                isHighlighted={highlightedInsightId && item.short_id === highlightedInsightId}
+                                isOnEditMode={dashboardMode === DashboardMode.Edit}
+                                setEditMode={() => setDashboardMode(DashboardMode.Edit, DashboardEventSource.LongPress)}
+                                index={index}
+                            />
+                        </div>
+                    )
+                )}
+            </ReactGridLayout>
+        </div>
     )
 }


### PR DESCRIPTION
## Changes

Simplifies the way the dashboard grid is sized by way of `useResizeObserver`, at the same time fixing the grid not being resized appropriately when the sidebar gets hidden (see https://github.com/PostHog/posthog/pull/7726#pullrequestreview-834121648).

## How did you test this code?

![2021-12-17 14 04 43](https://user-images.githubusercontent.com/4550621/146569012-9f92a6bf-7aa2-4b87-853d-ccc65940d1c9.gif)

