### PR TITLE
fix(lifecycle): use status or breakdown_value

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -65,7 +65,9 @@ export function ActionsLineGraph({
                               date_from: day,
                               date_to: day,
                               filters,
-                              breakdown_value: points.clickedPointNotLine ? dataset.breakdown_value : undefined,
+                              breakdown_value: points.clickedPointNotLine
+                                  ? dataset.breakdown_value || dataset.status
+                                  : undefined,
                               saveOriginal: true,
                               pointValue: dataset?.data?.[index] ?? undefined,
                           }


### PR DESCRIPTION
## Changes

*Please describe.*  
- clicking on retention bar for persons was erroring because[ a previous refactor](https://github.com/PostHog/posthog/pull/7722/files) removed the status field
- note: temporary. Should pass person URL back on original return and just use the formatted URL like we do for trends now
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
Go to retention graph and click on a bar
