### PR TITLE
fix: Update the person block style to use full-width

### DIFF
--- a/frontend/src/scenes/trends/PersonsModal.scss
+++ b/frontend/src/scenes/trends/PersonsModal.scss
@@ -36,7 +36,7 @@
     .person-ids {
         display: flex;
         flex-direction: column;
-        width: 100%;
+        flex: 1;
     }
 
     .user-count-subheader {

--- a/frontend/src/scenes/trends/PersonsModal.scss
+++ b/frontend/src/scenes/trends/PersonsModal.scss
@@ -36,6 +36,7 @@
     .person-ids {
         display: flex;
         flex-direction: column;
+        width: 100%;
     }
 
     .user-count-subheader {


### PR DESCRIPTION
We are using Posthog in our production instance at Chatwoot. We have created an active users graph and if I click ("Click on Datapoint to view persons") on the graph to expand the list of users who were active in a given time, the list does not display the full email address, instead, it truncates it. See the screenshot below.

| Before | After|
| - | - |
| <img width="623" alt="Screenshot 2021-12-17 at 1 45 54 PM" src="https://user-images.githubusercontent.com/2246121/146629890-02f9de7e-9bc0-4beb-80fe-100fba7ae9fc.png"> | <img width="619" alt="Screenshot 2021-12-17 at 1 46 22 PM" src="https://user-images.githubusercontent.com/2246121/146629888-32b6bee6-2d43-4368-b415-08a30827a747.png"> |


## How did you test this code?

Honestly, I tested this by updating the browser console, have not set up the project. If it feels like a hack, please feel free to close this PR. I can create an issue for the same. 