### PR TITLE
[fix] Retention line graph modal

### DIFF
--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -57,8 +57,8 @@ export function RetentionLineGraph({
                 onClick={
                     dashboardItemId
                         ? undefined
-                        : (point) => {
-                              const { points } = point
+                        : (payload) => {
+                              const { points } = payload
                               const datasetIndex = points.clickedPointNotLine
                                   ? points.pointsIntersectingClick[0].dataset.index
                                   : points.pointsIntersectingLine[0].dataset.index

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -42,7 +42,6 @@ export function RetentionLineGraph({
     if (trendSeries.length === 0) {
         return null
     }
-
     return trendSeries ? (
         <>
             <LineGraph
@@ -61,8 +60,8 @@ export function RetentionLineGraph({
                         : (point) => {
                               const { points } = point
                               const datasetIndex = points.clickedPointNotLine
-                                  ? points.pointsIntersectingClick[0]._datasetIndex
-                                  : points.pointsIntersectingLine[0]._datasetIndex
+                                  ? points.pointsIntersectingClick[0].dataset.index
+                                  : points.pointsIntersectingLine[0].dataset.index
                               loadPeople(datasetIndex) // start from 0
                               selectRow(datasetIndex)
                               setModalVisible(true)

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -62,8 +62,10 @@ export function RetentionLineGraph({
                               const datasetIndex = points.clickedPointNotLine
                                   ? points.pointsIntersectingClick[0].dataset.index
                                   : points.pointsIntersectingLine[0].dataset.index
-                              loadPeople(datasetIndex) // start from 0
-                              selectRow(datasetIndex)
+                              if (datasetIndex) {
+                                  loadPeople(datasetIndex) // start from 0
+                                  selectRow(datasetIndex)
+                              }
                               setModalVisible(true)
                           }
                 }

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -3,10 +3,8 @@ import { retentionTableLogic } from './retentionTableLogic'
 import { LineGraph } from '../insights/LineGraph/LineGraph'
 import { useActions, useValues } from 'kea'
 import { InsightEmptyState } from '../insights/EmptyStates'
-import { Modal, Button } from 'antd'
-import { PersonsTable } from 'scenes/persons/PersonsTable'
-import { GraphType, PersonType, GraphDataset } from '~/types'
-import { RetentionTablePayload, RetentionTablePeoplePayload, RetentionTrendPeoplePayload } from 'scenes/retention/types'
+import { GraphType, GraphDataset } from '~/types'
+import { RetentionTablePayload, RetentionTablePeoplePayload } from 'scenes/retention/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import './RetentionLineGraph.scss'
 import { RetentionModal } from './RetentionModal'
@@ -25,14 +23,21 @@ export function RetentionLineGraph({
 }: RetentionLineGraphProps): JSX.Element | null {
     const { insightProps, insight } = useValues(insightLogic)
     const logic = retentionTableLogic(insightProps)
-    const { results: _results, filters, trendSeries, people: _people, peopleLoading, loadingMore, aggregationTargetLabel } = useValues(logic)
+    const {
+        results: _results,
+        filters,
+        trendSeries,
+        people: _people,
+        peopleLoading,
+        loadingMore,
+        aggregationTargetLabel,
+    } = useValues(logic)
     const results = _results as RetentionTablePayload[]
     const people = _people as RetentionTablePeoplePayload
 
     const { loadPeople, loadMorePeople } = useActions(logic)
     const [modalVisible, setModalVisible] = useState(false)
     const [selectedRow, selectRow] = useState(0)
-
 
     if (trendSeries.length === 0) {
         return null
@@ -54,25 +59,29 @@ export function RetentionLineGraph({
                     dashboardItemId
                         ? undefined
                         : (point) => {
-                              const { index } = point
-                              console.log(point)
-                              loadPeople(index) // start from 0
-                              selectRow(index)
+                              const { points } = point
+                              const datasetIndex = points.clickedPointNotLine
+                                  ? points.pointsIntersectingClick[0]._datasetIndex
+                                  : points.pointsIntersectingLine[0]._datasetIndex
+                              loadPeople(datasetIndex) // start from 0
+                              selectRow(datasetIndex)
                               setModalVisible(true)
                           }
                 }
             />
-            {results && <RetentionModal
-                results={results}
-                actors={people}
-                selectedRow={selectedRow}
-                visible={modalVisible}
-                dismissModal={() => setModalVisible(false)}
-                actorsLoading={peopleLoading}
-                loadMore={() => loadMorePeople()}
-                loadingMore={loadingMore}
-                aggregationTargetLabel={aggregationTargetLabel}
-            />}
+            {results && (
+                <RetentionModal
+                    results={results}
+                    actors={people}
+                    selectedRow={selectedRow}
+                    visible={modalVisible}
+                    dismissModal={() => setModalVisible(false)}
+                    actorsLoading={peopleLoading}
+                    loadMore={() => loadMorePeople()}
+                    loadingMore={loadingMore}
+                    aggregationTargetLabel={aggregationTargetLabel}
+                />
+            )}
         </>
     ) : (
         <InsightEmptyState color={color} isDashboard={!!dashboardItemId} />

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -51,7 +51,7 @@ export function RetentionModal({
             {!actorsLoading ? (
                 <div>
                     {results[selectedRow]?.values[0]?.count === 0 ? (
-                        <span>No persons during this period.</span>
+                        <span>No {aggregationTargetLabel.plural} during this period.</span>
                     ) : (
                         <div>
                             <table className="table-bordered full-width">
@@ -133,7 +133,7 @@ export function RetentionModal({
                             >
                                 {actors.next ? (
                                     <Button type="primary" onClick={loadMore} loading={loadingMore}>
-                                        Load more people
+                                        Load more {aggregationTargetLabel.plural}
                                     </Button>
                                 ) : null}
                             </div>

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -14,7 +14,7 @@ import { urls } from 'scenes/urls'
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 import { asDisplay } from 'scenes/persons/PersonHeader'
 
-export function RetentionModal({ 
+export function RetentionModal({
     results,
     visible,
     selectedRow,
@@ -23,8 +23,8 @@ export function RetentionModal({
     actors,
     loadMore,
     loadingMore,
-    aggregationTargetLabel
- }: { 
+    aggregationTargetLabel,
+}: {
     results: RetentionTablePayload[]
     visible: boolean
     selectedRow: number
@@ -32,127 +32,117 @@ export function RetentionModal({
     loadMore: () => void
     actorsLoading: boolean
     loadingMore: boolean
-    actors: RetentionTablePeoplePayload,
+    actors: RetentionTablePeoplePayload
     aggregationTargetLabel: { singular: string; plural: string }
-  }): JSX.Element | null {
-
+}): JSX.Element | null {
     return (
-            <Modal
-                visible={visible}
-                closable={true}
-                onCancel={dismissModal}
-                footer={<Button onClick={dismissModal}>Close</Button>}
-                style={{
-                    top: 20,
-                    minWidth: results[selectedRow]?.values[0]?.count === 0 ? '10%' : '90%',
-                    fontSize: 16,
-                }}
-                title={results[selectedRow] ? dayjs(results[selectedRow].date).format('MMMM D, YYYY') : ''}
-            >
-                {!actorsLoading ? (
-                    <div>
-                        {results[selectedRow]?.values[0]?.count === 0 ? (
-                            <span>No persons during this period.</span>
-                        ) : (
-                            <div>
-                                <table className="table-bordered full-width">
-                                    <tbody>
-                                        <tr>
-                                            <th />
-                                            {results &&
-                                                results
-                                                    .slice(0, results[selectedRow]?.values.length)
-                                                    .map((data, index) => <th key={index}>{data.label}</th>)}
-                                        </tr>
-                                        <tr>
-                                            <td>{capitalizeFirstLetter(aggregationTargetLabel.singular)}</td>
-                                            {results &&
-                                                results[selectedRow]?.values.map((data: any, index: number) => (
-                                                    <td key={index}>
-                                                        {data.count}&nbsp;{' '}
-                                                        {data.count > 0 && (
-                                                            <span>
-                                                                (
-                                                                {percentage(
-                                                                    data.count /
-                                                                        results[selectedRow]?.values[0]['count']
-                                                                )}
-                                                                )
-                                                            </span>
-                                                        )}
-                                                    </td>
-                                                ))}
-                                        </tr>
-                                        {actors.result &&
-                                            actors.result.map((personAppearances: RetentionTableAppearanceType) => (
-                                                <tr key={personAppearances.person.id}>
-                                                    <td className="text-overflow" style={{ minWidth: 200 }}>
-                                                        {isGroupType(personAppearances.person) ? (
-                                                            <Link
-                                                                to={urls.group(
-                                                                    String(
-                                                                        personAppearances.person.group_type_index
-                                                                    ),
-                                                                    personAppearances.person.group_key
-                                                                )}
-                                                                data-attr="retention-person-link"
-                                                            >
-                                                                {groupDisplayId(
-                                                                    personAppearances.person.group_key,
-                                                                    personAppearances.person.properties
-                                                                )}
-                                                            </Link>
-                                                        ) : (
-                                                            <Link
-                                                                to={urls.person(
-                                                                    personAppearances.person.distinct_ids[0]
-                                                                )}
-                                                                data-attr="retention-person-link"
-                                                            >
-                                                                {asDisplay(personAppearances.person)}
-                                                            </Link>
-                                                        )}
-                                                    </td>
-                                                    {personAppearances.appearances.map(
-                                                        (appearance: number, index: number) => {
-                                                            return (
-                                                                <td
-                                                                    key={index}
-                                                                    className={
-                                                                        appearance
-                                                                            ? 'retention-success'
-                                                                            : 'retention-dropped'
-                                                                    }
-                                                                />
+        <Modal
+            visible={visible}
+            closable={true}
+            onCancel={dismissModal}
+            footer={<Button onClick={dismissModal}>Close</Button>}
+            style={{
+                top: 20,
+                minWidth: results[selectedRow]?.values[0]?.count === 0 ? '10%' : '90%',
+                fontSize: 16,
+            }}
+            title={results[selectedRow] ? dayjs(results[selectedRow].date).format('MMMM D, YYYY') : ''}
+        >
+            {!actorsLoading ? (
+                <div>
+                    {results[selectedRow]?.values[0]?.count === 0 ? (
+                        <span>No persons during this period.</span>
+                    ) : (
+                        <div>
+                            <table className="table-bordered full-width">
+                                <tbody>
+                                    <tr>
+                                        <th />
+                                        {results &&
+                                            results
+                                                .slice(0, results[selectedRow]?.values.length)
+                                                .map((data, index) => <th key={index}>{data.label}</th>)}
+                                    </tr>
+                                    <tr>
+                                        <td>{capitalizeFirstLetter(aggregationTargetLabel.singular)}</td>
+                                        {results &&
+                                            results[selectedRow]?.values.map((data: any, index: number) => (
+                                                <td key={index}>
+                                                    {data.count}&nbsp;{' '}
+                                                    {data.count > 0 && (
+                                                        <span>
+                                                            (
+                                                            {percentage(
+                                                                data.count / results[selectedRow]?.values[0]['count']
+                                                            )}
                                                             )
-                                                        }
+                                                        </span>
                                                     )}
-                                                </tr>
+                                                </td>
                                             ))}
-                                    </tbody>
-                                </table>
-                                <div
-                                    style={{
-                                        margin: '1rem',
-                                        textAlign: 'center',
-                                    }}
-                                >
-                                    {actors.next ? (
-                                        <Button
-                                            type="primary"
-                                            onClick={loadMore}
-                                            loading={loadingMore}
-                                        >
-                                            Load more people
-                                        </Button>
-                                    ) : null}
-                                </div>
+                                    </tr>
+                                    {actors.result &&
+                                        actors.result.map((personAppearances: RetentionTableAppearanceType) => (
+                                            <tr key={personAppearances.person.id}>
+                                                <td className="text-overflow" style={{ minWidth: 200 }}>
+                                                    {isGroupType(personAppearances.person) ? (
+                                                        <Link
+                                                            to={urls.group(
+                                                                String(personAppearances.person.group_type_index),
+                                                                personAppearances.person.group_key
+                                                            )}
+                                                            data-attr="retention-person-link"
+                                                        >
+                                                            {groupDisplayId(
+                                                                personAppearances.person.group_key,
+                                                                personAppearances.person.properties
+                                                            )}
+                                                        </Link>
+                                                    ) : (
+                                                        <Link
+                                                            to={urls.person(personAppearances.person.distinct_ids[0])}
+                                                            data-attr="retention-person-link"
+                                                        >
+                                                            {asDisplay(personAppearances.person)}
+                                                        </Link>
+                                                    )}
+                                                </td>
+                                                {personAppearances.appearances.map(
+                                                    (appearance: number, index: number) => {
+                                                        return (
+                                                            <td
+                                                                key={index}
+                                                                className={
+                                                                    appearance
+                                                                        ? 'retention-success'
+                                                                        : 'retention-dropped'
+                                                                }
+                                                            />
+                                                        )
+                                                    }
+                                                )}
+                                            </tr>
+                                        ))}
+                                </tbody>
+                            </table>
+                            <div
+                                style={{
+                                    margin: '1rem',
+                                    textAlign: 'center',
+                                }}
+                            >
+                                {actors.next ? (
+                                    <Button type="primary" onClick={loadMore} loading={loadingMore}>
+                                        Load more people
+                                    </Button>
+                                ) : null}
                             </div>
-                        )}
-                    </div>
-                ) : (
-                    <Spinner size="sm" />
-                )}
-            </Modal>
+                        </div>
+                    )}
+                </div>
+            ) : (
+                <Spinner size="sm" />
+            )}
+        </Modal>
     )
 }

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { Modal, Button } from 'antd'
+import { capitalizeFirstLetter, isGroupType, percentage } from 'lib/utils'
+import { Link } from 'lib/components/Link'
+import {
+    RetentionTablePayload,
+    RetentionTablePeoplePayload,
+    RetentionTableAppearanceType,
+} from 'scenes/retention/types'
+import { dayjs } from 'lib/dayjs'
+import { Spinner } from 'lib/components/Spinner/Spinner'
+import './RetentionTable.scss'
+import { urls } from 'scenes/urls'
+import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
+import { asDisplay } from 'scenes/persons/PersonHeader'
+
+export function RetentionModal({ 
+    results,
+    visible,
+    selectedRow,
+    dismissModal,
+    actorsLoading,
+    actors,
+    loadMore,
+    loadingMore,
+    aggregationTargetLabel
+ }: { 
+    results: RetentionTablePayload[]
+    visible: boolean
+    selectedRow: number
+    dismissModal: () => void
+    loadMore: () => void
+    actorsLoading: boolean
+    loadingMore: boolean
+    actors: RetentionTablePeoplePayload,
+    aggregationTargetLabel: { singular: string; plural: string }
+  }): JSX.Element | null {
+
+    return (
+            <Modal
+                visible={visible}
+                closable={true}
+                onCancel={dismissModal}
+                footer={<Button onClick={dismissModal}>Close</Button>}
+                style={{
+                    top: 20,
+                    minWidth: results[selectedRow]?.values[0]?.count === 0 ? '10%' : '90%',
+                    fontSize: 16,
+                }}
+                title={results[selectedRow] ? dayjs(results[selectedRow].date).format('MMMM D, YYYY') : ''}
+            >
+                {!actorsLoading ? (
+                    <div>
+                        {results[selectedRow]?.values[0]?.count === 0 ? (
+                            <span>No persons during this period.</span>
+                        ) : (
+                            <div>
+                                <table className="table-bordered full-width">
+                                    <tbody>
+                                        <tr>
+                                            <th />
+                                            {results &&
+                                                results
+                                                    .slice(0, results[selectedRow]?.values.length)
+                                                    .map((data, index) => <th key={index}>{data.label}</th>)}
+                                        </tr>
+                                        <tr>
+                                            <td>{capitalizeFirstLetter(aggregationTargetLabel.singular)}</td>
+                                            {results &&
+                                                results[selectedRow]?.values.map((data: any, index: number) => (
+                                                    <td key={index}>
+                                                        {data.count}&nbsp;{' '}
+                                                        {data.count > 0 && (
+                                                            <span>
+                                                                (
+                                                                {percentage(
+                                                                    data.count /
+                                                                        results[selectedRow]?.values[0]['count']
+                                                                )}
+                                                                )
+                                                            </span>
+                                                        )}
+                                                    </td>
+                                                ))}
+                                        </tr>
+                                        {actors.result &&
+                                            actors.result.map((personAppearances: RetentionTableAppearanceType) => (
+                                                <tr key={personAppearances.person.id}>
+                                                    <td className="text-overflow" style={{ minWidth: 200 }}>
+                                                        {isGroupType(personAppearances.person) ? (
+                                                            <Link
+                                                                to={urls.group(
+                                                                    String(
+                                                                        personAppearances.person.group_type_index
+                                                                    ),
+                                                                    personAppearances.person.group_key
+                                                                )}
+                                                                data-attr="retention-person-link"
+                                                            >
+                                                                {groupDisplayId(
+                                                                    personAppearances.person.group_key,
+                                                                    personAppearances.person.properties
+                                                                )}
+                                                            </Link>
+                                                        ) : (
+                                                            <Link
+                                                                to={urls.person(
+                                                                    personAppearances.person.distinct_ids[0]
+                                                                )}
+                                                                data-attr="retention-person-link"
+                                                            >
+                                                                {asDisplay(personAppearances.person)}
+                                                            </Link>
+                                                        )}
+                                                    </td>
+                                                    {personAppearances.appearances.map(
+                                                        (appearance: number, index: number) => {
+                                                            return (
+                                                                <td
+                                                                    key={index}
+                                                                    className={
+                                                                        appearance
+                                                                            ? 'retention-success'
+                                                                            : 'retention-dropped'
+                                                                    }
+                                                                />
+                                                            )
+                                                        }
+                                                    )}
+                                                </tr>
+                                            ))}
+                                    </tbody>
+                                </table>
+                                <div
+                                    style={{
+                                        margin: '1rem',
+                                        textAlign: 'center',
+                                    }}
+                                >
+                                    {actors.next ? (
+                                        <Button
+                                            type="primary"
+                                            onClick={loadMore}
+                                            loading={loadingMore}
+                                        >
+                                            Load more people
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <Spinner size="sm" />
+                )}
+            </Modal>
+    )
+}

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -1,24 +1,19 @@
 import React, { useState, useEffect } from 'react'
 import { useValues, useActions } from 'kea'
-import { Table, Modal, Button } from 'antd'
-import { capitalizeFirstLetter, isGroupType, percentage } from 'lib/utils'
-import { Link } from 'lib/components/Link'
+import { Table } from 'antd'
 import { retentionTableLogic } from './retentionTableLogic'
 import { Tooltip } from 'lib/components/Tooltip'
 import {
     RetentionTablePayload,
     RetentionTablePeoplePayload,
-    RetentionTableAppearanceType,
 } from 'scenes/retention/types'
 import { ColumnsType } from 'antd/lib/table'
 import clsx from 'clsx'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { dayjs } from 'lib/dayjs'
-import { Spinner } from 'lib/components/Spinner/Spinner'
 import './RetentionTable.scss'
-import { urls } from 'scenes/urls'
-import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
-import { asDisplay } from 'scenes/persons/PersonHeader'
+
+import { RetentionModal } from './RetentionModal'
 
 export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: number | null }): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -96,6 +91,10 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
         setModalVisible(false)
     }
 
+    function loadMore(): void {
+        loadMorePeople()
+    }
+
     return (
         <>
             <Table
@@ -118,125 +117,17 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
                     },
                 })}
             />
-            {results && (
-                <Modal
-                    visible={modalVisible}
-                    closable={true}
-                    onCancel={dismissModal}
-                    footer={<Button onClick={dismissModal}>Close</Button>}
-                    style={{
-                        top: 20,
-                        minWidth: results[selectedRow]?.values[0]?.count === 0 ? '10%' : '90%',
-                        fontSize: 16,
-                    }}
-                    title={results[selectedRow] ? dayjs(results[selectedRow].date).format('MMMM D, YYYY') : ''}
-                >
-                    {!peopleLoading ? (
-                        <div>
-                            {results[selectedRow]?.values[0]?.count === 0 ? (
-                                <span>No persons during this period.</span>
-                            ) : (
-                                <div>
-                                    <table className="table-bordered full-width">
-                                        <tbody>
-                                            <tr>
-                                                <th />
-                                                {results &&
-                                                    results
-                                                        .slice(0, results[selectedRow]?.values.length)
-                                                        .map((data, index) => <th key={index}>{data.label}</th>)}
-                                            </tr>
-                                            <tr>
-                                                <td>{capitalizeFirstLetter(aggregationTargetLabel.singular)}</td>
-                                                {results &&
-                                                    results[selectedRow]?.values.map((data: any, index: number) => (
-                                                        <td key={index}>
-                                                            {data.count}&nbsp;{' '}
-                                                            {data.count > 0 && (
-                                                                <span>
-                                                                    (
-                                                                    {percentage(
-                                                                        data.count /
-                                                                            results[selectedRow]?.values[0]['count']
-                                                                    )}
-                                                                    )
-                                                                </span>
-                                                            )}
-                                                        </td>
-                                                    ))}
-                                            </tr>
-                                            {people.result &&
-                                                people.result.map((personAppearances: RetentionTableAppearanceType) => (
-                                                    <tr key={personAppearances.person.id}>
-                                                        <td className="text-overflow" style={{ minWidth: 200 }}>
-                                                            {isGroupType(personAppearances.person) ? (
-                                                                <Link
-                                                                    to={urls.group(
-                                                                        String(
-                                                                            personAppearances.person.group_type_index
-                                                                        ),
-                                                                        personAppearances.person.group_key
-                                                                    )}
-                                                                    data-attr="retention-person-link"
-                                                                >
-                                                                    {groupDisplayId(
-                                                                        personAppearances.person.group_key,
-                                                                        personAppearances.person.properties
-                                                                    )}
-                                                                </Link>
-                                                            ) : (
-                                                                <Link
-                                                                    to={urls.person(
-                                                                        personAppearances.person.distinct_ids[0]
-                                                                    )}
-                                                                    data-attr="retention-person-link"
-                                                                >
-                                                                    {asDisplay(personAppearances.person)}
-                                                                </Link>
-                                                            )}
-                                                        </td>
-                                                        {personAppearances.appearances.map(
-                                                            (appearance: number, index: number) => {
-                                                                return (
-                                                                    <td
-                                                                        key={index}
-                                                                        className={
-                                                                            appearance
-                                                                                ? 'retention-success'
-                                                                                : 'retention-dropped'
-                                                                        }
-                                                                    />
-                                                                )
-                                                            }
-                                                        )}
-                                                    </tr>
-                                                ))}
-                                        </tbody>
-                                    </table>
-                                    <div
-                                        style={{
-                                            margin: '1rem',
-                                            textAlign: 'center',
-                                        }}
-                                    >
-                                        {people.next ? (
-                                            <Button
-                                                type="primary"
-                                                onClick={() => loadMorePeople()}
-                                                loading={loadingMore}
-                                            >
-                                                Load more people
-                                            </Button>
-                                        ) : null}
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    ) : (
-                        <Spinner size="sm" />
-                    )}
-                </Modal>
-            )}
+            {results && <RetentionModal
+                results={results}
+                actors={people}
+                selectedRow={selectedRow}
+                visible={modalVisible}
+                dismissModal={dismissModal}
+                actorsLoading={peopleLoading}
+                loadMore={loadMore}
+                loadingMore={loadingMore}
+                aggregationTargetLabel={aggregationTargetLabel}
+            />}
         </>
     )
 }

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -3,10 +3,7 @@ import { useValues, useActions } from 'kea'
 import { Table } from 'antd'
 import { retentionTableLogic } from './retentionTableLogic'
 import { Tooltip } from 'lib/components/Tooltip'
-import {
-    RetentionTablePayload,
-    RetentionTablePeoplePayload,
-} from 'scenes/retention/types'
+import { RetentionTablePayload, RetentionTablePeoplePayload } from 'scenes/retention/types'
 import { ColumnsType } from 'antd/lib/table'
 import clsx from 'clsx'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -117,17 +114,19 @@ export function RetentionTable({ dashboardItemId = null }: { dashboardItemId?: n
                     },
                 })}
             />
-            {results && <RetentionModal
-                results={results}
-                actors={people}
-                selectedRow={selectedRow}
-                visible={modalVisible}
-                dismissModal={dismissModal}
-                actorsLoading={peopleLoading}
-                loadMore={loadMore}
-                loadingMore={loadingMore}
-                aggregationTargetLabel={aggregationTargetLabel}
-            />}
+            {results && (
+                <RetentionModal
+                    results={results}
+                    actors={people}
+                    selectedRow={selectedRow}
+                    visible={modalVisible}
+                    dismissModal={dismissModal}
+                    actorsLoading={peopleLoading}
+                    loadMore={loadMore}
+                    loadingMore={loadingMore}
+                    aggregationTargetLabel={aggregationTargetLabel}
+                />
+            )}
         </>
     )
 }

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -106,7 +106,7 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
                 // go further and translate thhese numbers into percentage of the previous value
                 // so we get some idea for the rate of convergence.
 
-                return results.map((cohortRetention) => {
+                return results.map((cohortRetention, datasetIndex) => {
                     const retentionPercentages = cohortRetention.values
                         .map((value) => value.count / cohortRetention.values[0].count)
                         // Make them display in the right scale
@@ -142,6 +142,7 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
                                       // map values to percentage of previous
                                       .map(([value, previous]) => (100 * value) / previous)
                                 : retentionPercentages,
+                        index: datasetIndex,
                     }
                 })
             },

--- a/frontend/src/scenes/retention/types.ts
+++ b/frontend/src/scenes/retention/types.ts
@@ -11,6 +11,7 @@ export interface RetentionTrendPayload {
     data: number[]
     days: string[]
     labels: string[]
+    index: number
 }
 
 export interface RetentionTablePeoplePayload {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1527,6 +1527,7 @@ export type GraphDataset = ChartDataset<ChartType> &
         dotted?: boolean // toggled on to draw incompleteness lines in LineGraph.tsx
         breakdownValues?: (string | number | undefined)[] // array of breakdown values used only in ActionsHorizontalBar.tsx data
         personsValues?: (Person | undefined)[] // array of persons ussed only in (ActionsHorizontalBar|ActionsPie).tsx
+        index?: number
     }
 
 interface PointsPayload {


### PR DESCRIPTION
## Changes

*Please describe.*  
- fixes #7619 
- line graph will now return the same modal as table
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- clicked both line graph points and table points to make sure they return the same thing