### PR TITLE
perf(lifecycle): remove nesting from get person ids query

### DIFF
--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -254,14 +254,10 @@ INSERT_PERSON_STATIC_COHORT = (
 
 GET_TEAM_PERSON_DISTINCT_IDS = """
 SELECT distinct_id, argMax(person_id, _timestamp) as person_id
-FROM (
-    SELECT distinct_id, person_id, max(_timestamp) as _timestamp
-    FROM person_distinct_id
-    WHERE team_id = %(team_id)s
-    GROUP BY person_id, distinct_id, team_id
-    HAVING max(is_deleted) = 0
-)
-GROUP BY distinct_id
+FROM person_distinct_id
+WHERE team_id = %(team_id)s
+GROUP BY person_id, distinct_id, team_id
+HAVING argMax(is_deleted, _timestamp) = 0
 """
 
 # Query to query distinct ids using the new table, will be used if PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS applies


### PR DESCRIPTION
There seems to be unnecessary nesting in the query that makes the
mapping from distinct_ids to person_ids, for the legacy table at least.
Just as a quick update that doesn't require completeing the migration to
the new table I've updated the old query, as for large tables the
benefit is not inconsiderable and is pretty low effort.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
