### PR TITLE
Add benchmark for funnel query

### DIFF
--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -9,6 +9,7 @@ from ee.clickhouse.queries.trends.lifecycle import ClickhouseLifecycle
 from ee.clickhouse.materialized_columns import backfill_materialized_columns, get_materialized_columns, materialize
 from ee.clickhouse.queries.stickiness.clickhouse_stickiness import ClickhouseStickiness
 from ee.clickhouse.queries.funnels.funnel_correlation import FunnelCorrelation
+from ee.clickhouse.queries.funnels import ClickhouseFunnel
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
 from ee.clickhouse.queries.session_recordings.clickhouse_session_recording_list import ClickhouseSessionRecordingList
 from ee.clickhouse.queries.retention.clickhouse_retention import ClickhouseRetention
@@ -241,6 +242,18 @@ class QuerySuite:
         filter = Filter(data={"actions": [{"id": action.id}], **DATE_RANGE}, team=self.team)
         with no_materialized_columns():
             ClickhouseTrends().run(filter, self.team)
+
+    @benchmark_clickhouse
+    def track_funnel_normal(self):
+        filter = Filter(
+            data={
+                "insight": "FUNNELS",
+                "events": [{"id": "user signed up", "order": 0}, {"id": "insight analyzed", "order": 1}],
+                **DATE_RANGE,
+            },
+            team=self.team,
+        )
+        ClickhouseFunnel(filter, self.team).run()
 
     @benchmark_clickhouse
     def track_correlations_by_events(self):

--- a/ee/clickhouse/queries/event_query.py
+++ b/ee/clickhouse/queries/event_query.py
@@ -79,7 +79,7 @@ class ClickhouseEventQuery(metaclass=ABCMeta):
         if self._should_join_distinct_ids:
             return f"""
             INNER JOIN ({get_team_distinct_ids_query(self._team_id)}) AS {self.DISTINCT_ID_TABLE_ALIAS}
-            ON events.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id
+            ON {self.EVENT_TABLE_ALIAS}.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id
             """
         else:
             return ""

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -82,7 +82,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id
                        FROM person
@@ -263,7 +263,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id
                        FROM person
@@ -345,7 +345,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id
                        FROM person
@@ -499,7 +499,7 @@
                                          distinct_id,
                                          team_id
                                 HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -656,7 +656,7 @@
                                          distinct_id,
                                          team_id
                                 HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -805,7 +805,7 @@
                                          distinct_id,
                                          team_id
                                 HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -958,7 +958,7 @@
                                          distinct_id,
                                          team_id
                                 HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -1111,7 +1111,7 @@
                                          distinct_id,
                                          team_id
                                 HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -1264,7 +1264,7 @@
                                          distinct_id,
                                          team_id
                                 HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -68,7 +68,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up', 'user signed up', 'paid']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -185,7 +185,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -290,7 +290,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -386,7 +386,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -482,7 +482,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -578,7 +578,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -674,7 +674,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -779,7 +779,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -874,7 +874,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -969,7 +969,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1064,7 +1064,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1159,7 +1159,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1272,7 +1272,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1385,7 +1385,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1488,7 +1488,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1587,7 +1587,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1686,7 +1686,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1785,7 +1785,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1885,7 +1885,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -1998,7 +1998,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -2107,7 +2107,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -2215,7 +2215,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2320,7 +2320,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2417,7 +2417,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2514,7 +2514,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2611,7 +2611,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2708,7 +2708,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2815,7 +2815,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2920,7 +2920,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3017,7 +3017,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3114,7 +3114,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3211,7 +3211,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3308,7 +3308,7 @@
                                       distinct_id,
                                       team_id
                              HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -110,7 +110,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -241,7 +241,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -364,7 +364,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -491,7 +491,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -618,7 +618,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -745,7 +745,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -162,7 +162,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -234,7 +234,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -306,7 +306,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -483,7 +483,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -553,7 +553,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -623,7 +623,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -803,7 +803,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -873,7 +873,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -943,7 +943,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1123,7 +1123,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1193,7 +1193,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1263,7 +1263,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1398,7 +1398,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1468,7 +1468,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1538,7 +1538,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1714,7 +1714,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1784,7 +1784,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1854,7 +1854,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -109,7 +109,7 @@
                  distinct_id,
                  team_id
         HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -196,7 +196,7 @@
                  distinct_id,
                  team_id
         HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -301,7 +301,7 @@
                  distinct_id,
                  team_id
         HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -344,7 +344,7 @@
                  distinct_id,
                  team_id
         HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -92,7 +92,7 @@
                                             distinct_id,
                                             team_id
                                    HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -175,7 +175,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -300,7 +300,7 @@
                                             distinct_id,
                                             team_id
                                    HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -380,7 +380,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -503,7 +503,7 @@
                                             distinct_id,
                                             team_id
                                    HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -583,7 +583,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -706,7 +706,7 @@
                                             distinct_id,
                                             team_id
                                    HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -786,7 +786,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -909,7 +909,7 @@
                                             distinct_id,
                                             team_id
                                    HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -989,7 +989,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -1088,7 +1088,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -1190,7 +1190,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -1292,7 +1292,7 @@
                                 distinct_id,
                                 team_id
                        HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_1

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -208,7 +208,7 @@
                        distinct_id,
                        team_id
               HAVING max(is_deleted) = 0)
-           GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+           GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0
@@ -248,7 +248,7 @@
                        distinct_id,
                        team_id
               HAVING max(is_deleted) = 0)
-           GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+           GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0
@@ -314,7 +314,7 @@
                        distinct_id,
                        team_id
               HAVING max(is_deleted) = 0)
-           GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+           GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0
@@ -353,7 +353,7 @@
                        distinct_id,
                        team_id
               HAVING max(is_deleted) = 0)
-           GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+           GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -101,7 +101,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -367,7 +367,7 @@
                           distinct_id,
                           team_id
                  HAVING max(is_deleted) = 0)
-              GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+              GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
            INNER JOIN
              (SELECT id
               FROM person

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -87,7 +87,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['$pageleave', '$pageview']
                       AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -20,7 +20,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -53,7 +53,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -86,7 +86,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -119,7 +119,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -153,7 +153,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -194,7 +194,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -235,7 +235,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -276,7 +276,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -34,7 +34,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -83,7 +83,7 @@
                           distinct_id,
                           team_id
                  HAVING max(is_deleted) = 0)
-              GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+              GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
@@ -116,7 +116,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -183,7 +183,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -235,7 +235,7 @@
                              distinct_id,
                              team_id
                     HAVING max(is_deleted) = 0)
-                 GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                 GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
@@ -269,7 +269,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -375,7 +375,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -507,7 +507,7 @@
                     distinct_id,
                     team_id
            HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -57,7 +57,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -127,7 +127,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -206,7 +206,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -277,7 +277,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -356,7 +356,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -426,7 +426,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -502,7 +502,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -580,7 +580,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -58,7 +58,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -109,7 +109,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -180,7 +180,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -232,7 +232,7 @@
                                    distinct_id,
                                    team_id
                           HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON events.distinct_id = pdi.distinct_id
+                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'


### PR DESCRIPTION
Used to test out new events sorting order. That takes the benchmark from 3.5s -> 1.5s \o/
