### PR TITLE
do not start worker, plugins, or events if migrations not complete

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+python manage.py migrate --check
+
 gunicorn posthog.wsgi \
     --config gunicorn.config.py \
     --bind 0.0.0.0:8000 \

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
 
+python manage.py migrate --check
+
 ./bin/plugin-server &
 ./bin/docker-worker-celery --with-scheduler

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -77,6 +77,9 @@ FLAGS+=("-n node@%h")
 echo
 echo "SKIP_ASYNC_MIGRATIONS_SETUP=0 celery -A posthog worker ${FLAGS[*]}"
 echo
+
+python manage.py migrate --check
+
 SKIP_ASYNC_MIGRATIONS_SETUP=0 celery -A posthog worker ${FLAGS[*]}
 
 # Stop the beat!

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -37,6 +37,8 @@ if [[ -n $DYNO_RAM ]]; then
   export WORKER_CONCURRENCY=$(( ($DYNO_RAM - 1) / 512 + 1 ))
 fi
 
+python manage.py migrate --check
+
 cd plugin-server
 
 if [[ -n $DEBUG ]]; then


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

as per a conversation with Guido about code relying on a certain db state on upgrades

https://docs.djangoproject.com/en/3.2/ref/django-admin/#cmdoption-migrate-check

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
