### PR TITLE
Update last_seen_at directly

### DIFF
--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -60,9 +60,6 @@ export const workerTasks: Record<string, TaskRunner> = {
     flushKafkaMessages: async (hub) => {
         await hub.kafkaProducer?.flush()
     },
-    flushLastSeenAtCache: async (hub) => {
-        await hub.teamManager.flushLastSeenAtCache()
-    },
     sendPluginMetrics: async (hub) => {
         await hub.pluginMetricsManager.sendPluginMetrics(hub)
     },

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -25,6 +25,7 @@ describe('TeamManager()', () => {
         ;[hub, closeHub] = await createHub()
         await resetTestDatabase()
         teamManager = hub.teamManager
+        Settings.defaultZoneName = 'utc'
     })
 
     afterEach(async () => {
@@ -175,6 +176,8 @@ describe('TeamManager()', () => {
                     id: expect.any(String),
                     is_numerical: false,
                     name: 'property_name',
+                    property_type: null,
+                    property_type_format: null,
                     query_usage_30_day: null,
                     team_id: 2,
                     volume_30_day: null,
@@ -183,6 +186,8 @@ describe('TeamManager()', () => {
                     id: expect.any(String),
                     is_numerical: true,
                     name: 'numeric_prop',
+                    property_type: null,
+                    property_type_format: null,
                     query_usage_30_day: null,
                     team_id: 2,
                     volume_30_day: null,
@@ -191,6 +196,8 @@ describe('TeamManager()', () => {
                     id: expect.any(String),
                     is_numerical: true,
                     name: 'number',
+                    property_type: null,
+                    property_type_format: null,
                     query_usage_30_day: null,
                     team_id: 2,
                     volume_30_day: null,
@@ -198,39 +205,38 @@ describe('TeamManager()', () => {
             ])
         })
 
-        it('sets or updates lastSeenCache on event', async () => {
+        it('sets or updates eventLastSeenCache', async () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T04:04:04.000Z').getTime())
-            // Existing event
+
+            expect(teamManager.eventLastSeenCache.length).toEqual(0)
             await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+            expect(teamManager.eventLastSeenCache.length).toEqual(1)
+            expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(20150404)
 
-            expect(teamManager.eventLastSeenCache.size).toEqual(1)
-            expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(1428120244000)
+            // Start tracking queries
+            const postgresQuery = jest.spyOn(teamManager.db, 'postgresQuery')
 
-            // New event
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T05:05:05.000Z').getTime())
+            // New event, 10 sec later (all caches should be hit)
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T04:04:14.000Z').getTime())
             await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
-            expect(teamManager.eventLastSeenCache.size).toEqual(1)
-            expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(1428123905000)
-        })
+            expect(postgresQuery).not.toHaveBeenCalled()
 
-        it('does not set lastSeenCache on new event', async () => {
-            // last_seen_at is set in the same INSERT statement, so we don't need to update it
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2018-01-01T12:12:12.000Z').getTime())
-            await teamManager.updateEventNamesAndProperties(2, 'this_is_new_3881', {})
-            expect(teamManager.eventLastSeenCache.size).toEqual(0)
-        })
-
-        it('does not update lastSeenCache if event timestamp is older', async () => {
-            jest.spyOn(hub.db, 'postgresQuery')
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2014-03-23T23:23:23.000Z').getTime())
+            // New event, 1 day later (all caches should be empty)
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-05T04:04:14.000Z').getTime())
             await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+            expect(postgresQuery).toHaveBeenCalledWith(
+                'UPDATE posthog_eventdefinition SET last_seen_at=$1 WHERE team_id=$2 and name=$3',
+                [DateTime.now(), 2, 'another_test_event'],
+                'updateEventLastSeenAt'
+            )
 
-            // Received event at an older time
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2014-03-23T23:23:00.000Z').getTime())
+            // Re-ingest, should add no queries
+            postgresQuery.mockClear()
             await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+            expect(postgresQuery).not.toHaveBeenCalled()
 
-            expect(teamManager.eventLastSeenCache.size).toEqual(1)
-            expect(teamManager.eventLastSeenCache.get(JSON.stringify([2, 'another_test_event']))).toEqual(1395617003000)
+            expect(teamManager.eventLastSeenCache.length).toEqual(1)
+            expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(20150405)
         })
 
         // TODO: #7422 temporary test
@@ -240,14 +246,11 @@ describe('TeamManager()', () => {
                 EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: false,
             })
             const newTeamManager = newHub.teamManager
-            newTeamManager.lastFlushAt = DateTime.fromISO('2010-01-01T22:22:22.000Z') // a long time ago
             await newTeamManager.updateEventNamesAndProperties(2, '$pageview', {})
             jest.spyOn(newHub.db, 'postgresQuery')
-            jest.spyOn(newTeamManager, 'flushLastSeenAtCache')
             await newTeamManager.updateEventNamesAndProperties(2, '$pageview', {}) // Called twice to test both insert and update
             expect(newHub.db.postgresQuery).toHaveBeenCalledTimes(0)
-            expect(newTeamManager.eventLastSeenCache.size).toBe(0)
-            expect(newTeamManager.flushLastSeenAtCache).toHaveBeenCalledTimes(0)
+            expect(newTeamManager.eventLastSeenCache.length).toBe(0)
             const eventDefinitions = await newHub.db.fetchEventDefinitions()
             for (const def of eventDefinitions) {
                 if (def.name === 'disabled-feature') {
@@ -256,90 +259,6 @@ describe('TeamManager()', () => {
             }
 
             await closeNewHub()
-        })
-
-        it('flushes lastSeenCache properly', async () => {
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-01-01T00:00:00.000Z').getTime())
-
-            await teamManager.updateEventNamesAndProperties(2, 'new-event', {})
-            await hub.db.postgresQuery(
-                "UPDATE posthog_eventdefinition SET last_seen_at = to_timestamp(1497307499) WHERE team_id = 2 AND name = '$pageview'",
-                undefined,
-                'test'
-            )
-            teamManager.eventLastSeenCache.set(JSON.stringify([2, '$pageview']), 1497307450000) // older than currently last_seen_at
-            teamManager.eventLastSeenCache.set(JSON.stringify([2, 'new-event']), 1626129850000) // regular
-            teamManager.eventLastSeenCache.set(JSON.stringify([2, 'another_test_event']), 1623537850000)
-            teamManager.eventLastSeenCache.set(JSON.stringify([3, '$pageview']), 1528843450000) // inexistent team
-
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-03-03T03:03:03Z').getTime())
-            jest.spyOn(hub.db, 'postgresQuery')
-            await teamManager.flushLastSeenAtCache()
-            expect(teamManager.eventLastSeenCache.size).toBe(0)
-            expect(teamManager.lastFlushAt.valueOf()).toBe(DateTime.fromISO('2020-03-03T03:03:03Z').valueOf())
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1) // only a single query is fired
-            expect(hub.db.postgresQuery).toHaveBeenCalledWith(
-                `UPDATE posthog_eventdefinition AS t1 SET last_seen_at = GREATEST(t1.last_seen_at, to_timestamp(t2.last_seen_at::numeric))
-                FROM (VALUES ($1,$2,$3),($4,$5,$6),($7,$8,$9),($10,$11,$12)) AS t2(team_id, name, last_seen_at)
-                WHERE t1.name = t2.name AND t1.team_id = t2.team_id::integer`,
-                [
-                    2,
-                    '$pageview',
-                    1497307450,
-                    2,
-                    'new-event',
-                    1626129850,
-                    2,
-                    'another_test_event',
-                    1623537850,
-                    3,
-                    '$pageview',
-                    1528843450,
-                ],
-                'updateEventLastSeen'
-            )
-
-            const eventDefinitions = await hub.db.fetchEventDefinitions()
-            expect(eventDefinitions).toEqual([
-                {
-                    id: expect.any(String),
-                    name: '$pageview',
-                    query_usage_30_day: 2,
-                    team_id: 2,
-                    volume_30_day: 3,
-                    last_seen_at: '2017-06-12T22:44:59.000Z', // previously existing value
-                    created_at: expect.any(String),
-                },
-                {
-                    id: expect.any(String),
-                    name: 'new-event',
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                    last_seen_at: '2021-07-12T22:44:10.000Z',
-                    created_at: expect.any(String),
-                },
-                {
-                    id: expect.any(String),
-                    name: 'another_test_event',
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                    last_seen_at: '2021-06-12T22:44:10.000Z',
-                    created_at: expect.any(String),
-                },
-            ])
-        })
-
-        it('empty lastSeenCache does not query postgres', async () => {
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-04-04T04:04:04Z').getTime())
-            jest.spyOn(hub.db, 'postgresQuery')
-            await teamManager.flushLastSeenAtCache()
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
-
-            expect(teamManager.eventLastSeenCache.size).toBe(0)
-            // lastFlushAt does get updated
-            expect(teamManager.lastFlushAt.valueOf()).toBe(DateTime.fromISO('2020-04-04T04:04:04Z').valueOf())
         })
 
         it('does not capture event', async () => {


### PR DESCRIPTION
## Changes

- Removes the flush for `last_seen_at`. Instead, once per day, makes one postgres query for every new event seen per team... per plugin server thread. 
- The last seen at cache was deadlocking ingestion recently. It's running in unfavourable conditions and could be improved, but this can not be mitigated. Best to remove the chance for deadlocks completely. 
- We could optimise and unify all the caching systems in the plugin server, but this PR tries to stay on topic.

## How did you test this code?

- Wrote and adapted tests
- Ran the plugin server locally and browsed around, all seemed normal.