### PR TITLE
Add skip inactivity to the recording player

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerController.tsx
@@ -11,8 +11,8 @@ import { Seekbar } from 'scenes/session-recordings/player/Seekbar'
 import { Timestamp } from 'scenes/session-recordings/player/Timestamp'
 
 export function PlayerController(): JSX.Element {
-    const { togglePlayPause, setSpeed } = useActions(sessionRecordingPlayerLogic)
-    const { currentPlayerState, speed, isSmallScreen } = useValues(sessionRecordingPlayerLogic)
+    const { togglePlayPause, setSpeed, setSkipInactivitySetting } = useActions(sessionRecordingPlayerLogic)
+    const { currentPlayerState, speed, isSmallScreen, skipInactivitySetting } = useValues(sessionRecordingPlayerLogic)
 
     return (
         <div className="rrweb-controller">
@@ -51,7 +51,7 @@ export function PlayerController(): JSX.Element {
             </Select>
             <div className="rrweb-inactivity-toggle">
                 <span className="inactivity-label">Skip inactivity</span>
-                <Switch disabled size="small" />
+                <Switch checked={skipInactivitySetting} onChange={setSkipInactivitySetting} size="small" />
             </div>
         </div>
     )

--- a/frontend/src/scenes/session-recordings/player/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerController.tsx
@@ -49,9 +49,14 @@ export function PlayerController(): JSX.Element {
                     ))}
                 </Select.OptGroup>
             </Select>
-            <div className="rrweb-inactivity-toggle">
+            <div
+                onClick={() => {
+                    setSkipInactivitySetting(!skipInactivitySetting)
+                }}
+                className="rrweb-inactivity-toggle"
+            >
                 <span className="inactivity-label">Skip inactivity</span>
-                <Switch checked={skipInactivitySetting} onChange={setSkipInactivitySetting} size="small" />
+                <Switch checked={skipInactivitySetting} size="small" />
             </div>
         </div>
     )

--- a/frontend/src/scenes/session-recordings/player/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerController.tsx
@@ -4,7 +4,7 @@ import {
     PLAYBACK_SPEEDS,
     sessionRecordingPlayerLogic,
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
-import { Select } from 'antd'
+import { Select, Switch } from 'antd'
 import { SessionPlayerState } from '~/types'
 import { IconPause, IconPlay } from 'scenes/session-recordings/player/icons'
 import { Seekbar } from 'scenes/session-recordings/player/Seekbar'
@@ -49,6 +49,10 @@ export function PlayerController(): JSX.Element {
                     ))}
                 </Select.OptGroup>
             </Select>
+            <div className="rrweb-inactivity-toggle">
+                <span className="inactivity-label">Skip inactivity</span>
+                <Switch disabled size="small" />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -56,6 +56,9 @@ export const PlayerFrame = React.forwardRef<HTMLDivElement>(function PlayerFrame
                 </div>
             )
         }
+        if (currentPlayerState === SessionPlayerState.SKIP) {
+            return <div className="rrweb-overlay">Skipping inactivity</div>
+        }
         return null
     }
 

--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -64,6 +64,23 @@ $tick_hover_size: 5px;
             left: 1px;
             width: 0; // starting point
         }
+
+        .inactivity-bar {
+            z-index: 4;
+            position: absolute;
+            height: 2px;
+            top: ($slider-height - 2px) / 2;
+            left: 1px;
+            width: 100%;
+            .activity-section {
+                float: left;
+                height: 100%;
+            }
+            .inactive-section {
+                border-bottom: 1px solid $border;
+                background: repeating-linear-gradient(325deg, transparent, transparent 3px, #fff 3px, #fff 6px);
+            }
+        }
     }
 
     .ticks {

--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -27,6 +27,7 @@ $tick_hover_size: 5px;
             background-color: $brand_red;
             transform-origin: center;
             transform: translateX(-$thumb_size / 2);
+            transition: transform 50ms;
         }
 
         .slider-bar,
@@ -77,8 +78,7 @@ $tick_hover_size: 5px;
                 height: 100%;
             }
             .inactive-section {
-                border-bottom: 1px solid $border;
-                background: repeating-linear-gradient(325deg, transparent, transparent 3px, #fff 3px, #fff 6px);
+                background: repeating-linear-gradient(325deg, transparent, transparent 2px, #fff 2px, #fff 4px);
             }
         }
     }

--- a/frontend/src/scenes/session-recordings/player/Seekbar.tsx
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import clsx from 'clsx'
 import { seekbarLogic } from 'scenes/session-recordings/player/seekbarLogic'
-import { RecordingEventType } from '~/types'
+import { RecordingEventType, RecordingSegment } from '~/types'
 import { sessionRecordingLogic } from '../sessionRecordingLogic'
 
 function Tick({ event }: { event: RecordingEventType }): JSX.Element {
@@ -39,7 +39,7 @@ export function Seekbar(): JSX.Element {
     const sliderRef = useRef<HTMLDivElement | null>(null)
     const thumbRef = useRef<HTMLDivElement | null>(null)
     const { handleDown, setSlider, setThumb } = useActions(seekbarLogic)
-    const { eventsToShow } = useValues(sessionRecordingLogic)
+    const { eventsToShow, sessionPlayerData } = useValues(sessionRecordingLogic)
     const { thumbLeftPos, bufferPercent } = useValues(seekbarLogic)
 
     // Workaround: Something with component and logic mount timing that causes slider and thumb
@@ -54,6 +54,19 @@ export function Seekbar(): JSX.Element {
     return (
         <div className="rrweb-controller-slider">
             <div className="slider" ref={sliderRef} onMouseDown={handleDown} onTouchStart={handleDown}>
+                <div className="inactivity-bar">
+                    {sessionPlayerData?.metadata?.segments?.map((segment: RecordingSegment) => (
+                        <div
+                            key={`${segment.windowId}-${segment.startTimeEpochMs}`}
+                            className={clsx('activity-section', !segment.isActive && 'inactive-section')}
+                            style={{
+                                width: `${
+                                    (100 * segment.durationMs) / sessionPlayerData.metadata.recordingDurationMs
+                                }%`,
+                            }}
+                         />
+                    ))}
+                </div>
                 <div className="slider-bar" />
                 <div className="thumb" ref={thumbRef} style={{ transform: `translateX(${thumbLeftPos}px)` }} />
                 <div className="current-bar" style={{ width: `${Math.max(thumbLeftPos, 0)}px` }} />

--- a/frontend/src/scenes/session-recordings/player/Seekbar.tsx
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.tsx
@@ -64,7 +64,7 @@ export function Seekbar(): JSX.Element {
                                     (100 * segment.durationMs) / sessionPlayerData.metadata.recordingDurationMs
                                 }%`,
                             }}
-                         />
+                        />
                     ))}
                 </div>
                 <div className="slider-bar" />

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -195,6 +195,7 @@
 
     .rrweb-speed-toggle {
         cursor: pointer;
+        margin-right: $default_spacing;
     }
 
     .rrweb-inactivity-toggle {

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -203,6 +203,7 @@
         flex-direction: row;
         align-items: center;
         white-space: nowrap;
+        cursor: pointer;
 
         .inactivity-label {
             font-size: 14px;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -384,6 +384,7 @@ export enum SessionPlayerState {
     PLAY = 'play',
     PAUSE = 'pause',
     SCRUB = 'scrub',
+    SKIP = 'skip',
 }
 
 /** Sync with plugin-server/src/types.ts */


### PR DESCRIPTION
## Changes

This PR adds the concept of "inactive sections" to the recording player. It
* Shows inactive segments to the user
* Adds a toggle that allows users to skip inactive segments
* If a segment is being skipped, it overlays a "Skipping inactivity" text

![image](https://user-images.githubusercontent.com/4813045/146658409-6f45549d-09e3-424a-ba7f-59ddcd4d1517.png)


## How did you test this code?

Verified that it:
* Skips segments when the player hits an inactive segment
* Skips segments if you scrub to the middle of an inactive segment
* Skips segments if the player starts on an inactive one
* Does not skip segments if the user toggles off "skip inactivity"
* Starts skipping a segment if the user toggles on "skip inactivity" in the middle of a segment

Note: We **really** should write tests for `SessionRecordingsPlayerLogic.ts`. Going to put up a PR for that soon.
