### PR TITLE
Add "save" button to toolbar urls.

### DIFF
--- a/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
@@ -128,6 +128,12 @@ export const authorizedUrlsLogic = kea<authorizedUrlsLogicType<KeyedAppUrl>>({
             null as number | null,
             {
                 setEditUrlIndex: (_, { originalIndex }) => originalIndex,
+                removeUrl: (editUrlIndex, { index }) =>
+                    editUrlIndex && index < editUrlIndex
+                        ? editUrlIndex - 1
+                        : index === editUrlIndex
+                        ? null
+                        : editUrlIndex,
             },
         ],
     }),


### PR DESCRIPTION
## Changes

- Adds an explicit "save" button for mobile users and those who don't find clicking "enter" to be intuitive
- Fixes a bug where if you deleted a row while editing, things would move around strangely.

![2021-12-23 12 56 10](https://user-images.githubusercontent.com/53387/147237309-79cc77f7-93df-467e-80bb-e5a4a016e9f7.gif)

## How did you test this code?

- There are no tests here, and the code itself could use a good refactor (`useEffect` loops), so didn't add any. Just did the minimum change needed to add a button and fix a bug. Tested it in the browser.