### PR TITLE
Throw when trying to save insight with empty filters

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -29,6 +29,7 @@ describe('Insights', () => {
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
         // Save
+        cy.wait(500) // TODO: hoxfix until we disable "save" when loading
         cy.get('[data-attr="insight-save-button"]').click()
         cy.get('[data-attr="insight-edit-button"]').click()
 

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -6,7 +6,7 @@ describe('Trends', () => {
         cy.location('pathname').should('include', '/edit')
     })
 
-    it('Can load a graph from a URL directly', () => {
+    it.skip('Can load a graph from a URL directly', () => {
         // regression test, the graph wouldn't load when going directly to a URL
         cy.visit(
             '/insights/new?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&filter_test_accounts=false&breakdown=%24referrer&breakdown_type=event&properties=%5B%7B"key"%3A"%24current_url"%2C"value"%3A"http%3A%2F%2Fhogflix.com"%2C"operator"%3A"icontains"%2C"type"%3A"event"%7D%5D'
@@ -15,7 +15,7 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it('Add a pageview action filter', () => {
+    it.skip('Add a pageview action filter', () => {
         // when
         cy.contains('Add graph series').click()
         cy.get('[data-attr=trend-element-subject-1]').click()
@@ -26,13 +26,13 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it('DAU on 1 element', () => {
+    it.skip('DAU on 1 element', () => {
         cy.get('[data-attr=math-selector-0]').click()
         cy.get('[data-attr=math-dau-0]').click()
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it('Show property select dynamically', () => {
+    it.skip('Show property select dynamically', () => {
         cy.get('[data-attr=math-property-selector-0]').should('not.exist')
 
         // Test that the math selector dropdown is shown on hover
@@ -44,7 +44,7 @@ describe('Trends', () => {
         cy.get('[data-attr=math-property-select]').should('exist')
     })
 
-    it('Apply specific filter on default pageview event', () => {
+    it.skip('Apply specific filter on default pageview event', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.get('.property-key-info').contains('Pageview').click() // Tooltip is shown with description
         cy.get('[data-attr=trend-element-subject-0]').should('have.text', 'Pageview')
@@ -58,7 +58,7 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })
 
-    it('Apply 1 overall filter', () => {
+    it.skip('Apply 1 overall filter', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.get('.property-key-info').contains('Pageview').click()
         cy.get('[data-attr=trend-element-subject-0]').should('have.text', 'Pageview')
@@ -71,21 +71,21 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })
 
-    it('Apply interval filter', () => {
+    it.skip('Apply interval filter', () => {
         cy.get('[data-attr=interval-filter]').click()
         cy.contains('Week').click()
 
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it('Apply pie filter', () => {
+    it.skip('Apply pie filter', () => {
         cy.get('[data-attr=chart-filter]').click()
         cy.contains('Pie').click()
 
         cy.get('[data-attr=trend-pie-graph]').should('exist')
     })
 
-    it('Apply table filter', () => {
+    it.skip('Apply table filter', () => {
         cy.get('[data-attr=chart-filter]').click()
         cy.contains('Table').click()
 
@@ -99,7 +99,7 @@ describe('Trends', () => {
         cy.get('[data-attr=insights-table-graph]').find('.ant-table-cell').its('length').should('be.gte', 1)
     })
 
-    it('Apply date filter', () => {
+    it.skip('Apply date filter', () => {
         cy.get('[data-attr=date-filter]').click()
         cy.contains('Last 30 days').click()
 
@@ -107,13 +107,13 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 10000 }).should('exist')
     })
 
-    it('Apply property breakdown', () => {
+    it.skip('Apply property breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=prop-filter-event_properties-2]').click()
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it('Apply all users cohort breakdown', () => {
+    it.skip('Apply all users cohort breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=taxonomic-tab-cohorts_with_all]').click()
         cy.contains('All Users*').click()
@@ -121,6 +121,13 @@ describe('Trends', () => {
     })
 
     it('Save to dashboard', () => {
+        // apply random filter
+        cy.get('[data-attr=new-prop-filter-trends-filters]').click()
+        cy.get('[data-attr=taxonomic-filter-searchfield]').click()
+        cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
+        cy.get('[data-attr=prop-val]').click()
+        cy.get('[data-attr=prop-val-0]').click({ force: true })
+
         cy.get('[data-attr=save-to-dashboard-button]').click()
         cy.get('form > .ant-select > .ant-select-selector').click()
         cy.get(':nth-child(1) > .ant-select-item-option-content').click()

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -6,7 +6,7 @@ describe('Trends', () => {
         cy.location('pathname').should('include', '/edit')
     })
 
-    it.skip('Can load a graph from a URL directly', () => {
+    it('Can load a graph from a URL directly', () => {
         // regression test, the graph wouldn't load when going directly to a URL
         cy.visit(
             '/insights/new?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B"id"%3A"%24pageview"%2C"name"%3A"%24pageview"%2C"type"%3A"events"%2C"order"%3A0%7D%5D&filter_test_accounts=false&breakdown=%24referrer&breakdown_type=event&properties=%5B%7B"key"%3A"%24current_url"%2C"value"%3A"http%3A%2F%2Fhogflix.com"%2C"operator"%3A"icontains"%2C"type"%3A"event"%7D%5D'
@@ -15,7 +15,7 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it.skip('Add a pageview action filter', () => {
+    it('Add a pageview action filter', () => {
         // when
         cy.contains('Add graph series').click()
         cy.get('[data-attr=trend-element-subject-1]').click()
@@ -26,13 +26,13 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it.skip('DAU on 1 element', () => {
+    it('DAU on 1 element', () => {
         cy.get('[data-attr=math-selector-0]').click()
         cy.get('[data-attr=math-dau-0]').click()
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it.skip('Show property select dynamically', () => {
+    it('Show property select dynamically', () => {
         cy.get('[data-attr=math-property-selector-0]').should('not.exist')
 
         // Test that the math selector dropdown is shown on hover
@@ -44,7 +44,7 @@ describe('Trends', () => {
         cy.get('[data-attr=math-property-select]').should('exist')
     })
 
-    it.skip('Apply specific filter on default pageview event', () => {
+    it('Apply specific filter on default pageview event', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.get('.property-key-info').contains('Pageview').click() // Tooltip is shown with description
         cy.get('[data-attr=trend-element-subject-0]').should('have.text', 'Pageview')
@@ -58,7 +58,7 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })
 
-    it.skip('Apply 1 overall filter', () => {
+    it('Apply 1 overall filter', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
         cy.get('.property-key-info').contains('Pageview').click()
         cy.get('[data-attr=trend-element-subject-0]').should('have.text', 'Pageview')
@@ -71,21 +71,21 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })
 
-    it.skip('Apply interval filter', () => {
+    it('Apply interval filter', () => {
         cy.get('[data-attr=interval-filter]').click()
         cy.contains('Week').click()
 
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it.skip('Apply pie filter', () => {
+    it('Apply pie filter', () => {
         cy.get('[data-attr=chart-filter]').click()
         cy.contains('Pie').click()
 
         cy.get('[data-attr=trend-pie-graph]').should('exist')
     })
 
-    it.skip('Apply table filter', () => {
+    it('Apply table filter', () => {
         cy.get('[data-attr=chart-filter]').click()
         cy.contains('Table').click()
 
@@ -99,7 +99,7 @@ describe('Trends', () => {
         cy.get('[data-attr=insights-table-graph]').find('.ant-table-cell').its('length').should('be.gte', 1)
     })
 
-    it.skip('Apply date filter', () => {
+    it('Apply date filter', () => {
         cy.get('[data-attr=date-filter]').click()
         cy.contains('Last 30 days').click()
 
@@ -107,13 +107,13 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]', { timeout: 10000 }).should('exist')
     })
 
-    it.skip('Apply property breakdown', () => {
+    it('Apply property breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=prop-filter-event_properties-2]').click()
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it.skip('Apply all users cohort breakdown', () => {
+    it('Apply all users cohort breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
         cy.get('[data-attr=taxonomic-tab-cohorts_with_all]').click()
         cy.contains('All Users*').click()

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -264,11 +264,11 @@ describe('dateFilterToText()', () => {
         })
 
         it('can have overridden date format', () => {
-            const from = dayjs('2018-04-04T16:00:00.000Z')
-            const to = dayjs('2018-04-09T15:05:00.000Z')
+            const from = dayjs('2018-04-04T16:00:00.000Z').tz('America/New_York')
+            const to = dayjs('2018-04-09T15:05:00.000Z').tz('America/New_York')
 
             expect(dateFilterToText(from, to, 'custom', dateMapping, true, 'YYYY-MM-DD hh:mm:ss')).toEqual(
-                '2018-04-04 04:00:00 - 2018-04-09 03:05:00'
+                '2018-04-04 12:00:00 - 2018-04-09 11:05:00'
             )
         })
     })

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -627,6 +627,7 @@ describe('insightLogic', () => {
         logic = insightLogic({
             dashboardItemId: Insight42,
             filters: { insight: InsightType.FUNNELS },
+            cachedResults: {},
         })
         logic.mount()
 

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -678,6 +678,9 @@ describe('insightLogic', () => {
 
         logic.actions.setInsight({ id: 42, short_id: Insight42, filters: {} }, {})
         logic.actions.saveInsight()
-        expect(Sentry.captureException).toHaveBeenCalledWith(new Error('Tried to override filters'), expect.any(Object))
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+            new Error('Will not override empty filters in saveInsight.'),
+            expect.any(Object)
+        )
     })
 })

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -143,14 +143,15 @@ export const insightLogic = kea<insightLogicType>({
                         insight.filters &&
                         JSON.stringify(cleanFilters(insight.filters)) === JSON.stringify(cleanFilters({}))
                     ) {
-                        Sentry.captureException(new Error(`Tried to override filters`), {
+                        const error = new Error('Will not override empty filters in updateInsight.')
+                        Sentry.captureException(error, {
                             extra: {
                                 filters: JSON.stringify(insight.filters),
                                 insight: JSON.stringify(insight),
                                 valuesInsight: JSON.stringify(values.insight),
                             },
                         })
-                        throw new Error('Will not override empty filters.')
+                        throw error
                     }
 
                     const response = await api.update(
@@ -176,7 +177,14 @@ export const insightLogic = kea<insightLogicType>({
                     }
 
                     if (metadata.filters) {
-                        throw new Error('Can not update "filters" via setInsightMetadata')
+                        const error = new Error(`Will not override filters in setInsightMetadata`)
+                        Sentry.captureException(error, {
+                            extra: {
+                                filters: JSON.stringify(values.insight.filters),
+                                insight: JSON.stringify(values.insight),
+                            },
+                        })
+                        throw error
                     }
 
                     const response = await api.update(
@@ -619,10 +627,11 @@ export const insightLogic = kea<insightLogicType>({
                 !values.insight.filters ||
                 JSON.stringify(cleanFilters(values.insight.filters)) === JSON.stringify(cleanFilters({}))
             ) {
-                Sentry.captureException(new Error(`Tried to override filters`), {
+                const error = new Error('Will not override empty filters in saveInsight.')
+                Sentry.captureException(error, {
                     extra: { filters: JSON.stringify(values.insight.filters), insight: JSON.stringify(values.insight) },
                 })
-                throw new Error('Will not override empty filters.')
+                throw error
             }
             const savedInsight: InsightModel = await api.update(
                 `api/projects/${teamLogic.values.currentTeamId}/insights/${insightId}`,


### PR DESCRIPTION
## Changes

- Somehow, sometimes we save insights with empty filters. This has caused data loss for some clients already. Instead of continuing this practice, let's fail loudly and debug.

## How did you test this code?

- Made a test. 