### PR TITLE
Run e2e tests via docker postgres

### DIFF
--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -1,14 +1,16 @@
 #!/bin/bash
 set -e
 
+DATABASE="posthog_e2e_test"
+
 export PGHOST="${PGHOST:=localhost}"
 export PGUSER="${PGUSER:=posthog}"
 export PGPASSWORD="${PGPASSWORD:=posthog}"
 export PGPORT="${PGPORT:=5432}"
-export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/posthog_e2e_test"
+export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DATABASE}"
 
-dropdb --if-exists posthog_e2e_test
-createdb posthog_e2e_test
+dropdb --if-exists $DATABASE
+createdb $DATABASE
 DEBUG=1 python manage.py migrate &&
 DEBUG=1 python manage.py setup_dev &
 yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -e
 
+export PGHOST=localhost
+export PGUSER=posthog
+export PGPASSWORD=posthog
 dropdb --if-exists posthog_e2e_test
 createdb posthog_e2e_test
-DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py migrate &&
-DEBUG=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test python manage.py setup_dev &
+DEBUG=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test python manage.py migrate &&
+DEBUG=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test python manage.py setup_dev &
 yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
 
-NO_RESTART_LOOP=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test ./bin/plugin-server &
+NO_RESTART_LOOP=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test ./bin/plugin-server &
 # Only start webpack if not already running
 nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
 
 CYPRESS_BASE_URL=http://localhost:8080 npx cypress open --config-file cypress.e2e.json &
-OPT_OUT_CAPTURE=1 SECURE_COOKIES=0 DEBUG=0 TEST=1 E2E_TESTING=1 DATABASE_URL=postgres://localhost:5432/posthog_e2e_test EMAIL_HOST=email.test.posthog.net SITE_URL=test.posthog.net python manage.py runserver 8080
+OPT_OUT_CAPTURE=1 SECURE_COOKIES=0 DEBUG=0 TEST=1 E2E_TESTING=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test EMAIL_HOST=email.test.posthog.net SITE_URL=test.posthog.net python manage.py runserver 8080
 yarn remove cypress cypress-terminal-report @cypress/react @cypress/webpack-preprocessor

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -1,19 +1,22 @@
 #!/bin/bash
 set -e
 
-export PGHOST=localhost
-export PGUSER=posthog
-export PGPASSWORD=posthog
+export PGHOST="${PGHOST:=localhost}"
+export PGUSER="${PGUSER:=posthog}"
+export PGPASSWORD="${PGPASSWORD:=posthog}"
+export PGPORT="${PGPORT:=5432}"
+export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/posthog_e2e_test"
+
 dropdb --if-exists posthog_e2e_test
 createdb posthog_e2e_test
-DEBUG=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test python manage.py migrate &&
-DEBUG=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test python manage.py setup_dev &
+DEBUG=1 python manage.py migrate &&
+DEBUG=1 python manage.py setup_dev &
 yarn add cypress@6.7.0 cypress-terminal-report@2.1.0 @cypress/react@4.16.4 @cypress/webpack-preprocessor@5.7.0
 
-NO_RESTART_LOOP=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test ./bin/plugin-server &
+NO_RESTART_LOOP=1 ./bin/plugin-server &
 # Only start webpack if not already running
 nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
 
 CYPRESS_BASE_URL=http://localhost:8080 npx cypress open --config-file cypress.e2e.json &
-OPT_OUT_CAPTURE=1 SECURE_COOKIES=0 DEBUG=0 TEST=1 E2E_TESTING=1 DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_e2e_test EMAIL_HOST=email.test.posthog.net SITE_URL=test.posthog.net python manage.py runserver 8080
+OPT_OUT_CAPTURE=1 SECURE_COOKIES=0 DEBUG=0 TEST=1 E2E_TESTING=1 EMAIL_HOST=email.test.posthog.net SITE_URL=test.posthog.net python manage.py runserver 8080
 yarn remove cypress cypress-terminal-report @cypress/react @cypress/webpack-preprocessor


### PR DESCRIPTION
## Changes

Makes the `bin/e2e-test-runner` use the docker postgres instance, instead of the local one.

## How did you test this code?

Ran the test runner, saw it fail, fixed the envs, saw it work.

I tagged a few people for this PR, to be sure I'm not stepping on too many toes by doing this. As I understand, we started to settle on using postgres via docker as the suggested [local development](https://posthog.com/docs/contribute/developing-locally) strategy. Thus we should update all local dev scripts to reflect this.

Any objections to doing this for the e2e test runner script that we only run locally?