### PR TITLE
Unify "Unique users/groups" casing

### DIFF
--- a/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
@@ -31,7 +31,7 @@ export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element
             }}
         >
             <LockOutlined style={{ marginRight: 6, color: 'var(--warning)' }} />
-            unique groups –{' '}
+            Unique groups –{' '}
             <Link
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
                 target="_blank"

--- a/frontend/src/scenes/insights/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/AggregationSelect.tsx
@@ -25,7 +25,7 @@ export function AggregationSelect({ aggregationGroupTypeIndex, onChange }: Aggre
             dropdownMatchSelectWidth={false}
         >
             <Select.Option key="unique_users" value={UNIQUE_USERS} data-attr="aggregation-selector-users">
-                <div style={{ height: '100%', width: '100%' }}>unique users</div>
+                <div style={{ height: '100%', width: '100%' }}>Unique users</div>
             </Select.Option>
             {groupTypes.map((groupType) => (
                 <Select.Option
@@ -33,7 +33,7 @@ export function AggregationSelect({ aggregationGroupTypeIndex, onChange }: Aggre
                     value={groupType.group_type_index}
                     data-attr="aggregation-selector-group"
                 >
-                    <div style={{ height: '100%', width: '100%' }}>unique {groupType.group_type}(s)</div>
+                    <div style={{ height: '100%', width: '100%' }}>Unique {groupType.group_type}(s)</div>
                 </Select.Option>
             ))}
             {/* :KLUDGE: Select only allows Select.Option as children, so render groups option directly rather than as a child */}


### PR DESCRIPTION
## Changes

Fixes concern from [Slack thread](https://posthog.slack.com/archives/C01G8S5T08Z/p1639892518451200).

After:
<img width="267" alt="Screenshot 2021-12-20 at 22 16 23" src="https://user-images.githubusercontent.com/4550621/146833916-23a5ea56-8e75-4480-bed2-5df47d622018.png">

