### PR TITLE
Replace old insight table with lemon table

### DIFF
--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -96,7 +96,7 @@ describe('Trends', () => {
         cy.get('[data-attr=math-total-0]').click()
 
         // Should contain more than label column
-        cy.get('[data-attr=insights-table-graph]').find('.ant-table-cell').its('length').should('be.gte', 1)
+        cy.get('[data-attr=insights-table-graph]').find('td').its('length').should('be.gte', 1)
     })
 
     it('Apply date filter', () => {

--- a/frontend/src/lib/components/DateDisplay/DateDisplay.scss
+++ b/frontend/src/lib/components/DateDisplay/DateDisplay.scss
@@ -1,11 +1,12 @@
 @import '~/vars';
+
 .dated-highlight {
-    color: $text_muted;
+    color: var(--text-muted);
     margin-right: 4px;
     padding: 2px 4px;
-    border: 1px solid $border_light;
-    background-color: white;
-    border-radius: $radius;
+    border: 1px solid var(--border-light);
+    background-color: #fff;
+    border-radius: var(--radius);
     white-space: nowrap;
 }
 
@@ -15,7 +16,7 @@
 
     .secondary-date {
         margin-left: 2px;
-        color: $text_muted_alt;
+        color: var(--muted-alt);
         font-weight: normal;
     }
 }

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -281,7 +281,10 @@ export function LemonTable<T extends Record<string, any>>({
                                                     })
                                                 }
                                             >
-                                                <div className="LemonTable__header-content">
+                                                <div
+                                                    className="LemonTable__header-content"
+                                                    style={{ justifyContent: column.align }}
+                                                >
                                                     {column.title}
                                                     {column.sorter && (
                                                         <SortingIndicator

--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -93,7 +93,7 @@ $funnel_canvas_background: #fafafa;
     .insight-controls {
         overflow: visible;
         position: relative;
-        margin-bottom: $default_spacing / 2;
+        margin-bottom: 1rem;
 
         .ant-card-body {
             padding: $default_spacing * 0.8 $default_spacing;

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -115,12 +115,7 @@ export function InsightContainer({ disableTable }: { disableTable?: boolean } = 
             filters?.layout === FunnelLayout.horizontal &&
             !disableTable
         ) {
-            return (
-                <Card>
-                    <h3 className="l3">Details table</h3>
-                    <FunnelStepTable />
-                </Card>
-            )
+            return <FunnelStepTable />
         }
         if (
             (!filters.display ||
@@ -134,16 +129,13 @@ export function InsightContainer({ disableTable }: { disableTable?: boolean } = 
         2. Bar value chart. Because this view displays data in completely different dimensions.
     */
             return (
-                <Card style={{ marginTop: 8 }}>
-                    <BindLogic logic={trendsLogic} props={insightProps}>
-                        <h3 className="l3">Details table</h3>
-                        <InsightsTable
-                            showTotalCount={activeView !== InsightType.SESSIONS}
-                            filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
-                            canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
-                        />
-                    </BindLogic>
-                </Card>
+                <BindLogic logic={trendsLogic} props={insightProps}>
+                    <InsightsTable
+                        showTotalCount={activeView !== InsightType.SESSIONS}
+                        filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
+                        canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
+                    />
+                </BindLogic>
             )
         }
 

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
@@ -5,18 +5,17 @@
     align-items: center;
 
     .edit-icon {
-        color: $primary;
+        color: var(--primary);
         cursor: pointer;
-        padding-right: 4px;
+        margin-left: 0.5rem;
     }
 
     .insights-label {
-        flex-grow: 1;
         &.editable {
             cursor: pointer;
             .ant-typography {
-                color: $primary;
-                font-weight: $medium;
+                color: var(--primary);
+                font-weight: 500;
             }
         }
     }

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -230,7 +230,7 @@ export function InsightsTable({
                 )
             },
             sorter: (a, b) => (a.count || a.aggregated_value) - (b.count || b.aggregated_value),
-            key: 'count',
+            dataIndex: 'count',
             width: 120,
             align: 'center',
         })

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -78,9 +78,10 @@ export function InsightsTable({
             {Object.keys(CALC_COLUMN_LABELS).map((key) => (
                 <Menu.Item
                     key={key}
-                    onClick={() => {
+                    onClick={(e) => {
                         setCalcColumnState(key as CalcColumnState)
                         reportInsightsTableCalcToggled(key)
+                        e.domEvent.stopPropagation() // Prevent click here from affecting table sorting
                     }}
                 >
                     {CALC_COLUMN_LABELS[key as CalcColumnState]}

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Dropdown, Menu, Skeleton } from 'antd'
+import { Dropdown, Menu } from 'antd'
 import { Tooltip } from 'lib/components/Tooltip'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
@@ -236,16 +236,14 @@ export function InsightsTable({
         })
     }
 
-    if (resultsLoading) {
-        return <Skeleton active paragraph={{ rows: 4 }} />
-    }
-
     return (
         <LemonTable
             dataSource={indexedResults}
             columns={columns}
             rowKey="id"
             pagination={{ pageSize: 100, hideOnSinglePage: true }}
+            loading={resultsLoading}
+            emptyState="No insight results yet…"
             data-attr="insights-table-graph"
         />
     )

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -94,7 +94,6 @@ export function InsightsTable({
 
     if (isLegend) {
         columns.push({
-            title: '',
             render: function RenderCheckbox(_, item: IndexedTrendResult) {
                 return (
                     <PHCheckbox
@@ -104,43 +103,15 @@ export function InsightsTable({
                     />
                 )
             },
-            width: 30,
-        })
-    }
-
-    if (filters.breakdown) {
-        columns.push({
-            title: (
-                <PropertyKeyInfo disableIcon disablePopover value={filters.breakdown.toString() || 'Breakdown Value'} />
-            ),
-            render: function RenderBreakdownValue(_, item: IndexedTrendResult) {
-                const breakdownLabel = formatBreakdownLabel(cohorts, item.breakdown_value)
-                return (
-                    <SeriesToggleWrapper id={item.id} toggleVisibility={toggleVisibility}>
-                        {breakdownLabel && <div title={breakdownLabel}>{stringWithWBR(breakdownLabel, 20)}</div>}
-                    </SeriesToggleWrapper>
-                )
-            },
-            key: 'breakdown',
-            width: 150,
-            sorter: (a, b) => {
-                const labelA = formatBreakdownLabel(cohorts, a.breakdown_value)
-                const labelB = formatBreakdownLabel(cohorts, b.breakdown_value)
-                return labelA.localeCompare(labelB)
-            },
+            width: 0,
         })
     }
 
     columns.push({
-        title: 'Event or Action',
+        title: 'Series',
         render: function RenderLabel(_, item: IndexedTrendResult): JSX.Element {
             return (
                 <div className="series-name-wrapper-col">
-                    {canEditSeriesNameInline && (
-                        <div className="edit-icon" onClick={() => handleEditClick(item)}>
-                            <EditOutlined />
-                        </div>
-                    )}
                     <InsightLabel
                         seriesColor={colorList[item.id]}
                         action={item.action}
@@ -156,17 +127,45 @@ export function InsightsTable({
                         compareValue={filters.compare ? formatCompareLabel(item) : undefined}
                         onLabelClick={canEditSeriesNameInline ? () => handleEditClick(item) : undefined}
                     />
+                    {canEditSeriesNameInline && (
+                        <EditOutlined
+                            title="Rename graph series"
+                            className="edit-icon"
+                            onClick={() => handleEditClick(item)}
+                        />
+                    )}
                 </div>
             )
         },
         key: 'label',
-        width: 200,
         sorter: (a, b) => {
             const labelA = a.action?.name || a.label || ''
             const labelB = b.action?.name || b.label || ''
             return labelA.localeCompare(labelB)
         },
     })
+
+    if (filters.breakdown) {
+        columns.push({
+            title: (
+                <PropertyKeyInfo disableIcon disablePopover value={filters.breakdown.toString() || 'Breakdown Value'} />
+            ),
+            render: function RenderBreakdownValue(_, item: IndexedTrendResult) {
+                const breakdownLabel = formatBreakdownLabel(cohorts, item.breakdown_value)
+                return (
+                    <SeriesToggleWrapper id={item.id} toggleVisibility={toggleVisibility}>
+                        {breakdownLabel && <div title={breakdownLabel}>{stringWithWBR(breakdownLabel, 20)}</div>}
+                    </SeriesToggleWrapper>
+                )
+            },
+            key: 'breakdown',
+            sorter: (a, b) => {
+                const labelA = formatBreakdownLabel(cohorts, a.breakdown_value)
+                const labelB = formatBreakdownLabel(cohorts, b.breakdown_value)
+                return labelA.localeCompare(labelB)
+            },
+        })
+    }
 
     if (indexedResults?.length > 0 && indexedResults[0].data) {
         const previousResult = !!filters.compare
@@ -189,7 +188,7 @@ export function InsightsTable({
                 },
                 key: `data[${index}]`,
                 sorter: (a, b) => a.data[index] - b.data[index],
-                align: 'center', // doesn't matter since it's overridden in css
+                align: 'right',
             })
         )
 
@@ -201,7 +200,8 @@ export function InsightsTable({
             title: (
                 <Dropdown overlay={calcColumnMenu}>
                     <span className="cursor-pointer">
-                        {CALC_COLUMN_LABELS[calcColumnState]} <DownOutlined />
+                        {CALC_COLUMN_LABELS[calcColumnState]}
+                        <DownOutlined className="ml-025" />
                     </span>
                 </Dropdown>
             ),
@@ -231,8 +231,7 @@ export function InsightsTable({
             },
             sorter: (a, b) => (a.count || a.aggregated_value) - (b.count || b.aggregated_value),
             dataIndex: 'count',
-            width: 120,
-            align: 'center',
+            align: 'right',
         })
     }
 
@@ -244,7 +243,6 @@ export function InsightsTable({
         <LemonTable
             dataSource={indexedResults}
             columns={columns}
-            size="small"
             rowKey="id"
             pagination={{ pageSize: 100, hideOnSinglePage: true }}
             data-attr="insights-table-graph"

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -771,14 +771,14 @@ code.code {
 
 .main-app-content {
     min-width: 0;
-    padding: 0 2rem 2rem;
+    padding: 0 2rem 4rem;
 
     @media (min-width: $sm) and (max-width: $lg) {
         padding: 0 1rem 2rem;
     }
 
     @media (max-width: $sm) {
-        padding: 0 1rem;
+        padding: 0 1rem 1rem;
     }
 }
 


### PR DESCRIPTION
## Changes

This makes the insights page usable when showing a huge table. Resolves #7543. Should resolve #7751 too.

Before, the page used to crash and stall all the time:
![2021-12-21 18 26 46](https://user-images.githubusercontent.com/53387/146972879-9203063c-0c83-42f7-84b5-f9c5550ffff9.gif)

After we lose the fixed columns, but the table is fast and insights > 180 days with a few breakdowns are actually usable:
![2021-12-21 18 25 08](https://user-images.githubusercontent.com/53387/146972693-6b14a201-7571-4e55-b11a-d61299768329.gif)


## How did you test this code?

Checked it in the interface.

There's another bug in the screencast where annotations push the page's width through the roof, but that's for another day.