### PR TITLE
Only disable computing of new materialize columns - still use MCs that exist for querying

### DIFF
--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -74,8 +74,8 @@ class Migration(AsyncMigrationDefinition):
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DETACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
             rollback=f"ATTACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
-            side_effect=lambda: setattr(config, "MATERIALIZED_COLUMNS_ENABLED", False),
-            side_effect_rollback=lambda: setattr(config, "MATERIALIZED_COLUMNS_ENABLED", True),
+            side_effect=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
+            side_effect_rollback=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
         ),
         AsyncMigrationOperation(
             database=AnalyticsDBMS.CLICKHOUSE,
@@ -113,8 +113,8 @@ class Migration(AsyncMigrationDefinition):
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"ATTACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
             rollback=f"DETACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER {CLICKHOUSE_CLUSTER}",
-            side_effect=lambda: setattr(config, "MATERIALIZED_COLUMNS_ENABLED", True),
-            side_effect_rollback=lambda: setattr(config, "MATERIALIZED_COLUMNS_ENABLED", False),
+            side_effect=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
+            side_effect_rollback=lambda: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
         ),
     ]
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -252,7 +252,12 @@ def clickhouse_mutation_count():
 
 
 def materialized_columns_enabled() -> bool:
-    if is_clickhouse_enabled() and settings.EE_AVAILABLE and getattr(config, "MATERIALIZED_COLUMNS_ENABLED"):
+    if (
+        is_clickhouse_enabled()
+        and settings.EE_AVAILABLE
+        and getattr(config, "MATERIALIZED_COLUMNS_ENABLED")
+        and getattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED")
+    ):
         return True
     return False
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -251,7 +251,7 @@ def clickhouse_mutation_count():
         pass
 
 
-def materialized_columns_enabled() -> bool:
+def recompute_materialized_columns_enabled() -> bool:
     if (
         is_clickhouse_enabled()
         and settings.EE_AVAILABLE
@@ -264,7 +264,7 @@ def materialized_columns_enabled() -> bool:
 
 @app.task(ignore_result=True)
 def clickhouse_materialize_columns():
-    if materialized_columns_enabled():
+    if recompute_materialized_columns_enabled():
         from ee.clickhouse.materialized_columns.analyze import materialize_properties_task
 
         materialize_properties_task()
@@ -272,7 +272,7 @@ def clickhouse_materialize_columns():
 
 @app.task(ignore_result=True)
 def clickhouse_mark_all_materialized():
-    if materialized_columns_enabled():
+    if recompute_materialized_columns_enabled():
         from ee.tasks.materialized_columns import mark_all_materialized
 
         mark_all_materialized()

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -7,7 +7,12 @@ CONSTANCE_DATABASE_PREFIX = "constance:posthog:"
 CONSTANCE_CONFIG = {
     "MATERIALIZED_COLUMNS_ENABLED": (
         get_from_env("MATERIALIZED_COLUMNS_ENABLED", True, type_cast=str_to_bool),
-        "Whether materialized columns should be, created or used at query time",
+        "Whether materialized columns should be created or used at query time",
+        bool,
+    ),
+    "COMPUTE_MATERIALIZED_COLUMNS_ENABLED": (
+        get_from_env("COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True, type_cast=str_to_bool),
+        "Whether materialized columns should be created or updated (existing columns will still be used at query time)",
         bool,
     ),
 }


### PR DESCRIPTION
## Changes

A much more efficient way of performing this migration allowing users to still leverage materialized columns while the migration is going on.

## How did you test this code?

Run it!
